### PR TITLE
fix(node): strip feature-gated events from ClusterEvents under .for() narrowing

### DIFF
--- a/packages/node/src/behavior/cluster/ClusterEvents.ts
+++ b/packages/node/src/behavior/cluster/ClusterEvents.ts
@@ -14,15 +14,16 @@ import type { ActionContext } from "../context/ActionContext.js";
 /**
  * Event instance type for ClusterBehaviors.
  *
- * The Omit key uses `keyof Properties<N>` rather than `keyof Properties<InterfaceOf<BaseT>>` (which would
- * mirror main's pattern of stripping OLD cluster events).  TypeScript can't resolve the latter through nested
- * ClusterEvents types.  Using N is equivalent because old and new are always the same cluster (same
- * attribute/event keys), just different feature selections.
+ * Omit key uses `keyof CompleteProperties<N>` — the full set of event-shaped keys the cluster can ever expose
+ * regardless of feature selection.  This keeps the Omit stable across narrowing chains (e.g.
+ * `Base.with(all features).for(Cluster)` → base's Events carries feature-gated keys that must be stripped
+ * even when the narrower N's `Properties<N>` no longer lists them), while letting the optimizer resolve the
+ * key set through nested ClusterEvents types.
  */
 export type ClusterEvents<N extends ClusterTyping = ClusterTyping, BaseT extends Behavior.Type = Behavior.Type> =
