### PR TITLE
Optimize MDNS issues

### DIFF
--- a/packages/general/src/net/RetrySchedule.ts
+++ b/packages/general/src/net/RetrySchedule.ts
@@ -40,7 +40,7 @@ export class RetrySchedule {
         while ((timeout === undefined || timeSoFar < timeout) && (maximumCount === undefined || maximumCount > count)) {
             count++;
             const maxJitter = jitterFactor * baseInterval;
-            const jitter = Math.floor((2 * maxJitter * this.#crypto.randomUint32) / Math.pow(2, 32) - maxJitter);
+            const jitter = Math.floor((maxJitter * this.#crypto.randomUint32) / Math.pow(2, 32));
             let interval = baseInterval + jitter;
 
             if (timeout !== undefined && timeSoFar + interval > timeout) {

--- a/packages/protocol/src/mdns/MdnsServer.ts
+++ b/packages/protocol/src/mdns/MdnsServer.ts
@@ -71,7 +71,7 @@ export class MdnsServer {
         const { sourceIntf, sourceIp, transactionId, messageType, queries, answers: knownAnswers } = message;
         if (messageType !== DnsMessageType.Query && messageType !== DnsMessageType.TruncatedQuery) return;
         if (queries.length === 0) return; // No queries to answer can happen in a TruncatedQuery, let's ignore for now
-        logger.info("DNS Query", messageType, queries, knownAnswers);
+        logger.info("DNS Query", sourceIntf, messageType, queries, knownAnswers);
         for (const portRecords of records.values()) {
             let answers = queries.flatMap(query => this.#queryRecords(query, portRecords));
             if (answers.length === 0) continue;
@@ -125,7 +125,7 @@ export class MdnsServer {
                     this.#recordLastSentAsMulticastAnswer.set(this.buildDnsRecordKey(answer, sourceIntf), now),
                 );
             }
-            logger.info("Final answers", answers, "uniCastResponse", uniCastResponse);
+            logger.info("Sending", answers, "uniCastResponse", uniCastResponse, sourceIp, sourceIntf);
 
             this.#socket
                 .send(

--- a/packages/protocol/src/mdns/MdnsServer.ts
+++ b/packages/protocol/src/mdns/MdnsServer.ts
@@ -69,7 +69,7 @@ export class MdnsServer {
 
         const { sourceIntf, sourceIp, transactionId, messageType, queries, answers: knownAnswers } = message;
         if (messageType !== DnsMessageType.Query && messageType !== DnsMessageType.TruncatedQuery) return;
-        if (queries.length === 0) return; // No queries to answer can happen in a TruncatedQuery, let's ignore for now
+        if (queries.length === 0) return; // No queries to answer, can happen in a TruncatedQuery, let's ignore for now
         for (const portRecords of records.values()) {
             let answers = queries.flatMap(query => this.#queryRecords(query, portRecords));
             if (answers.length === 0) continue;

--- a/packages/protocol/src/mdns/MdnsServer.ts
+++ b/packages/protocol/src/mdns/MdnsServer.ts
@@ -14,9 +14,9 @@ import {
     MatterAggregateError,
     NetworkInterfaceDetails,
     ObserverGroup,
+    SrvRecordValue,
     Time,
 } from "#general";
-import { SrvRecordValue } from "@matter/general";
 import { MdnsSocket } from "./MdnsSocket.js";
 
 const logger = Logger.get("MdnsServer");
@@ -118,7 +118,11 @@ export class MdnsServer {
             }
             logger.info("Preparing answers", answers, "uniCastResponse", uniCastResponse);
             if (!uniCastResponse) {
-                answers = answers.filter((_, index) => answersTimeSinceLastSent[index].timeSinceLastMultiCast >= 900);
+                answers = answers.filter(
+                    (_, index) =>
+                        answersTimeSinceLastSent[index].timeSinceLastMultiCast === 0 || // Never sent as multicast
+                        answersTimeSinceLastSent[index].timeSinceLastMultiCast >= 900, // The last time sent as multicast was more than 900 ms ago
+                );
                 if (answers.length === 0) continue; // Nothing to send
 
                 answers.forEach(answer =>

--- a/packages/protocol/src/mdns/MdnsServer.ts
+++ b/packages/protocol/src/mdns/MdnsServer.ts
@@ -70,7 +70,7 @@ export class MdnsServer {
 
         const { sourceIntf, sourceIp, transactionId, messageType, queries, answers: knownAnswers } = message;
         if (messageType !== DnsMessageType.Query && messageType !== DnsMessageType.TruncatedQuery) return;
-        if (queries.length === 0) return; // No queries to answer, can happen in a TruncatedQuery, let's ignore for now
+        if (queries.length === 0) return; // No queries to answer can happen in a TruncatedQuery, let's ignore for now
         for (const portRecords of records.values()) {
             let answers = queries.flatMap(query => this.#queryRecords(query, portRecords));
             if (answers.length === 0) continue;
@@ -118,14 +118,14 @@ export class MdnsServer {
                 uniCastResponse = false;
             }
             if (!uniCastResponse) {
-                answers = answers.filter((_, index) => answersTimeSinceLastSent[index].timeSinceLastMultiCast > 1000);
+                answers = answers.filter((_, index) => answersTimeSinceLastSent[index].timeSinceLastMultiCast > 10);
                 if (answers.length === 0) continue; // Nothing to send
 
                 answers.forEach(answer =>
                     this.#recordLastSentAsMulticastAnswer.set(this.buildDnsRecordKey(answer, sourceIntf), now),
                 );
             } else {
-                answers = answers.filter((_, index) => answersTimeSinceLastSent[index].timeSinceLastUniCast > 1000);
+                answers = answers.filter((_, index) => answersTimeSinceLastSent[index].timeSinceLastUniCast > 10);
                 if (answers.length === 0) continue; // Nothing to send
 
                 answers.forEach(answer =>

--- a/packages/protocol/src/mdns/MdnsSocket.ts
+++ b/packages/protocol/src/mdns/MdnsSocket.ts
@@ -127,8 +127,6 @@ export class MdnsSocket {
             chunk.additionalRecords.push(additionalRecordEncoded);
         }
 
-        logger.info("Sending", message, "chunkSize", chunkSize);
-        logger.info(DnsCodec.encode(message));
         await this.#send(chunk, intf, unicastDest);
     }
 

--- a/packages/protocol/src/mdns/MdnsSocket.ts
+++ b/packages/protocol/src/mdns/MdnsSocket.ts
@@ -99,7 +99,7 @@ export class MdnsSocket {
                     );
                 }
 
-                // New answer do not fit anymore, send out the message
+                // New answer does not fit anymore, send out the message
                 await this.#send(chunk, intf, unicastDest);
 
                 // Reset the message, length counter and included answers to count for next message
@@ -127,6 +127,8 @@ export class MdnsSocket {
             chunk.additionalRecords.push(additionalRecordEncoded);
         }
 
+        logger.info("Sending", message, "chunkSize", chunkSize);
+        logger.info(DnsCodec.encode(message));
         await this.#send(chunk, intf, unicastDest);
     }
 

--- a/packages/protocol/test/mdns/MdnsServerTest.ts
+++ b/packages/protocol/test/mdns/MdnsServerTest.ts
@@ -750,7 +750,7 @@ describe("MdnsServer", () => {
             expect(responses).deep.equal([{ ...RESPONSE, uniCastTarget: undefined }]); // multicast
         });
 
-        it("server responds to an ANY query as multicast if unicast requested and after a unicast query with less than 1/4 of ttl", async () => {
+        it("server responds to an ANY query as multicast when unicast is requested after a previous unicast query with less than 1/4 of TTL remaining", async () => {
             const responses = new Array<{ message?: DnsMessage; netInterface?: string; uniCastTarget?: string }>();
             onResponse = async (message: Uint8Array, netInterface?: string, uniCastTarget?: string) => {
                 responses.push({ message: DnsCodec.decode(message), netInterface, uniCastTarget });

--- a/packages/protocol/test/mdns/MdnsServerTest.ts
+++ b/packages/protocol/test/mdns/MdnsServerTest.ts
@@ -737,7 +737,7 @@ describe("MdnsServer", () => {
             netInterface: INTERFACE_NAME,
         };
 
-        it("server responds to an ANY query as unicast if requested", async () => {
+        it("server responds to an ANY query as multicast if requested by unicast but records were never sent before", async () => {
             const responses = new Array<{ message?: DnsMessage; netInterface?: string; uniCastTarget?: string }>();
             onResponse = async (message: Uint8Array, netInterface?: string, uniCastTarget?: string) => {
                 responses.push({ message: DnsCodec.decode(message), netInterface, uniCastTarget });
@@ -747,10 +747,10 @@ describe("MdnsServer", () => {
 
             await MockTime.yield3();
 
-            expect(responses).deep.equal([{ ...RESPONSE, uniCastTarget: DUMMY_IP }]);
+            expect(responses).deep.equal([{ ...RESPONSE, uniCastTarget: undefined }]); // multicast
         });
 
-        it("server responds to an ANY query as unicast if requested and after a unicast query with less than 1/4 of ttl", async () => {
+        it("server responds to an ANY query as multicast if unicast requested and after a unicast query with less than 1/4 of ttl", async () => {
             const responses = new Array<{ message?: DnsMessage; netInterface?: string; uniCastTarget?: string }>();
             onResponse = async (message: Uint8Array, netInterface?: string, uniCastTarget?: string) => {
                 responses.push({ message: DnsCodec.decode(message), netInterface, uniCastTarget });
@@ -766,12 +766,12 @@ describe("MdnsServer", () => {
             await MockTime.yield3();
 
             expect(responses).deep.equal([
-                { ...RESPONSE, uniCastTarget: DUMMY_IP }, // unicast
+                { ...RESPONSE, uniCastTarget: undefined }, // multicast
                 { ...RESPONSE, uniCastTarget: DUMMY_IP }, // unicast
             ]);
         });
 
-        it("server responds to an ANY query as unicast even if requested as unicast and after a multicast query with more than 1/4 of ttl but never sent as multicast", async () => {
+        it("server responds to an ANY query as multicast even if requested as unicast and after a multicast query with more than 1/4 of ttl but never sent as multicast", async () => {
             const responses = new Array<{ message?: DnsMessage; netInterface?: string; uniCastTarget?: string }>();
             onResponse = async (message: Uint8Array, netInterface?: string, uniCastTarget?: string) => {
                 responses.push({ message: DnsCodec.decode(message), netInterface, uniCastTarget });
@@ -787,8 +787,8 @@ describe("MdnsServer", () => {
             await MockTime.yield3();
 
             expect(responses).deep.equal([
-                { ...RESPONSE, uniCastTarget: DUMMY_IP }, // unicast
-                { ...RESPONSE, uniCastTarget: DUMMY_IP }, // multicast
+                { ...RESPONSE, uniCastTarget: undefined }, // multicast
+                { ...RESPONSE, uniCastTarget: undefined }, // multicast
             ]);
         });
 

--- a/packages/protocol/test/mdns/MdnsServerTest.ts
+++ b/packages/protocol/test/mdns/MdnsServerTest.ts
@@ -737,7 +737,7 @@ describe("MdnsServer", () => {
             netInterface: INTERFACE_NAME,
         };
 
-        it("server responds to an ANY query as multicast if requested by unicast but records were never sent before", async () => {
+        it("server responds to an ANY query as multicast if requested via unicast but records were never sent before", async () => {
             const responses = new Array<{ message?: DnsMessage; netInterface?: string; uniCastTarget?: string }>();
             onResponse = async (message: Uint8Array, netInterface?: string, uniCastTarget?: string) => {
                 responses.push({ message: DnsCodec.decode(message), netInterface, uniCastTarget });


### PR DESCRIPTION
This PR stabilizes the current MDNS issues.

It changes the following:
* Removes the duplicate prevention optimization for unicast, unicast requests will always be answered - just potentially as multicast
* Only sort out duplicate multicast values there were sent within 900ms (because 1s is the initial retry interval by definition and so we might run into timing issues
* Fix clearing dns records when expiring announcements - clear is totally fine because net get will regenerate via generators