### PR TITLE
fix(node): preserve original write-decline error and roll back local cache

### DIFF
--- a/packages/general/src/transaction/Tx.ts
+++ b/packages/general/src/transaction/Tx.ts
@@ -6,7 +6,7 @@
 
 import { Diagnostic } from "#log/Diagnostic.js";
 import { Logger } from "#log/Logger.js";
-import { ImplementationError, ReadOnlyError } from "#MatterError.js";
+import { ImplementationError, MatterAggregateError, ReadOnlyError } from "#MatterError.js";
 import { Time, Timer } from "#time/Time.js";
 import { Timestamp } from "#time/Timestamp.js";
 import { Millis } from "#time/TimeUnit.js";
@@ -689,7 +689,7 @@ class Tx implements Transaction, Transaction.Finalization {
     #executeCommit2() {
         // Commit phase 2
         this.#status = Status.CommittingPhaseTwo;
-        let errored: undefined | Array<Participant>;
+        let errored: undefined | Array<ParticipantError>;
         let ongoing: undefined | Array<Promise<void>>;
         for (const participant of this.participants) {
             const promise = MaybePromise.then(
@@ -699,9 +699,9 @@ class Tx implements Transaction, Transaction.Finalization {
                     logger.error(`Error committing (phase two) ${participant}, state inconsistency possible:`, error);
 
                     if (errored) {
-                        errored.push(participant);
+                        errored.push({ participant, error });
                     } else {
-                        errored = [participant];
+                        errored = [{ participant, error }];
                     }
                 },
             );
@@ -765,7 +765,7 @@ class Tx implements Transaction, Transaction.Finalization {
      */
     #executeRollback() {
         this.#status = Status.RollingBack;
-        let errored: undefined | Array<Participant>;
+        let errored: undefined | Array<ParticipantError>;
         let ongoing: undefined | Array<Promise<void>>;
 
         for (const participant of this.participants) {
@@ -777,9 +777,9 @@ class Tx implements Transaction, Transaction.Finalization {
                     logger.error(`Error rolling back ${participant}, state inconsistency possible:`, error);
 
                     if (errored) {
-                        errored.push(participant);
+                        errored.push({ participant, error });
                     } else {
-                        errored = [participant];
+                        errored = [{ participant, error }];
                     }
                 },
             );
@@ -796,7 +796,7 @@ class Tx implements Transaction, Transaction.Finalization {
 
         const finished = () => {
             this.#status = Status.Shared;
-            throwIfErrored(errored, "in commit phase 2");
+            throwIfErrored(errored, "during rollback");
         };
 
         if (ongoing) {
@@ -842,16 +842,21 @@ class Tx implements Transaction, Transaction.Finalization {
     }
 }
 
-function throwIfErrored(errored: undefined | Array<Participant>, when: string) {
+interface ParticipantError {
+    participant: Participant;
+    error: unknown;
+}
+
+function throwIfErrored(errored: undefined | Array<ParticipantError>, when: string) {
     if (!errored?.length) {
         return;
     }
-    const suffix = errored.length > 1 ? "s" : "";
-    throw new FinalizationError(
-        `Unhandled error${suffix} ${when} participant${suffix} ${describeList(
-            "and",
-            ...errored.map(p => p.toString()),
-        )}`,
+    if (errored.length === 1) {
+        throw errored[0].error;
+    }
+    throw new MatterAggregateError(
+        errored.map(({ error }) => error),
+        `Errors ${when} participants ${describeList("and", ...errored.map(({ participant }) => participant.toString()))}`,
     );
 }
 

--- a/packages/general/test/transaction/TransactionTest.ts
+++ b/packages/general/test/transaction/TransactionTest.ts
@@ -5,6 +5,7 @@
  */
 
 import { Lifetime } from "#index.js";
+import { MatterAggregateError } from "#MatterError.js";
 import {
     FinalizationError,
     SynchronousTransactionConflictError,
@@ -365,6 +366,60 @@ describe("Transaction", () => {
             await expect(transaction.commit()).rejectedWith(FinalizationError);
 
             p.expect("commit1", "rollback");
+            validateUnlocked(transaction);
+        });
+    });
+
+    describe("propagates commit phase 2 errors to the caller", () => {
+        test("rethrows the original error when a single participant fails", async () => {
+            const original = new SomeError("phase 2 boom");
+            const p = join({
+                async commit2() {
+                    throw original;
+                },
+            });
+
+            await transaction.begin();
+
+            await expect(transaction.commit()).rejectedWith(original);
+
+            p.expect("commit1", "commit2");
+            validateUnlocked(transaction);
+        });
+
+        test("aggregates with MatterAggregateError when multiple participants fail", async () => {
+            const e1 = new SomeError("phase 2 boom 1");
+            const e2 = new SomeError("phase 2 boom 2");
+
+            const p1 = TestParticipant({
+                async commit2() {
+                    throw e1;
+                },
+            });
+            p1.toString = () => "P1";
+            const p2 = TestParticipant({
+                async commit2() {
+                    throw e2;
+                },
+            });
+            p2.toString = () => "P2";
+            transaction.addParticipants(p1, p2);
+
+            await transaction.begin();
+
+            let caught: unknown;
+            try {
+                await transaction.commit();
+            } catch (e) {
+                caught = e;
+            }
+
+            expect(caught).instanceOf(MatterAggregateError);
+            const aggregate = caught as MatterAggregateError;
+            expect(aggregate.errors).deep.equals([e1, e2]);
+
+            p1.expect("commit1", "commit2");
+            p2.expect("commit1", "commit2");
             validateUnlocked(transaction);
         });
     });

--- a/packages/node/src/storage/client/DatasourceCache.ts
+++ b/packages/node/src/storage/client/DatasourceCache.ts
@@ -5,7 +5,7 @@
  */
 
 import { Datasource } from "#behavior/state/managed/Datasource.js";
-import { InternalError, StorageDriver, Transaction } from "@matter/general";
+import { InternalError, isDeepEqual, StorageDriver, Transaction } from "@matter/general";
 import { Val } from "@matter/protocol";
 import { EndpointNumber } from "@matter/types";
 import type { ClientCacheBuffer } from "./ClientCacheBuffer.js";
@@ -18,7 +18,7 @@ import type { RemoteWriter } from "./RemoteWriter.js";
  *
  * This implements storage for attribute values for a single cluster loaded from peers.
  */
-export class DatasourceCache implements Datasource.ExternallyMutableStore {
+export class DatasourceCache implements Datasource.ExternallyMutableStore, RemoteWriteParticipant.Compensator {
     #writer: RemoteWriter;
     #endpointNumber: EndpointNumber;
     #behaviorId: string;
@@ -61,7 +61,40 @@ export class DatasourceCache implements Datasource.ExternallyMutableStore {
             participant = new RemoteWriteParticipant(this.#writer);
             transaction.addParticipants(participant);
         }
-        (participant as RemoteWriteParticipant).set(this.#endpointNumber, this.#behaviorId, values);
+        const previousValues = this.#consumer?.readValues(new Set(Object.keys(values))) ?? {};
+        (participant as RemoteWriteParticipant).set(this.#endpointNumber, this.#behaviorId, values, {
+            compensator: this,
+            previousValues,
+        });
+    }
+
+    /**
+     * Restores local cache values whose remote write was declined.
+     *
+     * Only restores keys that:
+     *   - had a captured pre-write value (skip if the snapshot doesn't know the prior state), AND
+     *   - still hold the value we attempted to write (skip if a concurrent subscription update already moved on).
+     */
+    async compensate(failedAttributeIds: Set<string>, previousValues: Val.Struct, writtenValues: Val.Struct) {
+        if (this.#erased || this.#reclaimed || !this.#consumer) {
+            return;
+        }
+
+        const restore = new Map<string, Val>();
+        const current = this.#consumer.readValues(failedAttributeIds);
+        for (const id of failedAttributeIds) {
+            if (!(id in previousValues)) {
+                continue;
+            }
+            if (!isDeepEqual(current[id], writtenValues[id])) {
+                continue;
+            }
+            restore.set(id, previousValues[id]);
+        }
+
+        if (restore.size) {
+            await this.externalSet(restore);
+        }
     }
 
     async externalSet(values: Val.StructMap) {

--- a/packages/node/src/storage/client/DatasourceCache.ts
+++ b/packages/node/src/storage/client/DatasourceCache.ts
@@ -5,7 +5,7 @@
  */
 
 import { Datasource } from "#behavior/state/managed/Datasource.js";
-import { InternalError, isDeepEqual, StorageDriver, Transaction } from "@matter/general";
+import { InternalError, StorageDriver, Transaction } from "@matter/general";
 import { Val } from "@matter/protocol";
 import { EndpointNumber } from "@matter/types";
 import type { ClientCacheBuffer } from "./ClientCacheBuffer.js";
@@ -86,7 +86,10 @@ export class DatasourceCache implements Datasource.ExternallyMutableStore, Remot
             if (!(id in previousValues)) {
                 continue;
             }
-            if (!isDeepEqual(current[id], writtenValues[id])) {
+            // Datasource keeps user values by reference; integrateExternalChange only replaces the
+            // reference when a subscription actually changed the value, so a different ref here means
+            // a real concurrent update arrived.
+            if (current[id] !== writtenValues[id]) {
                 continue;
             }
             restore.set(id, previousValues[id]);

--- a/packages/node/src/storage/client/RemoteWriteParticipant.ts
+++ b/packages/node/src/storage/client/RemoteWriteParticipant.ts
@@ -4,10 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Transaction } from "@matter/general";
-import { Val } from "@matter/protocol";
+import { Logger, Transaction } from "@matter/general";
+import { Val, WriteResult } from "@matter/protocol";
 import { EndpointNumber } from "@matter/types";
 import type { RemoteWriter } from "./RemoteWriter.js";
+
+const logger = Logger.get("RemoteWriteParticipant");
 
 /**
  * A transaction participant that persists changes to a remote node.
@@ -17,6 +19,7 @@ import type { RemoteWriter } from "./RemoteWriter.js";
 export class RemoteWriteParticipant implements Transaction.Participant {
     #request: RemoteWriter.Request = [];
     #writer: RemoteWriter;
+    #snapshots = new Map<string, RemoteWriteParticipant.Snapshot>();
 
     /**
      * There is one participant for each transaction/writer pair.  We use the writer function itself as the dedup key.
@@ -27,13 +30,41 @@ export class RemoteWriteParticipant implements Transaction.Participant {
 
     /**
      * Add an attribute update to the write request.
+     *
+     * The optional {@link snapshot} captures the pre-write values for the affected attributes plus a
+     * {@link RemoteWriteParticipant.Compensator} the participant invokes if the remote rejects the write.
      */
-    set(endpointNumber: EndpointNumber, behaviorId: string, values: Val.Struct) {
+    set(
+        endpointNumber: EndpointNumber,
+        behaviorId: string,
+        values: Val.Struct,
+        snapshot?: RemoteWriteParticipant.SnapshotInput,
+    ) {
         this.#request.push({
             number: endpointNumber,
             behaviorId: behaviorId,
             values,
         });
+
+        if (snapshot) {
+            const key = snapshotKey(endpointNumber, behaviorId);
+            const existing = this.#snapshots.get(key);
+            if (existing) {
+                Object.assign(existing.writtenValues, values);
+                for (const [k, v] of Object.entries(snapshot.previousValues)) {
+                    // Keep the earliest captured baseline; later writes within the same transaction don't overwrite it
+                    if (!(k in existing.previousValues)) {
+                        existing.previousValues[k] = v;
+                    }
+                }
+            } else {
+                this.#snapshots.set(key, {
+                    compensator: snapshot.compensator,
+                    previousValues: { ...snapshot.previousValues },
+                    writtenValues: { ...values },
+                });
+            }
+        }
     }
 
     async commit2() {
@@ -42,13 +73,48 @@ export class RemoteWriteParticipant implements Transaction.Participant {
         }
 
         const request = this.#request;
+        const snapshots = this.#snapshots;
         this.#request = [];
+        this.#snapshots = new Map();
 
-        await this.#writer(request);
+        await this.#writer(request, failures => this.#compensate(snapshots, failures));
+    }
+
+    async #compensate(
+        snapshots: Map<string, RemoteWriteParticipant.Snapshot>,
+        failures: WriteResult.AttributeStatus[],
+    ) {
+        if (!snapshots.size) {
+            return;
+        }
+
+        const failedByCluster = new Map<string, Set<string>>();
+        for (const f of failures) {
+            const key = snapshotKey(f.path.endpointId, String(f.path.clusterId));
+            let ids = failedByCluster.get(key);
+            if (!ids) {
+                ids = new Set();
+                failedByCluster.set(key, ids);
+            }
+            ids.add(String(f.path.attributeId));
+        }
+
+        for (const [key, snapshot] of snapshots) {
+            const failedIds = failedByCluster.get(key);
+            if (!failedIds?.size) {
+                continue;
+            }
+            try {
+                await snapshot.compensator.compensate(failedIds, snapshot.previousValues, snapshot.writtenValues);
+            } catch (compensateError) {
+                logger.warn(`Failed to restore local state for ${key} after remote write decline:`, compensateError);
+            }
+        }
     }
 
     rollback() {
         this.#request = [];
+        this.#snapshots = new Map();
     }
 
     toString() {
@@ -57,5 +123,44 @@ export class RemoteWriteParticipant implements Transaction.Participant {
 
     constructor(writer: RemoteWriter) {
         this.#writer = writer;
+    }
+}
+
+function snapshotKey(endpointNumber: EndpointNumber | number, behaviorId: string) {
+    return `${endpointNumber}|${behaviorId}`;
+}
+
+export namespace RemoteWriteParticipant {
+    /**
+     * Restores local cache state for attribute writes the remote device declined.
+     *
+     * The participant invokes this with the failed attribute keys after a write fails.  Implementations should only
+     * restore values for keys present in {@link previousValues} AND only when the current local value still equals
+     * what was just written — leaving concurrently-mutated values alone.
+     */
+    export interface Compensator {
+        compensate(
+            failedAttributeIds: Set<string>,
+            previousValues: Val.Struct,
+            writtenValues: Val.Struct,
+        ): Promise<void>;
+    }
+
+    /**
+     * The pre-write baseline supplied by the caller of {@link RemoteWriteParticipant.set} together with the
+     * {@link Compensator} responsible for restoring it.
+     */
+    export interface SnapshotInput {
+        compensator: Compensator;
+        previousValues: Val.Struct;
+    }
+
+    /**
+     * Internal per-cluster snapshot held by the participant for the duration of a transaction.
+     */
+    export interface Snapshot {
+        compensator: Compensator;
+        previousValues: Val.Struct;
+        writtenValues: Val.Struct;
     }
 }

--- a/packages/node/src/storage/client/RemoteWriter.ts
+++ b/packages/node/src/storage/client/RemoteWriter.ts
@@ -6,9 +6,9 @@
 
 import { ClientStructure } from "#node/client/ClientStructure.js";
 import type { ClientNode } from "#node/ClientNode.js";
-import { InternalError } from "@matter/general";
+import { InternalError, MaybePromise } from "@matter/general";
 import { Write, WriteResult, type Val } from "@matter/protocol";
-import type { ClusterId, ClusterType, EndpointNumber } from "@matter/types";
+import { Status, type ClusterId, type ClusterType, type EndpointNumber } from "@matter/types";
 import type { ClientNodeStore } from "./ClientNodeStore.js";
 
 /**
@@ -16,15 +16,18 @@ import type { ClientNodeStore } from "./ClientNodeStore.js";
  *
  * A remote writer conveys updates to the remote node.  This performs actual persistence for client nodes where the
  * local store is just a cache and the source of truth is on the remote device.
+ *
+ * The optional {@link RemoteWriter.FailureHandler} is invoked with the per-attribute failure statuses before the
+ * write rejects, giving callers a chance to compensate local cache state for declined writes.
  */
 export interface RemoteWriter {
-    (request: RemoteWriter.Request): Promise<void>;
+    (request: RemoteWriter.Request, onFailure?: RemoteWriter.FailureHandler): Promise<void>;
 }
 
 const attrCache = new WeakMap<object, Record<string, ClusterType.Attribute>>();
 
 export function RemoteWriter(node: ClientNode, structure: ClientStructure): RemoteWriter {
-    return async function writeRemote(request: RemoteWriter.Request) {
+    return async function writeRemote(request: RemoteWriter.Request, onFailure?: RemoteWriter.FailureHandler) {
         const attrWrites = Array<Write.Attribute>();
         for (const { number, behaviorId, values } of request) {
             const cluster = structure.clusterFor(number, Number.parseInt(behaviorId) as ClusterId);
@@ -55,7 +58,16 @@ export function RemoteWriter(node: ClientNode, structure: ClientStructure): Remo
         }
 
         const write = Write(...attrWrites);
-        WriteResult.assertSuccess(await node.interaction.write(write));
+        const result = (await node.interaction.write(write)) as WriteResult.AttributeStatus[];
+
+        if (onFailure) {
+            const failures = result.filter(s => s.status !== Status.Success);
+            if (failures.length) {
+                await onFailure(failures);
+            }
+        }
+
+        WriteResult.assertSuccess(result);
     };
 }
 
@@ -67,6 +79,8 @@ export namespace RemoteWriter {
     }
 
     export interface Request extends Array<EndpointUpdateRequest> {}
+
+    export type FailureHandler = (failures: WriteResult.AttributeStatus[]) => MaybePromise<void>;
 }
 
 function attrsFor(cluster: ClusterType) {

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -13,7 +13,7 @@ import {
     BooleanStateConfigurationClient,
     BooleanStateConfigurationServer,
 } from "#behaviors/boolean-state-configuration";
-import { IdentifyClient } from "#behaviors/identify";
+import { IdentifyClient, IdentifyServer } from "#behaviors/identify";
 import { OnOffClient } from "#behaviors/on-off";
 import { WindowCoveringClient, WindowCoveringServer } from "#behaviors/window-covering";
 import { ContactSensorDevice } from "#devices/contact-sensor";
@@ -29,6 +29,7 @@ import {
     Crypto,
     deepCopy,
     Entropy,
+    MatterAggregateError,
     Minutes,
     MockCrypto,
     Observable,
@@ -38,7 +39,7 @@ import {
 } from "@matter/general";
 import { Specification } from "@matter/model";
 import { ControllerCommissioner, FabricAuthority, FabricManager, PeerSet, Val } from "@matter/protocol";
-import { FabricIndex } from "@matter/types";
+import { FabricIndex, Status, StatusResponseError } from "@matter/types";
 import { WindowCovering } from "@matter/types/clusters/window-covering";
 import { MyBehavior } from "../behavior/cluster/cluster-behavior-test-util.js";
 import { MockSite } from "./mock-site.js";
@@ -533,6 +534,195 @@ describe("ClientNode", () => {
             );
 
             expect(ep1Server.stateOf(BscWithSensLevel).currentSensitivityLevel).equals(2);
+        });
+    });
+
+    class DecliningBsc extends BooleanStateConfigurationServer.with("SensitivityLevel") {
+        override initialize() {
+            super.initialize();
+            this.reactTo(this.events.currentSensitivityLevel$Changing, () => {
+                throw new StatusResponseError("currentSensitivityLevel write declined", Status.ConstraintError);
+            });
+        }
+    }
+
+    const DecliningBscWithLevels = DecliningBsc.set({
+        supportedSensitivityLevels: 3,
+        currentSensitivityLevel: 0,
+        defaultSensitivityLevel: 0,
+    });
+
+    class DecliningIdentify extends IdentifyServer {
+        override initialize() {
+            super.initialize();
+            this.reactTo(this.events.identifyTime$Changing, () => {
+                throw new StatusResponseError("identifyTime write declined", Status.ResourceExhausted);
+            });
+        }
+    }
+
+    async function captureRejection(write: () => unknown) {
+        let caught: unknown;
+        try {
+            await MockTime.resolve(Promise.resolve(write() as Promise<unknown>));
+        } catch (e) {
+            caught = e;
+        }
+        return caught;
+    }
+
+    describe("surfaces a server-side write rejection to the caller", () => {
+        // A server-side $Changing listener throws StatusResponseError so the remote write returns a
+        // failure status.  The client's setStateOf / agent.state / endpoint.set must reject with a
+        // StatusResponseError carrying the device's code, not the generic transaction
+        // FinalizationError that previously hid it.
+
+        const DecliningContactSensor = ContactSensorDevice.with(DecliningBscWithLevels);
+
+        async function setup() {
+            const site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: {
+                    type: ServerNode.RootEndpoint,
+                    device: DecliningContactSensor,
+                },
+            });
+
+            const peer1 = await subscribedPeer(controller, "peer1");
+            const ep1Client = peer1.parts.get("ep1")!;
+            const ep1Server = device.parts.get(1)!;
+
+            return { site, ep1Client, ep1Server };
+        }
+
+        it("via agent.state assignment", async () => {
+            const { site, ep1Client, ep1Server } = await setup();
+            await using _site = site;
+
+            const caught = await captureRejection(() =>
+                ep1Client.act(agent => {
+                    agent.get(BooleanStateConfigurationClient).state.currentSensitivityLevel = 1;
+                }),
+            );
+
+            expect(caught).instanceOf(StatusResponseError);
+            expect((caught as StatusResponseError).code).equals(Status.ConstraintError);
+            expect(ep1Server.stateOf(DecliningBscWithLevels).currentSensitivityLevel).equals(0);
+        });
+
+        it("via setStateOf", async () => {
+            const { site, ep1Client, ep1Server } = await setup();
+            await using _site = site;
+
+            const caught = await captureRejection(() =>
+                ep1Client.setStateOf(BooleanStateConfigurationClient, { currentSensitivityLevel: 1 }),
+            );
+
+            expect(caught).instanceOf(StatusResponseError);
+            expect((caught as StatusResponseError).code).equals(Status.ConstraintError);
+            expect(ep1Server.stateOf(DecliningBscWithLevels).currentSensitivityLevel).equals(0);
+        });
+
+        it("via endpoint.set", async () => {
+            const { site, ep1Client, ep1Server } = await setup();
+            await using _site = site;
+
+            const typedClient = ep1Client as Endpoint<typeof DecliningContactSensor>;
+            const caught = await captureRejection(() =>
+                typedClient.set({
+                    booleanStateConfiguration: { currentSensitivityLevel: 1 },
+                }),
+            );
+
+            expect(caught).instanceOf(StatusResponseError);
+            expect((caught as StatusResponseError).code).equals(Status.ConstraintError);
+            expect(ep1Server.stateOf(DecliningBscWithLevels).currentSensitivityLevel).equals(0);
+        });
+
+        it("via local ServerNode set surfaces the listener's StatusResponseError", async () => {
+            const { site, ep1Server } = await setup();
+            await using _site = site;
+
+            const caught = await captureRejection(() =>
+                ep1Server.act(agent => {
+                    agent.get(DecliningBsc).state.currentSensitivityLevel = 1;
+                }),
+            );
+
+            expect(caught).instanceOf(StatusResponseError);
+            expect((caught as StatusResponseError).code).equals(Status.ConstraintError);
+            expect(ep1Server.stateOf(DecliningBscWithLevels).currentSensitivityLevel).equals(0);
+        });
+    });
+
+    describe("aggregates multiple write rejections in one transaction", () => {
+        // Two writes in a single transaction, declined on the server via $Changing listeners on
+        // attributes from different clusters.  Verifies the caller's view:
+        //  - one of two declined: WriteResult throws a single PathError → caller sees a
+        //    StatusResponseError carrying that attribute's status code
+        //  - both declined: WriteResult throws a MatterAggregateError carrying both PathErrors
+
+        const PartialDeclineDevice = ContactSensorDevice.with(DecliningBscWithLevels);
+        const FullDeclineDevice = ContactSensorDevice.with(DecliningBscWithLevels, DecliningIdentify);
+
+        async function setup(deviceType: typeof PartialDeclineDevice | typeof FullDeclineDevice) {
+            const site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: {
+                    type: ServerNode.RootEndpoint,
+                    device: deviceType,
+                },
+            });
+
+            const peer1 = await subscribedPeer(controller, "peer1");
+            const ep1Client = peer1.parts.get("ep1")!;
+            const ep1Server = device.parts.get(1)!;
+
+            return { site, ep1Client, ep1Server };
+        }
+
+        it("when one of two writes is declined, surfaces only that rejection", async () => {
+            const { site, ep1Client, ep1Server } = await setup(PartialDeclineDevice);
+            await using _site = site;
+
+            const caught = await captureRejection(() =>
+                ep1Client.act(agent => {
+                    agent.get(BooleanStateConfigurationClient).state.currentSensitivityLevel = 1;
+                    agent.get(IdentifyClient).state.identifyTime = 5;
+                }),
+            );
+
+            expect(caught).instanceOf(StatusResponseError);
+            expect((caught as StatusResponseError).code).equals(Status.ConstraintError);
+
+            // The accepted write committed on the server; the rejected one did not.
+            expect(ep1Server.stateOf(DecliningBscWithLevels).currentSensitivityLevel).equals(0);
+            expect(ep1Server.stateOf(IdentifyServer).identifyTime).equals(5);
+        });
+
+        it("when both writes are declined, surfaces a MatterAggregateError with each per-attribute error", async () => {
+            const { site, ep1Client, ep1Server } = await setup(FullDeclineDevice);
+            await using _site = site;
+
+            const caught = await captureRejection(() =>
+                ep1Client.act(agent => {
+                    agent.get(BooleanStateConfigurationClient).state.currentSensitivityLevel = 1;
+                    agent.get(IdentifyClient).state.identifyTime = 5;
+                }),
+            );
+
+            expect(caught).instanceOf(MatterAggregateError);
+            const aggregate = caught as MatterAggregateError;
+            expect(aggregate.errors).lengthOf(2);
+            for (const inner of aggregate.errors) {
+                expect(inner).instanceOf(StatusResponseError);
+            }
+            const codes = (aggregate.errors as StatusResponseError[]).map(e => e.code);
+            expect(codes).contains(Status.ConstraintError);
+            expect(codes).contains(Status.ResourceExhausted);
+
+            expect(ep1Server.stateOf(DecliningBscWithLevels).currentSensitivityLevel).equals(0);
+            expect(ep1Server.stateOf(IdentifyServer).identifyTime).equals(0);
         });
     });
 

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -726,6 +726,95 @@ describe("ClientNode", () => {
         });
     });
 
