### PR TITLE
Fixes Environment Service Blocking

### DIFF
--- a/packages/general/src/environment/Environment.ts
+++ b/packages/general/src/environment/Environment.ts
@@ -61,13 +61,18 @@ export class Environment {
      * Access an environmental service.
      */
     get<T extends object>(type: abstract new (...args: any[]) => T): T {
-        let instance = this.#services?.get(type) ?? this.#parent?.maybeGet(type);
+        const mine = this.#services?.get(type);
 
-        if (instance !== undefined && instance !== null) {
-            return instance as T;
+        if (mine !== undefined && mine !== null) {
+            return mine as T;
         }
 
-        if (instance !== null) {
+        if (mine !== null) {
+            let instance = this.#parent?.maybeGet(type);
+            if (instance !== undefined && instance !== null) {
+                return instance;
+            }
+
             if ((type as Environmental.Factory<T>)[Environmental.create]) {
                 this.set(type, (instance = (type as any)[Environmental.create](this)));
                 return instance as T;
@@ -113,8 +118,17 @@ export class Environment {
      * @param type the class of the service to block
      */
     block(type: abstract new (...args: any[]) => any) {
-        if (this.has(type)) {
-            this.delete(type);
+        const instance = this.#services?.get(type);
+
+        if (instance !== undefined && instance !== null) {
+            this.#services?.delete(type);
+
+            this.#deleted.emit(type, instance);
+
+            const serviceEvents = this.#serviceEvents.get(type);
+            if (serviceEvents) {
+                serviceEvents.deleted.emit(instance);
+            }
         }
 
         this.#services?.set(type, null);

--- a/packages/general/src/environment/Environment.ts
+++ b/packages/general/src/environment/Environment.ts
@@ -67,12 +67,15 @@ export class Environment {
             return mine as T;
         }
 
-        if (mine !== null) {
+        // When null then we do not have it and also do not want to inherit from parent
+        if (mine === undefined) {
             let instance = this.#parent?.maybeGet(type);
             if (instance !== undefined && instance !== null) {
+                // Parent has it, use it
                 return instance;
             }
 
+            // ... otherwise try to create it
             if ((type as Environmental.Factory<T>)[Environmental.create]) {
                 this.set(type, (instance = (type as any)[Environmental.create](this)));
                 return instance as T;


### PR DESCRIPTION
Blocking a service in one env was also removing the same service, if existing, from the parent. The reason is that it uses "has" which not only checks the local scope but also the parent. same for delete