### PR TITLE
fix(tlv): always strip fabricIndex on write interactions

### DIFF
--- a/packages/nodejs-shell/src/shell/cmd_tlv.ts
+++ b/packages/nodejs-shell/src/shell/cmd_tlv.ts
@@ -160,6 +160,10 @@ export default function commands() {
                     },
                     async argv => {
                         const { value } = argv;
+                        if (!value) {
+                            console.error("Please provide a Hex value to decode");
+                            return;
+                        }
                         const bytes = Bytes.fromHex(value);
                         const tlvEncoded = TlvAny.decode(bytes);
                         logAnyTlvStream(tlvEncoded);

--- a/packages/types/src/tlv/TlvObject.ts
+++ b/packages/types/src/tlv/TlvObject.ts
@@ -117,13 +117,14 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
                 "Encode options cannot indicate a write interaction and a fabric filtered read interaction at the same time.",
             );
         }
+        if (forWriteInteraction && id === <number>FabricIndex.id) {
+            // MatterSpecification §7.13.6: fabricIndex SHALL NOT be present in write interactions, regardless of
+            // whether the caller provided a value. Server derives it from the accessing fabric.
+            return;
+        }
         const fieldValue = (value as any)[name];
         if (fieldValue === undefined) {
             if (!isOptional && !allowMissingFieldsForNonFabricFilteredRead) {
-                if (forWriteInteraction && id === <number>FabricIndex.id) {
-                    // FabricIndex field should not be included in encoded data for write interactions
-                    return;
-                }
                 throw new ValidationMandatoryFieldMissingError(`Missing mandatory field ${name}`, name);
             }
             return;

--- a/packages/types/test/tlv/TlvObjectTest.ts
+++ b/packages/types/test/tlv/TlvObjectTest.ts
@@ -154,6 +154,11 @@ describe("TlvObject tests", () => {
                     optionalField: "test",
                     fabricIndex: FabricIndex(1),
                 });
+
+                // Without the forWriteInteraction flag the encoded payload must keep the fabricIndex field
+                // and therefore differ from the variant that omits it.
+                const noFabricEncoded = schema.encodeTlv({ mandatoryField: 1, optionalField: "test" });
+                expect(tlvEncoded).not.deep.equal(noFabricEncoded);
             });
 
             it(`encode/decodes with ignoring fabricIndex for write interaction`, () => {
@@ -176,6 +181,22 @@ describe("TlvObject tests", () => {
                     mandatoryField: 1,
                     optionalField: "test",
                 });
+            });
+
+            it(`strips fabricIndex for write interaction even when caller provided a value`, () => {
+                const noFabricEncoded = schema.encodeTlv({ mandatoryField: 1, optionalField: "test" });
+
+                const tlvEncoded = schemaWithFabricIndex.encodeTlv(
+                    {
+                        mandatoryField: 1,
+                        optionalField: "test",
+                        fabricIndex: FabricIndex(1),
+                    },
+                    { forWriteInteraction: true },
+                );
+
+                // The Tlv encoded data must not contain FabricIndex even though caller included it
+                expect(tlvEncoded).deep.equal(noFabricEncoded);
             });
         });
 


### PR DESCRIPTION
## Summary
- Per Matter spec §7.13.6 the fabricIndex field (id 254) SHALL NOT appear in write interactions — the server derives it from the accessing fabric. The existing strip in `ObjectSchema` only fired when the field was undefined in the caller's value, relying on callers (`AttributeClient.set`) to normalize it away first. Paths that bypass that normalization — the chip-tool WebSocket controller handler and the new `ClientNodeInteraction` write path — ended up encoding a caller-supplied `fabricIndex` into the TLV payload.
- Move the strip to an unconditional outer check: whenever `forWriteInteraction` is set and the field id matches `FabricIndex`, skip encoding regardless of whether the caller provided a value.
- Adds a regression test for the defined-value case plus an explicit byte-level check that the field IS preserved when the flag is absent.
- Drive-by: print a helpful error in the `tlv log` shell command when invoked without a hex value instead of letting `Bytes.fromHex(undefined)` throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)