### PR TITLE
Make ProtocolStatus extensible

### DIFF
--- a/packages/protocol/src/protocol/ProtocolHandler.ts
+++ b/packages/protocol/src/protocol/ProtocolHandler.ts
@@ -8,8 +8,15 @@ import { Message } from "../codec/MessageCodec.js";
 import { MessageExchange } from "./MessageExchange.js";
 
 export interface ProtocolHandler {
+    /** Protocol ID that this handler implements */
     readonly id: number;
+
+    /** Indicates whether this protocol requires a secure session to be established before it can be used */
     readonly requiresSecureSession: boolean;
+
+    /** Called on a new exchange that uses this protocol. The message is the first message of the exchange. */
     onNewExchange(exchange: MessageExchange, message: Message): Promise<void>;
+
+    /** Called when the protocol handler is no longer needed and can clean up resources. */
     close(): Promise<void>;
 }

--- a/packages/protocol/src/securechannel/SecureChannelMessenger.ts
+++ b/packages/protocol/src/securechannel/SecureChannelMessenger.ts
@@ -8,7 +8,7 @@ import { Diagnostic, MatterError, UnexpectedDataError } from "#general";
 import { GeneralStatusCode, SecureChannelStatusCode, SecureMessageType, TlvSchema } from "#types";
 import { Message } from "../codec/MessageCodec.js";
 import { ExchangeSendOptions, MessageExchange } from "../protocol/MessageExchange.js";
