### PR TITLE
fix(mdns): DnssdNames discovery, staging, and TXT-parameter fixes

### DIFF
--- a/packages/general/src/net/dns-sd/DnssdName.ts
+++ b/packages/general/src/net/dns-sd/DnssdName.ts
@@ -66,9 +66,22 @@ export class DnssdName extends BasicObservable<[changes: DnssdName.Changes], May
         return this.#records.values();
     }
 
-    get parameters() {
+    get parameters(): ReadonlyMap<string, string> {
         if (this.#parameters === undefined) {
-            this.#parameters = new Map();
+            const parameters = (this.#parameters = new Map<string, string>());
+            for (const record of this.#records.values()) {
+                if (record.recordType !== DnsRecordType.TXT) {
+                    continue;
+                }
+                for (const entry of record.value as string[]) {
+                    const pos = entry.indexOf("=");
+                    if (pos === -1) {
+                        parameters.set(entry, "");
+                    } else {
+                        parameters.set(entry.slice(0, pos), entry.slice(pos + 1));
+                    }
+                }
+            }
         }
         return this.#parameters;
     }
@@ -78,19 +91,6 @@ export class DnssdName extends BasicObservable<[changes: DnssdName.Changes], May
     }
 
     installRecord(record: DnsRecord<any>, options?: DnssdName.InstallOptions) {
-        // For TXT records, extract the standard DNS-SD k/v's
-        if (record.recordType === DnsRecordType.TXT) {
-            const entries = record.value;
-            for (const entry of entries) {
-                const pos = entry.indexOf("=");
-                if (pos === -1) {
-                    this.parameters.set(entry, "");
-                } else {
-                    this.parameters.set(entry.slice(0, pos), entry.slice(pos + 1));
-                }
-            }
-        }
-
         const key = keyOf(record);
         if (key === undefined) {
             this.#deleteIfUnused();
@@ -116,6 +116,10 @@ export class DnssdName extends BasicObservable<[changes: DnssdName.Changes], May
         } as DnssdName.Record;
 
         this.#records.set(key, recordWithExpire);
+
+        if (record.recordType === DnsRecordType.TXT) {
+            this.#parameters = undefined;
+        }
 
         this.#context.registerForExpiration(recordWithExpire);
 
@@ -150,6 +154,10 @@ export class DnssdName extends BasicObservable<[changes: DnssdName.Changes], May
 
         this.#records.delete(key);
         this.#recordCount--;
+
+        if (record.recordType === DnsRecordType.TXT) {
+            this.#parameters = undefined;
+        }
 
         const dependency = this.#dependencies?.get(key);
         if (dependency) {
@@ -251,7 +259,8 @@ function keyOf(record: DnsRecord): string | undefined {
 
         case DnsRecordType.TXT:
             if (Array.isArray(record.value)) {
-                return `${record.recordType} ${record.value.sort().join(" ")}`;
+                // Spread before sort: keyOf must not mutate record.value (parameters recompute relies on wire order)
+                return `${record.recordType} ${[...record.value].sort().join(" ")}`;
             }
             break;
     }

--- a/packages/general/src/net/dns-sd/DnssdNames.ts
+++ b/packages/general/src/net/dns-sd/DnssdNames.ts
@@ -106,7 +106,6 @@ export class DnssdNames {
             Minutes(1),
             this.#pruneStagedIpRecords.bind(this),
         );
-        // Mark as utility so the prune timer doesn't keep the Node event loop alive
         this.#stagedIpExpirationTimer.utility = true;
         this.#stagedIpExpirationTimer.start();
     }
@@ -226,33 +225,43 @@ export class DnssdNames {
             }
         } while (filteredBeforePass > filtered.size);
 
+        // Honour goodbye (ttl=0) for already-staged hostnames regardless of packetRelevant: eviction only
+        // touches entries we previously admitted under the gate, so a stray goodbye cannot poison anything new.
+        for (const record of filtered) {
+            if (
+                (record.recordType !== DnsRecordType.A && record.recordType !== DnsRecordType.AAAA) ||
+                record.ttl !== 0 ||
+                this.has(record.name)
+            ) {
+                continue;
+            }
+            const key = record.name.toLowerCase();
+            const staged = this.#stagedIpRecords.get(key);
+            if (staged === undefined) {
+                continue;
+            }
+            const remaining = staged.filter(
+                s => !(s.record.recordType === record.recordType && s.record.value === record.value),
+            );
+            if (remaining.length === 0) {
+                this.#stagedIpRecords.delete(key);
+            } else {
+                this.#stagedIpRecords.set(key, remaining);
+            }
+        }
+
         // Stage A/AAAA for unknown hostnames — replayed when a later SRV creates the name.
         // packetRelevant gate prevents unrelated LAN traffic from poisoning the cache.
         if (packetRelevant) {
             for (let record of filtered) {
                 if (
                     (record.recordType !== DnsRecordType.A && record.recordType !== DnsRecordType.AAAA) ||
+                    record.ttl === 0 ||
                     this.has(record.name)
                 ) {
                     continue;
                 }
                 const key = record.name.toLowerCase();
-
-                if (record.ttl === 0) {
-                    const staged = this.#stagedIpRecords.get(key);
-                    if (staged === undefined) {
-                        continue;
-                    }
-                    const remaining = staged.filter(
-                        s => !(s.record.recordType === record.recordType && s.record.value === record.value),
-                    );
-                    if (remaining.length === 0) {
-                        this.#stagedIpRecords.delete(key);
-                    } else {
-                        this.#stagedIpRecords.set(key, remaining);
-                    }
-                    continue;
-                }
 
                 if (record.ttl < this.#minTtl) {
                     record = { ...record, ttl: this.#minTtl };

--- a/packages/general/src/net/dns-sd/DnssdNames.ts
+++ b/packages/general/src/net/dns-sd/DnssdNames.ts
@@ -213,9 +213,9 @@ export class DnssdNames {
         }
 
         // Filtered records may be relevant to us if they are referenced by services, e.g. SRV targets become relevant.
-        // So iteratively process until the set of filtered records does not change
-        let filteredBeforePass = records.length;
-        while (filteredBeforePass > filtered.size) {
+        // Iteratively process until the set of filtered records does not change.
+        let filteredBeforePass: number;
+        do {
             filteredBeforePass = filtered.size;
             for (const record of filtered) {
                 if (!this.has(record.name)) {
@@ -224,7 +224,7 @@ export class DnssdNames {
 
                 handleRecord(record);
             }
-        }
+        } while (filteredBeforePass > filtered.size);
 
         // Stage A/AAAA for unknown hostnames — replayed when a later SRV creates the name.
         // packetRelevant gate prevents unrelated LAN traffic from poisoning the cache.

--- a/packages/general/src/net/dns-sd/IpService.ts
+++ b/packages/general/src/net/dns-sd/IpService.ts
@@ -95,7 +95,7 @@ export class IpService {
     /**
      * Values from TXT records.
      */
-    get parameters() {
+    get parameters(): ReadonlyMap<string, string> {
         return this.#name.parameters;
     }
 

--- a/packages/general/test/net/dns-sd/DnssdNamesTest.ts
+++ b/packages/general/test/net/dns-sd/DnssdNamesTest.ts
@@ -55,7 +55,7 @@ describe("DnssdNames", () => {
                 recordClass: 1,
                 recordType: 16,
                 ttl: 3600000,
-                value: ["flag", "foo=bar"],
+                value: ["foo=bar", "flag"],
             },
         ]);
 
@@ -573,6 +573,145 @@ describe("DnssdNames", () => {
                 r => r.recordType === DnsRecordType.A || r.recordType === DnsRecordType.AAAA,
             );
             expect(ips.length).equals(0);
+        });
+    });
+
+    describe("TXT parameters", () => {
+        it("recomputes parameters when a TXT record is removed", async () => {
+            await using site = new MockSite();
+            const { client, server } = await site.addPair();
+
+            const qname = qnameOf(1);
+
+            // Include an SRV so the name survives when the TXT is later goodbye'd
+            const discovered = new Promise<void>(resolve => {
+                client.names.discovered.once(() => resolve());
+            });
+            await server.mdns.send({
+                messageType: DnsMessageType.Response,
+                answers: [
+                    {
+                        name: MOCK_SERVICE_DOMAIN,
+                        recordType: DnsRecordType.PTR,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: qname,
+                    },
+                    {
+                        name: qname,
+                        recordType: DnsRecordType.SRV,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: { port: 1234, priority: 10, weight: 1, target: server.hostname },
+                    },
+                    {
+                        name: qname,
+                        recordType: DnsRecordType.TXT,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: ["a=1", "b=2"],
+                    },
+                ],
+                additionalRecords: [],
+            });
+            await MockTime.resolve(discovered);
+
+            expect([...client.names.get(qname).parameters]).deep.equals([
+                ["a", "1"],
+                ["b", "2"],
+            ]);
+
+            // Past goodbye-protection window so the deleteRecord is honoured
+            await MockTime.advance(Seconds(2));
+
+            await server.mdns.send({
+                messageType: DnsMessageType.Response,
+                answers: [
+                    {
+                        name: qname,
+                        recordType: DnsRecordType.TXT,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: 0,
+                        value: ["a=1", "b=2"],
+                    },
+                ],
+                additionalRecords: [],
+            });
+            await MockTime.advance(10);
+
+            expect([...client.names.get(qname).parameters]).deep.equals([]);
+        });
+
+        it("drops keys absent from a replacement TXT record", async () => {
+            await using site = new MockSite();
+            const { client, server } = await site.addPair();
+
+            const qname = qnameOf(1);
+
+            const discovered = new Promise<void>(resolve => {
+                client.names.discovered.once(() => resolve());
+            });
+            await server.mdns.send({
+                messageType: DnsMessageType.Response,
+                answers: [
+                    {
+                        name: MOCK_SERVICE_DOMAIN,
+                        recordType: DnsRecordType.PTR,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: qname,
+                    },
+                    {
+                        name: qname,
+                        recordType: DnsRecordType.SRV,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: { port: 1234, priority: 10, weight: 1, target: server.hostname },
+                    },
+                    {
+                        name: qname,
+                        recordType: DnsRecordType.TXT,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: ["a=1", "b=2"],
+                    },
+                ],
+                additionalRecords: [],
+            });
+            await MockTime.resolve(discovered);
+
+            expect([...client.names.get(qname).parameters]).deep.equals([
+                ["a", "1"],
+                ["b", "2"],
+            ]);
+
+            // Past goodbye-protection window
+            await MockTime.advance(Seconds(2));
+
+            // Goodbye the original TXT, then send a new TXT that omits key "a"
+            await server.mdns.send({
+                messageType: DnsMessageType.Response,
+                answers: [
+                    {
+                        name: qname,
+                        recordType: DnsRecordType.TXT,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: 0,
+                        value: ["a=1", "b=2"],
+                    },
+                    {
+                        name: qname,
+                        recordType: DnsRecordType.TXT,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: ["b=3"],
+                    },
+                ],
+                additionalRecords: [],
+            });
+            await MockTime.advance(10);
+
+            expect([...client.names.get(qname).parameters]).deep.equals([["b", "3"]]);
         });
     });
 

--- a/packages/general/test/net/dns-sd/DnssdNamesTest.ts
+++ b/packages/general/test/net/dns-sd/DnssdNamesTest.ts
@@ -372,6 +372,73 @@ describe("DnssdNames", () => {
             expect(ips.length).equals(2);
         });
 
+        it("ingests A/AAAA arriving in a packet alone after the SRV target is known", async () => {
+            await using site = new MockSite();
+            const { client, server } = await site.addPair();
+
+            const qname = qnameOf(1);
+
+            client.configureNames({
+                filter: record =>
+                    record.name === MOCK_SERVICE_DOMAIN || record.name.endsWith(`.${MOCK_SERVICE_DOMAIN}`),
+            });
+
+            // PTR + SRV; SRV installation creates the hostname DnssdName via dependency
+            await server.mdns.send({
+                messageType: DnsMessageType.Response,
+                answers: [
+                    {
+                        name: MOCK_SERVICE_DOMAIN,
+                        recordType: DnsRecordType.PTR,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: qname,
+                    },
+                    {
+                        name: qname,
+                        recordType: DnsRecordType.SRV,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: { port: 1234, priority: 10, weight: 1, target: server.hostname },
+                    },
+                ],
+                additionalRecords: [],
+            });
+            await MockTime.advance(10);
+
+            expect(client.names.has(server.hostname)).true;
+
+            // Solicited response carrying ONLY A/AAAA for the hostname — no filter-matching records.
+            // The dependency pass must still attach these records because the hostname is already known.
+            await server.mdns.send({
+                messageType: DnsMessageType.Response,
+                answers: [
+                    {
+                        name: server.hostname,
+                        recordType: DnsRecordType.A,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: "10.10.10.145",
+                    },
+                    {
+                        name: server.hostname,
+                        recordType: DnsRecordType.AAAA,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: "abcd::91",
+                    },
+                ],
+                additionalRecords: [],
+            });
+            await MockTime.advance(10);
+
+            const host = client.names.get(server.hostname);
+            const ips = [...host.records].filter(
+                r => r.recordType === DnsRecordType.A || r.recordType === DnsRecordType.AAAA,
+            );
+            expect(ips.length).equals(2);
+        });
+
         it("discards staged IP records after their TTL expires", async () => {
             await using site = new MockSite();
             const { client, server } = await site.addPair();

--- a/packages/general/test/net/dns-sd/DnssdNamesTest.ts
+++ b/packages/general/test/net/dns-sd/DnssdNamesTest.ts
@@ -439,6 +439,82 @@ describe("DnssdNames", () => {
             expect(ips.length).equals(2);
         });
 
+        it("evicts a staged IP record via goodbye in a packet with no other relevant records", async () => {
+            await using site = new MockSite();
+            const { client, server } = await site.addPair();
+
+            const qname = qnameOf(1);
+
+            client.configureNames({
+                filter: record =>
+                    record.name === MOCK_SERVICE_DOMAIN || record.name.endsWith(`.${MOCK_SERVICE_DOMAIN}`),
+            });
+
+            // Packet 1: PTR + A — A gets staged because the packet carries a filter-matching PTR
+            await server.mdns.send({
+                messageType: DnsMessageType.Response,
+                answers: [
+                    {
+                        name: MOCK_SERVICE_DOMAIN,
+                        recordType: DnsRecordType.PTR,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: qname,
+                    },
+                    {
+                        name: server.hostname,
+                        recordType: DnsRecordType.A,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: "10.10.10.145",
+                    },
+                ],
+                additionalRecords: [],
+            });
+            await MockTime.advance(10);
+
+            // Hostname not yet a real DnssdName — record is in the staging cache only
+            expect(client.names.has(server.hostname)).false;
+
+            // Packet 2: goodbye for the staged record, no other records
+            await server.mdns.send({
+                messageType: DnsMessageType.Response,
+                answers: [
+                    {
+                        name: server.hostname,
+                        recordType: DnsRecordType.A,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: 0,
+                        value: "10.10.10.145",
+                    },
+                ],
+                additionalRecords: [],
+            });
+            await MockTime.advance(10);
+
+            // Packet 3: SRV creates the hostname — staged record (if any) replays
+            await server.mdns.send({
+                messageType: DnsMessageType.Response,
+                answers: [
+                    {
+                        name: qname,
+                        recordType: DnsRecordType.SRV,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: { port: 1234, priority: 10, weight: 1, target: server.hostname },
+                    },
+                ],
+                additionalRecords: [],
+            });
+            await MockTime.advance(10);
+
+            const host = client.names.get(server.hostname);
+            const ips = [...host.records].filter(
+                r => r.recordType === DnsRecordType.A || r.recordType === DnsRecordType.AAAA,
+            );
+            expect(ips.length).equals(0);
+        });
+
         it("discards staged IP records after their TTL expires", async () => {
             await using site = new MockSite();
             const { client, server } = await site.addPair();

--- a/packages/protocol/src/common/Scanner.ts
+++ b/packages/protocol/src/common/Scanner.ts
@@ -58,7 +58,7 @@ export type DiscoveryData = {
     ICD?: number;
 };
 
-export function DiscoveryData(kvs: Map<string, string>) {
+export function DiscoveryData(kvs: ReadonlyMap<string, string>) {
     const dd: DiscoveryData = {};
 
     for (const key of kvs.keys()) {


### PR DESCRIPTION
## Summary

Three independent fixes in `DnssdNames` / `DnssdName` that surface together as commissioning failures (matterjs-server#524) and stale TXT data.

- **`fix(mdns): run dependency pass even when filter accepts nothing`** — `#processMessage`'s iterative dependency pass had a `while` guard that compared `filteredBeforePass = records.length` against `filtered.size` (also `records.length`), so the body never ran when the filter pass deleted nothing. A solicited A/AAAA-only response for an already-known SRV target hostname was therefore dropped wholesale. `IpService.addresses` stayed empty, `CommissionableMdnsScanner` never delivered the device, and `avahi-browse` would show the AAAA while matter.js logged `hasAddresses: false`. Convert to `do/while`.
- **`refactor(mdns): honour staged-record goodbyes outside the relevance gate`** — TTL=0 eviction for staged A/AAAA lived inside `if (packetRelevant)`. A goodbye for a staged hostname arriving in a packet without any other matter records was silently ignored, leaving the stale entry to be replayed on the next SRV. Split goodbye-evict from staging-add and run eviction unconditionally; it only touches hostnames already in `#stagedIpRecords`, so it can't poison anything new. Also drops a redundant inline comment.
- **`fix(mdns): clear stale TXT parameters when a record is removed or replaced`** — `DnssdName.parameters` was populated eagerly in `installRecord` and never cleaned up on TXT removal. After a TXT goodbye or a replacement TXT that omits a key, downstream consumers kept seeing the old values. Make `parameters` a derived view recomputed lazily from the current TXT records, invalidate on every TXT install/delete, tighten the getter (and `DiscoveryData`'s arg) to `ReadonlyMap<string, string>`. Also fixes a latent in-place mutation in `keyOf` (`record.value.sort()` reordered the wire array).

related to https://github.com/matter-js/matterjs-server/issues/524

🤖 Generated with [Claude Code](https://claude
.com/claude-code)