### PR TITLE
fix(types): populate reverse mapping in cluster enum runtime objects

### DIFF
--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -44,6 +44,7 @@ import {
     DiscoveryData,
     Fabric,
     FabricGroups,
+    FabricLabelConflictError,
     NodeSession,
     PeerSet,
     SecureSession,
@@ -56,10 +57,12 @@ import {
     FabricId,
     FabricIndex,
     NodeId,
+    StatusResponseError,
     TypeFromPartialBitSchema,
     VendorId,
 } from "@matter/types";
 import { BasicInformation } from "@matter/types/clusters/basic-information";
+import { OperationalCredentials } from "@matter/types/clusters/operational-credentials";
 import { CommissioningControllerNodeOptions, NodeStates, PairedNode } from "./device/PairedNode.js";
 import { MatterController, PairedNodeDetails } from "./MatterController.js";
 
@@ -908,10 +911,20 @@ export class CommissioningController {
                 this.fabric.addressOf(nodeId),
                 `Fabric label "${fabric.label}" does not match requested admin fabric Label "${label}". Updating...`,
             );
-            await node.node.commandsOf(OperationalCredentialsClient).updateFabricLabel({
-                label,
-                fabricIndex: fabric.fabricIndex,
-            });
+            try {
+                await node.node.commandsOf(OperationalCredentialsClient).updateFabricLabel({
+                    label,
+                    fabricIndex: fabric.fabricIndex,
+                });
+            } catch (error) {
+                const sre = StatusResponseError.of(error);
+                if (sre?.clusterCode === OperationalCredentials.NodeOperationalCertStatus.LabelConflict) {
+                    throw new FabricLabelConflictError(
+                        `Cannot set fabric label to "${label}" because another fabric on this device already uses this name. Please adjust fabric labels to be unique.`,
+                    );
+                }
+                throw error;
+            }
         }
     }
 

--- a/packages/protocol/src/peer/ControllerCommissioningFlow.ts
+++ b/packages/protocol/src/peer/ControllerCommissioningFlow.ts
@@ -593,11 +593,14 @@ export class ControllerCommissioningFlow {
                 throw new MaximumCommissionedFabricsReachedError(
                     `Commission error: This device reached the maximum number of fabrics it can be part of. Please remove a fabric before trying to add another one.`,
                 );
-            } else if (statusCode === OperationalCredentials.NodeOperationalCertStatus.LabelConflict) {
-                throw new FabricLabelConflictError(
-                    `Commission error: This device is already commissioned with a fabric with the same label. Please choose a different label.`,
-                );
             }
