### PR TITLE
Adjustments to Persisted subscriptions and MDNS initial announces

### DIFF
--- a/packages/node/src/behavior/system/commissioning/CommissioningServer.ts
+++ b/packages/node/src/behavior/system/commissioning/CommissioningServer.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { SubscriptionsBehavior } from "#behavior/system/subscriptions/SubscriptionsServer.js";
 import { Endpoint } from "#endpoint/Endpoint.js";
 import {
     AsyncObservable,
@@ -204,6 +205,9 @@ export class CommissioningServer extends Behavior {
     async #enterOnlineMode() {
         // If already commissioned, trigger operational announcement
         if ((this.endpoint.lifecycle as NodeLifecycle).isCommissioned) {
+            // Restore subscriptions if we have some persisted
+            await this.endpoint.act(agent => agent.get(SubscriptionsBehavior).reestablishFormerSubscriptions());
+
             this.enterOperationalMode();
             return;
         }

--- a/packages/node/src/behavior/system/subscriptions/SubscriptionsServer.ts
+++ b/packages/node/src/behavior/system/subscriptions/SubscriptionsServer.ts
@@ -49,7 +49,7 @@ export class SubscriptionsBehavior extends Behavior {
         this.reactTo(sessions.events.subscriptionAdded, this.#addSubscription, { lock: true });
     }
 
-    static override schema = new DatatypeModel(
+    static override readonly schema = new DatatypeModel(
         {
             name: "SubscriptionState",
             type: "struct",
@@ -59,6 +59,8 @@ export class SubscriptionsBehavior extends Behavior {
                 name: "subscriptions",
                 type: "list",
                 quality: "N",
+                conformance: "M",
+                default: [],
             },
             FieldElement(
                 {
@@ -197,13 +199,14 @@ export class SubscriptionsBehavior extends Behavior {
         await this.context.transaction.commit();
     }
 
-    async reestablishFormerSubscriptions(interactionServer: InteractionServer) {
+    async reestablishFormerSubscriptions() {
         if (this.state.persistenceEnabled === false) return;
 
         // get and clear former subscriptions
         const { formerSubscriptions } = this.internal;
 
         if (!formerSubscriptions.length) {
+            logger.info("No former subscriptions to re-establish");
             return;
         } else {
             this.internal.formerSubscriptions = [];
@@ -211,6 +214,7 @@ export class SubscriptionsBehavior extends Behavior {
         }
         const peers = this.env.get(PeerSet);
         const sessions = this.env.get(SessionManager);
+        const interactionServer = this.env.get(InteractionServer);
 
         const peerStopList = new PeerAddressSet();
 
@@ -291,7 +295,7 @@ export namespace SubscriptionsBehavior {
          * List of subscriptions. This list is collected automatically.
          * The state value should not be initialized by the developer.
          */
-        subscriptions!: PeerSubscription[];
+        subscriptions: PeerSubscription[] = [];
     }
 
     export class Internal {

--- a/packages/protocol/src/protocol/DeviceAdvertiser.ts
+++ b/packages/protocol/src/protocol/DeviceAdvertiser.ts
@@ -9,9 +9,11 @@ import { Advertiser } from "#advertisement/Advertiser.js";
 import { ServiceDescription } from "#advertisement/ServiceDescription.js";
 import { Fabric } from "#fabric/Fabric.js";
 import { FabricManager } from "#fabric/FabricManager.js";
-import { Environment, Environmental, MatterAggregateError, ObserverGroup } from "#general";
+import { Environment, Environmental, Logger, MatterAggregateError, ObserverGroup } from "#general";
 import { SecureSession } from "#session/SecureSession.js";
 import { SessionManager } from "#session/SessionManager.js";
+
+const logger = Logger.get("DeviceAdvertiser");
 
 /**
  * Interfaces the {@link DeviceAdvertiser} with other components.
@@ -100,6 +102,13 @@ export class DeviceAdvertiser {
 
             // Each time we retry a transmission, also trigger retry broadcast for associated fabric
             this.#advertiseFabric(session.associatedFabric, "retransmit");
+        });
+
+        this.#observers.on(this.#context.sessions.subscriptionsChanged, (session, subscription) => {
+            if (this.#isOperational && subscription.isCanceledByPeer && session.fabric !== undefined) {
+                logger.debug(`Subscription canceled by peer, re-announce`);
+                this.#advertiseFabric(session.fabric, "reconnect");
+            }
         });
     }
 
@@ -241,6 +250,14 @@ export class DeviceAdvertiser {
         }
 
         for (const advertiser of this.#advertisers) {
+            if (event === "startup") {
+                // For a startup events where we have active subscriptions somewhere on the fabric, we just convert
+                // into "retransmit" to send out one ping for client convenience
+                if (this.#context.sessions.forFabric(fabric).some(session => session.subscriptions.size > 0)) {
+                    event = "retransmit";
+                }
+            }
+
             advertiser.advertise(ServiceDescription.Operational({ fabric }), event);
         }
     }

--- a/packages/protocol/src/protocol/DeviceAdvertiser.ts
+++ b/packages/protocol/src/protocol/DeviceAdvertiser.ts
@@ -251,7 +251,7 @@ export class DeviceAdvertiser {
 
         for (const advertiser of this.#advertisers) {
             if (event === "startup") {
-                // For a startup events where we have active subscriptions somewhere on the fabric, we just convert
+                // For startup events where we have active subscriptions somewhere on the fabric, we just convert
                 // into "retransmit" to send out one ping for client convenience
                 if (this.#context.sessions.forFabric(fabric).some(session => session.subscriptions.size > 0)) {
                     event = "retransmit";

--- a/packages/protocol/src/session/SessionManager.ts
+++ b/packages/protocol/src/session/SessionManager.ts
@@ -410,6 +410,15 @@ export class SessionManager {
         ) as NodeSession;
     }
 
+    forFabric(fabric: Fabric) {
+        this.#construction.assert();
+
+        return [...this.#sessions].filter(
+            session =>
+                NodeSession.is(session) && session.isSecure && session.fabric?.fabricIndex === fabric.fabricIndex,
+        ) as NodeSession[];
+    }
+
     getSessionForNode(address: PeerAddress) {
         this.#construction.assert();
 

--- a/packages/protocol/src/session/SessionManager.ts
+++ b/packages/protocol/src/session/SessionManager.ts
@@ -416,7 +416,7 @@ export class SessionManager {
         return [...this.#sessions].filter(
             session =>
                 NodeSession.is(session) && session.isSecure && session.fabric?.fabricIndex === fabric.fabricIndex,
-        ) as NodeSession[];
+        );
     }
 
     getSessionForNode(address: PeerAddress) {


### PR DESCRIPTION
Ensures that persisted subscriptions are tried to be re-established before MDNS is kicked off. Additionally, makes sure that MDNS is only broadcasted actively if no subscription exists - or in fact adjusted now to just send a ping.