### PR TITLE
Fix for Logger returning on first higher log level

### DIFF
--- a/packages/general/src/log/Logger.ts
+++ b/packages/general/src/log/Logger.ts
@@ -215,7 +215,7 @@ export class Logger {
             const dest = Logger.destinations[name];
 
             if (level < (dest.facilityLevels?.[this.#name] ?? dest.level)) {
-                return;
+                continue;
             }
 
             if (!dest.context) {


### PR DESCRIPTION
The Logger currently just exits the log function on the first log destination that has a higher log level. I just replaced the return statement with a continue statement to fix this.