+    describe("rolls local cache back when a remote write is declined", () => {
+        // After a declined remote write, the local cache must NOT keep the value the user attempted to
+        // write.  Compensation restores the pre-write value via the same path subscription updates
+        // use, so the client mirror stays consistent with the server.
+
+        const PartialDeclineDevice = ContactSensorDevice.with(DecliningBscWithLevels);
+        const FullDeclineDevice = ContactSensorDevice.with(DecliningBscWithLevels, DecliningIdentify);
+
+        async function setup(deviceType: typeof PartialDeclineDevice | typeof FullDeclineDevice) {
+            const site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: {
+                    type: ServerNode.RootEndpoint,
+                    device: deviceType,
+                },
+            });
+
+            const peer1 = await subscribedPeer(controller, "peer1");
+            const ep1Client = peer1.parts.get("ep1")!;
+            const ep1Server = device.parts.get(1)!;
+
+            return { site, ep1Client, ep1Server };
+        }
+
+        async function readClientCurrentSensitivityLevel(ep1Client: Endpoint) {
+            let value: number | undefined;
+            await ep1Client.act(agent => {
+                value = agent.get(BooleanStateConfigurationClient).state.currentSensitivityLevel;
+            });
+            return value;
+        }
+
+        async function readClientIdentifyTime(ep1Client: Endpoint) {
+            let value: number | undefined;
+            await ep1Client.act(agent => {
+                value = agent.get(IdentifyClient).state.identifyTime;
+            });
+            return value;
+        }
+
+        it("restores the pre-write value when the only write is declined", async () => {
+            const { site, ep1Client } = await setup(PartialDeclineDevice);
+            await using _site = site;
+
+            const caught = await captureRejection(() =>
+                ep1Client.setStateOf(BooleanStateConfigurationClient, { currentSensitivityLevel: 1 }),
+            );
+
+            expect(caught).instanceOf(StatusResponseError);
+            expect(await readClientCurrentSensitivityLevel(ep1Client)).equals(0);
+        });
+
+        it("restores only the declined attribute when one of two writes is declined", async () => {
+            const { site, ep1Client, ep1Server } = await setup(PartialDeclineDevice);
+            await using _site = site;
+
+            const caught = await captureRejection(() =>
+                ep1Client.act(agent => {
+                    agent.get(BooleanStateConfigurationClient).state.currentSensitivityLevel = 1;
+                    agent.get(IdentifyClient).state.identifyTime = 5;
+                }),
+            );
+
+            expect(caught).instanceOf(StatusResponseError);
+            // Declined: client and server both back at 0
+            expect(await readClientCurrentSensitivityLevel(ep1Client)).equals(0);
+            expect(ep1Server.stateOf(DecliningBscWithLevels).currentSensitivityLevel).equals(0);
+            // Accepted: client and server both at 5
+            expect(await readClientIdentifyTime(ep1Client)).equals(5);
+            expect(ep1Server.stateOf(IdentifyServer).identifyTime).equals(5);
+        });
+
+        it("restores both attributes when both writes are declined", async () => {
+            const { site, ep1Client } = await setup(FullDeclineDevice);
+            await using _site = site;
+
+            const caught = await captureRejection(() =>
+                ep1Client.act(agent => {
+                    agent.get(BooleanStateConfigurationClient).state.currentSensitivityLevel = 1;
+                    agent.get(IdentifyClient).state.identifyTime = 5;
+                }),
+            );
+
+            expect(caught).instanceOf(MatterAggregateError);
+            expect(await readClientCurrentSensitivityLevel(ep1Client)).equals(0);
+            expect(await readClientIdentifyTime(ep1Client)).equals(0);
+        });
+    });
+
     it("emits Matter events", async () => {
         // *** SETUP ***
 


### PR DESCRIPTION
## Summary

When a remote Matter device declines a write, two things were going wrong on the client side:

1. The original `StatusResponseError` (carrying the device's status code) was hidden inside a generic `FinalizationError` produced by transaction commit phase 2, so callers of `setStateOf` / `agent.state.x = …` / `endpoint.set` had no way to detect or react to the device's specific failure.
2. The local client cache had already accepted the value the user attempted to write. Subscriptions only deliver server-side changes, so the cache stayed divergent from the server until the process restarted.

This PR fixes both — in two commits so the contract change in commit phase 2 is reviewable independently from the cache-rollback work.

### Commit 1 — `fix(general): surface original commit-phase-2 errors to transaction caller`

`Tx#executeCommit2` no longer wraps the participant error in a generic `FinalizationError`. `throwIfErrored` rethrows the original error when a single participant fails, and aggregates with `MatterAggregateError` when multiple do. The rollback path's mislabeled `"in commit phase 2"` message is corrected to `"during rollback"`.

`TransactionTest` covers the new contract directly (single-error rethrow + multi-error aggregate). End-to-end `ClientNodeTest` cases cover single decline, partial decline (1 of 2 cross-cluster writes), and full decline. A server-side regression test locks in the existing preCommit-phase-1 path.

### Commit 2 — `feat(node): roll back local client cache on declined remote writes`

- `RemoteWriter` accepts an optional `onFailure(failures: WriteResult.AttributeStatus[])` callback that fires before the write rejects.
- `RemoteWriteParticipant` captures a per-cluster snapshot (`previousValues`, `writtenValues`, `compensator`) at every `set()` call. On `commit2` failure it groups failures by endpoint+cluster and invokes the compensator with the failed attribute IDs.
- `DatasourceCache` implements the `Compensator` interface. `compensate()` restores the pre-write value via the existing `externalSet` path so persistence + listeners fire as if a subscription update arrived, but only when:
  - a baseline previous value was captured for the key (skip otherwise), AND
  - the current local value still equals what was just written (skip if a concurrent subscription update changed it).

Three new `ClientNodeTest` cases cover single decline, partial decline across two clusters, and full decline. The tests fail with `expected 1 to equal 0` when `compensate()` is neutered, confirming they exercise compensation rather than relying on subscription delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)