### PR TITLE
Exclude REFALM tests from matterjs-chip tests

### DIFF
--- a/.github/workflows/chip-matterjs-tests.yml
+++ b/.github/workflows/chip-matterjs-tests.yml
@@ -106,7 +106,7 @@ jobs:
               --runner chip_tool_python \
               --log-level info \
               --target-glob "{Test_*,}" \
-              --target-skip-glob "{Test_TC_BDX_*,Test_TC_DGTHREAD*,Test_TC_DGWIFI*,Test_TC_S_2_3}" \
+              --target-skip-glob "{Test_TC_BDX_*,Test_TC_DGTHREAD*,Test_TC_DGWIFI*,Test_TC_S_2_3,Test_TC_REFALM_2_*}" \
               run \
               --tool-path chip-tool:../support/chip-testing/dist/esm/ControllerWebSocketTestApp.js \
               --app-path all-clusters:../bin/chip-all-clusters-app \


### PR DESCRIPTION
... because expects manual device adjustments