### PR TITLE
fix: validate WAL commit shape in deserializer

### DIFF
--- a/packages/general/src/storage/wal/WalCommit.ts
+++ b/packages/general/src/storage/wal/WalCommit.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { StorageError } from "../StorageDriver.js";
 import { type SupportedStorageTypes, fromJson, toJson } from "../StringifyTools.js";
 
 export type StoreData = Record<string, Record<string, SupportedStorageTypes>>;
@@ -66,13 +67,61 @@ export function serializeCommit(commit: WalCommit): string {
  * Deserialize a JSON line back to a commit.
  *
  * Handles legacy bare-array format by wrapping as `{ ts: 0, ops }`.
+ *
+ * Throws if the parsed value is not a structurally valid commit so callers
+ * (e.g. {@link WalReader}) can skip the line rather than yielding a commit
+ * that crashes replay downstream.
  */
 export function deserializeCommit(line: string): WalCommit {
-    const parsed = fromJson(line);
+    const parsed: unknown = fromJson(line);
+
     if (Array.isArray(parsed)) {
+        parsed.forEach(validateOp);
         return { ts: 0, ops: parsed as WalOp[] };
     }
-    return parsed as unknown as WalCommit;
+
+    if (!isPlainRecord(parsed)) {
+        throw new StorageError("WAL commit is not an object");
+    }
+    const { ts, ops } = parsed;
+    if (typeof ts !== "number") {
+        throw new StorageError("WAL commit `ts` is missing or not a number");
+    }
+    if (!Array.isArray(ops)) {
+        throw new StorageError("WAL commit `ops` is missing or not an array");
+    }
+    ops.forEach(validateOp);
+    return { ts, ops: ops as WalOp[] };
+}
+
+function isPlainRecord(v: unknown): v is Record<string, unknown> {
+    return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+function validateOp(op: unknown, index: number): void {
+    if (!isPlainRecord(op)) {
+        throw new StorageError(`WAL op[${index}] is not an object`);
+    }
+    const { op: kind, key, values } = op;
+    if (typeof key !== "string") {
+        throw new StorageError(`WAL op[${index}] \`key\` is not a string`);
+    }
+    if (kind === "upd") {
+        if (!isPlainRecord(values)) {
+            throw new StorageError(`WAL op[${index}] upd \`values\` is not an object`);
+        }
+        return;
+    }
+    if (kind === "del") {
+        if (values === undefined) {
+            return;
+        }
+        if (!Array.isArray(values) || !values.every(v => typeof v === "string")) {
+            throw new StorageError(`WAL op[${index}] del \`values\` is not a string array`);
+        }
+        return;
+    }
+    throw new StorageError(`WAL op[${index}] has unknown op kind \`${String(kind)}\``);
 }
 
 /**

--- a/packages/general/test/storage/wal/WalCommitTest.ts
+++ b/packages/general/test/storage/wal/WalCommitTest.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { StorageError } from "#storage/StorageDriver.js";
 import {
     type WalCommit,
     type WalCommitId,
@@ -95,6 +96,40 @@ describe("WalCommit", () => {
             const result = deserializeCommit(legacyLine);
             expect(result.ts).equal(0);
             expect(result.ops).deep.equal([{ op: "upd", key: "a", values: { x: 1 } }]);
+        });
+
+        it("validates ops inside legacy bare-array format", () => {
+            expect(() => deserializeCommit('[{"op":"mystery","key":"a"}]')).throw(/unknown op kind/);
+            expect(() => deserializeCommit('[{"op":"upd","key":"a"}]')).throw(/op\[0\] upd `values`/);
+        });
+
+        it("throws for non-object payloads", () => {
+            expect(() => deserializeCommit("42")).throw(StorageError, /not an object/);
+            expect(() => deserializeCommit('"foo"')).throw(StorageError, /not an object/);
+            expect(() => deserializeCommit("null")).throw(StorageError, /not an object/);
+        });
+
+        it("throws when ts is missing or not a number", () => {
+            expect(() => deserializeCommit('{"ops":[]}')).throw(StorageError, /`ts`/);
+            expect(() => deserializeCommit('{"ts":"now","ops":[]}')).throw(StorageError, /`ts`/);
+        });
+
+        it("throws when ops is missing or wrong type", () => {
+            expect(() => deserializeCommit('{"ts":1}')).throw(/`ops`/);
+            expect(() => deserializeCommit('{"ts":1,"ops":"nope"}')).throw(/`ops`/);
+        });
+
+        it("throws for invalid op entries", () => {
+            expect(() => deserializeCommit('{"ts":1,"ops":[null]}')).throw(/op\[0\]/);
+            expect(() => deserializeCommit('{"ts":1,"ops":[{"op":"upd","key":1,"values":{}}]}')).throw(/op\[0\] `key`/);
+            expect(() => deserializeCommit('{"ts":1,"ops":[{"op":"upd","key":"a"}]}')).throw(/op\[0\] upd `values`/);
+            expect(() => deserializeCommit('{"ts":1,"ops":[{"op":"upd","key":"a","values":[]}]}')).throw(
+                /op\[0\] upd `values`/,
+            );
+            expect(() => deserializeCommit('{"ts":1,"ops":[{"op":"del","key":"a","values":[1]}]}')).throw(
+                /op\[0\] del `values`/,
+            );
+            expect(() => deserializeCommit('{"ts":1,"ops":[{"op":"mystery","key":"a"}]}')).throw(/unknown op kind/);
         });
     });
 

--- a/packages/general/test/storage/wal/WalCommitTest.ts
+++ b/packages/general/test/storage/wal/WalCommitTest.ts
@@ -115,8 +115,8 @@ describe("WalCommit", () => {
         });
 
         it("throws when ops is missing or wrong type", () => {
-            expect(() => deserializeCommit('{"ts":1}')).throw(/`ops`/);
-            expect(() => deserializeCommit('{"ts":1,"ops":"nope"}')).throw(/`ops`/);
+            expect(() => deserializeCommit('{"ts":1}')).throw(StorageError, /`ops`/);
+            expect(() => deserializeCommit('{"ts":1,"ops":"nope"}')).throw(StorageError, /`ops`/);
         });
 
         it("throws for invalid op entries", () => {

--- a/packages/general/test/storage/wal/WalReaderTest.ts
+++ b/packages/general/test/storage/wal/WalReaderTest.ts
@@ -125,6 +125,34 @@ describe("WalReader", () => {
         expect(results[0].commit).deep.equal(commit1);
     });
 
+    it("skips lines that parse as JSON but have wrong shape", async () => {
+        const walDir = fs.directory("wal");
+        await walDir.mkdir();
+
+        const commit1: WalCommit = { ts: 1000, ops: [{ op: "upd", key: "a", values: { x: 1 } }] };
+        const commit2: WalCommit = { ts: 2000, ops: [{ op: "del", key: "b" }] };
+        // Mix valid commits with shape-invalid JSON lines that would otherwise crash replay
+        const content =
+            serializeCommit(commit1) +
+            "\n" +
+            '{"ts":1500,"ops":"not-an-array"}' +
+            "\n" +
+            '{"ts":1600,"ops":[{"op":"upd","key":"a"}]}' +
+            "\n" +
+            '{"ts":1700,"ops":[{"op":"mystery","key":"a"}]}' +
+            "\n" +
+            serializeCommit(commit2) +
+            "\n";
+        await walDir.file(segmentFilename(1)).write(content);
+
+        const reader = new WalReader(walDir);
+        const results = await collectAll(reader.read());
+
+        expect(results.length).equal(2);
+        expect(results[0].commit).deep.equal(commit1);
+        expect(results[1].commit).deep.equal(commit2);
+    });
+
     it("lists segments sorted", async () => {
         const walDir = fs.directory("wal");
         await walDir.mkdir();


### PR DESCRIPTION
## Summary
- `deserializeCommit` now validates that parsed JSON conforms to `WalCommit` shape — `ts` is a number, `ops` is an array, each op has a known `op` discriminant, string `key`, and correctly typed `values` — and throws `StorageError` on mismatch.
- `WalReader` already catches and skips malformed lines at `warn` level; shape-invalid lines now take the same path instead of yielding a bogus commit that crashes `applyCommit` during replay.
- Previously, a single bit-flip in a line that still parsed as JSON (e.g. `{"ts":1,"ops":[{"op":"upd","key":"a"}]}` without `values`) would abort `WalStorageDriver.#load()` and render the driver unusable.
