### PR TITLE
fix(node): stabilize OTA flaky tests by awaiting sustained subscription

### DIFF
--- a/packages/node/src/behavior/system/software-update/SoftwareUpdateManager.ts
+++ b/packages/node/src/behavior/system/software-update/SoftwareUpdateManager.ts
@@ -42,6 +42,7 @@ import {
     OtaUpdateError,
     OtaUpdateSource,
     PeerAddress,
+    PeerAddressMap,
     SessionManager,
 } from "@matter/protocol";
 import { VendorId } from "@matter/types";
@@ -494,7 +495,7 @@ export class SoftwareUpdateManager extends Behavior {
             try {
                 const peers = await this.#checkProductForUpdates(infos, includeStoredUpdates);
                 for (const peer of peers) {
-                    const info = this.internal.knownUpdates.get(peer.toString());
+                    const info = this.internal.knownUpdates.get(peer);
                     if (info === undefined) {
                         continue; // Race condition should normally not happen
                     }
@@ -522,9 +523,7 @@ export class SoftwareUpdateManager extends Behavior {
         // No need to query again if we already did and know that updates are available
         if (
             includeStoredUpdates &&
-            [...otaEndpoints.values()].every(({ peerAddress }) =>
-                this.internal.knownUpdates.has(peerAddress.toString()),
-            )
+            [...otaEndpoints.values()].every(({ peerAddress }) => this.internal.knownUpdates.has(peerAddress))
         ) {
             return [...otaEndpoints.values()].map(({ peerAddress }) => peerAddress);
         }
@@ -565,7 +564,7 @@ export class SoftwareUpdateManager extends Behavior {
                 specificationVersion,
                 source,
             };
-            this.internal.knownUpdates.set(peerAddress.toString(), details);
+            this.internal.knownUpdates.set(peerAddress, details);
 
             const hasConsent = this.internal.consents.some(
                 consent =>
@@ -661,9 +660,9 @@ export class SoftwareUpdateManager extends Behavior {
         );
 
         if (isStartUp) {
-            const suppressedSessionId = this.internal.pendingStartUpSuppress.get(peerAddress.toString());
+            const suppressedSessionId = this.internal.pendingStartUpSuppress.get(peerAddress);
             if (suppressedSessionId !== undefined) {
-                this.internal.pendingStartUpSuppress.delete(peerAddress.toString());
+                this.internal.pendingStartUpSuppress.delete(peerAddress);
                 // Use session from event context when available (avoids extra lookup); fall back to
                 // SessionManager for local/test contexts where there is no remote actor.
                 const sessionId = currentSession?.id ?? this.env.get(SessionManager).maybeSessionFor(peerAddress)?.id;
@@ -699,7 +698,7 @@ export class SoftwareUpdateManager extends Behavior {
                     `Device ${peerAddress.toString()} rebooted after applying update but reports softwareVersion ${newVersion} (expected >= ${expectedVersion}), update failed to apply`,
                 );
                 this.internal.updateQueue.splice(entryIndex, 1);
-                this.internal.pendingStartUpSuppress.delete(peerAddress.toString());
+                this.internal.pendingStartUpSuppress.delete(peerAddress);
                 this.events.updateFailed.emit(peerAddress);
                 this.#triggerQueuedUpdate();
                 return;
@@ -712,8 +711,8 @@ export class SoftwareUpdateManager extends Behavior {
         logger.info(
             `Software version changed to ${newVersion} (expected ${expectedVersion}) for node ${peerAddress.toString()}, removing from update queue`,
         );
-        this.internal.knownUpdates.delete(peerAddress.toString());
-        this.internal.pendingStartUpSuppress.delete(peerAddress.toString());
+        this.internal.knownUpdates.delete(peerAddress);
+        this.internal.pendingStartUpSuppress.delete(peerAddress);
         this.events.updateDone.emit(peerAddress);
         this.internal.updateQueue.splice(entryIndex, 1);
 
@@ -871,6 +870,7 @@ export class SoftwareUpdateManager extends Behavior {
      * manner, please use `addUpdateConsent()`.
      */
     async forceUpdate(peerAddress: PeerAddress, vendorId: VendorId, productId: number, targetSoftwareVersion: number) {
+        peerAddress = PeerAddress(peerAddress);
         const existingEntry = this.internal.updateQueue.find(
             e =>
                 e.peerAddress.fabricIndex === peerAddress.fabricIndex &&
@@ -893,7 +893,7 @@ export class SoftwareUpdateManager extends Behavior {
             const staleIndex = this.internal.updateQueue.indexOf(existingEntry);
             if (staleIndex >= 0) {
                 this.internal.updateQueue.splice(staleIndex, 1);
-                this.internal.pendingStartUpSuppress.delete(peerAddress.toString());
+                this.internal.pendingStartUpSuppress.delete(peerAddress);
             }
             try {
                 await bdxProtocol.disablePeerForScope(peerAddress, this.storage, true);
@@ -928,6 +928,7 @@ export class SoftwareUpdateManager extends Behavior {
 
     /** Tries to cancel an ongoing OTA update for the given peer address. */
     async #cancelUpdate(peerAddress: PeerAddress) {
+        peerAddress = PeerAddress(peerAddress);
         const bdxProtocol = this.env.get(BdxProtocol);
 
         // Disable the Peer on BdxProtocol for the OTA scope if registered and also cancel an open BDX session, if any
@@ -953,7 +954,7 @@ export class SoftwareUpdateManager extends Behavior {
         this.internal.updateQueue.splice(entryIndex, 1);
         // Clean up any pending startUp suppression for this peer — it will never arrive if the peer
         // is permanently removed from tracking (decommissioned / disconnected).
-        this.internal.pendingStartUpSuppress.delete(peerAddress.toString());
+        this.internal.pendingStartUpSuppress.delete(peerAddress);
         logger.info(`Cancelled OTA update for node ${peerAddress.toString()}`);
         this.events.updateFailed.emit(peerAddress);
         this.#triggerQueuedUpdate();
@@ -972,6 +973,7 @@ export class SoftwareUpdateManager extends Behavior {
         productId: number,
         targetSoftwareVersion: number,
     ) {
+        peerAddress = PeerAddress(peerAddress);
         // Filter out all existing consents for this peer, they are replaced by the new one
         const consents = this.internal.consents.filter(
             consent =>
@@ -1045,7 +1047,7 @@ export class SoftwareUpdateManager extends Behavior {
      * so the startUp event that follows is not treated as a new failure-after-apply.
      */
     suppressNextStartUp(peerAddress: PeerAddress, sessionId: number) {
-        this.internal.pendingStartUpSuppress.set(peerAddress.toString(), sessionId);
+        this.internal.pendingStartUpSuppress.set(peerAddress, sessionId);
     }
 
     /**
@@ -1056,6 +1058,7 @@ export class SoftwareUpdateManager extends Behavior {
      * messages, and triggers the necessary events.
      */
     onOtaStatusChange(peerAddress: PeerAddress, status: OtaUpdateStatus, toVersion?: number) {
+        peerAddress = PeerAddress(peerAddress);
         const entryIndex = this.internal.updateQueue.findIndex(
             e => e.peerAddress.fabricIndex === peerAddress.fabricIndex && e.peerAddress.nodeId === peerAddress.nodeId,
         );
@@ -1072,8 +1075,8 @@ export class SoftwareUpdateManager extends Behavior {
         if (status === OtaUpdateStatus.Done) {
             logger.info(`OTA update completed for node`, peerAddress.toString());
             this.internal.updateQueue.splice(entryIndex, 1);
-            this.internal.knownUpdates.delete(peerAddress.toString());
-            this.internal.pendingStartUpSuppress.delete(peerAddress.toString());
+            this.internal.knownUpdates.delete(peerAddress);
+            this.internal.pendingStartUpSuppress.delete(peerAddress);
             this.events.updateDone.emit(peerAddress);
             this.#triggerQueuedUpdate();
         } else if (status === OtaUpdateStatus.Cancelled) {
@@ -1134,17 +1137,17 @@ export namespace SoftwareUpdateManager {
 
         versionUpdateObservers = new ObserverGroup();
 
-        knownUpdates = new Map<string, SoftwareUpdateInfo>();
+        knownUpdates = new PeerAddressMap<SoftwareUpdateInfo>();
 
         /**
-         * peer address string → session ID on which the reboot-triggering queryImage was received.
+         * Peer → session ID on which the reboot-triggering queryImage was received.
          *
          * Intentionally ephemeral (not persisted): the suppress window is sub-second — between the
          * queryImage response and the subsequent startUp event that follows on the same session.
          * Entries are consumed immediately when the matching startUp fires in #onSoftwareVersionChanged,
          * or cleaned up in #cancelUpdate when the peer is permanently removed from tracking.
          */
-        pendingStartUpSuppress = new Map<string, number>();
+        pendingStartUpSuppress = new PeerAddressMap<number>();
     }
 
     export class Events extends EventEmitter {

--- a/packages/node/test/behaviors/ota/OtaTest.ts
+++ b/packages/node/test/behaviors/ota/OtaTest.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { NetworkClient } from "#behavior/system/network/NetworkClient.js";
 import { OtaUpdateStatus, SoftwareUpdateManager } from "#behavior/system/software-update/SoftwareUpdateManager.js";
 import { BasicInformationServer } from "#behaviors/basic-information";
 import { OtaSoftwareUpdateProviderServer } from "#behaviors/ota-software-update-provider";
@@ -14,7 +15,14 @@ import {
 import { OtaProviderEndpoint } from "#endpoints/ota-provider";
 import { ServerNode } from "#node/ServerNode.js";
 import { Bytes, createPromise, Hours, MockFetch, Timestamp } from "@matter/general";
-import { BdxProtocol, BdxSession, FabricAuthority, PeerAddress, SessionManager } from "@matter/protocol";
+import {
+    BdxProtocol,
+    BdxSession,
+    FabricAuthority,
+    PeerAddress,
+    SessionManager,
+    SustainedSubscription,
+} from "@matter/protocol";
 import { FabricIndex, NodeId, VendorId } from "@matter/types";
 import { OtaSoftwareUpdateProvider } from "@matter/types/clusters/ota-software-update-provider";
 import { OtaSoftwareUpdateRequestor } from "@matter/types/clusters/ota-software-update-requestor";
@@ -489,11 +497,19 @@ describe("Ota", () => {
             entry.lastProgressUpdateTime = Timestamp(1000);
         });
 
+        // Await teardown and re-prime on the sustained subscription — the startUp handler only runs
+        // once the priming report delivers the buffered event.
+        const subscription = peer1.behaviors.internalsOf(NetworkClient).activeSubscription!;
+        expect(subscription).not.undefined;
+        SustainedSubscription.assert(subscription);
+
         // Simulate device rebooting with the ORIGINAL (old) version — apply failed
         // The startUp event will fire with the old softwareVersion via the registered observer
         await MockTime.resolve(device.stop());
+        await MockTime.resolve(subscription.inactive);
         // Keep the original softwareVersion (do NOT set it to targetSoftwareVersion)
         await MockTime.resolve(device.start());
+        await MockTime.resolve(subscription.active);
 
         await MockTime.macrotasks;
 
@@ -816,9 +832,7 @@ describe("Ota", () => {
 
         // suppressNextStartUp should have been registered: pendingStartUpSuppress must contain the peer
         const hasSuppressEntry = await otaProvider.act(agent => {
-            return agent
-                .get(SoftwareUpdateManager)
-                .internal.pendingStartUpSuppress.has(PeerAddress(peerAddress).toString());
+            return agent.get(SoftwareUpdateManager).internal.pendingStartUpSuppress.has(peerAddress);
         });
         expect(hasSuppressEntry).equals(true);
 
@@ -952,18 +966,28 @@ describe("Ota", () => {
             };
         });
 
+        // Flush any deferred startUp deliveries that addUpdateConsent's announceOtaProvider flow may
+        // have queued — they would otherwise consume the suppression entry before the real restart.
+        await MockTime.macrotasks;
+
         // Register the suppression with the fake ID — BEFORE device restarts.
         // The startUp fires during device.start(), and at that point the patched maybeSessionFor
         // returns id=42, which matches the suppressed id=42 → suppress!
-        // NOTE: peerAddress must be interned (via PeerAddress()) so .toString() returns "@1:1"
-        // rather than "[object Object]". The handler uses the interned form for its key lookup.
         await otaProvider.act(agent => {
-            agent.get(SoftwareUpdateManager).suppressNextStartUp(PeerAddress(peerAddress), FAKE_SESSION_ID);
+            agent.get(SoftwareUpdateManager).suppressNextStartUp(peerAddress, FAKE_SESSION_ID);
         });
+
+        // Await teardown and re-prime on the sustained subscription — the startUp handler only runs
+        // once the priming report delivers the buffered event.
+        const subscription = peer1.behaviors.internalsOf(NetworkClient).activeSubscription!;
+        expect(subscription).not.undefined;
+        SustainedSubscription.assert(subscription);
 
         // Restart the device with the same (old) version — this fires startUp
         await MockTime.resolve(device.stop());
+        await MockTime.resolve(subscription.inactive);
         await MockTime.resolve(device.start());
+        await MockTime.resolve(subscription.active);
         await MockTime.macrotasks;
 
         // startUp should have been suppressed — no updateFailed event
@@ -971,9 +995,7 @@ describe("Ota", () => {
 
         // The suppression entry should be consumed (deleted by the startUp handler)
         const hasSuppressedAfter = await otaProvider.act(agent => {
-            return agent
-                .get(SoftwareUpdateManager)
-                .internal.pendingStartUpSuppress.has(PeerAddress(peerAddress).toString());
+            return agent.get(SoftwareUpdateManager).internal.pendingStartUpSuppress.has(peerAddress);
         });
         expect(hasSuppressedAfter).equals(false);
     }).timeout(10_000);
@@ -1032,16 +1054,28 @@ describe("Ota", () => {
             };
         });
 
+        // Flush any deferred startUp deliveries that addUpdateConsent's announceOtaProvider flow may
+        // have queued — they would otherwise consume the suppression entry and emit a spurious
+        // updateFailed before the real restart.
+        await MockTime.macrotasks;
+
         // Suppress with a WRONG ID — 999 ≠ 77
-        // NOTE: peerAddress must be interned (via PeerAddress()) so .toString() returns "@1:1"
         const WRONG_SESSION_ID = 999;
         await otaProvider.act(agent => {
-            agent.get(SoftwareUpdateManager).suppressNextStartUp(PeerAddress(peerAddress), WRONG_SESSION_ID);
+            agent.get(SoftwareUpdateManager).suppressNextStartUp(peerAddress, WRONG_SESSION_ID);
         });
+
+        // Await teardown and re-prime on the sustained subscription — the startUp handler only runs
+        // once the priming report delivers the buffered event.
+        const subscription = peer1.behaviors.internalsOf(NetworkClient).activeSubscription!;
+        expect(subscription).not.undefined;
+        SustainedSubscription.assert(subscription);
 
         // Restart the device (same old version = apply failed scenario)
         await MockTime.resolve(device.stop());
+        await MockTime.resolve(subscription.inactive);
         await MockTime.resolve(device.start());
+        await MockTime.resolve(subscription.active);
         await MockTime.macrotasks;
 
         // The session IDs don't match (77 ≠ 999) → suppression NOT applied → updateFailed should fire
@@ -1049,9 +1083,7 @@ describe("Ota", () => {
 
         // The suppression entry should be consumed (even though it didn't suppress)
         const hasSuppressedAfter = await otaProvider.act(agent => {
-            return agent
-                .get(SoftwareUpdateManager)
-                .internal.pendingStartUpSuppress.has(PeerAddress(peerAddress).toString());
+            return agent.get(SoftwareUpdateManager).internal.pendingStartUpSuppress.has(peerAddress);
         });
         expect(hasSuppressedAfter).equals(false);
     }).timeout(10_000);


### PR DESCRIPTION
## Summary

- Fixes intermittent CI failure in `Ota ➡ suppressNextStartUp: suppresses startUp on matching session ID` (and two sibling tests) that relied on a buffered `startUp` event reaching the controller's `SoftwareUpdateManager` handler within `MockTime.macrotasks`. Delivery actually crosses mDNS rediscovery + CASE + subscription re-prime, which isn't guaranteed to finish in that window — hence the flake (see [run 24792752084 job 72554643882](https://github.com/matter-js/matter.js/actions/runs/24792752084/job/72554643882)).
- Replaces the `MockTime.macrotasks`-only wait with awaiting the peer's `SustainedSubscription`: `subscription.inactive` after `device.stop()`, `subscription.active` after `device.start()`. The priming report that flips `active` true carries the buffered startUp, so the handler is guaranteed to have run.
- For the two `suppressNextStartUp` tests, also flush pending macrotasks **before** arming the suppression — `addUpdateConsent` kicks off an `announceOtaProvider` flow that replays a buffered startUp which would otherwise consume the suppression entry before the real restart.
- Switches `SoftwareUpdateManager`'s `knownUpdates` and `pendingStartUpSuppress` from `Map<string, T>` to `PeerAddressMap<T>` so key operations auto-intern the PeerAddress. Fixes `"[object Object]"` log noise (`Queuing update consent for node [object Object]`) and potential key mismatches when non-interned addresses reach `.toString()`. Entry-point interning stays on four public methods whose log lines format the raw parameter directly.


🤖 Generated with [Claude Code](https://claude.com/claude-code)