+        } else if (
+            context === "updateFabricLabel" &&
+            statusCode === OperationalCredentials.NodeOperationalCertStatus.LabelConflict
+        ) {
+            throw new FabricLabelConflictError(
+                `Cannot set fabric label to "${this.fabric.label}" because another fabric on this device already uses this name. Please adjust fabric labels to be unique.`,
+            );
         }
         throw new CommissioningError(
             `Commission error for "${context}": ${OperationalCredentials.NodeOperationalCertStatus[statusCode]} (${statusCode}), ${debugText}${
@@ -1254,7 +1257,6 @@ export class ControllerCommissioningFlow {
                 }),
             );
         } catch (error) {
-            // convert error
             throw repackErrorAs(error, RecoverableCommissioningError);
         }
 

--- a/packages/types/src/cluster/EnumForValueModel.ts
+++ b/packages/types/src/cluster/EnumForValueModel.ts
@@ -6,7 +6,12 @@
 
 import { Schema, ValueModel } from "@matter/model";
 
-const cache = new WeakMap<ValueModel, Record<string, string | number>>();
+/**
+ * Runtime shape of a TypeScript numeric enum: name→number forward lookup, number→name reverse lookup.
+ */
+export type EnumLikeObject = { [k: string]: number } & { [k: number]: string };
+
+const cache = new WeakMap<ValueModel, EnumLikeObject>();
 
 /**
  * Create a frozen enum object with the runtime shape of a TypeScript numeric enum (forward and reverse mapping).
@@ -15,13 +20,13 @@ const cache = new WeakMap<ValueModel, Record<string, string | number>>();
  *
  * Results are cached per model instance.
  */
-export function EnumForValueModel(model: ValueModel): Record<string, string | number> {
+export function EnumForValueModel(model: ValueModel): EnumLikeObject {
     let result = cache.get(model);
     if (result !== undefined) {
         return result;
     }
 
-    const values: Record<string, string | number> = {};
+    const values: Record<string | number, string | number> = {};
     for (const child of model.children) {
         if (typeof child.id === "number") {
             values[child.name] = child.id;
@@ -29,7 +34,7 @@ export function EnumForValueModel(model: ValueModel): Record<string, string | nu
         }
     }
 
-    result = Object.freeze(values);
+    result = Object.freeze(values) as EnumLikeObject;
     Schema.set(result, model);
 
     cache.set(model, result);

--- a/packages/types/src/cluster/EnumForValueModel.ts
+++ b/packages/types/src/cluster/EnumForValueModel.ts
@@ -6,26 +6,26 @@
 
 import { Schema, ValueModel } from "@matter/model";
 
-const cache = new WeakMap<ValueModel, Record<string, number>>();
+const cache = new WeakMap<ValueModel, Record<string, string | number>>();
 
 /**
- * Create a frozen enum object for an enum value model.
+ * Create a frozen enum object with the runtime shape of a TypeScript numeric enum (forward and reverse mapping).
  *
- * The returned object maps enum member names to their numeric IDs.  Schema is associated via {@link Schema.set} so it
- * can be resolved by `@field` decorators.
+ * Schema is associated via {@link Schema.set} so it can be resolved by `@field` decorators.
  *
  * Results are cached per model instance.
  */
-export function EnumForValueModel(model: ValueModel): Record<string, number> {
+export function EnumForValueModel(model: ValueModel): Record<string, string | number> {
     let result = cache.get(model);
     if (result !== undefined) {
         return result;
     }
 
-    const values: Record<string, number> = {};
+    const values: Record<string, string | number> = {};
     for (const child of model.children) {
         if (typeof child.id === "number") {
             values[child.name] = child.id;
+            values[child.id] = child.name;
         }
     }
 

--- a/packages/types/src/common/StatusResponseError.ts
+++ b/packages/types/src/common/StatusResponseError.ts
@@ -25,7 +25,7 @@ export class StatusResponseError extends MatterError {
         return this.message.replace(/ \(code .+\)$/, "");
     }
 
-    static is(error: unknown, ...codes: Status[]) {
+    static is(error: unknown, ...codes: Status[]): error is StatusResponseError {
         const sre = StatusResponseError.of(error);
         return !!sre && (!codes.length || codes.includes(sre.code));
     }

--- a/packages/types/src/common/StatusResponseError.ts
+++ b/packages/types/src/common/StatusResponseError.ts
@@ -25,7 +25,7 @@ export class StatusResponseError extends MatterError {
         return this.message.replace(/ \(code .+\)$/, "");
     }
 
-    static is(error: unknown, ...codes: Status[]): error is StatusResponseError {
+    static is(error: unknown, ...codes: Status[]) {
         const sre = StatusResponseError.of(error);
         return !!sre && (!codes.length || codes.includes(sre.code));
     }

--- a/packages/types/test/cluster/EnumForValueModelTest.ts
+++ b/packages/types/test/cluster/EnumForValueModelTest.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { OperationalCredentials } from "#clusters/operational-credentials.js";
+
+describe("EnumForValueModel runtime shape", () => {
+    it("exposes forward name→value mapping like a TS numeric enum", () => {
+        expect(OperationalCredentials.NodeOperationalCertStatus.Ok).equal(0);
+        expect(OperationalCredentials.NodeOperationalCertStatus.LabelConflict).equal(10);
+        expect(OperationalCredentials.NodeOperationalCertStatus.InvalidFabricIndex).equal(11);
+    });
+
+    it("exposes reverse value→name mapping like a TS numeric enum", () => {
+        expect(OperationalCredentials.NodeOperationalCertStatus[0]).equal("Ok");
+        expect(OperationalCredentials.NodeOperationalCertStatus[10]).equal("LabelConflict");
+        expect(OperationalCredentials.NodeOperationalCertStatus[11]).equal("InvalidFabricIndex");
+    });
+
+    it("returns undefined for unknown values", () => {
+        expect(OperationalCredentials.NodeOperationalCertStatus[999]).equal(undefined);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes [matterjs-server#581](https://github.com/matter-js/matterjs-server/issues/581) — commissioning logs surfaced `Commission error for "updateFabricLabel": undefined (10), undefined` instead of a useful name like `LabelConflict`.

Root cause: cluster `.d.ts` files declare cluster enums (e.g. `OperationalCredentials.NodeOperationalCertStatus`) as TypeScript numeric enums, which would carry value→name reverse mapping at runtime. The matter.js runtime equivalent built by `EnumForValueModel` only populated forward (name→value) entries, so `Cluster.SomeEnum[10]` returned `undefined` everywhere a status code was logged or reverse-resolved.

## Changes

- **`packages/types/src/cluster/EnumForValueModel.ts`** — populate the reverse `id → name` entry alongside the forward one so the runtime shape matches a TS numeric enum. Return type is the new `EnumLikeObject = { [k: string]: number } & { [k: number]: string }`, preserving `number` for forward name lookups and typing reverse number lookups as `string`. All 20+ existing reverse-lookup call sites (status logs, BDX errors, OTA, etc.) now produce real names.
- **`packages/types/test/cluster/EnumForValueModelTest.ts`** — new tests covering forward, reverse, and unknown-key lookups against `OperationalCredentials.NodeOperationalCertStatus` to lock in the runtime enum shape.
- **`packages/protocol/src/peer/ControllerCommissioningFlow.ts`**
  - Drop the unreachable `LabelConflict` branch from the `addNoc` block — AddNoc takes no `Label` argument and cannot return this status per Matter spec; only `UpdateFabricLabel` can.
  - Add a matching branch for `context === "updateFabricLabel"` that throws `FabricLabelConflictError` with a descriptive message naming the conflicting label.
- **`packages/matter.js/src/CommissioningController.ts`** — `validateAndUpdateFabricLabel` now detects `LabelConflict` via `StatusResponseError.of(error)?.clusterCode` and rethrows `FabricLabelConflictError` with the same wording, so the post-commission label-update path produces the same actionable error as the commissioning-time path.

`StatusResponseError.is()` semantics are unchanged. (An earlier commit added a `error is StatusResponseError` type predicate, but it was reverted in f2c2317 because the body uses `of()` which matches the cause chain — narrowing `error` itself would lie when the SRE only sits in `error.cause`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)