### PR TITLE
Ensure cached attributes to be updated correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 -->
 
 ### __WORK IN PROGRESS__
--   Breaking: matter.js now requires node.js 20+
+-   Breaking: matter.js now requires node.js 20.19+ or 22.13+ or 24.0+ (LTS versions).  Node.js 18.x is no longer supported.
 -   Breaking: Because of the upgrade to TypeScript 5.9 all usages of Uint8Array were changed to use a more convenient own type alias Bytes
 
 -   @matter/general
@@ -35,6 +35,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: MDNS client and server efficiency is improved with a shared socket and message parser
     - Fix: Controller networking was previously throwing the incorrect error after a communication timeout
     - Fix: Ensures to only include the MaxTcpMessageSize in Session parameters when TCP is enabled
+    - Fix: Fixes an issue that prevented cached attribute data to be updated correctly
 
 -   @matter/node
     - Breaking: `Endpoint` and `Node` initialization values now require the correct type for some time values and IDs.  So for example, `VendorId(1234)` instead of just `1234`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Controller networking was previously throwing the incorrect error after a communication timeout
     - Fix: Ensures to only include the MaxTcpMessageSize in Session parameters when TCP is enabled
     - Fix: Fixes an issue that prevented cached attribute data to be updated correctly
+    - Fix: Allow to also trigger attribute updates when initial read before subscription had updated attributes
 
 -   @matter/node
     - Breaking: `Endpoint` and `Node` initialization values now require the correct type for some time values and IDs.  So for example, `VendorId(1234)` instead of just `1234`

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -876,7 +876,7 @@ export class PairedNode {
             dataVersionFilters: this.#interactionClient.getCachedClusterDataVersions(),
             executeQueued: !!threadConnected, // We queue subscriptions for thread devices
         });
-        await this.#interactionClient.addAttributesToCache(attributeData);
+        await this.#interactionClient.processAttributeUpdates(attributeData, subscriptionHandler.attributeListener);
         attributeData.length = 0; // Clear the array to save memory
 
         // If we subscribe anything we use these data to create the endpoint structure, so we do not need to fetch again
@@ -889,8 +889,7 @@ export class PairedNode {
             enrichCachedAttributeData: true,
             eventFilters: maxKnownEventNumber !== undefined ? [{ eventMin: maxKnownEventNumber + 1n }] : undefined,
             executeQueued: !!threadConnected, // We queue subscriptions for thread devices
-            attributeListener: (data, changed, oldValue) =>
-                subscriptionHandler.attributeListener(data, changed, oldValue),
+            attributeListener: subscriptionHandler.attributeListener,
             eventListener: data => subscriptionHandler.eventListener(data),
             updateTimeoutHandler: () => subscriptionHandler.updateTimeoutHandler(),
             updateReceived: () => subscriptionHandler.subscriptionAlive(),

--- a/packages/protocol/src/interaction/InteractionClient.ts
+++ b/packages/protocol/src/interaction/InteractionClient.ts
@@ -1446,6 +1446,7 @@ export class InteractionClient {
         if (attributeReports.length === 0) {
             return;
         }
+
         const changedAttributes = new Array<DecodedAttributeReportValue<any>>();
         let {
             path: { endpointId: currentEndpoint, clusterId: currentCluster },
@@ -1480,6 +1481,10 @@ export class InteractionClient {
                     changedAttributes.push(data);
                 }
             }
+        }
+
+        if (changedAttributes.length > 0) {
+            await this.#nodeStore?.persistAttributes(changedAttributes);
         }
     }
 


### PR DESCRIPTION
Issue was basically that with the first updated attribute the clusterversion was updated and so prevented more attributes from being updated in cache.