### PR TITLE
Fix and Optimize session handling

### DIFF
--- a/packages/general/src/time/Duration.ts
+++ b/packages/general/src/time/Duration.ts
@@ -177,5 +177,5 @@ export namespace Duration {
 }
 
 function toPrecision(number: number, precision: number) {
-    return number.toPrecision(precision).replace(/\.?0+/, "");
+    return number.toPrecision(precision).replace(/(\.\d*?[1-9])0+$|\.0+$/, "$1");
 }

--- a/packages/protocol/src/mdns/MdnsClient.ts
+++ b/packages/protocol/src/mdns/MdnsClient.ts
@@ -1532,9 +1532,9 @@ export class MdnsClient implements Scanner {
     static discoveryDataDiagnostics(data: DiscoveryData, kind?: string) {
         return Diagnostic.dict({
             kind,
-            SII: Duration.format(data.SII),
-            SAI: Duration.format(data.SAI),
-            SAT: Duration.format(data.SAT),
+            SII: data.SII ? Duration.format(data.SII) : undefined,
+            SAI: data.SAI ? Duration.format(data.SAI) : undefined,
+            SAT: data.SAT ? Duration.format(data.SAT) : undefined,
             T: data.T,
             DT: data.DT,
             PH: data.PH,

--- a/packages/protocol/src/protocol/ExchangeManager.ts
+++ b/packages/protocol/src/protocol/ExchangeManager.ts
@@ -416,7 +416,11 @@ export class ExchangeManager {
         channel: MessageChannel,
         expectedProcessingTime = DEFAULT_EXPECTED_PROCESSING_TIME,
     ) {
-        return channel.calculateMaximumPeerResponseTime(this.#sessionManager.sessionParameters, expectedProcessingTime);
+        return channel.calculateMaximumPeerResponseTime(
+            channel.session.parameters,
+            this.#sessionManager.sessionParameters,
+            expectedProcessingTime,
+        );
     }
 
     #messageExchangeContextFor(channel: MessageChannel): MessageExchangeContext {

--- a/packages/protocol/src/protocol/ExchangeManager.ts
+++ b/packages/protocol/src/protocol/ExchangeManager.ts
@@ -261,7 +261,11 @@ export class ExchangeManager {
 
             // Having a "Secure Session" means it is encrypted in our internal working
             // TODO When adding Group sessions, we need to check how to adjust that handling
-            if (protocolHandler !== undefined && protocolHandler.requiresSecureSession !== session.isSecure) {
+            if (
+                protocolHandler !== undefined &&
+                protocolHandler.requiresSecureSession !== session.isSecure &&
+                !isStandaloneAck
+            ) {
                 logger.debug(
                     `Ignoring message ${messageId} for protocol ${message.payloadHeader.protocolId} and exchange id ${message.payloadHeader.exchangeId} on channel ${channel.name} because not matching the security requirements.`,
                 );
@@ -313,7 +317,7 @@ export class ExchangeManager {
                         );
                     }
                     return;
-                } else {
+                } else if (!isStandaloneAck) {
                     logger.info(
                         `Discarding unexpected message ${messageId} for protocol ${
                             message.payloadHeader.protocolId

--- a/packages/protocol/src/session/NodeSession.ts
+++ b/packages/protocol/src/session/NodeSession.ts
@@ -13,6 +13,7 @@ import {
     CRYPTO_SYMMETRIC_KEY_LENGTH,
     Crypto,
     Diagnostic,
+    Duration,
     Logger,
     MatterError,
     MatterFlowError,
@@ -176,9 +177,9 @@ export class NodeSession extends SecureSession {
     get parameterDiagnostics() {
         return Diagnostic.dict(
             {
-                SII: this.idleInterval,
-                SAI: this.activeInterval,
-                SAT: this.activeThreshold,
+                SII: Duration.format(this.idleInterval),
+                SAI: Duration.format(this.activeInterval),
+                SAT: Duration.format(this.activeThreshold),
                 DMRev: this.dataModelRevision,
                 IMRev: this.interactionModelRevision,
                 spec: Diagnostic.hex(this.specificationVersion),

--- a/packages/protocol/src/session/SessionIntervals.ts
+++ b/packages/protocol/src/session/SessionIntervals.ts
@@ -49,7 +49,7 @@ export function SessionIntervals(intervals?: Partial<SessionIntervals>): Session
 }
 
 export namespace SessionIntervals {
-    export const defaults = {
+    export const defaults: SessionIntervals = {
         idleInterval: Millis(500),
         activeInterval: Millis(300),
         activeThreshold: Seconds(4),

--- a/packages/protocol/src/session/case/CaseMessages.ts
+++ b/packages/protocol/src/session/case/CaseMessages.ts
@@ -10,8 +10,8 @@ import {
     CRYPTO_HASH_LEN_BYTES,
     CRYPTO_PUBLIC_KEY_SIZE_BYTES,
 } from "#general";
-import { TlvByteString, TlvField, TlvObject, TlvOptionalField, TlvUInt16 } from "#types";
-import { TlvSessionParameters } from "../pase/PaseMessages.js";
+import { TlvByteString, TlvField, TlvObject, TlvOptionalField, TlvUInt16, TypeFromSchema } from "#types";
+import { TlvSessionParameters, WithDurationSessionParameters } from "../pase/PaseMessages.js";
 
 const CASE_SIGNATURE_LENGTH = CRYPTO_GROUP_SIZE_BYTES * 2;
 
@@ -34,6 +34,7 @@ export const TlvCaseSigma1 = TlvObject({
     resumptionId: TlvOptionalField(6, TlvByteString.bound({ length: 16 })),
     initiatorResumeMic: TlvOptionalField(7, TlvByteString.bound({ length: CRYPTO_AEAD_MIC_LENGTH_BYTES })),
 });
+export type CaseSigma1 = WithDurationSessionParameters<TypeFromSchema<typeof TlvCaseSigma1>, "initiatorSessionParams">;
 
 /** @see {@link MatterSpecification.v13.Core} § 4.14.2.3 */
 export const TlvCaseSigma2 = TlvObject({
@@ -43,6 +44,7 @@ export const TlvCaseSigma2 = TlvObject({
     encrypted: TlvField(4, TlvByteString),
     responderSessionParams: TlvOptionalField(5, TlvSessionParameters),
 });
+export type CaseSigma2 = WithDurationSessionParameters<TypeFromSchema<typeof TlvCaseSigma2>, "responderSessionParams">;
 
 /** @see {@link MatterSpecification.v13.Core} § 4.14.2.3 */
 export const TlvCaseSigma2Resume = TlvObject({
@@ -51,11 +53,13 @@ export const TlvCaseSigma2Resume = TlvObject({
     responderSessionId: TlvField(3, TlvUInt16),
     responderSessionParams: TlvOptionalField(4, TlvSessionParameters),
 });
+export type CaseSigma2Resume = TypeFromSchema<typeof TlvCaseSigma2Resume>;
 
 /** @see {@link MatterSpecification.v13.Core} § 4.14.2.3 */
 export const TlvCaseSigma3 = TlvObject({
     encrypted: TlvField(1, TlvByteString),
 });
+export type CaseSigma3 = TypeFromSchema<typeof TlvCaseSigma3>;
 
 /** @see {@link MatterSpecification.v10.Core} § 4.13.2.3 */
 export const TlvSignedData = TlvObject({
@@ -64,6 +68,7 @@ export const TlvSignedData = TlvObject({
     responderPublicKey: TlvField(3, TlvByteString.bound({ length: CRYPTO_PUBLIC_KEY_SIZE_BYTES })),
     initiatorPublicKey: TlvField(4, TlvByteString.bound({ length: CRYPTO_PUBLIC_KEY_SIZE_BYTES })),
 });
+export type SignedData = TypeFromSchema<typeof TlvSignedData>;
 
 /** @see {@link MatterSpecification.v10.Core} § 4.13.2.3 */
 export const TlvEncryptedDataSigma2 = TlvObject({
@@ -72,6 +77,7 @@ export const TlvEncryptedDataSigma2 = TlvObject({
     signature: TlvField(3, TlvByteString.bound({ length: CASE_SIGNATURE_LENGTH })),
     resumptionId: TlvField(4, TlvByteString.bound({ length: 16 })),
 });
+export type EncryptedDataSigma2 = TypeFromSchema<typeof TlvEncryptedDataSigma2>;
 
 /** @see {@link MatterSpecification.v10.Core} § 4.13.2.3 */
 export const TlvEncryptedDataSigma3 = TlvObject({
@@ -79,3 +85,4 @@ export const TlvEncryptedDataSigma3 = TlvObject({
     responderIcac: TlvOptionalField(2, TlvByteString),
     signature: TlvField(3, TlvByteString.bound({ length: CASE_SIGNATURE_LENGTH })),
 });
+export type EncryptedDataSigma3 = TypeFromSchema<typeof TlvEncryptedDataSigma3>;

--- a/packages/protocol/src/session/case/CaseMessenger.ts
+++ b/packages/protocol/src/session/case/CaseMessenger.ts
@@ -7,12 +7,20 @@
 import { MatterFlowError } from "#general";
 import { SecureMessageType, TypeFromSchema } from "#types";
 import { SecureChannelMessenger } from "../../securechannel/SecureChannelMessenger.js";
-import { TlvCaseSigma1, TlvCaseSigma2, TlvCaseSigma2Resume, TlvCaseSigma3 } from "./CaseMessages.js";
+import {
+    CaseSigma1,
+    CaseSigma2,
+    CaseSigma2Resume,
+    TlvCaseSigma1,
+    TlvCaseSigma2,
+    TlvCaseSigma2Resume,
+    TlvCaseSigma3,
+} from "./CaseMessages.js";
 
 export class CaseServerMessenger extends SecureChannelMessenger {
     async readSigma1() {
         const { payload } = await this.nextMessage(SecureMessageType.Sigma1);
-        return { sigma1Bytes: payload, sigma1: TlvCaseSigma1.decode(payload) };
+        return { sigma1Bytes: payload, sigma1: TlvCaseSigma1.decode(payload) as CaseSigma1 };
     }
 
     sendSigma2(sigma2: TypeFromSchema<typeof TlvCaseSigma2>) {
@@ -41,9 +49,9 @@ export class CaseClientMessenger extends SecureChannelMessenger {
         } = await this.anyNextMessage("Sigma2(Resume)");
         switch (messageType) {
             case SecureMessageType.Sigma2:
-                return { sigma2Bytes: payload, sigma2: TlvCaseSigma2.decode(payload) };
+                return { sigma2Bytes: payload, sigma2: TlvCaseSigma2.decode(payload) as CaseSigma2 };
             case SecureMessageType.Sigma2Resume:
-                return { sigma2Resume: TlvCaseSigma2Resume.decode(payload) };
+                return { sigma2Resume: TlvCaseSigma2Resume.decode(payload) as CaseSigma2Resume };
             default:
                 throw new MatterFlowError(
                     `Received unexpected message type while expecting CASE Sigma2(Resume): ${messageType}, expected: ${SecureMessageType.Sigma2} or ${SecureMessageType.Sigma2Resume}`,

--- a/packages/protocol/src/session/case/CaseServer.ts
+++ b/packages/protocol/src/session/case/CaseServer.ts
@@ -6,14 +6,15 @@
 
 import { Noc } from "#certificate/kinds/Noc.js";
 import { Bytes, Crypto, CryptoDecryptError, Logger, PublicKey, UnexpectedDataError } from "#general";
-import { TlvSessionParameters } from "#session/pase/PaseMessages.js";
+import { SessionParametersWithDurations } from "#session/pase/PaseMessages.js";
 import { ResumptionRecord, SessionManager } from "#session/SessionManager.js";
-import { NodeId, SECURE_CHANNEL_PROTOCOL_ID, SecureChannelStatusCode, TypeFromSchema } from "#types";
+import { NodeId, SECURE_CHANNEL_PROTOCOL_ID, SecureChannelStatusCode } from "#types";
 import { FabricManager, FabricNotFoundError } from "../../fabric/FabricManager.js";
 import { MessageExchange } from "../../protocol/MessageExchange.js";
 import { ProtocolHandler } from "../../protocol/ProtocolHandler.js";
 import { ChannelStatusResponseError } from "../../securechannel/SecureChannelMessenger.js";
 import {
+    CaseSigma1,
     KDFSR1_KEY_INFO,
     KDFSR2_INFO,
     KDFSR2_KEY_INFO,
@@ -22,7 +23,6 @@ import {
     RESUME2_MIC_NONCE,
     TBE_DATA2_NONCE,
     TBE_DATA3_NONCE,
-    TlvCaseSigma1,
     TlvEncryptedDataSigma2,
     TlvEncryptedDataSigma3,
     TlvSignedData,
@@ -313,7 +313,7 @@ class Sigma1Context {
     destinationId: Bytes;
     peerRandom: Bytes;
     peerEcdhPublicKey: Bytes;
-    peerSessionParams?: TypeFromSchema<typeof TlvSessionParameters>;
+    peerSessionParams?: SessionParametersWithDurations;
     resumptionRecord?: ResumptionRecord;
 
     #localResumptionId?: Bytes;
@@ -322,7 +322,7 @@ class Sigma1Context {
         crypto: Crypto,
         messenger: CaseServerMessenger,
         bytes: Bytes,
-        sigma1: TypeFromSchema<typeof TlvCaseSigma1>,
+        sigma1: CaseSigma1,
         resumptionRecord?: ResumptionRecord,
     ) {
         this.crypto = crypto;

--- a/packages/protocol/src/session/pase/PaseMessenger.ts
+++ b/packages/protocol/src/session/pase/PaseMessenger.ts
@@ -5,9 +5,14 @@
  */
 
 import { Bytes } from "#general";
-import { SecureMessageType, TypeFromSchema } from "#types";
+import { SecureMessageType } from "#types";
 import { DEFAULT_NORMAL_PROCESSING_TIME, SecureChannelMessenger } from "../../securechannel/SecureChannelMessenger.js";
 import {
+    PasePake1,
+    PasePake2,
+    PasePake3,
+    PbkdfParamRequest,
+    PbkdfParamResponse,
     TlvPasePake1,
     TlvPasePake2,
     TlvPasePake3,
@@ -18,16 +23,10 @@ import {
 export const DEFAULT_PASSCODE_ID = 0;
 export const SPAKE_CONTEXT = Bytes.fromString("CHIP PAKE V1 Commissioning");
 
-type PbkdfParamRequest = TypeFromSchema<typeof TlvPbkdfParamRequest>;
-type PbkdfParamResponse = TypeFromSchema<typeof TlvPbkdfParamResponse>;
-type PasePake1 = TypeFromSchema<typeof TlvPasePake1>;
-type PasePake2 = TypeFromSchema<typeof TlvPasePake2>;
-type PasePake3 = TypeFromSchema<typeof TlvPasePake3>;
-
 export class PaseServerMessenger extends SecureChannelMessenger {
     async readPbkdfParamRequest() {
         const { payload } = await this.nextMessage(SecureMessageType.PbkdfParamRequest, DEFAULT_NORMAL_PROCESSING_TIME);
-        return { requestPayload: payload, request: TlvPbkdfParamRequest.decode(payload) };
+        return { requestPayload: payload, request: TlvPbkdfParamRequest.decode(payload) as PbkdfParamRequest };
     }
 
     async sendPbkdfParamResponse(response: PbkdfParamResponse) {
@@ -37,7 +36,7 @@ export class PaseServerMessenger extends SecureChannelMessenger {
     }
 
     readPasePake1() {
-        return this.nextMessageDecoded(SecureMessageType.PasePake1, TlvPasePake1);
+        return this.nextMessageDecoded(SecureMessageType.PasePake1, TlvPasePake1) as Promise<PasePake1>;
     }
 
     sendPasePake2(pasePake2: PasePake2) {
@@ -61,7 +60,7 @@ export class PaseClientMessenger extends SecureChannelMessenger {
             SecureMessageType.PbkdfParamResponse,
             DEFAULT_NORMAL_PROCESSING_TIME,
         );
-        return { responsePayload: payload, response: TlvPbkdfParamResponse.decode(payload) };
+        return { responsePayload: payload, response: TlvPbkdfParamResponse.decode(payload) as PbkdfParamResponse };
     }
 
     sendPasePake1(pasePake1: PasePake1) {


### PR DESCRIPTION
The Duration refactoring lead to an issue  where we lost the three session interval fields because of the fact that the namechange from" xxxMs" to "xxx" was not done in [PaseMessages.ts](https://github.com/matter-js/matter.js/compare/optimize-sessions?expand=1#diff-423d99923dc8a0cb05925af69c99d475a47797f48264f72124d06cc2d0b58943) but in the other places. And because of that these are formally optional fields it was not seen.

I found that by testing which lead into errors for some real devices because SessionParameters struct was invalid with these 3 missing but more provided.

So this Pr:
* fixes the above
* Adjusts typing to tweak the decoded Pase/Case messages as "having Duration" in the relevant places to be compatible to the types used internally then ( I also tried getting a TlvDuration type but then went out more problematic)
* Fix a Duration formatting issue ( 800 was logged as "8ms" instead "800ms")
* Format intervals in other places too