### PR TITLE
remove vestigial dev-types

### DIFF
--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -63,9 +63,6 @@
         },
         "./platform": {
             "node": {
-                "dev-types": {
-                    "types": "./src/platform/nodejs.ts"
-                },
                 "import": {
                     "types": "./dist/esm/platform/nodejs.d.ts",
                     "default": "./dist/esm/platform/nodejs.js"
@@ -76,9 +73,6 @@
                 }
             },
             "react-native": {
-                "dev-types": {
-                    "types": "./src/platform/react-native.ts"
-                },
                 "import": {
                     "types": "./dist/esm/platform/react-native.d.ts",
                     "default": "./dist/esm/platform/react-native.js"
@@ -89,9 +83,6 @@
                 }
             },
             "default": {
-                "dev-types": {
-                    "types": "./src/platform/default.ts"
-                },
                 "import": {
                     "types": "./dist/esm/platform/default.d.ts",
                     "default": "./dist/esm/platform/default.js"
@@ -103,9 +94,6 @@
             }
         },
         "./clusters/*": {
-            "dev-types": {
-                "types": "./src/forwards/clusters/*.ts"
-            },
             "import": {
                 "types": "./dist/esm/forwards/clusters/*.d.ts",
                 "default": "./dist/esm/forwards/clusters/*.js"
@@ -116,9 +104,6 @@
             }
         },
         "./behaviors/*": {
-            "dev-types": {
-                "types": "./src/forwards/behaviors/*.ts"
-            },
             "import": {
                 "types": "./dist/esm/forwards/behaviors/*.d.ts",
                 "default": "./dist/esm/forwards/behaviors/*.js"
@@ -129,9 +114,6 @@
             }
         },
         "./devices/*": {
-            "dev-types": {
-                "types": "./src/forwards/devices/*.ts"
-            },
             "import": {
                 "types": "./dist/esm/forwards/devices/*.d.ts",
                 "default": "./dist/esm/forwards/devices/*.js"
@@ -142,9 +124,6 @@
             }
         },
         "./endpoints/*": {
-            "dev-types": {
-                "types": "./src/forwards/endpoints/*.ts"
-            },
             "import": {
                 "types": "./dist/esm/forwards/endpoints/*.d.ts",
                 "default": "./dist/esm/forwards/endpoints/*.js"
@@ -155,9 +134,6 @@
             }
         },
         "./*": {
-            "dev-types": {
-                "types": "./src/*.ts"
-            },
             "import": {
                 "types": "./dist/esm/*.d.ts",
                 "default": "./dist/esm/*.js"

--- a/packages/matter.js/package.json
+++ b/packages/matter.js/package.json
@@ -65,9 +65,6 @@
         },
         "./package.json": "./package.json",
         "./cluster": {
-            "dev-types": {
-                "types": "./src/cluster/export.ts"
-            },
             "import": {
                 "types": "./dist/esm/cluster/export.d.ts",
                 "default": "./dist/esm/cluster/export.js"
@@ -78,9 +75,6 @@
             }
         },
         "./device": {
-            "dev-types": {
-                "types": "./src/device/export.ts"
-            },
             "import": {
                 "types": "./dist/esm/device/export.d.ts",
                 "default": "./dist/esm/device/export.js"

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -56,9 +56,6 @@
             }
         },
         "./resources": {
-            "dev-types": {
-                "types": "./src/standard/resources/index.ts"
-            },
             "import": {
                 "types": "./dist/esm/standard/resources/index.d.ts",
                 "default": "./dist/esm/standard/resources/index.js"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -83,9 +83,6 @@
             }
         },
         "./behaviors": {
-            "dev-types": {
-                "types": "./src/behaviors/index.ts"
-            },
             "import": {
                 "types": "./dist/esm/behaviors/index.d.ts",
                 "default": "./dist/esm/behaviors/index.js"
@@ -96,9 +93,6 @@
             }
         },
         "./behaviors/system/*": {
-            "dev-types": {
-                "types": "./src/behavior/system/*/index.ts"
-            },
             "import": {
                 "types": "./dist/esm/behavior/system/*/index.d.ts",
                 "default": "./dist/esm/behavior/system/*/index.js"
@@ -109,9 +103,6 @@
             }
         },
         "./behaviors/*": {
-            "dev-types": {
-                "types": "./src/behaviors/*/index.ts"
-            },
             "import": {
                 "types": "./dist/esm/behaviors/*/index.d.ts",
                 "default": "./dist/esm/behaviors/*/index.js"
@@ -122,9 +113,6 @@
             }
         },
         "./devices": {
-            "dev-types": {
-                "types": "./src/devices/index.ts"
-            },
             "import": {
                 "types": "./dist/esm/devices/index.d.ts",
                 "default": "./dist/esm/devices/index.js"
@@ -135,9 +123,6 @@
             }
         },
         "./devices/*": {
-            "dev-types": {
-                "types": "./src/devices/*.ts"
-            },
             "import": {
                 "types": "./dist/esm/devices/*.d.ts",
                 "default": "./dist/esm/devices/*.js"
@@ -148,9 +133,6 @@
             }
         },
         "./endpoints": {
-            "dev-types": {
-                "types": "./src/endpoints/index.ts"
-            },
             "import": {
                 "types": "./dist/esm/endpoints/index.d.ts",
                 "default": "./dist/esm/endpoints/index.js"
@@ -161,9 +143,6 @@
             }
         },
         "./endpoints/*": {
-            "dev-types": {
-                "types": "./src/endpoints/*.ts"
-            },
             "import": {
                 "types": "./dist/esm/endpoints/*.d.ts",
                 "default": "./dist/esm/endpoints/*.js"

--- a/packages/nodejs/package.json
+++ b/packages/nodejs/package.json
@@ -71,9 +71,6 @@
             }
         },
         "./config": {
-            "dev-types": {
-                "types": "./src/config.ts"
-            },
             "import": {
                 "types": "./dist/esm/config.d.ts",
                 "default": "./dist/esm/config.js"

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -69,9 +69,6 @@
         },
         "./package.json": "./package.json",
         "./*": {
-            "dev-types": {
-                "types": "./src/*/index.ts"
-            },
             "import": {
                 "types": "./dist/esm/*/index.d.ts",
                 "default": "./dist/esm/*/index.js"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -72,9 +72,6 @@
             }
         },
         "./*": {
-            "dev-types": {
-                "types": "./src/*/index.ts"
-            },
             "import": {
                 "types": "./dist/esm/*/index.d.ts",
                 "default": "./dist/esm/*/index.js"

--- a/tsc/tsconfig.base.json
+++ b/tsc/tsconfig.base.json
@@ -30,6 +30,10 @@
         // Validating imports would be nice but is very slow; we can get by without
         "skipLibCheck": true,
 
+        // Resolve hand-authored .d.ts source files in packages that ship them (@matter/types/clusters/*,
+        // @matter/testing, @matter/node/load).  tsc cannot emit a proper .d.ts output from a .d.ts input,
+        // so the dist/ copy is not interchangeable with src for consumer symbol resolution.  Targets that
+        // ship as .ts sources do not need this — tsc emits dist/ .d.ts that work fine for consumers.
         "customConditions": [ "dev-types" ],
 
         "lib": [


### PR DESCRIPTION
I don't think these were useful anymore and they muck with importers who set the condition.