### PR TITLE
fix(general): close env services before removing them

### DIFF
--- a/packages/general/src/environment/Environment.ts
+++ b/packages/general/src/environment/Environment.ts
@@ -191,18 +191,21 @@ export class Environment implements ServiceProvider, Lifetime.Owner {
     close<T extends object>(
         type: Environmental.ServiceType<T>,
     ): T extends { close: () => MaybePromise<void> } ? MaybePromise<void> : void {
-        const instance = this.maybeGet(type);
-        this.delete(type, instance);
-        if (instance !== undefined) {
-            if (this.get(SharedServicesManager).has(type)) {
-                // still in use
-                return;
-            }
+        type Result = T extends { close: () => MaybePromise<void> } ? MaybePromise<void> : void;
 
-            return (instance as Partial<Destructable>).close?.() as T extends { close: () => MaybePromise<void> }
-                ? MaybePromise<void>
-                : void;
+        const instance = this.maybeGet(type);
+        if (instance === undefined || this.get(SharedServicesManager).has(type)) {
+            // No instance to close, or shared service still in use — just block local inheritance.
+            this.delete(type, instance);
+            return undefined as Result;
         }
+
+        // Close before deleting so close-time env.get(type) still resolves; finally guarantees cleanup
+        // even if close rejects.
+        return MaybePromise.finally(
+            () => (instance as Partial<Destructable>).close?.(),
+            () => this.delete(type, instance),
+        ) as MaybePromise<void> as Result;
     }
 
     /**

--- a/packages/general/src/environment/Environment.ts
+++ b/packages/general/src/environment/Environment.ts
@@ -194,9 +194,15 @@ export class Environment implements ServiceProvider, Lifetime.Owner {
         type Result = T extends { close: () => MaybePromise<void> } ? MaybePromise<void> : void;
 
         const instance = this.maybeGet(type);
-        if (instance === undefined || this.get(SharedServicesManager).has(type)) {
-            // No instance to close, or shared service still in use — just block local inheritance.
+
+        // No instance to close — still null the local slot to block future inheritance from parent.
+        if (instance === undefined) {
             this.delete(type, instance);
+            return undefined as Result;
+        }
+
+        // Shared service still in use elsewhere; do not close or remove it here.
+        if (this.get(SharedServicesManager).has(type)) {
             return undefined as Result;
         }
 

--- a/packages/general/test/environment/EnvironmentTest.ts
+++ b/packages/general/test/environment/EnvironmentTest.ts
@@ -100,6 +100,92 @@ describe("Environment", () => {
         });
     });
 
+    describe("close() ordering", () => {
+        it("keeps service resolvable inside its own sync close", () => {
+            let resolvedDuringClose: SelfRefService | undefined;
+
+            class SelfRefService {
+                static [Environmental.create](environment: Environment) {
+                    return environment.get(SelfRefService);
+                }
+                constructor(public env: Environment) {}
+                close() {
+                    resolvedDuringClose = this.env.get(SelfRefService);
+                }
+            }
+
+            const svc = new SelfRefService(env);
+            env.set(SelfRefService, svc);
+
+            env.close(SelfRefService);
+
+            expect(resolvedDuringClose).to.equal(svc);
+            expect(env.has(SelfRefService)).to.be.false;
+        });
+
+        it("keeps service resolvable inside its own async close", async () => {
+            let resolvedDuringClose: AsyncSelfRefService | undefined;
+
+            class AsyncSelfRefService {
+                static [Environmental.create](environment: Environment) {
+                    return environment.get(AsyncSelfRefService);
+                }
+                constructor(public env: Environment) {}
+                async close() {
+                    await Promise.resolve();
+                    resolvedDuringClose = this.env.get(AsyncSelfRefService);
+                }
+            }
+
+            const svc = new AsyncSelfRefService(env);
+            env.set(AsyncSelfRefService, svc);
+
+            await env.close(AsyncSelfRefService);
+
+            expect(resolvedDuringClose).to.equal(svc);
+            expect(env.has(AsyncSelfRefService)).to.be.false;
+        });
+
+        it("removes service from env even when sync close throws", () => {
+            class ThrowingService {
+                static [Environmental.create](environment: Environment) {
+                    return environment.get(ThrowingService);
+                }
+                close() {
+                    throw new Error("close failed");
+                }
+            }
+
+            env.set(ThrowingService, new ThrowingService());
+
+            expect(() => env.close(ThrowingService)).to.throw("close failed");
+            expect(env.has(ThrowingService)).to.be.false;
+        });
+
+        it("removes service from env even when async close rejects", async () => {
+            class RejectingService {
+                static [Environmental.create](environment: Environment) {
+                    return environment.get(RejectingService);
+                }
+                async close() {
+                    throw new Error("close rejected");
+                }
+            }
+
+            env.set(RejectingService, new RejectingService());
+
+            let error: Error | undefined;
+            try {
+                await env.close(RejectingService);
+            } catch (e) {
+                error = e as Error;
+            }
+
+            expect(error?.message).to.equal("close rejected");
+            expect(env.has(RejectingService)).to.be.false;
+        });
+    });
+
     describe("dependent tracking", () => {
         let dependent1: SharedEnvironmentServices;
         let dependent2: SharedEnvironmentServices;


### PR DESCRIPTION
## Summary
- `Environment.close` removed the service from the env synchronously and only then awaited `close()`. Close-time consumers transitively resolving the service via `env.get()` failed with `[unsupported-dependency]`.
- Observed during shutdown: WAL final snapshot reaches `ClientNode.toString → store → env.get(ServerNodeStore)` during `ServerNodeStore.close`, raising `WARN WalStorageDriver Snapshot failed: Required dependency ServerNodeStore is not available`.
- Fix: close-then-delete via `MaybePromise.finally` so the service stays resolvable while `close()` runs and the local slot is cleared regardless of sync throw or async rejection. Matches the existing JSDoc on `Environment.close`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)