### PR TITLE
Generate a random FabricId for new controllers

### DIFF
--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -42,7 +42,6 @@ import {
     ControllerCommissioner,
     DecodedAttributeReportValue,
     DEFAULT_ADMIN_VENDOR_ID,
-    DEFAULT_FABRIC_ID,
     DeviceAdvertiser,
     DiscoveryAndCommissioningOptions,
     DiscoveryData,
@@ -113,13 +112,15 @@ export class MatterController {
         rootFabric?: Fabric;
         crypto?: Crypto;
     }): Promise<MatterController> {
+        const crypto = options.crypto ?? Environment.default.get(Crypto);
+
         const {
             controllerStore,
             scanners,
             transports: netInterfaces,
             sessionClosedCallback,
             adminVendorId,
-            adminFabricId = FabricId(DEFAULT_FABRIC_ID),
+            adminFabricId = FabricId(crypto.randomBigInt(8)),
             adminFabricIndex = FabricIndex(DEFAULT_FABRIC_INDEX),
             caseAuthenticatedTags,
             adminFabricLabel,
@@ -127,8 +128,6 @@ export class MatterController {
             rootCertificateAuthority,
             rootFabric,
         } = options;
-
-        const crypto = options.crypto ?? Environment.default.get(Crypto);
 
         const ca = rootCertificateAuthority ?? (await CertificateAuthority.create(crypto, controllerStore.caStorage));
         const fabricStorage = controllerStore.fabricStorage;

--- a/packages/node/src/behavior/system/controller/ControllerBehavior.ts
+++ b/packages/node/src/behavior/system/controller/ControllerBehavior.ts
@@ -23,6 +23,7 @@ import {
     Scanner,
     ScannerSet,
 } from "#protocol";
+import { FabricId } from "@matter/types";
 import type { CommissioningClient } from "../commissioning/CommissioningClient.js";
 import { CommissioningServer } from "../commissioning/CommissioningServer.js";
 import { NetworkServer } from "../network/NetworkServer.js";
@@ -48,6 +49,7 @@ export class ControllerBehavior extends Behavior {
             throw new ImplementationError("adminFabricLabel must be set for ControllerBehavior.");
         }
         const adminFabricLabel = this.state.adminFabricLabel;
+        const adminFabricId = this.state.adminFabricId;
 
         // Configure discovery transports
         if (this.state.ip === undefined) {
@@ -76,6 +78,10 @@ export class ControllerBehavior extends Behavior {
 
                     override get adminFabricLabel() {
                         return adminFabricLabel;
+                    }
+
+                    get fabricId() {
+                        return adminFabricId;
                     }
                 })(),
             );
@@ -185,5 +191,12 @@ export namespace ControllerBehavior {
          * Contains the label of the admin fabric which is set for all commissioned devices
          */
         adminFabricLabel = "matter.js";
+
+        /**
+         * Contains the FabricId of the admin fabric when a defined number needs to be used because special Certificates
+         * are used.
+         * If not provided, a random FabricId will be generated.
+         */
+        adminFabricId?: FabricId = undefined;
     }
 }

--- a/packages/node/test/node/mock-site.ts
+++ b/packages/node/test/node/mock-site.ts
@@ -20,6 +20,7 @@ import {
 } from "#general";
 import { Node } from "#node/Node.js";
 import { ServerNode } from "#node/ServerNode.js";
+import { FabricId } from "#types";
 import type { MockServerNode } from "./mock-server-node.js";
 
 const logger = Logger.get("MockSite");
@@ -85,7 +86,11 @@ export class MockSite {
 
     async addUncommissionedPair(options?: MockSite.PairOptions) {
         options ??= {};
-
+        options.controller ??= {} as MockServerNode.Configuration<any>;
+        if (options.controller.controller?.adminFabricId === undefined) {
+            options.controller.controller ??= {};
+            options.controller.controller.adminFabricId = FabricId(1);
+        }
         const controller = await this.addNode(undefined, {
             online: false,
             ...options.controller,

--- a/packages/protocol/src/fabric/Fabric.ts
+++ b/packages/protocol/src/fabric/Fabric.ts
@@ -259,7 +259,7 @@ export class Fabric {
         };
     }
 
-    addressOf(nodeId: NodeId) {
+    addressOf(nodeId: NodeId): PeerAddress {
         return PeerAddress({ fabricIndex: this.fabricIndex, nodeId });
     }
 

--- a/packages/protocol/src/fabric/FabricAuthority.ts
+++ b/packages/protocol/src/fabric/FabricAuthority.ts
@@ -51,7 +51,6 @@ export interface FabricAuthorityContext {
 }
 
 export const DEFAULT_ADMIN_VENDOR_ID = VendorId(0xfff1);
-export const DEFAULT_FABRIC_ID = FabricId(1);
 
 /**
  * Manages fabrics controlled locally associated with a specific CA.
@@ -144,10 +143,11 @@ export class FabricAuthority {
             .setRootVendorId(this.#config.adminVendorId ?? DEFAULT_ADMIN_VENDOR_ID)
             .setLabel(this.#config.adminFabricLabel);
 
+        const fabricId = this.#config.fabricId ?? FabricId(this.#fabrics.crypto.randomBigInt(8));
         await fabricBuilder.setOperationalCert(
             await this.#ca.generateNoc(
                 fabricBuilder.publicKey,
-                this.#config.fabricId ?? DEFAULT_FABRIC_ID,
+                fabricId,
                 rootNodeId,
                 this.#config.caseAuthenticatedTags,
             ),

--- a/packages/protocol/src/fabric/TestFabric.ts
+++ b/packages/protocol/src/fabric/TestFabric.ts
@@ -6,7 +6,7 @@
 
 import { CertificateAuthority } from "#certificate/CertificateAuthority.js";
 import { ImplementationError, MockCrypto } from "#general";
-import { FabricIndex, VendorId } from "#types";
+import { FabricId, FabricIndex, VendorId } from "#types";
 import { FabricAuthority } from "./FabricAuthority.js";
 import { FabricManager } from "./FabricManager.js";
 
@@ -54,6 +54,7 @@ export namespace TestFabric {
                 adminFabricLabel: `mock-fabric-${index}`,
                 adminVendorId: VendorId(0xfff1),
                 fabricIndex: FabricIndex(index),
+                fabricId: FabricId(1),
             },
             fabrics,
         });


### PR DESCRIPTION
To prevent Fabric Id collisions we now generate random fabric IDs when controllers are initialized the first time and no defined adminFabricId is defined.