### PR TITLE
refactor(protocol,node): unify path logging via ExpandedPath/DataModelPath

### DIFF
--- a/packages/model/src/common/DataModelPath.ts
+++ b/packages/model/src/common/DataModelPath.ts
@@ -10,6 +10,9 @@ import { Diagnostic } from "@matter/general";
  * Utility for tracking location in the Matter data model.  This location is used for diagnostics.
  *
  * The path consists of a sequence of IDs, optionally with type information.
+ *
+ * Segments with type "marker" attach to the previous segment without an intervening "." separator (used for
+ * diagnostic suffixes such as "[ADD]" or "!").
  */
 export class DataModelPath implements Diagnostic {
     parent?: DataModelPath;
@@ -29,9 +32,10 @@ export class DataModelPath implements Diagnostic {
         return this.id;
     }
 
-    toString(includeType?: boolean) {
+    toString(includeType?: boolean): string {
         if (this.parent) {
-            return `${this.parent}.${this.#identity(includeType)}`;
+            const sep = this.type === "marker" ? "" : ".";
+            return `${this.parent.toString(includeType)}${sep}${this.#identity(includeType)}`;
         }
         return this.#identity(includeType).toString();
     }
@@ -45,13 +49,18 @@ export class DataModelPath implements Diagnostic {
 
     get [Diagnostic.value](): Diagnostic {
         const result = Array<unknown>();
-        for (const segment of this.toArray()) {
-            if (result.length) {
+        this.#appendDiagnostic(result);
+        return Diagnostic.squash(result);
+    }
+
+    #appendDiagnostic(result: unknown[]) {
+        if (this.parent) {
+            this.parent.#appendDiagnostic(result);
+            if (this.type !== "marker") {
                 result.push(".");
             }
-            result.push(Diagnostic.strong(segment));
         }
-        return Diagnostic.squash(result);
+        result.push(Diagnostic.strong(this.id));
     }
 
     at(id: string | number, type?: string): DataModelPath {

--- a/packages/node/src/node/integration/ProtocolService.ts
+++ b/packages/node/src/node/integration/ProtocolService.ts
@@ -49,15 +49,7 @@ import type {
     InteractionSession,
     NodeProtocol,
 } from "@matter/protocol";
-import {
-    EventTypeProtocol,
-    FabricManager,
-    hasRemoteActor,
-    Mark,
-    OccurrenceManager,
-    toWildcardOrHexPath,
-    Val,
-} from "@matter/protocol";
+import { EventTypeProtocol, FabricManager, hasRemoteActor, Mark, OccurrenceManager, Val } from "@matter/protocol";
 import {
     AttributeId,
     AttributePath,
@@ -630,7 +622,7 @@ function invokeCommand(
     logger.info(
         "Invoke",
         Mark.INBOUND,
-        Diagnostic.strong(`${path.toString()}.${command.name}`),
+        Diagnostic.strong(path.at(camelize(command.name))),
         session.transaction.via,
         requestDiagnostic,
     );
@@ -723,7 +715,7 @@ function invokeCommand(
                         logger.info(
                             "Invoke",
                             Mark.OUTBOUND,
-                            Diagnostic.strong(`${path.toString()}.${command.name}`),
+                            Diagnostic.strong(path.at(camelize(command.name))),
                             session.transaction!.via,
                             Diagnostic.dict(result),
                         );
@@ -750,7 +742,7 @@ function invokeCommand(
                 logger.info(
                     "Invoke",
                     Mark.OUTBOUND,
-                    Diagnostic.strong(`${path.toString()}.${command.name}`),
+                    Diagnostic.strong(path.at(camelize(command.name))),
                     session.transaction.via,
                     Diagnostic.dict(result),
                 );
@@ -766,58 +758,56 @@ function invokeCommand(
 }
 
 /**
- * Resolve a path into a human readable textual form for logging
- * TODO: Add a Diagnostic display formatter for this
+ * Resolve a wire-format path into a {@link DataModelPath} for logging.
+ *
+ * Mirrors {@link ExpandedPath}'s segment shape (state./events./markers) but resolves cluster/element names against
+ * the node-local protocol so custom clusters render with their type names rather than falling back to hex.
+ *
+ * Endpoint names from the node are intentionally not used — endpoints render by number — to keep client and server
+ * logs symmetric.
  */
-function resolvePathForNode(node: NodeProtocol, path: AttributePath | EventPath | CommandPath) {
+function resolvePathForNode(node: NodeProtocol, path: AttributePath | EventPath | CommandPath): DataModelPath {
     const { endpointId, clusterId } = path;
-    const isUrgentString = "isUrgent" in path && path.isUrgent ? "!" : "";
-    const listIndexString = "listIndex" in path && path.listIndex === null ? "[ADD]" : "";
-    const postString = `${listIndexString}${isUrgentString}`;
+    const endpoint = endpointId !== undefined ? node[endpointId] : undefined;
+    const cluster = endpoint && clusterId !== undefined ? endpoint[clusterId] : undefined;
 
-    const elementId =
-        "attributeId" in path
-            ? path.attributeId
-            : "eventId" in path
-              ? path.eventId
-              : "commandId" in path
-                ? path.commandId
-                : undefined;
+    let dmPath = new DataModelPath(endpointId ?? "*", "endpoint");
+    dmPath = dmPath.at(nameOf(cluster?.type.name, clusterId), "cluster");
 
-    if (endpointId === undefined) {
-        return `*.${toWildcardOrHexPath("", clusterId)}.${toWildcardOrHexPath("", elementId)}${postString}`;
-    }
-
-    const endpoint = node[endpointId];
-    if (endpoint === undefined) {
-        return `${toWildcardOrHexPath("?", endpointId)}.${toWildcardOrHexPath("", clusterId)}.${toWildcardOrHexPath("", elementId)}${postString}`;
-    }
-    const endpointName = toWildcardOrHexPath(endpoint.name, endpointId);
-
-    if (clusterId === undefined) {
-        return `${endpointName}.*.${toWildcardOrHexPath("", elementId)}${postString}`;
-    }
-
-    const cluster = endpoint[clusterId];
-    if (cluster === undefined) {
-        return `${endpointName}.${toWildcardOrHexPath("?", clusterId)}.${toWildcardOrHexPath("", elementId)}${postString}`;
-    }
-    const clusterName = toWildcardOrHexPath(cluster.type.name, clusterId);
-
-    if (elementId !== undefined) {
-        if ("eventId" in path) {
-            const event = cluster.type.events[elementId];
-            return `${endpointName}.${clusterName}.${toWildcardOrHexPath(event?.name ?? "?", elementId)}${postString}`;
-        } else if ("attributeId" in path) {
-            const attribute = cluster.type.attributes[elementId];
-            return `${endpointName}.${clusterName}.${toWildcardOrHexPath(attribute?.name ?? "?", elementId)}${postString}`;
-        } else if ("commandId" in path) {
-            const command = cluster.type.commands[elementId];
-            return `${endpointName}.${clusterName}.${toWildcardOrHexPath(command?.name ?? "?", elementId)}${postString}`;
-        } else {
-            throw new ImplementationError("Invalid path");
+    if ("attributeId" in path) {
+        const attribute =
+            cluster && path.attributeId !== undefined ? cluster.type.attributes[path.attributeId] : undefined;
+        dmPath = dmPath.at("state").at(nameOf(attribute?.name, path.attributeId));
+        if (path.listIndex === null) {
+            dmPath = dmPath.at("[ADD]", "marker");
         }
-    } else {
-        return `${endpointName}.${clusterName}.*${postString}`;
+        return dmPath;
+    }
+
+    if ("eventId" in path) {
+        const event = cluster && path.eventId !== undefined ? cluster.type.events[path.eventId] : undefined;
+        dmPath = dmPath.at("events").at(nameOf(event?.name, path.eventId));
+        if ("isUrgent" in path && path.isUrgent) {
+            dmPath = dmPath.at("!", "marker");
+        }
+        return dmPath;
+    }
+
+    if ("commandId" in path) {
+        const command = cluster && path.commandId !== undefined ? cluster.type.commands[path.commandId] : undefined;
+        return dmPath.at(nameOf(command?.name, path.commandId));
+    }
+
+    // Wildcard path with no element discriminator — render as bare element wildcard
+    return dmPath.at("*", "element");
+
+    function nameOf(name: string | undefined, id: number | undefined) {
+        if (name !== undefined) {
+            return camelize(name);
+        }
+        if (id === undefined) {
+            return "*";
+        }
+        return `0x${id.toString(16)}`;
     }
 }

--- a/packages/node/test/endpoint/server/InteractionProtocolTest.ts
+++ b/packages/node/test/endpoint/server/InteractionProtocolTest.ts
@@ -1777,7 +1777,7 @@ describe("InteractionProtocol", () => {
                     messenger,
                     interaction.BarelyMockedMessage,
                 ),
-            ).rejectedWith("Duplicate concrete command path RootNode:0x0.OnOff:0x6.on:0x1 on batch invoke");
+            ).rejectedWith("Duplicate concrete command path 0.onOff.on on batch invoke");
         });
 
         it("handles StatusResponseError gracefully", async () => {

--- a/packages/protocol/src/action/protocols.ts
+++ b/packages/protocol/src/action/protocols.ts
@@ -69,9 +69,9 @@ export interface NodeProtocol extends CollectionProtocol<EndpointProtocol> {
     attrsChanged: Observable<NodeProtocol.AttrChange, MaybePromise>;
 
     /**
-     * Inspects an Attribute- or Event path and log in human-readable form if possible
+     * Resolve a wire-format path into a {@link DataModelPath} for human-readable diagnostics.
      */
-    inspectPath(path: AttributePath | EventPath | CommandPath): string;
+    inspectPath(path: AttributePath | EventPath | CommandPath): DataModelPath;
 }
 
 export namespace NodeProtocol {

--- a/packages/protocol/src/action/request/Specifier.ts
+++ b/packages/protocol/src/action/request/Specifier.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { camelize } from "@matter/general";
+import { DataModelPath } from "@matter/model";
 import type { ClusterId, CommandId } from "@matter/types";
 import { ClusterType, EndpointNumber, Global, TlvSchema } from "@matter/types";
 import { MalformedRequestError } from "./MalformedRequestError.js";
@@ -197,16 +199,12 @@ export namespace Specifier {
     }
 }
 
-export function toWildcardOrHexPath(name: string, value: number | bigint | undefined) {
-    if (value === undefined) {
-        return "*";
-    }
-    return `${name ? `${name}:` : ""}0x${value.toString(16)}`;
-}
-
 /**
- * Resolve a path into a human readable textual form for logging
- * TODO: Add a Diagnostic display formatter for this
+ * Resolve a request-side specifier location into a {@link DataModelPath} for human-readable diagnostics.
+ *
+ * Mirrors the segment shape of {@link ExpandedPath} (state./events./markers) so client-side specifier paths and
+ * server-side wire paths render consistently. Element names fall back to camelized hex IDs when the element is
+ * unknown.
  */
 export function resolvePathForSpecifier<const C extends Specifier.ClusterLike>(location: {
     endpoint?: Specifier.Endpoint;
@@ -216,42 +214,48 @@ export function resolvePathForSpecifier<const C extends Specifier.ClusterLike>(l
     command?: Specifier.Command<Specifier.ClusterFor<C>>;
     isUrgent?: boolean;
     listIndex?: number | null;
-}) {
+}): DataModelPath {
     const endpointId = Specifier.endpointIdOf(location);
     const cluster = location.cluster ? Specifier.clusterFor(location.cluster) : undefined;
-    const attribute = location.attribute && cluster ? Specifier.attributeFor(cluster, location.attribute) : undefined;
-    const event = location.event && cluster ? Specifier.eventFor(cluster, location.event) : undefined;
-    const command = location.command && cluster ? Specifier.commandFor(cluster, location.command) : undefined;
-    const isUrgentString = "isUrgent" in location && location.isUrgent ? "!" : "";
-    const listIndexString = "listIndex" in location && location.listIndex === null ? "[ADD]" : "";
-    const postString = `${listIndexString}${isUrgentString}`;
 
-    const clusterId = cluster?.id;
-    const elementId = attribute ? attribute.id : event ? event.id : command ? command.id : undefined;
+    let dmPath = new DataModelPath(endpointId ?? "*", "endpoint");
+    dmPath = dmPath.at(cluster ? camelize(cluster.name) : "*", "cluster");
 
-    if (endpointId === undefined) {
-        return `*.${toWildcardOrHexPath("", clusterId)}.${toWildcardOrHexPath("", elementId)}${postString}`;
-    }
-
-    const endpointName = toWildcardOrHexPath("", endpointId);
-
-    if (cluster === undefined || clusterId === undefined) {
-        return `${endpointName}.*.${toWildcardOrHexPath("", elementId)}${postString}`;
-    }
-
-    const clusterName = toWildcardOrHexPath(cluster.name, clusterId);
-
-    if (elementId !== undefined) {
-        if (event) {
-            return `${endpointName}.${clusterName}.${toWildcardOrHexPath(typeof location.event === "string" ? location.event : "?", elementId)}${postString}`;
-        } else if (attribute) {
-            return `${endpointName}.${clusterName}.${toWildcardOrHexPath(typeof location.attribute === "string" ? location.attribute : "?", elementId)}${postString}`;
-        } else if (command) {
-            return `${endpointName}.${clusterName}.${toWildcardOrHexPath(typeof location.command === "string" ? location.command : "?", elementId)}${postString}`;
-        } else {
-            return "unknown";
+    if (location.attribute !== undefined) {
+        const name = nameForElement(location.attribute, cluster && Specifier.attributeFor(cluster, location.attribute));
+        dmPath = dmPath.at("state").at(name);
+        if (location.listIndex === null) {
+            dmPath = dmPath.at("[ADD]", "marker");
         }
-    } else {
-        return `${endpointName}.${clusterName}.*${postString}`;
+        return dmPath;
+    }
+
+    if (location.event !== undefined) {
+        const name = nameForElement(location.event, cluster && Specifier.eventFor(cluster, location.event));
+        dmPath = dmPath.at("events").at(name);
+        if (location.isUrgent) {
+            dmPath = dmPath.at("!", "marker");
+        }
+        return dmPath;
+    }
+
+    if (location.command !== undefined) {
+        const name = nameForElement(location.command, cluster && Specifier.commandFor(cluster, location.command));
+        return dmPath.at(name);
+    }
+
+    return dmPath.at("*", "element");
+
+    function nameForElement(specifier: string | object, resolved: { id?: number; name?: string } | undefined) {
+        if (typeof specifier === "string") {
+            return camelize(specifier);
+        }
+        if (resolved?.name !== undefined) {
+            return camelize(resolved.name);
+        }
+        if (resolved?.id !== undefined) {
+            return `0x${resolved.id.toString(16)}`;
+        }
+        return "?";
     }
 }

--- a/packages/protocol/src/action/request/Write.ts
+++ b/packages/protocol/src/action/request/Write.ts
@@ -61,6 +61,8 @@ export function Write(optionsOrData: Write.Options | Write.Attribute, ...data: W
         interactionModelRevision = Specification.INTERACTION_MODEL_REVISION,
     } = options;
 
+    let chunked = false;
+
     const result = {
         timedRequest: !!timed || !!timeout,
         timeout,
@@ -69,15 +71,24 @@ export function Write(optionsOrData: Write.Options | Write.Attribute, ...data: W
         suppressResponse,
         interactionModelRevision,
 
-        [Diagnostic.value]: () =>
-            Diagnostic.list(
-                data.map(entry => {
-                    const { version, value } = entry;
-                    return `${resolvePathForSpecifier(entry)} = ${Diagnostic.json(
-                        value,
-                    )}${version !== undefined ? `(version=${version})` : ""}`;
-                }),
-            ),
+        [Diagnostic.value]: () => {
+            const items = data.flatMap(entry => {
+                const { version, value, endpoint, cluster, attributes } = entry;
+                const valueString = Diagnostic.json(value);
+                const list = Array.isArray(attributes) ? attributes : [attributes];
+                const versionString = version !== undefined ? `(version=${version})` : "";
+                return list.map(attribute =>
+                    Diagnostic.squash(
+                        Diagnostic.strong(resolvePathForSpecifier({ endpoint, cluster, attribute })),
+                        ` = ${valueString}${versionString}`,
+                    ),
+                );
+            });
+            if (chunked) {
+                return [Diagnostic.asFlags({ chunked: true }), Diagnostic.list(items)];
+            }
+            return Diagnostic.list(items);
+        },
     } as Write;
 
     for (const entry of data) {
@@ -132,6 +143,7 @@ export function Write(optionsOrData: Write.Options | Write.Attribute, ...data: W
                 tlv instanceof ArraySchema &&
                 !isAclOrExtensionPath({ clusterId, attributeId })
             ) {
+                chunked = true;
                 writeRequests.push(
                     ...tlv
                         .encodeAsChunkedArray(value, { forWriteInteraction: true })

--- a/packages/protocol/src/common/ExpandedPath.ts
+++ b/packages/protocol/src/common/ExpandedPath.ts
@@ -40,8 +40,8 @@ export function ExpandedPath({ path, matter, base, kind }: ExpandedPath.Definiti
 
     if ("attributeId" in path) {
         base = base.at("state").at(identityOf(cluster, AttributeModel, path.attributeId));
-        if (path.listIndex) {
-            return base.at(path.listIndex, "entry");
+        if (path.listIndex === null) {
+            base = base.at("[ADD]", "marker");
         }
         return base;
     }
@@ -51,7 +51,11 @@ export function ExpandedPath({ path, matter, base, kind }: ExpandedPath.Definiti
     }
 
     if ("eventId" in path) {
-        return base.at("events").at(identityOf(cluster, EventModel, path.eventId));
+        base = base.at("events").at(identityOf(cluster, EventModel, path.eventId));
+        if ("isUrgent" in path && path.isUrgent) {
+            base = base.at("!", "marker");
+        }
+        return base;
     }
 
     return base.at("*", kind ?? "element");
@@ -66,7 +70,7 @@ export function ExpandedPath({ path, matter, base, kind }: ExpandedPath.Definiti
             if (typeof id === "string") {
                 return camelize(id);
             }
-            return id;
+            return `0x${id.toString(16)}`;
         }
 
         if (type === ClusterModel) {

--- a/packages/protocol/test/common/ExpandedPathTest.ts
+++ b/packages/protocol/test/common/ExpandedPathTest.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ExpandedPath } from "#common/ExpandedPath.js";
+import { AttributeId, ClusterId, CommandId, EndpointNumber, EventId } from "@matter/types";
+
+describe("ExpandedPath", () => {
+    describe("attribute paths", () => {
+        it("renders endpoint, cluster and attribute by name", () => {
+            const path = ExpandedPath({
+                path: {
+                    endpointId: EndpointNumber(0),
+                    clusterId: ClusterId(0x6),
+                    attributeId: AttributeId(0x0),
+                },
+            });
+
+            expect(path.toString()).equal("0.onOff.state.onOff");
+        });
+
+        it("renders [ADD] marker without separator for listIndex === null", () => {
+            const path = ExpandedPath({
+                path: {
+                    endpointId: EndpointNumber(0),
+                    clusterId: ClusterId(0x1f), // Access Control
+                    attributeId: AttributeId(0x0), // ACL
+                    listIndex: null,
+                },
+            });
+
+            expect(path.toString()).equal("0.accessControl.state.acl[ADD]");
+        });
+
+        it("renders wildcard endpoint as *", () => {
+            const path = ExpandedPath({
+                path: {
+                    endpointId: undefined,
+                    clusterId: ClusterId(0x6),
+                    attributeId: AttributeId(0x0),
+                },
+            });
+
+            expect(path.toString()).equal("*.onOff.state.onOff");
+        });
+
+        it("renders unknown cluster id as hex", () => {
+            const path = ExpandedPath({
+                path: {
+                    endpointId: EndpointNumber(0),
+                    clusterId: 0xabcd as ClusterId,
+                    attributeId: AttributeId(0x0),
+                },
+            });
+
+            expect(path.toString()).equal("0.0xabcd.state.0x0");
+        });
+
+        it("renders unknown attribute id as hex", () => {
+            const path = ExpandedPath({
+                path: {
+                    endpointId: EndpointNumber(0),
+                    clusterId: ClusterId(0x6),
+                    attributeId: AttributeId(0xff),
+                },
+            });
+
+            expect(path.toString()).equal("0.onOff.state.0xff");
+        });
+    });
+
+    describe("event paths", () => {
+        // Switch cluster (0x3b) has events: switchLatched=0, initialPress=1, ...
+        it("renders event path with name", () => {
+            const path = ExpandedPath({
+                path: {
+                    endpointId: EndpointNumber(0),
+                    clusterId: ClusterId(0x3b),
+                    eventId: EventId(0x0),
+                },
+            });
+
+            expect(path.toString()).equal("0.switch.events.switchLatched");
+        });
+
+        it("renders ! marker without separator when isUrgent is true", () => {
+            const path = ExpandedPath({
+                path: {
+                    endpointId: EndpointNumber(0),
+                    clusterId: ClusterId(0x3b),
+                    eventId: EventId(0x0),
+                    isUrgent: true,
+                },
+            });
+
+            expect(path.toString()).equal("0.switch.events.switchLatched!");
+        });
+    });
+
+    describe("command paths", () => {
+        it("renders command path", () => {
+            const path = ExpandedPath({
+                path: {
+                    endpointId: EndpointNumber(0),
+                    clusterId: ClusterId(0x6),
+                    commandId: CommandId(0x1), // on
+                },
+            });
+
+            expect(path.toString()).equal("0.onOff.on");
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Routes all interaction-type diagnostics (Read/Write/Subscribe/Invoke, client + server) through a single `DataModelPath` produced by `ExpandedPath` (wire paths) or `resolvePathForSpecifier` (specifier paths). Output: `endpointId.clusterName.elementName` (camelCase property names, hex fallback `0xNN` when name unknown).
- Adds `[ADD]` (`listIndex === null`) and `!` (event `isUrgent`) markers via a new `marker` segment type on `DataModelPath` that renders without an intervening `.`.
- Fixes a wildcard-vs-concrete logging bug in `Write`: the diagnostic passed `entry` directly to `resolvePathForSpecifier` (which looks for singular `attribute`), but `Write.Attribute` carries plural `attributes`. Concrete writes were logged as `*` instead of the actual attribute name.
- Surfaces chunked-list writes via a `chunked` flag in the Write diagnostic.
- `inspectPath()` now returns `DataModelPath` instead of `string`. Legacy callers keep working via `toString()`.

Closes #2584

## Output examples

| Case | Before | After |
| --- | --- | --- |
| Concrete write | `0x0.BasicInformation:0x28.* = "..."` | `0.basicInformation.state.nodeLabel = "..."` |
| Mixed read | `0x0.OnOff:0x6.onOff:0x0` | `0.onOff.state.onOff` |
| ACL append | `0x0.AccessControl:0x1f.acl:0x0[ADD]` | `0.accessControl.state.acl[ADD]` |
| Urgent event | `0x0.Switch:0x3b.switchLatched:0x0!` | `0.switch.events.switchLatched!` |
| Unknown cluster | `?:0xabcd.?:0x0` | `0.0xabcd.state.0x0` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)