### PR TITLE
Fix CLI parameter examples in examples

### DIFF
--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -45,11 +45,11 @@ Then after `cd packages/examples` you can use `npm run matter-device` to run the
 ### General CLI information
 Some command line parameters, for example those used to set the level of logging or the MDNS interface are now included in the new environment processing. These can be set by generic command line arguments or by using environment variables. These parameters are processed automatically so are no longer handled by the new example code directly. These are:
 
-* `--log-level=...` or environment variable `MATTER_LOG_LEVEL` or in code `environment.vars.set('log.level', Level.DEBUG)`. Allowed values are: Level.FATAL ("fatal"), Level.ERROR ("error"), Level.WARN ("warn"), Level.NOTICE ("notice"), Level.INFO ("info"), Level.DEBUG ("debug")
-* `--log-format=...` or environment variable `MATTER_LOG_FORMAT` or `environment.vars.set('log.format', Format.PLAIN)`. Allowed values are: Format.PLAIN ("plain"), Format.HTML ("html"), Format.ANSI ("ansi")
-* `--storage-path=...` or environment variable `MATTER_STORAGE_PATH` or `environment.vars.set('storage.path', "...")` allows to set the storage location. By default, it will be stored in the users home directory in `.matter/...`. If specified, the given path will be used relative to the current working directory.
+* `--log-level ...` or environment variable `MATTER_LOG_LEVEL` or in code `environment.vars.set('log.level', Level.DEBUG)`. Allowed values are: Level.FATAL ("fatal"), Level.ERROR ("error"), Level.WARN ("warn"), Level.NOTICE ("notice"), Level.INFO ("info"), Level.DEBUG ("debug")
+* `--log-format ...` or environment variable `MATTER_LOG_FORMAT` or `environment.vars.set('log.format', Format.PLAIN)`. Allowed values are: Format.PLAIN ("plain"), Format.HTML ("html"), Format.ANSI ("ansi")
+* `--storage-path ...` or environment variable `MATTER_STORAGE_PATH` or `environment.vars.set('storage.path', "...")` allows to set the storage location. By default, it will be stored in the users home directory in `.matter/...`. If specified, the given path will be used relative to the current working directory.
 * `--storage-clear` or environment variable `MATTER_STORAGE_CLEAR=1` or `environment.vars.set('storage.clear', true)` allows to define if the storage is reset on startup.
-* `--mdns-networkinterface=...` or environment variable `MATTER_MDNS_NETWORKINTERFACE` or `environment.vars.set('mdns.networkInterface', "...")` allows to limit the DNS announcements and scanning to one network interface. By default, all available interfaces are used.
+* `--mdns-networkinterface ...` or environment variable `MATTER_MDNS_NETWORKINTERFACE` or `environment.vars.set('mdns.networkInterface', "...")` allows to limit the DNS announcements and scanning to one network interface. By default, all available interfaces are used.
   Additionally, all command line parameters now require to start with two dashes!
 
 (if using `npm run ...` to run examples then an additional "--" if needed to separate commandline parameters between the npm run and the executed script. Please see the relevant examples README too.)

--- a/packages/examples/src/controller/README.md
+++ b/packages/examples/src/controller/README.md
@@ -14,13 +14,13 @@ The controller currently is not discovering the device to pair, but directly con
 To run from the build files:
 
 ```bash
-matter-controller --pairingcode=12345678901
+matter-controller --pairingcode 12345678901
 ```
 
 To run directly from Typescript files with on the fly compilation:
 
 ```bash
-npm run matter-controller -- --pairingcode=12345678901
+npm run matter-controller -- --pairingcode 12345678901
 ```
 
 This will commission a MatterServer device (for debugging/capability showing purpose only for now).

--- a/packages/examples/src/device-bridge-onoff/README.md
+++ b/packages/examples/src/device-bridge-onoff/README.md
@@ -13,21 +13,21 @@ The usage and parameter are comparable to above, but the bridge adds support for
 **If you want to start multiple parallel processes please make sure to use different storage locations, different network port and ideally also different passcodes for each process!**
 
 The usage is as above but with modified parameters:
-* --num=X: number of devices to expose (default 2)
-* --typeX=socket: type of the devices to expose as device number X (default Light bulb)
+* --num X: number of devices to expose (default 2)
+* --typeX socket: type of the devices to expose as device number X (default Light bulb)
 * --onX "script": script to run when the device number X is turned on
 * --offX "script": script to run when the device number X is turned off
 
