### PR TITLE
fix(protocol): bound Peer.connect timeout independently of abort

### DIFF
--- a/packages/protocol/src/peer/Peer.ts
+++ b/packages/protocol/src/peer/Peer.ts
@@ -273,7 +273,7 @@ export class Peer {
             // in-flight handshake.  Callers wanting unbounded wait pass Forever explicitly.
             let timeout: Duration | undefined =
                 options?.connectionTimeout ?? this.#context.timing.defaultConnectionTimeout;
-            if (timeout === undefined || timeout === Infinity) {
+            if (timeout === Infinity) {
                 timeout = undefined;
             } else if (timeout <= 0) {
                 timeout = Instant;

--- a/packages/protocol/src/peer/Peer.ts
+++ b/packages/protocol/src/peer/Peer.ts
@@ -269,15 +269,17 @@ export class Peer {
 
             this.#initiateConnection(options);
 
+            // abort and connectionTimeout are orthogonal: abort cancels, timeout bounds the wait on a shared
+            // in-flight handshake.  Callers wanting unbounded wait pass Forever explicitly.
             let timeout: Duration | undefined =
-                options?.connectionTimeout ??
-                (options?.abort ? undefined : this.#context.timing.defaultConnectionTimeout);
+                options?.connectionTimeout ?? this.#context.timing.defaultConnectionTimeout;
             if (timeout === undefined || timeout === Infinity) {
                 timeout = undefined;
             } else if (timeout <= 0) {
                 timeout = Instant;
             } else if (!options?.kick) {
-                timeout = Millis(timeout - this.timeOffline);
+                const remaining = timeout - this.timeOffline;
+                timeout = remaining <= 0 ? Instant : Millis(remaining);
             }
 
             using localAbort = new Abort({
@@ -478,6 +480,10 @@ export namespace Peer {
          * A timeout relative to beginning of connection process.
          *
          * If the peer is already connecting, connection time is reduced by this amount.
+         *
+         * If omitted, defaults to {@link PeerTimingParameters.defaultConnectionTimeout}.  Pass `Forever` to wait
+         * without bound (only appropriate for background sustain loops — invokes, reads, writes and non-sustained
+         * subscribes should always allow the default to apply so a hung handshake cannot deadlock a request).
          */
         connectionTimeout?: Duration;
 

--- a/packages/protocol/test/peer/PeerConnectTimeoutTest.ts
+++ b/packages/protocol/test/peer/PeerConnectTimeoutTest.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Peer } from "#peer/Peer.js";
+import { PeerTimingParameters } from "#peer/PeerTimingParameters.js";
+import { Duration, Forever, Instant, Millis } from "@matter/general";
+
+/**
+ * Regression tests for the timeout semantics in {@link Peer.connect}.
+ *
+ * The method is integration-heavy, so these tests validate the isolated timeout-resolution expression it uses.  The
+ * expression must always yield a bounded timeout unless the caller explicitly opts out with {@link Forever}; a previous
+ * shape of `options?.connectionTimeout ?? (options?.abort ? undefined : timing.defaultConnectionTimeout)` silently
+ * disabled the timeout whenever the caller passed an abort signal, which caused non-sustained invokes/reads to wait
+ * forever on the shared `#connecting` promise (see PR #3644).
+ */
+function resolveTimeout(options: Peer.ConnectOptions | undefined, timing: PeerTimingParameters) {
+    let timeout: Duration | undefined = options?.connectionTimeout ?? timing.defaultConnectionTimeout;
+    if (timeout === Infinity) {
+        timeout = undefined;
+    } else if (timeout <= 0) {
+        timeout = Instant;
+    }
+    return timeout;
+}
+
+describe("Peer.connect timeout semantics", () => {
+    it("defaults.defaultConnectionTimeout is defined and positive", () => {
+        const { defaultConnectionTimeout } = PeerTimingParameters.defaults;
+        expect(defaultConnectionTimeout).not.equals(undefined);
+        expect(defaultConnectionTimeout as number).greaterThan(0);
+    });
+
+    it("falls back to defaultConnectionTimeout when abort is provided without connectionTimeout", () => {
+        const timing = PeerTimingParameters();
+        const abort = new AbortController().signal;
+
+        expect(resolveTimeout({ abort }, timing)).equals(timing.defaultConnectionTimeout);
+    });
+
+    it("uses caller's connectionTimeout when one is supplied alongside abort", () => {
+        const timing = PeerTimingParameters();
+        const abort = new AbortController().signal;
+
+        expect(resolveTimeout({ abort, connectionTimeout: Millis(5_000) }, timing)).equals(Millis(5_000));
+    });
+
+    it("remains unbounded when caller explicitly passes Forever", () => {
+        const timing = PeerTimingParameters();
+        const abort = new AbortController().signal;
+
+        expect(resolveTimeout({ abort, connectionTimeout: Forever }, timing)).equals(undefined);
+    });
+
+    it("normalizes non-positive timeouts to Instant", () => {
+        const timing = PeerTimingParameters();
+
+        expect(resolveTimeout({ connectionTimeout: Millis(0) }, timing)).equals(Instant);
+        expect(resolveTimeout({ connectionTimeout: Millis(-1) }, timing)).equals(Instant);
+    });
+});


### PR DESCRIPTION
## Summary
- Decouple `connectionTimeout` from `abort` in `Peer.connect`. Previously a caller-supplied abort signal silently suppressed `defaultConnectionTimeout`, causing non-sustained invokes/reads/writes/subscribes (which always set abort but no explicit timeout) to wait forever on the shared `#connecting` promise whenever a `SustainedSubscription` reconnect owned it with `Forever`.
- Observed as a multi-minute hang on `removeFabric` after a peer shutdown event (controller UI clicked "remove" → `Sigma1` retried for 2+ minutes, the legacy `CommissioningController.removeNode` catch/fallback never fired because the underlying call never threw).
- `connectionTimeout` now always falls back to `defaultConnectionTimeout` (90s). Callers that genuinely want unbounded wait — only `SustainedSubscription` in the current tree — pass `Forever` explicitly (already the case).
- Small cleanup: when the subtracted remaining timeout is non-positive, normalize to `Instant` instead of passing a negative `Duration` down to `Abort`. Behavior was already correct; this just makes intent explicit.


🤖 Generated with [Claude Code](https://claude.com/claude-code)