### PR TITLE
fix(commissioner): extend operational connect timeout to 4m15s

### DIFF
--- a/packages/protocol/src/peer/ControllerCommissioner.ts
+++ b/packages/protocol/src/peer/ControllerCommissioner.ts
@@ -582,6 +582,7 @@ export class ControllerCommissioner {
                 const peer = this.#context.peers.for(address);
                 peer.descriptor.discoveryData = discoveryData;
                 await peer.connect({
+                    // 4m15s allows two ~2-minute server-side retry windows to complete before we abort.
                     connectionTimeout: Seconds(255),
                     timing: caseConnectionTiming,
 

--- a/packages/protocol/src/peer/ControllerCommissioner.ts
+++ b/packages/protocol/src/peer/ControllerCommissioner.ts
@@ -40,7 +40,6 @@ import {
     Logger,
     MaybePromise,
     Millis,
-    Minutes,
     NoResponseTimeoutError,
     Seconds,
     ServerAddress,
@@ -583,7 +582,7 @@ export class ControllerCommissioner {
                 const peer = this.#context.peers.for(address);
                 peer.descriptor.discoveryData = discoveryData;
                 await peer.connect({
-                    connectionTimeout: Minutes(4),
+                    connectionTimeout: Seconds(255),
                     timing: caseConnectionTiming,
 
                     handleError: error => {


### PR DESCRIPTION
## Summary
- Bump CASE operational connect timeout in `ControllerCommissioner` from `Minutes(4)` to `Seconds(255)` (4m15s) so commissioning steps that trigger up to ~2 minute server-side delays still have headroom before we abort the connect.
- 255 s stays comfortably inside the 5 minute failsafe re-arm window (`CASE_RECONNECT_TIMEOUT`).
- Failsafe reset on operational connect failure (`armFailSafe expiryLengthSeconds=0` while PASE is still alive) already fires through the existing `CommissioningError` catch path in `ControllerCommissioningFlow.executeCommissioning` — verified in production logs (operative-connection-failed → immediate `armFailSafe` invoke with `expiryLengthSeconds: 0`).

## Test plan
- [ ] Concurrent BLE+UDP commissioning where the device is briefly unreachable (>4 min, <4m15s) — connect should now succeed.
- [ ] Concurrent BLE+UDP commissioning where the device is unreachable >4m15s — `OperativeConnectionFailedError` thrown and `armFailSafe(0)` still invoked over PASE before peer cleanup.
- [ ] Existing FailsafeCommissioningTest suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)