### PR TITLE
fix(general): decode TXT records as raw bytes per RFC 6763 §6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/general
     - Breaking: Blob/File-related storage methods were removed from the normal Storage implementation
+    - Breaking: `DnsCodec.decodeTxtRecord`/`encodeTxtRecord` and the `TxtRecord` factory now operate on `Bytes[]` per RFC 6763 §6 so binary TXT values (e.g. Thread MeshCoP `xa`, `xp`, `at`, `pt`, `sb`, `dd`) survive encode/decode losslessly; `encodeTxtRecord` and `TxtRecord` accept `(Bytes | string)[]` so ASCII-only senders are unchanged
     - Feature: Added a new `wal`-based storage engine (not yet the default) to optimize persistence
+    - Feature: `DnssdName.parameters` and `IpService.parameters` now return a `DnssdParameters` instance — a `ReadonlyMap<string, string>` plus a `.raw(key): Bytes` accessor for binary TXT consumers (e.g. Thread Border Router enrichment)
     - Enhancement: Added locking to storage implementations to prevent concurrent access issues and data corruption
     - Enhancement: Split out Blob-Storage into its own `dir`-based BlobStorage implementation
     - Enhancement: Added Storage Migration logic that can generically migrate between different storage engines

--- a/packages/general/src/codec/DnsCodec.ts
+++ b/packages/general/src/codec/DnsCodec.ts
@@ -448,7 +448,15 @@ export class DnsCodec {
     static encodeTxtRecord(entries: (Bytes | string)[]) {
         const writer = new DataWriter();
         entries.forEach(entry => {
-            const bytes = typeof entry === "string" ? Bytes.fromString(entry) : Bytes.of(entry);
+            let bytes = typeof entry === "string" ? Bytes.fromString(entry) : Bytes.of(entry);
+            if (bytes.byteLength > 0xff) {
+                // RFC 6763 §6.1: TXT entries are length-prefixed by a single octet — silently wrapping the length
+                // byte produces garbage on the wire, so warn loudly and truncate to the spec limit.
+                logger.warn(
+                    `TXT record entry length ${bytes.byteLength} exceeds the RFC 6763 §6.1 limit of 255 bytes; truncating.`,
+                );
+                bytes = Bytes.of(bytes).subarray(0, 0xff);
+            }
             writer.writeUInt8(bytes.byteLength);
             writer.writeByteArray(bytes);
         });

--- a/packages/general/src/codec/DnsCodec.ts
+++ b/packages/general/src/codec/DnsCodec.ts
@@ -61,12 +61,12 @@ export const AAAARecord = (
 });
 export const TxtRecord = (
     name: string,
-    entries: string[],
+    entries: (Bytes | string)[],
     ttl = DEFAULT_MDNS_TTL,
     flushCache = false,
-): DnsRecord<string[]> => ({
+): DnsRecord<Bytes[]> => ({
     name,
-    value: entries,
+    value: entries.map(e => (typeof e === "string" ? Bytes.fromString(e) : Bytes.of(e))),
     ttl,
     recordType: DnsRecordType.TXT,
     recordClass: DnsRecordClass.IN,
@@ -312,13 +312,14 @@ export class DnsCodec {
         return { priority, weight, port, target };
     }
 
-    static decodeTxtRecord(valueBytes: Bytes): string[] {
+    static decodeTxtRecord(valueBytes: Bytes): Bytes[] {
         const reader = new DataReader(valueBytes);
-        const result = new Array<string>();
+        const result = new Array<Bytes>();
         let bytesRead = 0;
         while (bytesRead < valueBytes.byteLength) {
             const length = reader.readUInt8();
-            result.push(reader.readUtf8String(length));
+            // readByteArray returns a view; copy so retained entries don't alias the source buffer.
+            result.push(reader.readByteArray(length).slice());
             bytesRead += length + 1;
         }
         return result;
@@ -410,7 +411,7 @@ export class DnsCodec {
             case DnsRecordType.SRV:
                 return this.encodeSrvRecord(value as SrvRecordValue);
             case DnsRecordType.TXT:
-                return this.encodeTxtRecord(value as string[]);
+                return this.encodeTxtRecord(value as (Bytes | string)[]);
             case DnsRecordType.AAAA:
                 return this.encodeAaaaRecord(value as string);
             case DnsRecordType.A:
@@ -431,12 +432,12 @@ export class DnsCodec {
         return ipv6ToBytes(ip);
     }
 
-    static encodeTxtRecord(entries: string[]) {
+    static encodeTxtRecord(entries: (Bytes | string)[]) {
         const writer = new DataWriter();
         entries.forEach(entry => {
-            const entryData = Bytes.fromString(entry);
-            writer.writeUInt8(entryData.byteLength);
-            writer.writeByteArray(entryData);
+            const bytes = typeof entry === "string" ? Bytes.fromString(entry) : Bytes.of(entry);
+            writer.writeUInt8(bytes.byteLength);
+            writer.writeByteArray(bytes);
         });
         return writer.toByteArray();
     }

--- a/packages/general/src/codec/DnsCodec.ts
+++ b/packages/general/src/codec/DnsCodec.ts
@@ -59,6 +59,13 @@ export const AAAARecord = (
     recordClass: DnsRecordClass.IN,
     flushCache,
 });
+
+/**
+ * Build a TXT {@link DnsRecord} (RFC 6763 §6).
+ *
+ * Accepts `(Bytes | string)[]` for ergonomic ASCII senders; entries are normalized to {@link Bytes} before storage so
+ * downstream consumers always see the spec-correct binary shape.
+ */
 export const TxtRecord = (
     name: string,
     entries: (Bytes | string)[],
@@ -432,6 +439,12 @@ export class DnsCodec {
         return ipv6ToBytes(ip);
     }
 
+    /**
+     * Encode TXT record entries (RFC 6763 §6).
+     *
+     * Accepts `(Bytes | string)[]` for ergonomic ASCII senders; the `string` arm exists to spare callers a per-entry
+     * `Bytes.fromString` wrap.
+     */
     static encodeTxtRecord(entries: (Bytes | string)[]) {
         const writer = new DataWriter();
         entries.forEach(entry => {

--- a/packages/general/src/net/dns-sd/DnssdName.ts
+++ b/packages/general/src/net/dns-sd/DnssdName.ts
@@ -71,11 +71,17 @@ export class DnssdName extends BasicObservable<[changes: DnssdName.Changes], May
     get parameters(): DnssdParameters {
         if (this.#parameters === undefined) {
             const raw = new Map<string, Bytes>();
+            // Process newest TXT records first so an updated record's keys win over the not-yet-expired older copy;
+            // first-wins (RFC 6763 §6.4) then applies to entries within each record in their wire order.
+            const txtRecords = new Array<DnssdName.TextRecord>();
             for (const record of this.#records.values()) {
-                if (record.recordType !== DnsRecordType.TXT) {
-                    continue;
+                if (record.recordType === DnsRecordType.TXT) {
+                    txtRecords.push(record);
                 }
-                for (const entry of record.value as Bytes[]) {
+            }
+            txtRecords.sort((a, b) => b.installedAt - a.installedAt);
+            for (const record of txtRecords) {
+                for (const entry of record.value) {
                     const bytes = Bytes.of(entry);
                     // RFC 6763 §6.5: ignore zero-length entry.
                     if (bytes.byteLength === 0) {

--- a/packages/general/src/net/dns-sd/DnssdName.ts
+++ b/packages/general/src/net/dns-sd/DnssdName.ts
@@ -9,6 +9,7 @@ import { Logger } from "#log/Logger.js";
 import { Time } from "#time/Time.js";
 import type { Timestamp } from "#time/Timestamp.js";
 import { Millis } from "#time/TimeUnit.js";
+import { Bytes } from "#util/Bytes.js";
 import { AsyncObserver, BasicObservable } from "#util/Observable.js";
 import { MaybePromise } from "#util/Promises.js";
 import type { DnssdNames } from "./DnssdNames.js";
@@ -73,12 +74,17 @@ export class DnssdName extends BasicObservable<[changes: DnssdName.Changes], May
                 if (record.recordType !== DnsRecordType.TXT) {
                     continue;
                 }
-                for (const entry of record.value as string[]) {
-                    const pos = entry.indexOf("=");
-                    if (pos === -1) {
-                        parameters.set(entry, "");
+                for (const entry of record.value as Bytes[]) {
+                    const bytes = Bytes.of(entry);
+                    // 0x3D is '=' — RFC 6763 §6.4 splits each TXT entry on the first '=' byte; subsequent '=' bytes (e.g. base64 padding) belong to the value.
+                    const eqIndex = bytes.indexOf(0x3d);
+                    if (eqIndex === -1) {
+                        parameters.set(Bytes.toString(bytes), "");
                     } else {
-                        parameters.set(entry.slice(0, pos), entry.slice(pos + 1));
+                        parameters.set(
+                            Bytes.toString(bytes.subarray(0, eqIndex)),
+                            Bytes.toString(bytes.subarray(eqIndex + 1)),
+                        );
                     }
                 }
             }
@@ -259,8 +265,9 @@ function keyOf(record: DnsRecord): string | undefined {
 
         case DnsRecordType.TXT:
             if (Array.isArray(record.value)) {
-                // Spread before sort: keyOf must not mutate record.value (parameters recompute relies on wire order)
-                return `${record.recordType} ${[...record.value].sort().join(" ")}`;
+                const keys = (record.value as Bytes[]).map(entry => Bytes.toHex(entry));
+                keys.sort();
+                return `${record.recordType} ${keys.join(" ")}`;
             }
             break;
     }
@@ -307,7 +314,7 @@ export namespace DnssdName {
         recordType: DnsRecordType.SRV;
     }
 
-    export interface TextRecord extends DnsRecord<string[]>, Expiration {
+    export interface TextRecord extends DnsRecord<Bytes[]>, Expiration {
         recordType: DnsRecordType.TXT;
     }
 

--- a/packages/general/src/net/dns-sd/DnssdName.ts
+++ b/packages/general/src/net/dns-sd/DnssdName.ts
@@ -77,14 +77,18 @@ export class DnssdName extends BasicObservable<[changes: DnssdName.Changes], May
                 }
                 for (const entry of record.value as Bytes[]) {
                     const bytes = Bytes.of(entry);
-                    // RFC 6763 §6.5: receivers MUST silently ignore zero-length TXT entries.
+                    // RFC 6763 §6.5: ignore zero-length entry.
                     if (bytes.byteLength === 0) {
                         continue;
                     }
-                    // 0x3D is '=' — RFC 6763 §6.4 splits each TXT entry on the first '=' byte; subsequent '=' bytes (e.g. base64 padding) belong to the value.
+                    // 0x3D = '='. RFC 6763 §6.4: split on the first '=' (later '=' bytes, e.g. base64 padding, belong to the value).
                     const eqIndex = bytes.indexOf(0x3d);
+                    // RFC 6763 §6.4: ignore entry with empty key.
+                    if (eqIndex === 0) {
+                        continue;
+                    }
                     const key = eqIndex === -1 ? Bytes.toString(bytes) : Bytes.toString(bytes.subarray(0, eqIndex));
-                    // RFC 6763 §6.4: if the same key appears more than once, the first occurrence wins.
+                    // RFC 6763 §6.4: first occurrence wins on duplicates.
                     if (raw.has(key)) {
                         continue;
                     }

--- a/packages/general/src/net/dns-sd/DnssdName.ts
+++ b/packages/general/src/net/dns-sd/DnssdName.ts
@@ -13,6 +13,7 @@ import { Bytes } from "#util/Bytes.js";
 import { AsyncObserver, BasicObservable } from "#util/Observable.js";
 import { MaybePromise } from "#util/Promises.js";
 import type { DnssdNames } from "./DnssdNames.js";
+import { DnssdParameters } from "./DnssdParameters.js";
 
 const logger = Logger.get("DnssdName");
 
@@ -37,7 +38,7 @@ export class DnssdName extends BasicObservable<[changes: DnssdName.Changes], May
     #changes?: Map<string, { kind: "update" | "delete"; record: DnssdName.Record }>;
     #notified?: Promise<void>;
     #maybeDeleting?: Promise<void>;
-    #parameters?: Map<string, string>;
+    #parameters?: DnssdParameters;
     #dependencies?: Map<string, DnssdName>;
     #nullObserver?: () => void;
 
@@ -67,9 +68,9 @@ export class DnssdName extends BasicObservable<[changes: DnssdName.Changes], May
         return this.#records.values();
     }
 
-    get parameters(): ReadonlyMap<string, string> {
+    get parameters(): DnssdParameters {
         if (this.#parameters === undefined) {
-            const parameters = (this.#parameters = new Map<string, string>());
+            const raw = new Map<string, Bytes>();
             for (const record of this.#records.values()) {
                 if (record.recordType !== DnsRecordType.TXT) {
                     continue;
@@ -79,15 +80,13 @@ export class DnssdName extends BasicObservable<[changes: DnssdName.Changes], May
                     // 0x3D is '=' — RFC 6763 §6.4 splits each TXT entry on the first '=' byte; subsequent '=' bytes (e.g. base64 padding) belong to the value.
                     const eqIndex = bytes.indexOf(0x3d);
                     if (eqIndex === -1) {
-                        parameters.set(Bytes.toString(bytes), "");
+                        raw.set(Bytes.toString(bytes), new Uint8Array(0));
                     } else {
-                        parameters.set(
-                            Bytes.toString(bytes.subarray(0, eqIndex)),
-                            Bytes.toString(bytes.subarray(eqIndex + 1)),
-                        );
+                        raw.set(Bytes.toString(bytes.subarray(0, eqIndex)), bytes.subarray(eqIndex + 1));
                     }
                 }
             }
+            this.#parameters = new DnssdParameters(raw);
         }
         return this.#parameters;
     }

--- a/packages/general/src/net/dns-sd/DnssdName.ts
+++ b/packages/general/src/net/dns-sd/DnssdName.ts
@@ -77,13 +77,18 @@ export class DnssdName extends BasicObservable<[changes: DnssdName.Changes], May
                 }
                 for (const entry of record.value as Bytes[]) {
                     const bytes = Bytes.of(entry);
+                    // RFC 6763 §6.5: receivers MUST silently ignore zero-length TXT entries.
+                    if (bytes.byteLength === 0) {
+                        continue;
+                    }
                     // 0x3D is '=' — RFC 6763 §6.4 splits each TXT entry on the first '=' byte; subsequent '=' bytes (e.g. base64 padding) belong to the value.
                     const eqIndex = bytes.indexOf(0x3d);
-                    if (eqIndex === -1) {
-                        raw.set(Bytes.toString(bytes), new Uint8Array(0));
-                    } else {
-                        raw.set(Bytes.toString(bytes.subarray(0, eqIndex)), bytes.subarray(eqIndex + 1));
+                    const key = eqIndex === -1 ? Bytes.toString(bytes) : Bytes.toString(bytes.subarray(0, eqIndex));
+                    // RFC 6763 §6.4: if the same key appears more than once, the first occurrence wins.
+                    if (raw.has(key)) {
+                        continue;
                     }
+                    raw.set(key, eqIndex === -1 ? new Uint8Array(0) : bytes.subarray(eqIndex + 1));
                 }
             }
             this.#parameters = new DnssdParameters(raw);

--- a/packages/general/src/net/dns-sd/DnssdParameters.ts
+++ b/packages/general/src/net/dns-sd/DnssdParameters.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Bytes } from "#util/Bytes.js";
+
+/**
+ * Parsed key/value pairs from a DNS-SD service's TXT records.
+ *
+ * Implements {@link ReadonlyMap}<string, string> with UTF-8 decoded values. Use {@link raw} for the original byte
+ * sequence — required for binary TXT fields such as the Thread MeshCoP `xa`, `xp`, `at`, `pt`, `sb`, and `dd` keys
+ * (RFC 6763 §6 — TXT values are opaque binary data; non-UTF-8 bytes mojibake to U+FFFD via the string accessors).
+ */
+export class DnssdParameters implements ReadonlyMap<string, string> {
+    readonly #raw: ReadonlyMap<string, Bytes>;
+
+    constructor(raw: ReadonlyMap<string, Bytes>) {
+        this.#raw = raw;
+    }
+
+    get(key: string): string | undefined {
+        const v = this.#raw.get(key);
+        return v === undefined ? undefined : Bytes.toString(v);
+    }
+
+    /**
+     * The original bytes for {@link key}, or `undefined` if absent.
+     */
+    raw(key: string): Bytes | undefined {
+        return this.#raw.get(key);
+    }
+
+    has(key: string): boolean {
+        return this.#raw.has(key);
+    }
+
+    get size(): number {
+        return this.#raw.size;
+    }
+
+    keys(): MapIterator<string> {
+        return this.#raw.keys();
+    }
+
+    *values(): MapIterator<string> {
+        for (const v of this.#raw.values()) {
+            yield Bytes.toString(v);
+        }
+    }
+
+    *entries(): MapIterator<[string, string]> {
+        for (const [k, v] of this.#raw) {
+            yield [k, Bytes.toString(v)];
+        }
+    }
+
+    [Symbol.iterator](): MapIterator<[string, string]> {
+        return this.entries();
+    }
+
+    forEach(cb: (value: string, key: string, map: ReadonlyMap<string, string>) => void, thisArg?: unknown): void {
+        for (const [k, v] of this.entries()) {
+            cb.call(thisArg, v, k, this);
+        }
+    }
+}

--- a/packages/general/src/net/dns-sd/DnssdParameters.ts
+++ b/packages/general/src/net/dns-sd/DnssdParameters.ts
@@ -26,7 +26,7 @@ export class DnssdParameters implements ReadonlyMap<string, string> {
     }
 
     /**
-     * The original bytes for {@link key}, or `undefined` if absent.
+     * The original bytes for the given key, or `undefined` if absent.
      */
     raw(key: string): Bytes | undefined {
         return this.#raw.get(key);

--- a/packages/general/src/net/dns-sd/IpService.ts
+++ b/packages/general/src/net/dns-sd/IpService.ts
@@ -14,6 +14,7 @@ import { Abort } from "#util/Abort.js";
 import { AsyncObservable, AsyncObservableValue, ObserverGroup } from "#util/Observable.js";
 import { DnssdName } from "./DnssdName.js";
 import { DnssdNames } from "./DnssdNames.js";
+import { DnssdParameters } from "./DnssdParameters.js";
 import { IpServiceStatus } from "./IpServiceStatus.js";
 
 /**
@@ -95,7 +96,7 @@ export class IpService {
     /**
      * Values from TXT records.
      */
-    get parameters(): ReadonlyMap<string, string> {
+    get parameters(): DnssdParameters {
         return this.#name.parameters;
     }
 

--- a/packages/general/src/net/dns-sd/index.ts
+++ b/packages/general/src/net/dns-sd/index.ts
@@ -6,6 +6,7 @@
 
 export * from "./DnssdName.js";
 export * from "./DnssdNames.js";
+export * from "./DnssdParameters.js";
 export * from "./DnssdSolicitor.js";
 export * from "./IpService.js";
 export * from "./IpServiceResolution.js";

--- a/packages/general/src/util/Bytes.ts
+++ b/packages/general/src/util/Bytes.ts
@@ -77,7 +77,7 @@ export namespace Bytes {
         }
 
         if (ArrayBuffer.isView(source)) {
-            return new Uint8Array(source.buffer, source.byteLength, source.byteOffset);
+            return new Uint8Array(source.buffer, source.byteOffset, source.byteLength);
         }
 
         return new Uint8Array(source);

--- a/packages/general/test/codec/DnsCodecTest.ts
+++ b/packages/general/test/codec/DnsCodecTest.ts
@@ -294,6 +294,13 @@ describe("DnsCodec", () => {
             const reEncoded = DnsCodec.encodeTxtRecord(decoded);
             expect(Bytes.areEqual(reEncoded, wire)).to.equal(true);
         });
+
+        it("truncates entries longer than 255 bytes per RFC 6763 §6.1", () => {
+            const oversize = new Uint8Array(300).fill(0x41);
+            const wire = DnsCodec.encodeTxtRecord([oversize]);
+            expect(wire[0]).equal(0xff);
+            expect(wire.byteLength).equal(0xff + 1);
+        });
     });
 
     describe("encode and decode AAAA records", () => {

--- a/packages/general/test/codec/DnsCodecTest.ts
+++ b/packages/general/test/codec/DnsCodecTest.ts
@@ -16,7 +16,7 @@ import {
 } from "#codec/DnsCodec.js";
 import { Seconds } from "#time/TimeUnit.js";
 import { Bytes } from "#util/Bytes.js";
-import { DataReader } from "#util/index.js";
+import { DataReader, DataWriter } from "#util/index.js";
 
 const DNS_RESPONSE: DnsMessage = {
     transactionId: 0,
@@ -115,7 +115,7 @@ const DECODED_WITH_PRIVATE_TYPE = {
                 "RI=0900669ED4F3C8043FCD77A39EEBD96F672A",
                 "PH=36",
                 "PI=",
-            ],
+            ].map(Bytes.fromString),
         },
         {
             flushCache: false,
@@ -274,6 +274,26 @@ describe("DnsCodec", () => {
                 }
             });
         }
+    });
+
+    describe("encode and decode TXT records", () => {
+        it("round-trips a TXT entry containing high bytes losslessly", () => {
+            // xa = 0x5AAF359C0501A1B0 — real Apple HomePod border-router extended MAC
+            const rawXa = Bytes.fromHex("5aaf359c0501a1b0");
+            const entry = Bytes.concat(Bytes.fromString("xa="), rawXa);
+
+            const writer = new DataWriter();
+            writer.writeUInt8(entry.byteLength);
+            writer.writeByteArray(entry);
+            const wire = writer.toByteArray();
+
+            const decoded = DnsCodec.decodeTxtRecord(wire);
+            expect(decoded).to.have.length(1);
+            expect(Bytes.areEqual(decoded[0], entry)).to.equal(true);
+
+            const reEncoded = DnsCodec.encodeTxtRecord(decoded);
+            expect(Bytes.areEqual(reEncoded, wire)).to.equal(true);
+        });
     });
 
     describe("encode and decode AAAA records", () => {

--- a/packages/general/test/net/dns-sd/DnssdNamesTest.ts
+++ b/packages/general/test/net/dns-sd/DnssdNamesTest.ts
@@ -714,6 +714,55 @@ describe("DnssdNames", () => {
 
             expect([...client.names.get(qname).parameters]).deep.equals([["b", "3"]]);
         });
+
+        it("exposes binary TXT values via parameters.raw while preserving the string view for ASCII keys", async () => {
+            await using site = new MockSite();
+            const { client, server } = await site.addPair();
+
+            const qname = qnameOf(1);
+
+            const xaBytes = Bytes.fromHex("5aaf359c0501a1b0");
+
+            const discovered = new Promise<void>(resolve => {
+                client.names.discovered.once(() => resolve());
+            });
+            await server.mdns.send({
+                messageType: DnsMessageType.Response,
+                answers: [
+                    {
+                        name: MOCK_SERVICE_DOMAIN,
+                        recordType: DnsRecordType.PTR,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: qname,
+                    },
+                    {
+                        name: qname,
+                        recordType: DnsRecordType.SRV,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: { port: 1234, priority: 10, weight: 1, target: server.hostname },
+                    },
+                    {
+                        name: qname,
+                        recordType: DnsRecordType.TXT,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: [Bytes.fromString("SII=5000"), Bytes.concat(Bytes.fromString("xa="), xaBytes)],
+                    },
+                ],
+                additionalRecords: [],
+            });
+            await MockTime.resolve(discovered);
+
+            const parameters = client.names.get(qname).parameters;
+
+            const xa = parameters.raw("xa");
+            expect(xa).not.equal(undefined);
+            expect(Bytes.areEqual(xa!, xaBytes)).true;
+
+            expect(parameters.get("SII")).equal("5000");
+        });
     });
 
     describe("coalesced discovery", () => {

--- a/packages/general/test/net/dns-sd/DnssdNamesTest.ts
+++ b/packages/general/test/net/dns-sd/DnssdNamesTest.ts
@@ -763,6 +763,91 @@ describe("DnssdNames", () => {
 
             expect(parameters.get("SII")).equal("5000");
         });
+
+        it("first-wins on duplicate keys per RFC 6763 §6.4", async () => {
+            await using site = new MockSite();
+            const { client, server } = await site.addPair();
+
+            const qname = qnameOf(1);
+
+            const discovered = new Promise<void>(resolve => {
+                client.names.discovered.once(() => resolve());
+            });
+            await server.mdns.send({
+                messageType: DnsMessageType.Response,
+                answers: [
+                    {
+                        name: MOCK_SERVICE_DOMAIN,
+                        recordType: DnsRecordType.PTR,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: qname,
+                    },
+                    {
+                        name: qname,
+                        recordType: DnsRecordType.SRV,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: { port: 1234, priority: 10, weight: 1, target: server.hostname },
+                    },
+                    {
+                        name: qname,
+                        recordType: DnsRecordType.TXT,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: [Bytes.fromString("foo=first"), Bytes.fromString("foo=second")],
+                    },
+                ],
+                additionalRecords: [],
+            });
+            await MockTime.resolve(discovered);
+
+            expect(client.names.get(qname).parameters.get("foo")).equal("first");
+        });
+
+        it("ignores zero-length TXT entries per RFC 6763 §6.5", async () => {
+            await using site = new MockSite();
+            const { client, server } = await site.addPair();
+
+            const qname = qnameOf(1);
+
+            const discovered = new Promise<void>(resolve => {
+                client.names.discovered.once(() => resolve());
+            });
+            await server.mdns.send({
+                messageType: DnsMessageType.Response,
+                answers: [
+                    {
+                        name: MOCK_SERVICE_DOMAIN,
+                        recordType: DnsRecordType.PTR,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: qname,
+                    },
+                    {
+                        name: qname,
+                        recordType: DnsRecordType.SRV,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: { port: 1234, priority: 10, weight: 1, target: server.hostname },
+                    },
+                    {
+                        name: qname,
+                        recordType: DnsRecordType.TXT,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: [new Uint8Array(0), Bytes.fromString("real=value")],
+                    },
+                ],
+                additionalRecords: [],
+            });
+            await MockTime.resolve(discovered);
+
+            const parameters = client.names.get(qname).parameters;
+            expect(parameters.size).equal(1);
+            expect(parameters.has("")).false;
+            expect(parameters.get("real")).equal("value");
+        });
     });
 
     describe("coalesced discovery", () => {

--- a/packages/general/test/net/dns-sd/DnssdNamesTest.ts
+++ b/packages/general/test/net/dns-sd/DnssdNamesTest.ts
@@ -8,6 +8,7 @@ import { DnsMessageType, type DnsRecord, DnsRecordClass, DnsRecordType } from "#
 import { Hours, Millis, Minutes, Seconds } from "#index.js";
 import { Time } from "#time/Time.js";
 import { Abort } from "#util/Abort.js";
+import { Bytes } from "#util/Bytes.js";
 import { MOCK_SERVICE_DOMAIN, MockSite, qnameOf } from "./dns-sd-helpers.js";
 
 describe("DnssdNames", () => {
@@ -55,7 +56,7 @@ describe("DnssdNames", () => {
                 recordClass: 1,
                 recordType: 16,
                 ttl: 3600000,
-                value: ["foo=bar", "flag"],
+                value: ["foo=bar", "flag"].map(Bytes.fromString),
             },
         ]);
 

--- a/packages/general/test/net/dns-sd/DnssdNamesTest.ts
+++ b/packages/general/test/net/dns-sd/DnssdNamesTest.ts
@@ -805,6 +805,50 @@ describe("DnssdNames", () => {
             expect(client.names.get(qname).parameters.get("foo")).equal("first");
         });
 
+        it("ignores TXT entries with empty keys per RFC 6763 §6.4", async () => {
+            await using site = new MockSite();
+            const { client, server } = await site.addPair();
+
+            const qname = qnameOf(1);
+
+            const discovered = new Promise<void>(resolve => {
+                client.names.discovered.once(() => resolve());
+            });
+            await server.mdns.send({
+                messageType: DnsMessageType.Response,
+                answers: [
+                    {
+                        name: MOCK_SERVICE_DOMAIN,
+                        recordType: DnsRecordType.PTR,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: qname,
+                    },
+                    {
+                        name: qname,
+                        recordType: DnsRecordType.SRV,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: { port: 1234, priority: 10, weight: 1, target: server.hostname },
+                    },
+                    {
+                        name: qname,
+                        recordType: DnsRecordType.TXT,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: [Bytes.fromString("=value"), Bytes.fromString("="), Bytes.fromString("real=value")],
+                    },
+                ],
+                additionalRecords: [],
+            });
+            await MockTime.resolve(discovered);
+
+            const parameters = client.names.get(qname).parameters;
+            expect(parameters.size).equal(1);
+            expect(parameters.has("")).false;
+            expect(parameters.get("real")).equal("value");
+        });
+
         it("ignores zero-length TXT entries per RFC 6763 §6.5", async () => {
             await using site = new MockSite();
             const { client, server } = await site.addPair();
@@ -847,6 +891,51 @@ describe("DnssdNames", () => {
             expect(parameters.size).equal(1);
             expect(parameters.has("")).false;
             expect(parameters.get("real")).equal("value");
+        });
+
+        it("preserves empty-value TXT entries (key=) per RFC 6763 §6.4", async () => {
+            await using site = new MockSite();
+            const { client, server } = await site.addPair();
+
+            const qname = qnameOf(1);
+
+            const discovered = new Promise<void>(resolve => {
+                client.names.discovered.once(() => resolve());
+            });
+            await server.mdns.send({
+                messageType: DnsMessageType.Response,
+                answers: [
+                    {
+                        name: MOCK_SERVICE_DOMAIN,
+                        recordType: DnsRecordType.PTR,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: qname,
+                    },
+                    {
+                        name: qname,
+                        recordType: DnsRecordType.SRV,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: { port: 1234, priority: 10, weight: 1, target: server.hostname },
+                    },
+                    {
+                        name: qname,
+                        recordType: DnsRecordType.TXT,
+                        recordClass: DnsRecordClass.IN,
+                        ttl: Hours(1),
+                        value: [Bytes.fromString("yy="), Bytes.fromString("flag")],
+                    },
+                ],
+                additionalRecords: [],
+            });
+            await MockTime.resolve(discovered);
+
+            const parameters = client.names.get(qname).parameters;
+            expect(parameters.has("yy")).true;
+            expect(parameters.get("yy")).equal("");
+            expect(parameters.has("flag")).true;
+            expect(parameters.get("flag")).equal("");
         });
     });
 

--- a/packages/general/test/net/dns-sd/DnssdParametersTest.ts
+++ b/packages/general/test/net/dns-sd/DnssdParametersTest.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DnssdParameters } from "#net/dns-sd/DnssdParameters.js";
+import { Bytes } from "#util/Bytes.js";
+
+describe("DnssdParameters", () => {
+    const xaBytes = Bytes.fromHex("5aaf359c0501a1b0");
+
+    function fixture() {
+        return new DnssdParameters(
+            new Map<string, Bytes>([
+                ["SII", Bytes.fromString("5000")],
+                ["flag", new Uint8Array(0)],
+                ["xa", xaBytes],
+            ]),
+        );
+    }
+
+    describe("get", () => {
+        it("UTF-8 decodes ASCII values", () => {
+            expect(fixture().get("SII")).equal("5000");
+        });
+
+        it("returns empty string for empty values", () => {
+            expect(fixture().get("flag")).equal("");
+        });
+
+        it("returns undefined for missing keys", () => {
+            expect(fixture().get("missing")).equal(undefined);
+        });
+    });
+
+    describe("raw", () => {
+        it("returns the original bytes losslessly", () => {
+            const raw = fixture().raw("xa");
+            expect(raw).not.equal(undefined);
+            expect(Bytes.areEqual(raw!, xaBytes)).true;
+        });
+
+        it("returns undefined for missing keys", () => {
+            expect(fixture().raw("missing")).equal(undefined);
+        });
+    });
+
+    describe("has", () => {
+        it("reflects presence", () => {
+            const p = fixture();
+            expect(p.has("SII")).true;
+            expect(p.has("xa")).true;
+            expect(p.has("missing")).false;
+        });
+    });
+
+    describe("size", () => {
+        it("matches the underlying entry count", () => {
+            expect(fixture().size).equal(3);
+        });
+    });
+
+    describe("keys", () => {
+        it("yields all keys", () => {
+            expect([...fixture().keys()]).deep.equals(["SII", "flag", "xa"]);
+        });
+    });
+
+    describe("values", () => {
+        it("yields UTF-8 decoded strings", () => {
+            expect([...fixture().values()]).deep.equals(["5000", "", Bytes.toString(xaBytes)]);
+        });
+    });
+
+    describe("entries", () => {
+        it("yields [key, decoded-value] pairs", () => {
+            expect([...fixture().entries()]).deep.equals([
+                ["SII", "5000"],
+                ["flag", ""],
+                ["xa", Bytes.toString(xaBytes)],
+            ]);
+        });
+    });
+
+    describe("Symbol.iterator", () => {
+        it("yields the same shape as entries()", () => {
+            expect([...fixture()]).deep.equals([...fixture().entries()]);
+        });
+    });
+
+    describe("forEach", () => {
+        it("invokes callback with (value, key, map)", () => {
+            const seen = new Array<[string, string, ReadonlyMap<string, string>]>();
+            const p = fixture();
+            p.forEach((value, key, map) => seen.push([value, key, map]));
+            expect(seen).deep.equals([
+                ["5000", "SII", p],
+                ["", "flag", p],
+                [Bytes.toString(xaBytes), "xa", p],
+            ]);
+        });
+
+        it("honours thisArg", () => {
+            const ctx = { tag: "captured" };
+            const seen = new Array<string>();
+            fixture().forEach(function (this: typeof ctx) {
+                seen.push(this.tag);
+            }, ctx);
+            expect(seen).deep.equals(["captured", "captured", "captured"]);
+        });
+    });
+});

--- a/packages/general/test/util/BytesTest.ts
+++ b/packages/general/test/util/BytesTest.ts
@@ -90,4 +90,15 @@ describe("ByteArray", () => {
             expect(result).deep.equal(Uint8Array.of(0x12, 0x34));
         });
     });
+
+    describe("of", () => {
+        it("preserves byteOffset and byteLength of a non-Uint8Array view", () => {
+            const buffer = Uint8Array.of(0x01, 0x02, 0x03, 0x04, 0x05, 0x06).buffer;
+            const view = new DataView(buffer, 2, 3);
+
+            const result = Bytes.of(view);
+
+            expect(result).deep.equal(Uint8Array.of(0x03, 0x04, 0x05));
+        });
+    });
 });

--- a/packages/protocol/test/mdns/MdnsTest.ts
+++ b/packages/protocol/test/mdns/MdnsTest.ts
@@ -7,6 +7,7 @@
 import { Fabric } from "#fabric/Fabric.js";
 import { Advertisement, CommissioningMode, MdnsAdvertiser, MdnsServer, ServiceDescription } from "#index.js";
 import {
+    Bytes,
     ConnectionlessTransport,
     DnsCodec,
     DnsMessage,
@@ -926,17 +927,32 @@ function expectMessage(actual: DnsMessage | undefined, expected: DnsMessage) {
         if (!message) {
             continue;
         }
-        message.answers.sort((a, b) => a.name.localeCompare(b.name) || a.value.localeCompare(b.value));
+        message.answers.sort(
+            (a, b) => a.name.localeCompare(b.name) || sortKey(a.value).localeCompare(sortKey(b.value)),
+        );
         message.additionalRecords.sort(
-            (a, b) => a.name.localeCompare(b.name) || a.value.toString().localeCompare(b.value),
+            (a, b) => a.name.localeCompare(b.name) || sortKey(a.value).localeCompare(sortKey(b.value)),
         );
 
         message.additionalRecords.forEach(r => {
             if (r.recordType === DnsRecordType.TXT && Array.isArray(r.value)) {
-                r.value.sort();
+                r.value = (r.value as (Uint8Array | string)[])
+                    .map(b => Bytes.toString(b))
+                    .sort()
+                    .map(s => Bytes.fromString(s));
             }
         });
     }
 
     expect(actual).deep.equals(expected);
+}
+
+function sortKey(value: unknown): string {
+    if (Array.isArray(value)) {
+        return (value as (Uint8Array | string)[]).map(b => Bytes.toString(b)).join(",");
+    }
+    if (typeof value === "string") {
+        return value;
+    }
+    return String(value);
 }

--- a/packages/protocol/test/mdns/MdnsTest.ts
+++ b/packages/protocol/test/mdns/MdnsTest.ts
@@ -949,7 +949,9 @@ function expectMessage(actual: DnsMessage | undefined, expected: DnsMessage) {
 
 function sortKey(value: unknown): string {
     if (Array.isArray(value)) {
-        return (value as (Uint8Array | string)[]).map(b => Bytes.toString(b)).join(",");
+        return (value as (Uint8Array | string)[])
+            .map(entry => Bytes.toHex(typeof entry === "string" ? Bytes.fromString(entry) : entry))
+            .join(",");
     }
     if (typeof value === "string") {
         return value;

--- a/packages/protocol/test/mdns/MdnsTest.ts
+++ b/packages/protocol/test/mdns/MdnsTest.ts
@@ -936,10 +936,10 @@ function expectMessage(actual: DnsMessage | undefined, expected: DnsMessage) {
 
         message.additionalRecords.forEach(r => {
             if (r.recordType === DnsRecordType.TXT && Array.isArray(r.value)) {
+                // Fixtures may declare value as string[]; normalize to Bytes[] then sort by hex (lossless on binary).
                 r.value = (r.value as (Uint8Array | string)[])
-                    .map(b => Bytes.toString(b))
-                    .sort()
-                    .map(s => Bytes.fromString(s));
+                    .map(b => (typeof b === "string" ? Bytes.fromString(b) : b))
+                    .sort((a, b) => Bytes.toHex(a).localeCompare(Bytes.toHex(b)));
             }
         });
     }


### PR DESCRIPTION
## Summary

- **Codec layer (breaking):** `DnsCodec.decodeTxtRecord` now returns `Bytes[]` instead of UTF-8-decoded `string[]`, so binary TXT values (Thread MeshCoP `xa`, `xp`, `at`, `pt`, `sb`, `dd`) survive encode/decode losslessly per RFC 6763 §6. `encodeTxtRecord` and the `TxtRecord` factory accept `(Bytes | string)[]` for ergonomic ASCII senders.
- **Façade (additive):** `DnssdName.parameters` and `IpService.parameters` now return a `DnssdParameters` instance — implements `ReadonlyMap<string, string>` (zero-touch for existing consumers like `DiscoveryData`, `CommissionableMdnsScanner`, `Peer`) plus a new `.raw(key): Bytes` accessor for binary TXT consumers (driver: matterjs-server 406 Thread Border Router enrichment).
- **RFC 6763 conformance fixes:** `DnssdName.parameters` now first-wins on duplicate keys (§6.4), silently ignores zero-length entries (§6.5), and ignores entries with empty keys (§6.4).
- **Pre-existing bug:** `Bytes.of` had swapped `Uint8Array` constructor args (`(buffer, byteLength, byteOffset)` instead of `(buffer, byteOffset, length)`). Latent because every existing call site passed a `Uint8Array` and hit the early-return branch — fired on `DataView`/`Int8Array`/etc.

## Why

`DnsCodec.decodeTxtRecord` previously decoded each TXT entry via `readUtf8String`, which silently replaced any byte ≥ 0x80 with U+FFFD. That made arbitrary-bytes TXT values (per RFC 6763 §6: "The value can contain any eight-bit values including '='.") unrecoverable from the matter.js public API. The Thread Border Router `_meshcop._udp` and `_trel._udp` services advertise binary fields like `xa = 0x5AAF359C0501A1B0` that mojibaked to garbage; consumers couldn't match BRs to neighbor tables.

Internal Matter consumers see no observable change — Matter spec keys (D, CM, SII, SAI, SAT, T, ICD, VP, DN, …) are all ASCII; the `Map<string, string>`-shaped façade preserves the existing contract.

## Test plan

- [x] New round-trip test in `DnsCodecTest.ts` proves a TXT entry containing `0x5AAF359C0501A1B0` survives encode → decode bytewise (`Bytes.areEqual`).
- [x] New `DnssdParameters` unit tests (13) cover the full `ReadonlyMap` contract plus `.raw()` lossless retrieval, missing-key handling, iteration, `forEach` with `thisArg`.
- [x] New end-to-end test in `DnssdNamesTest.ts` installs a TXT record with both ASCII (`SII=5000`) and binary (`xa=…high-byte-bytes…`) entries; asserts `.raw("xa")` is bytewise equal to the original and `.get("SII") === "5000"`.
- [x] RFC 6763 §6.4 / §6.5 conformance tests: first-wins on duplicate keys, ignore empty-key entries, ignore zero-length entries, preserve `key=` empty-value entries.
- [x] `Bytes.of` regression test: a `DataView` with non-zero offset round-trips correctly.
- [x] Full repo test suite green.
- [x] `npm run format-verify` clean.
- [x] `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)