-**Please especially use the --uniqueidX parameters to assign unique own IDs to the single deices in order to remember their structure in the bridge. Such an ID should never be reused if you ever remove or add new devices! If you do not use --uniqueidX then the order you added them here is not allowed to ever change.**
+**Please especially use the --uniqueidX parameters to assign unique own IDs to the single devices to remember their structure in the bridge. Such an ID should never be reused if you ever remove or add new devices! If you do not use --uniqueidX then the order you added them here is not allowed to ever change.**
 
 ```bash
-matter-bridge --num=2 --on1="echo 255 > /sys/class/leds/led1/brightness" --off1="echo 0 > /sys/class/leds/led1/brightness" --type2=socket --on2="echo 255 > /sys/class/leds/led2/brightness" --off2="echo 0 > /sys/class/leds/led2/brightness"
+matter-bridge --num 2 --on1 "echo 255 > /sys/class/leds/led1/brightness" --off1 "echo 0 > /sys/class/leds/led1/brightness" --type2 socket --on2 "echo 255 > /sys/class/leds/led2/brightness" --off2 "echo 0 > /sys/class/leds/led2/brightness"
 ```
 
 or when starting from TS files:
 
 ```bash
-npm run matter-bridge -- --num=2 --on1="echo 255 > /sys/class/leds/led1/brightness" --off1="echo 0 > /sys/class/leds/led1/brightness" --type2=socket --on2="echo 255 > /sys/class/leds/led2/brightness" --off2="echo 0 > /sys/class/leds/led2/brightness"
+npm run matter-bridge -- --num 2 --on1 "echo 255 > /sys/class/leds/led1/brightness" --off1 "echo 0 > /sys/class/leds/led1/brightness" --type2 socket --on2 "echo 255 > /sys/class/leds/led2/brightness" --off2 "echo 0 > /sys/class/leds/led2/brightness"
 ```
 (Please note the "--" to separate commandline parameters between the npm run and the executed script.
 

--- a/packages/examples/src/device-composed-onoff/README.md
+++ b/packages/examples/src/device-composed-onoff/README.md
@@ -11,13 +11,13 @@ For general documentation about the CLI parameters or environment variables that
 The parameters are like with the bridge but with an added "-type light/socket" parameter to define the type of the composed device itself.
 
 ```bash
-matter-composeddevice --type=socket --num=2 --on1="echo 255 > /sys/class/leds/led1/brightness" --off1="echo 0 > /sys/class/leds/led1/brightness" --type2=socket --on2="echo 255 > /sys/class/leds/led2/brightness" --off2="echo 0 > /sys/class/leds/led2/brightness"
+matter-composeddevice --type socket --num 2 --on1 "echo 255 > /sys/class/leds/led1/brightness" --off1 "echo 0 > /sys/class/leds/led1/brightness" --type2 socket --on2 "echo 255 > /sys/class/leds/led2/brightness" --off2 "echo 0 > /sys/class/leds/led2/brightness"
 ```
 
 or when starting from TS files:
 
 ```bash
-npm run matter-composeddevice -- --type=socket --num=2 --on1="echo 255 > /sys/class/leds/led1/brightness" --off1="echo 0 > /sys/class/leds/led1/brightness" --type2=socket --on2="echo 255 > /sys/class/leds/led2/brightness" --off2="echo 0 > /sys/class/leds/led2/brightness"
+npm run matter-composeddevice -- --type socket --num 2 --on1 "echo 255 > /sys/class/leds/led1/brightness" --off1 "echo 0 > /sys/class/leds/led1/brightness" --type2 socket --on2 "echo 255 > /sys/class/leds/led2/brightness" --off2 "echo 0 > /sys/class/leds/led2/brightness"
 ```
 (Please note the "--" to separate commandline parameters between the npm run and the executed script.
 

--- a/packages/examples/src/device-multiple-onoff/README.md
+++ b/packages/examples/src/device-multiple-onoff/README.md
@@ -11,13 +11,13 @@ For general documentation about the CLI parameters or environment variables that
 The parameters are like with the composed device or bridge.
 
 ```bash
-matter-multidevice --type=socket --num=2 --on1="echo 255 > /sys/class/leds/led1/brightness" --off1="echo 0 > /sys/class/leds/led1/brightness" --type2=socket --on2="echo 255 > /sys/class/leds/led2/brightness" --off2="echo 0 > /sys/class/leds/led2/brightness"
+matter-multidevice --type socket --num 2 --on1 "echo 255 > /sys/class/leds/led1/brightness" --off1 "echo 0 > /sys/class/leds/led1/brightness" --type2 socket --on2 "echo 255 > /sys/class/leds/led2/brightness" --off2 "echo 0 > /sys/class/leds/led2/brightness"
 ```
 
 or when starting from TS files:
 
 ```bash
-npm run matter-multidevice -- --type=socket --num=2 --on1="echo 255 > /sys/class/leds/led1/brightness" --off1="echo 0 > /sys/class/leds/led1/brightness" --type2=socket --on2="echo 255 > /sys/class/leds/led2/brightness" --off2="echo 0 > /sys/class/leds/led2/brightness"
+npm run matter-multidevice -- --type socket --num 2 --on1 "echo 255 > /sys/class/leds/led1/brightness" --off1 "echo 0 > /sys/class/leds/led1/brightness" --type2 socket --on2 "echo 255 > /sys/class/leds/led2/brightness" --off2 "echo 0 > /sys/class/leds/led2/brightness"
 ```
 (Please note the "--" to separate commandline parameters between the npm run and the executed script.
 

--- a/packages/examples/src/device-onoff-advanced/README.md
+++ b/packages/examples/src/device-onoff-advanced/README.md
@@ -25,20 +25,20 @@ Please also make sure you follow the [BLE enablement steps for your operating sy
 
 The following parameters are available:
 * --ble-enable: enable BLE support (default: false) If this is enabled the device will announce itself _only_ via BLE if not commissioned and also presents a "Wifi only" device for commissioning to show this feature!
-* --ble-hci-id=...: Optionally, HCI ID to use (Linux only, default 0)
+* --ble-hci-id ...: Optionally, HCI ID to use (Linux only, default 0)
 
 Additionally, you need to choose if the device should simulate a Thread or a Wifi enabled device. This can be done by adding `--ble-fake-wifi` or `--ble-fake-thread` to the command line. Then a dummy WifiNetworkCommissioning or ThreadNetworkCommissioning cluster is added to the device node.
 
 Depending on the method you chose you probably need to also add additional parameters for either Wifi or thread which are returned when the device is asked to scn for available networks.
 
 For Wifi the parameters to use are:
-* --ble-wifi-scanSsid=...: The Wi-Fi SSID returned by the "ScanNetworks" call of the Wifi Network commissioning cluster used when using BLE commissioning (default: "TestSSID"). Ideally use a really existing SSID that also the commissioner (Apple, Alexa, ...) knows to make it easier to commission. Else you could get errors while commissioning.
-* --ble-wifi-scanBssid=...: The Wi-Fi BSSID returned by the "ScanNetworks" call of the Wifi Network commissioning cluster used when using BLE commissioning (default: "00:00:00:00:00:00").
+* --ble-wifi-scanSsid ...: The Wi-Fi SSID returned by the "ScanNetworks" call of the Wifi Network commissioning cluster used when using BLE commissioning (default: "TestSSID"). Ideally use a really existing SSID that also the commissioner (Apple, Alexa, ...) knows to make it easier to commission. Else you could get errors while commissioning.
+* --ble-wifi-scanBssid ...: The Wi-Fi BSSID returned by the "ScanNetworks" call of the Wifi Network commissioning cluster used when using BLE commissioning (default: "00:00:00:00:00:00").
 
 For Thread the parameters to use are:
-* --ble.thread.panId=...: The PAN ID to use for the Thread network
-* --ble.thread.extendedPanId=...: The extended PAN ID to use for the Thread network
-* --ble.thread.networkName=...: The network name to use for the Thread network
-* --ble.thread.channel=...: The channel to use for the Thread network
-* --ble.thread.address=...: The address to use for the Thread network
+* --ble.thread.panId ...: The PAN ID to use for the Thread network
+* --ble.thread.extendedPanId ...: The extended PAN ID to use for the Thread network
+* --ble.thread.networkName ...: The network name to use for the Thread network
+* --ble.thread.channel ...: The channel to use for the Thread network
+* --ble.thread.address ...: The address to use for the Thread network
 Thread parameters are as of now only needed when commissioning with Amazon because the others are currently not scanning for Thread networks.

--- a/packages/examples/src/device-onoff/README.md
+++ b/packages/examples/src/device-onoff/README.md
@@ -25,13 +25,13 @@ You can use -on and -off parameter to run a script to control something.
 For instance, on a Raspberry Pi, this will turn on / off the red LED:
 
 ```bash
-matter-device --type socket --on="echo 255 > /sys/class/leds/led1/brightness" --off="echo 0 > /sys/class/leds/led1/brightness"
+matter-device --type socket --on "echo 255 > /sys/class/leds/led1/brightness" --off "echo 0 > /sys/class/leds/led1/brightness"
 ```
 
 or when starting from TS files:
 
 ```bash
-npm run matter-device -- --type socket --on="echo 255 > /sys/class/leds/led1/brightness" --off="echo 0 > /sys/class/leds/led1/brightness"
+npm run matter-device -- --type socket --on "echo 255 > /sys/class/leds/led1/brightness" --off "echo 0 > /sys/class/leds/led1/brightness"
 ```
 (Please note the "--" to separate commandline parameters between the npm run and the executed script.)
 

--- a/packages/examples/src/device-sensor/README.md
+++ b/packages/examples/src/device-sensor/README.md
@@ -1,6 +1,6 @@
 # Temperature/Humidity sensor with a CLI command interface to get the value
 
-This example shows how to build a simple Sensor device with a temperature (default) or humidity (`--type humidity`) sensor. The sensor values are updated by default every 60 seconds, or the number of seconds specified via the CLI parameter `--interval`. The value can be defined by the output of a CLI script provided via parameter `--value` or, if no command is specified, are randomly set in the interval -50..+50. To read the Temperature of a Raspberry Pi as example use `--value ="echo \$((\$(</sys/class/thermal/thermal_zone0/temp)/10))"` or to read temperature of your location `--value="curl -s 'wttr.in/?format=%t\&m' | sed 's/°C//'| awk '{print \$1*100}'"` (or use `?format=%h` for humidity).
+This example shows how to build a simple Sensor device with a temperature (default) or humidity (`--type humidity`) sensor. The sensor values are updated by default every 60 seconds, or the number of seconds specified via the CLI parameter `--interval`. The value can be defined by the output of a CLI script provided via parameter `--value` or, if no command is specified, are randomly set in the interval -50..+50. To read the Temperature of a Raspberry Pi as example use `--value  "echo \$((\$(</sys/class/thermal/thermal_zone0/temp)/10))"` or to read temperature of your location `--value "curl -s 'wttr.in/?format=%t\&m' | sed 's/°C//'| awk '{print \$1*100}'"` (or use `?format=%h` for humidity).
 
 ## Usage
 

--- a/packages/examples/src/device-sensor/README.md
+++ b/packages/examples/src/device-sensor/README.md
@@ -1,6 +1,6 @@
 # Temperature/Humidity sensor with a CLI command interface to get the value
 
-This example shows how to build a simple Sensor device with a temperature (default) or humidity (`--type humidity`) sensor. The sensor values are updated by default every 60 seconds, or the number of seconds specified via the CLI parameter `--interval`. The value can be defined by the output of a CLI script provided via parameter `--value` or, if no command is specified, are randomly set in the interval -50..+50. To read the Temperature of a Raspberry Pi as example use `--value  "echo \$((\$(</sys/class/thermal/thermal_zone0/temp)/10))"` or to read temperature of your location `--value "curl -s 'wttr.in/?format=%t\&m' | sed 's/°C//'| awk '{print \$1*100}'"` (or use `?format=%h` for humidity).
+This example shows how to build a simple Sensor device with a temperature (default) or humidity (`--type humidity`) sensor. The sensor values are updated by default every 60 seconds, or the number of seconds specified via the CLI parameter `--interval`. The value can be defined by the output of a CLI script provided via parameter `--value` or, if no command is specified, are randomly set in the interval -50..+50. To read the Temperature of a Raspberry Pi as example use `--value "echo \$((\$(</sys/class/thermal/thermal_zone0/temp)/10))"` or to read temperature of your location `--value "curl -s 'wttr.in/?format=%t\&m' | sed 's/°C//'| awk '{print \$1*100}'"` (or use `?format=%h` for humidity).
 
 ## Usage
 


### PR DESCRIPTION
We now use the environment CLI options which do not use equal signs anymore