### PR TITLE
Node.js HTTP endpoint implementation

### DIFF
--- a/packages/general/src/storage/StorageService.ts
+++ b/packages/general/src/storage/StorageService.ts
@@ -18,9 +18,17 @@ export class StorageService {
     #factory?: (namespace: string) => Storage;
     #location?: string;
 
-    constructor(environment: Environment, factory?: (namespace: string) => Storage) {
+    constructor(
+        environment: Environment,
+        factory?: (namespace: string) => Storage,
+        resolver?: (...paths: string[]) => string,
+    ) {
         environment.set(StorageService, this);
         this.#factory = factory;
+
+        // Fallback resolver is dumb and probably not useful; expected to be replaced by platform implementation if
+        // file resolution is necessary
+        this.resolve = resolver ?? ((...paths: []) => paths.join("/"));
     }
 
     static [Environmental.create](environment: Environment) {
@@ -60,6 +68,11 @@ export class StorageService {
     set location(location: string | undefined) {
         this.#location = location;
     }
+
+    /**
+     * Join one or more relative paths to some platform-dependent notion of an absolute storage path.
+     */
+    resolve: (...paths: string[]) => string;
 
     [Diagnostic.value]() {
         return [

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -52,8 +52,8 @@
     "devDependencies": {
         "@matter/model": "*",
         "@matter/protocol": "*",
-        "@matter/tools": "*",
         "@matter/testing": "*",
+        "@matter/tools": "*",
         "@project-chip/matter.js": "*",
         "@types/bytebuffer": "^5.0.49"
     },
@@ -77,7 +77,6 @@
                 "default": "./dist/cjs/index.js"
             }
         },
-
         "./config": {
             "import": {
                 "types": "./dist/esm/config.d.ts",

--- a/packages/nodejs/src/environment/NodeJsEnvironment.ts
+++ b/packages/nodejs/src/environment/NodeJsEnvironment.ts
@@ -11,6 +11,7 @@ import {
     Boot,
     Crypto,
     Environment,
+    HttpEndpointFactory,
     ImplementationError,
     LogFormat,
     Logger,
@@ -19,6 +20,7 @@ import {
     StorageService,
     VariableService,
 } from "#general";
+import { NodeJsHttpEndpoint } from "#net/NodeJsHttpEndpoint.js";
 import { existsSync, readFileSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
@@ -65,6 +67,8 @@ import { ProcessManager } from "./ProcessManager.js";
  * * `runtime.signals` - By default register SIGINT and SIGUSR2 (diag) handlers, set to false if not wanted
  * * `runtime.exitcode` - By default we set the process.exitcode to 0 (ok) or 1 (crash); set to false to disable
  * * `runtime.unhandlederrors` - By default we log unhandled errors to matter.js log; set to false to disable
+ *
+ * TODO - this should go away.  Node.js services should register with {@link ServiceBundle.default}
  */
 export function NodeJsEnvironment() {
     const env = new Environment("default");
@@ -144,9 +148,16 @@ function configureNetwork(env: Environment) {
 
     Boot.init(() => {
         if (config.installNetwork || (env.vars.boolean("nodejs.network") ?? true)) {
+            const basePathForUnixSockets = env.maybeGet(StorageService)?.location;
             env.set(Network, new NodeJsNetwork());
-        } else if (Environment.default.has(Network)) {
-            env.set(Network, Environment.default.get(Network));
+            env.set(HttpEndpointFactory, new NodeJsHttpEndpoint.Factory(basePathForUnixSockets));
+        } else {
+            if (Environment.default.has(Network)) {
+                env.set(Network, Environment.default.get(Network));
+            }
+            if (Environment.default.has(HttpEndpointFactory)) {
+                env.set(HttpEndpointFactory, Environment.default.get(HttpEndpointFactory));
+            }
         }
     });
 }
@@ -169,6 +180,8 @@ function configureStorage(env: Environment) {
 
     service.factory = namespace =>
         new StorageBackendDisk(resolve(service.location ?? ".", namespace), env.vars.get("storage.clear", false));
+
+    service.resolve = (...paths) => resolve(service.location ?? ".", ...paths);
 }
 
 export function loadConfigFile(vars: VariableService) {

--- a/packages/nodejs/src/net/NodeJsHttpEndpoint.ts
+++ b/packages/nodejs/src/net/NodeJsHttpEndpoint.ts
@@ -140,9 +140,9 @@ export class NodeJsHttpEndpoint implements HttpEndpoint {
                     settled = true;
                     resolve();
                 });
-                server.once("error", error => {
+                server.on("error", error => {
                     if (settled) {
-                        logger.error("Underlying server reported error after success listen", error);
+                        logger.warn("HTTP server error:", error.message);
                         return;
                     }
 

--- a/packages/nodejs/src/net/NodeJsHttpEndpoint.ts
+++ b/packages/nodejs/src/net/NodeJsHttpEndpoint.ts
@@ -1,0 +1,358 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AppAddress, asError, HttpEndpoint, HttpEndpointFactory, Logger, NetworkError } from "#general";
+import { existsSync, ReadStream, rmSync, statSync } from "node:fs";
+import { createServer, IncomingMessage, Server, ServerResponse } from "node:http";
+import { ListenOptions } from "node:net";
+import { normalize, resolve } from "node:path";
+import { Duplex } from "node:stream";
+
+// Node's ReadableStream type definition do not exactly match the standard version so we need to import to support casts
+import type { ReadableStream as NodeReadableStream } from "node:stream/web";
+import { WsAdapter } from "./WsAdapter.js";
+
+const logger = new Logger("NodeJsHttpEndpoint");
+
+/**
+ * An implementation of {@link HttpEndpoint} that uses Node.js's standard {@link Server}.
+ *
+ * WebSocket support is optional.  You can install by importing `@matter/nodejs-ws`.
+ *
+ * This implementation is a little ugly because the native Node.js HTTP server API is pre-async and has some design
+ * flaws.  Other runtimes tend build on WinterTC standards and adapters will be much simpler.
+ */
+export class NodeJsHttpEndpoint implements HttpEndpoint {
+    #server: Server;
+    #ready: Promise<void>;
+    #http?: HttpEndpoint.HttpHandler;
+    #httpListener?: (req: IncomingMessage, res: ServerResponse) => void;
+    #ws?: HttpEndpoint.WsHandler;
+    #wsListener?: (req: IncomingMessage, socket: Duplex, head: Buffer) => void;
+    #notFound: (res: ServerResponse) => void;
+
+    #wsAdapter?: WsAdapter;
+    #wsAdapterFactory?: WsAdapter.Factory;
+
+    static async create(options: NodeJsHttpEndpoint.Options): Promise<NodeJsHttpEndpoint> {
+        const endpoint = new NodeJsHttpEndpoint(options);
+        await endpoint.ready;
+        return endpoint;
+    }
+
+    /**
+     * Create a new endpoint.
+     *
+     * You may pass an existing {@link Server} or pass {@link NodeJsHttpEndpoint.Options} to create a server dedicated
+     * to this endpoint.
+     */
+    constructor(optionsOrServer: Server | NodeJsHttpEndpoint.Options) {
+        let close, ready, server, notFound;
+
+        if ("on" in optionsOrServer) {
+            ({ close, ready, server, notFound } = this.#bindToServer(optionsOrServer));
+        } else {
+            ({ close, ready, server, notFound } = this.#createDedicatedServer(optionsOrServer));
+        }
+
+        this.#server = server;
+        this.#ready = ready;
+        this.close = close;
+        this.#notFound = notFound;
+    }
+
+    get server() {
+        return this.#server;
+    }
+
+    #bindToServer(server: Server) {
+        return {
+            server,
+            ready: Promise.resolve(),
+            close: async () => {
+                this.http = undefined;
+                this.ws = undefined;
+            },
+            notFound: () => undefined,
+        };
+    }
+
+    #createDedicatedServer(options: NodeJsHttpEndpoint.Options) {
+        const server = createServer({ keepAlive: true });
+
+        const opts = {} as ListenOptions;
+
+        const address = AppAddress.for(options.address);
+        const { transport } = address;
+        switch (transport.kind) {
+            case "ip":
+                if (!address.isWildcardHost) {
+                    opts.host = address.host;
+                }
+                if (!address.isWildcardPort) {
+                    opts.port = address.portNum;
+                }
+                break;
+
+            case "unix":
+                const path = decodeURIComponent(address.hostname);
+                if (options.basePathForUnixSockets) {
+                    opts.path = resolve(options.basePathForUnixSockets, normalize(path));
+                } else {
+                    opts.path = normalize(path);
+                }
+                if (existsSync(opts.path)) {
+                    if (statSync(opts.path).isSocket()) {
+                        try {
+                            rmSync(opts.path);
+                        } catch (e) {
+                            throw new NetworkError(
+                                `Error deleting previous socket at ${opts.path}: ${asError(e).message}`,
+                            );
+                        }
+                    } else {
+                        throw new NetworkError(`UNIX socket path ${opts.path} exists and is not a socket`);
+                    }
+                }
+                break;
+
+            default:
+                throw new NetworkError(
+                    `Unsupported address type "${(options.address as any)?.type}" for HTTP endpoint`,
+                );
+        }
+
+        server.listen(opts);
+
+        return {
+            server,
+
+            ready: new Promise<void>((resolve, reject) => {
+                let settled = false;
+                server.once("listening", () => {
+                    if (settled) {
+                        return;
+                    }
+
+                    settled = true;
+                    resolve();
+                });
+                server.once("error", error => {
+                    if (settled) {
+                        logger.error("Underlying server reported error after success listen", error);
+                        return;
+                    }
+
+                    settled = true;
+                    reject(error);
+                });
+            }),
+
+            close: async () => {
+                return new Promise<void>((resolve, reject) => {
+                    server.close(err => {
+                        if (err) {
+                            reject(err);
+                            return;
+                        }
+
+                        resolve();
+                    });
+                });
+            },
+
+            notFound: (res: ServerResponse) => respondError(res, 404),
+        };
+    }
+
+    get ready() {
+        return this.#ready;
+    }
+
+    set http(handler: HttpEndpoint.HttpHandler | undefined) {
+        this.#http = handler;
+
+        if (!this.#http) {
+            if (this.#httpListener) {
+                this.#server.off("request", this.#httpListener);
+            }
+            return;
+        }
+
+        if (this.#httpListener) {
+            return;
+        }
+
+        this.#httpListener = (req, res) => {
+            this.#handleHttp(req, res).catch(error => {
+                logger.error("Unhandled error in HTTP endpoint handler", error);
+                respondError(res, 500);
+            });
+        };
+
+        this.#server.on("request", this.#httpListener);
+    }
+
+    set ws(handler: HttpEndpoint.WsHandler | undefined) {
+        this.#ws = handler;
+
+        if (!this.#ws) {
+            if (this.#wsListener) {
+                this.#server.off("upgrade", this.#wsListener);
+            }
+            return;
+        }
+
+        let adapter = this.#wsAdapter;
+        if (!adapter) {
+            const factory = this.#wsAdapterFactory ?? WsAdapter.defaultFactory;
+            if (!factory) {
+                logger.warn(
+                    "WebSocket support disabled because no adapter is installed; please import @matter/nodejs-ws or equivalent",
+                );
+                return;
+            }
+            adapter = this.#wsAdapter = factory();
+        }
+
+        this.#wsListener = (req, socket, head) => {
+            this.#handleUpgrade(adapter, req, socket, head).catch(error => {
+                logger.error("Unhandled error WebSocket endpoint", error);
+            });
+        };
+
+        this.#server.on("upgrade", this.#wsListener);
+    }
+
+    close: () => Promise<void>;
+
+    async #handleHttp(req: IncomingMessage, res: ServerResponse) {
+        if (!this.#http) {
+            return;
+        }
+
+        const request = new NodeJsHttpRequest(req);
+
+        const response = await this.#http(request);
+        if (!response) {
+            this.#notFound(res);
+            return;
+        }
+
+        res.statusCode = response.status;
+        res.statusMessage = response.statusText;
+
+        response.headers.forEach(([name, value]) => res.appendHeader(name, value));
+
+        if (response.body === null) {
+            res.end();
+            return;
+        }
+
+        const nodeBodyStream = ReadStream.fromWeb(response.body as NodeReadableStream);
+
+        nodeBodyStream.on("error", error => {
+            logger.error("Error transmitting HTTP body", error);
+            respondError(res, 500);
+        });
+
+        nodeBodyStream.pipe(res);
+    }
+
+    async #handleUpgrade(adapter: WsAdapter, req: IncomingMessage, socket: Duplex, head: Buffer) {
+        if (req.headers.upgrade !== "websocket") {
+            // Not clear how to send a 426 with Node's API
+            socket.destroy();
+            return;
+        }
+
+        // This shouldn't happen
+        if (!this.#ws) {
+            socket.destroy();
+            return;
+        }
+
+        const request = new NodeJsHttpRequest(req);
+
+        try {
+            await this.#ws(request, async () => {
+                return adapter.handle(req, socket, head);
+            });
+        } finally {
+            // Node API is fairly broken and offers no way to indicate we've skipped the socket so we must destroy it
+            // if not already handled
+            if (!socket.destroyed) {
+                socket.destroy();
+            }
+        }
+    }
+}
+
+class NodeJsHttpRequest extends Request {
+    constructor(message: IncomingMessage) {
+        const { method, rawHeaders } = message;
+
+        const url = `http://${message.headers.host ?? "unknown"}${message.url ?? "/"}`;
+
+        const headers = new Headers();
+
+        for (let i = 0; i < message.rawHeaders.length; i += 2) {
+            headers.append(rawHeaders[i], rawHeaders[i + 1]);
+        }
+
+        const init = {
+            method,
+            headers,
+            duplex: "half", // Not in RequestInit type but required by node
+        } as RequestInit;
+
+        if (method !== "GET" && method !== "HEAD") {
+            init.body = IncomingMessage.toWeb(message) as ReadableStream;
+        }
+
+        super(url, init);
+    }
+}
+
+function respondError(res: ServerResponse, code: number) {
+    if (res.closed) {
+        return;
+    }
+
+    try {
+        if (!res.headersSent) {
+            res.statusCode = code;
+            res.setHeader("Content-Type", "text/plain");
+            res.end(`HTTP error ${code}\n`);
+        } else {
+            res.end();
+        }
+    } catch (e) {
+        logger.warn(`Error conveying ${code} error:`, asError(e).message);
+    }
+}
+
+export namespace NodeJsHttpEndpoint {
+    export interface Options extends HttpEndpoint.Options {
+        basePathForUnixSockets?: string;
+    }
+
+    export class Factory extends HttpEndpointFactory {
+        #basePathForUnixSockets?: string;
+
+        constructor(basePathForUnixSockets?: string) {
+            super();
+            this.#basePathForUnixSockets = basePathForUnixSockets;
+        }
+
+        async create(options: HttpEndpoint.Options) {
+            return NodeJsHttpEndpoint.create({
+                basePathForUnixSockets: this.#basePathForUnixSockets,
+                ...options,
+            });
+        }
+    }
+}

--- a/packages/nodejs/src/net/WsAdapter.ts
+++ b/packages/nodejs/src/net/WsAdapter.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2022-2025 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { HttpEndpoint } from "#general";
+
+import { IncomingMessage } from "node:http";
+import { Duplex } from "node:stream";
+
+/**
+ * This is a pluggable component that handles the upgrade to a WsConnection.
+ *
+ * We do not implement directly here because Node.js does not support WebSocket servers natively, so we must use a
+ * third-party dependency.
+ */
+export interface WsAdapter {
+    handle(req: IncomingMessage, socket: Duplex, head: Buffer): Promise<HttpEndpoint.WsConnection>;
+    close(): Promise<void>;
+}
+
+export namespace WsAdapter {
+    // eslint-disable-next-line prefer-const
+    export let defaultFactory = undefined as undefined | Factory;
+
+    export interface Factory {
+        (): WsAdapter;
+    }
+}

--- a/packages/nodejs/src/net/index.ts
+++ b/packages/nodejs/src/net/index.ts
@@ -4,5 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export * from "./NodeJsHttpEndpoint.js";
 export * from "./NodeJsNetwork.js";
 export * from "./NodeJsUdpChannel.js";
+export * from "./WsAdapter.js";


### PR DESCRIPTION
Node.js HTTP endpoint implementation

This includes an adapter from Node's old HTTP API to our WinterTC-style API.  This adapter is ugly due to Node's ancient API, but adapters for other platforms will be much more straightforward because they generally already use native Request and Response objects.

The adapter has WebSocket support, but since Node doesn't include a WebSocket server, this requires yet another plugin to enable WebSockets (called `WsAdapter` here).

Depends on #2524