### PR TITLE
fix(node): tear down sessions on decommission and Leave event

### DIFF
--- a/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
+++ b/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
@@ -58,6 +58,7 @@ import {
     LocatedNodeCommissioningOptions,
     Peer,
     PeerAddress,
+    PeerLeftError,
     PeerSet,
     PeerTimingParameters,
     PeerAddress as ProtocolPeerAddress,
@@ -297,6 +298,11 @@ export class CommissioningClient extends Behavior {
                 `Removing node ${formerAddress} failed with status ${result.statusCode} "${result.debugText}".`,
             );
         }
+
+        // Peer left our fabric; local sessions are dead.  Force-close here, before the commit unbinds Peer via the
+        // peerAddress$Changed reactor, otherwise the graceful close path defers on MRP retransmissions that never ack.
+        const node = this.endpoint as ClientNode;
+        await node.env.maybeGet(Peer)?.disconnect(new PeerLeftError());
 
         this.state.peerAddress = undefined;
         this.state.commissionedAt = undefined;

--- a/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
+++ b/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
@@ -299,10 +299,13 @@ export class CommissioningClient extends Behavior {
             );
         }
 
-        // Peer left our fabric; local sessions are dead.  Force-close here, before the commit unbinds Peer via the
-        // peerAddress$Changed reactor, otherwise the graceful close path defers on MRP retransmissions that never ack.
+        // Must run before commit unbinds Peer via peerAddress$Changed.
         const node = this.endpoint as ClientNode;
-        await node.env.maybeGet(Peer)?.disconnect(new PeerLeftError());
+        try {
+            await node.env.maybeGet(Peer)?.disconnect(new PeerLeftError());
+        } catch (error) {
+            logger.warn(`Error force-closing sessions for ${formerAddress} after decommission:`, error);
+        }
 
         this.state.peerAddress = undefined;
         this.state.commissionedAt = undefined;

--- a/packages/node/src/node/client/Peers.ts
+++ b/packages/node/src/node/client/Peers.ts
@@ -41,7 +41,9 @@ import {
     ClientSubscriptionHandler,
     ClientSubscriptions,
     FabricManager,
+    Peer,
     PeerAddress,
+    PeerLeftError,
     SessionManager,
 } from "@matter/protocol";
 import { FabricIndex } from "@matter/types";
@@ -468,6 +470,7 @@ export class Peers extends EndpointContainer<ClientNode> {
 
             logger.notice("Peer", Diagnostic.strong(node.id), "has left the fabric");
             node.lifecycle.decommissioned.emit(LocalActorContext.ReadOnly);
+            await node.env.maybeGet(Peer)?.disconnect(new PeerLeftError());
             await node.delete();
         });
     }

--- a/packages/node/src/node/client/Peers.ts
+++ b/packages/node/src/node/client/Peers.ts
@@ -470,7 +470,11 @@ export class Peers extends EndpointContainer<ClientNode> {
 
             logger.notice("Peer", Diagnostic.strong(node.id), "has left the fabric");
             node.lifecycle.decommissioned.emit(LocalActorContext.ReadOnly);
-            await node.env.maybeGet(Peer)?.disconnect(new PeerLeftError());
+            try {
+                await node.env.maybeGet(Peer)?.disconnect(new PeerLeftError());
+            } catch (error) {
+                logger.warn(`Error force-closing sessions for ${node.id} on Leave:`, error);
+            }
             await node.delete();
         });
     }

