### PR TITLE
Add proper units for intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 -   Breaking: Because of the upgrade to TypeScript 5.9 all usages of Uint8Array were changed to use a more convenient own type alias Bytes
 
 -   @matter/general
+    - Breaking: Our time API is upgraded, most notably with proper typing for time intervals.  This makes time handling more consistent and safer but it does change how you convey intervals to matter.js.  For example: `delay: Seconds(1)` rather than `delayMs: 1000`
     - Breaking: SyncStorage interface got removed
     - Breaking: MaybeAsyncStorage got renamed to Storage because it is the only interface from now on
     - Feature: Adds Blob support to the Storage interface

--- a/packages/cli-tool/src/repl.ts
+++ b/packages/cli-tool/src/repl.ts
@@ -6,7 +6,7 @@
 
 import { Domain } from "#domain.js";
 import { IncompleteError } from "#errors.js";
-import { Environment, InternalError, Observable, RuntimeService, StorageService, Time } from "#general";
+import { Environment, InternalError, Observable, RuntimeService, Seconds, StorageService, Time } from "#general";
 import { isCommand } from "#parser.js";
 import colors from "ansi-colors";
 import { readFile } from "node:fs/promises";
@@ -42,7 +42,7 @@ export async function repl() {
 
 // Maybe worth sharing spinner implementation with tools.  Maybe not
 const SPINNER = "◐◓◑◒";
-const SPINNER_INTERVAL = 100;
+const SPINNER_INTERVAL = Seconds.tenth;
 
 // Node.js repl implementation does good stuff for us so want to keep it but we don't want the "." commands and it has
 // no way to disable those.  So use this prefix as a hack to prevent it from noticing lines that start with "."

--- a/packages/examples/src/controller/ControllerNode.ts
+++ b/packages/examples/src/controller/ControllerNode.ts
@@ -65,7 +65,7 @@ class ControllerNode {
             : environment.vars.number("port");
         const uniqueId = (await controllerStorage.has("uniqueid"))
             ? await controllerStorage.get<string>("uniqueid")
-            : (environment.vars.string("uniqueid") ?? Time.nowMs().toString());
+            : (environment.vars.string("uniqueid") ?? Time.nowMs.toString());
         await controllerStorage.set("uniqueid", uniqueId);
         const adminFabricLabel = (await controllerStorage.has("fabriclabel"))
             ? await controllerStorage.get<string>("fabriclabel")

--- a/packages/examples/src/device-bridge-onoff/BridgedDevicesNode.ts
+++ b/packages/examples/src/device-bridge-onoff/BridgedDevicesNode.ts
@@ -219,7 +219,7 @@ async function getConfiguration() {
     const port = environment.vars.number("port") ?? 5540;
 
     const uniqueId =
-        environment.vars.string("uniqueid") ?? (await deviceStorage.get("uniqueid", Time.nowMs().toString()));
+        environment.vars.string("uniqueid") ?? (await deviceStorage.get("uniqueid", Time.nowMs.toString()));
 
     // Persist basic data to keep them also on restart
     await deviceStorage.set({

--- a/packages/examples/src/device-composed-onoff/ComposedDeviceNode.ts
+++ b/packages/examples/src/device-composed-onoff/ComposedDeviceNode.ts
@@ -159,7 +159,7 @@ async function getConfiguration() {
     const port = environment.vars.number("port") ?? 5540;
 
     const uniqueId =
-        environment.vars.string("uniqueid") ?? (await deviceStorage.get("uniqueid", Time.nowMs().toString()));
+        environment.vars.string("uniqueid") ?? (await deviceStorage.get("uniqueid", Time.nowMs.toString()));
 
     // Persist basic data to keep them also on restart
     await deviceStorage.set({

--- a/packages/examples/src/device-measuring-socket/MeasuredSocketDevice.ts
+++ b/packages/examples/src/device-measuring-socket/MeasuredSocketDevice.ts
@@ -7,7 +7,7 @@
 
 // This demonstrates bringing a "socket" device with electrical power and energy measurement online with matter.js.
 
-import { Endpoint, ServerNode, Time } from "@matter/main";
+import { Endpoint, Seconds, ServerNode, Time } from "@matter/main";
 import { ElectricalEnergyMeasurementServer, ElectricalPowerMeasurementServer } from "@matter/main/behaviors";
 import { ElectricalEnergyMeasurement, ElectricalPowerMeasurement } from "@matter/main/clusters";
 import { OnOffPlugInUnitDevice } from "@matter/main/devices";
@@ -97,7 +97,7 @@ measuredSocketEndpoint.events.onOff.onOff$Changed.on(value => {
 // We will simulate the device sending measurements every 10 seconds.
 // When the device is turned off, the measurements will be zero, otherwise they will be random values.
 // Note: This is just example code. In a real device, you would set the data to 0 once the device is turned off.
-const fakeMeasurementTimer = Time.getPeriodicTimer("fakeMeasurement", 10_000, async () => {
+const fakeMeasurementTimer = Time.getPeriodicTimer("fakeMeasurement", Seconds(10), async () => {
     const turnedOn = measuredSocketEndpoint.state.onOff.onOff;
     const power = turnedOn ? Math.round(Math.random() * 1000) : 0; // W
     const current = turnedOn ? Math.round(Math.random() * 32) : 0; // A

--- a/packages/examples/src/device-multiple-onoff/MultiDeviceNode.ts
+++ b/packages/examples/src/device-multiple-onoff/MultiDeviceNode.ts
@@ -168,8 +168,7 @@ async function getConfiguration() {
         const port = environment.vars.number(`port${i}`) ?? defaultPort++;
 
         const uniqueId =
-            environment.vars.string(`uniqueid${i}`) ??
-            (await deviceStorage.get(`uniqueid${i}`, `${i}-${Time.nowMs()}`));
+            environment.vars.string(`uniqueid${i}`) ?? (await deviceStorage.get(`uniqueid${i}`, `${i}-${Time.nowMs}`));
 
         // Persist basic data to keep them also on restart
         await deviceStorage.set(`passcode${i}`, passcode);

--- a/packages/examples/src/device-onoff-advanced/DeviceNodeFull.ts
+++ b/packages/examples/src/device-onoff-advanced/DeviceNodeFull.ts
@@ -128,7 +128,7 @@ const productId = environment.vars.number("productid") ?? (await deviceStorage.g
 
 const port = environment.vars.number("port") ?? 5540;
 
-const uniqueId = environment.vars.string("uniqueid") ?? (await deviceStorage.get("uniqueid", Time.nowMs().toString()));
+const uniqueId = environment.vars.string("uniqueid") ?? (await deviceStorage.get("uniqueid", Time.nowMs.toString()));
 
 await deviceStorage.set({
     passcode,

--- a/packages/examples/src/device-onoff/DeviceNode.ts
+++ b/packages/examples/src/device-onoff/DeviceNode.ts
@@ -162,7 +162,7 @@ async function getConfiguration() {
     const port = environment.vars.number("port") ?? 5540;
 
     const uniqueId =
-        environment.vars.string("uniqueid") ?? (await deviceStorage.get("uniqueid", Time.nowMs())).toString();
+        environment.vars.string("uniqueid") ?? (await deviceStorage.get("uniqueid", Time.nowMs)).toString();
 
     // Persist basic data to keep them also on restart
     await deviceStorage.set({

--- a/packages/examples/src/device-robotic-vacuum-cleaner/RvcDeviceLogic.ts
+++ b/packages/examples/src/device-robotic-vacuum-cleaner/RvcDeviceLogic.ts
@@ -3,7 +3,7 @@
  * Copyright 2022-2025 Matter.js Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Behavior, Logger, Node, Time, Timer } from "@matter/main";
+import { Behavior, Hours, Logger, Minutes, Node, Seconds, Time, Timer } from "@matter/main";
 import { ServiceAreaServer } from "@matter/main/behaviors/service-area";
 import { RvcOperationalState } from "@matter/main/clusters/rvc-operational-state";
 import { CustomRvcCleanModeServer } from "./behaviors/CustomRvcCleanModeServer.js";
@@ -57,7 +57,7 @@ enum DetailOperationalDeviceState {
 }
 
 // We simulate cleaning rounds of 10 minutes
-const CLEANING_MAPPING_ROUND_TIME = 10 * 60_000;
+const CLEANING_MAPPING_ROUND_TIME = Minutes(10);
 
 /**
  * This class implements the Logic of our fictional robotic vacuum cleaner device and should demonstrate how the
@@ -81,9 +81,11 @@ export class RvcDeviceLogic extends Behavior {
         this.internal.mappingTimer = Time.getTimer("MappingTimer", CLEANING_MAPPING_ROUND_TIME, () =>
             this.#handleMappingDone(),
         );
-        this.internal.rechargingTimer = Time.getTimer("RechargingTimer", 2 * 60_000, () => this.#handleRechargeDone());
-        this.internal.autoWaitTimer = Time.getTimer("AutoWaitTimer", 180 * 60_000, () => this.#handleAutoWaitDone());
-        this.internal.seekingChargerTimer = Time.getTimer("SeekingChargerTimer", 30_000, () => this.#handleDocking());
+        this.internal.rechargingTimer = Time.getTimer("RechargingTimer", Minutes(2), () => this.#handleRechargeDone());
+        this.internal.autoWaitTimer = Time.getTimer("AutoWaitTimer", Hours(3), () => this.#handleAutoWaitDone());
+        this.internal.seekingChargerTimer = Time.getTimer("SeekingChargerTimer", Seconds(30), () =>
+            this.#handleDocking(),
+        );
     }
 
     async #initializeNode() {
@@ -368,7 +370,7 @@ export class RvcDeviceLogic extends Behavior {
 
         this.internal.serviceAreaChangeTimer = Time.getPeriodicTimer(
             "ServiceAreaChangeTimer",
-            CLEANING_MAPPING_ROUND_TIME / numberOfAreas + 1000, // Two Areas by default
+            CLEANING_MAPPING_ROUND_TIME.dividedBy(numberOfAreas).plus(Seconds(1)), // Two Areas by default
             () => this.#changeCurrentServiceArea(),
         ).start();
         await this.#changeCurrentServiceArea();

--- a/packages/examples/src/device-sensor/SensorDeviceNode.ts
+++ b/packages/examples/src/device-sensor/SensorDeviceNode.ts
@@ -208,7 +208,7 @@ async function getConfiguration() {
     const port = environment.vars.number("port") ?? 5540;
 
     const uniqueId =
-        environment.vars.string("uniqueid") ?? (await deviceStorage.get("uniqueid", Time.nowMs().toString()));
+        environment.vars.string("uniqueid") ?? (await deviceStorage.get("uniqueid", Time.nowMs.toString()));
 
     // Persist basic data to keep them also on restart
     await deviceStorage.set({

--- a/packages/general/src/codec/DnsCodec.ts
+++ b/packages/general/src/codec/DnsCodec.ts
@@ -4,11 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Interval } from "#time/Interval.js";
+import { Seconds } from "#time/TimeUnit.js";
 import { InternalError, NotImplementedError, UnexpectedDataError } from "../MatterError.js";
 import { Bytes, Endian } from "../util/Bytes.js";
 import { DataReader } from "../util/DataReader.js";
 import { DataWriter } from "../util/DataWriter.js";
 import { ipv4BytesToString, ipv4ToBytes, ipv6BytesToString, ipv6ToBytes, isIPv4, isIPv6 } from "../util/Ip.js";
+
+export const DEFAULT_MDNS_TTL = Seconds(120);
 
 /**
  * The maximum MDNS message size to usually fit into one UDP network MTU packet. Data are split into multiple messages
@@ -16,7 +20,12 @@ import { ipv4BytesToString, ipv4ToBytes, ipv6BytesToString, ipv6ToBytes, isIPv4,
  */
 export const MAX_MDNS_MESSAGE_SIZE = 1232; // 1280bytes (IPv6 packet size) - 8bytes (UDP header) - 40bytes (IPv6 IP header, IPv4 is only 20bytes)
 
-export const PtrRecord = (name: string, ptr: string, ttl = 120, flushCache = false): DnsRecord<string> => ({
+export const PtrRecord = (
+    name: string,
+    ptr: string,
+    ttl = DEFAULT_MDNS_TTL,
+    flushCache = false,
+): DnsRecord<string> => ({
     name,
     value: ptr,
     ttl,
@@ -24,7 +33,7 @@ export const PtrRecord = (name: string, ptr: string, ttl = 120, flushCache = fal
     recordClass: DnsRecordClass.IN,
     flushCache,
 });
-export const ARecord = (name: string, ip: string, ttl = 120, flushCache = false): DnsRecord<string> => ({
+export const ARecord = (name: string, ip: string, ttl = DEFAULT_MDNS_TTL, flushCache = false): DnsRecord<string> => ({
     name,
     value: ip,
     ttl,
@@ -32,7 +41,12 @@ export const ARecord = (name: string, ip: string, ttl = 120, flushCache = false)
     recordClass: DnsRecordClass.IN,
     flushCache,
 });
-export const AAAARecord = (name: string, ip: string, ttl = 120, flushCache = false): DnsRecord<string> => ({
+export const AAAARecord = (
+    name: string,
+    ip: string,
+    ttl = DEFAULT_MDNS_TTL,
+    flushCache = false,
+): DnsRecord<string> => ({
     name,
     value: ip,
     ttl,
@@ -40,7 +54,12 @@ export const AAAARecord = (name: string, ip: string, ttl = 120, flushCache = fal
     recordClass: DnsRecordClass.IN,
     flushCache,
 });
-export const TxtRecord = (name: string, entries: string[], ttl = 120, flushCache = false): DnsRecord<string[]> => ({
+export const TxtRecord = (
+    name: string,
+    entries: string[],
+    ttl = DEFAULT_MDNS_TTL,
+    flushCache = false,
+): DnsRecord<string[]> => ({
     name,
     value: entries,
     ttl,
@@ -51,7 +70,7 @@ export const TxtRecord = (name: string, entries: string[], ttl = 120, flushCache
 export const SrvRecord = (
     name: string,
     srv: SrvRecordValue,
-    ttl = 120,
+    ttl = DEFAULT_MDNS_TTL,
     flushCache = false,
 ): DnsRecord<SrvRecordValue> => ({
     name,
@@ -81,7 +100,7 @@ export type DnsRecord<T = unknown> = {
     recordType: DnsRecordType;
     recordClass: DnsRecordClass;
     flushCache?: boolean;
-    ttl: number;
+    ttl: Interval;
     value: T;
 };
 
@@ -168,7 +187,7 @@ export class DnsCodec {
         const classInt = reader.readUInt16();
         const flushCache = (classInt & 0x8000) !== 0;
         const recordClass = classInt & 0x7fff;
-        const ttl = reader.readUInt32();
+        const ttl = Seconds(reader.readUInt32());
         const valueLength = reader.readUInt16();
         const valueBytes = reader.readByteArray(valueLength);
         const value = this.decodeRecordValue(valueBytes, recordType, message);
@@ -298,7 +317,7 @@ export class DnsCodec {
         writer.writeByteArray(this.encodeQName(name));
         writer.writeUInt16(recordType);
         writer.writeUInt16(recordClass | (flushCache ? 0x8000 : 0));
-        writer.writeUInt32(ttl);
+        writer.writeUInt32(ttl.secs);
         const encodedValue = this.encodeRecordValue(value, recordType);
         writer.writeUInt16(encodedValue.byteLength);
         writer.writeByteArray(encodedValue);

--- a/packages/general/src/environment/Environment.ts
+++ b/packages/general/src/environment/Environment.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Instant } from "#time/TimeUnit.js";
 import { MaybePromise } from "#util/Promises.js";
 import { DiagnosticSource } from "../log/DiagnosticSource.js";
 import { Logger } from "../log/Logger.js";
@@ -227,7 +228,7 @@ export class Environment {
      * Display tasks that supply diagnostics.
      */
     diagnose() {
-        Time.getTimer("Diagnostics", 0, () => {
+        Time.getTimer("Diagnostics", Instant, () => {
             try {
                 logger.notice("Diagnostics follow", DiagnosticSource);
             } catch (e) {

--- a/packages/general/src/log/Diagnostic.ts
+++ b/packages/general/src/log/Diagnostic.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Interval } from "#time/Interval.js";
+import { Millisecs } from "#time/TimeUnit.js";
 import { Bytes } from "#util/Bytes.js";
 import type { Lifecycle } from "../util/Lifecycle.js";
 import { LogLevel } from "./LogLevel.js";
@@ -303,40 +305,8 @@ export namespace Diagnostic {
 
     export interface Elapsed {
         readonly startedAt: number;
-        readonly time: number;
+        readonly time: Interval;
         toString(): string;
-    }
-
-    /**
-     * Convert an interval to text.
-     */
-    export function interval(ms: number) {
-        if (ms < 0) {
-            return `${(ms * 1000).toPrecision(3)}μs`;
-        } else if (ms < 1000) {
-            return `${ms.toPrecision(3)}ms`;
-        } else if (ms < 60000) {
-            return `${(ms / 1000).toPrecision(3)}s`;
-        }
-
-        let days;
-        if (ms > 86_400_000) {
-            days = `${Math.floor(ms / 86_400_000)}d `;
-            ms %= 86_400_000;
-        } else {
-            days = "";
-        }
-        const hours = Math.floor(ms / 3_600_000)
-            .toString()
-            .padStart(2, "0");
-        ms %= 3_600_000;
-        const minutes = Math.floor(ms / 60_000)
-            .toString()
-            .padStart(2, "0");
-        ms %= 60_000;
-        const seconds = Math.floor(ms).toString().padStart(2, "0");
-
-        return `${days}${hours}:${minutes}:${seconds}`;
     }
 
     /**
@@ -347,11 +317,11 @@ export namespace Diagnostic {
             startedAt: performance.now(),
 
             get time() {
-                return performance.now() - this.startedAt;
+                return Millisecs(performance.now() - this.startedAt);
             },
 
             toString() {
-                return interval(this.time);
+                return this.time.toString();
             },
         };
     }

--- a/packages/general/src/log/Logger.ts
+++ b/packages/general/src/log/Logger.ts
@@ -225,7 +225,7 @@ export class Logger {
             dest.context.run(() =>
                 dest.add(
                     Diagnostic.message({
-                        now: Time.now(),
+                        now: Time.now,
                         facility: this.#name,
                         level,
                         prefix: nestingPrefix(),

--- a/packages/general/src/net/RetrySchedule.ts
+++ b/packages/general/src/net/RetrySchedule.ts
@@ -5,6 +5,8 @@
  */
 
 import { Crypto } from "#crypto/Crypto.js";
+import { Interval } from "#time/Interval.js";
+import { Instant, Millisecs, Seconds } from "#time/TimeUnit.js";
 
 /**
  * An iterable of retry values based on a scheduling configuration.
@@ -29,31 +31,31 @@ export class RetrySchedule {
             maximumInterval,
             maximumCount,
             jitterFactor = 0,
-            initialInterval = 1000,
+            initialInterval = Seconds.one,
             backoffFactor = 2,
         } = this.config;
 
         let count = 0;
         let baseInterval = initialInterval;
-        let timeSoFar = 0;
+        let timeSoFar = Instant;
 
         while ((timeout === undefined || timeSoFar < timeout) && (maximumCount === undefined || maximumCount > count)) {
             count++;
-            const maxJitter = jitterFactor * baseInterval;
-            const jitter = Math.floor((maxJitter * this.#crypto.randomUint32) / Math.pow(2, 32));
-            let interval = baseInterval + jitter;
+            const maxJitter = jitterFactor * baseInterval.ms;
+            const jitter = Millisecs((maxJitter * this.#crypto.randomUint32) / Math.pow(2, 32)).floor;
+            let interval = baseInterval.plus(jitter);
 
-            if (timeout !== undefined && timeSoFar + interval > timeout) {
-                interval = timeout - timeSoFar;
+            if (timeout !== undefined && timeSoFar.plus(interval) > timeout) {
+                interval = timeout.minus(timeSoFar);
             }
             if (maximumInterval !== undefined && interval > maximumInterval) {
                 interval = maximumInterval;
             }
 
             yield interval;
-            timeSoFar += interval;
+            timeSoFar = timeSoFar.plus(interval);
 
-            baseInterval *= backoffFactor;
+            baseInterval = baseInterval.times(backoffFactor);
         }
     }
 }
@@ -61,16 +63,14 @@ export class RetrySchedule {
 export namespace RetrySchedule {
     /**
      * Configuration parameters for retry schedule.
-     *
-     * All intervals are in milliseconds.
      */
     export interface Configuration {
         /**
-         * Overall timeout in seconds.
+         * Overall timeout.
          *
          * Leave undefined to allow indefinite transmission.
          */
-        readonly timeout?: number;
+        readonly timeout?: Interval;
 
         /**
          * Maximum number of occurrences (including first).
@@ -82,9 +82,9 @@ export namespace RetrySchedule {
         /**
          * Interval between first request and final interval.
          *
-         * Defaults to 1000 ms.
+         * Defaults to 1s.
          */
-        readonly initialInterval?: number;
+        readonly initialInterval?: Interval;
 
         /**
          * Multiplier for subsequent retries.
@@ -98,7 +98,7 @@ export namespace RetrySchedule {
          *
          * Leave undefined for interval to allow interval to grow continuously.
          */
-        readonly maximumInterval?: number;
+        readonly maximumInterval?: Interval;
 
         /**
          * Multiplier for retry jitter.

--- a/packages/general/src/net/ServerAddress.ts
+++ b/packages/general/src/net/ServerAddress.ts
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Diagnostic } from "#log/Diagnostic.js";
+import { Interval } from "#time/Interval.js";
+import { Seconds } from "#time/TimeUnit.js";
+
 export type ServerAddressIp = {
     type: "udp";
     ip: string;
@@ -19,12 +23,46 @@ export interface Lifespan {
     /** Beginning of lifespan (system time in milliseconds) */
     discoveredAt: number;
 
-    /** Length of lifespan, if known (milliseconds) */
-    ttl: number;
+    /** Length of lifespan, if known (seconds) */
+    ttl: Interval;
 }
 
 export type ServerAddress = (ServerAddressIp | ServerAddressBle) & Partial<Lifespan>;
 
-export function serverAddressToString(address: ServerAddress): string {
-    return address.type === "udp" ? `udp://[${address.ip}]:${address.port}` : `ble://${address.peripheralAddress}`;
+export function ServerAddress(definition: ServerAddress.Definition) {
+    return {
+        discoveredAt: undefined,
+        ...definition,
+        ttl: Seconds(definition.ttl),
+    } as ServerAddress;
+}
+
+export namespace ServerAddress {
+    export function urlFor(address: ServerAddress): string {
+        return address.type === "udp" ? `udp://[${address.ip}]:${address.port}` : `ble://${address.peripheralAddress}`;
+    }
+
+    export function diagnosticFor(address: ServerAddress) {
+        const diagnostic = Array<unknown>();
+
+        if (address.type === "udp") {
+            diagnostic.push("udp://", Diagnostic.strong(address.ip), ":", address.port);
+        } else {
+            diagnostic.push("ble://", Diagnostic.strong(address.peripheralAddress));
+        }
+
+        if ("ttl" in address && address.ttl !== undefined && address.ttl !== null) {
+            diagnostic.push(" ttl ", address.ttl);
+        }
+
+        return Diagnostic.squash(...diagnostic);
+    }
+
+    export function definitionOf(address: ServerAddress): Definition {
+        return address;
+    }
+
+    export interface Definition extends Omit<ServerAddress, "ttl"> {
+        ttl?: Interval;
+    }
 }

--- a/packages/general/src/net/UdpMulticastServer.ts
+++ b/packages/general/src/net/UdpMulticastServer.ts
@@ -5,6 +5,7 @@
  */
 
 import { MatterAggregateError } from "#MatterError.js";
+import { Minutes } from "#time/TimeUnit.js";
 import { Bytes } from "#util/Bytes.js";
 import { Logger } from "../log/Logger.js";
 import { Cache } from "../util/Cache.js";
@@ -72,7 +73,7 @@ export class UdpMulticastServer {
     private readonly broadcastChannels = new Cache<Promise<UdpChannel>>(
         "UDP broadcast channel",
         (netInterface, iPv4) => this.createBroadcastChannel(netInterface, iPv4),
-        5 * 60 * 1000 /* 5mn */,
+        Minutes(5),
         async (_netInterface, channel) => (await channel).close(),
     );
 

--- a/packages/general/src/storage/StringifyTools.ts
+++ b/packages/general/src/storage/StringifyTools.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Interval } from "#time/Interval.js";
+import { Millisecs } from "#time/TimeUnit.js";
 import { UnexpectedDataError } from "../MatterError.js";
 import { Bytes } from "../util/Bytes.js";
 import { isObject } from "../util/Type.js";
@@ -17,6 +19,7 @@ type SupportedComplexStorageTypes =
     | { [key: string]: SupportedStorageBaseTypes | SupportedComplexStorageTypes | null | undefined } // Objects
     | Array<[SupportedStorageBaseTypes, SupportedStorageBaseTypes | SupportedComplexStorageTypes | null | undefined]> // Map style arrays
     | Map<SupportedStorageBaseTypes, SupportedStorageBaseTypes | SupportedComplexStorageTypes>
+    | Interval
     | null
     | undefined; // Maps
 
@@ -52,6 +55,9 @@ export function toJson(object: SupportedStorageTypes, spaces?: number): string {
                     toJson(Array.from(value.entries())),
                 )}}`;
             }
+            if (value instanceof Interval) {
+                return `{"${JSON_SPECIAL_KEY_TYPE}":"Interval","${JSON_SPECIAL_KEY_VALUE}":${value.ms}`;
+            }
             return value;
         },
         spaces,
@@ -77,6 +83,8 @@ export function fromJson(json: string): SupportedStorageTypes {
                             SupportedStorageBaseTypes,
                         ][],
                     );
+                case "Interval":
+                    return Millisecs(data);
 
                 // TODO Remove in the future, leave here for now for backward compatibility?
                 case "AttributeId":

--- a/packages/general/src/time/Interval.ts
+++ b/packages/general/src/time/Interval.ts
@@ -1,0 +1,237 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Diagnostic } from "#log/Diagnostic.js";
+import { DeepComparable } from "#util/DeepEqual.js";
+import type { TimeUnit } from "./TimeUnit.js";
+
+/**
+ * An interval of time.
+ *
+ * An interval consists of a {@link unit} and {@link length}.  We track the units but store the value as milliseconds.
+ *
+ * You may create an interval using {@link TimeUnit} factories such as `Seconds.one` or `Millisecs(1000)`.  You may
+ * compare intervals using standard comparison operators.
+ *
+ * Typescript doesn't allow for arithmetic operations with intervals (even though javascript does).  You may instead use
+ * arithmetic functions such as {@link plus} and {@link minus} or perform arithmetic using {@link ms} values such as
+ * `Millisecs(interval1.ms + interval2.ms)`.
+ */
+export class Interval implements DeepComparable {
+    /**
+     * The units of this interval.
+     */
+    readonly unit: TimeUnit;
+
+    /**
+     * The length of this interval in {@link unit}.
+     */
+    readonly ms: number;
+
+    constructor(unit: TimeUnit, length: number | Interval.Definition) {
+        this.unit = unit;
+        if (typeof length === "number") {
+            this.ms = length * unit.scale;
+        } else if ("ms" in length) {
+            this.ms = length.ms as number;
+        } else {
+            this.ms = length.unit.scale * length.length;
+        }
+    }
+
+    /**
+     * Access the interval in {@link unit}.
+     */
+    get length(): number {
+        return this.ms / this.unit.scale;
+    }
+
+    /**
+     * Access the interval as raw seconds.
+     */
+    get secs(): number {
+        return Interval.units.second(this).length;
+    }
+
+    equals(other: Interval) {
+        return this.ms === other.ms;
+    }
+
+    dividedBy(divisor: number) {
+        return this.unit(this.length / divisor);
+    }
+
+    times(multiplier: number) {
+        return this.unit(this.length * multiplier);
+    }
+
+    plus(other: Interval) {
+        return this.unit((this.ms + other.ms) / this.unit.scale);
+    }
+
+    minus(other: Interval) {
+        return this.unit((this.ms - other.ms) / this.unit.scale);
+    }
+
+    /**
+     * Add this interval to a POSIX timestamp.
+     */
+    before(time: number): number;
+
+    /**
+     * Add this interval to a Date.
+     */
+    before(time: Date): Date;
+
+    before(time: number | Date): number | Date {
+        return typeof time === "number" ? time - this.ms : new Date(time.getTime() - this.ms);
+    }
+
+    /**
+     * Subtract this interval from a POSIX timestamp.
+     */
+    after(time: number): number;
+
+    /**
+     * Subtract this interval from a Date.
+     */
+    after(time: Date): Date;
+
+    after(time: number | Date): number | Date {
+        return typeof time === "number" ? time + this.ms : new Date(time.getTime() + this.ms);
+    }
+
+    /**
+     * Round the interval to the nearest whole unit.
+     */
+    get round() {
+        return new Interval(this.unit, Math.round(this.length));
+    }
+
+    /**
+     * Round the interval to the next highest whole unit.
+     */
+    get ceil() {
+        return new Interval(this.unit, Math.ceil(this.length));
+    }
+
+    /**
+     * Round the interval to the next lowest whole unit.
+     */
+    get floor() {
+        return new Interval(this.unit, Math.floor(this.length));
+    }
+
+    valueOf() {
+        return this.ms;
+    }
+
+    toString() {
+        let { ms } = this;
+
+        if (typeof ms !== "number" || Number.isNaN(ms)) {
+            return "invalid";
+        }
+
+        switch (ms) {
+            case 0:
+                return "0";
+
+            case Infinity:
+                return "forever";
+
+            case -Infinity:
+                return "until now"; // Umm...  I guess?
+        }
+
+        if (ms === 0) {
+            return "0";
+        } else if (ms < 0) {
+            return `${toPrecision(ms * 1000, 3)}μs`;
+        } else if (ms < 1000) {
+            return `${toPrecision(ms, 3)}ms`;
+        } else if (ms < 60000) {
+            return `${toPrecision(ms / 1000, 3)}s`;
+        }
+
+        const parts = Array<string>();
+
+        if (ms > 86_400_000) {
+            parts.push(`${Math.floor(ms / 86_400_000)}d`);
+            ms %= 86_400_000;
+        }
+
+        const hours = Math.floor(ms / 3_600_000);
+        if (hours) {
+            parts.push(`${hours}h`);
+        }
+        ms %= 3_600_000;
+
+        const minutes = Math.floor(ms / 60_000);
+        if (minutes) {
+            parts.push(`${minutes}m`);
+        }
+        ms %= 60_000;
+
+        const seconds = Math.floor(ms / 1_000);
+        if (seconds) {
+            parts.push(`${seconds}s`);
+        }
+
+        return parts.join(" ");
+    }
+
+    get [Diagnostic.value]() {
+        return this.toString();
+    }
+
+    [DeepComparable.equals](other: unknown) {
+        if (!(other instanceof Interval)) {
+            return false;
+        }
+        return other.ms === this.ms;
+    }
+
+    /**
+     * Determine the greater of two intervals.
+     */
+    static max(a: Interval, b: Interval) {
+        if (b.ms > a.ms) {
+            return b;
+        }
+        return a;
+    }
+
+    /**
+     * Determine the lesser of two intervals.
+     */
+    static min(a: Interval, b: Interval) {
+        if (b.ms < a.ms) {
+            return b;
+        }
+        return a;
+    }
+}
+
+function toPrecision(number: number, precision: number) {
+    return number.toPrecision(precision).replace(/\.?0+/, "");
+}
+
+export namespace Interval {
+    export const units = {} as Record<TimeUnit.Kind, TimeUnit>;
+
+    export interface Definition {
+        /**
+         * The units of this interval.
+         */
+        readonly unit: TimeUnit;
+
+        /**
+         * The length of this interval in {@link unit}.
+         */
+        readonly length: number;
+    }
+}

--- a/packages/general/src/time/Time.ts
+++ b/packages/general/src/time/Time.ts
@@ -9,6 +9,8 @@ import { CancelablePromise } from "#util/Cancelable.js";
 import { ImplementationError } from "../MatterError.js";
 import { Diagnostic } from "../log/Diagnostic.js";
 import { DiagnosticSource } from "../log/DiagnosticSource.js";
+import { Interval } from "./Interval.js";
+import { Instant } from "./TimeUnit.js";
 
 const registry = new Set<Timer>();
 
@@ -19,56 +21,62 @@ const registry = new Set<Timer>();
  * environment.
  */
 export class Time {
-    static get: () => Time;
+    static default: Time;
 
     static startup = {
         systemMs: 0,
         processMs: 0,
     };
 
-    now() {
+    get now() {
         return new Date();
     }
-    static readonly now = (): Date => Time.get().now();
+    static get now() {
+        return Time.default.now;
+    }
 
-    nowMs() {
+    get nowMs() {
         return Date.now();
     }
-    static readonly nowMs = (): number => Time.get().nowMs();
+    static get nowMs() {
+        return Time.default.nowMs;
+    }
 
-    nowUs() {
+    get nowUs() {
         return Math.floor(performance.now() + performance.timeOrigin) * 1000;
     }
-    static readonly nowUs = (): number => Time.get().nowUs();
+    static get nowUs() {
+        return Time.default.nowUs;
+    }
 
     /**
      * Create a timer that will call callback after durationMs has passed.
      */
-    getTimer(name: string, durationMs: number, callback: Timer.Callback): Timer {
-        return new StandardTimer(name, durationMs, callback, false);
+    getTimer(name: string, duration: Interval, callback: Timer.Callback): Timer {
+        return new StandardTimer(name, duration, callback, false);
     }
-    static readonly getTimer = (name: string, durationMs: number, callback: Timer.Callback): Timer =>
-        Time.get().getTimer(name, durationMs, callback);
+    static readonly getTimer = (name: string, duration: Interval, callback: Timer.Callback): Timer =>
+        Time.default.getTimer(name, duration, callback);
 
     /**
      * Create a timer that will periodically call callback at intervalMs intervals.
      */
-    getPeriodicTimer(name: string, intervalMs: number, callback: Timer.Callback): Timer {
-        return new StandardTimer(name, intervalMs, callback, true);
+    getPeriodicTimer(name: string, interval: Interval, callback: Timer.Callback): Timer {
+        return new StandardTimer(name, interval, callback, true);
     }
-    static readonly getPeriodicTimer = (name: string, intervalMs: number, callback: Timer.Callback): Timer =>
-        Time.get().getPeriodicTimer(name, intervalMs, callback);
+    static readonly getPeriodicTimer = (name: string, interval: Interval, callback: Timer.Callback): Timer =>
+        Time.default.getPeriodicTimer(name, interval, callback);
 
     /**
      * Create a promise that resolves after a specific interval or when canceled, whichever comes first.
      */
-    sleep(name: string, durationMs: number): CancelablePromise {
+    sleep(name: string, duration: Interval): CancelablePromise {
         let timer: Timer;
         let resolver: () => void;
         return new CancelablePromise(
             resolve => {
                 resolver = resolve;
-                timer = Time.getTimer(name, durationMs, resolve);
+                timer = Time.getTimer(name, duration, resolve);
                 timer.start();
             },
 
@@ -78,8 +86,8 @@ export class Time {
             },
         );
     }
-    static sleep(name: string, durationMs: number) {
-        return Time.get().sleep(name, durationMs);
+    static sleep(name: string, duration: Interval) {
+        return Time.default.sleep(name, duration);
     }
 
     static register(timer: Timer) {
@@ -98,7 +106,11 @@ export class Time {
 
 // Check if performance API is available and has the required methods. Use lower accuracy fallback if not.
 if (!performance || typeof performance.now !== "function" || typeof performance.timeOrigin !== "number") {
-    Time.prototype.nowUs = () => Time.nowMs() * 1000; // Fallback is a bit less accurate
+    Object.defineProperty(Time.prototype.nowUs, "nowUs", {
+        get() {
+            return Time.nowMs * 1000; // Fallback is a bit less accurate
+        },
+    });
 }
 
 export interface Timer {
@@ -112,7 +124,7 @@ export interface Timer {
     systemId: unknown;
 
     /** Interval (diagnostics) */
-    intervalMs: number;
+    interval: Interval;
 
     /** Is the timer periodic? (diagnostics) */
     isPeriodic: boolean;
@@ -137,7 +149,7 @@ export namespace Timer {
 export class StandardTimer implements Timer {
     #timerId: unknown;
     #utility = false;
-    #intervalMs = -1;
+    #interval = Instant;
     isRunning = false;
 
     get systemId() {
@@ -146,11 +158,11 @@ export class StandardTimer implements Timer {
 
     constructor(
         readonly name: string,
-        intervalMs: number,
+        interval: Interval,
         private readonly callback: Timer.Callback,
         readonly isPeriodic: boolean,
     ) {
-        this.intervalMs = intervalMs;
+        this.interval = interval;
     }
 
     /**
@@ -158,17 +170,17 @@ export class StandardTimer implements Timer {
      *
      * You can change this value but changes have no effect until the timer restarts.
      */
-    set intervalMs(intervalMs: number) {
-        if (intervalMs < 0 || intervalMs > 2147483647) {
+    set interval(interval: Interval) {
+        if (interval.ms < 0 || interval.ms > 2147483647) {
             throw new ImplementationError(
-                `Invalid intervalMs: ${intervalMs}. The value must be between 0 and 32-bit maximum value (2147483647)`,
+                `Invalid intervalMs: ${interval}. The value must be between 0 and 32-bit maximum value (2147483647)`,
             );
         }
-        this.#intervalMs = intervalMs;
+        this.#interval = interval;
     }
 
-    get intervalMs() {
-        return this.#intervalMs;
+    get interval() {
+        return this.#interval;
     }
 
     get utility() {
@@ -203,7 +215,7 @@ export class StandardTimer implements Timer {
                 this.isRunning = false;
             }
             this.callback();
-        }, this.intervalMs);
+        }, this.interval.ms);
         return this;
     }
 
@@ -222,7 +234,7 @@ DiagnosticSource.add({
                 timer.name,
                 Diagnostic.dict({
                     periodic: timer.isPeriodic,
-                    interval: Diagnostic.interval(timer.intervalMs),
+                    interval: timer.interval,
                     system: timer.systemId,
                     elapsed: timer.elapsed,
                 }),
@@ -232,11 +244,9 @@ DiagnosticSource.add({
 });
 
 Boot.init(() => {
-    const time = new Time();
+    Time.default = new Time();
 
-    Time.startup.systemMs = Time.startup.processMs = time.nowMs();
-
-    Time.get = () => time;
+    Time.startup.systemMs = Time.startup.processMs = Time.nowMs;
 
     // Hook for testing frameworks
     if (typeof MatterHooks !== "undefined") {

--- a/packages/general/src/time/TimeUnit.ts
+++ b/packages/general/src/time/TimeUnit.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Interval } from "./Interval.js";
+
+/**
+ * Details of a specific unit of time.
+ */
+export interface TimeUnit {
+    (scale: number | Interval.Definition): Interval;
+    (scale: undefined | number | Interval.Definition): undefined | Interval;
+
+    /**
+     * Long name of the unit.
+     */
+    readonly kind: TimeUnit.Kind;
+
+    /**
+     * Abbreviated name of the unit.
+     */
+    readonly abbrev: string;
+
+    /**
+     * Number of milliseconds in the unit.
+     */
+    readonly scale: number;
+
+    /**
+     * A single unit interval.
+     */
+    readonly one: Interval;
+
+    length: never;
+}
+
+export namespace TimeUnit {
+    /**
+     * Standard time units.
+     */
+    export type Kind = "nanosecond" | "millisecond" | "second" | "minute" | "hour" | "day";
+}
+
+/**
+ * Implement a {@link TimeUnit}.
+ */
+export function TimeUnit<T = {}>(kind: TimeUnit.Kind, abbrev: string, scale: number, props = {} as T): TimeUnit & T {
+    let one: Interval | undefined = undefined;
+
+    const unit = {
+        [kind]: (interval: undefined | number | Interval.Definition) => {
+            if (interval === undefined) {
+                return undefined;
+            }
+
+            if (typeof interval === "number") {
+                if (interval === 1) {
+                    return one!;
+                }
+                return new Interval(unit, interval);
+            }
+
+            if (interval instanceof Interval && interval.unit === unit) {
+                return interval;
+            }
+
+            return new Interval(unit, (interval.length * interval.unit.scale) / unit.scale);
+        },
+    }[kind] as TimeUnit & T;
+
+    // Add properties to the function
+    Object.assign(unit, {
+        ...props,
+        kind,
+        abbrev,
+        scale,
+        toString: kindOf,
+        [Symbol.for("nodejs.util.inspect.custom")]: kindOf,
+    });
+
+    // Create "one" after assigning other properties or initialization will fail
+    one = new Interval(unit, 1);
+    Object.assign(unit, { one });
+
+    // This is to avoid circular reference
+    Interval.units[kind] = unit;
+
+    return unit;
+}
+
+function kindOf(this: TimeUnit) {
+    return this.kind;
+}
+
+/**
+ * Create an interval in nanoseconds.
+ */
+export const Nanosecs = TimeUnit("nanosecond", "ns", 0.001);
+
+/**
+ * Create an interval in milliseconds.
+ */
+export const Millisecs = TimeUnit("millisecond", "ms", 1);
+
+/**
+ * Create an interval in seconds.
+ */
+export const Seconds = TimeUnit("second", "s", 1_000, {
+    tenth: Millisecs(100),
+    quarter: Millisecs(250),
+    half: Millisecs(500),
+});
+
+/**
+ * Create an interval in minutes.
+ */
+export const Minutes = TimeUnit("minute", "m", 60_000, { quarter: Seconds(15), half: Seconds(30) });
+
+/**
+ * Create an interval in hours.
+ */
+export const Hours = TimeUnit("hour", "h", 3_600_000, { quarter: Minutes(15), half: Minutes(30) });
+
+/**
+ * Create an interval in days.
+ */
+export const Days = TimeUnit("day", "d", 86_400_000);
+
+/**
+ * A zero-length interval.
+ */
+export const Instant = Millisecs(0);

--- a/packages/general/src/time/index.ts
+++ b/packages/general/src/time/index.ts
@@ -4,4 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export * from "./Interval.js";
 export * from "./Time.js";
+export * from "./TimeUnit.js";

--- a/packages/general/src/transaction/Status.ts
+++ b/packages/general/src/transaction/Status.ts
@@ -5,6 +5,7 @@
  */
 
 import { LogLevel } from "#log/LogLevel.js";
+import { Millisecs } from "#time/TimeUnit.js";
 import { TransactionFlowError } from "./errors.js";
 import type { Transaction } from "./Transaction.js";
 
@@ -74,7 +75,7 @@ export namespace Status {
      * A value of 0 forces lock reports for all async transactions; a negative value disables reporting.
      */
     // eslint-disable-next-line prefer-const
-    export let slowTransactionMs = 200;
+    export let slowTransactionTime = Millisecs(200);
 
     /**
      * The log level for slow transaction reporting.

--- a/packages/general/src/transaction/Tx.ts
+++ b/packages/general/src/transaction/Tx.ts
@@ -814,7 +814,7 @@ const Monitor = (function () {
     let monitor: Timer | undefined;
 
     function check() {
-        const now = Time.nowMs();
+        const now = Time.nowMs;
         for (const [tx, slowAt] of monitored) {
             if (now > slowAt) {
                 tx.treatAsSlow();
@@ -824,12 +824,12 @@ const Monitor = (function () {
 
     return {
         add(tx: Tx) {
-            const { slowTransactionMs } = Status;
-            if (slowTransactionMs < 0) {
+            const { slowTransactionTime } = Status;
+            if (slowTransactionTime.length < 0) {
                 return;
             }
 
-            if (!slowTransactionMs) {
+            if (!slowTransactionTime.length) {
                 tx.treatAsSlow();
                 return;
             }
@@ -838,9 +838,9 @@ const Monitor = (function () {
                 return;
             }
 
-            monitored.set(tx, Time.nowMs() + slowTransactionMs);
+            monitored.set(tx, Time.nowMs + slowTransactionTime.ms);
             if (monitor === undefined) {
-                monitor = Time.getPeriodicTimer("tx-lock-monitor", slowTransactionMs / 10, check);
+                monitor = Time.getPeriodicTimer("tx-lock-monitor", slowTransactionTime.dividedBy(10), check);
                 monitor.start();
             }
         },

--- a/packages/general/src/util/DeepEqual.ts
+++ b/packages/general/src/util/DeepEqual.ts
@@ -4,19 +4,41 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * An object that supports custom deep equality.
+ */
+export interface DeepComparable {
+    /**
+     * Deep-compare this object to another.
+     */
+    [DeepComparable.equals](other: unknown): boolean;
+}
+
+export namespace DeepComparable {
+    export const equals = Symbol("deepEquals");
+}
+
 // TODO - implement more efficient specialization for Array and ArrayBuffer
 // TODO - currently will hang on self-referential data structures
-export function isDeepEqual(a: any, b: any, ignoreUndefinedProperties = false): boolean {
-    if (
-        a === null ||
-        a === undefined ||
-        b === null ||
-        b === undefined ||
-        typeof a !== typeof b ||
-        (typeof a !== "object" && typeof b !== "object")
-    ) {
+export function isDeepEqual(a: unknown, b: unknown, ignoreUndefinedProperties = false): boolean {
+    const aIsObject = typeof a === "object" && a !== null;
+    if (aIsObject) {
+        if (DeepComparable.equals in a) {
+            return (a as DeepComparable)[DeepComparable.equals](b);
+        }
+    }
+
+    const bIsObject = typeof b === "object" && b !== null;
+    if (bIsObject) {
+        if (DeepComparable.equals in b) {
+            return (a as DeepComparable)[DeepComparable.equals](b);
+        }
+    }
+
+    if (!aIsObject || !bIsObject) {
         return a === b;
     }
+
     // Create arrays of property names
     const aProps = Object.getOwnPropertyNames(a);
     const bProps = Object.getOwnPropertyNames(b);
@@ -29,16 +51,19 @@ export function isDeepEqual(a: any, b: any, ignoreUndefinedProperties = false): 
     for (let i = 0; i < aProps.length; i++) {
         const propName = aProps[i];
 
-        if (typeof a[propName] !== typeof b[propName]) {
+        const aprop = (a as Record<string, unknown>)[propName];
+        const bprop = (b as Record<string, unknown>)[propName];
+
+        if (typeof aprop !== typeof bprop) {
             return false;
         }
-        if (typeof a[propName] === "object") {
-            if (!isDeepEqual(a[propName], b[propName])) {
+        if (typeof aprop === "object") {
+            if (!isDeepEqual(aprop, bprop)) {
                 return false;
             }
         } else {
             // If values of same property are not equal, objects are not equivalent
-            if (a[propName] !== b[propName]) {
+            if (aprop !== bprop) {
                 return false;
             }
         }

--- a/packages/general/src/util/PromiseQueue.ts
+++ b/packages/general/src/util/PromiseQueue.ts
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Interval } from "#time/Interval.js";
 import { Time } from "#time/Time.js";
+import { Instant } from "#time/TimeUnit.js";
 import { Logger } from "../log/Logger.js";
 import { createPromise } from "./Promises.js";
 
@@ -14,12 +16,12 @@ const logger = Logger.get("PromiseQueue");
  * A queue that processes promises with a given concurrency and delays after each promise if desired.
  */
 export class PromiseQueue {
-    readonly #delay: number;
+    readonly #delay: Interval;
     readonly #queue = new Array<{ func: () => Promise<any>; rejecter: (reason?: any) => void }>();
     readonly #concurrency: number;
     #runningCount = 0;
 
-    constructor(concurrency = 1, delay = 0) {
+    constructor(concurrency = 1, delay = Instant) {
         this.#concurrency = concurrency;
         this.#delay = delay;
     }
@@ -62,7 +64,7 @@ export class PromiseQueue {
                 }) // already catched internally, but rethrow if it happens to not hide it
                 .finally(() => {
                     logger.debug("Promise processed ... Still running:", this.#runningCount - 1);
-                    if (this.#delay > 0) {
+                    if (this.#delay.length > 0) {
                         // Keep the queue blocked for the delay time
                         Time.sleep("Queue delay", this.#delay)
                             .then(() => this.#runNext())

--- a/packages/general/src/util/Promises.ts
+++ b/packages/general/src/util/Promises.ts
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Interval } from "#time/Interval.js";
 import { asError } from "#util/Error.js";
 import { InternalError, TimeoutError } from "../MatterError.js";
 import { Time } from "../time/Time.js";
@@ -74,12 +75,12 @@ export class PromiseTimeoutError extends TimeoutError {}
  *
  * By default, rejects with {@link PromiseTimeoutError} on timeout but you can override by supplying {@link cancel}.
  *
- * @param timeoutMs the timeout in milliseconds
+ * @param timeout the timeout in milliseconds
  * @param promise a promise that resolves or rejects when the timed task completes
  * @param cancel invoked on timeout (default implementation throws {@link PromiseTimeoutError})
  */
 export async function withTimeout<T>(
-    timeoutMs: number,
+    timeout: Interval,
     promise: Promise<T>,
     cancel?: AbortController | (() => void),
 ): Promise<T> {
@@ -97,8 +98,8 @@ export async function withTimeout<T>(
     let cancelTimer: undefined | (() => void);
 
     // Sub-promise 1, the timer
-    const timeout = new Promise<void>((resolve, reject) => {
-        const timer = Time.getTimer("promise-timeout", timeoutMs, () => {
+    const timedOut = new Promise<void>((resolve, reject) => {
+        const timer = Time.getTimer("promise-timeout", timeout, () => {
             try {
                 cancelFn();
             } catch (e) {
@@ -130,7 +131,7 @@ export async function withTimeout<T>(
     );
 
     // Output promise, resolves like input promise unless timed out
-    await Promise.all([timeout, producer]);
+    await Promise.all([timedOut, producer]);
 
     return result as T;
 }

--- a/packages/general/test/codec/DnsCodecTest.ts
+++ b/packages/general/test/codec/DnsCodecTest.ts
@@ -14,6 +14,7 @@ import {
     SrvRecord,
     TxtRecord,
 } from "#codec/DnsCodec.js";
+import { Seconds } from "#time/TimeUnit.js";
 import { Bytes } from "#util/Bytes.js";
 import { DataReader } from "#util/index.js";
 
@@ -62,7 +63,7 @@ const DNS_DECODED = {
             name: "_companion-link._tcp.local",
             recordType: 12,
             recordClass: 1,
-            ttl: 4500,
+            ttl: Seconds(4500),
             value: "Kitchen._companion-link._tcp.local",
             flushCache: false,
         },
@@ -70,7 +71,7 @@ const DNS_DECODED = {
             name: "_homekit._tcp.local",
             recordType: 12,
             recordClass: 1,
-            ttl: 4500,
+            ttl: Seconds(4500),
             value: "AB6EC7A1-387B-5253-A854-9DA52635567F._homekit._tcp.local",
             flushCache: false,
         },
@@ -81,7 +82,7 @@ const DNS_DECODED = {
             name: "",
             recordType: 41,
             recordClass: 1440,
-            ttl: 4500,
+            ttl: Seconds(4500),
             value: Bytes.fromHex("0004000e0099929387b033db4275a6a31b2d"),
             flushCache: false,
         },
@@ -101,7 +102,7 @@ const DECODED_WITH_PRIVATE_TYPE = {
             name: "3BE0FCD63F79EEC2._matterc._udp.local",
             recordClass: 1,
             recordType: 16,
-            ttl: 4500,
+            ttl: Seconds(4500),
             value: [
                 "VP=4874+83",
                 "DT=266",
@@ -121,7 +122,7 @@ const DECODED_WITH_PRIVATE_TYPE = {
             name: "3BE0FCD63F79EEC2._matterc._udp.local",
             recordClass: 1,
             recordType: 65323,
-            ttl: 120,
+            ttl: Seconds(120),
             value: Bytes.fromHex("00000000"),
         },
         {
@@ -129,7 +130,7 @@ const DECODED_WITH_PRIVATE_TYPE = {
             name: "3BE0FCD63F79EEC2._matterc._udp.local",
             recordClass: 1,
             recordType: 33,
-            ttl: 120,
+            ttl: Seconds(120),
             value: {
                 port: 5540,
                 priority: 0,
@@ -236,6 +237,9 @@ describe("DnsCodec", () => {
 
     describe("encode", () => {
         it("encodes a message and verify with decoding again", () => {
+            const a = DnsCodec.decode(RESULT);
+            expect(a).deep.equals(DNS_RESPONSE);
+
             const result = DnsCodec.encode(DNS_RESPONSE);
 
             expect(Bytes.toHex(result)).equal(Bytes.toHex(RESULT));

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -10,6 +10,7 @@ import {
     ClassExtends,
     Crypto,
     Environment,
+    Hours,
     ImplementationError,
     InternalError,
     Logger,
@@ -662,13 +663,13 @@ export class CommissioningController {
         identifierData: CommissionableDeviceIdentifiers,
         discoveryCapabilities?: TypeFromPartialBitSchema<typeof DiscoveryCapabilitiesBitmap>,
         discoveredCallback?: (device: CommissionableDevice) => void,
-        timeoutSeconds = 900,
+        timeout = Hours.quarter,
     ) {
         this.#assertIsAddedToMatterServer();
         const controller = this.#assertControllerIsStarted();
         return await ControllerDiscovery.discoverCommissionableDevices(
             controller.collectScanners(discoveryCapabilities),
-            timeoutSeconds,
+            timeout,
             identifierData,
             discoveredCallback,
         );

--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -25,9 +25,10 @@ import {
     ImplementationError,
     Logger,
     MatterError,
+    Minutes,
     NetInterfaceSet,
+    ServerAddress,
     ServerAddressIp,
-    serverAddressToString,
     StorageBackendMemory,
     StorageManager,
 } from "#general";
@@ -477,7 +478,7 @@ export class MatterController {
             peerNodeId,
             {
                 discoveryType: NodeDiscoveryType.TimedDiscovery,
-                timeoutSeconds: 120,
+                timeout: Minutes(2),
                 discoveryData,
             },
             true,
@@ -511,7 +512,7 @@ export class MatterController {
             const { address, operationalAddress, discoveryData, deviceData } = peer as CommissionedPeer;
             return {
                 nodeId: address.nodeId,
-                operationalAddress: operationalAddress ? serverAddressToString(operationalAddress) : undefined,
+                operationalAddress: operationalAddress ? ServerAddress.urlFor(operationalAddress) : undefined,
                 advertisedName: discoveryData?.DN,
                 discoveryData,
                 deviceData,
@@ -527,7 +528,7 @@ export class MatterController {
         const { address, operationalAddress, discoveryData, deviceData } = nodeDetails;
         return {
             nodeId: address.nodeId,
-            operationalAddress: operationalAddress ? serverAddressToString(operationalAddress) : undefined,
+            operationalAddress: operationalAddress ? ServerAddress.urlFor(operationalAddress) : undefined,
             advertisedName: discoveryData?.DN,
             discoveryData,
             deviceData,

--- a/packages/matter.js/src/PaseCommissioner.ts
+++ b/packages/matter.js/src/PaseCommissioner.ts
@@ -3,7 +3,7 @@
  * Copyright 2022-2025 Matter.js Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Environment, ImplementationError, Logger, Network } from "#general";
+import { Environment, Hours, ImplementationError, Logger, Network } from "#general";
 import {
     CertificateAuthority,
     CommissionableDevice,
@@ -154,12 +154,12 @@ export class PaseCommissioner {
         identifierData: CommissionableDeviceIdentifiers,
         discoveryCapabilities?: TypeFromPartialBitSchema<typeof DiscoveryCapabilitiesBitmap>,
         discoveredCallback?: (device: CommissionableDevice) => void,
-        timeoutSeconds = 900,
+        timeout = Hours.quarter,
     ) {
         const controller = this.assertControllerIsStarted();
         return await ControllerDiscovery.discoverCommissionableDevices(
             controller.collectScanners(discoveryCapabilities),
-            timeoutSeconds,
+            timeout,
             identifierData,
             discoveredCallback,
         );

--- a/packages/matter.js/src/cluster/server/EventServer.ts
+++ b/packages/matter.js/src/cluster/server/EventServer.ts
@@ -114,7 +114,7 @@ export class EventServer<T = any> {
             eventId: this.id,
             clusterId: this.clusterId,
             endpointId: this.endpoint.number,
-            epochTimestamp: Time.nowMs(),
+            epochTimestamp: Time.nowMs,
             priority: this.priority,
             payload: data,
         };

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -14,9 +14,12 @@ import {
     Diagnostic,
     ImplementationError,
     InternalError,
+    Interval,
     Logger,
     MatterError,
+    Minutes,
     Observable,
+    Seconds,
     Time,
     Timer,
 } from "#general";
@@ -70,22 +73,22 @@ import { asClusterClientInternal, isClusterClient } from "./TypeHelpers.js";
 const logger = Logger.get("PairedNode");
 
 /** Delay after receiving a changed partList  from a device to update the device structure */
-const STRUCTURE_UPDATE_TIMEOUT_MS = 5_000; // 5 seconds
+const STRUCTURE_UPDATE_TIMEOUT = Seconds(5);
 
 /** Delay after a disconnect to try to reconnect to the device */
-const RECONNECT_DELAY_MS = 15_000; // 15 seconds
+const RECONNECT_DELAY = Minutes.quarter;
 
 /** Delay after a shutdown event to try to reconnect to the device */
-const RECONNECT_DELAY_AFTER_SHUTDOWN_MS = 30_000; // 30 seconds, to give device time to restart and maybe inform us about
+const RECONNECT_DELAY_AFTER_SHUTDOWN = Minutes.half; // Give device time to restart and maybe inform us about
 
 /** Maximum delay after a disconnect to try to reconnect to the device */
-const RECONNECT_MAX_DELAY_MS = 600_000; // 10 minutes
+const RECONNECT_MAX_DELAY = Minutes(10);
 
 /**
  * Delay after a new session was opened by the device while in discovery state.
  * This usually happens for devices that support persisted subscriptions.
  */
-const NEW_SESSION_WHILE_DISCOVERY_RECONNECT_DELAY_MS = 5_000;
+const NEW_SESSION_WHILE_DISCOVERY_RECONNECT_DELAY = Seconds(5);
 
 export enum NodeStates {
     /**
@@ -221,7 +224,7 @@ export class PairedNode {
     #reconnectDelayTimer?: Timer;
     #newChannelReconnectDelayTimer = Time.getTimer(
         "New Channel Reconnect Delay",
-        NEW_SESSION_WHILE_DISCOVERY_RECONNECT_DELAY_MS,
+        NEW_SESSION_WHILE_DISCOVERY_RECONNECT_DELAY,
         () => {
             if (
                 this.#connectionState === NodeStates.WaitingForDeviceDiscovery ||
@@ -232,18 +235,15 @@ export class PairedNode {
                 );
                 // Try last known address first to speed up reconnection
                 this.#setConnectionState(NodeStates.Reconnecting);
-                this.#scheduleReconnect(0);
+                this.#scheduleReconnect();
             }
         },
     );
     #reconnectErrorCount = 0;
-    readonly #updateEndpointStructureTimer = Time.getTimer(
-        "Endpoint structure update",
-        STRUCTURE_UPDATE_TIMEOUT_MS,
-        () =>
-            this.#updateEndpointStructure().catch(error =>
-                logger.warn(`Node ${this.nodeId}: Error updating endpoint structure`, error),
-            ),
+    readonly #updateEndpointStructureTimer = Time.getTimer("Endpoint structure update", STRUCTURE_UPDATE_TIMEOUT, () =>
+        this.#updateEndpointStructure().catch(error =>
+            logger.warn(`Node ${this.nodeId}: Error updating endpoint structure`, error),
+        ),
     );
     #connectionState: NodeStates = NodeStates.Disconnected;
     #reconnectionInProgress = false;
@@ -515,7 +515,7 @@ export class PairedNode {
             );
             return;
         }
-        this.#scheduleReconnect(0);
+        this.#scheduleReconnect();
     }
 
     /**
@@ -935,10 +935,10 @@ export class PairedNode {
     /** Handles a node shutDown event (if supported by the node and received). */
     #handleNodeShutdown() {
         logger.info(`Node ${this.nodeId}: Node shutdown detected, trying to reconnect ...`);
-        this.#scheduleReconnect(RECONNECT_DELAY_AFTER_SHUTDOWN_MS);
+        this.#scheduleReconnect(RECONNECT_DELAY_AFTER_SHUTDOWN);
     }
 
-    #scheduleReconnect(delay?: number) {
+    #scheduleReconnect(delay?: Interval) {
         if (this.state !== NodeStates.WaitingForDeviceDiscovery) {
             this.#setConnectionState(NodeStates.Reconnecting);
         }
@@ -948,10 +948,10 @@ export class PairedNode {
         }
         if (delay === undefined) {
             // Calculate a delay with a backoff strategy based on errorCount and maximum 10 minutes
-            delay = Math.min(RECONNECT_DELAY_MS * 2 ** this.#reconnectErrorCount, RECONNECT_MAX_DELAY_MS);
+            delay = Interval.min(RECONNECT_DELAY.times(2 ** this.#reconnectErrorCount), RECONNECT_MAX_DELAY);
         }
 
-        logger.info(`Node ${this.nodeId}: Reconnecting in ${Math.round(delay / 1000)}s ...`);
+        logger.info(`Node ${this.nodeId}: Reconnecting ${delay ? `in ${delay}` : "now"} ...`);
         this.#reconnectDelayTimer = Time.getTimer("Reconnect delay", delay, async () => await this.reconnect());
         this.#reconnectDelayTimer.start();
     }

--- a/packages/model/src/aspects/Constraint.ts
+++ b/packages/model/src/aspects/Constraint.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { camelize } from "#general";
+import { camelize, Interval } from "#general";
 import { Lexer } from "#parser/Lexer.js";
 import { BasicToken } from "#parser/Token.js";
 import { TokenStream } from "#parser/TokenStream.js";
@@ -300,7 +300,13 @@ namespace Serializer {
     }
 
     function serializeValue(value: Constraint.Expression, inExpr = false): string {
-        if (typeof value !== "object" || value === null || Array.isArray(value) || value instanceof Date) {
+        if (
+            typeof value !== "object" ||
+            value === null ||
+            Array.isArray(value) ||
+            value instanceof Date ||
+            value instanceof Interval
+        ) {
             return FieldValue.serialize(value);
         }
 

--- a/packages/model/src/common/FieldValue.ts
+++ b/packages/model/src/common/FieldValue.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes as ByteUtils, serialize as stringSerialize, UnexpectedDataError } from "#general";
+import { Bytes as ByteUtils, Interval, serialize as stringSerialize, UnexpectedDataError } from "#general";
 import type { Metatype } from "./Metatype.js";
 
 /**
@@ -18,6 +18,7 @@ export type FieldValue =
     | bigint
     | boolean
     | Date
+    | Interval
     | FieldValue[]
     | FieldValue.Properties
     | FieldValue.Reference
@@ -185,6 +186,9 @@ export namespace FieldValue {
         if (is(value, properties)) {
             return stringSerialize((value as Properties).properties) ?? "?";
         }
+        if (value instanceof Interval) {
+            return `${value.ms}ms`;
+        }
         return value.toString();
     }
 
@@ -239,7 +243,13 @@ export namespace FieldValue {
      * Unwrap wrapped values, leave others as-is.
      */
     export function unwrap(value: FieldValue | undefined, typeName?: string) {
-        if (value === null || typeof value !== "object" || Array.isArray(value) || value instanceof Date) {
+        if (
+            value === null ||
+            typeof value !== "object" ||
+            Array.isArray(value) ||
+            value instanceof Date ||
+            value instanceof Interval
+        ) {
             return value;
         }
 

--- a/packages/model/src/common/Metatype.ts
+++ b/packages/model/src/common/Metatype.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, isObject, UnexpectedDataError } from "#general";
+import { Bytes, Interval, isObject, Millisecs, UnexpectedDataError } from "#general";
 
 export class UnsupportedCastError extends UnexpectedDataError {}
 
@@ -23,6 +23,7 @@ export enum Metatype {
     object = "object",
     string = "string",
     date = "date",
+    interval = "interval",
 }
 
 export namespace Metatype {
@@ -71,6 +72,9 @@ export namespace Metatype {
 
             case Metatype.date:
                 return Date;
+
+            case Metatype.interval:
+                return Interval;
         }
     }
 
@@ -337,7 +341,22 @@ export namespace Metatype {
             }
         }
 
-        throw new UnexpectedDataError();
+        throw new UnexpectedDataError("Invalid date value");
+    };
+
+    cast.interval = (value: any): Interval | null | undefined => {
+        if (value === undefined || value === null || value instanceof Interval) {
+            return value;
+        }
+
+        if (typeof value === "number") {
+            const interval = Millisecs(value);
+            if (!Number.isNaN(interval.ms)) {
+                return interval;
+            }
+        }
+
+        throw new UnexpectedDataError("Invalid interval value");
     };
 
     /**

--- a/packages/model/src/logic/DefaultValue.ts
+++ b/packages/model/src/logic/DefaultValue.ts
@@ -6,7 +6,7 @@
 
 import type { FieldModel } from "#models/FieldModel.js";
 import { FeatureMap } from "#standard/elements/definitions.js";
-import { Bytes, camelize, NotImplementedError } from "@matter/general";
+import { Bytes, camelize, Interval, Millisecs, NotImplementedError } from "@matter/general";
 import { ElementTag, FieldValue, Metatype } from "../common/index.js";
 import { Model } from "../models/Model.js";
 import type { ValueModel } from "../models/ValueModel.js";
@@ -98,6 +98,15 @@ function castValue(model: ValueModel, modelDefault?: FieldValue): unknown {
             }
             if (typeof modelDefault === "number" || typeof modelDefault === "string") return new Date(modelDefault);
             return;
+
+        case Metatype.interval:
+            if (modelDefault instanceof Interval) {
+                return modelDefault;
+            }
+            if (typeof modelDefault === "number") {
+                return Millisecs(modelDefault);
+            }
+            break;
 
         case Metatype.array:
             if (Array.isArray(modelDefault)) {

--- a/packages/model/src/standard/elements/definitions.ts
+++ b/packages/model/src/standard/elements/definitions.ts
@@ -210,6 +210,7 @@ export * from "./locationdesc.element.js";
 export * from "./wildcard-path-flags-bitmap.element.js";
 export * from "./software-version-certification-status-enum.element.js";
 export * from "./any.element.js";
+export * from "./interval.element.js";
 export * from "./subject-id.element.js";
 export * from "./cluster-revision.element.js";
 export * from "./feature-map.element.js";

--- a/packages/model/src/standard/elements/interval.element.ts
+++ b/packages/model/src/standard/elements/interval.element.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import { MatterDefinition } from "../MatterDefinition.js";
+import { DatatypeElement as Datatype } from "../../elements/index.js";
+
+export const interval = Datatype({ name: "interval", metatype: "interval" });
+MatterDefinition.children.push(interval);

--- a/packages/model/src/standard/elements/models.ts
+++ b/packages/model/src/standard/elements/models.ts
@@ -218,6 +218,7 @@ export const locationdesc = new DatatypeModel(definitions.locationdesc);
 export const WildcardPathFlagsBitmap = new DatatypeModel(definitions.WildcardPathFlagsBitmap);
 export const SoftwareVersionCertificationStatusEnum = new DatatypeModel(definitions.SoftwareVersionCertificationStatusEnum);
 export const any = new DatatypeModel(definitions.any);
+export const interval = new DatatypeModel(definitions.interval);
 export const subjectId = new DatatypeModel(definitions.subjectId);
 export const ClusterRevision = new AttributeModel(definitions.ClusterRevision);
 export const FeatureMap = new AttributeModel(definitions.FeatureMap);

--- a/packages/model/src/standard/resources/index.ts
+++ b/packages/model/src/standard/resources/index.ts
@@ -211,6 +211,7 @@ import "./locationdesc.resource.js";
 import "./wildcard-path-flags-bitmap.resource.js";
 import "./software-version-certification-status-enum.resource.js";
 import "./any.resource.js";
+import "./interval.resource.js";
 import "./subject-id.resource.js";
 import "./cluster-revision.resource.js";
 import "./feature-map.resource.js";

--- a/packages/model/src/standard/resources/interval.resource.ts
+++ b/packages/model/src/standard/resources/interval.resource.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*** THIS FILE IS GENERATED, DO NOT EDIT ***/
+
+import { Resource } from "#models/Resource.js";
+
+Resource.add({
+    tag: "datatype", name: "interval",
+    description: "A datatype that represents an arbitrary time interval.",
+    details: "This is a matter.js extension to Matter semantics."
+});

--- a/packages/node/src/behavior/Events.ts
+++ b/packages/node/src/behavior/Events.ts
@@ -182,7 +182,7 @@ export class OnlineEvent<T extends any[] = any[], S extends ValueModel = ValueMo
         const trigger = (payload?: any) => {
             const maybePromise = occurrenceManager.add({
                 ...this.#baseOccurrence!,
-                epochTimestamp: Time.nowMs(),
+                epochTimestamp: Time.nowMs,
                 payload,
             });
 

--- a/packages/node/src/behavior/cluster/FabricScopedDataHandler.ts
+++ b/packages/node/src/behavior/cluster/FabricScopedDataHandler.ts
@@ -7,7 +7,7 @@
 import type { Behavior } from "#behavior/Behavior.js";
 import type { Endpoint } from "#endpoint/Endpoint.js";
 import type { SupportedElements } from "#endpoint/properties/Behaviors.js";
-import { createPromise, deepCopy, isObject, Logger, MaybePromise, withTimeout } from "#general";
+import { createPromise, deepCopy, isObject, Logger, MaybePromise, Seconds, withTimeout } from "#general";
 import type { ServerNode } from "#node/ServerNode.js";
 import { OccurrenceManager, Val } from "#protocol";
 import type { ClusterType, FabricIndex, ObjectSchema } from "#types";
@@ -67,7 +67,7 @@ async function sanitizeAttributeData(
         (endpoint.eventsOf(type) as Behavior.EventsOf<any>).stateChanged?.on(resolver);
         try {
             await endpoint.setStateOf(type, stateUpdate);
-            stateUpdatePromises.push(withTimeout(5_000, promise)); // 5s should be enough for state change
+            stateUpdatePromises.push(withTimeout(Seconds(5), promise)); // 5s should be enough for state change
         } catch (error) {
             logger.warn(
                 `Could not sanitize fabric-scoped attributes for cluster ${cluster.name} on endpoint ${endpoint.id}`,

--- a/packages/node/src/behavior/state/managed/values/PrimitiveManager.ts
+++ b/packages/node/src/behavior/state/managed/values/PrimitiveManager.ts
@@ -7,10 +7,9 @@
 import type { ValueSupervisor } from "../../../supervision/ValueSupervisor.js";
 
 /**
- * If you invoke {@link ValueSupervisor.manage} on a non-collection value, this is
- * the manage implementation you will receive.
+ * If you invoke {@link ValueSupervisor.manage} on a non-collection value, this is the manage implementation you will
+ * receive.
  *
- * Struct and list manager implementations optimize by bypassing
- * PrimitiveManager.
+ * Struct and list manager implementations optimize by bypassing PrimitiveManager.
  */
 export const PrimitiveManager: ValueSupervisor.Manage = reference => reference;

--- a/packages/node/src/behavior/state/validation/ValueValidator.ts
+++ b/packages/node/src/behavior/state/validation/ValueValidator.ts
@@ -73,6 +73,7 @@ export function ValueValidator(schema: Schema, supervisor: RootSupervisor): Valu
             break;
 
         case Metatype.date:
+        case Metatype.interval:
         case Metatype.any:
             break;
 

--- a/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
+++ b/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
@@ -7,7 +7,7 @@
 import { Behavior } from "#behavior/Behavior.js";
 import { Events as BaseEvents } from "#behavior/Events.js";
 import { OperationalCredentialsClient } from "#behaviors/operational-credentials";
-import { ImplementationError, NotImplementedError, Observable, ServerAddress, Time } from "#general";
+import { ImplementationError, Interval, NotImplementedError, Observable, ServerAddress, Time } from "#general";
 import { DatatypeModel, FieldElement } from "#model";
 import type { ClientNode } from "#node/ClientNode.js";
 import type { Node } from "#node/Node.js";
@@ -55,7 +55,7 @@ export class CommissioningClient extends Behavior {
         }
 
         if (this.state.discoveredAt === undefined) {
-            this.state.discoveredAt = Time.nowMs();
+            this.state.discoveredAt = Time.nowMs;
         }
 
         this.reactTo((this.endpoint as Node).lifecycle.partsReady, this.#initializeNode);
@@ -120,7 +120,7 @@ export class CommissioningClient extends Behavior {
         const address = identityService.assignNodeAddress(node, fabric.fabricIndex, opts.nodeId);
 
         const commissioningOptions: LocatedNodeCommissioningOptions = {
-            addresses,
+            addresses: addresses.map(ServerAddress),
             fabric,
             nodeId: address.nodeId,
             passcode,
@@ -259,9 +259,9 @@ export class CommissioningClient extends Behavior {
                 type: "struct",
                 quality: "N",
                 children: [
-                    FieldElement({ name: "idleIntervalMs", type: "uint32", constraint: "max 3600000" }),
-                    FieldElement({ name: "activeIntervalMs", type: "uint32", constraint: "max 3600000" }),
-                    FieldElement({ name: "activeThresholdMs", type: "uint16" }),
+                    FieldElement({ name: "idleInterval", type: "interval", constraint: "max 3600000" }),
+                    FieldElement({ name: "activeInterval", type: "interval", constraint: "max 3600000" }),
+                    FieldElement({ name: "activeThreshold", type: "interval", constraint: "max 65535" }),
                 ],
             }),
             FieldElement({ name: "tcpSupport", type: "uint8", quality: "N" }),
@@ -281,7 +281,7 @@ export namespace CommissioningClient {
          * Known network addresses for the device.  If this is undefined the node has not been located on any network
          * interface.
          */
-        addresses?: ServerAddress[];
+        addresses?: ServerAddress.Definition[];
 
         /**
          * Time at which the device was discovered.
@@ -299,9 +299,9 @@ export namespace CommissioningClient {
         offlineAt?: number;
 
         /**
-         * The TTL of the discovery record if applicable.
+         * The TTL of the discovery record if applicable (in seconds).
          */
-        ttl?: number;
+        ttl?: Interval;
 
         /**
          * The canonical global ID of the device.

--- a/packages/node/src/behavior/system/commissioning/RemoteDescriptor.ts
+++ b/packages/node/src/behavior/system/commissioning/RemoteDescriptor.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Immutable } from "#general";
+import { Immutable, Seconds, ServerAddress } from "#general";
 import { CommissionableDevice, OperationalDevice, PeerAddress, SessionParameters } from "#protocol";
 import { DeviceTypeId, VendorId } from "#types";
 import type { CommissioningClient } from "./CommissioningClient.js";
@@ -67,7 +67,7 @@ export namespace RemoteDescriptor {
         }
 
         if (ttl !== undefined) {
-            result.ttl = ttl;
+            result.ttl = Seconds(ttl);
         }
 
         if (deviceIdentifier !== undefined) {
@@ -103,18 +103,18 @@ export namespace RemoteDescriptor {
         }
 
         if (sessionParameters !== undefined) {
-            const { idleIntervalMs, activeIntervalMs, activeThresholdMs } = sessionParameters;
+            const { idleInterval, activeInterval, activeThreshold } = sessionParameters;
 
-            if (idleIntervalMs !== undefined) {
-                result.SII = idleIntervalMs;
+            if (idleInterval !== undefined) {
+                result.SII = idleInterval;
             }
 
-            if (activeIntervalMs !== undefined) {
-                result.SAI = activeIntervalMs;
+            if (activeInterval !== undefined) {
+                result.SAI = activeInterval;
             }
 
-            if (activeThresholdMs !== undefined) {
-                result.SAT = activeThresholdMs;
+            if (activeThreshold !== undefined) {
+                result.SAT = activeThreshold;
             }
         }
 
@@ -129,11 +129,11 @@ export namespace RemoteDescriptor {
         const isOperational = long.peerAddress !== undefined;
         if (isOperational) {
             if (addresses !== undefined) {
-                result.addresses = addresses?.filter(address => address.type === "udp");
+                result.addresses = addresses?.filter(address => address.type === "udp").map(ServerAddress);
             }
         } else {
             if (addresses !== undefined) {
-                result.addresses = addresses.map(address => ({ ...address }));
+                result.addresses = addresses.map(address => ({ ...address })).map(ServerAddress);
             }
 
             if (discriminator !== undefined) {
@@ -165,7 +165,7 @@ export namespace RemoteDescriptor {
         }
 
         if (addresses?.length) {
-            long.addresses = addresses;
+            long.addresses = addresses.map(ServerAddress.definitionOf);
         }
 
         if (deviceIdentifier !== undefined) {
@@ -181,13 +181,13 @@ export namespace RemoteDescriptor {
 
         let sessionParameters: Partial<SessionParameters> | undefined;
         if (SII !== undefined) {
-            (sessionParameters ??= {}).idleIntervalMs = SII;
+            (sessionParameters ??= {}).idleInterval = SII;
         }
         if (SAI !== undefined) {
-            (sessionParameters ??= {}).activeIntervalMs = SAI;
+            (sessionParameters ??= {}).activeInterval = SAI;
         }
         if (SAT !== undefined) {
-            (sessionParameters ??= {}).activeThresholdMs = SAT;
+            (sessionParameters ??= {}).activeThreshold = SAT;
         }
         long.sessionParameters = sessionParameters;
 

--- a/packages/node/src/behavior/system/controller/discovery/ContinuousDiscovery.ts
+++ b/packages/node/src/behavior/system/controller/discovery/ContinuousDiscovery.ts
@@ -22,7 +22,7 @@ export class ContinuousDiscovery extends Discovery<ClientNode[]> {
 
     constructor(owner: ServerNode, options?: Discovery.Options) {
         super(owner, options);
-        this.#bounded = options?.timeoutSeconds !== undefined;
+        this.#bounded = options?.timeout !== undefined;
     }
 
     /**

--- a/packages/node/src/behavior/system/controller/discovery/Discovery.ts
+++ b/packages/node/src/behavior/system/controller/discovery/Discovery.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CancelablePromise, Diagnostic, Logger, MaybePromise, withTimeout } from "#general";
+import { CancelablePromise, Diagnostic, Interval, Logger, MaybePromise, withTimeout } from "#general";
 import { ClientNodeFactory } from "#node/client/ClientNodeFactory.js";
 import type { ClientNode } from "#node/ClientNode.js";
 import type { ServerNode } from "#node/ServerNode.js";
@@ -224,8 +224,8 @@ export abstract class Discovery<T = unknown> extends CancelablePromise<T> {
 
         let promise = DiscoveryAggregateError.allSettled(promises, `${this} failed`);
 
-        if (this.#options.timeoutSeconds !== undefined) {
-            promise = withTimeout(this.#options.timeoutSeconds * 1_000, promise, this.stop.bind(this));
+        if (this.#options.timeout !== undefined) {
+            promise = withTimeout(this.#options.timeout, promise, this.stop.bind(this));
         }
 
         promise.then(this.#afterDiscovery.bind(this)).catch(this.#reject);
@@ -260,7 +260,7 @@ export abstract class Discovery<T = unknown> extends CancelablePromise<T> {
 
 export namespace Discovery {
     export type Options = CommissionableDeviceIdentifiers & {
-        timeoutSeconds?: number;
+        timeout?: Interval;
     };
 
     export type InstanceOptions = Options & {

--- a/packages/node/src/behaviors/color-control/ColorControlServer.ts
+++ b/packages/node/src/behaviors/color-control/ColorControlServer.ts
@@ -19,6 +19,7 @@ import {
     ImplementationError,
     Logger,
     MaybePromise,
+    Millisecs,
 } from "#general";
 import { ServerNode } from "#node/ServerNode.js";
 import { Val } from "#protocol";
@@ -1671,8 +1672,8 @@ export class ColorControlBaseServer extends ColorControlBase {
                 return readOnlyState.transitionEndTimeMs;
             },
 
-            get stepIntervalMs() {
-                return readOnlyState.transitionStepIntervalMs;
+            get stepInterval() {
+                return readOnlyState.transitionStepInterval;
             },
 
             properties: {
@@ -1803,12 +1804,12 @@ export namespace ColorControlBaseServer {
          * If transition management is disabled you may specify this as the "end time" for transitions.  The remaining
          * time attribute will then report correctly.
          */
-        transitionEndTimeMs = undefined;
+        transitionEndTimeMs?: number;
 
         /**
          * When managing transitions, this is the interval at which steps occur in ms.
          */
-        transitionStepIntervalMs = 100;
+        transitionStepInterval = Millisecs(100);
 
         [Val.properties](endpoint: Endpoint) {
             // Only return remaining time if the attribute is defined in the endpoint

--- a/packages/node/src/behaviors/general-commissioning/GeneralCommissioningServer.ts
+++ b/packages/node/src/behaviors/general-commissioning/GeneralCommissioningServer.ts
@@ -8,7 +8,7 @@ import { AdministratorCommissioningServer } from "#behaviors/administrator-commi
 import { BasicInformationServer } from "#behaviors/basic-information";
 import { AdministratorCommissioning } from "#clusters/administrator-commissioning";
 import { GeneralCommissioning } from "#clusters/general-commissioning";
-import { Bytes, Diagnostic, Logger, MatterFlowError, MaybePromise } from "#general";
+import { Bytes, Diagnostic, Logger, MatterFlowError, MaybePromise, Seconds } from "#general";
 import type { ServerNode } from "#node/ServerNode.js";
 import { DeviceCommissioner, FabricManager, GroupSession, NodeSession, SecureSession, SessionManager } from "#protocol";
 import { GeneralCommissioningBehavior } from "./GeneralCommissioningBehavior.js";
@@ -80,7 +80,7 @@ export class GeneralCommissioningServer extends GeneralCommissioningBehavior {
             }
 
             if (commissioner.isFailsafeArmed) {
-                await commissioner.failsafeContext.extend(session.fabric, expiryLengthSeconds);
+                await commissioner.failsafeContext.extend(session.fabric, Seconds(expiryLengthSeconds));
             } else {
                 // If ExpiryLengthSeconds is 0 and the fail-safe timer was not armed, then this command invocation SHALL
                 // lead to a success response with no side effect against the fail-safe context.
@@ -89,8 +89,8 @@ export class GeneralCommissioningServer extends GeneralCommissioningBehavior {
                 const failsafe = new ServerNodeFailsafeContext(this.endpoint as ServerNode, {
                     fabrics: this.env.get(FabricManager),
                     sessions: this.env.get(SessionManager),
-                    expiryLengthSeconds,
-                    maxCumulativeFailsafeSeconds: this.state.basicCommissioningInfo.maxCumulativeFailsafeSeconds,
+                    expiryLength: Seconds(expiryLengthSeconds),
+                    maxCumulativeFailsafe: Seconds(this.state.basicCommissioningInfo.maxCumulativeFailsafeSeconds),
                     associatedFabric: session.fabric,
                 });
 

--- a/packages/node/src/behaviors/general-diagnostics/GeneralDiagnosticsServer.ts
+++ b/packages/node/src/behaviors/general-diagnostics/GeneralDiagnosticsServer.ts
@@ -11,7 +11,7 @@ import { NetworkCommissioningServer } from "#behaviors/network-commissioning";
 import { TimeSynchronizationBehavior } from "#behaviors/time-synchronization";
 import { GeneralDiagnostics } from "#clusters/general-diagnostics";
 import type { Endpoint } from "#endpoint/Endpoint.js";
-import { Bytes, ImplementationError, ipv4ToBytes, Logger, MaybePromise, Time, Timer } from "#general";
+import { Bytes, ImplementationError, ipv4ToBytes, Logger, MaybePromise, Minutes, Time, Timer } from "#general";
 import { FieldElement, Specification } from "#model";
 import type { NodeLifecycle } from "#node/NodeLifecycle.js";
 import { MdnsService, Val } from "#protocol";
@@ -105,7 +105,7 @@ export class GeneralDiagnosticsServer extends Base {
     }
 
     override timeSnapshot(): MaybePromise<GeneralDiagnostics.TimeSnapshotResponse> {
-        const time = Time.nowMs();
+        const time = Time.nowMs;
 
         // TC_DGGEN_2_4.py fails us if we set this without TimeSynchronizationCluster support.  Spec is worded poorly
         // but my read of "SHALL only if" is "may not unless" and not "SHALL if and only if".  But conforming to tests
@@ -294,11 +294,11 @@ export class GeneralDiagnosticsServer extends Base {
         );
 
         // Update the timestamps now that node is really online.
-        this.internal.lastTotalOperationalHoursCounterUpdateTime = Time.nowMs();
+        this.internal.lastTotalOperationalHoursCounterUpdateTime = Time.nowMs;
 
         this.internal.lastTotalOperationalHoursTimer = Time.getPeriodicTimer(
             "GeneralDiagnostics.operationalHours",
-            5 * 60_000,
+            Minutes(5),
             this.callback(this.#updateTotalOperationalHoursCounter),
         ).start();
 
@@ -311,7 +311,7 @@ export class GeneralDiagnosticsServer extends Base {
     }
 
     #updateTotalOperationalHoursCounter() {
-        const now = Time.nowMs();
+        const now = Time.nowMs;
         const elapsedTime = now - this.internal.lastTotalOperationalHoursCounterUpdateTime;
         this.state.totalOperationalHoursCounter = this.state.totalOperationalHoursCounter + elapsedTime;
         this.internal.lastTotalOperationalHoursCounterUpdateTime = now;
@@ -382,7 +382,7 @@ export class GeneralDiagnosticsServer extends Base {
 export namespace GeneralDiagnosticsServer {
     export class Internal {
         /** Last time the total operational hours counter was updated. */
-        lastTotalOperationalHoursCounterUpdateTime: number = Time.nowMs();
+        lastTotalOperationalHoursCounterUpdateTime: number = Time.nowMs;
 
         /** Timer to update the total operational hours counter every 5 minutes. */
         lastTotalOperationalHoursTimer: Timer | undefined;
@@ -415,7 +415,7 @@ export namespace GeneralDiagnosticsServer {
                         return 0;
                     }
 
-                    return Math.round((Time.nowMs() - onlineAt.getTime()) / 1000);
+                    return Math.round((Time.nowMs - onlineAt.getTime()) / 1000);
                 },
 
                 /**
@@ -430,7 +430,7 @@ export namespace GeneralDiagnosticsServer {
                     const totalOperationalHoursCounter =
                         endpoint.stateOf(GeneralDiagnosticsServer).totalOperationalHoursCounter;
                     return Math.floor(
-                        (Time.nowMs() - lastTotalOperationalHoursCounterUpdateTime + totalOperationalHoursCounter) /
+                        (Time.nowMs - lastTotalOperationalHoursCounterUpdateTime + totalOperationalHoursCounter) /
                             (60 * 60_000),
                     );
                 },

--- a/packages/node/src/behaviors/identify/IdentifyServer.ts
+++ b/packages/node/src/behaviors/identify/IdentifyServer.ts
@@ -5,7 +5,7 @@
  */
 
 import { Identify } from "#clusters/identify";
-import { MaybePromise, Observable, Time, Timer } from "#general";
+import { MaybePromise, Observable, Seconds, Time, Timer } from "#general";
 import { IdentifyBehavior } from "./IdentifyBehavior.js";
 
 /**
@@ -37,7 +37,7 @@ export class IdentifyServer extends IdentifyBehavior {
         // Enable I/2.4 once this is done
         this.internal.identifyTimer = Time.getPeriodicTimer(
             "Identify time update",
-            1000,
+            Seconds.one,
             this.callback(this.#identifyTick, { lock: true }),
         );
 

--- a/packages/node/src/behaviors/level-control/LevelControlServer.ts
+++ b/packages/node/src/behaviors/level-control/LevelControlServer.ts
@@ -13,7 +13,7 @@ import { OnOffServer } from "#behaviors/on-off";
 import { GeneralDiagnostics } from "#clusters/general-diagnostics";
 import { LevelControl } from "#clusters/level-control";
 import { Endpoint } from "#endpoint/Endpoint.js";
-import { AsyncObservable, Identity, Logger, MaybePromise } from "#general";
+import { AsyncObservable, Identity, Logger, MaybePromise, Seconds } from "#general";
 import { ServerNode } from "#node/ServerNode.js";
 import { Val } from "#protocol";
 import { ClusterType, StatusCode, StatusResponseError, TypeFromPartialBitSchema } from "#types";
@@ -141,8 +141,8 @@ export class LevelControlBaseServer extends LevelControlBase {
                 return readOnlyState.transitionEndTimeMs;
             },
 
-            get stepIntervalMs() {
-                return readOnlyState.transitionStepIntervalMs;
+            get stepInterval() {
+                return readOnlyState.transitionStepInterval;
             },
 
             properties: {
@@ -614,7 +614,7 @@ export namespace LevelControlBaseServer {
         /**
          * When managing transitions, this is the interval at which steps occur in ms.
          */
-        transitionStepIntervalMs = 100;
+        transitionStepInterval = Seconds.tenth;
 
         [Val.properties](endpoint: Endpoint) {
             // Only return remaining time if the attribute is defined in the endpoint

--- a/packages/node/src/behaviors/on-off/OnOffServer.ts
+++ b/packages/node/src/behaviors/on-off/OnOffServer.ts
@@ -7,7 +7,7 @@
 import { GeneralDiagnosticsBehavior } from "#behaviors/general-diagnostics";
 import { GeneralDiagnostics } from "#clusters/general-diagnostics";
 import { OnOff } from "#clusters/on-off";
-import { MaybePromise, Time, Timer } from "#general";
+import { MaybePromise, Seconds, Time, Timer } from "#general";
 import { ServerNode } from "#node/ServerNode.js";
 import { OnOffBehavior } from "./OnOffBehavior.js";
 
@@ -147,7 +147,7 @@ export class OnOffBaseServer extends OnOffLogicBase {
         if (timer === undefined) {
             timer = this.internal.timedOnTimer = Time.getPeriodicTimer(
                 "Timed on",
-                100,
+                Seconds.tenth,
                 this.callback(this.#timedOnTick, { lock: true }),
             );
         }
@@ -170,7 +170,7 @@ export class OnOffBaseServer extends OnOffLogicBase {
         if (timer === undefined) {
             timer = this.internal.delayedOffTimer = Time.getPeriodicTimer(
                 "Delayed off",
-                100,
+                Seconds.tenth,
                 this.callback(this.#delayedOffTick, { lock: true }),
             );
         }

--- a/packages/node/src/behaviors/power-source/PowerSourceServer.ts
+++ b/packages/node/src/behaviors/power-source/PowerSourceServer.ts
@@ -6,6 +6,7 @@
 
 import { DescriptorServer } from "#behaviors/descriptor";
 import { PowerSource } from "#clusters/power-source";
+import { Seconds } from "#general";
 import { ClusterType } from "#types";
 import { PowerSourceBehavior } from "./PowerSourceBehavior.js";
 
@@ -25,7 +26,7 @@ export class PowerSourceBaseServer extends PowerSourceLevelBase {
             this.events.batTimeToFullCharge$Changed,
         ].forEach(event => {
             if (event !== undefined) {
-                event.quiet.minimumEmitIntervalMs = 10_000;
+                event.quiet.minimumEmitInterval = Seconds(10);
             }
         });
     }

--- a/packages/node/src/endpoint/Endpoint.ts
+++ b/packages/node/src/endpoint/Endpoint.ts
@@ -13,6 +13,7 @@ import {
     Environment,
     Immutable,
     ImplementationError,
+    Interval,
     Lifecycle,
     Logger,
     MaybePromise,
@@ -206,8 +207,15 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
                         `State values for ${behaviorId} must be an object, not ${typeof vals}`,
                     );
                 }
+
+                if (vals instanceof Interval || vals instanceof Date) {
+                    throw new ImplementationError(
+                        `State values for ${behaviorId} must be an object, not ${vals.constructor.name}`,
+                    );
+                }
+
                 if (Array.isArray(vals)) {
-                    throw new ImplementationError(`StateValue for ${behaviorId} must be an object, not an array`);
+                    throw new ImplementationError(`State value for ${behaviorId} must be an object, not an array`);
                 }
 
                 patch(vals, behavior.state, this.path);
@@ -235,6 +243,11 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
 
             if (typeof values !== "object") {
                 throw new ImplementationError(`State values for ${type.id} must be an object, not ${typeof values}`);
+            }
+            if (values instanceof Interval || values instanceof Date) {
+                throw new ImplementationError(
+                    `State values for ${type.id} must be an object, not ${values.constructor.name}`,
+                );
             }
             if (Array.isArray(values)) {
                 throw new ImplementationError(`State values for ${type.id} must be an object, not an array`);

--- a/packages/node/src/node/client/ClientNodes.ts
+++ b/packages/node/src/node/client/ClientNodes.ts
@@ -10,7 +10,7 @@ import { ContinuousDiscovery } from "#behavior/system/controller/discovery/Conti
 import { Discovery } from "#behavior/system/controller/discovery/Discovery.js";
 import { InstanceDiscovery } from "#behavior/system/controller/discovery/InstanceDiscovery.js";
 import { EndpointContainer } from "#endpoint/properties/EndpointContainer.js";
-import { CancelablePromise, Lifespan, Logger, Time } from "#general";
+import { CancelablePromise, Hours, Interval, Logger, Minutes, Seconds, Time } from "#general";
 import { PeerAddress, PeerAddressStore } from "#protocol";
 import { ServerNodeStore } from "#storage/server/ServerNodeStore.js";
 import { ClientNode } from "../ClientNode.js";
@@ -20,8 +20,8 @@ import { NodePeerAddressStore } from "./NodePeerAddressStore.js";
 
 const logger = Logger.get("ClientNodes");
 
-const DEFAULT_TTL = 900 * 1000;
-const EXPIRATION_INTERVAL = 60 * 1000;
+const DEFAULT_TTL = Hours.quarter;
+const EXPIRATION_INTERVAL = Minutes.one;
 
 /**
  * Manages the set of known remote nodes.
@@ -160,7 +160,7 @@ export class ClientNodes extends EndpointContainer<ClientNode> {
     }
 
     async #cullExpiredNodesAndAddresses() {
-        const now = Time.nowMs();
+        const now = Time.nowMs;
 
         for (const node of this) {
             const state = node.state.commissioning;
@@ -243,11 +243,11 @@ class Factory extends ClientNodeFactory {
     }
 }
 
-function expirationOf<T extends Partial<Lifespan>>(
+function expirationOf<T extends { discoveredAt?: number; ttl?: Interval | number }>(
     lifespan: T,
 ): T extends { discoveredAt: number } ? number : number | undefined {
     if (lifespan.discoveredAt !== undefined) {
-        return lifespan.discoveredAt + (lifespan.ttl ?? DEFAULT_TTL);
+        return (Seconds(lifespan.ttl) ?? DEFAULT_TTL).after(lifespan.discoveredAt);
     }
     return undefined as unknown as number;
 }

--- a/packages/node/src/node/client/NodePeerAddressStore.ts
+++ b/packages/node/src/node/client/NodePeerAddressStore.ts
@@ -10,7 +10,7 @@ import { IdentityService } from "#node/server/IdentityService.js";
 import type { ServerNode } from "#node/ServerNode.js";
 import { OperationalPeer, PeerAddress, PeerAddressMap, PeerAddressStore } from "#protocol";
 import { FabricIndex, NodeId } from "#types";
-import { Crypto } from "@matter/general";
+import { Crypto, ServerAddress, ServerAddressIp } from "@matter/general";
 
 /**
  * This is an adapter for lower-level components in the protocol package.
@@ -61,9 +61,11 @@ export class NodePeerAddressStore extends PeerAddressStore {
 
                 this.#assignedAddresses.set(commissioning.peerAddress, node);
 
+                const addr = commissioning.addresses?.find(addr => addr.type === "udp");
+
                 return {
                     address: commissioning.peerAddress,
-                    operationalAddress: commissioning.addresses?.find(addr => addr.type === "udp"),
+                    operationalAddress: addr && (ServerAddress(addr) as ServerAddressIp),
                     discoveryData: RemoteDescriptor.fromLongForm(commissioning),
                 };
             })

--- a/packages/node/src/node/server/InteractionServer.ts
+++ b/packages/node/src/node/server/InteractionServer.ts
@@ -11,10 +11,13 @@ import {
     Crypto,
     Diagnostic,
     InternalError,
+    Interval,
     Logger,
     MatterError,
     MaybePromise,
+    Millisecs,
     Observable,
+    Seconds,
     ServerAddressIp,
 } from "#general";
 import { GLOBAL_IDS, Specification } from "#model";
@@ -63,13 +66,13 @@ const logger = Logger.get("InteractionServer");
 export interface PeerSubscription {
     subscriptionId: number;
     peerAddress: PeerAddress;
-    minIntervalFloorSeconds: number;
-    maxIntervalCeilingSeconds: number;
+    minIntervalFloor: Interval;
+    maxIntervalCeiling: Interval;
     attributeRequests?: TypeFromSchema<typeof TlvAttributePath>[];
     eventRequests?: TypeFromSchema<typeof TlvEventPath>[];
     isFabricFiltered: boolean;
-    maxInterval: number;
-    sendInterval: number;
+    maxInterval: Interval;
+    sendInterval: Interval;
     operationalAddress?: ServerAddressIp;
 }
 
@@ -516,12 +519,13 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
         }
 
         const maxInterval = subscription.maxInterval;
+
         // Then send the subscription response
         await messenger.send(
             MessageType.SubscribeResponse,
             TlvSubscribeResponse.encode({
                 subscriptionId,
-                maxInterval,
+                maxInterval: maxInterval.secs,
                 interactionModelRevision: Specification.INTERACTION_MODEL_REVISION,
             }),
             {
@@ -569,8 +573,8 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
                 eventFilters,
                 isFabricFiltered,
             },
-            minIntervalFloorSeconds,
-            maxIntervalCeilingSeconds,
+            minIntervalFloor: Seconds(minIntervalFloorSeconds),
+            maxIntervalCeiling: Seconds(maxIntervalCeilingSeconds),
             subscriptionOptions: this.#subscriptionConfig,
         });
 
@@ -586,7 +590,7 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
         logger.info(
             `Successfully created subscription ${id} for Session ${
                 session.id
-            } to ${session.peerAddress}. Updates: ${minIntervalFloorSeconds} - ${maxIntervalCeilingSeconds} => ${subscription.maxInterval} seconds (sendInterval = ${subscription.sendInterval} seconds)`,
+            } to ${session.peerAddress}. Updates: ${minIntervalFloorSeconds} - ${maxIntervalCeilingSeconds} => ${subscription.maxInterval} seconds (sendInterval = ${subscription.sendInterval})`,
         );
         return subscription;
     }
@@ -597,8 +601,8 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
             attributeRequests,
             eventRequests,
             isFabricFiltered,
-            minIntervalFloorSeconds,
-            maxIntervalCeilingSeconds,
+            minIntervalFloor,
+            maxIntervalCeiling,
             maxInterval,
             sendInterval,
         }: PeerSubscription,
@@ -620,8 +624,8 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
         const subscription = new ServerSubscription({
             id: subscriptionId,
             context,
-            minIntervalFloorSeconds,
-            maxIntervalCeilingSeconds,
+            minIntervalFloor,
+            maxIntervalCeiling,
             criteria: {
                 attributeRequests,
                 eventRequests,
@@ -644,7 +648,7 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
             logger.info(
                 `Successfully re-established subscription ${subscriptionId} for Session ${
                     session.id
-                } to ${session.peerAddress}. Updates: ${minIntervalFloorSeconds} - ${maxIntervalCeilingSeconds} => ${subscription.maxInterval} seconds (sendInterval = ${subscription.sendInterval} seconds)`,
+                } to ${session.peerAddress}. Updates: ${minIntervalFloor} - ${maxIntervalCeiling} => ${subscription.maxInterval} (sendInterval = ${subscription.sendInterval})`,
             );
         } catch (error) {
             await subscription.close(); // Cleanup
@@ -811,7 +815,9 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
     }
 
     handleTimedRequest(exchange: MessageExchange, { timeout, interactionModelRevision }: TimedRequest) {
-        logger.debug(`Received timed request (${timeout}ms) from ${exchange.channel.name}`);
+        const interval = Millisecs(timeout);
+
+        logger.debug(`Received timed request (${interval}) from ${exchange.channel.name}`);
 
         if (interactionModelRevision > Specification.INTERACTION_MODEL_REVISION) {
             logger.debug(
@@ -819,7 +825,7 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
             );
         }
 
-        exchange.startTimedInteraction(timeout);
+        exchange.startTimedInteraction(interval);
     }
 
     async close() {

--- a/packages/node/src/node/server/ServerSubscription.ts
+++ b/packages/node/src/node/server/ServerSubscription.ts
@@ -6,7 +6,20 @@
 
 import { NodeActivity } from "#behavior/context/NodeActivity.js";
 import { OnlineContext } from "#behavior/context/server/OnlineContext.js";
-import { Logger, MatterError, NetworkError, NoResponseTimeoutError, ObserverGroup, Time, Timer } from "#general";
+import {
+    Hours,
+    Interval,
+    Logger,
+    MatterError,
+    Millisecs,
+    Minutes,
+    NetworkError,
+    NoResponseTimeoutError,
+    ObserverGroup,
+    Seconds,
+    Time,
+    Timer,
+} from "#general";
 import { Specification } from "#model";
 import type { ServerNode } from "#node/ServerNode.js";
 import type { AttributeResponseFilter, Message, MessageExchange, NodeSession } from "#protocol";
@@ -45,10 +58,10 @@ const logger = Logger.get("ServerSubscription");
 // overridden for otherwise.
 //
 // To officially match the specs the developer needs to set these 60Minutes in the Subscription options!
-export const MAX_INTERVAL_PUBLISHER_LIMIT_S = 60 * 60; /** 1 hour */
-export const INTERNAL_INTERVAL_PUBLISHER_LIMIT_S = 3 * 60; /** 3 min */
-export const MIN_INTERVAL_S = 2; // We do not send faster than 2 seconds
-export const DEFAULT_RANDOMIZATION_WINDOW_S = 10; // 10 seconds
+export const MAX_INTERVAL_PUBLISHER_LIMIT = Hours.one;
+export const INTERNAL_INTERVAL_PUBLISHER_LIMIT = Minutes(3);
+export const MIN_INTERVAL = Seconds(2);
+export const DEFAULT_RANDOMIZATION_WINDOW = Seconds(10);
 
 /**
  * Server options that control subscription handling.
@@ -58,21 +71,21 @@ export interface ServerSubscriptionConfig {
      * Optional maximum subscription interval to use for sending subscription reports. It will be used if not too
      * low and inside the range requested by the connected controller.
      */
-    maxIntervalSeconds: number;
+    maxInterval: Interval;
 
     /**
      * Optional minimum subscription interval to use for sending subscription reports. It will be used when other
      * calculated values are smaller than it. Use this to make sure your device hardware can handle the load and to
      * set limits.
      */
-    minIntervalSeconds: number;
+    minInterval: Interval;
 
     /**
      * Optional subscription randomization window to use for sending subscription reports. This specifies a window
      * in seconds from which a random part is added to the calculated maximum interval to make sure that devices
      * that get powered on in parallel not all send at the same timepoint.
      */
-    randomizationWindowSeconds: number;
+    randomizationWindow: Interval;
 }
 
 export namespace ServerSubscriptionConfig {
@@ -83,9 +96,9 @@ export namespace ServerSubscriptionConfig {
      */
     export function of(options?: Partial<ServerSubscriptionConfig>) {
         return {
-            maxIntervalSeconds: options?.maxIntervalSeconds ?? INTERNAL_INTERVAL_PUBLISHER_LIMIT_S,
-            minIntervalSeconds: Math.max(options?.minIntervalSeconds ?? MIN_INTERVAL_S, MIN_INTERVAL_S),
-            randomizationWindowSeconds: options?.randomizationWindowSeconds ?? DEFAULT_RANDOMIZATION_WINDOW_S,
+            maxInterval: options?.maxInterval ?? INTERNAL_INTERVAL_PUBLISHER_LIMIT,
+            minInterval: Interval.max(options?.minInterval ?? MIN_INTERVAL, MIN_INTERVAL),
+            randomizationWindow: options?.randomizationWindow ?? DEFAULT_RANDOMIZATION_WINDOW,
         };
     }
 }
@@ -107,7 +120,7 @@ export class ServerSubscription extends Subscription {
 
     #lastUpdateTimeMs = 0;
     #updateTimer: Timer;
-    readonly #sendDelayTimer: Timer = Time.getTimer(`Subscription ${this.id} delay`, 50, () =>
+    readonly #sendDelayTimer: Timer = Time.getTimer(`Subscription ${this.id} delay`, Millisecs(50), () =>
         this.#triggerSendUpdate(),
     );
     #outstandingAttributeUpdates?: AttributeResponseFilter;
@@ -117,9 +130,9 @@ export class ServerSubscription extends Subscription {
     #sendUpdatesActivated = false;
     #seededClusterDetails? = new Map<string, number>();
     #latestSeededEventNumber? = EventNumber(0);
-    readonly #sendIntervalMs: number;
-    readonly #minIntervalFloorMs: number;
-    readonly #maxIntervalCeilingMs: number;
+    readonly #sendInterval: Interval;
+    readonly #minIntervalFloor: Interval;
+    readonly #maxIntervalCeiling: Interval;
     readonly #peerAddress: PeerAddress;
 
     #sendNextUpdateImmediately = false;
@@ -130,18 +143,18 @@ export class ServerSubscription extends Subscription {
         id: number;
         context: ServerSubscriptionContext;
         criteria: SubscriptionCriteria;
-        minIntervalFloorSeconds: number;
-        maxIntervalCeilingSeconds: number;
+        minIntervalFloor: Interval;
+        maxIntervalCeiling: Interval;
         subscriptionOptions: ServerSubscriptionConfig;
-        useAsMaxInterval?: number;
-        useAsSendInterval?: number;
+        useAsMaxInterval?: Interval;
+        useAsSendInterval?: Interval;
     }) {
         const {
             id,
             context,
             criteria,
-            minIntervalFloorSeconds,
-            maxIntervalCeilingSeconds,
+            minIntervalFloor,
+            maxIntervalCeiling,
             subscriptionOptions,
             useAsMaxInterval,
             useAsSendInterval,
@@ -151,59 +164,59 @@ export class ServerSubscription extends Subscription {
         this.#context = context;
 
         this.#peerAddress = this.session.peerAddress;
-        this.#minIntervalFloorMs = minIntervalFloorSeconds * 1000;
-        this.#maxIntervalCeilingMs = maxIntervalCeilingSeconds * 1000;
+        this.#minIntervalFloor = minIntervalFloor;
+        this.#maxIntervalCeiling = maxIntervalCeiling;
 
-        let maxInterval: number;
-        let sendInterval: number;
+        let maxInterval: Interval;
+        let sendInterval: Interval;
         if (useAsMaxInterval !== undefined && useAsSendInterval !== undefined) {
-            maxInterval = useAsMaxInterval * 1000;
-            sendInterval = useAsSendInterval * 1000;
+            maxInterval = useAsMaxInterval;
+            sendInterval = useAsSendInterval;
         } else {
             ({ maxInterval, sendInterval } = this.#determineSendingIntervals(
-                subscriptionOptions.minIntervalSeconds * 1000,
-                subscriptionOptions.maxIntervalSeconds * 1000,
-                subscriptionOptions.randomizationWindowSeconds * 1000,
+                subscriptionOptions.minInterval,
+                subscriptionOptions.maxInterval,
+                subscriptionOptions.randomizationWindow,
             ));
         }
-        this.maxIntervalMs = maxInterval;
-        this.#sendIntervalMs = sendInterval;
+        this.maxInterval = maxInterval;
+        this.#sendInterval = sendInterval;
 
-        this.#updateTimer = Time.getTimer(`Subscription ${this.id} update`, this.#sendIntervalMs, () =>
+        this.#updateTimer = Time.getTimer(`Subscription ${this.id} update`, this.#sendInterval, () =>
             this.#prepareDataUpdate(),
         ); // will be started later
     }
 
     #determineSendingIntervals(
-        subscriptionMinIntervalMs: number,
-        subscriptionMaxIntervalMs: number,
-        subscriptionRandomizationWindowMs: number,
-    ): { maxInterval: number; sendInterval: number } {
+        subscriptionMinInterval: Interval,
+        subscriptionMaxInterval: Interval,
+        subscriptionRandomizationWindow: Interval,
+    ): { maxInterval: Interval; sendInterval: Interval } {
         // Max Interval is the Max interval that the controller request, unless the configured one from the developer
         // is lower. In that case we use the configured one. But we make sure to not be smaller than the requested
         // controller minimum. But in general never faster than minimum interval configured or 2 seconds
         // (SUBSCRIPTION_MIN_INTERVAL_S). Additionally, we add a randomization window to the max interval to avoid all
         // devices sending at the same time. But we make sure not to exceed the global max interval.
-        const maxInterval = Math.min(
-            Math.max(
-                subscriptionMinIntervalMs,
-                Math.max(this.#minIntervalFloorMs, Math.min(subscriptionMaxIntervalMs, this.#maxIntervalCeilingMs)),
-            ) + Math.floor(subscriptionRandomizationWindowMs * Math.random()),
-            MAX_INTERVAL_PUBLISHER_LIMIT_S * 1000,
+        const maxInterval = Interval.min(
+            Interval.max(
+                subscriptionMinInterval,
+                Interval.max(this.#minIntervalFloor, Interval.min(subscriptionMaxInterval, this.#maxIntervalCeiling)),
+            ).plus(subscriptionRandomizationWindow.times(Math.random()).floor),
+            MAX_INTERVAL_PUBLISHER_LIMIT,
         );
-        let sendInterval = Math.floor(maxInterval / 2); // Ideally we send at half the max interval
-        if (sendInterval < 60_000) {
+        let sendInterval = maxInterval.dividedBy(2).floor; // Ideally we send at half the max interval
+        if (sendInterval < Minutes.one) {
             // But if we have no chance of at least one full resubmission process we do like chip-tool.
             // One full resubmission process takes 33-45 seconds. So 60s means we reach at least first 2 retries of a
             // second subscription report after first failed.
-            sendInterval = Math.max(this.#minIntervalFloorMs, Math.floor(maxInterval * 0.8));
+            sendInterval = Interval.max(this.#minIntervalFloor, maxInterval.times(0.8).floor);
         }
-        if (sendInterval < subscriptionMinIntervalMs) {
+        if (sendInterval < subscriptionMinInterval) {
             // But not faster than once every 2s
             logger.warn(
-                `Determined subscription send interval of ${sendInterval}ms is too low. Using maxInterval (${maxInterval}ms) instead.`,
+                `Determined subscription send interval of ${sendInterval} is too low. Using maxInterval (${maxInterval}) instead.`,
             );
-            sendInterval = subscriptionMinIntervalMs;
+            sendInterval = subscriptionMinInterval;
         }
         return { maxInterval, sendInterval };
     }
@@ -271,16 +284,16 @@ export class ServerSubscription extends Subscription {
         );
     }
 
-    get sendInterval(): number {
-        return Math.ceil(this.#sendIntervalMs / 1000);
+    get sendInterval() {
+        return this.#sendInterval;
     }
 
-    get minIntervalFloorSeconds(): number {
-        return Math.ceil(this.#minIntervalFloorMs / 1000);
+    get minIntervalFloor() {
+        return this.#minIntervalFloor;
     }
 
-    get maxIntervalCeilingSeconds(): number {
-        return Math.ceil(this.#maxIntervalCeilingMs / 1000);
+    get maxIntervalCeiling() {
+        return this.#maxIntervalCeiling;
     }
 
     override activate() {
@@ -306,7 +319,7 @@ export class ServerSubscription extends Subscription {
         if (this.#outstandingAttributeUpdates !== undefined || this.#outstandingEventsMinNumber !== undefined) {
             this.#triggerSendUpdate();
         }
-        this.#updateTimer = Time.getTimer("Subscription update", this.#sendIntervalMs, () =>
+        this.#updateTimer = Time.getTimer("Subscription update", this.#sendInterval, () =>
             this.#prepareDataUpdate(),
         ).start();
     }
@@ -326,20 +339,20 @@ export class ServerSubscription extends Subscription {
         }
 
         this.#updateTimer.stop();
-        const now = Time.nowMs();
-        const timeSinceLastUpdateMs = now - this.#lastUpdateTimeMs;
-        if (timeSinceLastUpdateMs < this.#minIntervalFloorMs) {
+        const now = Time.nowMs;
+        const timeSinceLastUpdate = Millisecs(now - this.#lastUpdateTimeMs);
+        if (timeSinceLastUpdate < this.#minIntervalFloor) {
             // Respect minimum delay time between updates
             this.#updateTimer = Time.getTimer(
                 "Subscription update",
-                this.#minIntervalFloorMs - timeSinceLastUpdateMs,
+                this.#minIntervalFloor.minus(timeSinceLastUpdate),
                 () => this.#prepareDataUpdate(),
             ).start();
             return;
         }
 
         this.#sendDelayTimer.start();
-        this.#updateTimer = Time.getTimer(`Subscription update ${this.id}`, this.#sendIntervalMs, () =>
+        this.#updateTimer = Time.getTimer(`Subscription update ${this.id}`, this.#sendInterval, () =>
             this.#prepareDataUpdate(),
         ).start();
     }
@@ -371,7 +384,7 @@ export class ServerSubscription extends Subscription {
             return;
         }
 
-        this.#lastUpdateTimeMs = Time.nowMs();
+        this.#lastUpdateTimeMs = Time.nowMs;
 
         try {
             if (await this.#sendUpdateMessage(attributeFilter, eventsMinNumber, onlyWithData)) {
@@ -526,7 +539,7 @@ export class ServerSubscription extends Subscription {
         } finally {
             session[Symbol.dispose]();
         }
-        this.#lastUpdateTimeMs = Time.nowMs();
+        this.#lastUpdateTimeMs = Time.nowMs;
     }
 
     async sendInitialReport(

--- a/packages/node/test/behaviors/color-control/ColorControlServerTest.ts
+++ b/packages/node/test/behaviors/color-control/ColorControlServerTest.ts
@@ -71,16 +71,16 @@ async function setup() {
         ms: number;
     }>();
 
-    let last = Time.nowMs();
+    let last = Time.nowMs;
 
     endpoint.events.colorControl.remainingTime$Changed!.online.on(value => {
-        events.push({ kind: "time", value, ms: Time.nowMs() - last });
-        last = Time.nowMs();
+        events.push({ kind: "time", value, ms: Time.nowMs - last });
+        last = Time.nowMs;
     });
 
     endpoint.events.colorControl.currentHue$Changed.online.on(value => {
-        events.push({ kind: "hue", value, ms: Time.nowMs() - last });
-        last = Time.nowMs();
+        events.push({ kind: "hue", value, ms: Time.nowMs - last });
+        last = Time.nowMs;
     });
 
     const complete = new Promise<void>(resolve =>

--- a/packages/node/test/behaviors/level-control/LevelControlServerTest.ts
+++ b/packages/node/test/behaviors/level-control/LevelControlServerTest.ts
@@ -193,16 +193,16 @@ async function setup() {
         ms: number;
     }>();
 
-    let last = Time.nowMs();
+    let last = Time.nowMs;
 
     endpoint.events.levelControl.remainingTime$Changed.online.on(value => {
-        const now = Time.nowMs();
+        const now = Time.nowMs;
         events.push({ kind: "time", value, ms: now - last });
         last = now;
     });
 
     endpoint.events.levelControl.currentLevel$Changed.online.on(value => {
-        const now = Time.nowMs();
+        const now = Time.nowMs;
         events.push({ kind: "level", value, ms: now - last });
         last = now;
     });

--- a/packages/node/test/behaviors/switch/SwitchServerTest.ts
+++ b/packages/node/test/behaviors/switch/SwitchServerTest.ts
@@ -6,9 +6,11 @@
 
 import { SwitchServer } from "#behaviors/switch";
 import { Switch } from "#clusters/switch";
+import { EndpointType } from "#endpoint/type/EndpointType.js";
+import { Instant, Millisecs, Seconds } from "@matter/general";
 import { MockEndpoint } from "../../endpoint/mock-endpoint.js";
 
-function createEventCatcher(device: MockEndpoint<any>) {
+function createEventCatcher(device: MockEndpoint<EndpointType>) {
     return device.captureEvents(
         SwitchServer.for(Switch.Complete).with(
             Switch.Feature.LatchingSwitch,
@@ -79,7 +81,7 @@ async function createMsAsMslMsmSwitch() {
     );
 }
 async function doTestPress(
-    device: MockEndpoint<any>,
+    device: MockEndpoint<EndpointType>,
     delay: number,
     expectedEvents: any[],
     pressSequence: number[] = [1, 0],
@@ -139,11 +141,11 @@ describe("SwitchServer", () => {
     });
 
     describe("Test Debounce", () => {
-        let device: MockEndpoint<any>;
+        let device: Awaited<ReturnType<typeof createLatchingSwitch>>;
 
         beforeEach(async () => {
             device = await createLatchingSwitch();
-            await device.set({ switch: { debounceDelay: 50 } });
+            await device.set({ switch: { debounceDelay: Millisecs(50) } });
         });
 
         it("set currentState is immediately", async () => {
@@ -169,7 +171,7 @@ describe("SwitchServer", () => {
         });
 
         it("set rawPosition with debounceDelay=0 is immediately", async () => {
-            await device.set({ switch: { debounceDelay: 0 } });
+            await device.set({ switch: { debounceDelay: Instant } });
 
             const events = createEventCatcher(device);
 
@@ -587,11 +589,11 @@ describe("SwitchServer", () => {
     });
 
     describe("Test MS & MSR & MSL", () => {
-        let device: MockEndpoint<any>;
+        let device: Awaited<ReturnType<typeof createMsMsrMslSwitch>>;
 
         beforeEach(async () => {
             device = await createMsMsrMslSwitch();
-            await device.set({ switch: { longPressDelay: 100 } });
+            await device.set({ switch: { longPressDelay: Seconds.tenth } });
         });
 
         it("Test short Press with 2 positions", async () => {
@@ -683,7 +685,7 @@ describe("SwitchServer", () => {
     });
 
     describe("Test MS & MSR & !MSL", () => {
-        let device: MockEndpoint<any>;
+        let device: Awaited<ReturnType<typeof createMsMsrSwitch>>;
 
         beforeEach(async () => {
             device = await createMsMsrSwitch();
@@ -855,7 +857,7 @@ describe("SwitchServer", () => {
     });
 
     describe("Test MS & !MSR & !MSL", () => {
-        let device: MockEndpoint<any>;
+        let device: Awaited<ReturnType<typeof createMsSwitch>>;
 
         beforeEach(async () => {
             device = await createMsSwitch();
@@ -920,11 +922,13 @@ describe("SwitchServer", () => {
     });
 
     describe("Test MS & MSR & MSL & MSM", () => {
-        let device: MockEndpoint<any>;
+        let device: Awaited<ReturnType<typeof createMsMsrMslMsmSwitch>>;
 
         beforeEach(async () => {
             device = await createMsMsrMslMsmSwitch();
-            await device.set({ switch: { longPressDelay: 100, multiPressDelay: 150, multiPressMax: 3 } });
+            await device.set({
+                switch: { longPressDelay: Seconds.tenth, multiPressDelay: Millisecs(150), multiPressMax: 3 },
+            });
         });
 
         it("Test long Press with 2 positions", async () => {
@@ -1583,7 +1587,7 @@ describe("SwitchServer", () => {
             await device.set({
                 switch: {
                     currentPosition: 1,
-                    longPressDelay: 300,
+                    longPressDelay: Millisecs(300),
                 },
             });
 
@@ -1712,11 +1716,13 @@ describe("SwitchServer", () => {
     });
 
     describe("Test MS & AS & MSL & MSM", () => {
-        let device: MockEndpoint<any>;
+        let device: Awaited<ReturnType<typeof createMsAsMslMsmSwitch>>;
 
         beforeEach(async () => {
             device = await createMsAsMslMsmSwitch();
-            await device.set({ switch: { longPressDelay: 100, multiPressDelay: 150, multiPressMax: 3 } });
+            await device.set({
+                switch: { longPressDelay: Seconds.tenth, multiPressDelay: Millisecs(150), multiPressMax: 3 },
+            });
         });
 
         it("Test long Press with 2 positions", async () => {
@@ -2208,7 +2214,7 @@ describe("SwitchServer", () => {
             await device.set({
                 switch: {
                     currentPosition: 1,
-                    longPressDelay: 300,
+                    longPressDelay: Millisecs(300),
                 },
             });
 
@@ -2335,7 +2341,7 @@ describe("SwitchServer", () => {
             await device.set({
                 switch: {
                     currentPosition: 1,
-                    longPressDelay: 300,
+                    longPressDelay: Millisecs(300),
                 },
             });
 

--- a/packages/node/test/node/ServerNodeTest.ts
+++ b/packages/node/test/node/ServerNodeTest.ts
@@ -177,7 +177,7 @@ describe("ServerNode", () => {
 
         const advertisement = DnsCodec.decode(await advertisementReceived);
 
-        expect(advertisement?.answers[0]?.ttl).equals(120);
+        expect(advertisement?.answers[0]?.ttl.secs).equals(120);
 
         function answer(name: string) {
             for (const answer of (advertisement as DnsMessage).answers) {
@@ -212,7 +212,7 @@ describe("ServerNode", () => {
         await node.close();
 
         const expiration = DnsCodec.decode(await expirationReceived);
-        expect(expiration?.answers[0]?.ttl).equals(0);
+        expect(expiration?.answers[0]?.ttl.secs).equals(0);
     });
 
     it("commissions", async () => {

--- a/packages/node/test/node/mock-site.ts
+++ b/packages/node/test/node/mock-site.ts
@@ -13,6 +13,7 @@ import {
     MockCrypto,
     Network,
     NetworkSimulator,
+    Seconds,
     Storage,
     StorageBackendMemory,
     StorageService,
@@ -108,7 +109,7 @@ export class MockSite {
         controllerCrypto.entropic = deviceCrypto.entropic = true;
 
         const { passcode, discriminator } = device.state.commissioning;
-        await MockTime.resolve(controller.nodes.commission({ passcode, discriminator, timeoutSeconds: 90 }), {
+        await MockTime.resolve(controller.nodes.commission({ passcode, discriminator, timeout: Seconds(90) }), {
             macrotasks: true,
         });
 

--- a/packages/nodejs-ble/src/BlenoBleServer.ts
+++ b/packages/nodejs-ble/src/BlenoBleServer.ts
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, Channel, InternalError, Logger, Time, createPromise } from "#general";
+import { Bytes, Channel, InternalError, Logger, Seconds, Time, createPromise } from "#general";
 import {
     BLE_MATTER_C1_CHARACTERISTIC_UUID,
     BLE_MATTER_C2_CHARACTERISTIC_UUID,
     BLE_MATTER_C3_CHARACTERISTIC_UUID,
     BLE_MATTER_SERVICE_UUID_SHORT,
-    BTP_CONN_RSP_TIMEOUT_MS,
+    BTP_CONN_RSP_TIMEOUT,
     BleChannel,
     BleError,
     BtpFlowError,
@@ -146,7 +146,7 @@ export class BlenoBleServer extends BleChannel<Bytes> {
     private writeConformationResolver: ((value: void) => void) | undefined;
 
     public clientAddress: string | undefined;
-    private btpHandshakeTimeout = Time.getTimer("BTP handshake timeout", BTP_CONN_RSP_TIMEOUT_MS, () =>
+    private btpHandshakeTimeout = Time.getTimer("BTP handshake timeout", BTP_CONN_RSP_TIMEOUT, () =>
         this.btpHandshakeTimeoutTriggered(),
     );
     #disconnected = false;
@@ -331,8 +331,8 @@ export class BlenoBleServer extends BleChannel<Bytes> {
         }
     }
 
-    async advertise(advertiseData: Bytes, additionalAdvertisementData?: Bytes, intervalMs = 100) {
-        process.env["BLENO_ADVERTISING_INTERVAL"] = intervalMs.toString();
+    async advertise(advertiseData: Bytes, additionalAdvertisementData?: Bytes, interval = Seconds.tenth) {
+        process.env["BLENO_ADVERTISING_INTERVAL"] = interval.ms.toString();
 
         this.advertisingData = Buffer.from(Bytes.of(advertiseData));
 

--- a/packages/nodejs-ble/src/BlenoPeripheralInterface.ts
+++ b/packages/nodejs-ble/src/BlenoPeripheralInterface.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, Channel, ChannelType, TransportInterface } from "#general";
+import { Bytes, Channel, ChannelType, Interval, TransportInterface } from "#general";
 import { BlePeripheralInterface } from "@matter/protocol";
 import { BlenoBleServer } from "./BlenoBleServer.js";
 
@@ -35,8 +35,8 @@ export class BlenoPeripheralInterface implements BlePeripheralInterface {
         return this.blenoServer.clientAddress === address;
     }
 
-    advertise(advertiseData: Bytes, additionalAdvertisementData?: Bytes, intervalMs?: number) {
-        return this.blenoServer.advertise(advertiseData, additionalAdvertisementData, intervalMs);
+    advertise(advertiseData: Bytes, additionalAdvertisementData?: Bytes, interval?: Interval) {
+        return this.blenoServer.advertise(advertiseData, additionalAdvertisementData, interval);
     }
 
     stopAdvertising() {

--- a/packages/nodejs-shell/src/shell/cmd_discover.ts
+++ b/packages/nodejs-shell/src/shell/cmd_discover.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Diagnostic } from "#general";
+import { Diagnostic, Seconds } from "#general";
 import { CommissionableDeviceIdentifiers } from "#protocol";
 import { ManualPairingCodeCodec, VendorId } from "#types";
 import type { Argv } from "yargs";
@@ -113,7 +113,7 @@ export default function commands(theNode: MatterNode) {
                                 onIpNetwork: true,
                             },
                             device => console.log(`Discovered device ${Diagnostic.json(device)}`),
-                            timeoutSeconds,
+                            Seconds(timeoutSeconds),
                         );
 
                         console.log(`Discovered ${results.length} devices`, results);

--- a/packages/nodejs/src/net/NodeJsNetwork.ts
+++ b/packages/nodejs/src/net/NodeJsNetwork.ts
@@ -9,6 +9,7 @@ import {
     InterfaceType,
     isIPv6,
     Logger,
+    Minutes,
     Network,
     NetworkError,
     NetworkInterface,
@@ -82,7 +83,7 @@ export class NodeJsNetwork extends Network {
     private static readonly netInterfaces = new Cache<string | undefined>(
         "Network interface",
         (ip: string) => this.getNetInterfaceForRemoteAddress(ip),
-        5 * 60 * 1000 /* 5mn */,
+        Minutes(5),
     );
 
     override async close() {

--- a/packages/nodejs/src/net/NodeJsUdpChannel.ts
+++ b/packages/nodejs/src/net/NodeJsUdpChannel.ts
@@ -13,9 +13,11 @@ import {
     isIPv6,
     Logger,
     MAX_UDP_MESSAGE_SIZE,
+    Millisecs,
     NetworkError,
     NoAddressAvailableError,
     repackErrorAs,
+    Seconds,
     Time,
     UdpChannel,
     UdpChannelOptions,
@@ -29,7 +31,7 @@ const logger = Logger.get("NodejsChannel");
 
 // UDP should be sent out in some ms so if we needed 1s+, we have a problem
 // 1s should be fine because we do not require any DNS lookups because we usually work with IPs directly
-const UDP_SEND_TIMEOUT_CHECK_INTERVAL_MS = 1_000;
+const UDP_SEND_TIMEOUT_CHECK_INTERVAL = Seconds.one;
 
 function createDgramSocket(host: string | undefined, port: number | undefined, options: dgram.SocketOptions) {
     const socket = dgram.createSocket(options);
@@ -105,7 +107,7 @@ export class NodeJsUdpChannel implements UdpChannel {
      * Timer for a maximum interval to check for dangling send calls that are not completed.
      * The way it is implemented we ensure that any "send" is rejected latest after < 2s
      */
-    readonly #sendTimer = Time.getTimer("UDPChannel.send timeout check", UDP_SEND_TIMEOUT_CHECK_INTERVAL_MS, () =>
+    readonly #sendTimer = Time.getTimer("UDPChannel.send timeout check", UDP_SEND_TIMEOUT_CHECK_INTERVAL, () =>
         this.#rejectDanglingSends(),
     );
     readonly #sendsInProgress = new Map<Promise<void>, { sendMs: number; rejecter: (reason?: any) => void }>();
@@ -177,10 +179,10 @@ export class NodeJsUdpChannel implements UdpChannel {
             // nothing to do
             return;
         }
-        const now = Time.nowMs();
+        const now = Time.nowMs;
         for (const [promise, { sendMs, rejecter }] of this.#sendsInProgress) {
-            const elapsed = now - sendMs;
-            if (elapsed >= UDP_SEND_TIMEOUT_CHECK_INTERVAL_MS) {
+            const elapsed = Millisecs(now - sendMs);
+            if (elapsed >= UDP_SEND_TIMEOUT_CHECK_INTERVAL) {
                 this.#sendsInProgress.delete(promise);
                 rejecter(new NetworkError("UDP send timeout"));
             }
@@ -215,7 +217,7 @@ export class NodeJsUdpChannel implements UdpChannel {
             }
         };
 
-        this.#sendsInProgress.set(promise, { sendMs: Time.nowMs(), rejecter });
+        this.#sendsInProgress.set(promise, { sendMs: Time.nowMs, rejecter });
         if (!this.#sendTimer.isRunning) {
             this.#sendTimer.start();
         }

--- a/packages/nodejs/src/storage/StorageBackendJsonFile.ts
+++ b/packages/nodejs/src/storage/StorageBackendJsonFile.ts
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { fromJson, StorageBackendMemory, StorageError, SupportedStorageTypes, Time, toJson } from "#general";
+import { fromJson, Seconds, StorageBackendMemory, StorageError, SupportedStorageTypes, Time, toJson } from "#general";
 import { readFileSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 
 export class StorageBackendJsonFile extends StorageBackendMemory {
     /** We store changes after a value was set to the storage, but not more often than this setting (in ms). */
-    static commitDelay = 1000;
+    static commitDelay = Seconds.one;
     committed = Promise.resolve();
 
     private readonly commitTimer = Time.getTimer("Storage commit", StorageBackendJsonFile.commitDelay, () =>

--- a/packages/nodejs/src/time/startup.ts
+++ b/packages/nodejs/src/time/startup.ts
@@ -7,5 +7,5 @@
 import { Time } from "#general";
 import { uptime } from "node:os";
 
-Time.startup.processMs = Math.floor(Time.nowMs() - process.uptime() * 1000);
-Time.startup.systemMs = Math.floor(Time.nowMs() - uptime());
+Time.startup.processMs = Math.floor(Time.nowMs - process.uptime() * 1000);
+Time.startup.systemMs = Math.floor(Time.nowMs - uptime());

--- a/packages/protocol/src/action/client/ClientSubscriptions.ts
+++ b/packages/protocol/src/action/client/ClientSubscriptions.ts
@@ -14,6 +14,7 @@ import {
     Environment,
     Environmental,
     Logger,
+    Millisecs,
     Time,
     TimeoutError,
     Timer,
@@ -88,7 +89,7 @@ export class ClientSubscriptions {
      * Restart the timeout timer for the current set of active subscriptions.
      */
     resetTimer() {
-        const now = Time.nowMs();
+        const now = Time.nowMs;
         let nextTimeoutAt: number | undefined;
 
         // Process each subscription
@@ -127,9 +128,13 @@ export class ClientSubscriptions {
             this.#nextTimeoutAt = nextTimeoutAt;
             if (this.#timeout) {
                 this.#timeout?.stop();
-                this.#timeout.intervalMs = nextTimeoutAt - now;
+                this.#timeout.interval = Millisecs(nextTimeoutAt - now);
             } else {
-                this.#timeout = Time.getTimer("SubscriptionTimeout", nextTimeoutAt - now, this.resetTimer.bind(this));
+                this.#timeout = Time.getTimer(
+                    "SubscriptionTimeout",
+                    Millisecs(nextTimeoutAt - now),
+                    this.resetTimer.bind(this),
+                );
             }
         }
     }

--- a/packages/protocol/src/advertisement/ble/BleAdvertisement.ts
+++ b/packages/protocol/src/advertisement/ble/BleAdvertisement.ts
@@ -5,18 +5,19 @@
  */
 
 import { BtpCodec } from "#codec/BtpCodec.js";
+import { Days, Hours, Interval, Minutes } from "#general";
 import { Advertisement } from "../Advertisement.js";
 import { ServiceDescription } from "../ServiceDescription.js";
 import type { BleAdvertiser } from "./BleAdvertiser.js";
 
 // Period for "fast" broadcast.  See core spec 5.4.2.5.3
-const EARLY_INTERVAL_SLEEP = 30_000;
+const EARLY_INTERVAL_SLEEP = Minutes.half;
 
 // Period for "medium" broadcast.  See core spec 5.4.2.5.3
-const LATE_INTERVAL_SLEEP = 15 * 60_000 - EARLY_INTERVAL_SLEEP;
+const LATE_INTERVAL_SLEEP = Hours.quarter.minus(EARLY_INTERVAL_SLEEP);
 
 // Period for "extended" broadcast.  See core spec 5.4.2.5.3
-const EXTENDED_INTERVAL_SLEEP = 48 * 60 * 60_000 - LATE_INTERVAL_SLEEP;
+const EXTENDED_INTERVAL_SLEEP = Days(2).minus(LATE_INTERVAL_SLEEP);
 
 export class BleAdvertisement extends Advertisement<ServiceDescription.Commissionable> {
     declare advertiser: BleAdvertiser;
@@ -58,10 +59,10 @@ export class BleAdvertisement extends Advertisement<ServiceDescription.Commissio
                 await peripheral.advertise(advertisementData, aad, broadcastInterval);
 
                 // Wait for timeout at this broadcast interval
-                await context.sleep("BLE advertisement interval", Math.min(timeout, sleepTime));
+                await context.sleep("BLE advertisement interval", Interval.min(timeout, sleepTime));
 
-                timeout -= sleepTime;
-                if ((timeout -= sleepTime) <= 0) {
+                timeout = timeout.minus(sleepTime);
+                if (timeout.length <= 0) {
                     break;
                 }
             }

--- a/packages/protocol/src/advertisement/ble/BleAdvertiser.ts
+++ b/packages/protocol/src/advertisement/ble/BleAdvertiser.ts
@@ -5,9 +5,9 @@
  */
 
 import { BlePeripheralInterface } from "#ble/Ble.js";
-import { ImplementationError } from "#general";
+import { ImplementationError, Interval, Millisecs } from "#general";
 import { DatatypeModel, FieldElement } from "#model";
-import { MAXIMUM_COMMISSIONING_TIMEOUT_S } from "#types";
+import { MAXIMUM_COMMISSIONING_TIMEOUT } from "#types";
 import { Advertisement } from "../Advertisement.js";
 import { Advertiser } from "../Advertiser.js";
 import { CommissioningMode } from "../CommissioningMode.js";
@@ -66,38 +66,38 @@ export namespace BleAdvertiser {
         /**
          * Advertisement timeout.
          */
-        readonly timeout: number;
+        readonly timeout: Interval;
 
         /**
          * Transmission interval for first 30 seconds.
          *
          * Per core spec 5.4.2.5.3 should be 20-60ms.
          */
-        readonly earlyInterval: number;
+        readonly earlyInterval: Interval;
 
         /**
          * Transmission interval after first 30 seconds but before 15 minutes.
          *
          * Per core spec 5.4.2.5.3 should be 150-1285ms.
          */
-        readonly lateInterval: number;
+        readonly lateInterval: Interval;
 
         /**
          * Transmission interval after 15 minutes.
          *
          * Per core spec 5.4.2.5.3 should be ~1285ms.
          */
-        readonly extendedInterval: number;
+        readonly extendedInterval: Interval;
     }
 
     export interface Options extends Partial<Configuration> {}
 
     export function Configuration(options?: Options) {
         return {
-            timeout: MAXIMUM_COMMISSIONING_TIMEOUT_S,
-            earlyInterval: 20,
-            lateInterval: 150,
-            extendedInterval: 1285,
+            timeout: MAXIMUM_COMMISSIONING_TIMEOUT,
+            earlyInterval: Millisecs(20),
+            lateInterval: Millisecs(150),
+            extendedInterval: Millisecs(1285),
             ...options,
         };
     }

--- a/packages/protocol/src/advertisement/mdns/MdnsAdvertisement.ts
+++ b/packages/protocol/src/advertisement/mdns/MdnsAdvertisement.ts
@@ -51,7 +51,7 @@ export abstract class MdnsAdvertisement<T extends ServiceDescription = ServiceDe
         this.#stopAt = undefined;
         let number = 0;
         for (const retryInterval of this.advertiser.broadcastScheduleFor(this, event)) {
-            if (this.#stopAt !== undefined && this.#stopAt <= Time.nowMs()) {
+            if (this.#stopAt !== undefined && this.#stopAt <= Time.nowMs) {
                 break;
             }
 
@@ -89,12 +89,12 @@ export abstract class MdnsAdvertisement<T extends ServiceDescription = ServiceDe
             return;
         }
 
-        if (broadcastAfterConnection <= 0) {
+        if (broadcastAfterConnection.length <= 0) {
             this.stop();
             return;
         }
 
-        this.#stopAt = Time.nowMs() + broadcastAfterConnection;
+        this.#stopAt = Time.nowMs + broadcastAfterConnection.ms;
     }
 
     override serviceDisconnected() {
@@ -148,9 +148,9 @@ export abstract class MdnsAdvertisement<T extends ServiceDescription = ServiceDe
 
     get #txtValues() {
         const values: Record<string, unknown> = {
-            SII: this.description.idleIntervalMs /* Session Idle Interval */,
-            SAI: this.description.activeIntervalMs /* Session Active Interval */,
-            SAT: this.description.activeThresholdMs /* Session Active Threshold */,
+            SII: this.description.idleInterval?.ms /* Session Idle Interval */,
+            SAI: this.description.activeInterval?.ms /* Session Active Interval */,
+            SAT: this.description.activeThreshold?.ms /* Session Active Threshold */,
             ...this.txtValues,
         };
 

--- a/packages/protocol/src/advertisement/mdns/MdnsAdvertiser.ts
+++ b/packages/protocol/src/advertisement/mdns/MdnsAdvertiser.ts
@@ -6,10 +6,20 @@
 
 import { Advertiser } from "#advertisement/Advertiser.js";
 import { ServiceDescription } from "#advertisement/ServiceDescription.js";
-import { Bytes, Crypto, ImplementationError, InternalError, RetrySchedule, STANDARD_MATTER_PORT } from "#general";
+import {
+    Bytes,
+    Crypto,
+    ImplementationError,
+    Instant,
+    InternalError,
+    Interval,
+    RetrySchedule,
+    Seconds,
+    STANDARD_MATTER_PORT,
+} from "#general";
 import type { MdnsServer } from "#mdns/MdnsServer.js";
 import { DatatypeModel, FieldElement } from "#model";
-import { MAXIMUM_COMMISSIONING_TIMEOUT_S } from "#types";
+import { MAXIMUM_COMMISSIONING_TIMEOUT } from "#types";
 import { CommissionableMdnsAdvertisement } from "./CommissionableMdnsAdvertisement.js";
 import { CommissionerMdnsAdvertisement } from "./CommissionerMdnsAdvertisement.js";
 import type { MdnsAdvertisement } from "./MdnsAdvertisement.js";
@@ -188,7 +198,7 @@ export namespace MdnsAdvertiser {
          * Set to zero to terminate broadcast immediately after connection.  If undefined broadcasts will continue until
          * terminated by {@link timeout} or {@link maximumCount}.
          */
-        readonly broadcastAfterConnection?: number;
+        readonly broadcastAfterConnection?: Interval;
     }
 
     /**
@@ -196,23 +206,23 @@ export namespace MdnsAdvertiser {
      */
     export const DefaultBroadcastSchedule: BroadcastSchedule = {
         // Mandated by MDNS specification
-        initialInterval: 1_000,
+        initialInterval: Seconds.one,
 
         // Maximum commissioning timeout per Matter specification 5.4.2.3.1, although
-        timeout: MAXIMUM_COMMISSIONING_TIMEOUT_S * 1000,
+        timeout: MAXIMUM_COMMISSIONING_TIMEOUT,
 
         // Minimum per MDNS specification
         backoffFactor: 2,
 
         // Technically this may result in us emitting more than 8 packets which is the maximum per the MDNS
         // specification but extra packets will only come every 90 seconds
-        maximumInterval: 90_000,
+        maximumInterval: Seconds(90),
 
         // Not in any specification AFAIK but common sense to reduce thundering herd
         jitterFactor: 0.25,
 
         // Generally operational broadcast is unnecessary once an operational connection is established
-        broadcastAfterConnection: 0,
+        broadcastAfterConnection: Instant,
     };
 
     /**

--- a/packages/protocol/src/ble/Ble.ts
+++ b/packages/protocol/src/ble/Ble.ts
@@ -4,7 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, Channel, ChannelType, MatterError, NetInterface, NoProviderError, TransportInterface } from "#general";
+import {
+    Bytes,
+    Channel,
+    ChannelType,
+    Interval,
+    MatterError,
+    NetInterface,
+    NoProviderError,
+    TransportInterface,
+} from "#general";
 import { Scanner } from "../common/Scanner.js";
 import { BLE_MAX_MATTER_PAYLOAD_SIZE } from "./BleConsts.js";
 
@@ -28,7 +37,7 @@ export abstract class Ble {
 }
 
 export interface BlePeripheralInterface extends TransportInterface {
-    advertise(advertiseData: Bytes, additionalAdvertisementData?: Bytes, intervalMs?: number): Promise<void>;
+    advertise(advertiseData: Bytes, additionalAdvertisementData?: Bytes, interval?: Interval): Promise<void>;
     stopAdvertising(): Promise<void>;
 }
 

--- a/packages/protocol/src/ble/BleConsts.ts
+++ b/packages/protocol/src/ble/BleConsts.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MAX_UDP_MESSAGE_SIZE } from "#general";
+import { MAX_UDP_MESSAGE_SIZE, Minutes, Seconds } from "#general";
 
 /** @see {@link MatterSpecification.v11.Core} § 4.17.3.2 */
 export const BLE_MATTER_SERVICE_UUID_SHORT = "fff6";
@@ -22,18 +22,18 @@ export const BTP_MAXIMUM_WINDOW_SIZE = 255; // Server maximum window size
  * The maximum amount of time after sending a BTP Session Handshake request to wait for a BTP Session Handshake response
  * before closing the connection.
  */
-export const BTP_CONN_RSP_TIMEOUT_MS = 5_000; // timer starts when receives handshake request & waits for a subscription request on c2
+export const BTP_CONN_RSP_TIMEOUT = Seconds(5); // timer starts when receives handshake request & waits for a subscription request on c2
 
 /** The maximum amount of time after receipt of a segment before a stand-alone ACK must be sent. */
-export const BTP_ACK_TIMEOUT_MS = 15_000; // timer in ms before ack should be sent for a segment
+export const BTP_ACK_TIMEOUT = Minutes.quarter; // timer in ms before ack should be sent for a segment
 
-export const BTP_SEND_ACK_TIMEOUT_MS = BTP_ACK_TIMEOUT_MS / 3; // timer starts when we receive a packet and stops when we sends its ack
+export const BTP_SEND_ACK_TIMEOUT = BTP_ACK_TIMEOUT.dividedBy(3); // timer starts when we receive a packet and stops when we sends its ack
 
 /**
  * The maximum amount of time no unique data has been sent over a BTP session before the Central Device must close the
  * BTP session.
  */
-export const BTP_CONN_IDLE_TIMEOUT = 30_000;
+export const BTP_CONN_IDLE_TIMEOUT = Minutes.half;
 
 /**
  * The maximum message size that can be transported in a Matter message via BTP.

--- a/packages/protocol/src/ble/BtpSessionHandler.ts
+++ b/packages/protocol/src/ble/BtpSessionHandler.ts
@@ -9,10 +9,10 @@ import { BtpCodec } from "../codec/BtpCodec.js";
 import {
     BLE_MAXIMUM_BTP_MTU,
     BLE_MINIMUM_ATT_MTU,
-    BTP_ACK_TIMEOUT_MS,
+    BTP_ACK_TIMEOUT,
     BTP_CONN_IDLE_TIMEOUT,
     BTP_MAXIMUM_WINDOW_SIZE,
-    BTP_SEND_ACK_TIMEOUT_MS,
+    BTP_SEND_ACK_TIMEOUT,
 } from "./BleConsts.js";
 
 export class BtpMatterError extends MatterError {}
@@ -29,7 +29,7 @@ export class BtpSessionHandler {
     private currentIncomingSegmentedPayload: Bytes | undefined;
     private prevIncomingSequenceNumber = 255; // Incoming Sequence Number received. Set to 255 to start at 0
     private prevIncomingAckNumber = -1; // Previous ackNumber received
-    private readonly ackReceiveTimer = Time.getTimer("BTP ack timeout", BTP_ACK_TIMEOUT_MS, () =>
+    private readonly ackReceiveTimer = Time.getTimer("BTP ack timeout", BTP_ACK_TIMEOUT, () =>
         this.btpAckTimeoutTriggered(),
     );
 
@@ -37,7 +37,7 @@ export class BtpSessionHandler {
     private prevAckedSequenceNumber = -1; // Previous (outgoing) Acked Sequence Number
     private readonly queuedOutgoingMatterMessages = new Array<DataReader<Endian.Little>>();
     private sendInProgress = false;
-    private readonly sendAckTimer = Time.getTimer("BTP send timeout", BTP_SEND_ACK_TIMEOUT_MS, () =>
+    private readonly sendAckTimer = Time.getTimer("BTP send timeout", BTP_SEND_ACK_TIMEOUT, () =>
         this.btpSendAckTimeoutTriggered(),
     );
     private isActive = true;

--- a/packages/protocol/src/certificate/AttestationCertificateManager.ts
+++ b/packages/protocol/src/certificate/AttestationCertificateManager.ts
@@ -76,7 +76,7 @@ export class AttestationCertificateManager {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     private async generatePAACert(vendorId?: VendorId) {
-        const now = Time.get().now();
+        const now = Time.now;
         const cert = new Paa({
             serialNumber: Bytes.fromHex(toHex(this.paaCertId)),
             signatureAlgorithm: 1 /* EcdsaWithSHA256 */,
@@ -111,7 +111,7 @@ export class AttestationCertificateManager {
     }
 
     private async generatePAICert(vendorId: VendorId, productId?: number) {
-        const now = Time.get().now();
+        const now = Time.now;
         const cert = new Pai({
             serialNumber: Bytes.fromHex(toHex(this.#paiCertId)),
             signatureAlgorithm: 1 /* EcdsaWithSHA256 */,
@@ -146,7 +146,7 @@ export class AttestationCertificateManager {
     }
 
     async generateDaCert(publicKey: Bytes, vendorId: VendorId, productId: number) {
-        const now = Time.get().now();
+        const now = Time.now;
         const certId = this.#nextCertificateId++;
         const cert = new Dac({
             serialNumber: Bytes.fromHex(toHex(certId)),

--- a/packages/protocol/src/certificate/CertificateAuthority.ts
+++ b/packages/protocol/src/certificate/CertificateAuthority.ts
@@ -117,7 +117,7 @@ export class CertificateAuthority {
     }
 
     async #generateRootCert() {
-        const now = Time.get().now();
+        const now = Time.now;
         const cert = new Rcac({
             serialNumber: Bytes.fromHex(toHex(this.#rootCertId)),
             signatureAlgorithm: 1 /* EcdsaWithSHA256 */,
@@ -148,7 +148,7 @@ export class CertificateAuthority {
         nodeId: NodeId,
         caseAuthenticatedTags?: CaseAuthenticatedTag[],
     ) {
-        const now = Time.get().now();
+        const now = Time.now;
         const certId = this.#nextCertificateId++;
         const cert = new Noc({
             serialNumber: Bytes.fromHex(toHex(certId)),

--- a/packages/protocol/src/certificate/kinds/OperationalBase.ts
+++ b/packages/protocol/src/certificate/kinds/OperationalBase.ts
@@ -62,10 +62,10 @@ export abstract class OperationalBase<CT extends X509Certificate> extends X509Ba
 
         // notBefore date should be already reached, notAfter is not checked right now
         // TODO: implement real checks when we add "Last known Good UTC time"
-        if (cert.notBefore * 1000 > Time.nowMs()) {
-            logger.warn(`Certificate notBefore date is in the future: ${cert.notBefore * 1000} vs ${Time.nowMs()}`);
+        if (cert.notBefore * 1000 > Time.nowMs) {
+            logger.warn(`Certificate notBefore date is in the future: ${cert.notBefore * 1000} vs ${Time.nowMs}`);
             /*throw new CertificateError(
-                `Certificate notBefore date is in the future: ${cert.notBefore * 1000} vs ${Time.nowMs()}`,
+                `Certificate notBefore date is in the future: ${cert.notBefore * 1000} vs ${Time.nowMs}`,
             );*/
         }
     }

--- a/packages/protocol/src/cluster/client/ClusterClient.ts
+++ b/packages/protocol/src/cluster/client/ClusterClient.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { capitalize, Diagnostic, ImplementationError, Logger, Merge } from "#general";
+import { capitalize, Diagnostic, ImplementationError, Interval, Logger, Merge } from "#general";
 import {
     Attribute,
     AttributeId,
@@ -387,16 +387,16 @@ export function ClusterClient<const T extends ClusterType>(
             request: RequestT,
             options: {
                 asTimedRequest?: boolean;
-                timedRequestTimeoutMs?: number;
-                expectedProcessingTimeMs?: number;
+                timedRequestTimeout?: Interval;
+                expectedProcessingTime?: Interval;
                 useExtendedFailSafeMessageResponseTimeout?: boolean;
             } = {},
         ) => {
             const {
                 asTimedRequest,
-                timedRequestTimeoutMs,
+                timedRequestTimeout,
                 useExtendedFailSafeMessageResponseTimeout,
-                expectedProcessingTimeMs,
+                expectedProcessingTime,
             } = options;
             if (isGroupAddress) {
                 return interactionClient.invokeWithSuppressedResponse<Command<RequestT, ResponseT, any>>({
@@ -404,7 +404,7 @@ export function ClusterClient<const T extends ClusterType>(
                     command: commandDef[commandName],
                     request,
                     asTimedRequest,
-                    timedRequestTimeoutMs,
+                    timedRequestTimeout,
                 });
             }
             return interactionClient.invoke<Command<RequestT, ResponseT, any>>({
@@ -413,8 +413,8 @@ export function ClusterClient<const T extends ClusterType>(
                 command: commandDef[commandName],
                 request,
                 asTimedRequest,
-                timedRequestTimeoutMs,
-                expectedProcessingTimeMs,
+                timedRequestTimeout,
+                expectedProcessingTime,
                 useExtendedFailSafeMessageResponseTimeout,
             });
         };

--- a/packages/protocol/src/cluster/client/ClusterClientTypes.ts
+++ b/packages/protocol/src/cluster/client/ClusterClientTypes.ts
@@ -3,7 +3,7 @@
  * Copyright 2022-2025 Matter.js Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Merge } from "#general";
+import { Interval, Merge } from "#general";
 import {
     Attribute,
     AttributeId,
@@ -63,13 +63,13 @@ export type SignatureFromCommandSpec<C extends Command<any, any, any>> = (
         asTimedRequest?: boolean;
 
         /** Override the request timeout when the command is sent as times request. Default are 10s. */
-        timedRequestTimeoutMs?: number;
+        timedRequestTimeout?: Interval;
 
         /**
          * Expected processing time on the device side for this command.
          * useExtendedFailSafeMessageResponseTimeout is ignored if this value is set.
          */
-        expectedProcessingTimeMs?: number;
+        expectedProcessingTime?: Interval;
 
         /**
          * Use the extended fail-safe message response timeout of 30 seconds. Use this for all commands

--- a/packages/protocol/src/cluster/client/EventClient.ts
+++ b/packages/protocol/src/cluster/client/EventClient.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ImplementationError } from "#general";
+import { ImplementationError, Interval } from "#general";
 import { ClusterId, EndpointNumber, Event, EventId, EventNumber } from "#types";
 import { DecodedEventData } from "../../interaction/EventDataDecoder.js";
 import { InteractionClient } from "../../interaction/InteractionClient.js";
@@ -58,8 +58,8 @@ export class EventClient<T> {
     }
 
     async subscribe(
-        minIntervalFloorSeconds: number,
-        maxIntervalCeilingSeconds: number,
+        minIntervalFloor: Interval,
+        maxIntervalCeiling: Interval,
         isUrgent = true,
         minimumEventNumber?: EventNumber,
         isFabricFiltered?: boolean,
@@ -71,8 +71,8 @@ export class EventClient<T> {
             endpointId: this.endpointId,
             clusterId: this.clusterId,
             event: this.event,
-            minIntervalFloorSeconds,
-            maxIntervalCeilingSeconds,
+            minIntervalFloor,
+            maxIntervalCeiling,
             isUrgent,
             minimumEventNumber,
             isFabricFiltered,

--- a/packages/protocol/src/common/FailsafeContext.ts
+++ b/packages/protocol/src/common/FailsafeContext.ts
@@ -8,6 +8,7 @@ import {
     AsyncObservable,
     Bytes,
     Construction,
+    Interval,
     Logger,
     MatterFlowError,
     UnexpectedDataError,
@@ -46,7 +47,7 @@ export abstract class FailsafeContext {
     #commissioned = AsyncObservable<[], void>();
 
     constructor(options: FailsafeContext.Options) {
-        const { expiryLengthSeconds, associatedFabric, maxCumulativeFailsafeSeconds } = options;
+        const { expiryLength, associatedFabric, maxCumulativeFailsafe } = options;
 
         this.#sessions = options.sessions;
         this.#fabrics = options.fabrics;
@@ -61,21 +62,18 @@ export abstract class FailsafeContext {
 
             // If ExpiryLengthSeconds is non-zero and the fail-safe timer was not currently armed, then the fail-safe
             // timer SHALL be armed for that duration.
-            this.#failsafe = new FailsafeTimer(
-                associatedFabric,
-                expiryLengthSeconds,
-                maxCumulativeFailsafeSeconds,
-                () => this.#failSafeExpired(),
+            this.#failsafe = new FailsafeTimer(associatedFabric, expiryLength, maxCumulativeFailsafe, () =>
+                this.#failSafeExpired(),
             );
-            logger.debug(`Arm failSafe timer for ${expiryLengthSeconds}s.`);
+            logger.debug(`Arm failSafe timer for ${expiryLength}`);
         });
     }
 
-    async extend(fabric: Fabric | undefined, expiryLengthSeconds: number) {
+    async extend(fabric: Fabric | undefined, expiryLength: Interval) {
         await this.#construction;
-        await this.#failsafe?.reArm(fabric, expiryLengthSeconds);
-        if (expiryLengthSeconds > 0) {
-            logger.debug(`Extend failSafe timer for ${expiryLengthSeconds}s.`);
+        await this.#failsafe?.reArm(fabric, expiryLength);
+        if (expiryLength.length > 0) {
+            logger.debug(`Extend failSafe timer for ${expiryLength}`);
         }
     }
 
@@ -341,8 +339,8 @@ export namespace FailsafeContext {
     export interface Options {
         sessions: SessionManager;
         fabrics: FabricManager;
-        expiryLengthSeconds: number;
-        maxCumulativeFailsafeSeconds: number;
+        expiryLength: Interval;
+        maxCumulativeFailsafe: Interval;
         associatedFabric: Fabric | undefined;
     }
 }

--- a/packages/protocol/src/common/FailsafeTimer.ts
+++ b/packages/protocol/src/common/FailsafeTimer.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Logger, MatterFlowError, Time, Timer } from "#general";
+import { Interval, Logger, MatterFlowError, Time, Timer } from "#general";
 import { Fabric } from "../fabric/Fabric.js";
 import type { FailsafeContext } from "./FailsafeContext.js";
 
@@ -22,16 +22,14 @@ export class FailsafeTimer {
 
     constructor(
         public associatedFabric: Fabric | undefined,
-        expiryLengthSeconds: number,
-        maxCumulativeFailsafeSeconds: number,
+        expiryLength: Interval,
+        maxCumulativeFailsafe: Interval,
         expiryCallback: () => Promise<void>,
     ) {
         this.#expiryCallback = expiryCallback;
-        this.#failsafeTimer = this.#startFailsafeTimer(expiryLengthSeconds);
-        this.#maxCumulativeFailsafeTimer = Time.getTimer(
-            "Max cumulative failsafe",
-            maxCumulativeFailsafeSeconds * 1000,
-            () => this.expire(),
+        this.#failsafeTimer = this.#startFailsafeTimer(expiryLength);
+        this.#maxCumulativeFailsafeTimer = Time.getTimer("Max cumulative failsafe", maxCumulativeFailsafe, () =>
+            this.expire(),
         ).start();
     }
 
@@ -45,7 +43,7 @@ export class FailsafeTimer {
     }
 
     /** Handle "Re-Arming" an existing FailSafe context to extend the timer, expire or fail if not allowed. */
-    async reArm(associatedFabric: Fabric | undefined, expiryLengthSeconds: number) {
+    async reArm(associatedFabric: Fabric | undefined, expiry: Interval) {
         if (!this.#failsafeTimer.isRunning) {
             throw new MatterFlowError("FailSafe already expired.");
         }
@@ -58,7 +56,7 @@ export class FailsafeTimer {
 
         this.#failsafeTimer.stop();
 
-        if (expiryLengthSeconds === 0) {
+        if (expiry.length === 0) {
             // If ExpiryLengthSeconds is 0 and the fail-safe timer was already armed and the accessing fabric matches
             // the Fabric currently associated with the fail-safe context, then the fail-safe timer SHALL be
             // immediately expired (see further below for side-effects of expiration).
@@ -67,7 +65,7 @@ export class FailsafeTimer {
             // If ExpiryLengthSeconds is non-zero and the fail-safe timer was currently armed, and the accessing Fabric
             // matches the fail-safe context’s associated Fabric, then the fail-safe timer SHALL be re- armed to expire
             // in ExpiryLengthSeconds.
-            this.#failsafeTimer = this.#startFailsafeTimer(expiryLengthSeconds);
+            this.#failsafeTimer = this.#startFailsafeTimer(expiry);
         }
     }
 
@@ -83,8 +81,8 @@ export class FailsafeTimer {
         this.#maxCumulativeFailsafeTimer.stop();
     }
 
-    #startFailsafeTimer(expiryLengthSeconds: number) {
-        return Time.getTimer("Failsafe expiration", expiryLengthSeconds * 1000, () =>
+    #startFailsafeTimer(expiry: Interval) {
+        return Time.getTimer("Failsafe expiration", expiry, () =>
             this.expire().catch(e => logger.error("Error during failsafe expiration", e)),
         ).start();
     }

--- a/packages/protocol/src/common/Scanner.ts
+++ b/packages/protocol/src/common/Scanner.ts
@@ -4,7 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BasicSet, ChannelType, Environment, Environmental, Lifespan, ServerAddress, ServerAddressIp } from "#general";
+import {
+    BasicSet,
+    ChannelType,
+    Environment,
+    Environmental,
+    Interval,
+    Lifespan,
+    ServerAddress,
+    ServerAddressIp,
+} from "#general";
 import { DiscoveryCapabilitiesBitmap, NodeId, TypeFromPartialBitSchema, VendorId } from "#types";
 import { Fabric } from "../fabric/Fabric.js";
 
@@ -32,13 +41,13 @@ export type DiscoveryData = {
     PI?: string;
 
     /** Sleep Idle Interval */
-    SII?: number;
+    SII?: Interval;
 
     /** Sleep Active Interval */
-    SAI?: number;
+    SAI?: Interval;
 
     /** Session active threshold */
-    SAT?: number;
+    SAT?: Interval;
 
     /** TCP supported */
     T?: number; // SupportedTransportsBitmap but comes in as number, so converted on usage
@@ -116,7 +125,7 @@ export interface Scanner {
     findOperationalDevice(
         fabric: Fabric,
         nodeId: NodeId,
-        timeoutSeconds?: number,
+        timeout?: Interval,
         ignoreExistingRecords?: boolean,
     ): Promise<OperationalDevice | undefined>;
 
@@ -132,7 +141,7 @@ export interface Scanner {
      */
     findCommissionableDevices(
         identifier: CommissionableDeviceIdentifiers,
-        timeoutSeconds?: number,
+        timeout?: Interval,
         ignoreExistingRecords?: boolean,
     ): Promise<CommissionableDevice[]>;
 
@@ -144,7 +153,7 @@ export interface Scanner {
     findCommissionableDevicesContinuously(
         identifier: CommissionableDeviceIdentifiers,
         callback: (device: CommissionableDevice) => void,
-        timeoutSeconds?: number,
+        timeout?: Interval,
         cancelSignal?: Promise<void>,
     ): Promise<CommissionableDevice[]>;
 

--- a/packages/protocol/src/events/OccurrenceManager.ts
+++ b/packages/protocol/src/events/OccurrenceManager.ts
@@ -277,7 +277,7 @@ export class OccurrenceManager {
 
     add(occurrence: Occurrence): MaybePromise<NumberedOccurrence> {
         return MaybePromise.then(this.#store.add(occurrence), entry => {
-            logger.debug(`Recorded event #${entry.number}: ${Diagnostic.json(occurrence)}`);
+            logger.debug(`Recorded event #${entry.number}`, Diagnostic.dict(occurrence));
             this.#occurrences.push(entry);
             if (this.#occurrences.length > this.#bufferConfig.maxEventAllowance) {
                 this.#startCull();

--- a/packages/protocol/src/groups/FabricGroups.ts
+++ b/packages/protocol/src/groups/FabricGroups.ts
@@ -96,7 +96,7 @@ export class FabricGroups {
 
     /*
     TODO for Controller to generate new epochs
-    addGroupEpoch(groupKeySetId: number, startTimeMs = Time.nowMs()) {
+    addGroupEpoch(groupKeySetId: number, startTimeMs = Time.nowMs) {
         // TODO for Controller to generate new epochs
         const epochKey = Crypto.getRandomData(CRYPTO_SYMMETRIC_KEY_LENGTH);
         const operationalEpochKey = Crypto.hkdf(epochKey, this.#fabric.operationalId, GROUP_SECURITY_INFO);

--- a/packages/protocol/src/groups/KeySets.ts
+++ b/packages/protocol/src/groups/KeySets.ts
@@ -96,7 +96,7 @@ export class KeySets<T extends OperationalKeySet> extends BasicSet<T> {
             // epoch key (specifically, the epoch key with the latest start time that is not in the future).
             // TODO Nodes that cannot reliably keep track of time calculate the current epoch key as described in
             //  Section 4.17.3.4, “Epoch Key Rotation without Time Synchronization”.
-            const now = Time.nowUs();
+            const now = Time.nowUs;
             const relevantKeys = operationalKeys.filter(({ startTime }) => startTime <= now);
             if (relevantKeys.length === 0) {
                 throw new ImplementationError(

--- a/packages/protocol/src/interaction/Subscription.ts
+++ b/packages/protocol/src/interaction/Subscription.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AsyncObservable, InternalError, Logger } from "#general";
+import { AsyncObservable, InternalError, Interval, Logger } from "#general";
 import { NodeSession } from "#session/NodeSession.js";
 import { TlvAttributePath, TlvDataVersionFilter, TlvEventFilter, TlvEventPath, TypeFromSchema } from "#types";
 
@@ -30,7 +30,7 @@ export abstract class Subscription {
     #isCanceledByPeer?: boolean;
     #criteria: SubscriptionCriteria;
     #cancelled = AsyncObservable<[subscription: Subscription]>();
-    #maxIntervalMs?: number;
+    #maxInterval?: Interval;
 
     constructor(session: NodeSession, id: SubscriptionId, criteria: SubscriptionCriteria) {
         this.#session = session;
@@ -62,22 +62,18 @@ export abstract class Subscription {
         return this.#cancelled;
     }
 
-    get maxIntervalMs(): number {
-        if (this.#maxIntervalMs === undefined) {
-            throw new InternalError("Subscription MaxIntervalMs accessed before it was set");
+    get maxInterval() {
+        if (this.#maxInterval === undefined) {
+            throw new InternalError("Subscription maxInterval accessed before it was set");
         }
-        return this.#maxIntervalMs;
+        return this.#maxInterval;
     }
 
-    set maxIntervalMs(value: number) {
-        if (this.#maxIntervalMs !== undefined) {
-            throw new InternalError("Subscription MaxIntervalMs set twice. This should never happen.");
+    set maxInterval(value: Interval) {
+        if (this.#maxInterval !== undefined) {
+            throw new InternalError("Subscription maxInterval set twice");
         }
-        this.#maxIntervalMs = value;
-    }
-
-    get maxInterval(): number {
-        return Math.ceil(this.maxIntervalMs / 1000);
+        this.#maxInterval = value;
     }
 
     /**

--- a/packages/protocol/src/interaction/SubscriptionClient.ts
+++ b/packages/protocol/src/interaction/SubscriptionClient.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Environment, Environmental, Logger, MaybePromise, Time, Timer } from "#general";
+import { Environment, Environmental, Interval, Logger, MaybePromise, Time, Timer } from "#general";
 import { MessageExchange } from "#protocol/MessageExchange.js";
 import { ProtocolHandler } from "#protocol/ProtocolHandler.js";
 import { INTERACTION_PROTOCOL_ID } from "#types";
@@ -14,8 +14,8 @@ const logger = Logger.get("SubscriptionClient");
 
 export interface RegisteredSubscription {
     id: number;
-    maximumPeerResponseTimeMs: number;
-    maxIntervalS: number;
+    maximumPeerResponseTime: Interval;
+    maxInterval: Interval;
     onData: (dataReport: DataReport) => MaybePromise<void>;
     onTimeout?: () => void;
 }
@@ -53,10 +53,10 @@ export class SubscriptionClient implements ProtocolHandler {
                 this.#timeouts.delete(id);
             }
 
-            const maxIntervalMs = subscription.maxIntervalS * 1000 + subscription.maximumPeerResponseTimeMs;
+            const maxInterval = subscription.maxInterval.plus(subscription.maximumPeerResponseTime);
 
-            timer = Time.getTimer("Subscription timeout", maxIntervalMs, () => {
-                logger.info(`Subscription ${id} timed out after ${maxIntervalMs}ms`);
+            timer = Time.getTimer("Subscription timeout", maxInterval, () => {
+                logger.info(`Subscription ${id} timed out after ${maxInterval}`);
                 this.delete(id);
                 onTimeout();
             }).start();

--- a/packages/protocol/src/mdns/MdnsClient.ts
+++ b/packages/protocol/src/mdns/MdnsClient.ts
@@ -14,11 +14,18 @@ import {
     DnsRecord,
     DnsRecordClass,
     DnsRecordType,
+    Hours,
     ImplementationError,
+    Instant,
     InternalError,
+    Interval,
     Lifespan,
     Logger,
+    Millisecs,
+    Minutes,
     ObserverGroup,
+    Seconds,
+    ServerAddress,
     ServerAddressIp,
     SrvRecordValue,
     Time,
@@ -86,7 +93,7 @@ type StructuredDnsAnswers = {
 } & StructuredDnsAddressAnswers;
 
 /** The initial number of seconds between two announcements. MDNS specs require 1-2 seconds, so lets use the middle. */
-const START_ANNOUNCE_INTERVAL_SECONDS = 1.5;
+const START_ANNOUNCE_INTERVAL = Seconds(1.5);
 
 /**
  * Interface to add criteria for MDNS discovery a node is interested in
@@ -141,7 +148,7 @@ export class MdnsClient implements Scanner {
     >();
 
     #queryTimer?: Timer;
-    #nextAnnounceIntervalSeconds = START_ANNOUNCE_INTERVAL_SECONDS;
+    #nextAnnounceInterval = START_ANNOUNCE_INTERVAL;
     readonly #periodicTimer: Timer;
     #closing = false;
     readonly #socket: MdnsSocket;
@@ -158,7 +165,7 @@ export class MdnsClient implements Scanner {
     constructor(socket: MdnsSocket) {
         this.#socket = socket;
         this.#observers.on(this.#socket.receipt, this.#handleMessage.bind(this));
-        this.#periodicTimer = Time.getPeriodicTimer("Discovered node expiration", 60 * 1000 /* 1 mn */, () =>
+        this.#periodicTimer = Time.getPeriodicTimer("Discovered node expiration", Minutes.one, () =>
             this.#expire(),
         ).start();
 
@@ -230,8 +237,8 @@ export class MdnsClient implements Scanner {
         }
     }
 
-    #effectiveTTL(ttl: number) {
-        return Math.ceil(ttl * MDNS_EXPIRY_GRACE_PERIOD_FACTOR);
+    #effectiveTTL(ttl: Interval) {
+        return ttl.times(MDNS_EXPIRY_GRACE_PERIOD_FACTOR).ceil;
     }
 
     /**
@@ -250,16 +257,16 @@ export class MdnsClient implements Scanner {
             ),
         );
 
-        this.#queryTimer = Time.getTimer("MDNS discovery", this.#nextAnnounceIntervalSeconds * 1000, () =>
+        this.#queryTimer = Time.getTimer("MDNS discovery", this.#nextAnnounceInterval, () =>
             this.#sendQueries(),
         ).start();
 
         logger.debug(
-            `Sending ${queries.length} query records for ${this.#activeAnnounceQueries.size} queries with ${answers.length} known answers. Re-Announce in ${this.#nextAnnounceIntervalSeconds} seconds`,
+            `Sending ${queries.length} query records for ${this.#activeAnnounceQueries.size} queries with ${answers.length} known answers. Re-Announce in ${this.#nextAnnounceInterval}`,
         );
 
-        const nextAnnounceInterval = this.#nextAnnounceIntervalSeconds * 2;
-        this.#nextAnnounceIntervalSeconds = Math.min(nextAnnounceInterval, 60 * 60 /* 1 hour */);
+        const nextAnnounceInterval = this.#nextAnnounceInterval.times(2);
+        this.#nextAnnounceInterval = Interval.min(nextAnnounceInterval, Hours.one);
 
         await this.#socket.send({
             messageType: DnsMessageType.Query,
@@ -298,8 +305,8 @@ export class MdnsClient implements Scanner {
         this.#activeAnnounceQueries.set(queryId, { queries, answers });
         logger.debug(`Set ${queries.length} query records for query ${queryId}: ${Diagnostic.json(queries)}`);
         this.#queryTimer?.stop();
-        this.#nextAnnounceIntervalSeconds = START_ANNOUNCE_INTERVAL_SECONDS; // Reset query interval
-        this.#queryTimer = Time.getTimer("MDNS discovery", 0, () => this.#sendQueries()).start();
+        this.#nextAnnounceInterval = START_ANNOUNCE_INTERVAL; // Reset query interval
+        this.#queryTimer = Time.getTimer("MDNS discovery", Instant, () => this.#sendQueries()).start();
     }
 
     /**
@@ -322,7 +329,7 @@ export class MdnsClient implements Scanner {
         if (this.#activeAnnounceQueries.size === 0) {
             logger.debug(`Removing last query ${queryId} and stopping announce timer`);
             this.#queryTimer?.stop();
-            this.#nextAnnounceIntervalSeconds = START_ANNOUNCE_INTERVAL_SECONDS;
+            this.#nextAnnounceInterval = START_ANNOUNCE_INTERVAL;
         } else {
             logger.debug(`Removing query ${queryId}`);
         }
@@ -395,14 +402,14 @@ export class MdnsClient implements Scanner {
     async #registerWaiterPromise(
         queryId: string,
         commissionable: boolean,
-        timeoutSeconds?: number,
+        timeout?: Interval,
         resolveOnUpdatedRecords = true,
         cancelResolver?: (value: void) => void,
     ) {
         const { promise, resolver } = createPromise<void>();
         const timer =
-            timeoutSeconds !== undefined
-                ? Time.getTimer("MDNS timeout", timeoutSeconds * 1000, () => {
+            timeout !== undefined
+                ? Time.getTimer("MDNS timeout", timeout, () => {
                       cancelResolver?.();
                       this.#finishWaiter(queryId, true);
                   }).start()
@@ -415,7 +422,7 @@ export class MdnsClient implements Scanner {
         }
         logger.debug(
             `Registered waiter for query ${queryId} with ${
-                timeoutSeconds !== undefined ? `timeout ${timeoutSeconds} seconds` : "no timeout"
+                timeout !== undefined ? `timeout ${timeout}` : "no timeout"
             }${resolveOnUpdatedRecords ? "" : " (not resolving on updated records)"}`,
         );
         await promise;
@@ -482,7 +489,7 @@ export class MdnsClient implements Scanner {
     async findOperationalDevice(
         { operationalId }: Fabric,
         nodeId: NodeId,
-        timeoutSeconds?: number,
+        timeout?: Interval,
         ignoreExistingRecords = false,
     ): Promise<OperationalDevice | undefined> {
         if (this.#closing) {
@@ -492,7 +499,7 @@ export class MdnsClient implements Scanner {
 
         let storedDevice = ignoreExistingRecords ? undefined : this.#getOperationalDeviceRecords(deviceMatterQname);
         if (storedDevice === undefined) {
-            const promise = this.#registerWaiterPromise(deviceMatterQname, false, timeoutSeconds);
+            const promise = this.#registerWaiterPromise(deviceMatterQname, false, timeout);
 
             this.#setQueryRecords(deviceMatterQname, [
                 {
@@ -711,7 +718,7 @@ export class MdnsClient implements Scanner {
      */
     async findCommissionableDevices(
         identifier: CommissionableDeviceIdentifiers,
-        timeoutSeconds = 5,
+        timeout = Seconds(5),
         ignoreExistingRecords = false,
     ): Promise<CommissionableDevice[]> {
         let storedRecords = ignoreExistingRecords
@@ -719,7 +726,7 @@ export class MdnsClient implements Scanner {
             : this.#getCommissionableDeviceRecords(identifier).filter(({ addresses }) => addresses.length > 0);
         if (storedRecords.length === 0) {
             const queryId = this.#buildCommissionableQueryIdentifier(identifier);
-            const promise = this.#registerWaiterPromise(queryId, true, timeoutSeconds);
+            const promise = this.#registerWaiterPromise(queryId, true, timeout);
 
             this.#setQueryRecords(queryId, this.#getCommissionableQueryRecords(identifier));
 
@@ -737,12 +744,12 @@ export class MdnsClient implements Scanner {
     async findCommissionableDevicesContinuously(
         identifier: CommissionableDeviceIdentifiers,
         callback: (device: CommissionableDevice) => void,
-        timeoutSeconds?: number,
+        timeout?: Interval,
         cancelSignal?: Promise<void>,
     ): Promise<CommissionableDevice[]> {
         const discoveredDevices = new Set<string>();
 
-        const discoveryEndTime = timeoutSeconds ? Time.nowMs() + timeoutSeconds * 1000 : undefined;
+        const discoveryEndTime = timeout ? Time.nowMs + timeout.ms : undefined;
         const queryId = this.#buildCommissionableQueryIdentifier(identifier);
         this.#setQueryRecords(queryId, this.#getCommissionableQueryRecords(identifier));
 
@@ -778,8 +785,8 @@ export class MdnsClient implements Scanner {
 
             let remainingTime;
             if (discoveryEndTime !== undefined) {
-                remainingTime = Math.ceil((discoveryEndTime - Time.nowMs()) / 1000);
-                if (remainingTime <= 0) {
+                remainingTime = Seconds((discoveryEndTime - Time.nowMs) / 1000).ceil;
+                if (remainingTime.length <= 0) {
                     break;
                 }
             }
@@ -810,7 +817,7 @@ export class MdnsClient implements Scanner {
     #structureAnswers(...answersList: DnsRecord<any>[][]): StructuredDnsAnswers {
         const structuredAnswers: StructuredDnsAnswers = {};
 
-        const discoveredAt = Time.nowMs();
+        const discoveredAt = Time.nowMs;
         answersList.forEach(answers =>
             answers.forEach(answer => {
                 const { name, recordType } = answer;
@@ -869,7 +876,7 @@ export class MdnsClient implements Scanner {
                     records.forEach(record => {
                         const existingRecord = combinedAnswers.operational![recordType].get(record.name);
                         if (existingRecord && existingRecord.discoveredAt < record.discoveredAt) {
-                            if (record.ttl === 0) {
+                            if (record.ttl.ms === 0) {
                                 combinedAnswers.operational![recordType].delete(record.name);
                             } else {
                                 combinedAnswers.operational![recordType].set(record.name, record);
@@ -889,7 +896,7 @@ export class MdnsClient implements Scanner {
                     records.forEach(record => {
                         const existingRecord = combinedAnswers.commissionable![recordType].get(record.name);
                         if (existingRecord && existingRecord.discoveredAt < record.discoveredAt) {
-                            if (record.ttl === 0) {
+                            if (record.ttl.ms === 0) {
                                 combinedAnswers.commissionable![recordType].delete(record.name);
                             } else {
                                 combinedAnswers.commissionable![recordType].set(record.name, record);
@@ -1037,7 +1044,7 @@ export class MdnsClient implements Scanner {
         const interfaceRecords = this.#discoveredIpRecords.get(netInterface) ?? {};
         for (const record of ipAddresses) {
             const { recordType, name, value: ip, ttl } = record as DnsRecord<string>;
-            if (ttl === 0) continue; // Skip records with ttl=0
+            if (ttl.ms === 0) continue; // Skip records with ttl=0
             if (recordType === DnsRecordType.AAAA) {
                 interfaceRecords.addressesV6 = interfaceRecords.addressesV6 ?? {};
                 interfaceRecords.addressesV6[name] = interfaceRecords.addressesV6[name] ?? new Map();
@@ -1055,7 +1062,7 @@ export class MdnsClient implements Scanner {
         answers: StructuredDnsAnswers[],
         target: string,
         netInterface: string,
-    ): { value: string; ttl: number }[] {
+    ): { value: string; ttl: Interval }[] {
         const ipRecords = new Array<AnyDnsRecordWithExpiry>();
         answers.forEach(answer => {
             if (answer.addressesV6?.[target]) {
@@ -1073,7 +1080,7 @@ export class MdnsClient implements Scanner {
         this.#registerIpRecords(ipRecords, netInterface); // Register for potential later usage
 
         // If an IP is included multiple times we only keep the latest record
-        const collectedIps = new Map<string, { value: string; ttl: number }>();
+        const collectedIps = new Map<string, { value: string; ttl: Interval }>();
         ipRecords.forEach(record => {
             const { value, ttl } = record as DnsRecord<string>;
             if (value.startsWith("fe80::")) {
@@ -1123,10 +1130,10 @@ export class MdnsClient implements Scanner {
 
     #handleOperationalTxtRecord(record: DnsRecord<any>, netInterface: string) {
         const { name: matterName, value, ttl } = record as DnsRecord<string[]>;
-        const discoveredAt = Time.nowMs();
+        const discoveredAt = Time.nowMs;
 
         // we got an expiry info, so we can remove the record if we know it already and are done
-        if (ttl === 0) {
+        if (ttl.ms === 0) {
             if (this.#operationalDeviceRecords.has(matterName)) {
                 logger.debug(
                     `Removing operational device ${matterName} from cache (interface ${netInterface}) because of ttl=0`,
@@ -1151,19 +1158,16 @@ export class MdnsClient implements Scanner {
             device = {
                 ...device,
                 discoveredAt,
-                ttl: ttl * 1000,
+                ttl,
                 ...txtData,
             };
         } else {
-            logger.debug(
-                `Adding operational device ${matterName} in cache (interface ${netInterface}, ttl=${ttl}) with TXT data:`,
-                MdnsClient.discoveryDataDiagnostics(txtData),
-            );
+            logNewService(matterName, "operational", txtData);
             device = {
                 deviceIdentifier: matterName,
                 addresses: new Map<string, MatterServerRecordWithExpire>(),
                 discoveredAt,
-                ttl: ttl * 1000,
+                ttl,
                 ...txtData,
             };
         }
@@ -1184,7 +1188,7 @@ export class MdnsClient implements Scanner {
         } = record;
 
         // We got device expiry info, so we can remove the record if we know it already and are done
-        if (ttl === 0) {
+        if (ttl.ms === 0) {
             if (this.#operationalDeviceRecords.has(matterName)) {
                 logger.debug(
                     `Removing operational device ${matterName} from cache (interface ${netInterface}) because of ttl=0`,
@@ -1203,18 +1207,18 @@ export class MdnsClient implements Scanner {
             return;
         }
 
-        const discoveredAt = Time.nowMs();
+        const discoveredAt = Time.nowMs;
         const device = this.#operationalDeviceRecords.get(matterName) ?? {
             deviceIdentifier: matterName,
             addresses: new Map<string, MatterServerRecordWithExpire>(),
             discoveredAt,
-            ttl: ttl * 1000,
+            ttl,
         };
         const ipsInitiallyEmpty = device.addresses.size === 0;
         const { addresses } = device;
         if (ips.length > 0) {
             for (const { value: ip, ttl } of ips) {
-                if (ttl === 0) {
+                if (ttl.ms === 0) {
                     logger.debug(
                         `Removing IP ${ip} for operational device ${matterName} from cache (interface ${netInterface}) because of ttl=0`,
                     );
@@ -1223,16 +1227,13 @@ export class MdnsClient implements Scanner {
                 }
                 const address = addresses.get(ip) ?? ({ ip, port, type: "udp" } as MatterServerRecordWithExpire);
                 address.discoveredAt = discoveredAt;
-                address.ttl = ttl * 1000;
+                address.ttl = ttl;
 
                 addresses.set(address.ip, address);
             }
             device.addresses = addresses;
             if (ipsInitiallyEmpty) {
-                logger.debug(
-                    `Added ${addresses.size} IPs for operational device ${matterName} to cache (interface ${netInterface}):`,
-                    ...MdnsClient.deviceAddressDiagnostics(addresses),
-                );
+                logNewAddresses(matterName, "operational", netInterface, addresses);
             }
             this.#operationalDeviceRecords.set(matterName, device);
         }
@@ -1275,7 +1276,7 @@ export class MdnsClient implements Scanner {
         const txtRecords = commissionableRecords[DnsRecordType.TXT] ?? [];
         for (const record of txtRecords) {
             const { name, ttl } = record;
-            if (ttl === 0) {
+            if (ttl.ms === 0) {
                 if (this.#commissionableDeviceRecords.has(name)) {
                     logger.debug(
                         `Removing commissionable device ${name} from cache (interface ${netInterface}) because of ttl=0`,
@@ -1305,10 +1306,7 @@ export class MdnsClient implements Scanner {
             if (storedRecord === undefined) {
                 queryMissingDataForInstances.add(name);
 
-                logger.debug(
-                    `Found commissionable device ${name} with data:`,
-                    MdnsClient.discoveryDataDiagnostics(parsedRecord),
-                );
+                logNewService(name, "commissionable", parsedRecord);
             } else {
                 parsedRecord.addresses = storedRecord.addresses;
             }
@@ -1324,7 +1322,7 @@ export class MdnsClient implements Scanner {
                 value: { target, port },
                 ttl,
             } = record as DnsRecord<SrvRecordValue>;
-            if (ttl === 0) {
+            if (ttl.ms === 0) {
                 logger.debug(
                     `Removing commissionable device ${record.name} from cache (interface ${netInterface}) because of ttl=0`,
                 );
@@ -1337,7 +1335,7 @@ export class MdnsClient implements Scanner {
             const ips = this.#handleIpRecords([formerAnswers, answers], target, netInterface);
             if (ips.length > 0) {
                 for (const { value: ip, ttl } of ips) {
-                    if (ttl === 0) {
+                    if (ttl.ms === 0) {
                         logger.debug(
                             `Removing IP ${ip} for commissionable device ${record.name} from cache (interface ${netInterface}) because of ttl=0`,
                         );
@@ -1346,8 +1344,8 @@ export class MdnsClient implements Scanner {
                     }
                     const matterServer =
                         storedRecord.addresses.get(ip) ?? ({ ip, port, type: "udp" } as MatterServerRecordWithExpire);
-                    matterServer.discoveredAt = Time.nowMs();
-                    matterServer.ttl = ttl * 1000;
+                    matterServer.discoveredAt = Time.nowMs;
+                    matterServer.ttl = ttl;
 
                     storedRecord.addresses.set(ip, matterServer);
                 }
@@ -1366,10 +1364,7 @@ export class MdnsClient implements Scanner {
                 );
                 this.#setQueryRecords(queryId, queries, answers);
             } else if (!recordAddressesKnown) {
-                logger.debug(
-                    `Added ${storedRecord.addresses.size} IPs for commissionable device ${record.name} to cache (interface ${netInterface}):`,
-                    ...MdnsClient.deviceAddressDiagnostics(storedRecord.addresses),
-                );
+                logNewAddresses(record.name, "commissionable", netInterface, storedRecord.addresses);
             }
             if (storedRecord.addresses.size === 0) continue;
 
@@ -1404,12 +1399,17 @@ export class MdnsClient implements Scanner {
             for (const item of value) {
                 const [key, value] = item.split("=");
                 if (key === undefined || value === undefined) continue;
-                if (["SII", "SAI", "SAT", "T", "D", "CM", "DT", "PH", "ICD"].includes(key)) {
+                if (["T", "D", "CM", "DT", "PH", "ICD"].includes(key)) {
                     const intValue = parseInt(value);
                     if (isNaN(intValue)) continue;
                     result[key] = intValue;
                 } else if (["VP", "DN", "RI", "PI"].includes(key)) {
                     result[key] = value;
+                } else if (["SII", "SAI", "SAT"].includes(key)) {
+                    const intValue = parseInt(value);
+                    if (isNaN(intValue)) continue;
+                    result[key] = intValue;
+                    result[key] = Millisecs(intValue);
                 }
             }
         }
@@ -1439,20 +1439,20 @@ export class MdnsClient implements Scanner {
         }
         return {
             addresses: new Map<string, MatterServerRecordWithExpire>(),
-            discoveredAt: Time.nowMs(),
-            ttl: ttl * 1000,
+            discoveredAt: Time.nowMs,
+            ttl,
             ...txtRecord,
         };
     }
 
     #expire() {
-        const now = Time.nowMs();
+        const now = Time.nowMs;
         [...this.#operationalDeviceRecords.entries()].forEach(([recordKey, { addresses, discoveredAt, ttl }]) => {
-            const expires = discoveredAt + this.#effectiveTTL(ttl);
+            const expires = this.#effectiveTTL(ttl).after(discoveredAt);
             if (now <= expires) {
                 // Only check expired IPs if not device itself has expired
                 [...addresses.entries()].forEach(([key, { discoveredAt, ttl }]) => {
-                    if (now < discoveredAt + this.#effectiveTTL(ttl)) return; // not expired yet
+                    if (now < this.#effectiveTTL(ttl).after(discoveredAt)) return; // not expired yet
                     addresses.delete(key);
                 });
             }
@@ -1462,11 +1462,11 @@ export class MdnsClient implements Scanner {
             }
         });
         [...this.#commissionableDeviceRecords.entries()].forEach(([recordKey, { addresses, discoveredAt, ttl }]) => {
-            const expires = discoveredAt + this.#effectiveTTL(ttl);
+            const expires = this.#effectiveTTL(ttl).after(discoveredAt);
             if (now <= expires) {
                 // Only check expired IPs if not device itself has expired
                 [...addresses.entries()].forEach(([key, { discoveredAt, ttl }]) => {
-                    if (now < discoveredAt + this.#effectiveTTL(ttl)) return; // not expired yet
+                    if (now < this.#effectiveTTL(ttl).after(discoveredAt)) return; // not expired yet
                     addresses.delete(key);
                 });
             }
@@ -1486,7 +1486,7 @@ export class MdnsClient implements Scanner {
             Object.keys(data.operational).forEach(recordType => {
                 const type = parseInt(recordType);
                 data.operational![type] = data.operational![type].filter(
-                    ({ discoveredAt, ttl }) => now < discoveredAt + this.#effectiveTTL(ttl * 1000),
+                    ({ discoveredAt, ttl }) => now < this.#effectiveTTL(ttl).after(discoveredAt),
                 );
                 if (data.operational![type].length === 0) {
                     delete data.operational![type];
@@ -1497,7 +1497,7 @@ export class MdnsClient implements Scanner {
             Object.keys(data.commissionable).forEach(recordType => {
                 const type = parseInt(recordType);
                 data.commissionable![type] = data.commissionable![type].filter(
-                    ({ discoveredAt, ttl }) => now < discoveredAt + this.#effectiveTTL(ttl * 1000),
+                    ({ discoveredAt, ttl }) => now < this.#effectiveTTL(ttl).after(discoveredAt),
                 );
                 if (data.commissionable![type].length === 0) {
                     delete data.commissionable![type];
@@ -1507,7 +1507,7 @@ export class MdnsClient implements Scanner {
         if (data.addressesV6) {
             Object.keys(data.addressesV6).forEach(name => {
                 for (const [ip, { discoveredAt, ttl }] of data.addressesV6![name].entries()) {
-                    if (now < discoveredAt + this.#effectiveTTL(ttl * 1000)) continue; // not expired yet
+                    if (now < this.#effectiveTTL(ttl).after(discoveredAt)) continue; // not expired yet
                     data.addressesV6![name].delete(ip);
                 }
                 if (data.addressesV6![name].size === 0) {
@@ -1518,7 +1518,7 @@ export class MdnsClient implements Scanner {
         if (data.addressesV4) {
             Object.keys(data.addressesV4).forEach(name => {
                 for (const [ip, { discoveredAt, ttl }] of data.addressesV4![name].entries()) {
-                    if (now < discoveredAt + this.#effectiveTTL(ttl * 1000)) continue; // not expired yet
+                    if (now < this.#effectiveTTL(ttl).after(discoveredAt)) continue; // not expired yet
                     data.addressesV4![name].delete(ip);
                 }
                 if (data.addressesV4![name].size === 0) {
@@ -1528,32 +1528,54 @@ export class MdnsClient implements Scanner {
         }
     }
 
-    static discoveryDataDiagnostics(data: DiscoveryData) {
-        return Diagnostic.dict(
-            {
-                SII: data.SII,
-                SAI: data.SAI,
-                SAT: data.SAT,
-                T: data.T,
-                DT: data.DT,
-                PH: data.PH,
-                ICD: data.ICD,
-                VP: data.VP,
-                DN: data.DN,
-                RI: data.RI,
-                PI: data.PI,
-            },
-            true,
-        );
+    static discoveryDataDiagnostics(data: DiscoveryData, kind?: string) {
+        return Diagnostic.dict({
+            kind,
+            SII: data.SII,
+            SAI: data.SAI,
+            SAT: data.SAT,
+            T: data.T,
+            DT: data.DT,
+            PH: data.PH,
+            ICD: data.ICD,
+            VP: data.VP,
+            DN: data.DN,
+            RI: data.RI,
+            PI: data.PI,
+        });
     }
 
     static deviceAddressDiagnostics(addresses: Map<string, MatterServerRecordWithExpire>) {
-        return Array.from(addresses.values()).map(address =>
-            Diagnostic.dict({
-                type: address.type,
-                ip: address.ip,
-                port: address.port,
-            }),
-        );
+        const diagnostic = Array<unknown>();
+        for (const address of addresses.values()) {
+            if (diagnostic.length) {
+                diagnostic.push(", ");
+            }
+            diagnostic.push(ServerAddress.diagnosticFor(address));
+        }
+        return Diagnostic.squash(...diagnostic);
     }
+}
+
+function logNewService(service: string, kind: string, data: DiscoveryData) {
+    logger.debug("Found device", Diagnostic.strong(service), MdnsClient.discoveryDataDiagnostics(data, kind));
+}
+
+function logNewAddresses(
+    service: string,
+    kind: string,
+    intf: string,
+    addresses: Map<string, MatterServerRecordWithExpire>,
+) {
+    logger.debug(
+        "Added",
+        addresses.size,
+        "addresses for",
+        Diagnostic.strong(service),
+        Diagnostic.dict({
+            kind,
+            addrs: MdnsClient.deviceAddressDiagnostics(addresses),
+            intf,
+        }),
+    );
 }

--- a/packages/protocol/src/peer/ControllerCommissioningFlow.ts
+++ b/packages/protocol/src/peer/ControllerCommissioningFlow.ts
@@ -15,9 +15,13 @@ import {
     Bytes,
     ChannelType,
     Diagnostic,
+    Instant,
+    Interval,
     Logger,
     MatterError,
+    Minutes,
     repackErrorAs,
+    Seconds,
     Time,
     UnexpectedDataError,
 } from "#general";
@@ -178,7 +182,7 @@ export class OperativeConnectionFailedError extends CommissioningError {}
 /** Error that throws when Commissioning fails but a process can be continued. */
 class RecoverableCommissioningError extends CommissioningError {}
 
-const DEFAULT_FAILSAFE_TIME_S = 60;
+const DEFAULT_FAILSAFE_TIME = Minutes.one;
 
 /**
  * Class to abstract the Device commission flow in a step wise way as defined in Specs. The specs are not 100%
@@ -200,7 +204,7 @@ export class ControllerCommissioningFlow {
     #currentFailSafeEndTime: number | undefined;
     protected lastBreadcrumb = 1;
     protected collectedCommissioningData: CollectedCommissioningData = {};
-    #defaultFailSafeTimeS = DEFAULT_FAILSAFE_TIME_S;
+    #defaultFailSafeTime = DEFAULT_FAILSAFE_TIME;
 
     constructor(
         /** InteractionClient for the initiated PASE session */
@@ -252,7 +256,7 @@ export class ControllerCommissioningFlow {
                 this.#setCommissioningStepResult(step, result);
 
                 if (this.#currentFailSafeEndTime !== undefined) {
-                    if (this.#commissioningExpiryTime !== undefined && Time.nowMs() > this.#commissioningExpiryTime) {
+                    if (this.#commissioningExpiryTime !== undefined && Time.nowMs > this.#commissioningExpiryTime) {
                         logger.error(
                             `Commissioning step ${step.stepNumber}.${step.subStepNumber}: ${step.name} succeeded, but commissioning took too long in general!`,
                         );
@@ -267,8 +271,8 @@ export class ControllerCommissioningFlow {
                      * timeout within 60 seconds of the completion of PASE session establishment, using the ArmFailSafe
                      * command (see Section 11.9.6.2, “ArmFailSafe Command”)
                      */
-                    const timeLeft = Math.floor((this.#currentFailSafeEndTime - Time.nowMs()) / 1000);
-                    if (timeLeft < this.#defaultFailSafeTimeS / 2) {
+                    const timeLeft = Math.floor((this.#currentFailSafeEndTime - Time.nowMs) / 1000);
+                    if (timeLeft < this.#defaultFailSafeTime.dividedBy(2).ms) {
                         logger.info(
                             `After Commissioning step ${step.stepNumber}.${step.subStepNumber}: ${
                                 step.name
@@ -595,45 +599,45 @@ export class ControllerCommissioningFlow {
      * reading BasicCommissioningInfo attribute (see Section 11.10.5.2, “BasicCommissioningInfo
      * Attribute”) prior to invoking the ArmFailSafe command.
      */
-    async #armFailsafe(timeS?: number) {
+    async #armFailsafe(time?: Interval) {
         const client = this.#getClusterClient(GeneralCommissioning.Cluster);
         if (this.collectedCommissioningData.basicCommissioningInfo === undefined) {
             const basicCommissioningInfo = await client.getBasicCommissioningInfoAttribute();
             this.collectedCommissioningData.basicCommissioningInfo = basicCommissioningInfo;
-            this.#defaultFailSafeTimeS = basicCommissioningInfo.failSafeExpiryLengthSeconds;
-            this.#commissioningStartedTime = Time.nowMs();
+            this.#defaultFailSafeTime = Seconds(basicCommissioningInfo.failSafeExpiryLengthSeconds);
+            this.#commissioningStartedTime = Time.nowMs;
             this.#commissioningExpiryTime =
                 this.#commissioningStartedTime + basicCommissioningInfo.maxCumulativeFailsafeSeconds * 1000;
         }
-        const expiryLengthSeconds = timeS ?? this.#defaultFailSafeTimeS;
+        const expiryLength = time ?? this.#defaultFailSafeTime;
         this.#ensureGeneralCommissioningSuccess(
             "armFailSafe",
             await client.armFailSafe({
                 breadcrumb: this.lastBreadcrumb,
-                expiryLengthSeconds,
+                expiryLengthSeconds: Seconds(expiryLength).length,
             }),
         );
-        this.#currentFailSafeEndTime = Time.nowMs() + expiryLengthSeconds * 1000;
+        this.#currentFailSafeEndTime = Time.nowMs + expiryLength.ms;
         return {
             code: CommissioningStepResultCode.Success,
             breadcrumb: this.lastBreadcrumb,
         };
     }
 
-    get #failSafeTimeLeftS() {
+    get #failSafeTimeLeft() {
         if (this.#currentFailSafeEndTime === undefined) {
-            return 0;
+            return Instant;
         }
-        return Math.max(0, Math.ceil((this.#currentFailSafeEndTime - Time.nowMs()) / 1000));
+        return Math.max(0, Math.ceil((this.#currentFailSafeEndTime - Time.nowMs) / 1000));
     }
 
-    async #ensureFailsafeTimerForS(maxProcessingTime: number) {
-        const minFailsafeTimeS = this.interactionClient.maximumPeerResponseTimeMs(maxProcessingTime);
+    async #ensureFailsafeTimerFor(maxProcessingTime: Interval) {
+        const minFailsafeTime = this.interactionClient.maximumPeerResponseTime(maxProcessingTime);
 
-        const timeLeft = this.#failSafeTimeLeftS;
-        if (timeLeft < minFailsafeTimeS) {
-            logger.debug(`Failsafe timer has only ${timeLeft}s left, re-arming for at least ${minFailsafeTimeS}s`);
-            await this.#armFailsafe(Math.max(minFailsafeTimeS, this.#defaultFailSafeTimeS));
+        const timeLeft = this.#failSafeTimeLeft;
+        if (timeLeft < minFailsafeTime) {
+            logger.debug(`Failsafe timer has only ${timeLeft}s left, re-arming for at least ${minFailsafeTime}`);
+            await this.#armFailsafe(Interval.max(minFailsafeTime, this.#defaultFailSafeTime));
         } else {
             logger.debug(`Failsafe timer is already set for at least ${timeLeft}s`);
         }
@@ -1019,8 +1023,8 @@ export class ControllerCommissioningFlow {
 
         // Only Scan when the device supports concurrent connections
         if (this.collectedCommissioningData.supportsConcurrentConnection !== false) {
-            const scanMaxTimeSeconds = await networkCommissioningClusterClient.getScanMaxTimeSecondsAttribute();
-            await this.#ensureFailsafeTimerForS(scanMaxTimeSeconds);
+            const scanMaxTime = Seconds(await networkCommissioningClusterClient.getScanMaxTimeSecondsAttribute());
+            await this.#ensureFailsafeTimerFor(scanMaxTime);
 
             const { networkingStatus, wiFiScanResults, debugText } =
                 await networkCommissioningClusterClient.scanNetworks(
@@ -1028,7 +1032,7 @@ export class ControllerCommissioningFlow {
                         ssid,
                         breadcrumb: this.lastBreadcrumb++,
                     },
-                    { expectedProcessingTimeMs: scanMaxTimeSeconds * 1000 },
+                    { expectedProcessingTime: scanMaxTime },
                 );
             if (networkingStatus !== NetworkCommissioning.NetworkCommissioningStatus.Success) {
                 throw new WifiNetworkSetupFailedError(`Commissionee failed to scan for WiFi networks: ${debugText}`);
@@ -1080,15 +1084,15 @@ export class ControllerCommissioningFlow {
             };
         }
 
-        const connectMaxTimeSeconds = await networkCommissioningClusterClient.getConnectMaxTimeSecondsAttribute();
-        await this.#ensureFailsafeTimerForS(connectMaxTimeSeconds);
+        const connectMaxTime = Seconds(await networkCommissioningClusterClient.getConnectMaxTimeSecondsAttribute());
+        await this.#ensureFailsafeTimerFor(connectMaxTime);
 
         const connectResult = await networkCommissioningClusterClient.connectNetwork(
             {
                 networkId: networkId,
                 breadcrumb: this.lastBreadcrumb++,
             },
-            { expectedProcessingTimeMs: connectMaxTimeSeconds * 1000 },
+            { expectedProcessingTime: connectMaxTime },
         );
 
         if (connectResult.networkingStatus !== NetworkCommissioning.NetworkCommissioningStatus.Success) {
@@ -1164,13 +1168,13 @@ export class ControllerCommissioningFlow {
 
         // Only Scan when the device supports concurrent connections
         if (this.collectedCommissioningData.supportsConcurrentConnection !== false) {
-            const scanMaxTimeSeconds = await networkCommissioningClusterClient.getScanMaxTimeSecondsAttribute();
-            await this.#ensureFailsafeTimerForS(scanMaxTimeSeconds);
+            const scanMaxTime = Seconds(await networkCommissioningClusterClient.getScanMaxTimeSecondsAttribute());
+            await this.#ensureFailsafeTimerFor(scanMaxTime);
 
             const { networkingStatus, threadScanResults, debugText } =
                 await networkCommissioningClusterClient.scanNetworks(
                     { breadcrumb: this.lastBreadcrumb++ },
-                    { expectedProcessingTimeMs: scanMaxTimeSeconds * 1000 },
+                    { expectedProcessingTime: scanMaxTime },
                 );
             if (networkingStatus !== NetworkCommissioning.NetworkCommissioningStatus.Success) {
                 throw new ThreadNetworkSetupFailedError(
@@ -1237,15 +1241,15 @@ export class ControllerCommissioningFlow {
             };
         }
 
-        const connectMaxTimeSeconds = await networkCommissioningClusterClient.getConnectMaxTimeSecondsAttribute();
-        await this.#ensureFailsafeTimerForS(connectMaxTimeSeconds);
+        const connectMaxTime = Seconds(await networkCommissioningClusterClient.getConnectMaxTimeSecondsAttribute());
+        await this.#ensureFailsafeTimerFor(connectMaxTime);
 
         const connectResult = await networkCommissioningClusterClient.connectNetwork(
             {
                 networkId: networkId,
                 breadcrumb: this.lastBreadcrumb++,
             },
-            { expectedProcessingTimeMs: connectMaxTimeSeconds * 1000 },
+            { expectedProcessingTime: connectMaxTime },
         );
 
         if (connectResult.networkingStatus !== NetworkCommissioning.NetworkCommissioningStatus.Success) {
@@ -1284,9 +1288,9 @@ export class ControllerCommissioningFlow {
         // TODO: Check whats needed for non-concurrent commissioning flows (maybe arm initially longer?)
         const reArmFailsafeInterval = Time.getPeriodicTimer(
             "Re-Arm Failsafe during reconnect",
-            (this.#defaultFailSafeTimeS / 2) * 1000,
+            this.#defaultFailSafeTime.dividedBy(2),
             () => {
-                const now = Time.nowMs();
+                const now = Time.nowMs;
                 if (this.#commissioningExpiryTime !== undefined && now < this.#commissioningExpiryTime) {
                     logger.error(
                         `Re-Arm Failsafe Timer during reconnect with device. Time left: ${Math.round((this.#commissioningExpiryTime - now) / 1000)}s`,

--- a/packages/protocol/src/peer/ControllerDiscovery.ts
+++ b/packages/protocol/src/peer/ControllerDiscovery.ts
@@ -4,7 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { anyPromise, ClassExtends, Diagnostic, Logger, NoResponseTimeoutError, serverAddressToString } from "#general";
+import {
+    anyPromise,
+    ClassExtends,
+    Diagnostic,
+    Interval,
+    Logger,
+    Minutes,
+    NoResponseTimeoutError,
+    ServerAddress,
+} from "#general";
 import { CommissionableDeviceDiscoveryFailedError } from "#peer/ControllerCommissioningFlow.js";
 import { NodeId } from "#types";
 import {
@@ -38,14 +47,14 @@ export class ControllerDiscovery {
     static async discoverDeviceAddressesByIdentifier(
         scanners: Array<Scanner>,
         identifier: CommissionableDeviceIdentifiers,
-        timeoutSeconds = 30,
+        timeout = Minutes.half,
     ): Promise<CommissionableDevice[]> {
         logger.info(`Start Discovering devices using identifier ${Diagnostic.json(identifier)} ...`);
 
         const scanResults = scanners.map(async scanner => {
             const foundDevices = await scanner.findCommissionableDevices(
                 identifier,
-                timeoutSeconds,
+                timeout,
                 scanner.type === "ble", // Force rediscovery for BLE
             );
             logger.info(`Found ${foundDevices.length} devices using identifier ${Diagnostic.json(identifier)}`);
@@ -73,7 +82,7 @@ export class ControllerDiscovery {
 
     static async discoverCommissionableDevices(
         scanners: Array<Scanner>,
-        timeoutSeconds: number,
+        timeout: Interval,
         identifier: CommissionableDeviceIdentifiers = {},
         discoveredCallback?: (device: CommissionableDevice) => void,
     ): Promise<CommissionableDevice[]> {
@@ -90,7 +99,7 @@ export class ControllerDiscovery {
                             discoveredCallback?.(device);
                         }
                     },
-                    timeoutSeconds,
+                    timeout,
                 );
             }),
         );
@@ -118,15 +127,10 @@ export class ControllerDiscovery {
         fabric: Fabric,
         peerNodeId: NodeId,
         scanner: MdnsClient,
-        timeoutSeconds?: number,
+        timeout?: Interval,
         ignoreExistingRecords?: boolean,
     ): Promise<OperationalDevice> {
-        const foundDevice = await scanner.findOperationalDevice(
-            fabric,
-            peerNodeId,
-            timeoutSeconds,
-            ignoreExistingRecords,
-        );
+        const foundDevice = await scanner.findOperationalDevice(fabric, peerNodeId, timeout, ignoreExistingRecords);
         if (foundDevice === undefined) {
             throw new DiscoveryError(
                 "The operational device cannot be found on the network. Please make sure it is online.",
@@ -160,7 +164,7 @@ export class ControllerDiscovery {
             address: AddressTypeFromDevice<DD>,
             device?: DD,
         ): Promise<{ result: T; resultAddress: AddressTypeFromDevice<DD>; resultDevice?: DD } | undefined> => {
-            const serverKey = serverAddressToString(address);
+            const serverKey = ServerAddress.urlFor(address);
 
             logger.debug(`Try to communicate with ${serverKey} ...`);
             try {
@@ -177,13 +181,13 @@ export class ControllerDiscovery {
         const addresses = new Map<string, { address: AddressTypeFromDevice<DD>; device?: DD }>();
 
         devices.forEach(device =>
-            device.addresses.forEach(address => addresses.set(serverAddressToString(address), { address, device })),
+            device.addresses.forEach(address => addresses.set(ServerAddress.urlFor(address), { address, device })),
         );
         const triedAddresses = new Set<string>();
 
         if (lastKnownAddress !== undefined) {
-            const knownKey = serverAddressToString(lastKnownAddress);
-            const knownDevice = addresses.has(serverAddressToString(lastKnownAddress))
+            const knownKey = ServerAddress.urlFor(lastKnownAddress);
+            const knownDevice = addresses.has(ServerAddress.urlFor(lastKnownAddress))
                 ? addresses.get(knownKey)?.device
                 : undefined;
             addresses.delete(knownKey);
@@ -203,7 +207,7 @@ export class ControllerDiscovery {
 
             let triedOne = false;
             for (const { address, device } of addresses.values()) {
-                const serverKey = serverAddressToString(address);
+                const serverKey = ServerAddress.urlFor(address);
                 if (triedAddresses.has(serverKey)) continue;
                 triedAddresses.add(serverKey);
 
@@ -224,7 +228,7 @@ export class ControllerDiscovery {
             if (triedOne) {
                 (await updateDevicesFunc()).forEach(device =>
                     device.addresses.forEach(address =>
-                        addresses.set(serverAddressToString(address), { address, device }),
+                        addresses.set(ServerAddress.urlFor(address), { address, device }),
                     ),
                 ); // Update list and add new
             } else {

--- a/packages/protocol/src/peer/InteractionQueue.ts
+++ b/packages/protocol/src/peer/InteractionQueue.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Environment, Environmental, PromiseQueue } from "#general";
+import { Environment, Environmental, PromiseQueue, Seconds } from "#general";
 
 const CONCURRENT_QUEUED_INTERACTIONS = 4;
-const INTERACTION_QUEUE_DELAY_MS = 100;
+const INTERACTION_QUEUE_DELAY = Seconds.tenth;
 
 export class InteractionQueue extends PromiseQueue {
     constructor() {
-        super(CONCURRENT_QUEUED_INTERACTIONS, INTERACTION_QUEUE_DELAY_MS);
+        super(CONCURRENT_QUEUED_INTERACTIONS, INTERACTION_QUEUE_DELAY);
     }
 
     static [Environmental.create](env: Environment) {

--- a/packages/protocol/src/peer/PeerSet.ts
+++ b/packages/protocol/src/peer/PeerSet.ts
@@ -16,15 +16,18 @@ import {
     Environmental,
     ImmutableSet,
     ImplementationError,
+    Interval,
     isIpNetworkChannel,
     isIPv6,
     Logger,
     MatterError,
+    Minutes,
     NetInterfaceSet,
     NoResponseTimeoutError,
     ObservableSet,
+    Seconds,
+    ServerAddress,
     ServerAddressIp,
-    serverAddressToString,
     STANDARD_MATTER_PORT,
     Time,
     Timer,
@@ -50,8 +53,8 @@ import { PeerAddressStore, PeerDataStore } from "./PeerAddressStore.js";
 
 const logger = Logger.get("PeerSet");
 
-const RECONNECTION_POLLING_INTERVAL_MS = 600_000; // 10 minutes
-const RETRANSMISSION_DISCOVERY_TIMEOUT_S = 5;
+const RECONNECTION_POLLING_INTERVAL = Minutes(10);
+const RETRANSMISSION_DISCOVERY_TIMEOUT = Seconds(5);
 
 /**
  * Types of discovery that may be performed when connecting operationally.
@@ -78,7 +81,7 @@ export class UnknownNodeError extends MatterError {}
  */
 export interface DiscoveryOptions {
     discoveryType?: NodeDiscoveryType;
-    timeoutSeconds?: number;
+    timeout?: Interval;
     discoveryData?: DiscoveryData;
 }
 
@@ -333,7 +336,10 @@ export class PeerSet implements ImmutableSet<OperationalPeer>, ObservableSet<Ope
                 await this.#sessions.removeAllSessionsForNode(address);
                 throw new RetransmissionLimitReachedError(`No operational address found for ${PeerAddress(address)}`);
             }
-            if ((await this.#reconnectKnownAddress(address, operationalAddress, discoveryData, 2_000)) === undefined) {
+            if (
+                (await this.#reconnectKnownAddress(address, operationalAddress, discoveryData, Seconds(2))) ===
+                undefined
+            ) {
                 throw new RetransmissionLimitReachedError(`${PeerAddress(address)} is not reachable.`);
             }
         });
@@ -438,10 +444,10 @@ export class PeerSet implements ImmutableSet<OperationalPeer>, ObservableSet<Ope
         address = PeerAddress(address);
         const {
             discoveryType: requestedDiscoveryType = NodeDiscoveryType.FullDiscovery,
-            timeoutSeconds,
+            timeout,
             discoveryData = this.#peersByAddress.get(address)?.discoveryData,
         } = discoveryOptions;
-        if (timeoutSeconds !== undefined && requestedDiscoveryType !== NodeDiscoveryType.TimedDiscovery) {
+        if (timeout !== undefined && requestedDiscoveryType !== NodeDiscoveryType.TimedDiscovery) {
             throw new ImplementationError("Cannot set timeout without timed discovery.");
         }
         if (requestedDiscoveryType === NodeDiscoveryType.RetransmissionDiscovery) {
@@ -480,7 +486,7 @@ export class PeerSet implements ImmutableSet<OperationalPeer>, ObservableSet<Ope
                 operationalAddress,
                 discoveryData,
                 // When we use a timeout for discovery also use this for reconnecting to the node
-                timeoutSeconds ? timeoutSeconds * 1000 : undefined,
+                timeout,
             );
             if (directReconnection !== undefined) {
                 return directReconnection;
@@ -515,14 +521,14 @@ export class PeerSet implements ImmutableSet<OperationalPeer>, ObservableSet<Ope
                 const { promise, resolver, rejecter } = createPromise<MessageChannel>();
 
                 logger.debug(
-                    `Starting reconnection polling for ${serverAddressToString(lastOperationalAddress)} (Interval ${RECONNECTION_POLLING_INTERVAL_MS / 1000}s)`,
+                    `Starting reconnection polling for ${ServerAddress.urlFor(lastOperationalAddress)} (Interval ${RECONNECTION_POLLING_INTERVAL})`,
                 );
                 reconnectionPollingTimer = Time.getPeriodicTimer(
                     "Controller reconnect",
-                    RECONNECTION_POLLING_INTERVAL_MS,
+                    RECONNECTION_POLLING_INTERVAL,
                     async () => {
                         try {
-                            logger.debug(`Polling for device at ${serverAddressToString(lastOperationalAddress)} ...`);
+                            logger.debug(`Polling for device at ${ServerAddress.urlFor(lastOperationalAddress)} ...`);
                             const result = await this.#reconnectKnownAddress(
                                 address,
                                 lastOperationalAddress,
@@ -565,8 +571,8 @@ export class PeerSet implements ImmutableSet<OperationalPeer>, ObservableSet<Ope
                 this.#sessions.fabricFor(address),
                 address.nodeId,
                 mdnsScanner,
-                timeoutSeconds,
-                timeoutSeconds === undefined,
+                timeout,
+                timeout === undefined,
             );
             const { stopTimerFunc } = this.#runningPeerDiscoveries.get(address) ?? {};
             stopTimerFunc?.();
@@ -611,21 +617,21 @@ export class PeerSet implements ImmutableSet<OperationalPeer>, ObservableSet<Ope
         address: PeerAddress,
         operationalAddress: ServerAddressIp,
         discoveryData?: DiscoveryData,
-        expectedProcessingTimeMs?: number,
+        expectedProcessingTime?: Interval,
     ): Promise<MessageChannel | undefined> {
         address = PeerAddress(address);
 
         const { ip, port } = operationalAddress;
-        const startTime = Time.nowMs();
+        const startTime = Time.nowMs;
         try {
             logger.debug(
                 `Resuming connection to ${PeerAddress(address)} at ${ip}:${port}${
-                    expectedProcessingTimeMs !== undefined
-                        ? ` with expected processing time of ${expectedProcessingTimeMs}ms`
+                    expectedProcessingTime !== undefined
+                        ? ` with expected processing time of ${expectedProcessingTime}`
                         : ""
                 }`,
             );
-            const channel = await this.#pair(address, operationalAddress, discoveryData, expectedProcessingTimeMs);
+            const channel = await this.#pair(address, operationalAddress, discoveryData, expectedProcessingTime);
             await this.#addOrUpdatePeer(address, operationalAddress);
             return channel;
         } catch (error) {
@@ -669,9 +675,9 @@ export class PeerSet implements ImmutableSet<OperationalPeer>, ObservableSet<Ope
         address: PeerAddress,
         operationalServerAddress: ServerAddressIp,
         discoveryData?: DiscoveryData,
-        expectedProcessingTimeMs?: number,
+        expectedProcessingTime?: Interval,
     ) {
-        logger.debug(`Pair with ${address} at ${serverAddressToString(operationalServerAddress)}`);
+        logger.debug(`Pair with ${address} at ${ServerAddress.urlFor(operationalServerAddress)}`);
         const { ip, port } = operationalServerAddress;
         // Do CASE pairing
         const isIpv6Address = isIPv6(ip);
@@ -693,9 +699,9 @@ export class PeerSet implements ImmutableSet<OperationalPeer>, ObservableSet<Ope
         const unsecureSession = this.#sessions.createInsecureSession({
             // Use the session parameters from MDNS announcements when available and rest is assumed to be fallbacks
             sessionParameters: {
-                idleIntervalMs: discoveryData?.SII ?? sessionParameters?.idleIntervalMs,
-                activeIntervalMs: discoveryData?.SAI ?? sessionParameters?.activeIntervalMs,
-                activeThresholdMs: discoveryData?.SAT ?? sessionParameters?.activeThresholdMs,
+                idleInterval: discoveryData?.SII ?? sessionParameters?.idleInterval,
+                activeInterval: discoveryData?.SAI ?? sessionParameters?.activeInterval,
+                activeThreshold: discoveryData?.SAT ?? sessionParameters?.activeThreshold,
             },
             isInitiator: true,
         });
@@ -704,7 +710,7 @@ export class PeerSet implements ImmutableSet<OperationalPeer>, ObservableSet<Ope
             const operationalSecureSession = await this.#doCasePair(
                 new MessageChannel(operationalChannel, unsecureSession),
                 address,
-                expectedProcessingTimeMs,
+                expectedProcessingTime,
             );
 
             const channel = new MessageChannel(operationalChannel, operationalSecureSession);
@@ -723,7 +729,7 @@ export class PeerSet implements ImmutableSet<OperationalPeer>, ObservableSet<Ope
     async #doCasePair(
         unsecureMessageChannel: MessageChannel,
         address: PeerAddress,
-        expectedProcessingTimeMs?: number,
+        expectedProcessingTime?: Interval,
     ): Promise<SecureSession> {
         const fabric = this.#sessions.fabricFor(address);
         let exchange: MessageExchange | undefined;
@@ -734,7 +740,7 @@ export class PeerSet implements ImmutableSet<OperationalPeer>, ObservableSet<Ope
                 exchange,
                 fabric,
                 address.nodeId,
-                expectedProcessingTimeMs,
+                expectedProcessingTime,
             );
 
             if (!resumed) {
@@ -755,7 +761,7 @@ export class PeerSet implements ImmutableSet<OperationalPeer>, ObservableSet<Ope
                         `Case client: Resumption record seems outdated for Fabric ${NodeId.toHexString(fabric.nodeId)} (index ${fabric.fabricIndex}) and PeerNode ${NodeId.toHexString(address.nodeId)}. Retrying pairing without resumption...`,
                     );
                     // An endless loop should not happen here, as the resumption record is deleted in the next step
-                    return await this.#doCasePair(unsecureMessageChannel, address, expectedProcessingTimeMs);
+                    return await this.#doCasePair(unsecureMessageChannel, address, expectedProcessingTime);
                 }
             }
             throw error;
@@ -844,7 +850,7 @@ export class PeerSet implements ImmutableSet<OperationalPeer>, ObservableSet<Ope
         this.#runningPeerDiscoveries.set(address, { type: NodeDiscoveryType.RetransmissionDiscovery });
         this.#scanners
             .scannerFor(ChannelType.UDP)
-            ?.findOperationalDevice(fabric, nodeId, RETRANSMISSION_DISCOVERY_TIMEOUT_S, true)
+            ?.findOperationalDevice(fabric, nodeId, RETRANSMISSION_DISCOVERY_TIMEOUT, true)
             .catch(error => {
                 logger.error(`Failed to discover ${address} after resubmission started.`, error);
             })

--- a/packages/protocol/src/protocol/DeviceCommissioner.ts
+++ b/packages/protocol/src/protocol/DeviceCommissioner.ts
@@ -24,7 +24,7 @@ import {
 import { SecureChannelProtocol } from "#securechannel/SecureChannelProtocol.js";
 import { PaseServer } from "#session/pase/PaseServer.js";
 import { SessionManager } from "#session/SessionManager.js";
-import { CommissioningOptions, STANDARD_COMMISSIONING_TIMEOUT_S, StatusCode, StatusResponseError } from "#types";
+import { CommissioningOptions, STANDARD_COMMISSIONING_TIMEOUT, StatusCode, StatusResponseError } from "#types";
 import type { ControllerCommissioner } from "../peer/ControllerCommissioner.js";
 import { DeviceAdvertiser } from "./DeviceAdvertiser.js";
 
@@ -161,7 +161,7 @@ export class DeviceCommissioner {
 
         this.#windowStatus = windowStatus;
         const commissioningConfig = this.#context.commissioningConfig.values;
-        const advertisementWindowS = commissioningConfig.advertisementWindowS ?? STANDARD_COMMISSIONING_TIMEOUT_S;
+        const advertisementWindowS = commissioningConfig.advertisementWindow ?? STANDARD_COMMISSIONING_TIMEOUT;
 
         const mode =
             windowStatus === AdministratorCommissioning.CommissioningWindowStatus.EnhancedWindowOpen

--- a/packages/protocol/src/protocol/ExchangeManager.ts
+++ b/packages/protocol/src/protocol/ExchangeManager.ts
@@ -26,7 +26,7 @@ import {
 import { PeerAddress } from "#peer/PeerAddress.js";
 import {
     ChannelNotConnectedError,
-    DEFAULT_EXPECTED_PROCESSING_TIME_MS,
+    DEFAULT_EXPECTED_PROCESSING_TIME,
     MessageChannel,
 } from "#protocol/MessageChannel.js";
 import { SecureChannelMessenger } from "#securechannel/SecureChannelMessenger.js";
@@ -412,12 +412,9 @@ export class ExchangeManager {
 
     calculateMaximumPeerResponseTimeMsFor(
         channel: MessageChannel,
-        expectedProcessingTimeMs = DEFAULT_EXPECTED_PROCESSING_TIME_MS,
+        expectedProcessingTime = DEFAULT_EXPECTED_PROCESSING_TIME,
     ) {
-        return channel.calculateMaximumPeerResponseTimeMs(
-            this.#sessionManager.sessionParameters,
-            expectedProcessingTimeMs,
-        );
+        return channel.calculateMaximumPeerResponseTime(this.#sessionManager.sessionParameters, expectedProcessingTime);
     }
 
     #messageExchangeContextFor(channel: MessageChannel): MessageExchangeContext {

--- a/packages/protocol/src/protocol/ExchangeProvider.ts
+++ b/packages/protocol/src/protocol/ExchangeProvider.ts
@@ -3,13 +3,13 @@
  * Copyright 2022-2025 Matter.js Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { ChannelType, Observable } from "#general";
+import { ChannelType, Interval, Observable } from "#general";
 import { PeerAddress } from "#peer/PeerAddress.js";
 import { ChannelManager } from "#protocol/ChannelManager.js";
 import { ExchangeManager } from "#protocol/ExchangeManager.js";
 import {
     ChannelNotConnectedError,
-    DEFAULT_EXPECTED_PROCESSING_TIME_MS,
+    DEFAULT_EXPECTED_PROCESSING_TIME,
     MessageChannel,
 } from "#protocol/MessageChannel.js";
 import { MessageExchange } from "#protocol/MessageExchange.js";
@@ -37,7 +37,7 @@ export abstract class ExchangeProvider {
         this.exchangeManager.addProtocolHandler(handler);
     }
 
-    abstract maximumPeerResponseTimeMs(expectedProcessingTimeMs?: number): number;
+    abstract maximumPeerResponseTime(expectedProcessingTime?: Interval): Interval;
     abstract initiateExchange(): Promise<MessageExchange>;
     abstract reconnectChannel(): Promise<boolean>;
     abstract session: Session;
@@ -72,8 +72,8 @@ export class DedicatedChannelExchangeProvider extends ExchangeProvider {
         return this.#channel.type;
     }
 
-    maximumPeerResponseTimeMs(expectedProcessingTimeMs = DEFAULT_EXPECTED_PROCESSING_TIME_MS) {
-        return this.exchangeManager.calculateMaximumPeerResponseTimeMsFor(this.#channel, expectedProcessingTimeMs);
+    maximumPeerResponseTime(expectedProcessingTime = DEFAULT_EXPECTED_PROCESSING_TIME) {
+        return this.exchangeManager.calculateMaximumPeerResponseTimeMsFor(this.#channel, expectedProcessingTime);
     }
 }
 
@@ -136,7 +136,7 @@ export class ReconnectableExchangeProvider extends ExchangeProvider {
         return this.channelManager.getChannel(this.#address).type;
     }
 
-    maximumPeerResponseTimeMs(expectedProcessingTimeMs = DEFAULT_EXPECTED_PROCESSING_TIME_MS) {
+    maximumPeerResponseTime(expectedProcessingTimeMs = DEFAULT_EXPECTED_PROCESSING_TIME) {
         const channel = this.channelManager.getChannel(this.#address);
         if (!channel) {
             throw new ChannelNotConnectedError("Channel not connected");

--- a/packages/protocol/src/protocol/MessageChannel.ts
+++ b/packages/protocol/src/protocol/MessageChannel.ts
@@ -5,7 +5,7 @@
  */
 
 import { Message, MessageCodec } from "#codec/MessageCodec.js";
-import { Bytes, Channel, Logger, MatterError, MatterFlowError } from "#general";
+import { Bytes, Channel, Logger, MatterError, MatterFlowError, Millisecs, Minutes, Seconds } from "#general";
 import type { ExchangeLogContext } from "#protocol/MessageExchange.js";
 import { Session, SessionParameters } from "#session/Session.js";
 
@@ -18,13 +18,13 @@ export class ChannelNotConnectedError extends MatterError {}
  * from chip implementation. This is basically the default used with different names, also kExpectedLowProcessingTime or
  * kExpectedSigma1ProcessingTime.
  */
-export const DEFAULT_EXPECTED_PROCESSING_TIME_MS = 2000;
+export const DEFAULT_EXPECTED_PROCESSING_TIME = Seconds(2);
 
 /**
  * The buffer time in milliseconds to add to the peer response time to also consider network delays and other factors.
  * TODO: This is a pure guess and should be adjusted in the future.
  */
-const PEER_RESPONSE_TIME_BUFFER_MS = 5_000;
+const PEER_RESPONSE_TIME_BUFFER = Seconds(5);
 
 export namespace MRP {
     /**
@@ -46,7 +46,7 @@ export namespace MRP {
     export const BACKOFF_THRESHOLD = 1;
 
     /** @see {@link MatterSpecification.v12.Core}, section 4.11.8 */
-    export const STANDALONE_ACK_TIMEOUT_MS = 200;
+    export const STANDALONE_ACK_TIMEOUT = Millisecs(200);
 }
 
 export class MessageChannel implements Channel<Message> {
@@ -113,26 +113,28 @@ export class MessageChannel implements Channel<Message> {
         }
     }
 
-    calculateMaximumPeerResponseTimeMs(
+    calculateMaximumPeerResponseTime(
         sessionParameters: SessionParameters,
-        expectedProcessingTimeMs = DEFAULT_EXPECTED_PROCESSING_TIME_MS,
+        expectedProcessingTime = DEFAULT_EXPECTED_PROCESSING_TIME,
     ) {
         switch (this.channel.type) {
             case "tcp":
                 // TCP uses 30s timeout according to chip sdk implementation, so do the same
-                return 30_000 + PEER_RESPONSE_TIME_BUFFER_MS;
+                return Minutes.half.plus(PEER_RESPONSE_TIME_BUFFER);
+
             case "udp":
                 // UDP normally uses MRP, if not we have Group communication, which normally have no responses
                 if (!this.usesMrp) {
                     throw new MatterFlowError("No response expected for this message exchange because UDP and no MRP.");
                 }
-                return (
-                    this.#calculateMrpMaximumPeerResponseTime(sessionParameters, expectedProcessingTimeMs) +
-                    PEER_RESPONSE_TIME_BUFFER_MS
+                return this.#calculateMrpMaximumPeerResponseTime(sessionParameters, expectedProcessingTime).plus(
+                    PEER_RESPONSE_TIME_BUFFER,
                 );
+
             case "ble":
                 // chip sdk uses BTP_ACK_TIMEOUT_MS which is wrong in my eyes, so we use static 30s as like TCP here
-                return 30_000 + PEER_RESPONSE_TIME_BUFFER_MS;
+                return Minutes.half.plus(PEER_RESPONSE_TIME_BUFFER);
+
             default:
                 throw new MatterFlowError(
                     `Can not calculate expected timeout for unknown channel type: ${this.channel.type}`,
@@ -149,27 +151,29 @@ export class MessageChannel implements Channel<Message> {
      * @see {@link MatterSpecification.v10.Core}, section 4.11.2.1
      */
     getMrpResubmissionBackOffTime(retransmissionCount: number, sessionParameters?: SessionParameters) {
-        const { activeIntervalMs, idleIntervalMs } = sessionParameters ?? this.session.parameters;
+        const { activeInterval: activeIntervalMs, idleInterval: idleIntervalMs } =
+            sessionParameters ?? this.session.parameters;
         const baseInterval =
             sessionParameters !== undefined || this.session.isPeerActive() ? activeIntervalMs : idleIntervalMs;
-        return Math.floor(
-            MRP.BACKOFF_MARGIN *
-                baseInterval *
-                Math.pow(MRP.BACKOFF_BASE, Math.max(0, retransmissionCount - MRP.BACKOFF_THRESHOLD)) *
-                (1 + (sessionParameters !== undefined ? 1 : Math.random()) * MRP.BACKOFF_JITTER),
-        );
+        return Millisecs(
+            baseInterval.times(
+                MRP.BACKOFF_MARGIN *
+                    Math.pow(MRP.BACKOFF_BASE, Math.max(0, retransmissionCount - MRP.BACKOFF_THRESHOLD)) *
+                    (1 + (sessionParameters !== undefined ? 1 : Math.random()) * MRP.BACKOFF_JITTER),
+            ),
+        ).floor;
     }
 
     #calculateMrpMaximumPeerResponseTime(
         sessionParameters: SessionParameters,
-        expectedProcessingTimeMs = DEFAULT_EXPECTED_PROCESSING_TIME_MS,
+        expectedProcessingTime = DEFAULT_EXPECTED_PROCESSING_TIME,
     ) {
         // We use the expected processing time and deduct the time we already waited since last resubmission
-        let finalWaitTime = expectedProcessingTimeMs;
+        let finalWaitTime = expectedProcessingTime;
 
         // and then add the time the other side needs for a full resubmission cycle under the assumption we are active
         for (let i = 0; i < MRP.MAX_TRANSMISSIONS; i++) {
-            finalWaitTime += this.getMrpResubmissionBackOffTime(i, sessionParameters);
+            finalWaitTime = finalWaitTime.plus(this.getMrpResubmissionBackOffTime(i, sessionParameters));
         }
 
         // TODO: Also add any network latency buffer, for now lets consider it's included in the processing time already

--- a/packages/protocol/src/protocol/MessageExchange.ts
+++ b/packages/protocol/src/protocol/MessageExchange.ts
@@ -12,7 +12,9 @@ import {
     CRYPTO_AEAD_MIC_LENGTH_BYTES,
     DataReadQueue,
     Diagnostic,
+    Instant,
     InternalError,
+    Interval,
     Logger,
     MatterError,
     MatterFlowError,
@@ -22,7 +24,7 @@ import {
 } from "#general";
 import {
     ChannelNotConnectedError,
-    DEFAULT_EXPECTED_PROCESSING_TIME_MS,
+    DEFAULT_EXPECTED_PROCESSING_TIME,
     MessageChannel,
     MRP,
 } from "#protocol/MessageChannel.js";
@@ -70,7 +72,7 @@ export type ExchangeSendOptions = {
      * Defined an expected processing time by the responder for the message. This is used to calculate the final
      * timeout for responses together with the normal retransmission logic when MRP is used.
      */
-    expectedProcessingTimeMs?: number;
+    expectedProcessingTime?: Interval;
 
     /** Allows to specify if the send message requires to be acknowledged by the receiver or not. */
     requiresAck?: boolean;
@@ -137,12 +139,12 @@ export class MessageExchange {
         );
     }
 
-    readonly #activeIntervalMs: number;
-    readonly #idleIntervalMs: number;
-    readonly #activeThresholdMs: number;
+    readonly #activeInterval: Interval;
+    readonly #idleInterval: Interval;
+    readonly #activeThreshold: Interval;
     readonly #messagesQueue = new DataReadQueue<Message>();
     #receivedMessageToAck: Message | undefined;
-    #receivedMessageAckTimer = Time.getTimer("Ack receipt timeout", MRP.STANDALONE_ACK_TIMEOUT_MS, () => {
+    #receivedMessageAckTimer = Time.getTimer("Ack receipt timeout", MRP.STANDALONE_ACK_TIMEOUT, () => {
         if (this.#receivedMessageToAck !== undefined) {
             const messageToAck = this.#receivedMessageToAck;
             this.#receivedMessageToAck = undefined;
@@ -188,10 +190,10 @@ export class MessageExchange {
         this.#exchangeId = exchangeId;
         this.#protocolId = protocolId;
 
-        const { activeIntervalMs, idleIntervalMs, activeThresholdMs } = SessionIntervals(session.parameters);
-        this.#activeIntervalMs = activeIntervalMs;
-        this.#idleIntervalMs = idleIntervalMs;
-        this.#activeThresholdMs = activeThresholdMs;
+        const { activeInterval, idleInterval, activeThreshold } = SessionIntervals(session.parameters);
+        this.#activeInterval = activeInterval;
+        this.#idleInterval = idleInterval;
+        this.#activeThreshold = activeThreshold;
 
         this.#used = !isInitiator; // If we are the initiator then exchange was not used yet, so track it
 
@@ -203,9 +205,9 @@ export class MessageExchange {
                 exId: this.#exchangeId,
                 sess: session.name,
                 peerSess: this.#peerSessionId,
-                SAT: this.#activeThresholdMs,
-                SAI: this.#activeIntervalMs,
-                SII: this.#idleIntervalMs,
+                SAT: this.#activeThreshold,
+                SAI: this.#activeInterval,
+                SII: this.#idleInterval,
                 maxTrans: MRP.MAX_TRANSMISSIONS,
                 exchangeFlags: Diagnostic.asFlags({
                     MRP: this.channel.usesMrp,
@@ -353,7 +355,7 @@ export class MessageExchange {
         const {
             expectAckOnly = false,
             disableMrpLogic,
-            expectedProcessingTimeMs = DEFAULT_EXPECTED_PROCESSING_TIME_MS,
+            expectedProcessingTime = DEFAULT_EXPECTED_PROCESSING_TIME,
             requiresAck,
             includeAcknowledgeMessageId,
             logContext,
@@ -440,7 +442,7 @@ export class MessageExchange {
             this.#retransmissionTimer = Time.getTimer(
                 `Message retransmission ${message.packetHeader.messageId}`,
                 this.channel.getMrpResubmissionBackOffTime(0),
-                () => this.#retransmitMessage(message, expectedProcessingTimeMs),
+                () => this.#retransmitMessage(message, expectedProcessingTime),
             );
             const { promise, resolver, rejecter } = createPromise<Message>();
             ackPromise = promise;
@@ -467,41 +469,39 @@ export class MessageExchange {
         }
     }
 
-    nextMessage(options?: { expectedProcessingTimeMs?: number; timeoutMs?: number }) {
-        let timeout: number;
-        if (options?.timeoutMs !== undefined) {
-            timeout = options.timeoutMs;
+    nextMessage(options?: { expectedProcessingTime?: Interval; timeout?: Interval }) {
+        let timeout: Interval;
+        if (options?.timeout !== undefined) {
+            timeout = options.timeout;
         } else if (this.#messagesQueue.size > 0) {
-            timeout = 0; // If we have messages in the queue, we can return them immediately
+            timeout = Instant; // If we have messages in the queue, we can return them immediately
         } else {
-            timeout = this.channel.calculateMaximumPeerResponseTimeMs(
+            timeout = this.channel.calculateMaximumPeerResponseTime(
                 this.context.localSessionParameters,
-                options?.expectedProcessingTimeMs,
+                options?.expectedProcessingTime,
             );
         }
         return this.#messagesQueue.read(timeout);
     }
 
-    calculateMaximumPeerResponseTimeMs(expectedProcessingTimeMs = DEFAULT_EXPECTED_PROCESSING_TIME_MS) {
-        return this.channel.calculateMaximumPeerResponseTimeMs(
+    calculateMaximumPeerResponseTimeMs(expectedProcessingTimeMs = DEFAULT_EXPECTED_PROCESSING_TIME) {
+        return this.channel.calculateMaximumPeerResponseTime(
             this.context.localSessionParameters,
             expectedProcessingTimeMs,
         );
     }
 
-    #retransmitMessage(message: Message, expectedProcessingTimeMs?: number) {
+    #retransmitMessage(message: Message, expectedProcessingTime?: Interval) {
         this.#retransmissionCounter++;
         if (this.#retransmissionCounter >= MRP.MAX_TRANSMISSIONS) {
             // Ok all 4 resubmissions are done, but we need to wait a bit longer because of processing time and
             // the resubmissions from the other side
-            if (expectedProcessingTimeMs !== undefined) {
+            if (expectedProcessingTime) {
                 // We already have waited after the last message was sent, so deduct this time from the final wait time
-                const finalWaitTime =
-                    this.channel.calculateMaximumPeerResponseTimeMs(
-                        this.context.localSessionParameters,
-                        expectedProcessingTimeMs,
-                    ) - (this.#retransmissionTimer?.intervalMs ?? 0);
-                if (finalWaitTime > 0) {
+                const finalWaitTime = this.channel
+                    .calculateMaximumPeerResponseTime(this.context.localSessionParameters, expectedProcessingTime)
+                    .minus(this.#retransmissionTimer?.interval ?? Instant);
+                if (finalWaitTime.length > 0) {
                     this.#retransmissionCounter--; // We will not resubmit the message again
                     logger.debug(
                         `Message ${message.packetHeader.messageId}: Wait additional ${finalWaitTime}ms for processing time and peer resubmissions after all our resubmissions`,
@@ -539,18 +539,18 @@ export class MessageExchange {
 
         this.channel
             .send(message)
-            .then(() => this.#initializeResubmission(message, resubmissionBackoffTime, expectedProcessingTimeMs))
+            .then(() => this.#initializeResubmission(message, resubmissionBackoffTime, expectedProcessingTime))
             .catch(error => {
                 logger.error("An error happened when retransmitting a message", error);
                 if (error instanceof ChannelNotConnectedError) {
                     this.#close().catch(error => logger.error("An error happened when closing the exchange", error));
                 } else {
-                    this.#initializeResubmission(message, resubmissionBackoffTime, expectedProcessingTimeMs);
+                    this.#initializeResubmission(message, resubmissionBackoffTime, expectedProcessingTime);
                 }
             });
     }
 
-    #initializeResubmission(message: Message, resubmissionBackoffTime: number, expectedProcessingTimeMs?: number) {
+    #initializeResubmission(message: Message, resubmissionBackoffTime: Interval, expectedProcessingTimeMs?: Interval) {
         this.#retransmissionTimer = Time.getTimer("Message retransmission", resubmissionBackoffTime, () =>
             this.#retransmitMessage(message, expectedProcessingTimeMs),
         ).start();
@@ -570,7 +570,7 @@ export class MessageExchange {
         await this.#close();
     }
 
-    startTimedInteraction(timeoutMs: number) {
+    startTimedInteraction(timeout: Interval) {
         if (this.#timedInteractionTimer !== undefined && this.#timedInteractionTimer.isRunning) {
             this.#timedInteractionTimer.stop();
             throw new StatusResponseError(
@@ -579,9 +579,9 @@ export class MessageExchange {
             );
         }
         logger.debug(
-            `Starting timed interaction with Transaction ID ${this.#exchangeId} for ${timeoutMs}ms from ${this.channel.name}`,
+            `Starting timed interaction with Transaction ID ${this.#exchangeId} for ${timeout}ms from ${this.channel.name}`,
         );
-        this.#timedInteractionTimer = Time.getTimer("Timed interaction", timeoutMs, () => {
+        this.#timedInteractionTimer = Time.getTimer("Timed interaction", timeout, () => {
             logger.debug(
                 `Timed interaction with Transaction ID ${this.#exchangeId} from ${this.channel.name} timed out`,
             );
@@ -653,9 +653,9 @@ export class MessageExchange {
         // Wait until all potential Resubmissions are done, also for Standalone-Acks.
         // We might wait a bit longer then needed but because this is mainly a failsafe mechanism it is acceptable.
         // in normal case this timer is cancelled before it triggers when all retries are done.
-        let maxResubmissionTime = 0;
+        let maxResubmissionTime = Instant;
         for (let i = this.#retransmissionCounter; i <= MRP.MAX_TRANSMISSIONS; i++) {
-            maxResubmissionTime += this.channel.getMrpResubmissionBackOffTime(i);
+            maxResubmissionTime = maxResubmissionTime.plus(this.channel.getMrpResubmissionBackOffTime(i));
         }
         this.#closeTimer = Time.getTimer(
             `Message exchange cleanup ${this.session.name} / ${this.#exchangeId}`,

--- a/packages/protocol/src/session/NodeSession.ts
+++ b/packages/protocol/src/session/NodeSession.ts
@@ -176,9 +176,9 @@ export class NodeSession extends SecureSession {
     parameterDiagnostics() {
         return Diagnostic.dict(
             {
-                SII: this.idleIntervalMs,
-                SAI: this.activeIntervalMs,
-                SAT: this.activeThresholdMs,
+                SII: this.idleInterval,
+                SAI: this.activeInterval,
+                SAT: this.activeThreshold,
                 DMRev: this.dataModelRevision,
                 IMRev: this.interactionModelRevision,
                 spec: Diagnostic.hex(this.specificationVersion),

--- a/packages/protocol/src/session/SessionIntervals.ts
+++ b/packages/protocol/src/session/SessionIntervals.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ImplementationError } from "@matter/general";
+import { Hours, ImplementationError, Interval, Millisecs, Seconds } from "#general";
 
 export interface SessionIntervals {
     /**
@@ -13,7 +13,7 @@ export interface SessionIntervals {
      *
      * Default: 500ms
      */
-    idleIntervalMs: number;
+    idleInterval: Interval;
 
     /**
      * Minimum amount of time between sender retries when the destination node is active. This SHALL be greater than or
@@ -21,27 +21,27 @@ export interface SessionIntervals {
      *
      * Default: 300ms
      */
-    activeIntervalMs: number;
+    activeInterval: Interval;
 
     /**
      * Minimum amount of time the node SHOULD stay active after network activity.
      *
      * Default: 4000ms
      */
-    activeThresholdMs: number;
+    activeThreshold: Interval;
 }
 
 export function SessionIntervals(intervals?: Partial<SessionIntervals>): SessionIntervals {
     const reified = { ...SessionIntervals.defaults, ...intervals };
-    const { idleIntervalMs, activeIntervalMs, activeThresholdMs } = reified;
+    const { idleInterval, activeInterval, activeThreshold } = reified;
 
-    if (idleIntervalMs !== undefined && idleIntervalMs > 3600000) {
+    if (idleInterval && idleInterval > Hours.one) {
         throw new ImplementationError("Session Idle Interval must be less than 1 hour");
     }
-    if (activeIntervalMs !== undefined && activeIntervalMs > 3600000) {
+    if (activeInterval && activeInterval > Hours.one) {
         throw new ImplementationError("Session Active Interval must be less than 1 hour");
     }
-    if (activeThresholdMs !== undefined && activeThresholdMs > 65535) {
+    if (activeThreshold && activeThreshold > Seconds(65535)) {
         throw new ImplementationError("Session Active Threshold must be less than 65535 seconds");
     }
 
@@ -50,8 +50,8 @@ export function SessionIntervals(intervals?: Partial<SessionIntervals>): Session
 
 export namespace SessionIntervals {
     export const defaults = {
-        idleIntervalMs: 500,
-        activeIntervalMs: 300,
-        activeThresholdMs: 4000,
+        idleInterval: Millisecs(500),
+        activeInterval: Millisecs(300),
+        activeThreshold: Seconds(4),
     };
 }

--- a/packages/protocol/src/session/SessionManager.ts
+++ b/packages/protocol/src/session/SessionManager.ts
@@ -13,6 +13,7 @@ import {
     Construction,
     Environment,
     Environmental,
+    Interval,
     Lifecycle,
     Logger,
     MatterAggregateError,
@@ -74,9 +75,9 @@ type ResumptionStorageRecord = {
     fabricId: FabricId;
     peerNodeId: NodeId;
     sessionParameters: {
-        idleIntervalMs: number;
-        activeIntervalMs: number;
-        activeThresholdMs: number;
+        idleInterval: Interval;
+        activeInterval: Interval;
+        activeThreshold: Interval;
         dataModelRevision: number;
         interactionModelRevision: number;
         specificationVersion: number;
@@ -575,9 +576,9 @@ export class SessionManager {
                 fabricId,
                 peerNodeId,
                 sessionParameters: {
-                    idleIntervalMs,
-                    activeIntervalMs,
-                    activeThresholdMs,
+                    idleInterval,
+                    activeInterval,
+                    activeThreshold,
                     dataModelRevision,
                     interactionModelRevision,
                     specificationVersion,
@@ -607,9 +608,9 @@ export class SessionManager {
                     peerNodeId,
                     sessionParameters: {
                         // Make sure to initialize default values when restoring an older resumption record
-                        idleIntervalMs: idleIntervalMs ?? SessionIntervals.defaults.idleIntervalMs,
-                        activeIntervalMs: activeIntervalMs ?? SessionIntervals.defaults.activeIntervalMs,
-                        activeThresholdMs: activeThresholdMs ?? SessionIntervals.defaults.activeThresholdMs,
+                        idleInterval: idleInterval ?? SessionIntervals.defaults.idleInterval,
+                        activeInterval: activeInterval ?? SessionIntervals.defaults.activeInterval,
+                        activeThreshold: activeThreshold ?? SessionIntervals.defaults.activeThreshold,
                         dataModelRevision: dataModelRevision ?? FALLBACK_DATAMODEL_REVISION,
                         interactionModelRevision: interactionModelRevision ?? FALLBACK_INTERACTIONMODEL_REVISION,
                         specificationVersion: specificationVersion ?? FALLBACK_SPECIFICATION_VERSION,

--- a/packages/protocol/src/session/case/CaseClient.ts
+++ b/packages/protocol/src/session/case/CaseClient.ts
@@ -6,7 +6,7 @@
 
 import { Icac } from "#certificate/kinds/Icac.js";
 import { Noc } from "#certificate/kinds/Noc.js";
-import { Bytes, Logger, PublicKey, UnexpectedDataError } from "#general";
+import { Bytes, Interval, Logger, PublicKey, UnexpectedDataError } from "#general";
 import { ChannelStatusResponseError } from "#securechannel/SecureChannelMessenger.js";
 import { SessionManager } from "#session/SessionManager.js";
 import { NodeId, SecureChannelStatusCode } from "#types";
@@ -36,8 +36,8 @@ export class CaseClient {
         this.#sessions = sessions;
     }
 
-    async pair(exchange: MessageExchange, fabric: Fabric, peerNodeId: NodeId, expectedProcessingTimeMs?: number) {
-        const messenger = new CaseClientMessenger(exchange, expectedProcessingTimeMs);
+    async pair(exchange: MessageExchange, fabric: Fabric, peerNodeId: NodeId, expectedProcessingTime?: Interval) {
+        const messenger = new CaseClientMessenger(exchange, expectedProcessingTime);
 
         try {
             return await this.#doPair(messenger, exchange, fabric, peerNodeId);

--- a/packages/protocol/src/session/pase/PaseMessenger.ts
+++ b/packages/protocol/src/session/pase/PaseMessenger.ts
@@ -6,10 +6,7 @@
 
 import { Bytes } from "#general";
 import { SecureMessageType, TypeFromSchema } from "#types";
-import {
-    DEFAULT_NORMAL_PROCESSING_TIME_MS,
-    SecureChannelMessenger,
-} from "../../securechannel/SecureChannelMessenger.js";
+import { DEFAULT_NORMAL_PROCESSING_TIME, SecureChannelMessenger } from "../../securechannel/SecureChannelMessenger.js";
 import {
     TlvPasePake1,
     TlvPasePake2,
@@ -29,16 +26,13 @@ type PasePake3 = TypeFromSchema<typeof TlvPasePake3>;
 
 export class PaseServerMessenger extends SecureChannelMessenger {
     async readPbkdfParamRequest() {
-        const { payload } = await this.nextMessage(
-            SecureMessageType.PbkdfParamRequest,
-            DEFAULT_NORMAL_PROCESSING_TIME_MS,
-        );
+        const { payload } = await this.nextMessage(SecureMessageType.PbkdfParamRequest, DEFAULT_NORMAL_PROCESSING_TIME);
         return { requestPayload: payload, request: TlvPbkdfParamRequest.decode(payload) };
     }
 
     async sendPbkdfParamResponse(response: PbkdfParamResponse) {
         return this.send(response, SecureMessageType.PbkdfParamResponse, TlvPbkdfParamResponse, {
-            expectedProcessingTimeMs: DEFAULT_NORMAL_PROCESSING_TIME_MS,
+            expectedProcessingTime: DEFAULT_NORMAL_PROCESSING_TIME,
         });
     }
 
@@ -58,14 +52,14 @@ export class PaseServerMessenger extends SecureChannelMessenger {
 export class PaseClientMessenger extends SecureChannelMessenger {
     sendPbkdfParamRequest(request: PbkdfParamRequest) {
         return this.send(request, SecureMessageType.PbkdfParamRequest, TlvPbkdfParamRequest, {
-            expectedProcessingTimeMs: DEFAULT_NORMAL_PROCESSING_TIME_MS,
+            expectedProcessingTime: DEFAULT_NORMAL_PROCESSING_TIME,
         });
     }
 
     async readPbkdfParamResponse() {
         const { payload } = await this.nextMessage(
             SecureMessageType.PbkdfParamResponse,
-            DEFAULT_NORMAL_PROCESSING_TIME_MS,
+            DEFAULT_NORMAL_PROCESSING_TIME,
         );
         return { responsePayload: payload, response: TlvPbkdfParamResponse.decode(payload) };
     }

--- a/packages/protocol/src/session/pase/PaseServer.ts
+++ b/packages/protocol/src/session/pase/PaseServer.ts
@@ -11,6 +11,7 @@ import {
     Logger,
     MatterFlowError,
     PbkdfParameters,
+    Seconds,
     Spake2p,
     Time,
     Timer,
@@ -27,7 +28,7 @@ const { bytesToNumberBE } = ec;
 
 const logger = Logger.get("PaseServer");
 
-const PASE_PAIRING_TIMEOUT_MS = 60_000;
+const PASE_PAIRING_TIMEOUT_MS = Seconds(60);
 const PASE_COMMISSIONING_MAX_ERRORS = 20;
 
 export class MaximumPasePairingErrorsReachedError extends MatterFlowError {}

--- a/packages/protocol/test/ble/BtpSessionHandlerTest.ts
+++ b/packages/protocol/test/ble/BtpSessionHandlerTest.ts
@@ -364,7 +364,7 @@ describe("BtpSessionHandler", () => {
 
             onHandleMatterMessageCallback = async (matterMessage: Bytes) => {
                 handleMatterMessageResolver(matterMessage);
-                MockTime.getTimer("Mock time", 5000, () =>
+                MockTime.getTimer("Mock time", { ms: 5000 }, () =>
                     btpSessionHandler?.sendMatterMessage(Bytes.fromHex("090807060504030201")),
                 );
             };

--- a/packages/protocol/test/common/FailsafeTimerTest.ts
+++ b/packages/protocol/test/common/FailsafeTimerTest.ts
@@ -5,7 +5,7 @@
  */
 
 import { FailsafeTimer } from "#common/FailsafeTimer.js";
-import { createPromise } from "#general";
+import { createPromise, Instant, Seconds } from "#general";
 
 // TODO identify more cases that are not handled by chip tool tests
 describe("FailSafeTimer Test", () => {
@@ -16,7 +16,7 @@ describe("FailSafeTimer Test", () => {
     describe("Verify Expiry handling", () => {
         it("Expiry callback is called when failsafe expires", async () => {
             const { promise, resolver } = createPromise<void>();
-            new FailsafeTimer(undefined, 1, 100, async () => resolver());
+            new FailsafeTimer(undefined, Seconds.one, Seconds(100), async () => resolver());
 
             await MockTime.advance(1000);
 
@@ -25,13 +25,13 @@ describe("FailSafeTimer Test", () => {
 
         it("Expiry callback is called when failsafe expires after being rearmed (extended)", async () => {
             let expired = false;
-            const failSafe = new FailsafeTimer(undefined, 3, 100, async () => {
+            const failSafe = new FailsafeTimer(undefined, Seconds(3), Seconds(100), async () => {
                 expired = true;
             });
 
             await MockTime.advance(1500);
             expect(expired).to.be.false;
-            await failSafe.reArm(undefined, 3);
+            await failSafe.reArm(undefined, Seconds(3));
             expect(expired).to.be.false;
             await MockTime.advance(1500);
             expect(expired).to.be.false;
@@ -43,25 +43,25 @@ describe("FailSafeTimer Test", () => {
 
         it("Expiry callback is called directly when failsafe expires after being rearmed (with 0)", async () => {
             let expired = false;
-            const failSafe = new FailsafeTimer(undefined, 3, 100, async () => {
+            const failSafe = new FailsafeTimer(undefined, Seconds(3), Seconds(100), async () => {
                 expired = true;
             });
 
             await MockTime.advance(1500);
             expect(expired).to.be.false;
-            await failSafe.reArm(undefined, 0);
+            await failSafe.reArm(undefined, Instant);
             expect(expired).to.be.true;
         });
 
         it("Expiry callback is called when max cumulative failsafe expires", async () => {
             let expired = false;
-            const failSafe = new FailsafeTimer(undefined, 3, 2, async () => {
+            const failSafe = new FailsafeTimer(undefined, Seconds(3), Seconds(2), async () => {
                 expired = true;
             });
 
             await MockTime.advance(1500);
             expect(expired).to.be.false;
-            await failSafe.reArm(undefined, 1);
+            await failSafe.reArm(undefined, Seconds.one);
             expect(expired).to.be.false;
             await MockTime.advance(500);
             expect(expired).to.be.true;
@@ -69,7 +69,7 @@ describe("FailSafeTimer Test", () => {
 
         it("Expiry callback is not called when failsafe was completed", async () => {
             let expired = false;
-            const failSafe = new FailsafeTimer(undefined, 3, 2, async () => {
+            const failSafe = new FailsafeTimer(undefined, Seconds(3), Seconds(2), async () => {
                 expired = true;
             });
 

--- a/packages/protocol/test/interaction/interaction-utils.ts
+++ b/packages/protocol/test/interaction/interaction-utils.ts
@@ -5,7 +5,7 @@
  */
 import { Message, SessionType } from "#codec/MessageCodec.js";
 import { Fabric } from "#fabric/Fabric.js";
-import { Bytes, DataReadQueue, MAX_UDP_MESSAGE_SIZE, PrivateKey, StandardCrypto } from "#general";
+import { Bytes, DataReadQueue, MAX_UDP_MESSAGE_SIZE, PrivateKey, Seconds, StandardCrypto } from "#general";
 import { ExchangeSendOptions, MATTER_MESSAGE_OVERHEAD, MessageExchange } from "#protocol/MessageExchange.js";
 import { NodeSession } from "#session/NodeSession.js";
 import { SecureSession } from "#session/SecureSession.js";
@@ -116,7 +116,7 @@ export async function createDummyMessageExchange(
         salt: Bytes.fromHex("00"),
         isInitiator: false,
         isResumption: false,
-        peerSessionParameters: { idleIntervalMs: 1000, activeIntervalMs: 1000 },
+        peerSessionParameters: { idleInterval: Seconds.one, activeInterval: Seconds.one },
     });
     return new DummyMessageExchange(
         session,

--- a/packages/protocol/test/mdns/MdnsTest.ts
+++ b/packages/protocol/test/mdns/MdnsTest.ts
@@ -11,11 +11,15 @@ import {
     DnsMessage,
     DnsMessageType,
     DnsRecordType,
+    Instant,
     InternalError,
+    Interval,
+    Millisecs,
     MockCrypto,
     MockNetwork,
     MockUdpChannel,
     NetworkSimulator,
+    Seconds,
     Time,
     TransportInterface,
     UdpChannel,
@@ -73,7 +77,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
             name: "00B0D063C2260000.local",
             recordType: 28,
             recordClass: 1,
-            ttl: 120,
+            ttl: Seconds(120),
             value: "fe80::e777:4f5e:c61e:7314",
         },
     ];
@@ -83,7 +87,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
             name: "00B0D063C2260000.local",
             recordType: 1,
             recordClass: 1,
-            ttl: 120,
+            ttl: Seconds(120),
             value: "192.168.200.1",
         });
     }
@@ -220,7 +224,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
             return waitForMessages({ count: 1 }).then(messages => messages[0]);
         }
 
-        function waitForMessages(config: { count: number } | { seconds: number }) {
+        function waitForMessages(config: { count: number } | Interval) {
             if ("count" in config) {
                 return new Promise<Array<DnsMessage>>((resolve, reject) => {
                     const collector = new MessageCollector(() => {
@@ -234,7 +238,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
 
             const collector = new MessageCollector();
             return MockTime.resolve(
-                Time.sleep("message collector", config.seconds * 1000)
+                Time.sleep("message collector", config)
                     .then(collector.close.bind(collector))
                     .then(() => collector),
             );
@@ -251,8 +255,8 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
 
                 advertise({
                     ...OPERATIONAL_SERVICE,
-                    idleIntervalMs: 100,
-                    activeIntervalMs: 200,
+                    idleInterval: Seconds.tenth,
+                    activeInterval: Millisecs(200),
                 });
 
                 expectMessage(await announcement, {
@@ -265,7 +269,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordType: 12,
                             recordClass: 1,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_matter._tcp.local",
                         },
                         {
@@ -273,7 +277,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordType: 12,
                             recordClass: 1,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_I0000000000000018._sub._matter._tcp.local",
                         },
                         {
@@ -281,7 +285,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_matter._tcp.local",
                             recordType: 12,
                             recordClass: 1,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "0000000000000018-0000000000000001._matter._tcp.local",
                         },
                         {
@@ -289,7 +293,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_I0000000000000018._sub._matter._tcp.local",
                             recordType: 12,
                             recordClass: 1,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "0000000000000018-0000000000000001._matter._tcp.local",
                         },
                     ],
@@ -300,7 +304,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "0000000000000018-0000000000000001._matter._tcp.local",
                             recordType: 33,
                             recordClass: 1,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: { priority: 0, weight: 0, port: PORT, target: "00B0D063C2260000.local" },
                         },
                         {
@@ -308,7 +312,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "0000000000000018-0000000000000001._matter._tcp.local",
                             recordType: 16,
                             recordClass: 1,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: ["SII=100", "SAI=200", "SAT=4000"],
                         },
                         ...IPDnsRecords,
@@ -333,7 +337,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordType: 12,
                             recordClass: 1,
-                            ttl: 0,
+                            ttl: Instant,
                             value: "_matter._tcp.local",
                         },
                         {
@@ -341,7 +345,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordType: 12,
                             recordClass: 1,
-                            ttl: 0,
+                            ttl: Instant,
                             value: "_I0000000000000018._sub._matter._tcp.local",
                         },
                         {
@@ -349,7 +353,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_matter._tcp.local",
                             recordType: 12,
                             recordClass: 1,
-                            ttl: 0,
+                            ttl: Instant,
                             value: "0000000000000018-0000000000000001._matter._tcp.local",
                         },
                         {
@@ -357,7 +361,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_I0000000000000018._sub._matter._tcp.local",
                             recordType: 12,
                             recordClass: 1,
-                            ttl: 0,
+                            ttl: Instant,
                             value: "0000000000000018-0000000000000001._matter._tcp.local",
                         },
                     ],
@@ -368,7 +372,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "0000000000000018-0000000000000001._matter._tcp.local",
                             recordType: 33,
                             recordClass: 1,
-                            ttl: 0,
+                            ttl: Instant,
                             value: { priority: 0, weight: 0, port: PORT, target: "00B0D063C2260000.local" },
                         },
                         {
@@ -376,10 +380,10 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "0000000000000018-0000000000000001._matter._tcp.local",
                             recordType: 16,
                             recordClass: 1,
-                            ttl: 0,
+                            ttl: Instant,
                             value: ["SII=100", "SAI=200", "SAT=4000"],
                         },
-                        ...IPDnsRecords.map(record => ({ ...record, ttl: 0 })),
+                        ...IPDnsRecords.map(record => ({ ...record, ttl: Instant })),
                     ],
                 });
             });
@@ -396,7 +400,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "8080808080808080._matterc._udp.local",
                             recordClass: 1,
                             recordType: 33,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: { port: PORT, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
                         },
                         {
@@ -404,7 +408,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "8080808080808080._matterc._udp.local",
                             recordClass: 1,
                             recordType: 16,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: [
                                 "VP=1+32768",
                                 "DT=1",
@@ -425,7 +429,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_matterc._udp.local",
                         },
                         {
@@ -433,7 +437,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_V1._sub._matterc._udp.local",
                         },
                         {
@@ -441,7 +445,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_T1._sub._matterc._udp.local",
                         },
                         {
@@ -449,7 +453,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_S4._sub._matterc._udp.local",
                         },
                         {
@@ -457,7 +461,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_L1234._sub._matterc._udp.local",
                         },
                         {
@@ -465,7 +469,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_CM._sub._matterc._udp.local",
                         },
                         {
@@ -473,7 +477,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_matterc._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "8080808080808080._matterc._udp.local",
                         },
                         {
@@ -481,7 +485,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_V1._sub._matterc._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "8080808080808080._matterc._udp.local",
                         },
                         {
@@ -489,7 +493,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_T1._sub._matterc._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "8080808080808080._matterc._udp.local",
                         },
                         {
@@ -497,7 +501,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_S4._sub._matterc._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "8080808080808080._matterc._udp.local",
                         },
                         {
@@ -505,7 +509,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_L1234._sub._matterc._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "8080808080808080._matterc._udp.local",
                         },
                         {
@@ -513,7 +517,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_CM._sub._matterc._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "8080808080808080._matterc._udp.local",
                         },
                     ],
@@ -546,7 +550,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "8080808080808080._matterd._udp.local",
                             recordClass: 1,
                             recordType: 33,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: { port: PORT, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
                         },
                         {
@@ -554,7 +558,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "8080808080808080._matterd._udp.local",
                             recordClass: 1,
                             recordType: 16,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: ["VP=1+32768", "DT=1", "DN=Test Commissioner", "SII=500", "SAI=300", "SAT=4000"],
                         },
                         ...IPDnsRecords,
@@ -565,7 +569,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_matterd._udp.local",
                         },
                         {
@@ -573,7 +577,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_matterd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_V1._sub._matterd._udp.local",
                         },
                         {
@@ -581,7 +585,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_V1._sub._matterd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "8080808080808080._matterd._udp.local",
                         },
                         {
@@ -589,7 +593,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_T1._sub._matterd._udp.local",
                         },
                         {
@@ -597,7 +601,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_T1._sub._matterd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "8080808080808080._matterd._udp.local",
                         },
                     ],
@@ -638,7 +642,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordType: 12,
                             recordClass: 1,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_matter._tcp.local",
                         },
                         {
@@ -646,7 +650,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordType: 12,
                             recordClass: 1,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_I0000000000000018._sub._matter._tcp.local",
                         },
                         {
@@ -654,7 +658,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_matter._tcp.local",
                             recordType: 12,
                             recordClass: 1,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "0000000000000018-0000000000000001._matter._tcp.local",
                         },
                         {
@@ -662,7 +666,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_I0000000000000018._sub._matter._tcp.local",
                             recordType: 12,
                             recordClass: 1,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "0000000000000018-0000000000000001._matter._tcp.local",
                         },
                     ],
@@ -673,7 +677,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "0000000000000018-0000000000000001._matter._tcp.local",
                             recordType: 33,
                             recordClass: 1,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: { priority: 0, weight: 0, port: PORT, target: "00B0D063C2260000.local" },
                         },
                         {
@@ -681,7 +685,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "0000000000000018-0000000000000001._matter._tcp.local",
                             recordType: 16,
                             recordClass: 1,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: ["SII=500", "SAI=300", "SAT=4000"],
                         },
                         ...IPDnsRecords,
@@ -695,7 +699,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "8080808080808080._matterc._udp.local",
                             recordClass: 1,
                             recordType: 33,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: { port: PORT2, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
                         },
                         {
@@ -703,7 +707,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "8080808080808080._matterc._udp.local",
                             recordClass: 1,
                             recordType: 16,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: [
                                 "VP=1+32768",
                                 "DT=1",
@@ -724,7 +728,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_matterc._udp.local",
                         },
                         {
@@ -732,7 +736,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_V1._sub._matterc._udp.local",
                         },
                         {
@@ -740,7 +744,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_T1._sub._matterc._udp.local",
                         },
                         {
@@ -748,7 +752,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_S4._sub._matterc._udp.local",
                         },
                         {
@@ -756,7 +760,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_L1234._sub._matterc._udp.local",
                         },
                         {
@@ -764,7 +768,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_CM._sub._matterc._udp.local",
                         },
                         {
@@ -772,7 +776,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_matterc._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "8080808080808080._matterc._udp.local",
                         },
                         {
@@ -780,7 +784,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_V1._sub._matterc._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "8080808080808080._matterc._udp.local",
                         },
                         {
@@ -788,7 +792,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_T1._sub._matterc._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "8080808080808080._matterc._udp.local",
                         },
                         {
@@ -796,7 +800,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_S4._sub._matterc._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "8080808080808080._matterc._udp.local",
                         },
                         {
@@ -804,7 +808,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_L1234._sub._matterc._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "8080808080808080._matterc._udp.local",
                         },
                         {
@@ -812,7 +816,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_CM._sub._matterc._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "8080808080808080._matterc._udp.local",
                         },
                     ],
@@ -829,7 +833,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "8080808080808080._matterd._udp.local",
                             recordClass: 1,
                             recordType: 33,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: { port: PORT3, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
                         },
                         {
@@ -837,7 +841,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "8080808080808080._matterd._udp.local",
                             recordClass: 1,
                             recordType: 16,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: ["VP=1+32768", "DT=1", "DN=Test Commissioner", "SII=500", "SAI=300", "SAT=4000"],
                         },
                         ...IPDnsRecords,
@@ -848,7 +852,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_matterd._udp.local",
                         },
                         {
@@ -856,7 +860,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_matterd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_V1._sub._matterd._udp.local",
                         },
                         {
@@ -864,7 +868,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_V1._sub._matterd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "8080808080808080._matterd._udp.local",
                         },
                         {
@@ -872,7 +876,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_services._dns-sd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "_T1._sub._matterd._udp.local",
                         },
                         {
@@ -880,7 +884,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "_T1._sub._matterd._udp.local",
                             recordClass: 1,
                             recordType: 12,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: "8080808080808080._matterd._udp.local",
                         },
                     ],
@@ -983,7 +987,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
             afterEach(() => client.targetCriteriaProviders.delete(criteria));
 
             it("the client directly returns server record if it has been announced before and records are removed on cancel", async () => {
-                const collection = waitForMessages({ seconds: 10 });
+                const collection = waitForMessages(Seconds(10));
                 advertise(OPERATIONAL_SERVICE);
 
                 const messages = await collection;
@@ -991,7 +995,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                 const result = await client.findOperationalDevice(
                     { operationalId: OPERATIONAL_ID } as unknown as Fabric,
                     NODE_ID,
-                    1,
+                    Seconds.one,
                 );
 
                 // Ensure no queries sent
@@ -1110,7 +1114,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "0000000000000018-0000000000000001._matter._tcp.local",
                             recordClass: 1,
                             recordType: 16,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: ["SII=500", "SAI=300", "SAT=4000"],
                         },
                         ...IPDnsRecords,
@@ -1121,7 +1125,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             name: "0000000000000018-0000000000000001._matter._tcp.local",
                             recordClass: 1,
                             recordType: 33,
-                            ttl: 120,
+                            ttl: Seconds(120),
                             value: { port: PORT2, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
                         },
                     ],
@@ -1191,10 +1195,10 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                         DT: 1,
                         P: 32768,
                         PH: 33,
-                        SAI: 300,
+                        SAI: Millisecs(300),
                         SD: 4,
-                        SII: 500,
-                        SAT: 4000,
+                        SII: Millisecs(500),
+                        SAT: Seconds(4),
                         T: 0,
                         ICD: 0,
                         V: 1,
@@ -1222,7 +1226,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
             });
 
             it("the client queries the server record and get correct response when announced before", async () => {
-                const collection = waitForMessages({ seconds: 10 });
+                const collection = waitForMessages(Seconds(10));
 
                 advertise(COMMISSIONABLE_SERVICE);
                 advertise(OPERATIONAL_SERVICE, PORT2);
@@ -1232,7 +1236,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                 const result = await client.findOperationalDevice(
                     { operationalId: OPERATIONAL_ID } as unknown as Fabric,
                     NODE_ID,
-                    10,
+                    Seconds(10),
                 );
 
                 // Ensure no queries sent
@@ -1257,10 +1261,10 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                         DT: 1,
                         P: 32768,
                         PH: 33,
-                        SAI: 300,
+                        SAI: Millisecs(300),
                         SD: 4,
-                        SII: 500,
-                        SAT: 4000,
+                        SII: Millisecs(500),
+                        SAT: Seconds(4),
                         T: 0,
                         ICD: 0,
                         V: 1,

--- a/packages/react-native/src/ble/ReactNativeBleChannel.ts
+++ b/packages/react-native/src/ble/ReactNativeBleChannel.ts
@@ -23,7 +23,7 @@ import {
     BLE_MATTER_C3_CHARACTERISTIC_UUID,
     BLE_MATTER_SERVICE_UUID,
     BLE_MAXIMUM_BTP_MTU,
-    BTP_CONN_RSP_TIMEOUT_MS,
+    BTP_CONN_RSP_TIMEOUT,
     BTP_MAXIMUM_WINDOW_SIZE,
     BTP_SUPPORTED_VERSIONS,
     Ble,
@@ -183,7 +183,7 @@ export class ReactNativeBleChannel extends BleChannel<Bytes> {
             Bytes.toBase64(btpHandshakeRequest),
         );
 
-        const btpHandshakeTimeout = Time.getTimer("BLE handshake timeout", BTP_CONN_RSP_TIMEOUT_MS, async () => {
+        const btpHandshakeTimeout = Time.getTimer("BLE handshake timeout", BTP_CONN_RSP_TIMEOUT, async () => {
             await peripheral.cancelConnection();
             logger.debug("Handshake Response not received. Disconnected from peripheral");
         }).start();

--- a/packages/react-native/src/net/NetworkReactNative.ts
+++ b/packages/react-native/src/net/NetworkReactNative.ts
@@ -24,6 +24,7 @@ import {
     InterfaceType,
     isIPv6,
     Logger,
+    Minutes,
     Network,
     NetworkError,
     NetworkInterface,
@@ -112,7 +113,7 @@ export class NetworkReactNative extends Network {
     private static readonly netInterfaces = new AsyncCache<string | undefined>(
         "Network interface",
         (ip: string) => this.getNetInterfaceForRemoveAddress(ip),
-        5 * 60 * 1000 /* 5mn */,
+        Minutes(5),
     );
 
     override async close() {

--- a/packages/testing/src/chai.ts
+++ b/packages/testing/src/chai.ts
@@ -28,6 +28,7 @@ expect.STRING = createDiffMarker("string");
 (Chai.config as any).deepEqual = (expected: unknown, actual: unknown) => {
     return (Chai.util as any).eql(expected, actual, {
         comparator(expected: unknown, actual: unknown) {
+            // Handle special "type-only" checks
             switch (expected) {
                 case expect.IGNORE:
                     return true;
@@ -44,6 +45,17 @@ expect.STRING = createDiffMarker("string");
                 case expect.BYTES:
                     return actual instanceof Uint8Array;
             }
+
+            // Specialized support for intervals
+            if (typeof actual === "object" && actual?.constructor.name === "Interval" && "ms" in actual) {
+                if (typeof expected === "number") {
+                    return actual.ms === expected;
+                }
+                if (typeof expected === "object" && expected !== null && "ms" in expected) {
+                    return actual.ms === expected.ms;
+                }
+            }
+
             return null;
         },
     });

--- a/packages/testing/src/mocks/time.ts
+++ b/packages/testing/src/mocks/time.ts
@@ -25,16 +25,16 @@ class MockTimer {
     isPeriodic = false;
 
     #mockTime: MockTime;
-    #durationMs: number;
+    #duration: { ms: number };
 
     isRunning = false;
     private readonly callback: TimerCallback;
 
-    constructor(mockTime: MockTime, name: string, durationMs: number, callback: TimerCallback) {
+    constructor(mockTime: MockTime, name: string, duration: { ms: number }, callback: TimerCallback) {
         this.name = name;
 
         this.#mockTime = mockTime;
-        this.#durationMs = durationMs;
+        this.#duration = duration;
 
         if (this instanceof MockInterval) {
             this.callback = callback;
@@ -48,7 +48,7 @@ class MockTimer {
 
     start() {
         registry.register(this);
-        this.#mockTime.callbackAtTime(this.#mockTime.nowMs() + this.#durationMs, this.callback);
+        this.#mockTime.callbackAtTime(this.#mockTime.nowMs + this.#duration.ms, this.callback);
         this.isRunning = true;
         return this;
     }
@@ -62,12 +62,12 @@ class MockTimer {
 }
 
 class MockInterval extends MockTimer {
-    constructor(mockTime: MockTime, name: string, durationMs: number, callback: TimerCallback) {
+    constructor(mockTime: MockTime, name: string, duration: { ms: number }, callback: TimerCallback) {
         const intervalCallback = async () => {
-            mockTime.callbackAtTime(mockTime.nowMs() + durationMs, intervalCallback);
+            mockTime.callbackAtTime(mockTime.nowMs + duration.ms, intervalCallback);
             await callback();
         };
-        super(mockTime, name, durationMs, intervalCallback);
+        super(mockTime, name, duration, intervalCallback);
     }
 }
 
@@ -165,20 +165,20 @@ export const MockTime = {
         }
     },
 
-    now(): Date {
+    get now(): Date {
         return new Date(nowMs);
     },
 
-    nowMs() {
+    get nowMs() {
         return nowMs;
     },
 
-    getTimer(name: string, durationMs: number, callback: TimerCallback): MockTimer {
-        return new MockTimer(this, name, durationMs, callback);
+    getTimer(name: string, duration: { ms: number }, callback: TimerCallback): MockTimer {
+        return new MockTimer(this, name, duration, callback);
     },
 
-    getPeriodicTimer(name: string, intervalMs: number, callback: TimerCallback): MockTimer {
-        return new MockInterval(this, name, intervalMs, callback);
+    getPeriodicTimer(name: string, interval: { ms: number }, callback: TimerCallback): MockTimer {
+        return new MockInterval(this, name, interval, callback);
     },
 
     /**
@@ -373,7 +373,7 @@ let installActiveImplementation: undefined | (() => void);
 
 export function timeSetup(Time: {
     startup: { systemMs: number; processMs: number };
-    get(): unknown;
+    default: unknown;
     register(timer: MockTimer): void;
     unregister(timer: MockTimer): void;
     timers: Set<MockTimer>;
@@ -382,9 +382,9 @@ export function timeSetup(Time: {
     registry.unregister = Time.unregister;
     registry.timers = Time.timers;
     Time.startup.systemMs = Time.startup.processMs = 0;
-    real = Time.get();
+    real = Time.default;
     (MockTime as any).sleep = (real as any).sleep;
-    installActiveImplementation = () => (Time.get = () => MockTime.activeImplementation);
+    installActiveImplementation = () => (Time.default = MockTime.activeImplementation);
     installActiveImplementation();
 }
 

--- a/packages/testing/test/mocks/MockTimeTest.ts
+++ b/packages/testing/test/mocks/MockTimeTest.ts
@@ -11,7 +11,7 @@ describe("MockTime", () => {
 
     describe("now", () => {
         it("returns the fake date", () => {
-            const result = MockTime.now();
+            const result = MockTime.now;
 
             expect(result.getTime()).equal(FAKE_TIME);
         });
@@ -19,7 +19,7 @@ describe("MockTime", () => {
 
     describe("nowMs", () => {
         it("returns the fake time", () => {
-            const result = MockTime.nowMs();
+            const result = MockTime.nowMs;
 
             expect(result).equal(FAKE_TIME);
         });
@@ -29,7 +29,7 @@ describe("MockTime", () => {
         it("advances the time by the duration specified", async () => {
             await MockTime.advance(45);
 
-            expect(MockTime.nowMs()).equal(FAKE_TIME + 45);
+            expect(MockTime.nowMs).equal(FAKE_TIME + 45);
         });
     });
 
@@ -37,7 +37,7 @@ describe("MockTime", () => {
         it("returns a periodic timer that will call a callback periodically", async () => {
             let firedTime;
 
-            const result = MockTime.getPeriodicTimer("Test periodic", 30, () => (firedTime = MockTime.nowMs()));
+            const result = MockTime.getPeriodicTimer("Test periodic", { ms: 30 }, () => (firedTime = MockTime.nowMs));
             expect(result.isRunning).equal(false);
 
             result.start();
@@ -62,7 +62,7 @@ describe("MockTime", () => {
         it("returns a periodic timer that can be stopped", async () => {
             let firedTime;
 
-            const result = MockTime.getPeriodicTimer("Test periodic", 30, () => (firedTime = MockTime.nowMs()));
+            const result = MockTime.getPeriodicTimer("Test periodic", { ms: 30 }, () => (firedTime = MockTime.nowMs));
             result.start();
             result.stop();
 
@@ -79,7 +79,7 @@ describe("MockTime", () => {
         it("returns a timer that will call a callback in the future", async () => {
             let firedTime;
 
-            const result = MockTime.getTimer("Test", 30, () => (firedTime = MockTime.nowMs()));
+            const result = MockTime.getTimer("Test", { ms: 30 }, () => (firedTime = MockTime.nowMs));
             expect(result.isRunning).equal(false);
             result.start();
             expect(result.isRunning).equal(true);
@@ -95,7 +95,7 @@ describe("MockTime", () => {
         it("returns a timer that can be stopped", async () => {
             let firedTime;
 
-            const result = MockTime.getTimer("Test", 30, () => (firedTime = MockTime.nowMs()));
+            const result = MockTime.getTimer("Test", { ms: 30 }, () => (firedTime = MockTime.nowMs));
             expect(result.isRunning).equal(false);
             result.start();
             expect(result.isRunning).equal(true);

--- a/packages/types/src/cluster/ClusterType.ts
+++ b/packages/types/src/cluster/ClusterType.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Branded, Merge } from "#general";
+import { Branded, Interval, Merge } from "#general";
 import { ClusterId } from "../datatype/ClusterId.js";
 import { BitSchema, TypeFromPartialBitSchema } from "../schema/BitmapSchema.js";
 import { TlvSchema } from "../tlv/TlvSchema.js";
@@ -246,13 +246,15 @@ export namespace ClusterType {
           ? number
           : V extends bigint
             ? bigint
-            : V extends object
-              ? V extends (...args: any[]) => any
-                  ? never
-                  : {
-                        [K in keyof V]?: PatchType<V[K]>;
-                    }
-              : V;
+            : V extends Interval
+              ? Interval
+              : V extends object
+                ? V extends (...args: any[]) => any
+                    ? never
+                    : {
+                          [K in keyof V]?: PatchType<V[K]>;
+                      }
+                : V;
 
     /**
      * A slightly relaxed version of AttributeValues for input.

--- a/packages/types/src/commissioning/CommissioningConstants.ts
+++ b/packages/types/src/commissioning/CommissioningConstants.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CRYPTO_GROUP_SIZE_BYTES, CRYPTO_PUBLIC_KEY_SIZE_BYTES } from "#general";
+import { CRYPTO_GROUP_SIZE_BYTES, CRYPTO_PUBLIC_KEY_SIZE_BYTES, Days, Hours, Minutes } from "#general";
 
-export const MINIMUM_COMMISSIONING_TIMEOUT_S = 3 * 60; // 3 minutes
-export const STANDARD_COMMISSIONING_TIMEOUT_S = 15 * 60; // 15 minutes
-export const MAXIMUM_COMMISSIONING_TIMEOUT_S = 48 * 60 * 60; // 48 hours (extended commissioning)
+export const MINIMUM_COMMISSIONING_TIMEOUT = Minutes(3);
+export const STANDARD_COMMISSIONING_TIMEOUT = Hours.quarter;
+export const MAXIMUM_COMMISSIONING_TIMEOUT = Days(2); // extended commissioning
 
 export const PAKE_PASSCODE_VERIFIER_LENGTH = CRYPTO_GROUP_SIZE_BYTES + CRYPTO_PUBLIC_KEY_SIZE_BYTES;

--- a/packages/types/src/commissioning/CommissioningOptions.ts
+++ b/packages/types/src/commissioning/CommissioningOptions.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Interval } from "@matter/general";
 import { ProductDescription } from "../common/ProductDescription.js";
 import { CommissioningFlowType } from "../schema/PairingCodeSchema.js";
 
@@ -55,6 +56,6 @@ export namespace CommissioningOptions {
          *
          * Defaults to 15 minutes.
          */
-        readonly advertisementWindowS?: number;
+        readonly advertisementWindow?: Interval;
     }
 }

--- a/support/chip-testing/src/AllClustersTestInstance.ts
+++ b/support/chip-testing/src/AllClustersTestInstance.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, InternalError, Logger } from "@matter/general";
+import { Bytes, InternalError, Logger, Seconds } from "@matter/general";
 import { Endpoint, NumberTag, ServerNode } from "@matter/main";
 import {
     AdministratorCommissioningServer,
@@ -290,7 +290,7 @@ export class AllClustersTestInstance extends NodeTestInstance {
                                 // the issue, so we just do that for now
                                 // TODO - if this is only an issue on macs either resolve the broadcast issue or make
                                 // this hack mac specific
-                                broadcastAfterConnection: 10_000,
+                                broadcastAfterConnection: Seconds(10),
                             },
                             MdnsAdvertiser.RetransmissionBroadcastSchedule,
                         ],
@@ -1013,8 +1013,8 @@ export class AllClustersTestInstance extends NodeTestInstance {
                 },
                 switch: {
                     rawPosition: 0,
-                    longPressDelay: 5000, // Expected by the Python test framework to simulate a long press
-                    multiPressDelay: 100,
+                    longPressDelay: Seconds(5), // Expected by the Python test framework to simulate a long press
+                    multiPressDelay: Seconds.tenth,
                     multiPressMax: 3,
                 },
             },
@@ -1044,7 +1044,7 @@ export class AllClustersTestInstance extends NodeTestInstance {
                 },
                 switch: {
                     rawPosition: 0,
-                    longPressDelay: 5000, // Expected by the Python test framework to simulate a long press
+                    longPressDelay: Seconds(5), // Expected by the Python test framework to simulate a long press
                 },
             },
         );

--- a/support/chip-testing/src/ChipToolWebSocketHandler.ts
+++ b/support/chip-testing/src/ChipToolWebSocketHandler.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, Diagnostic, Logger, LogLevel } from "@matter/general";
+import { Bytes, Diagnostic, Logger, LogLevel, Millisecs } from "@matter/general";
 import {
     AttributeId,
     camelize,
@@ -713,8 +713,10 @@ export class ChipToolWebSocketHandler {
                 clusterId: ClusterId(parseInt(clusterId)),
                 commandId: CommandId(parseInt(commandId)),
                 data: Object.keys(commandData).length ? commandData : undefined,
-                timedInteractionTimeoutMs:
-                    timedInteractionTimeoutMs !== undefined ? parseInt(timedInteractionTimeoutMs) : undefined,
+                timedInteractionTimeout:
+                    timedInteractionTimeoutMs !== undefined
+                        ? Millisecs(parseInt(timedInteractionTimeoutMs))
+                        : undefined,
             });
             return { results: [] };
         } catch (error) {
@@ -1208,8 +1210,10 @@ export class ChipToolWebSocketHandler {
                     Object.keys(commandData).length ? commandData : undefined,
                     commandModel,
                 ),
-                timedInteractionTimeoutMs:
-                    timedInteractionTimeoutMs !== undefined ? parseInt(timedInteractionTimeoutMs) : undefined,
+                timedInteractionTimeout:
+                    timedInteractionTimeoutMs !== undefined
+                        ? Millisecs(parseInt(timedInteractionTimeoutMs))
+                        : undefined,
                 suppressResponse: isGroupNode,
             });
             if (result && commandModel.responseModel) {

--- a/support/chip-testing/src/NodeTestInstance.ts
+++ b/support/chip-testing/src/NodeTestInstance.ts
@@ -11,6 +11,7 @@ import {
     ImplementationError,
     InternalError,
     Node,
+    Seconds,
     StorageService,
     Time,
     type ServerNode,
@@ -85,7 +86,7 @@ export abstract class NodeTestInstance extends DeviceTestInstance implements Sub
             node.lifecycle.ready.on(reduceTimeout);
 
             function reduceTimeout() {
-                node.behaviors.internalsOf(AdministratorCommissioningServer).minimumCommissioningTimeoutS = 1;
+                node.behaviors.internalsOf(AdministratorCommissioningServer).minimumCommissioningTimeout = Seconds.one;
             }
         }
     }
@@ -189,7 +190,7 @@ export abstract class NodeTestInstance extends DeviceTestInstance implements Sub
                 // "Check Instance Name" step.  Restarting Avahi might work but depends on how CHIP handles Avahi
                 // messages and would kill part of the value of the test
                 if (chip.activeTest.name === "Discovery") {
-                    await Time.sleep("wait for MDNS", 3000);
+                    await Time.sleep("wait for MDNS", Seconds(3));
                 }
 
                 break;

--- a/support/chip-testing/src/RvcTestInstance.ts
+++ b/support/chip-testing/src/RvcTestInstance.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InternalError, Logger } from "@matter/general";
+import { InternalError, Logger, Seconds } from "@matter/general";
 import {
     AreaNamespaceTag,
     capitalize,
@@ -211,7 +211,7 @@ export class RvcTestInstance extends NodeTestInstance {
                         schedules: [
                             {
                                 ...MdnsAdvertiser.DefaultBroadcastSchedule,
-                                broadcastAfterConnection: 10_000,
+                                broadcastAfterConnection: Seconds(10),
                             },
                             MdnsAdvertiser.RetransmissionBroadcastSchedule,
                         ],

--- a/support/chip-testing/src/cluster/TestWindowCoveringServer.ts
+++ b/support/chip-testing/src/cluster/TestWindowCoveringServer.ts
@@ -3,7 +3,7 @@
  * Copyright 2022-2025 Matter.js Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Logger, Time, Timer } from "@matter/main";
+import { Logger, Millisecs, Seconds, Time, Timer } from "@matter/main";
 import { MovementDirection, MovementType, WindowCoveringServer } from "@matter/main/behaviors/window-covering";
 import { WindowCovering } from "@matter/main/clusters/window-covering";
 
@@ -79,7 +79,7 @@ export class TestWindowCoveringServer extends TestWindowCoveringServerBase {
             counter: 0,
             timer: Time.getPeriodicTimer(
                 typeName,
-                950,
+                Millisecs(950),
                 MovementType.Lift === type
                     ? this.callback(this.#handleLiftMovementTick, { lock: true })
                     : this.callback(this.#handleTiltMovementTick, { lock: true }),
@@ -143,7 +143,7 @@ export class TestWindowCoveringServer extends TestWindowCoveringServerBase {
 
     override async executeCalibration() {
         logger.info("Calibration executed");
-        return Time.sleep("calibration", 1000);
+        return Time.sleep("calibration", Seconds.one);
     }
 
     override async [Symbol.asyncDispose]() {

--- a/support/chip-testing/src/handler/CommandHandler.ts
+++ b/support/chip-testing/src/handler/CommandHandler.ts
@@ -3,7 +3,17 @@
  * Copyright 2022-2025 Matter.js Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { AttributeId, Bytes, ClusterId, CommandId, EventId, EventNumber, NodeId, Observable } from "@matter/main";
+import {
+    AttributeId,
+    Bytes,
+    ClusterId,
+    CommandId,
+    EventId,
+    EventNumber,
+    Interval,
+    NodeId,
+    Observable,
+} from "@matter/main";
 import { CommissionableDeviceIdentifiers } from "@matter/main/protocol";
 import { EndpointNumber, Status } from "@matter/main/types";
 
@@ -111,7 +121,7 @@ export type InvokeRequest = {
     clusterId: ClusterId;
     commandId: CommandId;
     data: unknown;
-    timedInteractionTimeoutMs?: number;
+    timedInteractionTimeout?: Interval;
     suppressResponse?: boolean;
 };
 export type InvokeResponse = {
@@ -127,7 +137,7 @@ export type InvokeByIdRequest = {
     clusterId: ClusterId;
     commandId: CommandId;
     data: unknown;
-    timedInteractionTimeoutMs?: number;
+    timedInteractionTimeout?: Interval;
 };
 
 export type DelayRequest = {

--- a/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
+++ b/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, Logger } from "@matter/general";
+import { Bytes, Logger, Seconds } from "@matter/general";
 import { NodeId, Observable, ServerAddressIp } from "@matter/main";
 import { GeneralCommissioning, GroupKeyManagement } from "@matter/main/clusters";
 import {
@@ -330,7 +330,7 @@ export class LegacyControllerCommandHandler extends CommandHandler {
             clusterId,
             commandId,
             data: commandData,
-            timedInteractionTimeoutMs,
+            timedInteractionTimeout,
             suppressResponse,
         } = data;
         let client: InteractionClient;
@@ -374,24 +374,24 @@ export class LegacyControllerCommandHandler extends CommandHandler {
             clusterId,
             command: clusterCommand,
             request: commandData,
-            timedRequestTimeoutMs: timedInteractionTimeoutMs,
+            timedRequestTimeout: timedInteractionTimeout,
             skipValidation: true,
         });
     }
 
     /** InvokeById minimalistic handler because only used for error testing */
     async handleInvokeById(data: InvokeByIdRequest): Promise<void> {
-        const { nodeId, endpointId, clusterId, commandId, data: commandData, timedInteractionTimeoutMs } = data;
+        const { nodeId, endpointId, clusterId, commandId, data: commandData, timedInteractionTimeout } = data;
         const client = await (await this.#controllerInstance.getNode(nodeId)).getInteractionClient();
         await client.invoke<Command<any, any, any>>({
             endpointId,
             clusterId: clusterId,
             command: Command(commandId, TlvAny, 0x00, TlvNoResponse, {
-                timed: timedInteractionTimeoutMs !== undefined,
+                timed: timedInteractionTimeout !== undefined,
             }),
             request: commandData === undefined ? TlvVoid.encodeTlv() : TlvObject({}).encodeTlv(commandData as any),
-            asTimedRequest: timedInteractionTimeoutMs !== undefined,
-            timedRequestTimeoutMs: timedInteractionTimeoutMs,
+            asTimedRequest: timedInteractionTimeout !== undefined,
+            timedRequestTimeout: timedInteractionTimeout,
             skipValidation: true,
         });
     }
@@ -575,7 +575,7 @@ export class LegacyControllerCommandHandler extends CommandHandler {
             findBy,
             { onIpNetwork: true },
             undefined,
-            3, // Just check for 1 sec
+            Seconds(3),
         );
         logger.info("Discovered result", result);
         // Chip is not removing old discoveries when being stopped, so we still have old and new devices in the result

--- a/support/chip-testing/src/storage/StorageBackendAsyncJsonFile.ts
+++ b/support/chip-testing/src/storage/StorageBackendAsyncJsonFile.ts
@@ -40,7 +40,7 @@ export class StorageBackendAsyncJsonFile extends Storage {
         }
         this.store = new StorageBackendMemory(data);
         this.store.initialize();
-        this.lastStoredTime = Time.nowMs();
+        this.lastStoredTime = Time.nowMs;
     }
 
     get initialized() {
@@ -126,7 +126,7 @@ export class StorageBackendAsyncJsonFile extends Storage {
             throw new InternalError("Storage not initialized.");
         }
         if (this.closed) return;
-        if (!forced && this.lastStoredTime < Time.nowMs() - 1000) {
+        if (!forced && this.lastStoredTime < Time.nowMs - 1000) {
             return;
         }
         if (this.currentStoreItPromise !== undefined) {

--- a/support/chip-testing/test/app-slow/OO.test.ts
+++ b/support/chip-testing/test/app-slow/OO.test.ts
@@ -13,7 +13,7 @@ describe("OO", () => {
             // so maybe is based on latency estimates?  For now we just rewrite
             edit.sed("s/maxValue: 215/maxValue: 300/"),
 
-            // 30s exactly might be a bit too exact, so lets give CI s bit more time
+            // 30s exactly might be a bit too exact, so lets give CI a bit more time
             edit.sed("s/value: 30000/value: 30500/"),
         );
     });

--- a/support/codegen/src/endpoints/TypeGenerator.ts
+++ b/support/codegen/src/endpoints/TypeGenerator.ts
@@ -58,6 +58,9 @@ export class TypeGenerator {
             case Metatype.date:
                 return "Date";
 
+            case Metatype.interval:
+                return "Interval";
+
             case Metatype.enum:
             case Metatype.bitmap:
             case Metatype.object:

--- a/support/codegen/src/mom/spec/translate-datatype.ts
+++ b/support/codegen/src/mom/spec/translate-datatype.ts
@@ -366,6 +366,9 @@ export function selectMetatype(typeName: string) {
         case "date":
             return Metatype.date;
 
+        case "interval":
+            return Metatype.interval;
+
         case "status":
             return Metatype.enum;
     }

--- a/support/models/src/local/index.ts
+++ b/support/models/src/local/index.ts
@@ -22,6 +22,7 @@ import "./ElectricalPowerMeasurementOverrides.js";
 import "./GroupKeyManagementOverrides.js";
 import "./GroupsOverrides.js";
 import "./IlluminanceMeasurementOverrides.js";
+import "./interval.js";
 import "./LevelControlOverrides.js";
 import "./LocalizationConfigurationOverrides.js";
 import "./ModeBaseOverrides.js";

--- a/support/models/src/local/interval.ts
+++ b/support/models/src/local/interval.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Metatype } from "@matter/model";
+import { LocalMatter } from "../local.js";
+
+// Matter does not formally define an interval type but matter.js uses it for some fields
+LocalMatter.children.push({
+    tag: "datatype",
+    name: "interval",
+    metatype: Metatype.interval,
+    description: "A datatype that represents an arbitrary time interval.",
+    details: "This is a matter.js extension to Matter semantics.",
+});

--- a/support/tests/test/subscription-leaks.test.ts
+++ b/support/tests/test/subscription-leaks.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Time } from "@matter/main";
+import { Seconds, Time } from "@matter/main";
 import { ServerNode } from "@matter/node";
 import { TemperatureSensorDevice } from "@matter/node/devices/temperature-sensor";
 import { HeapDumpSet } from "@matter/testing";
@@ -28,7 +28,7 @@ describe("subscriptions", () => {
                     measuredValue: i,
                 },
             });
-            await Time.sleep("subscription delay", 1_000);
+            await Time.sleep("subscription delay", Seconds.one);
         }
 
         await dumps.create("baseline");
@@ -39,7 +39,7 @@ describe("subscriptions", () => {
                     measuredValue: i,
                 },
             });
-            await Time.sleep("subscription delay", 1_000);
+            await Time.sleep("subscription delay", Seconds.one);
         }
 
         await dumps.create("target");
@@ -50,7 +50,7 @@ describe("subscriptions", () => {
                     measuredValue: i,
                 },
             });
-            await Time.sleep("subscription delay", 1_000);
+            await Time.sleep("subscription delay", Seconds.one);
         }
 
         await dumps.create("final");


### PR DESCRIPTION
Creates new `TimeUnit` type to describe units of time and `Interval` class for intervals.  Convert many places that deal with intervals to take `Interval` as input rather than `number`.  This includes removing the suffixes we commonly used to convey units, e.g. "Ms", "Seconds", etc.

This adds type safety to time intervals and decouples the caller's units from the callee's units.

Note that we don't muck with names or types of properties defined by Matter standards.  Unfortunately Matter doesn't provide any interval-specific types so we can't codegen intervals based on the standard data model.  This commit does include an "interval" model type to facilitate configuration but we do not use this as an override type at this time.

The `Interval` and `TimeUnit` classes contain a variety of utility functionality to simplify time-interval-related reasoning.

Includes a bit of additional modernization for `Time` API and adds support for custom deep-comparison functionality.  This allows us to consider two intervals as identical regardless of the defining units.

Also improves formatting for various log messages I encountered while getting tests working.