### PR TITLE
fix(mdns): fast-reject unrelated LAN queries + case-insensitive matching

### DIFF
--- a/packages/protocol/src/mdns/MdnsServer.ts
+++ b/packages/protocol/src/mdns/MdnsServer.ts
@@ -276,10 +276,14 @@ export class MdnsServer {
     }
 
     #queryRecords({ name, recordType }: { name: string; recordType: DnsRecordType }, records: DnsRecord<any>[]) {
+        // DNS names are case-insensitive per RFC 6762 §16 / RFC 1035 §2.3.3.
+        const queryName = name.toLowerCase();
         if (recordType === DnsRecordType.ANY) {
-            return records.filter(record => record.name === name);
+            return records.filter(record => record.name.toLowerCase() === queryName);
         } else {
-            return records.filter(record => record.name === name && record.recordType === recordType);
+            return records.filter(
+                record => record.name.toLowerCase() === queryName && record.recordType === recordType,
+            );
         }
     }
 

--- a/packages/protocol/src/mdns/MdnsServer.ts
+++ b/packages/protocol/src/mdns/MdnsServer.ts
@@ -40,21 +40,21 @@ export class MdnsServer {
         "MDNS discovery",
         async (multicastInterface: string) => {
             const byService = new Map<string, DnsRecord<any>[]>();
-            const names = new Set<string>();
+            const ownedNames = new Set<string>();
             const addrs = await this.network.getIpMac(multicastInterface);
             if (addrs === undefined) {
-                return { byService, names };
+                return { byService, ownedNames };
             }
 
             for (const [service, generator] of this.#recordsGenerator) {
                 const records = generator(multicastInterface, addrs);
                 byService.set(service, records);
                 for (const record of records) {
-                    names.add(record.name.toLowerCase());
+                    ownedNames.add(record.name.toLowerCase());
                 }
             }
 
-            return { byService, names };
+            return { byService, ownedNames };
         },
         Minutes(15) /* matches maximum standard commissioning window time */,
     );
@@ -86,13 +86,13 @@ export class MdnsServer {
     }
 
     buildDnsRecordKey(record: DnsRecord<any>, netInterface?: string, unicastTarget?: string) {
-        return `${record.name}-${record.recordClass}-${record.recordType}-${netInterface}-${unicastTarget}`;
+        return `${record.name.toLowerCase()}-${record.recordClass}-${record.recordType}-${netInterface}-${unicastTarget}`;
     }
 
     async #handleMessage(incomingMessage: MdnsSocket.Message) {
         using _processing = this.#lifetime.join("processing message");
 
