### PR TITLE
fix(ble): silence noble disconnect-race rejections during unsubscribe

### DIFF
--- a/packages/nodejs-ble/src/NobleBleChannel.ts
+++ b/packages/nodejs-ble/src/NobleBleChannel.ts
@@ -502,9 +502,13 @@ export class NobleBleChannel extends BleChannel<Bytes> {
         const btpHandshakeTimeout = Time.getTimer("BLE handshake timeout", MatterBle.BTP_CONN_RSP_TIMEOUT, async () => {
             characteristicC2ForSubscribe.removeListener("data", handshakeHandler);
 
-            await characteristicC2ForSubscribe
-                .unsubscribeAsync()
-                .catch(error => logger.error(`Peripheral ${peripheralAddress}: Error while unsubscribing`, error));
+            if (peripheral.state === "connected") {
+                await characteristicC2ForSubscribe.unsubscribeAsync().catch(error => {
+                    if (!isNobleDisconnectError(error)) {
+                        logger.error(`Peripheral ${peripheralAddress}: Error while unsubscribing`, error);
+                    }
+                });
+            }
 
             logger.debug(
                 `Peripheral ${peripheralAddress}: Handshake Response not received. Disconnect from peripheral`,
@@ -560,14 +564,13 @@ export class NobleBleChannel extends BleChannel<Bytes> {
             async () => {
                 if (peripheral.state !== "connected" || !nobleChannel.connected) return;
                 logger.debug(`Peripheral ${peripheralAddress}: Disconnect from peripheral because btp session closed`);
-                // Unsubscribe from C2 notifications, then disconnect.  If unsubscribe fails (e.g. the
-                // peripheral already started disconnecting and Noble's _withDisconnectHandler rejected the
-                // pending operation with "Disconnected unknown"), proceed to disconnectAsync anyway.
                 characteristicC2ForSubscribe
                     .unsubscribeAsync()
-                    .catch(error =>
-                        logger.debug(`Peripheral ${peripheralAddress}: Error while unsubscribing from C2`, error),
-                    )
+                    .catch(error => {
+                        if (!isNobleDisconnectError(error)) {
+                            logger.debug(`Peripheral ${peripheralAddress}: Error while unsubscribing from C2`, error);
+                        }
+                    })
                     .then(() => {
                         if (peripheral.state !== "connected") {
                             return;
@@ -663,11 +666,11 @@ export class NobleBleChannel extends BleChannel<Bytes> {
         this.#cleanupDataListener();
         await this.btpSession.close();
         if (this.connected) {
-            this.peripheral
-                .disconnectAsync()
-                .catch(error =>
-                    logger.error(`Peripheral ${this.peripheral.address}: Error while disconnecting`, error),
-                );
+            this.peripheral.disconnectAsync().catch(error => {
+                if (!isNobleDisconnectError(error)) {
+                    logger.error(`Peripheral ${this.peripheral.address}: Error while disconnecting`, error);
+                }
+            });
         }
         this.emitClosed();
     }


### PR DESCRIPTION
## Summary
- When the BLE peripheral disconnects while a C2 `unsubscribeAsync` or final `disconnectAsync` call is in flight, noble rejects the pending operation with `Disconnected <N>`. Previously this surfaced as a real error log even though it is the expected outcome of a normal disconnect race.
- The handshake-timeout path now also gates the unsubscribe on `peripheral.state === "connected"` so we skip the call entirely when the peripheral is already gone, and uses the existing `isNobleDisconnectError` helper to silently swallow race-rejections. The BTP-close-callback unsubscribe and `close()` disconnect catch get the same filter for consistency.
- Genuine non-disconnect errors still surface (error level for handshake/close, debug for BTP-close path) so real failures remain diagnosable.

## Test plan
- [x] `npm run build -w @matter/nodejs-ble`
- [x] `npm run format-verify`
- [ ] Manual: commission a BLE device and confirm the `Error while unsubscribing from C2 Disconnected 22` line no longer appears in the post-commissioning teardown logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)