### PR TITLE
Stop MDNS broadcasts on cancel

### DIFF
--- a/packages/protocol/src/advertisement/Advertisement.ts
+++ b/packages/protocol/src/advertisement/Advertisement.ts
@@ -303,6 +303,9 @@ export namespace Advertisement {
          * resolving.
          */
         sleep(name: string, duration: Duration): Promise<void>;
+
+        /** True if the activity has been canceled. */
+        cancelled: boolean;
     }
 }
 
@@ -354,5 +357,9 @@ class ActivityContext extends CancelablePromise implements Advertisement.Activit
         if (this.#sleep) {
             this.#sleep.cancel(reason);
         }
+    }
+
+    get cancelled() {
+        return this.#cancelReason !== undefined;
     }
 }

--- a/packages/protocol/src/advertisement/mdns/MdnsAdvertisement.ts
+++ b/packages/protocol/src/advertisement/mdns/MdnsAdvertisement.ts
@@ -70,6 +70,9 @@ export abstract class MdnsAdvertisement<T extends ServiceDescription = ServiceDe
             logger.debug("Broadcast", this.dict({ number, next: Duration.format(retryInterval) }));
             await this.broadcast();
             await context.sleep("MDNS repeat", retryInterval);
+            if (context.cancelled) {
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
The sleep promise was fulfilling on cancel and so lead to the next round of advertisement rather than stopping. This lead to the node not stopping on shutdown and other strange errors