### PR TITLE
Tweak StandardCrypto initialization

### DIFF
--- a/packages/general/src/crypto/WebCrypto.ts
+++ b/packages/general/src/crypto/WebCrypto.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Our "Crypto" interface masks the standard web crypto "Crypto" type provided by typescript.  Make an alias to work
+ * around this.
+ */
+export interface WebCrypto extends Crypto {}

--- a/packages/general/src/crypto/index.ts
+++ b/packages/general/src/crypto/index.ts
@@ -11,3 +11,4 @@ export * from "./Key.js";
 export * from "./MockCrypto.js";
 export * from "./Spake2p.js";
 export * from "./StandardCrypto.js";
+export * from "./WebCrypto.js";

--- a/packages/react-native/src/crypto/ReactNativeCrypto.ts
+++ b/packages/react-native/src/crypto/ReactNativeCrypto.ts
@@ -13,6 +13,7 @@ import {
     PrivateKey,
     PublicKey,
     StandardCrypto,
+    WebCrypto,
 } from "#general";
 import { Buffer } from "@craftzdog/react-native-buffer";
 import QuickCrypto from "react-native-quick-crypto";
@@ -124,15 +125,6 @@ export class ReactNativeCrypto extends StandardCrypto {
         }
         return super.importKey(format, keyData, algorithm, extractable, keyUsages);
     }
-
-    /**
-     * getRandomValues is only available in the QuickCrypto implementation, so we need to use this.
-     */
-    override randomBytes(length: number): Uint8Array {
-        const result = new Uint8Array(length);
-        crypto.getRandomValues(result);
-        return result;
-    }
 }
 
-Environment.default.set(Crypto, new ReactNativeCrypto(crypto.subtle as unknown as SubtleCrypto));
+Environment.default.set(Crypto, new ReactNativeCrypto(crypto as unknown as WebCrypto));


### PR DESCRIPTION
It now takes the standard "crypto" as input rather than crypto.subtle because we use methods on the outer object and were (mistakenly) referencing the global instance.  Also add typing to ensure we don't do that again.