-        const { byService, names } = await this.#records.get(incomingMessage.sourceIntf);
+        const { byService, ownedNames } = await this.#records.get(incomingMessage.sourceIntf);
 
         // Ignore if we have no records for interface
         if (byService.size === 0) {
@@ -100,8 +100,10 @@ export class MdnsServer {
         }
 
         // Zero-query packets must pass: RFC 6762 §7.2 TC continuations rely on #prepareMessage to merge them.
-        const { queries: incomingQueries } = incomingMessage;
-        if (incomingQueries.length > 0 && !incomingQueries.some(q => names.has(q.name.toLowerCase()))) {
+        if (
+            incomingMessage.queries.length > 0 &&
+            !incomingMessage.queries.some(q => ownedNames.has(q.name.toLowerCase()))
+        ) {
             return;
         }
 
@@ -256,7 +258,6 @@ export class MdnsServer {
     }
 
     async setRecordsGenerator(service: string, generator: MdnsServer.RecordGenerator) {
-        // Racing queries must see the new generator before clear's await yields.
         this.#recordsGenerator.set(service, generator);
         await this.#records.clear();
         this.#recordLastSentAsMulticastAnswer.clear();
@@ -318,10 +319,10 @@ export class MdnsServer {
             }
         }
 
-        // Build query signature
+        // Build query signature; names lower-cased per RFC 6762 §16.
         const queryKey =
             queries
-                .map(q => `${q.name}-${q.recordType}`)
+                .map(q => `${q.name.toLowerCase()}-${q.recordType}`)
                 .sort()
                 .join("|") + `-${sourceIntf}`;
 
@@ -423,7 +424,7 @@ export namespace MdnsServer {
     export interface InterfaceRecords {
         byService: Map<string, DnsRecord<any>[]>;
 
-        /** Lower-cased record names across all services - used to fast-reject unrelated LAN queries. */
-        names: Set<string>;
+        /** Lower-cased names of records we own on this interface - used to fast-reject unrelated LAN queries. */
+        ownedNames: Set<string>;
     }
 }

--- a/packages/protocol/src/mdns/MdnsServer.ts
+++ b/packages/protocol/src/mdns/MdnsServer.ts
@@ -114,6 +114,7 @@ export class MdnsServer {
 
         const { sourceIntf, sourceIp, transactionId, queries, answers: knownAnswers } = message;
 
+        let sentPreviousPacket = false;
         for (const portRecords of byService.values()) {
             let answers = queries.flatMap(query => this.#queryRecords(query, portRecords));
             if (answers.length === 0) continue;
@@ -172,6 +173,10 @@ export class MdnsServer {
                 );
             }
 
+            // Pace successive outgoing packets per DNS-SD convention; no trailing wait after the last one.
+            if (sentPreviousPacket) {
+                await Time.sleep("MDNS delay", Millis(20 + Math.floor(Math.random() * 100)));
+            }
             this.#socket
                 .send(
                     {
@@ -186,7 +191,7 @@ export class MdnsServer {
                 .catch(error => {
                     logger.warn(`Failed to send mDNS response to ${sourceIp}`, error);
                 });
-            await Time.sleep("MDNS delay", Millis(20 + Math.floor(Math.random() * 100))); // as per DNS-SD spec wait 20-120ms before sending more packets
+            sentPreviousPacket = true;
         }
     }
 
@@ -210,11 +215,15 @@ export class MdnsServer {
         await MatterAggregateError.allSettled(
             (await this.#getMulticastInterfacesForAnnounce()).map(async ({ name: netInterface }) => {
                 const { byService } = await this.#records.get(netInterface);
+                let sentPreviousPacket = false;
                 for (const [service, serviceRecords] of byService) {
                     if (services.length && !services.includes(service)) continue;
 
+                    if (sentPreviousPacket) {
+                        await Time.sleep("MDNS delay", Millis(20 + Math.floor(Math.random() * 100)));
+                    }
                     await this.#announceRecordsForInterface(netInterface, serviceRecords);
-                    await Time.sleep("MDNS delay", Millis(20 + Math.floor(Math.random() * 100))); // as per DNS-SD spec wait 20-120ms before sending more packets
+                    sentPreviousPacket = true;
                 }
             }),
             "Error announcing MDNS messages",
@@ -227,6 +236,7 @@ export class MdnsServer {
         await MatterAggregateError.allSettled(
             this.#records.keys().map(async netInterface => {
                 const { byService } = await this.#records.get(netInterface);
+                let sentPreviousPacket = false;
                 for (const [service, serviceRecords] of byService) {
                     if (services.length && !services.includes(service)) continue;
 
@@ -235,9 +245,12 @@ export class MdnsServer {
                         record.ttl = Instant;
                     });
 
+                    if (sentPreviousPacket) {
+                        await Time.sleep("MDNS delay", Millis(20 + Math.floor(Math.random() * 100)));
+                    }
                     await this.#announceRecordsForInterface(netInterface, serviceRecords);
                     this.#recordsGenerator.delete(service);
-                    await Time.sleep("MDNS delay", Millis(20 + Math.floor(Math.random() * 100))); // as per DNS-SD spec wait 20-120ms before sending more packets
+                    sentPreviousPacket = true;
                 }
             }),
             "Error happened when expiring MDNS announcements",

--- a/packages/protocol/src/mdns/MdnsServer.ts
+++ b/packages/protocol/src/mdns/MdnsServer.ts
@@ -259,10 +259,11 @@ export class MdnsServer {
     }
 
     async setRecordsGenerator(service: string, generator: MdnsServer.RecordGenerator) {
+        // Racing queries must see the new generator before clear's await yields.
+        this.#recordsGenerator.set(service, generator);
         await this.#records.clear();
         this.#recordLastSentAsMulticastAnswer.clear();
         this.#recentlyAnsweredQueries.clear();
-        this.#recordsGenerator.set(service, generator);
     }
 
     async #resetServices() {

--- a/packages/protocol/src/mdns/MdnsServer.ts
+++ b/packages/protocol/src/mdns/MdnsServer.ts
@@ -99,9 +99,7 @@ export class MdnsServer {
             return;
         }
 
-        // Avoid truncation handling and per-service record scans for unrelated LAN traffic.
-        // Zero-query packets must fall through so RFC 6762 §7.2 TC continuations can merge
-        // their additional known-answer records into a cached fragment.
+        // Zero-query packets must pass: RFC 6762 §7.2 TC continuations rely on #prepareMessage to merge them.
         const { queries: incomingQueries } = incomingMessage;
         if (incomingQueries.length > 0 && !incomingQueries.some(q => names.has(q.name.toLowerCase()))) {
             return;
@@ -173,7 +171,6 @@ export class MdnsServer {
                 );
             }
 
-            // Pace successive outgoing packets per DNS-SD convention; no trailing wait after the last one.
             if (sentPreviousPacket) {
                 await Time.sleep("MDNS delay", Millis(20 + Math.floor(Math.random() * 100)));
             }

--- a/packages/protocol/src/mdns/MdnsServer.ts
+++ b/packages/protocol/src/mdns/MdnsServer.ts
@@ -36,20 +36,25 @@ export class MdnsServer {
     #lifetime: Lifetime;
     #observers = new ObserverGroup();
     #recordsGenerator = new Map<string, MdnsServer.RecordGenerator>();
-    readonly #records = new AsyncCache<Map<string, DnsRecord<any>[]>>(
+    readonly #records = new AsyncCache<MdnsServer.InterfaceRecords>(
         "MDNS discovery",
         async (multicastInterface: string) => {
-            const serviceRecords = new Map<string, DnsRecord<any>[]>();
+            const byService = new Map<string, DnsRecord<any>[]>();
+            const names = new Set<string>();
             const addrs = await this.network.getIpMac(multicastInterface);
             if (addrs === undefined) {
-                return serviceRecords;
+                return { byService, names };
             }
 
             for (const [service, generator] of this.#recordsGenerator) {
-                serviceRecords.set(service, generator(multicastInterface, addrs));
+                const records = generator(multicastInterface, addrs);
+                byService.set(service, records);
+                for (const record of records) {
+                    names.add(record.name.toLowerCase());
+                }
             }
 
-            return serviceRecords;
+            return { byService, names };
         },
         Minutes(15) /* matches maximum standard commissioning window time */,
     );
@@ -87,10 +92,20 @@ export class MdnsServer {
     async #handleMessage(incomingMessage: MdnsSocket.Message) {
         using _processing = this.#lifetime.join("processing message");
 
-        const records = await this.#records.get(incomingMessage.sourceIntf);
+        const { byService, names } = await this.#records.get(incomingMessage.sourceIntf);
 
         // Ignore if we have no records for interface
-        if (records.size === 0) return;
+        if (byService.size === 0) {
+            return;
+        }
+
+        // Avoid truncation handling and per-service record scans for unrelated LAN traffic.
+        // Zero-query packets must fall through so RFC 6762 §7.2 TC continuations can merge
+        // their additional known-answer records into a cached fragment.
+        const { queries: incomingQueries } = incomingMessage;
+        if (incomingQueries.length > 0 && !incomingQueries.some(q => names.has(q.name.toLowerCase()))) {
+            return;
+        }
 
         const message = this.#prepareMessage(incomingMessage);
         if (message === undefined) {
@@ -99,7 +114,7 @@ export class MdnsServer {
 
         const { sourceIntf, sourceIp, transactionId, queries, answers: knownAnswers } = message;
 
-        for (const portRecords of records.values()) {
+        for (const portRecords of byService.values()) {
             let answers = queries.flatMap(query => this.#queryRecords(query, portRecords));
             if (answers.length === 0) continue;
 
@@ -194,8 +209,8 @@ export class MdnsServer {
 
         await MatterAggregateError.allSettled(
             (await this.#getMulticastInterfacesForAnnounce()).map(async ({ name: netInterface }) => {
-                const records = await this.#records.get(netInterface);
-                for (const [service, serviceRecords] of records) {
+                const { byService } = await this.#records.get(netInterface);
+                for (const [service, serviceRecords] of byService) {
                     if (services.length && !services.includes(service)) continue;
 
                     await this.#announceRecordsForInterface(netInterface, serviceRecords);
@@ -211,8 +226,8 @@ export class MdnsServer {
 
         await MatterAggregateError.allSettled(
             this.#records.keys().map(async netInterface => {
-                const records = await this.#records.get(netInterface);
-                for (const [service, serviceRecords] of records) {
+                const { byService } = await this.#records.get(netInterface);
+                for (const [service, serviceRecords] of byService) {
                     if (services.length && !services.includes(service)) continue;
 
                     // Set TTL to Instant for all records to expire them
@@ -388,5 +403,12 @@ export class MdnsServer {
 export namespace MdnsServer {
     export interface RecordGenerator {
         (intf: string, addrs: NetworkInterfaceDetails): DnsRecord[];
+    }
+
+    export interface InterfaceRecords {
+        byService: Map<string, DnsRecord<any>[]>;
+
+        /** Lower-cased record names across all services - used to fast-reject unrelated LAN queries. */
+        names: Set<string>;
     }
 }

--- a/packages/protocol/src/mdns/MdnsServer.ts
+++ b/packages/protocol/src/mdns/MdnsServer.ts
@@ -99,20 +99,17 @@ export class MdnsServer {
             return;
         }
 
-        // Zero-query packets must pass: RFC 6762 §7.2 TC continuations rely on #prepareMessage to merge them.
-        if (
-            incomingMessage.queries.length > 0 &&
-            !incomingMessage.queries.some(q => ownedNames.has(q.name.toLowerCase()))
-        ) {
-            return;
-        }
-
         const message = this.#prepareMessage(incomingMessage);
         if (message === undefined) {
             return;
         }
 
         const { sourceIntf, sourceIp, transactionId, queries, answers: knownAnswers } = message;
+
+        // Skip unrelated LAN traffic; run after #prepareMessage so TC continuations are first merged.
+        if (!queries.some(q => ownedNames.has(q.name.toLowerCase()))) {
+            return;
+        }
 
         let sentPreviousPacket = false;
         for (const portRecords of byService.values()) {
@@ -128,14 +125,14 @@ export class MdnsServer {
                     : [];
             if (knownAnswers.length > 0) {
                 for (const knownAnswersRecord of knownAnswers) {
-                    answers = answers.filter(record => !isDeepEqual(record, knownAnswersRecord, true));
+                    answers = answers.filter(record => !this.#suppressedByKnownAnswer(record, knownAnswersRecord));
                     if (answers.length === 0) break; // Nothing to send
                 }
                 if (answers.length === 0) continue; // Nothing to send
                 if (additionalRecords.length > 0) {
                     for (const knownAnswersRecord of knownAnswers) {
                         additionalRecords = additionalRecords.filter(
-                            record => !isDeepEqual(record, knownAnswersRecord, true),
+                            record => !this.#suppressedByKnownAnswer(record, knownAnswersRecord),
                         );
                     }
                 }
@@ -285,6 +282,12 @@ export class MdnsServer {
     #getMulticastInterfacesForAnnounce() {
         const { netInterface } = this.#socket;
         return netInterface === undefined ? this.network.getNetInterfaces() : [{ name: netInterface }];
+    }
+
+    #suppressedByKnownAnswer(record: DnsRecord<any>, knownAnswer: DnsRecord<any>): boolean {
+        const lcName = knownAnswer.name.toLowerCase();
+        if (record.name.toLowerCase() !== lcName) return false;
+        return isDeepEqual({ ...record, name: lcName }, { ...knownAnswer, name: lcName }, true);
     }
 
     #queryRecords({ name, recordType }: { name: string; recordType: DnsRecordType }, records: DnsRecord<any>[]) {

--- a/packages/protocol/test/mdns/MdnsServerTest.ts
+++ b/packages/protocol/test/mdns/MdnsServerTest.ts
@@ -1280,7 +1280,7 @@ describe("MdnsServer", () => {
             };
 
             const newQname = "other.service.local";
-            await mdnsServer.setRecordsGenerator("bar", () => [
+            await mdnsServer.setRecordsGenerator("foo", () => [
                 PtrRecord(newQname, "efgh"),
                 SrvRecord(newQname, { priority: 0, weight: 0, port: 5678, target: "efgh.local" }),
             ]);
@@ -1302,6 +1302,131 @@ describe("MdnsServer", () => {
 
             await MockTime.yield3();
             expect(responses.length).equals(1);
+
+            // Old name was truly replaced - no response for the previous qname.
+            responses.length = 0;
+            send(
+                DnsCodec.encode({
+                    messageType: DnsMessageType.Query,
+                    queries: [
+                        {
+                            name: DUMMY_QNAME,
+                            recordClass: DnsRecordClass.IN,
+                            recordType: DnsRecordType.ANY,
+                        },
+                    ],
+                }),
+                DUMMY_IP,
+                INTERFACE_NAME,
+            );
+            await MockTime.yield3();
+            expect(responses.length).equals(0);
+        });
+
+        it("merges known-answers from a TC continuation that carries unrelated queries", async () => {
+            // Packet 1 carries our query with TC=1; packet 2 continues with an unrelated query
+            // plus a known-answer record for our PTR. The fast-reject path must evaluate the
+            // merged query set so packet 2 is not dropped before the known-answer is merged in.
+            const responses = new Array<{ message?: DnsMessage; netInterface?: string; uniCastTarget?: string }>();
+            onResponse = async (message: Bytes, netInterface?: string, uniCastTarget?: string) => {
+                responses.push({ message: DnsCodec.decode(message), netInterface, uniCastTarget });
+            };
+
+            send(
+                DnsCodec.encode({
+                    messageType: DnsMessageType.Query | DnsMessageTypeFlag.TC,
+                    queries: [
+                        {
+                            name: DUMMY_QNAME,
+                            recordClass: DnsRecordClass.IN,
+                            recordType: DnsRecordType.ANY,
+                        },
+                    ],
+                }),
+                DUMMY_IP,
+                INTERFACE_NAME,
+            );
+            await MockTime.yield3();
+            expect(responses.length).equals(0);
+
+            send(
+                DnsCodec.encode({
+                    messageType: DnsMessageType.Query,
+                    queries: [
+                        {
+                            name: "_googlecast._tcp.local",
+                            recordClass: DnsRecordClass.IN,
+                            recordType: DnsRecordType.PTR,
+                        },
+                    ],
+                    answers: [PtrRecord(DUMMY_QNAME, "abcd")],
+                }),
+                DUMMY_IP,
+                INTERFACE_NAME,
+            );
+            await MockTime.yield3();
+
+            expect(responses).deep.equal([
+                {
+                    message: {
+                        transactionId: 0,
+                        messageType: DnsMessageType.Response,
+                        answers: [
+                            SrvRecord(DUMMY_QNAME, { priority: 0, weight: 0, port: 1234, target: "abcd.local" }),
+                            TxtRecord(DUMMY_QNAME, [`A=1`, `B=2`]),
+                        ],
+                        additionalRecords: [ARecord("abcd.local", DUMMY_IP)],
+                        authorities: [],
+                        queries: [],
+                    },
+                    netInterface: INTERFACE_NAME,
+                    uniCastTarget: undefined,
+                },
+            ]);
+        });
+
+        it("suppresses known-answer records supplied with a different case (RFC 6762 §16)", async () => {
+            const responses = new Array<{ message?: DnsMessage; netInterface?: string; uniCastTarget?: string }>();
+            onResponse = async (message: Bytes, netInterface?: string, uniCastTarget?: string) => {
+                responses.push({ message: DnsCodec.decode(message), netInterface, uniCastTarget });
+            };
+
+            send(
+                DnsCodec.encode({
+                    messageType: DnsMessageType.Query,
+                    queries: [
+                        {
+                            name: DUMMY_QNAME,
+                            recordClass: DnsRecordClass.IN,
+                            recordType: DnsRecordType.ANY,
+                        },
+                    ],
+                    answers: [PtrRecord(DUMMY_QNAME.toUpperCase(), "abcd")],
+                }),
+                DUMMY_IP,
+                INTERFACE_NAME,
+            );
+
+            await MockTime.yield3();
+
+            // PTR must still be suppressed despite case-mismatch in the known-answer record.
+            expect(responses).deep.equal([
+                {
+                    message: {
+                        transactionId: 0,
+                        messageType: DnsMessageType.Response,
+                        answers: [
+                            SrvRecord(DUMMY_QNAME, { priority: 0, weight: 0, port: 1234, target: "abcd.local" }),
+                            TxtRecord(DUMMY_QNAME, [`A=1`, `B=2`]),
+                        ],
+                        additionalRecords: [ARecord("abcd.local", DUMMY_IP)],
+                        authorities: [],
+                        queries: [],
+                    },
+                    netInterface: INTERFACE_NAME,
+                    uniCastTarget: undefined,
+                },
+            ]);
         });
     });
 });

--- a/packages/protocol/test/mdns/MdnsServerTest.ts
+++ b/packages/protocol/test/mdns/MdnsServerTest.ts
@@ -1221,8 +1221,6 @@ describe("MdnsServer", () => {
         });
 
         it("lets zero-query continuation packets merge known-answers into a cached TC fragment", async () => {
-            // Guards the RFC 6762 §7.2 case where follow-up packets carry only additional
-            // known-answer records (no queries); the fast-reject path must not drop them.
             const responses = new Array<{ message?: DnsMessage; netInterface?: string; uniCastTarget?: string }>();
             onResponse = async (message: Bytes, netInterface?: string, uniCastTarget?: string) => {
                 responses.push({ message: DnsCodec.decode(message), netInterface, uniCastTarget });

--- a/packages/protocol/test/mdns/MdnsServerTest.ts
+++ b/packages/protocol/test/mdns/MdnsServerTest.ts
@@ -1108,4 +1108,206 @@ describe("MdnsServer", () => {
             expect(responses.length).equals(1); // Should respond after window expires
         });
     });
+
+    describe("Unknown-name query rejection", () => {
+        it("does not respond to queries for names we do not serve", async () => {
+            const responses = new Array<{ message?: DnsMessage; netInterface?: string; uniCastTarget?: string }>();
+            onResponse = async (message: Bytes, netInterface?: string, uniCastTarget?: string) => {
+                responses.push({ message: DnsCodec.decode(message), netInterface, uniCastTarget });
+            };
+
+            send(
+                DnsCodec.encode({
+                    messageType: DnsMessageType.Query,
+                    queries: [
+                        {
+                            name: "_googlecast._tcp.local",
+                            recordClass: DnsRecordClass.IN,
+                            recordType: DnsRecordType.PTR,
+                        },
+                        {
+                            name: "_airplay._tcp.local",
+                            recordClass: DnsRecordClass.IN,
+                            recordType: DnsRecordType.ANY,
+                        },
+                    ],
+                }),
+                DUMMY_IP,
+                INTERFACE_NAME,
+            );
+
+            await MockTime.yield3();
+            expect(responses.length).equals(0);
+        });
+
+        it("responds to A-record host name even though it differs from the service qname", async () => {
+            const responses = new Array<{ message?: DnsMessage; netInterface?: string; uniCastTarget?: string }>();
+            onResponse = async (message: Bytes, netInterface?: string, uniCastTarget?: string) => {
+                responses.push({ message: DnsCodec.decode(message), netInterface, uniCastTarget });
+            };
+
+            send(
+                DnsCodec.encode({
+                    messageType: DnsMessageType.Query,
+                    queries: [
+                        {
+                            name: "abcd.local",
+                            recordClass: DnsRecordClass.IN,
+                            recordType: DnsRecordType.A,
+                        },
+                    ],
+                }),
+                DUMMY_IP,
+                INTERFACE_NAME,
+            );
+
+            await MockTime.yield3();
+            expect(responses.length).equals(1);
+        });
+
+        it("still responds when a known-name query is mixed with unknown-name queries", async () => {
+            const responses = new Array<{ message?: DnsMessage; netInterface?: string; uniCastTarget?: string }>();
+            onResponse = async (message: Bytes, netInterface?: string, uniCastTarget?: string) => {
+                responses.push({ message: DnsCodec.decode(message), netInterface, uniCastTarget });
+            };
+
+            send(
+                DnsCodec.encode({
+                    messageType: DnsMessageType.Query,
+                    queries: [
+                        {
+                            name: "_googlecast._tcp.local",
+                            recordClass: DnsRecordClass.IN,
+                            recordType: DnsRecordType.PTR,
+                        },
+                        {
+                            name: DUMMY_QNAME,
+                            recordClass: DnsRecordClass.IN,
+                            recordType: DnsRecordType.ANY,
+                        },
+                    ],
+                }),
+                DUMMY_IP,
+                INTERFACE_NAME,
+            );
+
+            await MockTime.yield3();
+            expect(responses.length).equals(1);
+        });
+
+        it("rejects queries using wrong-case when name is lowercase in records", async () => {
+            // Pins current behavior: RFC 6762 §16 mandates case-insensitive name matching, but
+            // the per-record filter still uses strict ===, so uppercase queries produce no
+            // response. Both paths agree today; a future case-insensitivity fix should update
+            // this assertion.
+            const responses = new Array<{ message?: DnsMessage; netInterface?: string; uniCastTarget?: string }>();
+            onResponse = async (message: Bytes, netInterface?: string, uniCastTarget?: string) => {
+                responses.push({ message: DnsCodec.decode(message), netInterface, uniCastTarget });
+            };
+
+            send(
+                DnsCodec.encode({
+                    messageType: DnsMessageType.Query,
+                    queries: [
+                        {
+                            name: DUMMY_QNAME.toUpperCase(),
+                            recordClass: DnsRecordClass.IN,
+                            recordType: DnsRecordType.ANY,
+                        },
+                    ],
+                }),
+                DUMMY_IP,
+                INTERFACE_NAME,
+            );
+
+            await MockTime.yield3();
+            expect(responses.length).equals(0);
+        });
+
+        it("lets zero-query continuation packets merge known-answers into a cached TC fragment", async () => {
+            // Guards the RFC 6762 §7.2 case where follow-up packets carry only additional
+            // known-answer records (no queries); the fast-reject path must not drop them.
+            const responses = new Array<{ message?: DnsMessage; netInterface?: string; uniCastTarget?: string }>();
+            onResponse = async (message: Bytes, netInterface?: string, uniCastTarget?: string) => {
+                responses.push({ message: DnsCodec.decode(message), netInterface, uniCastTarget });
+            };
+
+            send(
+                DnsCodec.encode({
+                    messageType: DnsMessageType.Query | DnsMessageTypeFlag.TC,
+                    queries: [
+                        {
+                            name: DUMMY_QNAME,
+                            recordClass: DnsRecordClass.IN,
+                            recordType: DnsRecordType.ANY,
+                        },
+                    ],
+                }),
+                DUMMY_IP,
+                INTERFACE_NAME,
+            );
+            await MockTime.yield3();
+            expect(responses.length).equals(0);
+
+            send(
+                DnsCodec.encode({
+                    messageType: DnsMessageType.Query,
+                    queries: [],
+                    answers: [PtrRecord(DUMMY_QNAME, "abcd")],
+                }),
+                DUMMY_IP,
+                INTERFACE_NAME,
+            );
+            await MockTime.yield3();
+
+            expect(responses).deep.equal([
+                {
+                    message: {
+                        transactionId: 0,
+                        messageType: DnsMessageType.Response,
+                        answers: [
+                            SrvRecord(DUMMY_QNAME, { priority: 0, weight: 0, port: 1234, target: "abcd.local" }),
+                            TxtRecord(DUMMY_QNAME, [`A=1`, `B=2`]),
+                        ],
+                        additionalRecords: [ARecord("abcd.local", DUMMY_IP)],
+                        authorities: [],
+                        queries: [],
+                    },
+                    netInterface: INTERFACE_NAME,
+                    uniCastTarget: undefined,
+                },
+            ]);
+        });
+
+        it("picks up new names after the records generator is replaced", async () => {
+            const responses = new Array<{ message?: DnsMessage; netInterface?: string; uniCastTarget?: string }>();
+            onResponse = async (message: Bytes, netInterface?: string, uniCastTarget?: string) => {
+                responses.push({ message: DnsCodec.decode(message), netInterface, uniCastTarget });
+            };
+
+            const newQname = "other.service.local";
+            await mdnsServer.setRecordsGenerator("bar", () => [
+                PtrRecord(newQname, "efgh"),
+                SrvRecord(newQname, { priority: 0, weight: 0, port: 5678, target: "efgh.local" }),
+            ]);
+
+            send(
+                DnsCodec.encode({
+                    messageType: DnsMessageType.Query,
+                    queries: [
+                        {
+                            name: newQname,
+                            recordClass: DnsRecordClass.IN,
+                            recordType: DnsRecordType.ANY,
+                        },
+                    ],
+                }),
+                DUMMY_IP,
+                INTERFACE_NAME,
+            );
+
+            await MockTime.yield3();
+            expect(responses.length).equals(1);
+        });
+    });
 });

--- a/packages/protocol/test/mdns/MdnsServerTest.ts
+++ b/packages/protocol/test/mdns/MdnsServerTest.ts
@@ -1195,11 +1195,7 @@ describe("MdnsServer", () => {
             expect(responses.length).equals(1);
         });
 
-        it("rejects queries using wrong-case when name is lowercase in records", async () => {
-            // Pins current behavior: RFC 6762 §16 mandates case-insensitive name matching, but
-            // the per-record filter still uses strict ===, so uppercase queries produce no
-            // response. Both paths agree today; a future case-insensitivity fix should update
-            // this assertion.
+        it("matches uppercase query names against lowercase records (RFC 6762 §16)", async () => {
             const responses = new Array<{ message?: DnsMessage; netInterface?: string; uniCastTarget?: string }>();
             onResponse = async (message: Bytes, netInterface?: string, uniCastTarget?: string) => {
                 responses.push({ message: DnsCodec.decode(message), netInterface, uniCastTarget });
@@ -1221,7 +1217,7 @@ describe("MdnsServer", () => {
             );
 
             await MockTime.yield3();
-            expect(responses.length).equals(0);
+            expect(responses.length).equals(1);
         });
 
         it("lets zero-query continuation packets merge known-answers into a cached TC fragment", async () => {


### PR DESCRIPTION
## Summary

Fixes #3637. Addresses the MdnsServer CPU hotspot reported for busy LANs where every Chromecast / AppleTV / printer mDNS query was entering the full truncation-handling + per-service record-scan path even though the downstream guards correctly suppressed any response.

The first check already proved the PR's stated premise wrong — we do NOT send responses to unrelated queries. But the CPU work per packet is real, and cleaning it up exposed a few related issues worth addressing in the same branch.

- **Fast-reject** by lowercased record-name set stored alongside the AsyncCache'd records (no separate invalidation bookkeeping — piggybacks on the existing cache lifecycle). Zero-query packets still fall through so RFC 6762 §7.2 TC continuations can merge their known-answer records into cached fragments.
- **Case-insensitive name matching** per RFC 6762 §16 / RFC 1035 §2.3.3 in `#queryRecords`, extended to `buildDnsRecordKey` and `#shouldSuppressResponse` so duplicate-suppression and multicast TTL tracking agree with the invariant.
- **Removed trailing inter-packet sleep** after the final send in `#handleMessage`, `broadcast`, and `expireAnnouncements`. The 20-120ms pacing between successive packets is kept; the trailing sleep after the last one was pure latency waste.
- **Install generator synchronously before awaiting cache clear** in `setRecordsGenerator` so cache refills triggered during the clear use the new generator rather than re-caching stale records with the old one.
- 6 new tests covering unknown-name rejection, A-record for host qname (differs from SRV qname), mixed known/unknown queries, case-insensitive match, TC continuation known-answer merging, and generator replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)