### PR TITLE
chore: remove needless break statement

### DIFF
--- a/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
+++ b/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
@@ -465,7 +465,6 @@ export class LegacyControllerCommandHandler extends CommandHandler {
                     break;
                 default:
                     throw new Error("Unsupported value type for Any encoding");
-                    break;
             }
         }
 


### PR DESCRIPTION
Hi! Oxlint maintainer here - our `no-unreachable` moves to "correctness" in the next release, I'm just making this PR to help get our ecosystem CI green.

Since `throw new Error` ends the control flow, the `break` statement is unreachable and will never be executed so it's safe to remove.

Thanks!


```
  × eslint(no-unreachable): Unreachable code.
     ╭─[support/chip-testing/src/handler/LegacyControllerCommandHandler.ts:468:21]
 467 │                     throw new Error("Unsupported value type for Any encoding");
 468 │                     break;
     ·                     ──────
 469 │             }
     ╰────
  help: Remove the unreachable code or fix the control flow to make it reachable.

Found 0 warnings and 1 error.
Finished in 502ms on 3051 files with 62 rules using 4 threads.
Error: Process completed with exit code 1.
```