### PR TITLE
Add "endpoints" property to Node

### DIFF
--- a/packages/general/src/util/Set.ts
+++ b/packages/general/src/util/Set.ts
@@ -14,6 +14,7 @@ export interface ImmutableSet<T> {
     [Symbol.iterator]: () => Iterator<T, undefined>;
     has(item: T): boolean;
     get size(): number;
+    map<R>(mapper: (item: T) => R): R[];
     find(predicate: (item: T) => boolean | undefined): T | undefined;
     filter(predicate: (item: T) => boolean | undefined): T[];
 }

--- a/packages/node/src/endpoint/properties/Endpoints.ts
+++ b/packages/node/src/endpoint/properties/Endpoints.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IndexBehavior } from "#behavior/system/index/IndexBehavior.js";
+import type { Endpoint } from "#endpoint/Endpoint.js";
+import { EndpointType } from "#endpoint/type/EndpointType.js";
+import type { ImmutableSet } from "#general";
+import { Node } from "#node/Node.js";
+import { StatusResponse } from "#types";
+
+/**
+ * Access to all endpoints on a node, including the root endpoint.
+ */
+export class Endpoints implements ImmutableSet<Endpoint> {
+    #node: Node;
+
+    constructor(node: Node) {
+        this.#node = node;
+    }
+
+    has(endpoint: Endpoint | number): boolean {
+        if (endpoint === this.#node || endpoint === 0) {
+            return true;
+        }
+
+        if (typeof endpoint === "number") {
+            return endpoint in this.#index;
+        }
+
+        return endpoint.lifecycle.hasNumber && endpoint.number in this.#index;
+    }
+
+    get size(): number {
+        return this.#list.length + 1;
+    }
+
+    map<R>(mapper: (item: Endpoint<EndpointType.Empty>) => R): R[] {
+        return this.#list.map(mapper);
+    }
+
+    find(predicate: (item: Endpoint) => boolean | undefined): Endpoint | undefined {
+        return this.#list.find(predicate);
+    }
+
+    filter(predicate: (item: Endpoint) => boolean | undefined): Endpoint[] {
+        return this.#list.filter(predicate);
+    }
+
+    [Symbol.iterator]() {
+        return this.#list[Symbol.iterator]();
+    }
+
+    for(number: number): Endpoint {
+        if (number === 0) {
+            return this.#node;
+        }
+
+        const endpoint = this.#index[number];
+        if (endpoint === undefined) {
+            throw new StatusResponse.NotFoundError(`Endpoint ${number} does not exist`);
+        }
+        return endpoint;
+    }
+
+    /**
+     * Object mapping EndpointNumber -> Endpoint.
+     *
+     * Note that this does not include endpoint 0, but we have that in #node.
+     */
+    get #index() {
+        return this.#node.behaviors.internalsOf(IndexBehavior).partsByNumber;
+    }
+
+    /**
+     * Full list of endpoints.  Includes endpoint 0.
+     */
+    get #list() {
+        return [this.#node, ...Object.values(this.#index)];
+    }
+}

--- a/packages/node/src/endpoint/properties/index.ts
+++ b/packages/node/src/endpoint/properties/index.ts
@@ -9,5 +9,6 @@ export * from "./Commands.js";
 export * from "./EndpointContainer.js";
 export * from "./EndpointInitializer.js";
 export * from "./EndpointLifecycle.js";
+export * from "./Endpoints.js";
 export * from "./Parts.js";
 export * from "./SupportedBehaviors.js";

--- a/packages/node/src/node/Node.ts
+++ b/packages/node/src/node/Node.ts
@@ -11,6 +11,7 @@ import { NetworkBehavior } from "#behavior/system/network/NetworkBehavior.js";
 import { NetworkRuntime } from "#behavior/system/network/NetworkRuntime.js";
 import { PartsBehavior } from "#behavior/system/parts/PartsBehavior.js";
 import { Endpoint } from "#endpoint/Endpoint.js";
+import { Endpoints } from "#endpoint/properties/Endpoints.js";
 import { EndpointType } from "#endpoint/type/EndpointType.js";
 import { MutableEndpoint } from "#endpoint/type/MutableEndpoint.js";
 import {
@@ -24,6 +25,7 @@ import {
     RuntimeService,
 } from "#general";
 import { Interactable } from "#protocol";
+import type { EndpointNumber } from "#types";
 import { RootEndpoint } from "../endpoints/root.js";
 import { NodeLifecycle } from "./NodeLifecycle.js";
 import { ProtocolService } from "./server/ProtocolService.js";
@@ -146,6 +148,16 @@ export abstract class Node<T extends Node.CommonRootEndpoint = Node.CommonRootEn
      */
     async cancel() {
         await this.lifecycle.mutex.produce(this.cancelWithMutex.bind(this));
+    }
+
+    /**
+     * All endpoints owned by the node.
+     *
+     * Normally you access endpoints via {@link parts} but you can use this property access endpoints directly by
+     * {@link EndpointNumber}.
+     */
+    get endpoints(): Endpoints {
+        return new Endpoints(this);
     }
 
     protected async cancelWithMutex() {


### PR DESCRIPTION
This gives convenient access to all endpoints associated with a node, by ID or enumeration.