-    // Keep observables *not* supplied by the old cluster
-    Omit<InstanceType<BaseT["Events"]>, keyof ClusterEvents.Properties<N>> &
-        // Add observables supplied by the new cluster
+    // Keep observables that aren't contributed by the cluster (e.g. custom observables added on subclasses)
+    Omit<InstanceType<BaseT["Events"]>, keyof ClusterEvents.CompleteProperties<N>> &
+        // Add observables supplied by the new cluster, filtered by feature selection
         ClusterEvents.Properties<N>;
 
 export namespace ClusterEvents {
@@ -204,7 +205,7 @@ export namespace ClusterEvents {
     /**
      * Complete properties: all attribute change observables + all event observables, all mandatory.
      */
-    type CompleteProperties<N extends ClusterTyping> = CompleteChangingObservables<N> &
+    export type CompleteProperties<N extends ClusterTyping> = CompleteChangingObservables<N> &
         CompleteChangedObservables<N> &
         CompleteEventObservables<N>;
 

--- a/packages/node/test/behavior/cluster/ClusterNarrowingTypingTest.ts
+++ b/packages/node/test/behavior/cluster/ClusterNarrowingTypingTest.ts
@@ -153,12 +153,16 @@ describe("Cluster narrowing typing", () => {
         });
 
         it("exposes MomentarySwitch events after .with(MomentarySwitch)", () => {
+            // Presence: asserts initialPress is a key on the narrowed type.  A regression that drops the
+            // key entirely would fail here (optional-shape `satisfies` alone doesn't prove presence).
+            "initialPress" satisfies keyof EventsWithMomentary;
             ({}) as EventsWithMomentary satisfies { initialPress?: unknown };
             // @ts-expect-error switchLatched still absent without LatchingSwitch
             ({}) as EventsWithMomentary satisfies { switchLatched: unknown };
         });
 
         it("exposes LatchingSwitch events after .with(LatchingSwitch)", () => {
+            "switchLatched" satisfies keyof EventsWithLatching;
             ({}) as EventsWithLatching satisfies { switchLatched?: unknown };
             // @ts-expect-error initialPress still absent without MomentarySwitch
             ({}) as EventsWithLatching satisfies { initialPress: unknown };
@@ -197,6 +201,7 @@ describe("Cluster narrowing typing", () => {
         });
 
         it("exposes multiPressMax as optional after .with(MomentarySwitchMultiPress)", () => {
+            "multiPressMax" satisfies keyof StateWithMultiPress;
             ({}) as StateWithMultiPress satisfies { multiPressMax?: number };
         });
 
@@ -230,6 +235,8 @@ describe("Cluster narrowing typing", () => {
         });
 
         it("exposes multiPressMax$Changing/$Changed as optional after .with(MomentarySwitchMultiPress)", () => {
+            "multiPressMax$Changing" satisfies keyof ObsWithMultiPress;
+            "multiPressMax$Changed" satisfies keyof ObsWithMultiPress;
             ({}) as ObsWithMultiPress satisfies {
                 multiPressMax$Changing?: unknown;
                 multiPressMax$Changed?: unknown;
@@ -286,7 +293,8 @@ describe("Cluster narrowing typing", () => {
 
     describe(".alter({ optional: false }) flips optional to mandatory", () => {
         it("leaves countdownTime optional on bare OperationalStateServer", () => {
-            // Optional — structural subtype check (also matches mandatory; disambiguated by next test).
+            // Presence first — optional-shape `satisfies` below would pass even if the key is absent.
+            "countdownTime" satisfies keyof StateOpsBare;
             ({}) as StateOpsBare satisfies { countdownTime?: number | null };
             // @ts-expect-error countdownTime is optional on the base — must not be mandatory here
             ({}) as StateOpsBare satisfies { countdownTime: number | null };
@@ -297,6 +305,7 @@ describe("Cluster narrowing typing", () => {
         });
 
         it("leaves operationCompletion optional on bare OperationalStateServer", () => {
+            "operationCompletion" satisfies keyof EventsOpsBare;
             // @ts-expect-error operationCompletion is optional on the base — must not be mandatory here
             ({}) as EventsOpsBare satisfies { operationCompletion: unknown };
         });

--- a/packages/node/test/behavior/cluster/ClusterNarrowingTypingTest.ts
+++ b/packages/node/test/behavior/cluster/ClusterNarrowingTypingTest.ts
@@ -1,0 +1,432 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { OperationalStateServer } from "#behaviors/operational-state";
+import { SwitchServer } from "#behaviors/switch";
+import { ThermostatServer } from "#behaviors/thermostat";
+import { Endpoint } from "#endpoint/Endpoint.js";
+import { SupportedBehaviors } from "#endpoint/properties/SupportedBehaviors.js";
+import { MutableEndpoint } from "#endpoint/type/MutableEndpoint.js";
+import { DeviceClassification } from "@matter/model";
+import { DeviceTypeId } from "@matter/types";
+import { Switch } from "@matter/types/clusters/switch";
+import { Thermostat } from "@matter/types/clusters/thermostat";
+
+// Regression tests for narrowing via `.for(Namespace)` and `.with(...features)` on a cluster behavior.
+//
+// Matter-bridge (and any downstream consumer using the typed overloads) expects:
+//
+//   * `endpoint.eventsOf(SwitchServer)` — feature-gated events absent
+//   * `endpoint.stateOf(SwitchServer)`  — feature-gated attributes absent, custom state retained
+//   * `.with(feature)`                  — only that feature's events / attrs become visible
+//   * `.with(...).enable({ ... })`      — enabled events/attrs become mandatory (no `?`)
+//
+// These assertions run at type-check time (`satisfies` / `@ts-expect-error`).  A regression causes
+// `npm run build -w @matter/node` to fail — no runtime behavior is invoked.
+//
+// Builders are arrow functions whose bodies never execute; we only extract their `ReturnType`.
+
+const endpoint = {} as Endpoint;
+
+// ---- eventsOf ----------------------------------------------------------------------------------
+
+const _eventsBare = () => endpoint.eventsOf(SwitchServer);
+const _eventsWithMomentary = () => endpoint.eventsOf(SwitchServer.with(Switch.Feature.MomentarySwitch));
+const _eventsWithLatching = () => endpoint.eventsOf(SwitchServer.with(Switch.Feature.LatchingSwitch));
+const _eventsEnabled = () =>
+    endpoint.eventsOf(
+        SwitchServer.with(
+            Switch.Feature.MomentarySwitch,
+            Switch.Feature.MomentarySwitchRelease,
+            Switch.Feature.MomentarySwitchLongPress,
+            Switch.Feature.MomentarySwitchMultiPress,
+        ).enable({
+            events: {
+                initialPress: true,
+                longPress: true,
+                shortRelease: true,
+                longRelease: true,
+                multiPressOngoing: true,
+                multiPressComplete: true,
+            },
+        }),
+    );
+
+type EventsBare = ReturnType<typeof _eventsBare>;
+type EventsWithMomentary = ReturnType<typeof _eventsWithMomentary>;
+type EventsWithLatching = ReturnType<typeof _eventsWithLatching>;
+type EventsEnabled = ReturnType<typeof _eventsEnabled>;
+
+// ---- stateOf -----------------------------------------------------------------------------------
+
+const _stateBare = () => endpoint.stateOf(SwitchServer);
+const _stateWithMultiPress = () => endpoint.stateOf(SwitchServer.with(Switch.Feature.MomentarySwitchMultiPress));
+const _stateEnabledAttr = () =>
+    endpoint.stateOf(
+        SwitchServer.with(Switch.Feature.MomentarySwitchMultiPress).enable({
+            attributes: { multiPressMax: true },
+        }),
+    );
+
+type StateBare = ReturnType<typeof _stateBare>;
+type StateWithMultiPress = ReturnType<typeof _stateWithMultiPress>;
+type StateEnabledAttr = ReturnType<typeof _stateEnabledAttr>;
+
+// ---- attribute change observables (xxx$Changing / xxx$Changed) ---------------------------------
+
+const _obsBare = () => endpoint.eventsOf(SwitchServer);
+const _obsWithMultiPress = () => endpoint.eventsOf(SwitchServer.with(Switch.Feature.MomentarySwitchMultiPress));
+const _obsEnabledAttr = () =>
+    endpoint.eventsOf(
+        SwitchServer.with(Switch.Feature.MomentarySwitchMultiPress).enable({
+            attributes: { multiPressMax: true },
+        }),
+    );
+
+type ObsBare = ReturnType<typeof _obsBare>;
+type ObsWithMultiPress = ReturnType<typeof _obsWithMultiPress>;
+type ObsEnabledAttr = ReturnType<typeof _obsEnabledAttr>;
+
+// ---- commandsOf --------------------------------------------------------------------------------
+
+const _commandsBare = () => endpoint.commandsOf(ThermostatServer);
+const _commandsWithSchedule = () =>
+    endpoint.commandsOf(ThermostatServer.with(Thermostat.Feature.ScheduleConfiguration));
+const _commandsWithPresets = () => endpoint.commandsOf(ThermostatServer.with(Thermostat.Feature.Presets));
+
+type CommandsBare = ReturnType<typeof _commandsBare>;
+type CommandsWithSchedule = ReturnType<typeof _commandsWithSchedule>;
+type CommandsWithPresets = ReturnType<typeof _commandsWithPresets>;
+
+// ---- .alter({ optional: false }) flips optional -> mandatory -----------------------------------
+
+// OperationalState has `countdownTime?: number | null` (optional attr) and
+// `operationCompletion?: OperationCompletionEvent` (optional event) in BaseAttributes / BaseEvents.
+// Both are always applicable (base component, no feature gating) — perfect `.alter()` targets.
+
+const _stateOpsBare = () => endpoint.stateOf(OperationalStateServer);
+const _stateOpsAltered = () =>
+    endpoint.stateOf(OperationalStateServer.alter({ attributes: { countdownTime: { optional: false } } }));
+const _eventsOpsBare = () => endpoint.eventsOf(OperationalStateServer);
+const _eventsOpsAltered = () =>
+    endpoint.eventsOf(OperationalStateServer.alter({ events: { operationCompletion: { optional: false } } }));
+
+type StateOpsBare = ReturnType<typeof _stateOpsBare>;
+type StateOpsAltered = ReturnType<typeof _stateOpsAltered>;
+type EventsOpsBare = ReturnType<typeof _eventsOpsBare>;
+type EventsOpsAltered = ReturnType<typeof _eventsOpsAltered>;
+
+// ---- endpoint.set() patch-shape narrowing ------------------------------------------------------
+
+const BareSwitchEndpoint = MutableEndpoint({
+    name: "BareSwitchEndpoint",
+    deviceType: DeviceTypeId(0xf),
+    deviceRevision: 3,
+    deviceClass: DeviceClassification.Simple,
+    behaviors: SupportedBehaviors(SwitchServer),
+});
+const MsmSwitchEndpoint = MutableEndpoint({
+    name: "MsmSwitchEndpoint",
+    deviceType: DeviceTypeId(0xf),
+    deviceRevision: 3,
+    deviceClass: DeviceClassification.Simple,
+    behaviors: SupportedBehaviors(SwitchServer.with(Switch.Feature.MomentarySwitchMultiPress)),
+});
+
+declare const bareSwitchEndpoint: Endpoint<typeof BareSwitchEndpoint>;
+declare const msmSwitchEndpoint: Endpoint<typeof MsmSwitchEndpoint>;
+
+describe("Cluster narrowing typing", () => {
+    describe("eventsOf narrowing via .for()", () => {
+        it("hides feature-gated events on bare SwitchServer", () => {
+            // @ts-expect-error initialPress is a MomentarySwitch-gated event
+            ({}) as EventsBare satisfies { initialPress: unknown };
+            // @ts-expect-error switchLatched is a LatchingSwitch-gated event
+            ({}) as EventsBare satisfies { switchLatched: unknown };
+            // @ts-expect-error longPress is a MomentarySwitchLongPress-gated event
+            ({}) as EventsBare satisfies { longPress: unknown };
+            // @ts-expect-error shortRelease is a MomentarySwitchRelease-gated event
+            ({}) as EventsBare satisfies { shortRelease: unknown };
+        });
+
+        it("exposes MomentarySwitch events after .with(MomentarySwitch)", () => {
+            ({}) as EventsWithMomentary satisfies { initialPress?: unknown };
+            // @ts-expect-error switchLatched still absent without LatchingSwitch
+            ({}) as EventsWithMomentary satisfies { switchLatched: unknown };
+        });
+
+        it("exposes LatchingSwitch events after .with(LatchingSwitch)", () => {
+            ({}) as EventsWithLatching satisfies { switchLatched?: unknown };
+            // @ts-expect-error initialPress still absent without MomentarySwitch
+            ({}) as EventsWithLatching satisfies { initialPress: unknown };
+        });
+
+        it("marks enabled events mandatory via .enable()", () => {
+            // Mandatory (not optional) — no `?:` on the target shape.
+            ({}) as EventsEnabled satisfies {
+                initialPress: unknown;
+                longPress: unknown;
+                shortRelease: unknown;
+                longRelease: unknown;
+                multiPressOngoing: unknown;
+                multiPressComplete: unknown;
+            };
+        });
+    });
+
+    describe("stateOf narrowing via .for()", () => {
+        it("retains base-component attributes on bare SwitchServer", () => {
+            ({}) as StateBare satisfies { numberOfPositions: number; currentPosition: number };
+        });
+
+        it("hides feature-gated attributes on bare SwitchServer", () => {
+            // @ts-expect-error multiPressMax is a MomentarySwitchMultiPress-gated attribute
+            ({}) as StateBare satisfies { multiPressMax: number };
+        });
+
+        it("retains custom server-side state (rawPosition, etc.)", () => {
+            ({}) as StateBare satisfies {
+                rawPosition: number;
+                longPressDelay: unknown;
+                multiPressDelay: unknown;
+                momentaryNeutralPosition: number;
+            };
+        });
+
+        it("exposes multiPressMax as optional after .with(MomentarySwitchMultiPress)", () => {
+            ({}) as StateWithMultiPress satisfies { multiPressMax?: number };
+        });
+
+        it("marks multiPressMax mandatory via .enable()", () => {
+            ({}) as StateEnabledAttr satisfies { multiPressMax: number };
+        });
+    });
+
+    describe("attribute change observables narrowing via .for()", () => {
+        it("retains base-component attribute change observables on bare SwitchServer", () => {
+            ({}) as ObsBare satisfies {
+                numberOfPositions$Changing: unknown;
+                numberOfPositions$Changed: unknown;
+                currentPosition$Changing: unknown;
+                currentPosition$Changed: unknown;
+            };
+        });
+
+        it("hides feature-gated attribute change observables on bare SwitchServer", () => {
+            // @ts-expect-error multiPressMax$Changing is gated on MomentarySwitchMultiPress
+            ({}) as ObsBare satisfies { multiPressMax$Changing: unknown };
+            // @ts-expect-error multiPressMax$Changed is gated on MomentarySwitchMultiPress
+            ({}) as ObsBare satisfies { multiPressMax$Changed: unknown };
+        });
+
+        it("retains custom server-side change observables (rawPosition)", () => {
+            ({}) as ObsBare satisfies {
+                rawPosition$Changing: unknown;
+                rawPosition$Changed: unknown;
+            };
+        });
+
+        it("exposes multiPressMax$Changing/$Changed as optional after .with(MomentarySwitchMultiPress)", () => {
+            ({}) as ObsWithMultiPress satisfies {
+                multiPressMax$Changing?: unknown;
+                multiPressMax$Changed?: unknown;
+            };
+        });
+
+        it("marks multiPressMax$Changing/$Changed mandatory via .enable({ attributes: ... })", () => {
+            ({}) as ObsEnabledAttr satisfies {
+                multiPressMax$Changing: unknown;
+                multiPressMax$Changed: unknown;
+            };
+        });
+    });
+
+    describe("commandsOf narrowing via .for()", () => {
+        it("retains base-component commands on bare ThermostatServer", () => {
+            ({}) as CommandsBare satisfies { setpointRaiseLower: unknown };
+        });
+
+        it("hides feature-gated commands on bare ThermostatServer", () => {
+            // @ts-expect-error setWeeklySchedule is gated on ScheduleConfiguration
+            ({}) as CommandsBare satisfies { setWeeklySchedule: unknown };
+            // @ts-expect-error getWeeklySchedule is gated on ScheduleConfiguration
+            ({}) as CommandsBare satisfies { getWeeklySchedule: unknown };
+            // @ts-expect-error clearWeeklySchedule is gated on ScheduleConfiguration
+            ({}) as CommandsBare satisfies { clearWeeklySchedule: unknown };
+            // @ts-expect-error setActivePresetRequest is gated on Presets
+            ({}) as CommandsBare satisfies { setActivePresetRequest: unknown };
+            // @ts-expect-error atomicRequest is gated on Presets | MatterScheduleConfiguration
+            ({}) as CommandsBare satisfies { atomicRequest: unknown };
+        });
+
+        it("exposes ScheduleConfiguration commands after .with(ScheduleConfiguration)", () => {
+            ({}) as CommandsWithSchedule satisfies {
+                setpointRaiseLower: unknown;
+                setWeeklySchedule: unknown;
+                getWeeklySchedule: unknown;
+                clearWeeklySchedule: unknown;
+            };
+            // @ts-expect-error setActivePresetRequest still gated on Presets
+            ({}) as CommandsWithSchedule satisfies { setActivePresetRequest: unknown };
+        });
+
+        it("exposes Presets commands after .with(Presets)", () => {
+            ({}) as CommandsWithPresets satisfies {
+                setpointRaiseLower: unknown;
+                setActivePresetRequest: unknown;
+                atomicRequest: unknown;
+            };
+            // @ts-expect-error setWeeklySchedule still gated on ScheduleConfiguration
+            ({}) as CommandsWithPresets satisfies { setWeeklySchedule: unknown };
+        });
+    });
+
+    describe(".alter({ optional: false }) flips optional to mandatory", () => {
+        it("leaves countdownTime optional on bare OperationalStateServer", () => {
+            // Optional — structural subtype check (also matches mandatory; disambiguated by next test).
+            ({}) as StateOpsBare satisfies { countdownTime?: number | null };
+            // @ts-expect-error countdownTime is optional on the base — must not be mandatory here
+            ({}) as StateOpsBare satisfies { countdownTime: number | null };
+        });
+
+        it("makes countdownTime mandatory via .alter()", () => {
+            ({}) as StateOpsAltered satisfies { countdownTime: number | null };
+        });
+
+        it("leaves operationCompletion optional on bare OperationalStateServer", () => {
+            // @ts-expect-error operationCompletion is optional on the base — must not be mandatory here
+            ({}) as EventsOpsBare satisfies { operationCompletion: unknown };
+        });
+
+        it("makes operationCompletion mandatory via .alter()", () => {
+            ({}) as EventsOpsAltered satisfies { operationCompletion: unknown };
+        });
+    });
+
+    describe("endpoint.set() patch-shape narrowing", () => {
+        it("rejects feature-gated attributes on bare SwitchServer endpoint", () => {
+            // Arrow bodies are type-checked but never invoked — `bareSwitchEndpoint` is `declare const`.
+            const _ok = () => bareSwitchEndpoint.set({ switch: { numberOfPositions: 3 } });
+            const _err = () =>
+                bareSwitchEndpoint.set({
+                    switch: {
+                        // @ts-expect-error multiPressMax is not a valid patch key without MomentarySwitchMultiPress
+                        multiPressMax: 3,
+                    },
+                });
+            void _ok;
+            void _err;
+        });
+
+        it("accepts feature-gated attributes after .with(MomentarySwitchMultiPress)", () => {
+            const _msmOnly = () => msmSwitchEndpoint.set({ switch: { multiPressMax: 3 } });
+            const _combined = () => msmSwitchEndpoint.set({ switch: { numberOfPositions: 3, multiPressMax: 3 } });
+            void _msmOnly;
+            void _combined;
+        });
+    });
+
+    describe("Endpoint constructor InputStateOf narrowing", () => {
+        it("rejects feature-gated attributes in options arg on bare SwitchServer endpoint", () => {
+            // `new Endpoint(type, options?)` overload — options is BehaviorOptions<T>.
+            // Overload resolution reports excess-property errors at the call site, so the
+            // expect-error directive must sit immediately above the `new Endpoint(...)` invocation.
+            const _baseOk = () => new Endpoint(BareSwitchEndpoint, { switch: { numberOfPositions: 3 } });
+            const _featureErr = () =>
+                // @ts-expect-error multiPressMax is absent from bare SwitchServer InputStateOf
+                new Endpoint(BareSwitchEndpoint, { switch: { multiPressMax: 3 } });
+            void _baseOk;
+            void _featureErr;
+        });
+
+        it("rejects feature-gated attributes in single-arg Configuration on bare SwitchServer endpoint", () => {
+            // `new Endpoint(config)` overload — config = Configuration<T> = Options<T> & { type: T }.
+            const _baseOk = () => new Endpoint({ type: BareSwitchEndpoint, switch: { numberOfPositions: 3 } });
+            const _featureErr = () =>
+                // @ts-expect-error multiPressMax is absent from bare SwitchServer InputStateOf
+                new Endpoint({ type: BareSwitchEndpoint, switch: { multiPressMax: 3 } });
+            void _baseOk;
+            void _featureErr;
+        });
+
+        it("accepts feature-gated attributes after .with(MomentarySwitchMultiPress)", () => {
+            const _twoArg = () => new Endpoint(MsmSwitchEndpoint, { switch: { multiPressMax: 3 } });
+            const _oneArg = () => new Endpoint({ type: MsmSwitchEndpoint, switch: { multiPressMax: 3 } });
+            void _twoArg;
+            void _oneArg;
+        });
+    });
+
+    // Behavior subclasses extending a narrowed base must see `this.state` / `this.events` narrowed to the
+    // currently-selected feature set.  These classes are declared but never instantiated — type-check only.
+    describe("subclass this.state / this.events narrowing", () => {
+        it("bare SwitchServer subclass hides feature-gated state and events", () => {
+            class BareSwitchSubclass extends SwitchServer {
+                override initialize() {
+                    // Base-component members are always present.
+                    const _np: number = this.state.numberOfPositions;
+                    void _np;
+
+                    // @ts-expect-error multiPressMax is absent on bare SwitchServer state
+                    this.state.multiPressMax;
+                    // @ts-expect-error multiPressMax$Changing is absent on bare SwitchServer events
+                    this.events.multiPressMax$Changing;
+                    // @ts-expect-error initialPress is absent without MomentarySwitch
+                    this.events.initialPress;
+                }
+            }
+            void BareSwitchSubclass;
+        });
+
+        it("SwitchServer.with(MomentarySwitchMultiPress) subclass exposes MSM state + change observables", () => {
+            class MsmSwitchSubclass extends SwitchServer.with(Switch.Feature.MomentarySwitchMultiPress) {
+                override initialize() {
+                    // multiPressMax may be absent (optional) at runtime — type accepts number | undefined.
+                    const _mpm: number | undefined = this.state.multiPressMax;
+                    void _mpm;
+
+                    const _changing = this.events.multiPressMax$Changing;
+                    const _changed = this.events.multiPressMax$Changed;
+                    void _changing;
+                    void _changed;
+
+                    // @ts-expect-error switchLatched still absent without LatchingSwitch
+                    this.events.switchLatched;
+                }
+            }
+            void MsmSwitchSubclass;
+        });
+
+        it("SwitchServer.with(MomentarySwitch) subclass exposes initialPress in reactors", () => {
+            class MomentarySwitchSubclass extends SwitchServer.with(Switch.Feature.MomentarySwitch) {
+                override initialize() {
+                    const _obs = this.events.initialPress;
+                    void _obs;
+
+                    // @ts-expect-error longPress still absent without MomentarySwitchLongPress
+                    this.events.longPress;
+                }
+            }
+            void MomentarySwitchSubclass;
+        });
+
+        it("enabled-event subclass sees event as mandatory (no optional chaining needed)", () => {
+            class EnabledMomentarySwitchSubclass extends SwitchServer.with(Switch.Feature.MomentarySwitch).enable({
+                events: { initialPress: true },
+            }) {
+                override initialize() {
+                    // Mandatory access — no `?.` needed.  A regression making initialPress optional would
+                    // turn `.emit` into `.emit | undefined` and break the assignment below.
+                    const emit: (...args: never[]) => unknown = this.events.initialPress.emit as unknown as (
+                        ...args: never[]
+                    ) => unknown;
+                    void emit;
+                }
+            }
+            void EnabledMomentarySwitchSubclass;
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Fix `ClusterEvents<N, BaseT>` Omit leaking feature-gated events when a wider-featured base is narrowed via `.for(Cluster)` (e.g. `SwitchBaseServer.for(Switch)`), so `endpoint.eventsOf(SwitchServer).initialPress` no longer type-checks on a bare `SwitchServer`.
- Switch the Omit key from `keyof Properties<N>` to `keyof CompleteProperties<N>` — stable across narrowing chains while `Properties<N>` still adds back only feature-applicable observables.
- Add a 22-case type-level regression harness under `packages/node/test/behavior/cluster/ClusterNarrowingTypingTest.ts` covering `stateOf` / `eventsOf` / `commandsOf` / `.alter()` / `endpoint.set()` / constructor `InputStateOf` / subclass `this.state` & `this.events` narrowing.

## Root cause

Introduced by commit a295568c6 ("Bug 14 fix") under the premise that *old* and *new* `Properties<N>` always share key sets. That's false when features narrow: `Properties<Switch-with-all-features>` contains `initialPress`/`switchLatched`/etc., while `Properties<Switch-with-no-features>` does not — so the Omit against the new key set failed to strip feature-gated events inherited from the wider base. The comment at the top of `ClusterEvents.ts` even documented the faulty assumption.

`CompleteProperties<N>` is derived from *all* components regardless of feature flags, so its `keyof` is constant for a given cluster — stripping correctly for same-cluster narrowing while leaving subclass-contributed observables (e.g. `SwitchServer.State.rawPosition$Changing/Changed`) intact.


## Known limitation

`CompleteProperties<N>` only covers keys from the *current* cluster's components. Cross-cluster `.for(OtherNamespace)` chains (different base cluster, not just narrower features) retain the pre-existing behavior where old-cluster-specific event names would not be stripped. None of matter.js's in-tree behaviors hit this; same-cluster narrowing — the matter-bridge case and every in-repo usage — is fully fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)