### PR TITLE
fix(model): render DataModelPath via squash presentation

### DIFF
--- a/packages/model/src/common/DataModelPath.ts
+++ b/packages/model/src/common/DataModelPath.ts
@@ -47,10 +47,14 @@ export class DataModelPath implements Diagnostic {
         return [this.id];
     }
 
-    get [Diagnostic.value](): Diagnostic {
+    get [Diagnostic.presentation](): Diagnostic.Presentation {
+        return "squash";
+    }
+
+    get [Diagnostic.value](): unknown {
         const result = Array<unknown>();
         this.#appendDiagnostic(result);
-        return Diagnostic.squash(result);
+        return result;
     }
 
     #appendDiagnostic(result: unknown[]) {

--- a/packages/protocol/test/common/ExpandedPathTest.ts
+++ b/packages/protocol/test/common/ExpandedPathTest.ts
@@ -5,6 +5,7 @@
  */
 
 import { ExpandedPath } from "#common/ExpandedPath.js";
+import { Diagnostic, LogFormat } from "@matter/general";
 import { AttributeId, ClusterId, CommandId, EndpointNumber, EventId } from "@matter/types";
 
 describe("ExpandedPath", () => {
@@ -110,6 +111,24 @@ describe("ExpandedPath", () => {
             });
 
             expect(path.toString()).equal("0.onOff.on");
+        });
+    });
+
+    describe("Diagnostic rendering", () => {
+        // Ensures DataModelPath emitted by ExpandedPath renders properly when wrapped in Diagnostic helpers
+        // (i.e. not as "{}" — see https://github.com/matter-js/matter.js/pull/3664)
+        it("renders attribute path inline via plaintext formatter", () => {
+            const path = ExpandedPath({
+                path: {
+                    endpointId: EndpointNumber(0),
+                    clusterId: ClusterId(0x6),
+                    attributeId: AttributeId(0x0),
+                },
+            });
+
+            const text = LogFormat.formats.plain(Diagnostic.message({ values: [Diagnostic.strong(path), " = true"] }));
+
+            expect(text).contains("0.onOff.state.onOff = true");
         });
     });
 });


### PR DESCRIPTION
## Summary

Follow-up to #3664. Client-side `Write` and `Invoke` log lines were rendering the path segment as `\`{}\`` (e.g. `Write » @1:2•30d4 {} = "value"`).

`DataModelPath.[Diagnostic.value]` returned `Diagnostic.squash(result)` — a wrapper diagnostic. The log formatter's `valueFor` only does a single-level unwrap, so the squash wrapper made it past extraction but its inner items array did not. The renderer's `case "squash"` then fell through to `serialize(...)`, emitting `"{}"` for any `DataModelPath` wrapped in `Diagnostic.strong(...)`.

Fixed by setting `[Diagnostic.presentation] = "squash"` directly on `DataModelPath` and returning the items array from `[Diagnostic.value]`. The renderer now unwraps the items array on the first pass and concatenates segments correctly.

Adds a render-level regression test exercising the actual formatter chain.

## Test plan

- [x] `npm test -- -p packages/protocol` (671 tests)
- [x] `npm test -- -p packages/node` (935 tests)
- [x] `npm test -- -p packages/model` (426 tests)
- [x] `npm run format-verify`
- [x] New `Diagnostic rendering` test in `ExpandedPathTest.ts` asserts on `LogFormat.formats.plain` output
- [ ] Smoke-test in matter-server / matter-shell to confirm Write/Invoke client logs render path correctly on real devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)