-import { TlvSecureChannelStatusMessage } from "./SecureChannelStatusMessageSchema.js";
+import { SecureChannelStatusMessage } from "./SecureChannelStatusMessageSchema.js";
 
 /** Error base Class for all errors related to the status response messages. */
 export class ChannelStatusResponseError extends MatterError {
@@ -150,7 +150,7 @@ export class SecureChannelMessenger {
     ) {
         await this.exchange.send(
             SecureMessageType.StatusReport,
-            TlvSecureChannelStatusMessage.encode({
+            SecureChannelStatusMessage.encode({
                 generalStatus,
                 protocolStatus,
             }),
@@ -171,7 +171,7 @@ export class SecureChannelMessenger {
         } = message;
         if (messageType !== SecureMessageType.StatusReport) return;
 
-        const { generalStatus, protocolId, protocolStatus } = TlvSecureChannelStatusMessage.decode(payload);
+        const { generalStatus, protocolId, protocolStatus } = SecureChannelStatusMessage.decode(payload);
         if (generalStatus !== GeneralStatusCode.Success) {
             throw new ChannelStatusResponseError(
                 `Received general error status for protocol ${protocolId}${logHint ? ` (${logHint})` : ""}`,

--- a/packages/protocol/src/securechannel/SecureChannelProtocol.ts
+++ b/packages/protocol/src/securechannel/SecureChannelProtocol.ts
@@ -23,7 +23,7 @@ import { SecureSession } from "../session/SecureSession.js";
 import { CaseServer } from "../session/case/CaseServer.js";
 import { MaximumPasePairingErrorsReachedError, PaseServer } from "../session/pase/PaseServer.js";
 import { ChannelStatusResponseError, SecureChannelMessenger } from "./SecureChannelMessenger.js";
-import { TlvSecureChannelStatusMessage } from "./SecureChannelStatusMessageSchema.js";
+import { SecureChannelStatusMessage } from "./SecureChannelStatusMessageSchema.js";
 
 const logger = Logger.get("SecureChannelProtocol");
 
@@ -62,7 +62,7 @@ export class StatusReportOnlySecureChannelProtocol implements ProtocolHandler {
             );
         }
 
-        const { generalStatus, protocolId, protocolStatus } = TlvSecureChannelStatusMessage.decode(payload);
+        const { generalStatus, protocolId, protocolStatus } = SecureChannelStatusMessage.decode(payload);
         if (generalStatus !== GeneralStatusCode.Success) {
             throw new ChannelStatusResponseError(
                 `Received general error status (${protocolId})`,

--- a/packages/protocol/src/securechannel/SecureChannelStatusMessageSchema.ts
+++ b/packages/protocol/src/securechannel/SecureChannelStatusMessageSchema.ts
@@ -7,8 +7,8 @@
 import { ProtocolStatusMessage, ProtocolStatusMessageSchema } from "#protocol/ProtocolStatusMessage.js";
 import { SECURE_CHANNEL_PROTOCOL_ID, SecureChannelStatusCode } from "#types";
 
-export type SecureChannelStatusMessage = ProtocolStatusMessage<SecureChannelStatusCode>;
+export type SecureChannelStatus = ProtocolStatusMessage<SecureChannelStatusCode>;
 
-export class SecureChannelStatusMessageSchema extends ProtocolStatusMessageSchema<SecureChannelStatusMessage> {}
+export class SecureChannelStatusMessageSchema extends ProtocolStatusMessageSchema<SecureChannelStatus> {}
 
-export const TlvSecureChannelStatusMessage = new SecureChannelStatusMessageSchema(SECURE_CHANNEL_PROTOCOL_ID);
+export const SecureChannelStatusMessage = new SecureChannelStatusMessageSchema(SECURE_CHANNEL_PROTOCOL_ID);

--- a/packages/protocol/test/protocol/ProtocolStatusCodeTest.ts
+++ b/packages/protocol/test/protocol/ProtocolStatusCodeTest.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { ProtocolStatusMessage, ProtocolStatusMessageSchema } from "#protocol/index.js";
+import { Bytes } from "@matter/general";
+import { BDX_PROTOCOL_ID, BdxStatusCode, GeneralStatusCode, VendorId } from "@matter/types";
+
+class NumberProtocolStatusMessageSchema extends ProtocolStatusMessageSchema<ProtocolStatusMessage<number>> {}
+
+/** Validate ProtocolStatusMessageSchema with examples from Matter Specs */
+describe("ProtocolStatusCode", () => {
+    it("Encodes and decodes without protocol data", () => {
+        const schema = new NumberProtocolStatusMessageSchema(BDX_PROTOCOL_ID, false);
+        const encoded = schema.encode({
+            generalStatus: GeneralStatusCode.Failure,
+            protocolStatus: BdxStatusCode.StartOffsetNotSupported,
+        });
+        expect(Bytes.toHex(encoded)).equal("0100020000005200");
+
+        const decoded = schema.decode(encoded);
+        expect(decoded.generalStatus).equal(GeneralStatusCode.Failure);
+        expect(decoded.protocolId).equal(BDX_PROTOCOL_ID);
+        expect(decoded.vendorId).equal(VendorId(0));
+        expect(decoded.protocolStatus).equal(BdxStatusCode.StartOffsetNotSupported);
+        expect(decoded.protocolData).to.be.undefined;
+    });
+
+    it("Encodes and decodes vendor specific without protocol data", () => {
+        const schema = new NumberProtocolStatusMessageSchema({ protocolId: 0xaabb, vendorId: VendorId(0xfff1) }, false);
+        const encoded = schema.encode({
+            generalStatus: GeneralStatusCode.Success,
+            protocolStatus: 0,
+        });
+        expect(Bytes.toHex(encoded)).equal("0000bbaaf1ff0000");
+
+        const decoded = schema.decode(encoded);
+        expect(decoded.generalStatus).equal(GeneralStatusCode.Success);
+        expect(decoded.protocolId).equal(0xaabb);
+        expect(decoded.vendorId).equal(VendorId(0xfff1));
+        expect(decoded.protocolStatus).equal(0);
+        expect(decoded.protocolData).to.be.undefined;
+    });
+
+    it("Encodes and decodes vendor specific with protocol data", () => {
+        const schema = new NumberProtocolStatusMessageSchema({ protocolId: 0xaabb, vendorId: VendorId(0xfff1) }, true);
+        const encoded = schema.encode({
+            generalStatus: GeneralStatusCode.Failure,
+            protocolStatus: 9921,
+            protocolData: Bytes.fromHex("5566eeff"),
+        });
+        expect(Bytes.toHex(encoded)).equal("0100bbaaf1ffc1265566eeff");
+
+        const decoded = schema.decode(encoded);
+        expect(decoded.generalStatus).equal(GeneralStatusCode.Failure);
+        expect(decoded.protocolId).equal(0xaabb);
+        expect(decoded.vendorId).equal(VendorId(0xfff1));
+        expect(decoded.protocolStatus).equal(9921);
+        expect(Bytes.toHex(decoded.protocolData!)).equal("5566eeff");
+    });
+});

--- a/packages/types/src/protocol/definitions/bdx.ts
+++ b/packages/types/src/protocol/definitions/bdx.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const BDX_PROTOCOL_ID = 2;
+
+export enum BdxMessageTypes {
+    SendInit = 0x01,
+    SendAccept = 0x02,
+    ReceiveInit = 0x04,
+    ReceiveAccept = 0x05,
+    BlockQuery = 0x10,
+    Block = 0x11,
+    BlockEof = 0x12,
+    BlockAck = 0x13,
+    BlockAckEof = 0x14,
+    BlockQueryWithSkip = 0x15,
+}
+
+export enum BdxStatusCode {
+    /**
+     * Success.
+     */
+    Success = 0x00,
+
+    /**
+     * Definite length too large to support.
+     * For example, trying to SendInit with too large of a file.
+     */
+    LengthTooLarge = 0x12,
+
+    /**
+     * Definite length proposed for transfer is too short for the context based on the responder’s knowledge of
+     * expected size.
+     */
+    LengthTooShort = 0x13,
+
+    /**
+     * Pre-negotiated size of transfer was not fulfilled prior to BlockAckEOF.
+     */
+    LengthMismatch = 0x14,
+
+    /**
+     * Responder can only support proposed transfer if definite length is provided.
+     */
+    LengthRequired = 0x15,
+
+    /**
+     * Received a malformed protocol message.
+     */
+    BadMessageContent = 0x16,
+
+    /**
+     * Received block counter out of order from expectation.
+     */
+    BadBlockCounter = 0x17,
+
+    /**
+     * Received a well-formed message that was contextually inappropriate for the current state of the transfer.
+     */
+    UnexpectedMessage = 0x18,
+
+    /**
+     * Responder is too busy to proceed with a new transfer at this moment.
+     */
+    ResponderBusy = 0x19,
+
+    /**
+     * Other error occurred, such as perhaps an input/output error occurring at one of the peers.
+     */
+    TransferFailedUnknownError = 0x1f,
+
+    /**
+     * Received a message that mismatches the current transfer mode.
+     */
+    TransferMethodNotSupported = 0x50,
+
+    /**
+     * Attempted to request a file whose designator is unknown to the responder.
+     */
+    FileDesignatorUnknown = 0x51,
+
+    /**
+     * Proposed transfer with explicit start offset is not supported in current context.
+     */
+    StartOffsetNotSupported = 0x52,
+
+    /**
+     * Could not find a common supported version between initiator and responder.
+     */
+    VersionNotSupported = 0x53,
+
+    /**
+     * Other unexpected error.
+     */
+    Unknown = 0x5f,
+
+    /**
+     * No additional error details available.
+     */
+    GeneralError = 0xffff,
+}

--- a/packages/types/src/protocol/definitions/index.ts
+++ b/packages/types/src/protocol/definitions/index.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export * from "./bdx.js";
 export * from "./general.js";
 export * from "./interaction.js";
 export * from "./secure-channel.js";


### PR DESCRIPTION
Also BDX uses the ProtocolStatusMessage and this change prepares the existing structures and makes them extensible to be used for other protocols. It also adds handling for vendor specific protocols.