### PR TITLE
fix(node): make endpoint.state[id] and ClientNode.toString teardown-safe

### DIFF
--- a/packages/node/src/endpoint/properties/Behaviors.ts
+++ b/packages/node/src/endpoint/properties/Behaviors.ts
@@ -821,7 +821,17 @@ export class Behaviors {
     #augmentEndpoint(type: Behavior.Type) {
         const { id, Events } = type;
 
-        const get = () => this.#backingFor(type).stateView;
+        // Descriptors persist across the lifetime of the Behaviors instance (constructor + inject install them and
+        // close does not remove them so reuse paths like factory-reset can re-activate the same getter).  Returning
+        // undefined for endpoints that are tearing down keeps post-close access from re-entering #backingFor on a
+        // missing backing and surfacing a misleading BehaviorInitializationError.
+        const get = () => {
+            const status = this.#endpoint.construction.status;
+            if (status === Lifecycle.Status.Destroying || status === Lifecycle.Status.Destroyed) {
+                return undefined;
+            }
+            return this.#backingFor(type).stateView;
+        };
         Object.defineProperty(this.#endpoint.state, id, { get, enumerable: true, configurable: true });
         if (type.schema.id !== undefined) {
             Object.defineProperty(this.#endpoint.state, type.schema.id, { get, configurable: true });

--- a/packages/node/src/node/ClientNode.ts
+++ b/packages/node/src/node/ClientNode.ts
@@ -214,6 +214,11 @@ export class ClientNode extends Node<ClientNode.RootEndpoint> {
         await this.env.get(EndpointInitializer).eraseDescendant(this);
     }
 
+    protected override async resetWithMutex() {
+        this.#cachedPeerAddress = undefined;
+        await super.resetWithMutex();
+    }
+
     protected createRuntime(): NetworkRuntime {
         return new ClientNetworkRuntime(this);
     }

--- a/packages/node/src/node/ClientNode.ts
+++ b/packages/node/src/node/ClientNode.ts
@@ -20,6 +20,7 @@ import { ClientNodeStore } from "#storage/client/ClientNodeStore.js";
 import { RemoteWriter } from "#storage/client/RemoteWriter.js";
 import { ServerNodeStore } from "#storage/server/ServerNodeStore.js";
 import {
+    DependencyLifecycleError,
     Diagnostic,
     Identity,
     ImplementationError,
@@ -47,6 +48,7 @@ export class ClientNode extends Node<ClientNode.RootEndpoint> {
     #matter: MatterModel;
     #interaction?: ClientNodeInteraction;
     #blockInteractions = false;
+    #cachedPeerAddress?: PeerAddress;
 
     constructor(options: ClientNode.Options) {
         const opts = {
@@ -206,13 +208,9 @@ export class ClientNode extends Node<ClientNode.RootEndpoint> {
     }
 
     protected async eraseWithMutex() {
-        // First, ensure we're offline
         await this.cancelWithMutex();
-
-        // Then reset
         await super.resetWithMutex();
-
-        // and erase
+        this.#cachedPeerAddress = undefined;
         await this.env.get(EndpointInitializer).eraseDescendant(this);
     }
 
@@ -274,15 +272,32 @@ export class ClientNode extends Node<ClientNode.RootEndpoint> {
     }
 
     get peerAddress(): PeerAddress | undefined {
-        // If commissioned, use the peer address for logging purposes
-        let address = PeerAddress(this.behaviors.maybeStateOf("commissioning")?.peerAddress as PeerAddress | undefined);
-
-        // During early initialization commissioning state may not be loaded, so check directly in storage too
-        if (!address) {
-            address = PeerAddress(this.store.storeForEndpoint(this).peerAddress as PeerAddress | undefined);
+        // Whenever the commissioning backing is loaded its state is authoritative - mirror it (set or cleared)
+        // so the cache cannot survive a decommission as a stale value
+        const state = this.behaviors.maybeStateOf("commissioning");
+        if (state !== undefined) {
+            const live = PeerAddress(state.peerAddress as PeerAddress | undefined);
+            this.#cachedPeerAddress = live;
+            return live;
         }
 
-        return address;
+        if (this.#cachedPeerAddress !== undefined) {
+            return this.#cachedPeerAddress;
+        }
+
+        // Backing not yet loaded; consult storage directly, tolerating teardown
+        try {
+            const stored = PeerAddress(this.store.storeForEndpoint(this).peerAddress as PeerAddress | undefined);
+            if (stored !== undefined) {
+                this.#cachedPeerAddress = stored;
+                return stored;
+            }
+        } catch (error) {
+            DependencyLifecycleError.accept(error);
+            logger.info("Cannot resolve peer address from storage:", error);
+        }
+
+        return undefined;
     }
 
     override get identity() {

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -1362,6 +1362,28 @@ describe("ClientNode", () => {
             expect(address2.nodeId).not.equals(fabric.nodeId);
         });
     });
+
+    describe("peerAddress resilience", () => {
+        // Closing a ServerNode transitions ServerNodeStore.construction to "Closing" before the destructor releases
+        // child stores.  Pre-fix, peerAddress fell back to the storage layer via this.store, which would assert
+        // through to clientStores and throw [destroyed-dependency].  toString() (used in error message construction
+        // throughout Behaviors and Endpoint) then re-threw, masking the original cause.
+        it("peerAddress survives ServerNode shutdown via cache", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair();
+            const peer1 = controller.peers.get("peer1")!;
+            expect(peer1).not.undefined;
+
+            const cachedAddress = peer1.peerAddress;
+            expect(cachedAddress).not.undefined;
+
+            await MockTime.resolve(controller.close(), { macrotasks: true });
+
+            expect(() => peer1.peerAddress).not.throws();
+            expect(peer1.peerAddress).deep.equals(cachedAddress);
+            expect(() => peer1.toString()).not.throws();
+        });
+    });
 });
 
 const GLOBAL_ATTRS = [0xfff8, 0xfff9, 0xfffb, 0xfffc, 0xfffd];

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -1383,6 +1383,23 @@ describe("ClientNode", () => {
             expect(peer1.peerAddress).deep.equals(cachedAddress);
             expect(() => peer1.toString()).not.throws();
         });
+
+        // Behaviors.close() leaves the augmented endpoint.state[id] descriptors in place so that paths reusing the
+        // Behaviors instance (e.g. factory reset) can re-activate.  Post-close access must therefore not re-enter
+        // #backingFor and throw BehaviorInitializationError - the getter checks the construction status and returns
+        // undefined once the endpoint is tearing down.
+        it("endpoint.state[behaviorId] returns undefined after close", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair();
+            const peer1 = controller.peers.get("peer1")!;
+
+            expect(peer1.state.commissioning).not.undefined;
+
+            await MockTime.resolve(controller.close(), { macrotasks: true });
+
+            expect(() => peer1.state.commissioning).not.throws();
+            expect(peer1.state.commissioning).to.be.undefined;
+        });
     });
 });
 


### PR DESCRIPTION
## Summary

Fixes a misleading `WalStorageDriver Snapshot failed: [destroyed-dependency] client stores is closing` warning during ServerNode shutdown.

The shutdown sequence accesses `endpoint.state.<behaviorId>` on a ClientNode whose behaviors have already been closed.  The augmented descriptors on `endpoint.state` survive `Behaviors.close()` (so factory-reset can re-activate the same getter), but post-close access re-entered `#backingFor` on a missing backing and threw `BehaviorInitializationError`.  Constructing that error embedded `${this.#endpoint}` → `toString()` → `identity` → `peerAddress` → `this.store` → `ServerNodeStore.clientStores` (already in `Closing` state) → re-threw `[destroyed-dependency]`, masking the original cause.

Two layered fixes:

1. **`Behaviors.#augmentEndpoint` getter** now checks endpoint construction status and returns `undefined` for `Destroying`/`Destroyed` endpoints.  Active and Initializing paths (including late activation) are unchanged, so factory-reset still works.  This kills the root cause.
2. **`ClientNode.peerAddress`** mirrors live commissioning state into a cache and accepts `DependencyLifecycleError` around the storage probe.  `toString()` no longer throws even if a similar lifecycle race surfaces in another code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)