### PR TITLE
Constraint subproperty references

### DIFF
--- a/packages/model/src/common/FieldValue.ts
+++ b/packages/model/src/common/FieldValue.ts
@@ -149,7 +149,7 @@ export namespace FieldValue {
      */
     export type Properties = {
         type: properties;
-        properties: { [name: string]: FieldValue };
+        properties: Record<string, FieldValue>;
     };
 
     /**

--- a/packages/model/src/logic/definition-validation/ValueValidator.ts
+++ b/packages/model/src/logic/definition-validation/ValueValidator.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { camelize } from "#general";
 import { ModelTraversal } from "#logic/ModelTraversal.js";
 import { Access, Aspect, Conformance, Constraint, Quality } from "../../aspects/index.js";
 import { DefinitionError, FieldValue, Metatype } from "../../common/index.js";
@@ -34,6 +35,7 @@ export class ValueValidator<T extends ValueModel> extends ModelValidator<T> {
             }
 
             // Field lookup
+            name = camelize(name, true);
             for (let model = this.model.parent; model; model = model.parent) {
                 const member = model.member(name);
                 if (member) {

--- a/packages/model/src/parser/Lexer.ts
+++ b/packages/model/src/parser/Lexer.ts
@@ -121,7 +121,7 @@ function* lex(
         // The first digit may not actually be a digit if number is hexadecimal or binary
         let num = valueOf(current.value);
         if (num === undefined) {
-            error("INVALID_NUMBER", `Expected digit following numeric suffix`);
+            error("INVALID_NUMBER", `Expected digit following numeric prefix`);
             return { type: "value", value: 0, startLine, startChar };
         }
 

--- a/packages/model/src/parser/TokenStream.ts
+++ b/packages/model/src/parser/TokenStream.ts
@@ -52,8 +52,8 @@ export function TokenStream<T extends Token>(iterator: Iterator<T>): TokenStream
                 case "word":
                     return `word "${(this.token as unknown as BasicToken.Word).value}"`;
 
-                case "number":
-                    return `number "${(this.token as unknown as BasicToken.Number).value}"`;
+                case "value":
+                    return `value "${(this.token as unknown as BasicToken.Number).value}"`;
 
                 default:
                     if (this.token?.type.match(/[a-z]/i)) {

--- a/packages/model/test/aspects/ConstraintTest.ts
+++ b/packages/model/test/aspects/ConstraintTest.ts
@@ -94,6 +94,36 @@ const TEST_CONSTRAINTS: [text: string, ast: Constraint.Ast, expectedText?: strin
             },
         },
     ],
+    [
+        "holdTimeLimits.holdTimeMin to holdTimeLimits.holdTimeMax",
+        {
+            min: {
+                type: ".",
+
+                lhs: {
+                    type: "reference",
+                    name: "holdTimeLimits",
+                },
+                rhs: {
+                    type: "reference",
+                    name: "holdTimeMin",
+                },
+            },
+
+            max: {
+                type: ".",
+
+                lhs: {
+                    type: "reference",
+                    name: "holdTimeLimits",
+                },
+                rhs: {
+                    type: "reference",
+                    name: "holdTimeMax",
+                },
+            },
+        },
+    ],
 ];
 
 describe("Constraint", () => {

--- a/packages/node/src/behavior/state/managed/NameResolver.ts
+++ b/packages/node/src/behavior/state/managed/NameResolver.ts
@@ -7,7 +7,7 @@
 import { RootSupervisor } from "#behavior/supervision/RootSupervisor.js";
 import { camelize } from "#general";
 import type { Schema } from "#model";
-import { ClusterModel, Model, ValueModel } from "#model";
+import { ClusterModel, Model, ValueModel, type FieldValue } from "#model";
 import { Val } from "#protocol";
 import { Internal } from "./Internal.js";
 


### PR DESCRIPTION
Enables the "field.name" construct in constraint definitions.  Introduced in 1.4.2 and used exactly once.