### PR TITLE
fix(node): resolve id-keyed sibling values during client constraint validation

### DIFF
--- a/packages/node/src/behavior/state/managed/Datasource.ts
+++ b/packages/node/src/behavior/state/managed/Datasource.ts
@@ -713,12 +713,17 @@ class RootReference implements ValReference<Val.Struct>, Transaction.Participant
             const properties = (this.#values as Val.Dynamic)[Val.properties]
                 ? (this.#values as Val.Dynamic)[Val.properties](this.rootOwner, this.#session)
                 : undefined;
-            for (const index of this.#fields) {
-                if (properties && index in properties) {
+            // `#fields` only lists property names; client mirrors also store values at numeric attribute ids.
+            const keys = new Set<string>(this.#fields);
+            for (const key of Object.keys(old)) {
+                keys.add(key);
+            }
+            for (const key of keys) {
+                if (properties && key in properties) {
                     // Property is dynamic anyway, so do nothing
-                } else {
-                    this.#values[index] = old[index];
+                    continue;
                 }
+                this.#values[key] = old[key];
             }
 
             // Point subreferences to the clone

--- a/packages/node/src/behavior/state/managed/NameResolver.ts
+++ b/packages/node/src/behavior/state/managed/NameResolver.ts
@@ -38,7 +38,7 @@ export function NameResolver(
         if (!supervisor.memberNames.has(name)) {
             return;
         }
-        return createDirectResolver();
+        return createDirectResolver(findMemberId(supervisor.schema, name));
     }
 
     // Only structs may provide named properties
@@ -49,18 +49,36 @@ export function NameResolver(
     // Read directly if the named property is supported by this schema.  This is not indexed which is fine because:
     //   1. The spec uses this very lightly as of 1.4, and
     //   2. We only do this once and only for schema that utilizes this feature
-    if (supervisor.membersOf(model as Schema).find(model => model.propertyName === name)) {
-        return createDirectResolver();
+    const member = supervisor.membersOf(model as Schema).find(model => model.propertyName === name);
+    if (member) {
+        return createDirectResolver(member.id);
     }
 
     // Delegate to parent
     return createIndirectResolver();
 
     /**
-     * Create a reader that reads from this value.
+     * Read a property by name, preferring the id-keyed slot when available — client mirrors
+     * (`primaryKey: "id"`) hold live values at attribute ids while the property-name slot may be a stale default.
      */
-    function createDirectResolver() {
-        return (val: Val) => (val as Val.Struct)?.[name];
+    function createDirectResolver(id?: number) {
+        if (id === undefined) {
+            return (val: Val) => (val as Val.Struct)?.[name];
+        }
+        return (val: Val) => {
+            const struct = val as Val.Struct | undefined;
+            if (struct === undefined || struct === null) {
+                return undefined;
+            }
+            if (id in struct) {
+                return struct[id];
+            }
+            return struct[name];
+        };
+    }
+
+    function findMemberId(schema: Schema, name: string): number | undefined {
+        return supervisor.membersOf(schema).find(model => model.propertyName === name)?.id;
     }
 
     /**

--- a/packages/node/test/behavior/state/validation/constraintTest.ts
+++ b/packages/node/test/behavior/state/validation/constraintTest.ts
@@ -76,6 +76,36 @@ const AllTests = Tests({
         "accepts if reference value is null": { record: { test: 3, maxVal: null } },
     }),
 
+    // Client mirrors (primaryKey: "id") store live values at numeric ids; the resolver must prefer
+    // them over the property-name slot, which can hold a stale initial default.
+    "max with reference (sibling keyed by id)": Tests(
+        Fields({ id: 0, constraint: "max MaxVal" }, { id: 1, name: "MaxVal", quality: "X" }),
+        {
+            "rejects if over (id-keyed sibling)": {
+                record: { test: 5, 1: 4 },
+                error: {
+                    type: ConstraintError,
+                    message:
+                        'Validating Test.test: Constraint "max maxVal": Value 5 is not within bounds defined by constraint',
+                },
+            },
+            "accepts if under (id-keyed sibling)": {
+                record: { test: 3, 1: 4 },
+            },
+            "prefers id-keyed live value over name-keyed stale default": {
+                record: { test: 3, maxVal: 0, 1: 4 },
+            },
+            "rejects on id-keyed sibling even when name-keyed slot would accept": {
+                record: { test: 5, maxVal: 10, 1: 4 },
+                error: {
+                    type: ConstraintError,
+                    message:
+                        'Validating Test.test: Constraint "max maxVal": Value 5 is not within bounds defined by constraint',
+                },
+            },
+        },
+    ),
+
     compound: Tests(Fields({ constraint: "3 to 4, 6 to 7" }), {
         "rejects if under": {
             record: { test: 2 },

--- a/packages/node/test/behavior/state/validation/validation-test-utils.ts
+++ b/packages/node/test/behavior/state/validation/validation-test-utils.ts
@@ -21,6 +21,7 @@ import { StatusResponseError } from "@matter/types";
 export function Fields(
     ...definition: {
         name?: string;
+        id?: number;
         type?: string;
         conformance?: string;
         constraint?: string;

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -9,9 +9,14 @@ import { GlobalAttributeState } from "#behavior/cluster/ClusterState.js";
 import { ControllerBehavior } from "#behavior/system/controller/ControllerBehavior.js";
 import { DiscoveryError } from "#behavior/system/controller/discovery/DiscoveryError.js";
 import { BasicInformationBehavior, BasicInformationServer } from "#behaviors/basic-information";
+import {
+    BooleanStateConfigurationClient,
+    BooleanStateConfigurationServer,
+} from "#behaviors/boolean-state-configuration";
 import { IdentifyClient } from "#behaviors/identify";
 import { OnOffClient } from "#behaviors/on-off";
 import { WindowCoveringClient, WindowCoveringServer } from "#behaviors/window-covering";
+import { ContactSensorDevice } from "#devices/contact-sensor";
 import { OnOffLightDevice } from "#devices/on-off-light";
 import { WindowCoveringDevice } from "#devices/window-covering";
 import { Endpoint } from "#endpoint/Endpoint.js";
@@ -463,6 +468,72 @@ describe("ClientNode", () => {
         const ep1Server = device.parts.get(1) as Endpoint<OnOffLightDevice>;
         expect(ep1Server.state.onOff.onTime).equals(20);
         expect(ep1Server.state.identify.identifyTime).equals(5);
+    });
+
+    describe("writes attribute whose constraint references a sibling attribute", () => {
+        // currentSensitivityLevel has constraint "max supportedSensitivityLevels - 1"; with
+        // supportedSensitivityLevels = 3, value 2 must be accepted via every client commit path.
+
+        const BscWithSensLevel = BooleanStateConfigurationServer.with("SensitivityLevel").set({
+            supportedSensitivityLevels: 3,
+            currentSensitivityLevel: 0,
+            defaultSensitivityLevel: 0,
+        });
+        const ContactSensorWithSensLevel = ContactSensorDevice.with(BscWithSensLevel);
+
+        async function setup() {
+            const site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: {
+                    type: ServerNode.RootEndpoint,
+                    device: ContactSensorWithSensLevel,
+                },
+            });
+
+            const peer1 = await subscribedPeer(controller, "peer1");
+            const ep1Client = peer1.parts.get("ep1")!;
+            const ep1Server = device.parts.get(1)!;
+
+            return { site, ep1Client, ep1Server };
+        }
+
+        it("via agent.state assignment", async () => {
+            const { site, ep1Client, ep1Server } = await setup();
+            await using _site = site;
+
+            await MockTime.resolve(
+                ep1Client.act(agent => {
+                    agent.get(BooleanStateConfigurationClient).state.currentSensitivityLevel = 2;
+                }),
+            );
+
+            expect(ep1Server.stateOf(BscWithSensLevel).currentSensitivityLevel).equals(2);
+        });
+
+        it("via setStateOf", async () => {
+            const { site, ep1Client, ep1Server } = await setup();
+            await using _site = site;
+
+            await MockTime.resolve(
+                ep1Client.setStateOf(BooleanStateConfigurationClient, { currentSensitivityLevel: 2 }),
+            );
+
+            expect(ep1Server.stateOf(BscWithSensLevel).currentSensitivityLevel).equals(2);
+        });
+
+        it("via endpoint.set", async () => {
+            const { site, ep1Client, ep1Server } = await setup();
+            await using _site = site;
+
+            const typedClient = ep1Client as Endpoint<typeof ContactSensorWithSensLevel>;
+            await MockTime.resolve(
+                typedClient.set({
+                    booleanStateConfiguration: { currentSensitivityLevel: 2 },
+                }),
+            );
+
+            expect(ep1Server.stateOf(BscWithSensLevel).currentSensitivityLevel).equals(2);
+        });
     });
 
     it("emits Matter events", async () => {


### PR DESCRIPTION
Related to https://github.com/matter-js/matterjs-server/issues/589

## Summary

- ClientNode mirrors rejected valid attribute writes whose constraint referenced a sibling attribute (e.g. `BooleanStateConfiguration.currentSensitivityLevel` with constraint `max supportedSensitivityLevels - 1`). The validator's `NameResolver` read the stale name-keyed default (0) instead of the subscription-delivered id-keyed value (e.g. 3), so value 2 failed against `max = -1` with `Constraint "all": Value 2 is not within bounds defined by constraint`.
- Two compensating fixes: `Datasource.RootReference.change()` clone now also copies id-keyed entries that `#fields` (property-names-only) would otherwise drop; `NameResolver.createDirectResolver` now prefers `struct[id]` when present and falls back to `struct[name]`.

## Why this happens

`ClientBehaviorBacking` sets `primaryKey: "id"` so subscription deliveries land at numeric attribute ids while initial defaults from the schema sit under property names. The two coexist in the same struct with conflicting values — id-keyed is "live", name-keyed is stale. The constraint validator's sibling lookup hit the stale slot.

A deeper fix (consolidate to single key per attribute) is tracked separately as a refactor; see `Notes` below.

## Tests

- `packages/node/test/behavior/state/validation/constraintTest.ts` — 4 new validator-layer cases under `max with reference (sibling keyed by id)` covering id-only sibling, accept and reject paths, and id-key preference over a stale name-key default. These fail without the `NameResolver` change (verified by temporary revert).
- `packages/node/test/node/ClientNodeTest.ts` — 3 new full-stack cases under `writes attribute whose constraint references a sibling attribute` covering all three client write APIs: `agent.state` assignment, `setStateOf`, and `endpoint.set`.

## Notes

The two fixes patch consequences of the dual-keying scheme rather than the scheme itself. A follow-up refactor to normalize ClientNode mirror storage to a single key per attribute is captured locally; once that lands, both compensations in this PR can be reverted. Filed as a separate task because the blast radius (name-keyed reads in `ValueValidator.createStructValidator`, `StructManager` getter fallback, `integrateExternalChange`) warrants its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)