--- a/packages/node/src/storage/client/ClientEndpointStore.ts
+++ b/packages/node/src/storage/client/ClientEndpointStore.ts
@@ -15,6 +15,7 @@ import { DatasourceCache } from "./DatasourceCache.js";
 export class ClientEndpointStore extends EndpointStore {
     #owner: ClientNodeStore;
     #number: EndpointNumber;
+    #caches = new Set<DatasourceCache>();
 
     constructor(owner: ClientNodeStore, number: EndpointNumber, storage: StorageContext) {
         super(storage);
@@ -46,7 +47,7 @@ export class ClientEndpointStore extends EndpointStore {
      */
     createStoreForBehavior(behaviorId: string) {
         const initialValues = this.consumeInitialValues(behaviorId);
-        return new DatasourceCache({
+        const cache = new DatasourceCache({
             writer: this.#owner.write,
             endpointNumber: this.#number,
             behaviorId,
@@ -54,6 +55,17 @@ export class ClientEndpointStore extends EndpointStore {
             localWriter: this.#owner.localWriter,
             buffer: this.#owner.buffer,
         });
+        this.#caches.add(cache);
+        return cache;
+    }
+
+    override async erase() {
+        // Caches unregister themselves from the shared ClientCacheBuffer via their own erase().
+        for (const cache of this.#caches) {
+            await cache.erase();
+        }
+        this.#caches.clear();
+        await super.erase();
     }
 
     /**

--- a/packages/node/src/storage/client/ClientEndpointStore.ts
+++ b/packages/node/src/storage/client/ClientEndpointStore.ts
@@ -60,9 +60,8 @@ export class ClientEndpointStore extends EndpointStore {
     }
 
     override async erase() {
-        // Caches unregister themselves from the shared ClientCacheBuffer via their own erase().
         for (const cache of this.#caches) {
-            await cache.erase();
+            cache.discard();
         }
         this.#caches.clear();
         await super.erase();

--- a/packages/node/src/storage/client/ClientNodeStore.ts
+++ b/packages/node/src/storage/client/ClientNodeStore.ts
@@ -86,6 +86,10 @@ export class ClientNodeStore extends NodeStore {
     }
 
     override async erase() {
+        // Cascade so caches unregister from the shared ClientCacheBuffer before storage is cleared.
+        for (const store of this.#stores.values()) {
+            await store.erase();
+        }
         this.#stores = new Map();
         this.#onErase?.();
         await this.#storage?.clearAll();

--- a/packages/node/src/storage/client/DatasourceCache.ts
+++ b/packages/node/src/storage/client/DatasourceCache.ts
@@ -152,7 +152,7 @@ export class DatasourceCache implements Datasource.ExternallyMutableStore {
      * the enclosing transaction fails to commit.
      */
     async flush(tx?: StorageDriver.Transaction): Promise<Set<string> | undefined> {
-        if (!this.#dirtyKeys.size) {
+        if (this.#erased || !this.#dirtyKeys.size) {
             return;
         }
 

--- a/packages/node/src/storage/client/DatasourceCache.ts
+++ b/packages/node/src/storage/client/DatasourceCache.ts
@@ -123,12 +123,19 @@ export class DatasourceCache implements Datasource.ExternallyMutableStore {
     }
 
     /**
-     * Erase values just for this datasource.  After this call, {@link externalSet} is permanently disabled.
+     * Disable this cache in memory without touching persisted storage.
      */
-    async erase() {
+    discard() {
         this.#erased = true;
         this.#dirtyKeys.clear();
         this.#buffer?.removeDirty(this);
+    }
+
+    /**
+     * Erase values just for this datasource.  After this call, {@link externalSet} is permanently disabled.
+     */
+    async erase() {
+        this.discard();
         await this.#localWriter?.erase(this.#endpointNumber, this.#behaviorId);
     }
 

--- a/packages/protocol/src/peer/Peer.ts
+++ b/packages/protocol/src/peer/Peer.ts
@@ -309,8 +309,12 @@ export class Peer {
 
     /**
      * Abort any outstanding connection attempts.
+     *
+     * When {@link cause} is provided, also force-close any active sessions with the peer — use this when the peer
+     * is known to be unreachable (e.g. we just removed our fabric on the peer).  Without a cause the existing
+     * sessions are left alone so they can follow their normal graceful-close path.
      */
-    async disconnect() {
+    async disconnect(cause?: Error) {
         if (this.#connecting) {
             using _disconnecting = this.#lifetime.join("disconnecting");
             this.#connecting.abort();
@@ -321,8 +325,11 @@ export class Peer {
             }
         }
 
-        // TODO - need to shutdown exchanges and sessions here too so you can cleanly take down a single peer, but
-        // currently that's handled by "managers" for those entities
+        if (cause !== undefined) {
+            for (const session of this.#context.sessions.sessionsFor(this.address)) {
+                await session.initiateForceClose({ cause });
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- `Peer.disconnect(cause?)` (protocol layer) now fills its existing TODO: when a cause is supplied it force-closes active sessions with that cause. Without a cause the existing behavior (abort in-flight connection attempt only) is preserved.
- `CommissioningClient.decommission` calls `peer.disconnect(new PeerLeftError())` **before** clearing state and committing — the \`peerAddress\$Changed\` reactor synchronously unbinds Peer at commit time, so the force-close must run first.
- `Peers.#onLeave` calls the same `peer.disconnect(new PeerLeftError())` before `node.delete()` — covers the other direction where another admin removes our fabric and we hear about it via the Leave event.
- `ClientNodeStore.erase` now cascades to each `ClientEndpointStore.erase`, which in turn erases its tracked `DatasourceCache`s so they unregister from the shared `ClientCacheBuffer` before the node's storage is cleared. `DatasourceCache.flush` early-returns when already erased to close the flush/erase race.

## Why
- Without the session teardown: after a successful \`removeFabric\`, an in-flight outgoing exchange on the CASE session (commonly a \`StatusResponse\` acking the subscription \`ReportData\` that delivered the peer's Leave event) kept MRP-retransmitting for 25.8 s because the peer had invalidated the session the moment it dropped the fabric. \`Peer.close\`'s graceful close path defers when exchanges are active, so the session didn't wind down until the peer-unresponsive timeout fired — blocking shutdown.
- Without the cache cascade: \`Leave\` event dirtied a \`DatasourceCache\` for the node being removed; shutdown's final flush then warned \`Cache flush failed, will retry: [internal] No endpoint store for endpoint 0\` because the endpoint store was already gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)