### PR TITLE
Add SIGABRT handler

### DIFF
--- a/packages/nodejs/src/config.ts
+++ b/packages/nodejs/src/config.ts
@@ -164,7 +164,7 @@ export const config = {
     },
 
     /**
-     * Enables handling of SIGINT, SIGTERM and SIGUSR2 (depending on platform; default: true).
+     * Enables handling of SIGINT, SIGTERM, SIGUSR2 and SIGABRT (depending on platform; default: true).
      */
     get trapProcessSignals() {
         return trapProcessSignals;


### PR DESCRIPTION
Attempts to write Node.js diagnostics to matter.js logs on SIGABRT, then hard exits with error code -66.