### PR TITLE
feat(node): add Endpoint.get()/getStateOf(), nodeType discriminant, Read.AttributePaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Feature: (@adeepn) Added `DclBehavior` for centralized DCL configuration via environment variables (`MATTER_DCL_*`), config files, or programmatic setup
     - Feature: `CommissioningClient.BaseCommissioningOptions` now accepts `wifiNetwork`, `threadNetwork`, `regulatoryLocation`, and `regulatoryCountryCode` for passing network credentials and regulatory configuration during commissioning
     - Feature: DoorLockServer is fully implemented except for Aliro features
-    - Feature: New Supervision() factory allows for fine-grained control of validation for state, commands, and arbitrary JS values
+    - Feature: The new Supervision() factory allows for fine-grained control of validation for state, commands, and arbitrary JS values
+    - Feature: Added `Endpoint.get()` and `Endpoint.getStateOf()` — async read API with optional `fabricFilter` control; on a client endpoint issues a single batched Matter Read; on a server endpoint returns a snapshot of local state
     - Enhancement: Re-establish subscriptions in parallel per peer on device/bridge startup
     - Enhancement: Added more warnings on invalid values for BasicInformation cluster
     - Adjustment: Because we saw devices in the wild that needed up to 2 minutes to respond to mDNS queries, we increased the discovery time for commissioning targets to 3 minutes (previously 1 minute)

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
                 "support/tests"
             ],
             "dependencies": {
-                "@nacho-iot/js-tools": "^0.1.3",
+                "@nacho-iot/js-tools": "^0.1.4",
                 "memlab": "^2.0.2"
             },
             "devDependencies": {
@@ -334,9 +334,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-            "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+            "version": "7.29.3",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+            "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -521,9 +521,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+            "version": "7.29.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.29.0"
@@ -1710,19 +1710,19 @@
             "license": "MIT"
         },
         "node_modules/@nacho-iot/js-tools": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/@nacho-iot/js-tools/-/js-tools-0.1.3.tgz",
-            "integrity": "sha512-US7wxe1iuODbbhz5BKcBeZc2BWFRSMd+DzQjLw9IkJf9afYXOfJY71lUPqAVVSCa8d70BIevhJg3Q0Kt0Z+2uQ==",
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/@nacho-iot/js-tools/-/js-tools-0.1.4.tgz",
+            "integrity": "sha512-mMFSXKL69ydc0iayDpz6smNvfC7H26VGXXpil/Kiew89KPfAd2h7tNfJXfEuy741P2wXXgUL6n/uZTGq60vGaw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@microsoft/tsdoc": "^0.16.0",
                 "@typescript/native-preview": "^7.0.0-dev.20260413.1",
                 "ansi-colors": "^4.1.3",
                 "commander": "^14.0.3",
-                "detective-typescript": "^14.0.0",
+                "detective-typescript": "^14.1.2",
                 "esbuild": "^0.28.0",
                 "minimatch": "^10.2.5",
-                "type-fest": "^5.5.0",
+                "type-fest": "^5.6.0",
                 "typedoc": "^0.28.19",
                 "typedoc-github-theme": "^0.4.0",
                 "typescript": "~6.0.2"
@@ -1766,9 +1766,9 @@
             }
         },
         "node_modules/@oxlint-tsgolint/darwin-arm64": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.22.0.tgz",
-            "integrity": "sha512-/exgXceakHbQrzaHTtKOe7MuDATaWMCCWpsCDQCZKeYhLGXzComipTrCYnHzAXrdnNBb5r5K+RRf5A6ormrhMA==",
+            "version": "0.22.1",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.22.1.tgz",
+            "integrity": "sha512-4150Lpgc1YM09GcjA6GSrra1JoPjC7aOpfywLjWEY4vW0Sd1qKzqHF1WRaiw0/qUZ40OATYdv3aRd7ipPkWQbw==",
             "cpu": [
                 "arm64"
             ],
@@ -1780,9 +1780,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/darwin-x64": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-0.22.0.tgz",
-            "integrity": "sha512-xFGdIahlmUbK+/MpZ5y08D0ewMGLDbd2Vki5wxVFYg50lSrtgPAtdDl+kqKZLNaFu0zpMar8n9wv1le05sL/jw==",
+            "version": "0.22.1",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-0.22.1.tgz",
+            "integrity": "sha512-vFWcPWYOgZs4HWcgS1EjUZg33NLcNfEYU49KGImmCfZWkflENrmBYV4HN/C0YeAPum6ZZ/goPSvQrB/cOD+NfA==",
             "cpu": [
                 "x64"
             ],
@@ -1794,9 +1794,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/linux-arm64": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-0.22.0.tgz",
-            "integrity": "sha512-53RvC9f77eUo+V1dfQNwGVnsIfPJFMibRR0ee128EUpYNDOZe/ojmCfuXJeU7cY91V7r7fZSm42KPJocXUX8og==",
+            "version": "0.22.1",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-0.22.1.tgz",
+            "integrity": "sha512-6LiUpP0Zir3+29FvBm7Y28q/dBjSHqTZ5MhG1Ckw4fGhI4cAvbcwXaKvbjx1TP7rRmBNOoq/M5xdpHjTb+GAew==",
             "cpu": [
                 "arm64"
             ],
@@ -1808,9 +1808,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/linux-x64": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-0.22.0.tgz",
-            "integrity": "sha512-evZcJAZ9hjNyuN69RnXwbt+U2pAOcYt+yvqukgugiCkRm4iBZ0R0CvpY1tgfG2XcGUhEPh8dljO+nPZTEVGpCQ==",
+            "version": "0.22.1",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-0.22.1.tgz",
+            "integrity": "sha512-fuX1hEQfpHauUbXADsfqVhRzrUrGabzGXbj5wsp2vKhV5uk/Rze8Mba9GdjFGECzvXudMGqHqxB4r6jGRdhxVA==",
             "cpu": [
                 "x64"
             ],
@@ -1822,9 +1822,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/win32-arm64": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-0.22.0.tgz",
-            "integrity": "sha512-7jTO+k1mr5BxRAI2fxc1NRcE3MAbHNZ0Vef9SD1yAR6d1E6qEv5D/D7yuHpQpw6AO3qoecSVo2Jzr+JirN61+w==",
+            "version": "0.22.1",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-0.22.1.tgz",
+            "integrity": "sha512-8SZidAj+jrbZf9ZjBEYW0tiNZ+KasqB2zgW26qdiPpQSF/DzURnPmXz651IeA9YsmbVdHGIooEHUmev6QJdquA==",
             "cpu": [
                 "arm64"
             ],
@@ -1836,9 +1836,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/win32-x64": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-0.22.0.tgz",
-            "integrity": "sha512-7lbl9XFcqO+scsynxMzTQdl0XUe6sBUCyY/oGWvCB+JmV4U+70vzSyZJdTEzzxtkZiNnUVFFh9RJLmoiQSne+w==",
+            "version": "0.22.1",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-0.22.1.tgz",
+            "integrity": "sha512-QweSk9H5lFh5Y+WUf2Kq/OAN88V6+62ZwGhP38gqdRotI90luXSMkruFTj7Q2rYrzH4ZVNaSqx7NY8JpSfIzqg==",
             "cpu": [
                 "x64"
             ],
@@ -1850,9 +1850,9 @@
             ]
         },
         "node_modules/@oxlint/binding-android-arm-eabi": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.61.0.tgz",
-            "integrity": "sha512-6eZBPgiigK5txqoVgRqxbaxiom4lM8AP8CyKPPvpzKnQ3iFRFOIDc+0AapF+qsUSwjOzr5SGk4SxQDpQhkSJMQ==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.62.0.tgz",
+            "integrity": "sha512-pKsthNECyvJh8lPTICz6VcwVy2jOqdhhsp1rlxCkhgZR47aKvXPmaRWQDv+zlXpRae4qm1MaaTnutkaOk5aofg==",
             "cpu": [
                 "arm"
             ],
@@ -1867,9 +1867,9 @@
             }
         },
         "node_modules/@oxlint/binding-android-arm64": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.61.0.tgz",
-            "integrity": "sha512-CkwLR69MUnyv5wjzebvbbtTSUwqLxM35CXE79bHqDIK+NtKmPEUpStTcLQRZMCo4MP0qRT6TXIQVpK0ZVScnMA==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.62.0.tgz",
+            "integrity": "sha512-b1AUNViByvgmR2xJDubvLIr+dSuu3uraG7bsAoKo+xrpspPvu6RIn6Fhr2JUhobfep3jwUTy18Huco6GkwdvGQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1884,9 +1884,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-arm64": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.61.0.tgz",
-            "integrity": "sha512-8JbefTkbmvqkqWjmQrHke+MdpgT2UghhD/ktM4FOQSpGeCgbMToJEKdl9zwhr/YWTl92i4QI1KiTwVExpcUN8A==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.62.0.tgz",
+            "integrity": "sha512-iG+Tvf70UJ6otfwFYIHk36Sjq9cpPP5YLxkoggANNRtzgi3Tj3g8q6Ybqi6AtkU3+yg9QwF7bDCkCS6bbL4PCg==",
             "cpu": [
                 "arm64"
             ],
@@ -1901,9 +1901,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-x64": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.61.0.tgz",
-            "integrity": "sha512-uWpoxDT47hTnDLcdEh5jVbso8rlTTu5o0zuqa9J8E0JAKmIWn7kGFEIB03Pycn2hd2vKxybPGLhjURy/9We5FQ==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.62.0.tgz",
+            "integrity": "sha512-oOWI6YPPr5AJUx+yIDlxmuUbQjS5gZX3OH3QisawYvsZgLiQVvZtR0rPBcJTxLWqt2ClrWg0DlSrlUiG5SQNHg==",
             "cpu": [
                 "x64"
             ],
@@ -1918,9 +1918,9 @@
             }
         },
         "node_modules/@oxlint/binding-freebsd-x64": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.61.0.tgz",
-            "integrity": "sha512-K/o4hEyW7flfMel0iBVznmMBt7VIMHGdjADocHKpK1DUF9erpWnJ+BSSWd2W0c8K3mPtpph+CuHzRU6CI3l9jQ==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.62.0.tgz",
+            "integrity": "sha512-dLP33T7VLCmLVv4cvjkVX+rmkcwNk2UfxmsZPNur/7BQHoQR60zJ7XLiRvNUawlzn0u8ngCa3itjEG73MAMa/w==",
             "cpu": [
                 "x64"
             ],
@@ -1935,9 +1935,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.61.0.tgz",
-            "integrity": "sha512-P6040ZkcyweJ0Po9yEFqJCdvZnf3VNCGs1SIHgXDf8AAQNC6ID/heXQs9iSgo2FH7gKaKq32VWc59XZwL34C5Q==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.62.0.tgz",
+            "integrity": "sha512-fl//LWNks6qo9chNY60UDYyIwtp7a5cEx4Y/rHPjaarhuwqx6jtbzEpD5V5AqmdL4a6Y5D8zeXg5HF2Cr0QmSQ==",
             "cpu": [
                 "arm"
             ],
@@ -1952,9 +1952,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.61.0.tgz",
-            "integrity": "sha512-bwxrGCzTZkuB+THv2TQ1aTkVEfv5oz8sl+0XZZCpoYzErJD8OhPQOTA0ENPd1zJz8QsVdSzSrS2umKtPq4/JXg==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.62.0.tgz",
+            "integrity": "sha512-i5vkAuxvueTODV3J2dL61/TXewDHhMFKvtD156cIsk7GsdfiAu7zW7kY0NJXhKeFHeiMZIh7eFNjkPYH6J47HQ==",
             "cpu": [
                 "arm"
             ],
@@ -1969,9 +1969,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-gnu": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.61.0.tgz",
-            "integrity": "sha512-vkhb9/wKguMkLlrm3FoJW/Xmdv31GgYAE+x8lxxQ+7HeOxXUySI0q36a3NTVIuQUdLzxCI1zzMGsk1o37FOe3w==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.62.0.tgz",
+            "integrity": "sha512-QwN19LLuIGuOjEflSeJkZmOTfBdBMlTmW8xbMf8TZhjd//cxVNYQPq75q7oKZBJc6hRx3gY7sX0Egc8cEIFZYg==",
             "cpu": [
                 "arm64"
             ],
@@ -1986,9 +1986,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-musl": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.61.0.tgz",
-            "integrity": "sha512-bl1dQh8LnVqsj6oOQAcxwbuOmNJkwc4p6o//HTBZhNTzJy21TLDwAviMqUFNUxDHkPGpmdKTSN4tWTjLryP8xg==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.62.0.tgz",
+            "integrity": "sha512-8eCy3FCDuWUM5hWujAv6heMvfZPbcCOU3SdQUAkixZLu5bSzOkNfirJiLGoQFO943xceOKkiQRMQNzH++jM3WA==",
             "cpu": [
                 "arm64"
             ],
@@ -2003,9 +2003,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.61.0.tgz",
-            "integrity": "sha512-QoOX6KB2IiEpyOj/HKqaxi+NQHPnOgNgnr22n9N4ANJCzXkUlj1UmeAbFb4PpqdlHIzvGDM5xZ0OKtcLq9RhiQ==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.62.0.tgz",
+            "integrity": "sha512-NjQ7K7tpTPDe9J+yq8p/s/J0E7lRCkK2uDBDqvT4XIT6f4Z0tlnr59OBg/WcrmVHER1AbrcfyxhGTXgcG8ytWg==",
             "cpu": [
                 "ppc64"
             ],
@@ -2020,9 +2020,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.61.0.tgz",
-            "integrity": "sha512-1TGcTerjY6p152wCof3oKElccq3xHljS/Mucp04gV/4ATpP6nO7YNnp7opEg6SHkv2a57/b4b8Ndm9znJ1/qAw==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.62.0.tgz",
+            "integrity": "sha512-oKZed9gmSwze29dEt3/Wnsv6l/Ygw/FUst+8Kfpv2SGeS/glEoTGZAMQw37SVyzFV76UTHJN2snGgxK2t2+8ow==",
             "cpu": [
                 "riscv64"
             ],
@@ -2037,9 +2037,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-musl": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.61.0.tgz",
-            "integrity": "sha512-65wXEmZIrX2ADwC8i/qFL4EWLSbeuBpAm3suuX1vu4IQkKd+wLT/HU/BOl84kp91u2SxPkPDyQgu4yrqp8vwVA==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.62.0.tgz",
+            "integrity": "sha512-gBjBxQ+9lGpAYq+ELqw0w8QXsBnkZclFc7GRX2r0LnEVn3ZTEqeIKpKcGjucmp76Q53bvJD0i4qBWBhcfhSfGA==",
             "cpu": [
                 "riscv64"
             ],
@@ -2054,9 +2054,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-s390x-gnu": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.61.0.tgz",
-            "integrity": "sha512-TVvhgMvor7Qa6COeXxCJ7ENOM+lcAOGsQ0iUdPSCv2hxb9qSHLQ4XF1h50S6RE1gBOJ0WV3rNukg4JJJP1LWRA==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.62.0.tgz",
+            "integrity": "sha512-Ew2Kxs9EQ9/mbAIJ2hvocMC0wsOu6YKzStI2eFBDt+Td5O8seVC/oxgRIHqCcl5sf5ratA1nozQBAuv7tphkHg==",
             "cpu": [
                 "s390x"
             ],
@@ -2071,9 +2071,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-gnu": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.61.0.tgz",
-            "integrity": "sha512-SjpS5uYuFoDnDdZPwZE59ndF95AsY47R5MliuneTWR1pDm2CxGJaYXbKULI71t5TVfLQUWmrHEGRL9xvuq6dnA==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.62.0.tgz",
+            "integrity": "sha512-5z25jcAA0gfKyVwz71A0VXgaPlocPoTAxhlv/hgoK6tlCrfoNuw7haWbDHvGMfjXhdic4EqVXGRv5XsTqFnbRQ==",
             "cpu": [
                 "x64"
             ],
@@ -2088,9 +2088,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-musl": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.61.0.tgz",
-            "integrity": "sha512-gGfAeGD4sNJGILZbc/yKcIimO9wQnPMoYp9swAaKeEtwsSQAbU+rsdQze5SBtIP6j0QDzeYd4XSSUCRCF+LIeQ==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.62.0.tgz",
+            "integrity": "sha512-IWpHmMB6ZDllPvqWDkG6AmXrN7JF5e/c4g/0PuURsmlK+vHoYZPB70rr4u1bn3I4LsKCSpqqfveyx6UCOC8wdg==",
             "cpu": [
                 "x64"
             ],
@@ -2105,9 +2105,9 @@
             }
         },
         "node_modules/@oxlint/binding-openharmony-arm64": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.61.0.tgz",
-            "integrity": "sha512-OlVT0LrG/ct33EVtWRyR+B/othwmDWeRxfi13wUdPeb3lAT5TgTcFDcfLfarZtzB4W1nWF/zICMgYdkggX2WmQ==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.62.0.tgz",
+            "integrity": "sha512-fjlSxxrD5pA594vkyikCS9MnPRjQawW6/BLgyTYkO+73wwPlYjkcZ7LSd974l0Q2zkHQmu4DPvJFLYA7o8xrxQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2122,9 +2122,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-arm64-msvc": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.61.0.tgz",
-            "integrity": "sha512-vI//NZPJk6DToiovPtaiwD4iQ7kO1r5ReWQD0sOOyKRtP3E2f6jxin4uvwi3OvDzHA2EFfd7DcZl5dtkQh7g1w==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.62.0.tgz",
+            "integrity": "sha512-EiFXr8loNS0Ul3Gu80+9nr1T8jRmnKocqmHHg16tj5ZqTgUXyb97l2rrspVHdDluyFn9JfR4PoJFdNzw4paHww==",
             "cpu": [
                 "arm64"
             ],
@@ -2139,9 +2139,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-ia32-msvc": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.61.0.tgz",
-            "integrity": "sha512-0ySj4/4zd2XjePs3XAQq7IigIstN4LPQZgCyigX5/ERMLjdWAJfnxcTsrtxZxuij8guJW8foXuHmhGxW0H4dDA==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.62.0.tgz",
+            "integrity": "sha512-IgOFvL73li1bFgab+hThXYA0N2Xms2kV2MvZN95cebV+fmrZ9AVui1JSxfeeqRLo3CpPxKZlzhyq4G0cnaAvIw==",
             "cpu": [
                 "ia32"
             ],
@@ -2156,9 +2156,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-x64-msvc": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.61.0.tgz",
-            "integrity": "sha512-0xgSiyeqDLDZxXoe9CVJrOx3TUVsfyoOY7cNi03JbItNcC9WCZqrSNdrAbHONxhSPaVh/lzfnDcON1RqSUMhHw==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.62.0.tgz",
+            "integrity": "sha512-6hMpyDWQ2zGA1OXFKBrdYMUveUCO8UJhkO6JdwZPd78xIdHZNhjx+pib+4fC2Cljuhjyl0QwA2F3df/bs4Bp6A==",
             "cpu": [
                 "x64"
             ],
@@ -2199,9 +2199,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/codegen": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+            "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
@@ -2227,9 +2227,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/inquire": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+            "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
@@ -2245,9 +2245,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/utf8": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-            "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+            "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@puppeteer/browsers": {
@@ -2286,9 +2286,9 @@
             }
         },
         "node_modules/@puppeteer/browsers/node_modules/tar-stream": {
-            "version": "3.1.8",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
-            "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+            "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
             "license": "MIT",
             "dependencies": {
                 "b4a": "^1.6.4",
@@ -3341,13 +3341,13 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
-            "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
+            "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.59.0",
-                "@typescript-eslint/types": "^8.59.0",
+                "@typescript-eslint/tsconfig-utils": "^8.59.1",
+                "@typescript-eslint/types": "^8.59.1",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -3362,9 +3362,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
-            "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
+            "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3378,9 +3378,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
-            "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
+            "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3391,15 +3391,15 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
-            "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
+            "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.59.0",
-                "@typescript-eslint/tsconfig-utils": "8.59.0",
-                "@typescript-eslint/types": "8.59.0",
-                "@typescript-eslint/visitor-keys": "8.59.0",
+                "@typescript-eslint/project-service": "8.59.1",
+                "@typescript-eslint/tsconfig-utils": "8.59.1",
+                "@typescript-eslint/types": "8.59.1",
+                "@typescript-eslint/visitor-keys": "8.59.1",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -3418,12 +3418,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
-            "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
+            "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.0",
+                "@typescript-eslint/types": "8.59.1",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -3435,9 +3435,9 @@
             }
         },
         "node_modules/@typescript/native-preview": {
-            "version": "7.0.0-dev.20260426.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260426.1.tgz",
-            "integrity": "sha512-zE7B6TIG4XDYr4Your5E2Bxm1vD2YiPyD8OFG4nD5Odt/uN6gO0Y+T4TIbtGUBmOftMRqEV2Jw1ZC4ka0my1yw==",
+            "version": "7.0.0-dev.20260503.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260503.1.tgz",
+            "integrity": "sha512-gDro38CPFiBUGbaFGNt+ufOsEd1OrZrfrOPxsLSfBcvvoGaqAxV++ul/BHTOShoEkIYHiFsoDX2az1IPCDV2jQ==",
             "license": "Apache-2.0",
             "bin": {
                 "tsgo": "bin/tsgo.js"
@@ -3446,19 +3446,19 @@
                 "node": ">=16.20.0"
             },
             "optionalDependencies": {
-                "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260426.1",
-                "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260426.1",
-                "@typescript/native-preview-linux-arm": "7.0.0-dev.20260426.1",
-                "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260426.1",
-                "@typescript/native-preview-linux-x64": "7.0.0-dev.20260426.1",
-                "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260426.1",
-                "@typescript/native-preview-win32-x64": "7.0.0-dev.20260426.1"
+                "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260503.1",
+                "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260503.1",
+                "@typescript/native-preview-linux-arm": "7.0.0-dev.20260503.1",
+                "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260503.1",
+                "@typescript/native-preview-linux-x64": "7.0.0-dev.20260503.1",
+                "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260503.1",
+                "@typescript/native-preview-win32-x64": "7.0.0-dev.20260503.1"
             }
         },
         "node_modules/@typescript/native-preview-darwin-arm64": {
-            "version": "7.0.0-dev.20260426.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260426.1.tgz",
-            "integrity": "sha512-HzGvERpIFO7p6pMljPN1fIOHqAv2oMeVIqYLSt27TKILkTRpe7fANW3R2OAM+/A+pLtYNNXGDbKl/wR+DHz9KA==",
+            "version": "7.0.0-dev.20260503.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260503.1.tgz",
+            "integrity": "sha512-rUZQVuBcZlxADagx+pnhDHqjX2Ewh+KWave6vtilRWR5vsGyR3FaCzPFqXteiwPg6XRijEMnMaXg60t5itm8EA==",
             "cpu": [
                 "arm64"
             ],
@@ -3472,9 +3472,9 @@
             }
         },
         "node_modules/@typescript/native-preview-darwin-x64": {
-            "version": "7.0.0-dev.20260426.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260426.1.tgz",
-            "integrity": "sha512-aE17wCPNQ09K4jV7TQYYRYF/Q/6nFS9jLpbyTYHtS+i+0yV1Rrs4VsqboisS1R/iSWsq3m1Yhh3uS4x3/9KUkg==",
+            "version": "7.0.0-dev.20260503.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260503.1.tgz",
+            "integrity": "sha512-YtK8ac8RCkRh7jwoP8Wt4LaBhpGK8cOVMi3e0cvF/8Xn5XV1ewJK3/HdNBnlDhCib3j0eVRxK/Pg9GIq/hFUxQ==",
             "cpu": [
                 "x64"
             ],
@@ -3488,9 +3488,9 @@
             }
         },
         "node_modules/@typescript/native-preview-linux-arm": {
-            "version": "7.0.0-dev.20260426.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260426.1.tgz",
-            "integrity": "sha512-/XJRC8B6JeOOb2/iek/BrzW4r5Nut+fkucG7ntEOQn63IRTsfP+AfJdJodG1VIwXOleNlFgG4RtYTUsvcbDJhg==",
+            "version": "7.0.0-dev.20260503.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260503.1.tgz",
+            "integrity": "sha512-28vAomYeU8hpz1f0dDoWz6PYehz0ffEfkJhFq4tqXzUM/QY1I15u5y03EJQ5UcP4LRwrdJe22J5LdrYpM2Lr3w==",
             "cpu": [
                 "arm"
             ],
@@ -3504,9 +3504,9 @@
             }
         },
         "node_modules/@typescript/native-preview-linux-arm64": {
-            "version": "7.0.0-dev.20260426.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260426.1.tgz",
-            "integrity": "sha512-6OfhODChD1N6FX+ITzA1lny3WX6uew/Nw9kN7uWhymXlM3/vE0qtaAfsMpgdHdCbTPgcdpGaNFhbcMieju9Vdg==",
+            "version": "7.0.0-dev.20260503.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260503.1.tgz",
+            "integrity": "sha512-c5yM3Ea2WZSLKmscMxUhEDdaR2Ugp7P9CX6osciIPgZIF9c4LDiuKQohjQAyidx9JZKCsSXnfS88QssWH/+ONQ==",
             "cpu": [
                 "arm64"
             ],
@@ -3520,9 +3520,9 @@
             }
         },
         "node_modules/@typescript/native-preview-linux-x64": {
-            "version": "7.0.0-dev.20260426.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260426.1.tgz",
-            "integrity": "sha512-KPDpjmLo/4xY8ugfMGFm7Ona/1igPzZveLt/C0rb6/jNPYuShumRfKYnItGDRXBlmecJY/04lrqkWqQjhtSSPg==",
+            "version": "7.0.0-dev.20260503.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260503.1.tgz",
+            "integrity": "sha512-M64z7LwpqNfOXYCBKmD/ObwyxYOobUk4tDv0ECNLit7pDER1sswNZjJGjgRYjQsKokmydy6p3FqtJ1uUPUP/sw==",
             "cpu": [
                 "x64"
             ],
@@ -3536,9 +3536,9 @@
             }
         },
         "node_modules/@typescript/native-preview-win32-arm64": {
-            "version": "7.0.0-dev.20260426.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260426.1.tgz",
-            "integrity": "sha512-I7ThiopxuNKX/iAcwgMwsm6L32GOwmwLOyPwQmXjh5c3VD2acq3FYyZRDJVk0aUUy1w6bTbODlo5ZHoPnlZtvw==",
+            "version": "7.0.0-dev.20260503.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260503.1.tgz",
+            "integrity": "sha512-QHy3R1VBb8MYszjpz0IyuDjKaW6JUHg8hYEqzhZIxvrydKLF3gyDeKohnmWSFTS/oII0GvUmYM3h83fbanBvcQ==",
             "cpu": [
                 "arm64"
             ],
@@ -3552,9 +3552,9 @@
             }
         },
         "node_modules/@typescript/native-preview-win32-x64": {
-            "version": "7.0.0-dev.20260426.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260426.1.tgz",
-            "integrity": "sha512-4624MJq72vN4H1msiWVBqAIyerJRi5Ni/U6eeE1A1Opqg4c4QoalYQQ+5h5RIuaZ6rY+9kvUn+SjsvbZwyLbjQ==",
+            "version": "7.0.0-dev.20260503.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260503.1.tgz",
+            "integrity": "sha512-nrapqpVONrg0IZjKp3AzV9M+jxPwKGTQZEOxuKh6WHMhy/UElN8RnOFlfetA8ZMtKvPkmjgjqw0qoAa5QMwhPA==",
             "cpu": [
                 "x64"
             ],
@@ -3812,9 +3812,9 @@
             }
         },
         "node_modules/b4a": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
-            "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+            "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "react-native-b4a": "*"
@@ -3892,9 +3892,9 @@
             }
         },
         "node_modules/bare-os": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.0.tgz",
-            "integrity": "sha512-JTjuZyNIDpw+GytMO4a6TK1VXdVKKJr6DRxEHasyuYyShV2deuiHJK/ahGZlebc+SG0/wJCB9XK8gprBGDFi/Q==",
+            "version": "3.9.1",
+            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+            "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
             "license": "Apache-2.0",
             "engines": {
                 "bare": ">=1.14.0"
@@ -3910,9 +3910,9 @@
             }
         },
         "node_modules/bare-stream": {
-            "version": "2.13.0",
-            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
-            "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+            "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
             "license": "Apache-2.0",
             "dependencies": {
                 "streamx": "^2.25.0",
@@ -3972,9 +3972,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.22",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.22.tgz",
-            "integrity": "sha512-6qruVrb5rse6WylFkU0FhBKKGuecWseqdpQfhkawn6ztyk2QlfwSRjsDxMCLJrkfmfN21qvhl9ABgaMeRkuwww==",
+            "version": "2.10.25",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.25.tgz",
+            "integrity": "sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==",
             "license": "Apache-2.0",
             "peer": true,
             "bin": {
@@ -3985,9 +3985,9 @@
             }
         },
         "node_modules/basic-ftp": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-            "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+            "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -5074,9 +5074,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.344",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
-            "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+            "version": "1.5.349",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
+            "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
             "license": "ISC",
             "peer": true
         },
@@ -6350,9 +6350,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-            "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
@@ -7001,9 +7001,9 @@
             "peer": true
         },
         "node_modules/jsdom": {
-            "version": "29.1.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.0.tgz",
-            "integrity": "sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==",
+            "version": "29.1.1",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+            "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7443,9 +7443,9 @@
             "peer": true
         },
         "node_modules/metro": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/metro/-/metro-0.84.3.tgz",
-            "integrity": "sha512-1h3lbVrE6hGf1e/764HfhPGg/bGrWMJDDh7G2rc4gFYZboVuI40BlG/y+UhtbhQDNlO/csMvrcnK0YrTlHUVew==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro/-/metro-0.84.4.tgz",
+            "integrity": "sha512-8ETTubqfD6ornDy2zYDvRcKnVDOXdFJsjetYDBsY4oAsb6NJkiwFR+FaMESyGppFmQUyBQA4H4sFGxzcQSGtFA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -7457,7 +7457,6 @@
                 "@babel/traverse": "^7.29.0",
                 "@babel/types": "^7.29.0",
                 "accepts": "^2.0.0",
-                "chalk": "^4.0.0",
                 "ci-info": "^2.0.0",
                 "connect": "^3.6.5",
                 "debug": "^4.4.0",
@@ -7470,18 +7469,18 @@
                 "jest-worker": "^29.7.0",
                 "jsc-safe-url": "^0.2.2",
                 "lodash.throttle": "^4.1.1",
-                "metro-babel-transformer": "0.84.3",
-                "metro-cache": "0.84.3",
-                "metro-cache-key": "0.84.3",
-                "metro-config": "0.84.3",
-                "metro-core": "0.84.3",
-                "metro-file-map": "0.84.3",
-                "metro-resolver": "0.84.3",
-                "metro-runtime": "0.84.3",
-                "metro-source-map": "0.84.3",
-                "metro-symbolicate": "0.84.3",
-                "metro-transform-plugins": "0.84.3",
-                "metro-transform-worker": "0.84.3",
+                "metro-babel-transformer": "0.84.4",
+                "metro-cache": "0.84.4",
+                "metro-cache-key": "0.84.4",
+                "metro-config": "0.84.4",
+                "metro-core": "0.84.4",
+                "metro-file-map": "0.84.4",
+                "metro-resolver": "0.84.4",
+                "metro-runtime": "0.84.4",
+                "metro-source-map": "0.84.4",
+                "metro-symbolicate": "0.84.4",
+                "metro-transform-plugins": "0.84.4",
+                "metro-transform-worker": "0.84.4",
                 "mime-types": "^3.0.1",
                 "nullthrows": "^1.1.1",
                 "serialize-error": "^2.1.0",
@@ -7498,16 +7497,16 @@
             }
         },
         "node_modules/metro-babel-transformer": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.84.3.tgz",
-            "integrity": "sha512-svAA+yMLpeMiGcz/jKJs4oHpIGEx4nBqNEJ5AGj4CYIg1efvK+A0TjR6tgIuc6tKO5e8JmN/1lglpN2+f3/z/w==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.84.4.tgz",
+            "integrity": "sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/core": "^7.25.2",
                 "flow-enums-runtime": "^0.0.6",
                 "hermes-parser": "0.35.0",
-                "metro-cache-key": "0.84.3",
+                "metro-cache-key": "0.84.4",
                 "nullthrows": "^1.1.1"
             },
             "engines": {
@@ -7532,25 +7531,25 @@
             }
         },
         "node_modules/metro-cache": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.84.3.tgz",
-            "integrity": "sha512-0QElxwLaHqLZf+Xqio8QrjVbuXP/8sJfQBGSPiITlKDVXrVLefuzYVSH9Sj+QL6lrPj2gYZd/iwQh1yZuVKnLA==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.84.4.tgz",
+            "integrity": "sha512-gpcFQdSLUwUCk71saKoE64jLFbx2nwTfVCcPSULMNT8QYq0p1eZZE29Jvd0HtT/UlhC3ZOutLxJME5xqD2JUZg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "exponential-backoff": "^3.1.1",
                 "flow-enums-runtime": "^0.0.6",
                 "https-proxy-agent": "^7.0.5",
-                "metro-core": "0.84.3"
+                "metro-core": "0.84.4"
             },
             "engines": {
                 "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
         "node_modules/metro-cache-key": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.84.3.tgz",
-            "integrity": "sha512-TnSL1Fdvrw+2glTdBSRmA5TL8l/i16ECjsrUdf3E5HncA+sNx8KcwDG8r+3ct1UhfYcusJypzZqTN55FZZcwGg==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.84.4.tgz",
+            "integrity": "sha512-wVO79aGrkYImpnaVS4+d5RrRBRPX31QtvKB3wKGBuiNSznduZTQHzsrJZRroFJSwnygrzdsGUtDQPuqqFjFdvw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -7561,19 +7560,19 @@
             }
         },
         "node_modules/metro-config": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.84.3.tgz",
-            "integrity": "sha512-JmCzZWOETR+O22q8oPBWyQppx3roU9EbkbGzD8Gf1jukQ4b5T1fTzqqHruu6K4sTiNq5zVQySmKF6bp4kVARew==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.84.4.tgz",
+            "integrity": "sha512-PMotGDjXcXLWo2TMRH+VR99phFNgYTwqh4OoieIKK3yTJa1Jmkl+fZJxDO0jfBvNF+WESHciHvpNuBtXaF3B0Q==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "connect": "^3.6.5",
                 "flow-enums-runtime": "^0.0.6",
                 "jest-validate": "^29.7.0",
-                "metro": "0.84.3",
-                "metro-cache": "0.84.3",
-                "metro-core": "0.84.3",
-                "metro-runtime": "0.84.3",
+                "metro": "0.84.4",
+                "metro-cache": "0.84.4",
+                "metro-core": "0.84.4",
+                "metro-runtime": "0.84.4",
                 "yaml": "^2.6.1"
             },
             "engines": {
@@ -7581,24 +7580,24 @@
             }
         },
         "node_modules/metro-core": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.84.3.tgz",
-            "integrity": "sha512-cc0pvAa80ai1nDmqqz0P59a+0ZqCZ/YHU/3jEekZL6spFnYDfX8iDLdn9FR6kX+67rmzKxHNrbrSRFLX2AYocw==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.84.4.tgz",
+            "integrity": "sha512-HONpWC5LGXZn3ffkd4Hu6AIrfE7j4Z0g0wMo/goV24WOB3lhuFZ40KgvaDiSw8iyQHloMYay5N/wPX+z8oN/PQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "flow-enums-runtime": "^0.0.6",
                 "lodash.throttle": "^4.1.1",
-                "metro-resolver": "0.84.3"
+                "metro-resolver": "0.84.4"
             },
             "engines": {
                 "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
         "node_modules/metro-file-map": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.84.3.tgz",
-            "integrity": "sha512-1cL4m4Jv1yRUt9RJExZQLfccscdlMNOcRG6LHLtmJhf3BG9j3MujPVc7CIpKYdFl+KUl+sdjge6oO3+meKCHQA==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.84.4.tgz",
+            "integrity": "sha512-KSVDi/u60hKPx++NLu3MTIvyjzNoJnFAF8PQFxaj1jiSka/wjw+Ua6sNuJ0TDHQv+7AAoFQxeMgaRAe8Yic5wQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -7617,9 +7616,9 @@
             }
         },
         "node_modules/metro-minify-terser": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.84.3.tgz",
-            "integrity": "sha512-3ofrG2OQyJbO9RNhCfOcl8QU7EE2WrSsnN5dFkuZaJO5+4Imujr9bUXmspeNlXRsOVk0F/rVRbEFH98lFSCkBQ==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.84.4.tgz",
+            "integrity": "sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -7631,9 +7630,9 @@
             }
         },
         "node_modules/metro-resolver": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.84.3.tgz",
-            "integrity": "sha512-pjEzGDtoM8DTHAIPK/9u9ZxszEiuRohYUVImWvgbnB91V4gqYJpQcoEYUugf2NIm1lrX5HNu0OvNqWmPBnGYjA==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.84.4.tgz",
+            "integrity": "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -7644,9 +7643,9 @@
             }
         },
         "node_modules/metro-runtime": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.3.tgz",
-            "integrity": "sha512-o7HLRfMyVk9N2dUZ9VjQfB6xxUItL9Pi9WcqxURE7MEKOH6wbGt9/E92YdYLluTOtkzYAEVfdC6h6lcxqA+hMQ==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.4.tgz",
+            "integrity": "sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -7658,9 +7657,9 @@
             }
         },
         "node_modules/metro-source-map": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.3.tgz",
-            "integrity": "sha512-jS48CeSzw78M8y6VE0f9uy3lVmfbOS677j2VCxnlmlYmnahcXuC6IhoN9K6LynNvos9517yUadcfgioju38xYQ==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.4.tgz",
+            "integrity": "sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -7668,9 +7667,9 @@
                 "@babel/types": "^7.29.0",
                 "flow-enums-runtime": "^0.0.6",
                 "invariant": "^2.2.4",
-                "metro-symbolicate": "0.84.3",
+                "metro-symbolicate": "0.84.4",
                 "nullthrows": "^1.1.1",
-                "ob1": "0.84.3",
+                "ob1": "0.84.4",
                 "source-map": "^0.5.6",
                 "vlq": "^1.0.0"
             },
@@ -7689,15 +7688,15 @@
             }
         },
         "node_modules/metro-symbolicate": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.84.3.tgz",
-            "integrity": "sha512-J9Tpo8NCycYrozRvBIUyOwGAu4xkawOsAppmTscFiaegK0WvuDGwIM53GbzVSnytCHjVAF0io5GQxpkrKTuc7g==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.84.4.tgz",
+            "integrity": "sha512-OnfpacxUqGPZQ27t8qK9mFa7uqHIlVWeqRqkCbvMvreEBiamEeOn8krKtcwgP5M4cYDPwuSmCTopHMVthqG4zA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "flow-enums-runtime": "^0.0.6",
                 "invariant": "^2.2.4",
-                "metro-source-map": "0.84.3",
+                "metro-source-map": "0.84.4",
                 "nullthrows": "^1.1.1",
                 "source-map": "^0.5.6",
                 "vlq": "^1.0.0"
@@ -7720,9 +7719,9 @@
             }
         },
         "node_modules/metro-transform-plugins": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.84.3.tgz",
-            "integrity": "sha512-8S3baq2XhBaafHEH5Q8sJW6tmzsEJk80qKc3RU/nZV1MsnYq94RdjTUR6AyKjQd6Rfsk1BtBxhtiNnk7mgslCg==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.84.4.tgz",
+            "integrity": "sha512-kehr6HbAecqD0/a3xLXobELdPaAmRAl8bel0qagPF4vhZtux93nS8S4eq2kgKt6J2GnQpVjSoW1PXdst04mwow==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -7738,9 +7737,9 @@
             }
         },
         "node_modules/metro-transform-worker": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.84.3.tgz",
-            "integrity": "sha512-Wjba7PyYktNRsHbPmkx2J2UX32rAzcDXjCu49zPHeF/viJlYJhwRaNePQcHaCRqQ+kmgQT4ThprsnJfDj71ZMA==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.84.4.tgz",
+            "integrity": "sha512-W1IYMvvXTu4MxYr7d9h7CeG2vpIr3bmLLIavkPY4O1ilzDrvS8z/NEe6y+pC44Ff7raMXQgYSfdqDUwN/i39gg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -7749,13 +7748,13 @@
                 "@babel/parser": "^7.29.0",
                 "@babel/types": "^7.29.0",
                 "flow-enums-runtime": "^0.0.6",
-                "metro": "0.84.3",
-                "metro-babel-transformer": "0.84.3",
-                "metro-cache": "0.84.3",
-                "metro-cache-key": "0.84.3",
-                "metro-minify-terser": "0.84.3",
-                "metro-source-map": "0.84.3",
-                "metro-transform-plugins": "0.84.3",
+                "metro": "0.84.4",
+                "metro-babel-transformer": "0.84.4",
+                "metro-cache": "0.84.4",
+                "metro-cache-key": "0.84.4",
+                "metro-minify-terser": "0.84.4",
+                "metro-source-map": "0.84.4",
+                "metro-transform-plugins": "0.84.4",
                 "nullthrows": "^1.1.1"
             },
             "engines": {
@@ -8258,9 +8257,9 @@
             }
         },
         "node_modules/ob1": {
-            "version": "0.84.3",
-            "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.84.3.tgz",
-            "integrity": "sha512-J7554Ef8bzmKaDY365Afq6PF+qtdnY/d5PKUQFrsKlZHV/N3OGZewVrvDrQDyX5V5NJjTpcAKtlrFZcDr+HvpQ==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.84.4.tgz",
+            "integrity": "sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -8387,9 +8386,9 @@
             }
         },
         "node_modules/oxlint": {
-            "version": "1.61.0",
-            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.61.0.tgz",
-            "integrity": "sha512-ZC0ALuhDZ6ivOFG+sy0D0pEDN49EvsId98zVlmYdkcXHsEM14m/qTNUEsUpiFiCVbpIxYtVBmmLE87nsbUHohQ==",
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.62.0.tgz",
+            "integrity": "sha512-1uFkg6HakjsGIpW9wNdeW4/2LOHW9MEkoWjZUTUfQtIHyLIZPYt00w3Sg+H3lH+206FgBPHBbW5dVE5l2ExECQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -8402,25 +8401,25 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxlint/binding-android-arm-eabi": "1.61.0",
-                "@oxlint/binding-android-arm64": "1.61.0",
-                "@oxlint/binding-darwin-arm64": "1.61.0",
-                "@oxlint/binding-darwin-x64": "1.61.0",
-                "@oxlint/binding-freebsd-x64": "1.61.0",
-                "@oxlint/binding-linux-arm-gnueabihf": "1.61.0",
-                "@oxlint/binding-linux-arm-musleabihf": "1.61.0",
-                "@oxlint/binding-linux-arm64-gnu": "1.61.0",
-                "@oxlint/binding-linux-arm64-musl": "1.61.0",
-                "@oxlint/binding-linux-ppc64-gnu": "1.61.0",
-                "@oxlint/binding-linux-riscv64-gnu": "1.61.0",
-                "@oxlint/binding-linux-riscv64-musl": "1.61.0",
-                "@oxlint/binding-linux-s390x-gnu": "1.61.0",
-                "@oxlint/binding-linux-x64-gnu": "1.61.0",
-                "@oxlint/binding-linux-x64-musl": "1.61.0",
-                "@oxlint/binding-openharmony-arm64": "1.61.0",
-                "@oxlint/binding-win32-arm64-msvc": "1.61.0",
-                "@oxlint/binding-win32-ia32-msvc": "1.61.0",
-                "@oxlint/binding-win32-x64-msvc": "1.61.0"
+                "@oxlint/binding-android-arm-eabi": "1.62.0",
+                "@oxlint/binding-android-arm64": "1.62.0",
+                "@oxlint/binding-darwin-arm64": "1.62.0",
+                "@oxlint/binding-darwin-x64": "1.62.0",
+                "@oxlint/binding-freebsd-x64": "1.62.0",
+                "@oxlint/binding-linux-arm-gnueabihf": "1.62.0",
+                "@oxlint/binding-linux-arm-musleabihf": "1.62.0",
+                "@oxlint/binding-linux-arm64-gnu": "1.62.0",
+                "@oxlint/binding-linux-arm64-musl": "1.62.0",
+                "@oxlint/binding-linux-ppc64-gnu": "1.62.0",
+                "@oxlint/binding-linux-riscv64-gnu": "1.62.0",
+                "@oxlint/binding-linux-riscv64-musl": "1.62.0",
+                "@oxlint/binding-linux-s390x-gnu": "1.62.0",
+                "@oxlint/binding-linux-x64-gnu": "1.62.0",
+                "@oxlint/binding-linux-x64-musl": "1.62.0",
+                "@oxlint/binding-openharmony-arm64": "1.62.0",
+                "@oxlint/binding-win32-arm64-msvc": "1.62.0",
+                "@oxlint/binding-win32-ia32-msvc": "1.62.0",
+                "@oxlint/binding-win32-x64-msvc": "1.62.0"
             },
             "peerDependencies": {
                 "oxlint-tsgolint": ">=0.18.0"
@@ -8432,21 +8431,21 @@
             }
         },
         "node_modules/oxlint-tsgolint": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-0.22.0.tgz",
-            "integrity": "sha512-ku4MecLmCQIj1ScCtzNAqTuyl0BJQ02B36fJT+c5XQihHpYSFak+FC3GYO5fPyYk4oDwi0w0S7hTvrpNzuZhig==",
+            "version": "0.22.1",
+            "resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-0.22.1.tgz",
+            "integrity": "sha512-YUSGSLUnoolsu8gxISEDio3q1rtsCozwfOzASUn3DT2mR2EeQ93uEEnen7s+6LpF+lyTQFln1pQfqwBh/fsVEg==",
             "dev": true,
             "license": "MIT",
             "bin": {
                 "tsgolint": "bin/tsgolint.js"
             },
             "optionalDependencies": {
-                "@oxlint-tsgolint/darwin-arm64": "0.22.0",
-                "@oxlint-tsgolint/darwin-x64": "0.22.0",
-                "@oxlint-tsgolint/linux-arm64": "0.22.0",
-                "@oxlint-tsgolint/linux-x64": "0.22.0",
-                "@oxlint-tsgolint/win32-arm64": "0.22.0",
-                "@oxlint-tsgolint/win32-x64": "0.22.0"
+                "@oxlint-tsgolint/darwin-arm64": "0.22.1",
+                "@oxlint-tsgolint/darwin-x64": "0.22.1",
+                "@oxlint-tsgolint/linux-arm64": "0.22.1",
+                "@oxlint-tsgolint/linux-x64": "0.22.1",
+                "@oxlint-tsgolint/win32-arm64": "0.22.1",
+                "@oxlint-tsgolint/win32-x64": "0.22.1"
             }
         },
         "node_modules/p-defer": {
@@ -8874,22 +8873,22 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-            "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+            "version": "7.5.6",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+            "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
-                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/codegen": "^2.0.5",
                 "@protobufjs/eventemitter": "^1.1.0",
                 "@protobufjs/fetch": "^1.1.0",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/inquire": "^1.1.1",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
-                "@protobufjs/utf8": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.1",
                 "@types/node": ">=13.7.0",
                 "long": "^5.0.0"
             },
@@ -9207,9 +9206,9 @@
             }
         },
         "node_modules/react-native-nitro-modules": {
-            "version": "0.35.5",
-            "resolved": "https://registry.npmjs.org/react-native-nitro-modules/-/react-native-nitro-modules-0.35.5.tgz",
-            "integrity": "sha512-aa03UzC5dLg5qFfyBkVK+JGSwHTjmK7jUZzyRz11r1Yk9C/nJTFe59EeHPxxNNTagkiwQTM6p3sySgD/TDRC7Q==",
+            "version": "0.35.6",
+            "resolved": "https://registry.npmjs.org/react-native-nitro-modules/-/react-native-nitro-modules-0.35.6.tgz",
+            "integrity": "sha512-3Cb7s+O5tpZ6RdIiPOB/wi3IMfBxD6tl6VDF8gJ5zvM/BEGTWxwMMLjzmWmsYPKekdbYBznF6qp2d2SxixPy8g==",
             "license": "MIT",
             "peer": true,
             "peerDependencies": {
@@ -9245,9 +9244,9 @@
             }
         },
         "node_modules/react-native-quick-crypto": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/react-native-quick-crypto/-/react-native-quick-crypto-1.1.0.tgz",
-            "integrity": "sha512-9O1O5MP+H0o34MvigBHN13W6OL1NSCYvVkcDumDFlsifgkob++Xq+RrCc8OXbl9EpVcEep1k6Y35HOfAuFr1TQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/react-native-quick-crypto/-/react-native-quick-crypto-1.1.1.tgz",
+            "integrity": "sha512-MlaT8d5rwsAB1JHpJwlrIGGPVJBghUoHKzcHDj9DYcNoWaSoR6GhV3rqTdcXpOlmavvjBt/xtXPsw7s2VPnXPQ==",
             "license": "MIT",
             "dependencies": {
                 "@craftzdog/react-native-buffer": "6.1.0",
@@ -10046,12 +10045,12 @@
             }
         },
         "node_modules/socks": {
-            "version": "2.8.7",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-            "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+            "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
+            "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
             "license": "MIT",
             "dependencies": {
-                "ip-address": "^10.0.1",
+                "ip-address": "^10.1.1",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
@@ -10628,22 +10627,22 @@
             }
         },
         "node_modules/tldts": {
-            "version": "7.0.28",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
-            "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+            "version": "7.0.30",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+            "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "tldts-core": "^7.0.28"
+                "tldts-core": "^7.0.30"
             },
             "bin": {
                 "tldts": "bin/cli.js"
             }
         },
         "node_modules/tldts-core": {
-            "version": "7.0.28",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
-            "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+            "version": "7.0.30",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+            "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -11586,9 +11585,9 @@
             "peer": true
         },
         "node_modules/yaml": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+            "version": "2.8.4",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+            "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"
@@ -11684,7 +11683,7 @@
                 "@matter/nodejs": "*",
                 "@matter/protocol": "*",
                 "@matter/types": "*",
-                "@nacho-iot/js-tools": "*",
+                "@nacho-iot/js-tools": "0.1.4",
                 "@types/escodegen": "^0.0.10",
                 "acorn": "^8.16.0",
                 "ansi-colors": "^4.1.3",
@@ -11705,7 +11704,7 @@
                 "matter-create": "bin/create.js"
             },
             "devDependencies": {
-                "@nacho-iot/js-tools": "*",
+                "@nacho-iot/js-tools": "0.1.4",
                 "@types/node": "^25.6.0",
                 "@types/tar-stream": "^3.1.4"
             },
@@ -11790,7 +11789,7 @@
             },
             "devDependencies": {
                 "@matter/testing": "*",
-                "@nacho-iot/js-tools": "*"
+                "@nacho-iot/js-tools": "^0.1.4"
             }
         },
         "packages/nodejs": {
@@ -12001,7 +12000,7 @@
             "version": "0.0.0-git",
             "license": "Apache-2.0",
             "dependencies": {
-                "@nacho-iot/js-tools": "*",
+                "@nacho-iot/js-tools": "0.1.4",
                 "@types/express": "^5.0.6",
                 "ansi-colors": "^4.1.3",
                 "chai": "^4.5.0",
@@ -12293,96 +12292,6 @@
                 "@matter/testing": "*",
                 "@memlab/api": "^2.0.2",
                 "@memlab/heap-analysis": "^2.0.0"
-            }
-        },
-        "support/tests/node_modules/@memlab/api": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@memlab/api/-/api-2.0.2.tgz",
-            "integrity": "sha512-Nx0T7is5FwZDo9aZn6LTtBcVXf/hUoncyZWJVcoik7kT6icH7birXJk3Th06fGIydub3mhrU5zn5stzTRec5UQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@memlab/core": "^2.0.2",
-                "@memlab/e2e": "^2.0.2",
-                "@memlab/heap-analysis": "^2.0.2",
-                "ansi": "^0.3.1",
-                "babar": "^0.2.0",
-                "chalk": "^4.0.0",
-                "fs-extra": "^4.0.2",
-                "minimist": "^1.2.8",
-                "puppeteer": "^24.2.0",
-                "puppeteer-core": "^24.2.0",
-                "string-width": "^4.2.0",
-                "util.promisify": "^1.1.1",
-                "xvfb": "^0.4.0"
-            }
-        },
-        "support/tests/node_modules/@memlab/core": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@memlab/core/-/core-2.0.2.tgz",
-            "integrity": "sha512-63imCui8LzNmMxMTGj9PMimpqZrZP12Pr8H/leUjft19qPEyMivYp1koJN5HG2h9Bk7HKFHzGBOa7N+uU4yGfw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi": "^0.3.1",
-                "babar": "^0.2.0",
-                "chalk": "^4.0.0",
-                "fs-extra": "^4.0.2",
-                "minimist": "^1.2.8",
-                "puppeteer": "^24.2.0",
-                "puppeteer-core": "^24.2.0",
-                "string-width": "^4.2.0",
-                "util.promisify": "^1.1.1",
-                "xvfb": "^0.4.0"
-            },
-            "engines": {
-                "node": ">= 12.6.0"
-            }
-        },
-        "support/tests/node_modules/@memlab/e2e": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@memlab/e2e/-/e2e-2.0.2.tgz",
-            "integrity": "sha512-ENRu4X6GPBV9YWSfVEYigyyiTi9EsVEQRJBmKxkHrVRJdILIO+VamIh4EH6aUdwfCwyucm0UlNNEKpCRfScbmQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/generator": "^7.16.0",
-                "@babel/parser": "^7.16.4",
-                "@babel/template": "^7.16.0",
-                "@babel/traverse": "^7.16.3",
-                "@memlab/core": "^2.0.2",
-                "@memlab/lens": "^2.0.2",
-                "ansi": "^0.3.1",
-                "babar": "^0.2.0",
-                "chalk": "^4.0.0",
-                "fs-extra": "^4.0.2",
-                "minimist": "^1.2.8",
-                "puppeteer": "^24.2.0",
-                "puppeteer-core": "^24.2.0",
-                "string-width": "^4.2.0",
-                "util.promisify": "^1.1.1",
-                "xvfb": "^0.4.0"
-            }
-        },
-        "support/tests/node_modules/@memlab/heap-analysis": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@memlab/heap-analysis/-/heap-analysis-2.0.2.tgz",
-            "integrity": "sha512-SVTifv4hVyd/YxIB8L98W3o75fnT6vNP+b+qBiEYLC9vH+Tbh6vMfYqlwKLOUF2JF3QqISW1cyBOBtEUijfXdw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@memlab/core": "^2.0.2",
-                "@memlab/e2e": "^2.0.2",
-                "ansi": "^0.3.1",
-                "babar": "^0.2.0",
-                "chalk": "^4.0.0",
-                "fs-extra": "^4.0.2",
-                "minimist": "^1.2.8",
-                "puppeteer": "^24.2.0",
-                "puppeteer-core": "^24.2.0",
-                "string-width": "^4.2.0",
-                "util.promisify": "^1.1.1",
-                "xvfb": "^0.4.0"
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3972,9 +3972,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.25",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.25.tgz",
-            "integrity": "sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==",
+            "version": "2.10.27",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+            "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
             "license": "Apache-2.0",
             "peer": true,
             "bin": {
@@ -11683,7 +11683,7 @@
                 "@matter/nodejs": "*",
                 "@matter/protocol": "*",
                 "@matter/types": "*",
-                "@nacho-iot/js-tools": "0.1.4",
+                "@nacho-iot/js-tools": "^0.1.4",
                 "@types/escodegen": "^0.0.10",
                 "acorn": "^8.16.0",
                 "ansi-colors": "^4.1.3",
@@ -11704,7 +11704,7 @@
                 "matter-create": "bin/create.js"
             },
             "devDependencies": {
-                "@nacho-iot/js-tools": "0.1.4",
+                "@nacho-iot/js-tools": "^0.1.4",
                 "@types/node": "^25.6.0",
                 "@types/tar-stream": "^3.1.4"
             },
@@ -12000,7 +12000,7 @@
             "version": "0.0.0-git",
             "license": "Apache-2.0",
             "dependencies": {
-                "@nacho-iot/js-tools": "0.1.4",
+                "@nacho-iot/js-tools": "^0.1.4",
                 "@types/express": "^5.0.6",
                 "ansi-colors": "^4.1.3",
                 "chai": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
         }
     },
     "dependencies": {
-        "@nacho-iot/js-tools": "^0.1.3",
+        "@nacho-iot/js-tools": "^0.1.4",
         "memlab": "^2.0.2"
     }
 }

--- a/packages/cli-tool/package.json
+++ b/packages/cli-tool/package.json
@@ -39,7 +39,7 @@
         "@matter/model": "*",
         "@matter/node": "*",
         "@matter/protocol": "*",
-        "@nacho-iot/js-tools": "*",
+        "@nacho-iot/js-tools": "0.1.4",
         "@matter/types": "*",
         "@matter/nodejs": "*",
         "@types/escodegen": "^0.0.10",

--- a/packages/cli-tool/package.json
+++ b/packages/cli-tool/package.json
@@ -39,7 +39,7 @@
         "@matter/model": "*",
         "@matter/node": "*",
         "@matter/protocol": "*",
-        "@nacho-iot/js-tools": "0.1.4",
+        "@nacho-iot/js-tools": "^0.1.4",
         "@matter/types": "*",
         "@matter/nodejs": "*",
         "@types/escodegen": "^0.0.10",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -32,7 +32,7 @@
     },
     "homepage": "https://github.com/matter-js/matter.js#readme",
     "devDependencies": {
-        "@nacho-iot/js-tools": "0.1.4",
+        "@nacho-iot/js-tools": "^0.1.4",
         "@types/node": "^25.6.0",
         "@types/tar-stream": "^3.1.4"
     },

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -32,7 +32,7 @@
     },
     "homepage": "https://github.com/matter-js/matter.js#readme",
     "devDependencies": {
-        "@nacho-iot/js-tools": "*",
+        "@nacho-iot/js-tools": "0.1.4",
         "@types/node": "^25.6.0",
         "@types/tar-stream": "^3.1.4"
     },

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -42,7 +42,7 @@
         "@matter/protocol": "*"
     },
     "devDependencies": {
-        "@nacho-iot/js-tools": "*",
+        "@nacho-iot/js-tools": "^0.1.4",
         "@matter/testing": "*"
     },
     "files": [

--- a/packages/node/src/behavior/system/network/NetworkClient.ts
+++ b/packages/node/src/behavior/system/network/NetworkClient.ts
@@ -23,7 +23,7 @@ export class NetworkClient extends NetworkBehavior {
     declare readonly events: NetworkClient.Events;
 
     override initialize() {
-        if (this.#node.isGroup) {
+        if (this.#node.nodeType === "group") {
             // Groups can never subscribe
             this.state.autoSubscribe = false;
             this.state.defaultSubscription = undefined;

--- a/packages/node/src/behavior/system/software-update/OtaAnnouncements.ts
+++ b/packages/node/src/behavior/system/software-update/OtaAnnouncements.ts
@@ -219,7 +219,7 @@ export class OtaAnnouncements {
      * When a node is applicable for updates, it also subscribes to softwareVersion changes to be able to react
      */
     peerApplicableForUpdate(peer: ClientNode) {
-        if (peer.isGroup || !peer.behaviors.has(BasicInformationClient)) {
+        if (peer.nodeType === "group" || !peer.behaviors.has(BasicInformationClient)) {
             // We need more information on the node to request an update
             return;
         }

--- a/packages/node/src/endpoint/Endpoint.ts
+++ b/packages/node/src/endpoint/Endpoint.ts
@@ -1028,10 +1028,10 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
                 continue;
             }
 
-            const backing = this.behaviors.backingFor(type);
-            const allowedNames = backing.elements?.attributes;
+            const elements = this.behaviors.elementsOf(type);
+            const allowedNames = elements.attributes;
             for (const name of raw) {
-                if (allowedNames !== undefined && !allowedNames.has(name)) {
+                if (!allowedNames.has(name)) {
                     throw new AttributeNotPresentError(id, name);
                 }
                 const attrId = attrNameToId.get(name);

--- a/packages/node/src/endpoint/Endpoint.ts
+++ b/packages/node/src/endpoint/Endpoint.ts
@@ -994,7 +994,10 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
     ): Promise<unknown> {
         const selection = this.#resolveSelection(selector);
         const attributePaths = new Read.AttributePaths();
-        const clusterLookup = new Map<ClusterId, { behaviorId: string; attrs: Map<AttributeId, string> }>();
+        const clusterLookup = new Map<
+            ClusterId,
+            { behaviorId: string; attrs: Map<AttributeId, string>; attrNameToId: Map<string, AttributeId> }
+        >();
 
         for (const [id, raw] of selection) {
             const type = this.behaviors.supported[id]!;
@@ -1010,12 +1013,15 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
             }
 
             const attrs = new Map<AttributeId, string>();
+            const attrNameToId = new Map<string, AttributeId>();
             for (const attr of schema.attributes) {
                 if (attr.id !== undefined && attr.propertyName !== undefined) {
-                    attrs.set(attr.id as AttributeId, attr.propertyName);
+                    const attrId = attr.id as AttributeId;
+                    attrs.set(attrId, attr.propertyName);
+                    attrNameToId.set(attr.propertyName, attrId);
                 }
             }
-            clusterLookup.set(clusterId, { behaviorId: id, attrs });
+            clusterLookup.set(clusterId, { behaviorId: id, attrs, attrNameToId });
 
             if (raw === true) {
                 attributePaths.add({ endpointId, clusterId });
@@ -1025,14 +1031,14 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
             const backing = this.behaviors.backingFor(type);
             const allowedNames = backing.elements?.attributes;
             for (const name of raw) {
-                if (allowedNames?.size && !allowedNames.has(name)) {
+                if (allowedNames !== undefined && !allowedNames.has(name)) {
                     throw new AttributeNotPresentError(id, name);
                 }
-                const attr = schema.attributes.find(a => a.propertyName === name);
-                if (!attr) {
+                const attrId = attrNameToId.get(name);
+                if (attrId === undefined) {
                     throw new AttributeNotPresentError(id, name);
                 }
-                attributePaths.add({ endpointId, clusterId, attributeId: attr.id as AttributeId });
+                attributePaths.add({ endpointId, clusterId, attributeId: attrId });
             }
         }
 
@@ -1054,7 +1060,9 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
         if (node.nodeType === "client") {
             const fabricFilter = options?.fabricFilter ?? true;
             const baseRequest = Read({ attributes: [...attributePaths.paths], fabricFilter });
-            const request = options?.includeKnownVersions ? { ...baseRequest, includeKnownVersions: true } : baseRequest;
+            const request = options?.includeKnownVersions
+                ? { ...baseRequest, includeKnownVersions: true }
+                : baseRequest;
             const readValues = new Map<string, Map<string, unknown>>();
             for await (const chunk of node.interaction.read(request, undefined)) {
                 for (const report of chunk) {

--- a/packages/node/src/endpoint/Endpoint.ts
+++ b/packages/node/src/endpoint/Endpoint.ts
@@ -1347,6 +1347,8 @@ export type BehaviorSelection<B extends Behavior.Type> = true | readonly (keyof 
 
 export type RawBehaviorSelection = true | readonly string[];
 
+// TODO: use BehaviorSelection<BehaviorAt<T, K>> — blocked by SupportedBehaviors index sig (Record<string,...>
+// makes keyof=string → BehaviorAt→Behavior.Type → keyof {}=never). Fix: remove index sig. getStateOf() is ok.
 export type StateSelector<T extends EndpointType> = {
     [K in keyof T["behaviors"]]?: RawBehaviorSelection;
 };

--- a/packages/node/src/endpoint/Endpoint.ts
+++ b/packages/node/src/endpoint/Endpoint.ts
@@ -352,12 +352,16 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
      * Typed read of a single behavior's state.
      *
      * Same client/server semantics as {@link get}, including the partial-state-on-failure contract.
+     *
+     * When a key-list selector is provided, each returned value may be `undefined` — absent on unsupported
+     * attributes or those excluded by {@link EndpointReadFailedError}.
      */
-    getStateOf<B extends BehaviorOf<T>>(
+    getStateOf<B extends BehaviorOf<T>>(type: B, selector?: true, options?: Endpoint.GetOptions): Promise<Behavior.StateOf<B>>;
+    getStateOf<B extends BehaviorOf<T>, K extends keyof Behavior.StateOf<B>>(
         type: B,
-        selector?: BehaviorSelection<B>,
+        selector: readonly K[],
         options?: Endpoint.GetOptions,
-    ): Promise<Behavior.StateOf<B>>;
+    ): Promise<{ readonly [P in K]?: Behavior.StateOf<B>[P] }>;
 
     /**
      * Read of a single behavior's state by string id.
@@ -390,8 +394,8 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
      *
      * @remarks
      * **Client endpoint.** Issues a single batched Matter Read for the selected attribute paths
-     * and returns the fresh slice. State is updated as data arrives; non-fabric-filtered reads
-     * are not written to the local cache.
+     * and returns the fresh slice. State is updated as data arrives; reads whose fabric-filter
+     * setting differs from the active subscription are not cached.
      *
      * **Partial-state contract on failure.** On any per-path failure status, rejects with
      * {@link EndpointReadFailedError}. The error carries both the failed paths and the assembled
@@ -1093,6 +1097,7 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
                 partial[id] = freshValues?.size ? { ...stateValues, ...Object.fromEntries(freshValues) } : stateValues;
             }
             if (failed.length > 0) {
+                this.#excludeFailedPaths(partial, failed, clusterLookup);
                 throw new EndpointReadFailedError({ failed, partial });
             }
             return partial;
@@ -1113,11 +1118,34 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
             collectFailures(node.interaction.read(request, context)),
         );
 
-        const partial = this.#assembleSlice(selection);
+        const partial = this.#assembleSlice(selection) as Record<string, unknown>;
         if (failed.length > 0) {
+            this.#excludeFailedPaths(partial, failed, clusterLookup);
             throw new EndpointReadFailedError({ failed, partial });
         }
         return partial;
+    }
+
+    #excludeFailedPaths(
+        partial: Record<string, unknown>,
+        failed: ReadonlyArray<EndpointReadFailure>,
+        clusterLookup: Map<ClusterId, { behaviorId: string; attrs: Map<AttributeId, string> }>,
+    ): void {
+        for (const { path } of failed) {
+            const info = clusterLookup.get(path.clusterId);
+            if (info === undefined) continue;
+            if (path.attributeId === undefined) {
+                delete partial[info.behaviorId];
+                continue;
+            }
+            const propName = info.attrs.get(path.attributeId);
+            if (propName === undefined) continue;
+            const behaviorState = partial[info.behaviorId];
+            if (behaviorState === null || typeof behaviorState !== "object") continue;
+            const copy = { ...(behaviorState as Record<string, unknown>) };
+            delete copy[propName];
+            partial[info.behaviorId] = copy;
+        }
     }
 
     #assembleSlice(selection: Map<string, RawBehaviorSelection>): unknown {
@@ -1326,7 +1354,7 @@ export type StateSliceOf<T extends EndpointType, S> = S extends undefined
               ? Immutable<Behavior.StateOf<BehaviorAt<T, K>>>
               : S[K] extends readonly (infer A)[]
                 ? Immutable<
-                      Pick<Behavior.StateOf<BehaviorAt<T, K>>, Extract<A, keyof Behavior.StateOf<BehaviorAt<T, K>>>>
+                      Partial<Pick<Behavior.StateOf<BehaviorAt<T, K>>, Extract<A, keyof Behavior.StateOf<BehaviorAt<T, K>>>>>
                   >
                 : never;
       };

--- a/packages/node/src/endpoint/Endpoint.ts
+++ b/packages/node/src/endpoint/Endpoint.ts
@@ -36,6 +36,7 @@ import {
     EndpointBehaviorNotPresentError,
     EndpointReadFailedError,
     EndpointReadFailure,
+    InvalidGroupOperationError,
 } from "./errors.js";
 import { Behaviors } from "./properties/Behaviors.js";
 import { Commands } from "./properties/Commands.js";
@@ -993,6 +994,7 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
     ): Promise<unknown> {
         const selection = this.#resolveSelection(selector);
         const attributePaths = new Read.AttributePaths();
+        const clusterLookup = new Map<ClusterId, { behaviorId: string; attrs: Map<AttributeId, string> }>();
 
         for (const [id, raw] of selection) {
             const type = this.behaviors.supported[id]!;
@@ -1003,6 +1005,14 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
             if (clusterId === undefined) {
                 continue;
             }
+
+            const attrs = new Map<AttributeId, string>();
+            for (const attr of schema.attributes) {
+                if (attr.id !== undefined && attr.propertyName !== undefined) {
+                    attrs.set(attr.id as AttributeId, attr.propertyName);
+                }
+            }
+            clusterLookup.set(clusterId, { behaviorId: id, attrs });
 
             if (raw === true) {
                 attributePaths.add({ endpointId, clusterId });
@@ -1034,6 +1044,49 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
         const node = nodeEndpoint as unknown as Node<any>;
         const failed = new Array<EndpointReadFailure>();
 
+        if (node.nodeType === "group") {
+            throw new InvalidGroupOperationError("Groups do not support reading attributes");
+        }
+
+        if (node.nodeType === "client") {
+            const fabricFilter = options?.fabricFilter ?? true;
+            const baseRequest = Read({ attributes: [...attributePaths.paths], fabricFilter });
+            const request = options?.includeKnownVersions ? { ...baseRequest, includeKnownVersions: true } : baseRequest;
+            const readValues = new Map<string, Map<string, unknown>>();
+            for await (const chunk of node.interaction.read(request, undefined)) {
+                for (const report of chunk) {
+                    if (report.kind === "attr-value") {
+                        const info = clusterLookup.get(report.path.clusterId);
+                        if (info !== undefined) {
+                            const propName = info.attrs.get(report.path.attributeId);
+                            if (propName !== undefined) {
+                                let values = readValues.get(info.behaviorId);
+                                if (values === undefined) {
+                                    values = new Map();
+                                    readValues.set(info.behaviorId, values);
+                                }
+                                values.set(propName, report.value);
+                            }
+                        }
+                    } else if (report.kind === "attr-status" && report.status !== Status.Success) {
+                        failed.push({ path: report.path, status: report.status, clusterStatus: report.clusterStatus });
+                    }
+                }
+            }
+            // State view as base; received values overwrite (handles empty response from version-filter match)
+            const stateSlice = this.#assembleSlice(selection) as Record<string, Record<string, unknown> | undefined>;
+            const partial: Record<string, unknown> = {};
+            for (const [id] of selection) {
+                const stateValues = stateSlice[id] ?? {};
+                const freshValues = readValues.get(id);
+                partial[id] = freshValues?.size ? { ...stateValues, ...Object.fromEntries(freshValues) } : stateValues;
+            }
+            if (failed.length > 0) {
+                throw new EndpointReadFailedError({ failed, partial });
+            }
+            return partial;
+        }
+
         const collectFailures = async (stream: ReturnType<typeof node.interaction.read>) => {
             for await (const chunk of stream) {
                 for (const report of chunk) {
@@ -1044,22 +1097,10 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
             }
         };
 
-        if (node.nodeType === "group") {
-            throw new ImplementationError("Groups do not support reading attributes");
-        }
-
-        if (node.nodeType === "client") {
-            const request = Read({
-                attributes: [...attributePaths.paths],
-                fabricFilter: options?.fabricFilter ?? true,
-            });
-            await collectFailures(node.interaction.read(request, undefined));
-        } else {
-            const request = Read({ attributes: [...attributePaths.paths], fabricFilter: false });
-            await LocalActorContext.act("endpoint-get", context =>
-                collectFailures(node.interaction.read(request, context)),
-            );
-        }
+        const request = Read({ attributes: [...attributePaths.paths], fabricFilter: false });
+        await LocalActorContext.act("endpoint-get", context =>
+            collectFailures(node.interaction.read(request, context)),
+        );
 
         const partial = this.#assembleSlice(selection);
         if (failed.length > 0) {
@@ -1219,6 +1260,12 @@ export namespace Endpoint {
          * When `false`, the underlying Matter Read is not fabric-filtered. Defaults to `true`.
          */
         fabricFilter?: boolean;
+
+        /**
+         * When `true`, skips automatic data-version filter injection so the server returns all attribute values
+         * regardless of whether they have changed since the last read or subscription. Defaults to `false`.
+         */
+        includeKnownVersions?: boolean;
     }
 
     /**

--- a/packages/node/src/endpoint/Endpoint.ts
+++ b/packages/node/src/endpoint/Endpoint.ts
@@ -998,10 +998,13 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
 
         for (const [id, raw] of selection) {
             const type = this.behaviors.supported[id]!;
-            const schema = type.schema as ClusterModel;
+            const schema = type.schema;
             const endpointId = this.number;
-            const clusterId = schema.id as ClusterId | undefined;
 
+            if (!(schema instanceof ClusterModel)) {
+                continue;
+            }
+            const clusterId = schema.id as ClusterId | undefined;
             if (clusterId === undefined) {
                 continue;
             }

--- a/packages/node/src/endpoint/Endpoint.ts
+++ b/packages/node/src/endpoint/Endpoint.ts
@@ -356,7 +356,11 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
      * When a key-list selector is provided, each returned value may be `undefined` — absent on unsupported
      * attributes or those excluded by {@link EndpointReadFailedError}.
      */
-    getStateOf<B extends BehaviorOf<T>>(type: B, selector?: true, options?: Endpoint.GetOptions): Promise<Behavior.StateOf<B>>;
+    getStateOf<B extends BehaviorOf<T>>(
+        type: B,
+        selector?: true,
+        options?: Endpoint.GetOptions,
+    ): Promise<Behavior.StateOf<B>>;
     getStateOf<B extends BehaviorOf<T>, K extends keyof Behavior.StateOf<B>>(
         type: B,
         selector: readonly K[],
@@ -1354,7 +1358,9 @@ export type StateSliceOf<T extends EndpointType, S> = S extends undefined
               ? Immutable<Behavior.StateOf<BehaviorAt<T, K>>>
               : S[K] extends readonly (infer A)[]
                 ? Immutable<
-                      Partial<Pick<Behavior.StateOf<BehaviorAt<T, K>>, Extract<A, keyof Behavior.StateOf<BehaviorAt<T, K>>>>>
+                      Partial<
+                          Pick<Behavior.StateOf<BehaviorAt<T, K>>, Extract<A, keyof Behavior.StateOf<BehaviorAt<T, K>>>>
+                      >
                   >
                 : never;
       };

--- a/packages/node/src/endpoint/Endpoint.ts
+++ b/packages/node/src/endpoint/Endpoint.ts
@@ -26,11 +26,17 @@ import {
     toHex,
     UninitializedDependencyError,
 } from "@matter/general";
-import { DataModelPath } from "@matter/model";
-import { Val } from "@matter/protocol";
-import { EndpointNumber } from "@matter/types";
+import { ClusterModel, DataModelPath } from "@matter/model";
+import { Read, Val } from "@matter/protocol";
+import { AttributeId, ClusterId, EndpointNumber, Status } from "@matter/types";
 import { RootEndpoint } from "../endpoints/root.js";
 import { Agent } from "./Agent.js";
+import {
+    AttributeNotPresentError,
+    EndpointBehaviorNotPresentError,
+    EndpointReadFailedError,
+    EndpointReadFailure,
+} from "./errors.js";
 import { Behaviors } from "./properties/Behaviors.js";
 import { Commands } from "./properties/Commands.js";
 import { EndpointContainer } from "./properties/EndpointContainer.js";
@@ -339,6 +345,67 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
 
             patch(values, behavior.state, this.path);
         });
+    }
+
+    /**
+     * Typed read of a single behavior's state.
+     *
+     * Same client/server semantics as {@link get}, including the partial-state-on-failure contract.
+     */
+    getStateOf<B extends BehaviorOf<T>>(
+        type: B,
+        selector?: BehaviorSelection<B>,
+        options?: Endpoint.GetOptions,
+    ): Promise<Behavior.StateOf<B>>;
+
+    /**
+     * Read of a single behavior's state by string id.
+     *
+     * @throws {@link EndpointBehaviorNotPresentError} if `type` is not present on the endpoint.
+     */
+    getStateOf(type: string, selector?: readonly string[], options?: Endpoint.GetOptions): Promise<Val.Struct>;
+
+    async getStateOf(
+        type: Behavior.Type | string,
+        selector?: BehaviorSelection<Behavior.Type> | readonly string[],
+        options?: Endpoint.GetOptions,
+    ): Promise<unknown> {
+        const id = typeof type === "string" ? type : type.id;
+
+        const resolved = typeof type === "string" ? this.behaviors.supported[id] : type;
+        if (resolved === undefined || !this.behaviors.has(resolved)) {
+            throw new EndpointBehaviorNotPresentError(id);
+        }
+
+        const slice = (await this.#performRead(
+            { [id]: (selector ?? true) as RawBehaviorSelection } as StateSelector<T>,
+            options,
+        )) as Record<string, unknown>;
+        return slice[id];
+    }
+
+    /**
+     * Reads the selected behavior state.
+     *
+     * @remarks
+     * **Client endpoint.** Issues a single batched Matter Read for the selected attribute paths
+     * and returns the fresh slice. State is updated as data arrives; non-fabric-filtered reads
+     * are not written to the local cache.
+     *
+     * **Partial-state contract on failure.** On any per-path failure status, rejects with
+     * {@link EndpointReadFailedError}. The error carries both the failed paths and the assembled
+     * partial slice for successful paths.
+     *
+     * **Server endpoint.** Returns a snapshot of local immutable state. `fabricFilter` is ignored.
+     */
+    get(): Promise<Immutable<SupportedBehaviors.StateOf<T["behaviors"]>>>;
+    get(
+        selector: undefined,
+        options?: Endpoint.GetOptions,
+    ): Promise<Immutable<SupportedBehaviors.StateOf<T["behaviors"]>>>;
+    get<S extends StateSelector<T>>(selector: S, options?: Endpoint.GetOptions): Promise<StateSliceOf<T, S>>;
+    async get(selector?: StateSelector<T>, options?: Endpoint.GetOptions): Promise<unknown> {
+        return this.#performRead(selector, options);
     }
 
     /**
@@ -897,6 +964,129 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
         return this.initialize();
     }
 
+    #resolveSelection(selector: StateSelector<T> | undefined): Map<string, RawBehaviorSelection> {
+        const map = new Map<string, RawBehaviorSelection>();
+
+        if (selector === undefined) {
+            for (const type of this.behaviors) {
+                map.set(type.id, true);
+            }
+            return map;
+        }
+
+        for (const id of Object.keys(selector)) {
+            const type = this.behaviors.supported[id];
+            if (type === undefined) {
+                throw new EndpointBehaviorNotPresentError(id);
+            }
+            const raw = (selector as Record<string, RawBehaviorSelection | undefined>)[id];
+            if (raw === undefined) continue;
+            map.set(id, raw);
+        }
+
+        return map;
+    }
+
+    async #performRead(
+        selector: StateSelector<T> | undefined,
+        options: Endpoint.GetOptions | undefined,
+    ): Promise<unknown> {
+        const selection = this.#resolveSelection(selector);
+        const attributePaths = new Read.AttributePaths();
+
+        for (const [id, raw] of selection) {
+            const type = this.behaviors.supported[id]!;
+            const schema = type.schema as ClusterModel;
+            const endpointId = this.number;
+            const clusterId = schema.id as ClusterId | undefined;
+
+            if (clusterId === undefined) {
+                continue;
+            }
+
+            if (raw === true) {
+                attributePaths.add({ endpointId, clusterId });
+                continue;
+            }
+
+            const backing = this.behaviors.backingFor(type);
+            const allowedNames = backing.elements?.attributes;
+            for (const name of raw) {
+                if (allowedNames?.size && !allowedNames.has(name)) {
+                    throw new AttributeNotPresentError(id, name);
+                }
+                const attr = schema.attributes.find(a => a.propertyName === name);
+                if (!attr) {
+                    throw new AttributeNotPresentError(id, name);
+                }
+                attributePaths.add({ endpointId, clusterId, attributeId: attr.id as AttributeId });
+            }
+        }
+
+        if (attributePaths.paths.length === 0) {
+            return this.#assembleSlice(selection);
+        }
+
+        const nodeEndpoint = this.ownerOfType(RootEndpoint);
+        if (nodeEndpoint === undefined) {
+            throw new ImplementationError(`${this} is not installed in a node`);
+        }
+        const node = nodeEndpoint as unknown as Node<any>;
+        const failed = new Array<EndpointReadFailure>();
+
+        const collectFailures = async (stream: ReturnType<typeof node.interaction.read>) => {
+            for await (const chunk of stream) {
+                for (const report of chunk) {
+                    if (report.kind === "attr-status" && report.status !== Status.Success) {
+                        failed.push({ path: report.path, status: report.status, clusterStatus: report.clusterStatus });
+                    }
+                }
+            }
+        };
+
+        if (node.nodeType === "group") {
+            throw new ImplementationError("Groups do not support reading attributes");
+        }
+
+        if (node.nodeType === "client") {
+            const request = Read({
+                attributes: [...attributePaths.paths],
+                fabricFilter: options?.fabricFilter ?? true,
+            });
+            await collectFailures(node.interaction.read(request, undefined));
+        } else {
+            const request = Read({ attributes: [...attributePaths.paths], fabricFilter: false });
+            await LocalActorContext.act("endpoint-get", context =>
+                collectFailures(node.interaction.read(request, context)),
+            );
+        }
+
+        const partial = this.#assembleSlice(selection);
+        if (failed.length > 0) {
+            throw new EndpointReadFailedError({ failed, partial });
+        }
+        return partial;
+    }
+
+    #assembleSlice(selection: Map<string, RawBehaviorSelection>): unknown {
+        const view = this.#stateView as Record<string, Record<string, unknown> | undefined>;
+        const out: Record<string, unknown> = {};
+
+        for (const [id, raw] of selection) {
+            const behaviorState = view[id];
+            if (raw === true) {
+                out[id] = behaviorState ?? {};
+                continue;
+            }
+            const filtered: Record<string, unknown> = {};
+            for (const name of raw) {
+                filtered[name] = behaviorState?.[name];
+            }
+            out[id] = filtered;
+        }
+        return out;
+    }
+
     #logReady() {
         logger.info(Diagnostic.strong(this.toString()), "ready", this.diagnosticDict);
     }
@@ -1022,6 +1212,16 @@ export namespace Endpoint {
     export type Definition<T extends EndpointType = EndpointType.Empty> = T | Configuration<T> | Endpoint<T>;
 
     /**
+     * Options for {@link Endpoint.get} and {@link Endpoint.getStateOf}.
+     */
+    export interface GetOptions {
+        /**
+         * When `false`, the underlying Matter Read is not fabric-filtered. Defaults to `true`.
+         */
+        fabricFilter?: boolean;
+    }
+
+    /**
      * Obtain a configuration from constructor parameters.
      */
     export function configurationFor<T extends EndpointType>(
@@ -1048,3 +1248,27 @@ export namespace Endpoint {
         return new Endpoint(definition);
     }
 }
+
+export type BehaviorOf<T extends EndpointType> = T["behaviors"][keyof T["behaviors"]];
+
+export type BehaviorAt<T extends EndpointType, K extends keyof T["behaviors"]> = T["behaviors"][K];
+
+export type BehaviorSelection<B extends Behavior.Type> = true | readonly (keyof Behavior.StateOf<B>)[];
+
+export type RawBehaviorSelection = true | readonly string[];
+
+export type StateSelector<T extends EndpointType> = {
+    [K in keyof T["behaviors"]]?: RawBehaviorSelection;
+};
+
+export type StateSliceOf<T extends EndpointType, S> = S extends undefined
+    ? Immutable<SupportedBehaviors.StateOf<T["behaviors"]>>
+    : {
+          [K in keyof S & keyof T["behaviors"]]: S[K] extends true
+              ? Immutable<Behavior.StateOf<BehaviorAt<T, K>>>
+              : S[K] extends readonly (infer A)[]
+                ? Immutable<
+                      Pick<Behavior.StateOf<BehaviorAt<T, K>>, Extract<A, keyof Behavior.StateOf<BehaviorAt<T, K>>>>
+                  >
+                : never;
+      };

--- a/packages/node/src/endpoint/errors.ts
+++ b/packages/node/src/endpoint/errors.ts
@@ -6,6 +6,8 @@
 
 import type { BehaviorBacking } from "#behavior/internal/BehaviorBacking.js";
 import { describeList, MatterAggregateError, MatterError } from "@matter/general";
+import type { ReadResult } from "@matter/protocol";
+import type { Status } from "@matter/types";
 import type { Endpoint } from "./Endpoint.js";
 
 /**
@@ -49,3 +51,44 @@ export class EndpointPartsError extends MatterError {
  * Thrown when a requested child {@link Endpoint} does not exist.
  */
 export class PartNotFoundError extends MatterError {}
+
+/**
+ * Thrown when a behavior is not present on an endpoint.
+ */
+export class EndpointBehaviorNotPresentError extends MatterError {
+    constructor(behaviorId: string) {
+        super(`Behavior "${behaviorId}" is not present on this endpoint`);
+    }
+}
+
+/**
+ * Thrown when an attribute is not present on a behavior.
+ */
+export class AttributeNotPresentError extends MatterError {
+    constructor(behaviorId: string, attributeName: string) {
+        super(`Attribute "${attributeName}" is not present on behavior "${behaviorId}"`);
+    }
+}
+
+/**
+ * Describes a single failed attribute read.
+ */
+export interface EndpointReadFailure {
+    readonly path: ReadResult.ConcreteAttributePath;
+    readonly status: Status;
+    readonly clusterStatus?: number;
+}
+
+/**
+ * Thrown when attribute reads fail for one or more paths.
+ */
+export class EndpointReadFailedError extends MatterError {
+    readonly failed: ReadonlyArray<EndpointReadFailure>;
+    readonly partial: unknown;
+
+    constructor(detail: { failed: ReadonlyArray<EndpointReadFailure>; partial: unknown }) {
+        super(`Endpoint read failed for ${detail.failed.length} path(s)`);
+        this.failed = detail.failed;
+        this.partial = detail.partial;
+    }
+}

--- a/packages/node/src/endpoint/errors.ts
+++ b/packages/node/src/endpoint/errors.ts
@@ -5,7 +5,7 @@
  */
 
 import type { BehaviorBacking } from "#behavior/internal/BehaviorBacking.js";
-import { describeList, MatterAggregateError, MatterError } from "@matter/general";
+import { describeList, ImplementationError, MatterAggregateError, MatterError } from "@matter/general";
 import type { ReadResult } from "@matter/protocol";
 import type { Status } from "@matter/types";
 import type { Endpoint } from "./Endpoint.js";
@@ -92,3 +92,8 @@ export class EndpointReadFailedError extends MatterError {
         this.partial = detail.partial;
     }
 }
+
+/**
+ * Thrown when a group-level operation is not supported.
+ */
+export class InvalidGroupOperationError extends ImplementationError {}

--- a/packages/node/src/endpoint/properties/Behaviors.ts
+++ b/packages/node/src/endpoint/properties/Behaviors.ts
@@ -686,6 +686,16 @@ export class Behaviors {
     }
 
     /**
+     * @throws ImplementationError if the behavior is not supported.
+     */
+    backingFor(type: Behavior.Type): BehaviorBacking {
+        if (!this.has(type)) {
+            throw new ImplementationError(`Endpoint ${this.#endpoint} does not support behavior ${type.id}`);
+        }
+        return this.#backingFor(type);
+    }
+
+    /**
      * Access elements supported by a behavior.
      */
     elementsOf(type: Behavior.Type): SupportedElements {

--- a/packages/node/src/node/ClientGroup.ts
+++ b/packages/node/src/node/ClientGroup.ts
@@ -7,13 +7,19 @@ import type { ActionContext } from "#behavior/context/ActionContext.js";
 import { ServerNodeStore } from "#storage/server/ServerNodeStore.js";
 import { Interactable } from "@matter/protocol";
 import { ClientNode } from "./ClientNode.js";
-import { ClientGroupInteraction } from "./client/ClientGroupInteraction.js";
+import { ClientGroupInteraction, InvalidGroupOperationError } from "./client/ClientGroupInteraction.js";
 
 export class ClientGroup extends ClientNode {
     #interaction?: ClientGroupInteraction;
 
-    override get isGroup() {
-        return true;
+    override readonly nodeType = "group" as const;
+
+    override async get(_selector?: unknown, _options?: unknown): Promise<never> {
+        throw new InvalidGroupOperationError("Groups do not support reading attributes");
+    }
+
+    override async getStateOf(_type?: unknown, _selector?: unknown, _options?: unknown): Promise<never> {
+        throw new InvalidGroupOperationError("Groups do not support reading attributes");
     }
 
     override get interaction(): Interactable<ActionContext> {

--- a/packages/node/src/node/ClientNode.ts
+++ b/packages/node/src/node/ClientNode.ts
@@ -68,9 +68,7 @@ export class ClientNode extends Node<ClientNode.RootEndpoint> {
         this.#matter = options.matter ?? Matter;
     }
 
-    get isGroup() {
-        return false;
-    }
+    override readonly nodeType: "client" | "group" = "client";
 
     /**
      * Model of Matter semantics understood by this node.

--- a/packages/node/src/node/Node.ts
+++ b/packages/node/src/node/Node.ts
@@ -253,6 +253,8 @@ export abstract class Node<T extends Node.CommonRootEndpoint = Node.CommonRootEn
      */
     abstract interaction: Interactable<ActionContext>;
 
+    abstract readonly nodeType: "server" | "client" | "group";
+
     protected abstract prepareRuntimeShutdown(): Promise<void>;
 
     get [DiagnosticPresentation.name]() {

--- a/packages/node/src/node/ServerNode.ts
+++ b/packages/node/src/node/ServerNode.ts
@@ -196,6 +196,8 @@ export class ServerNode<T extends ServerNode.RootEndpoint = ServerNode.RootEndpo
         return this.#interaction;
     }
 
+    override readonly nodeType = "server" as const;
+
     protected override async initialize() {
         await ServerEnvironment.initialize(this);
         await this.#plugins.load();

--- a/packages/node/src/node/client/ClientGroupInteraction.ts
+++ b/packages/node/src/node/client/ClientGroupInteraction.ts
@@ -5,7 +5,7 @@
  */
 
 import type { ActionContext } from "#behavior/context/ActionContext.js";
-import { ImplementationError } from "@matter/general";
+import { InvalidGroupOperationError } from "#endpoint/errors.js";
 import {
     ClientInvoke,
     ClientSubscription,
@@ -18,7 +18,7 @@ import {
 } from "@matter/protocol";
 import { ClientNodeInteraction } from "./ClientNodeInteraction.js";
 
-export class InvalidGroupOperationError extends ImplementationError {}
+export { InvalidGroupOperationError };
 
 export class ClientGroupInteraction extends ClientNodeInteraction {
     /** Groups do not support reading or subscribing to attributes */

--- a/packages/node/src/node/client/ClientNodeInteraction.ts
+++ b/packages/node/src/node/client/ClientNodeInteraction.ts
@@ -66,7 +66,7 @@ export class ClientNodeInteraction implements Interactable<ActionContext> {
      * changed since the last read or subscription.
      */
     async *read(request: ClientRead, context?: ActionContext): ReadResult {
-        if (!request.includeKnownVersions && request.isFabricFiltered === this.#structure.subscribedFabricFiltered) {
+        if (!request.includeKnownVersions && (request.isFabricFiltered ?? true) === this.#structure.subscribedFabricFiltered) {
             request = this.#structure.injectVersionFilters(request);
         }
 

--- a/packages/node/src/node/client/ClientNodeInteraction.ts
+++ b/packages/node/src/node/client/ClientNodeInteraction.ts
@@ -66,7 +66,7 @@ export class ClientNodeInteraction implements Interactable<ActionContext> {
      * changed since the last read or subscription.
      */
     async *read(request: ClientRead, context?: ActionContext): ReadResult {
-        if (!request.includeKnownVersions) {
+        if (!request.includeKnownVersions && request.isFabricFiltered === this.#structure.subscribedFabricFiltered) {
             request = this.#structure.injectVersionFilters(request);
         }
 

--- a/packages/node/src/node/client/ClientNodeInteraction.ts
+++ b/packages/node/src/node/client/ClientNodeInteraction.ts
@@ -61,12 +61,14 @@ export class ClientNodeInteraction implements Interactable<ActionContext> {
 
     /**
      * Read chosen attributes remotely from the node. Known data versions are automatically injected into the request to
-     * optimize the read. Set `skipDataVersionInjection` in the request to prevent adding data versions.
-     * When data versions are used to filter the read request, the returned data only contains attributes that have
-     * changed since the last read or subscription.
+     * optimize the read when the fabric filter matches the active subscription. Set `includeKnownVersions` in the
+     * request to skip version injection and always receive a full response from the server.
      */
     async *read(request: ClientRead, context?: ActionContext): ReadResult {
-        if (!request.includeKnownVersions && (request.isFabricFiltered ?? true) === this.#structure.subscribedFabricFiltered) {
+        if (
+            !request.includeKnownVersions &&
+            (request.isFabricFiltered ?? true) === this.#structure.subscribedFabricFiltered
+        ) {
             request = this.#structure.injectVersionFilters(request);
         }
 

--- a/packages/node/src/node/client/ClientStructure.ts
+++ b/packages/node/src/node/client/ClientStructure.ts
@@ -333,7 +333,7 @@ export class ClientStructure {
     /**
      * Determines if the subscription is fabric filtered.
      */
-    protected get subscribedFabricFiltered(): boolean {
+    get subscribedFabricFiltered(): boolean {
         if (this.#subscribedFabricFiltered === undefined) {
             this.#subscribedFabricFiltered = true;
 

--- a/packages/node/test/endpoint/EndpointGetClientTest.ts
+++ b/packages/node/test/endpoint/EndpointGetClientTest.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Endpoint } from "#endpoint/Endpoint.js";
+import type { EndpointType } from "#endpoint/type/EndpointType.js";
+import { MockSite } from "../node/mock-site.js";
+import { subscribedPeer } from "../node/node-helpers.js";
+
+// The peer's static type (ClientNode.RootEndpoint) does not include device behaviors such as basicInformation,
+// which are added dynamically by ClientStructure after commissioning.
+function asEndpoint(peer: Endpoint): Endpoint<EndpointType> {
+    return peer as Endpoint<EndpointType>;
+}
+
+describe("Endpoint.get on a client endpoint", () => {
+    before(() => {
+        MockTime.init();
+    });
+
+    it("has nodeType 'client'", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+        const peer = await subscribedPeer(controller, "peer1");
+        expect((peer as unknown as { nodeType: string }).nodeType).to.equal("client");
+    });
+
+    it("returns state for the requested behavior (selection=true)", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+        const peer = await subscribedPeer(controller, "peer1");
+
+        const result = (await asEndpoint(peer).get({ basicInformation: true })) as Record<string, unknown>;
+        const bi = result.basicInformation as Record<string, unknown>;
+        const cachedBi = (peer as unknown as { state: { basicInformation: Record<string, unknown> } }).state
+            .basicInformation;
+        expect(bi.vendorName).to.equal(cachedBi.vendorName);
+    });
+
+    it("returns only selected attributes (attribute list)", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+        const peer = await subscribedPeer(controller, "peer1");
+
+        const result = (await asEndpoint(peer).get({
+            basicInformation: ["vendorName", "productName"],
+        })) as Record<string, unknown>;
+        const bi = result.basicInformation as Record<string, unknown>;
+        expect(Object.keys(bi).sort()).to.deep.equal(["productName", "vendorName"]);
+        const cachedBi = (peer as unknown as { state: { basicInformation: Record<string, unknown> } }).state
+            .basicInformation;
+        expect(bi.vendorName).to.equal(cachedBi.vendorName);
+        expect(bi.productName).to.equal(cachedBi.productName);
+    });
+
+    it("returns {} for empty selector", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+        const peer = await subscribedPeer(controller, "peer1");
+
+        const result = await asEndpoint(peer).get({});
+        expect(result).to.deep.equal({});
+    });
+});

--- a/packages/node/test/endpoint/EndpointGetServerTest.ts
+++ b/packages/node/test/endpoint/EndpointGetServerTest.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AttributeNotPresentError, EndpointBehaviorNotPresentError } from "#endpoint/errors.js";
+import { MockServerNode } from "../node/mock-server-node.js";
+
+describe("Endpoint.get on a server endpoint", () => {
+    let node: MockServerNode;
+
+    beforeEach(async () => {
+        node = new MockServerNode();
+        await node.construction;
+    });
+
+    afterEach(async () => {
+        await node.close();
+    });
+
+    it("has nodeType 'server'", () => {
+        expect(node.nodeType).to.equal("server");
+    });
+
+    it("returns full state when called with no selector", async () => {
+        const result = (await node.get()) as Record<string, unknown>;
+        expect(result).to.be.an("object");
+        expect(result).to.have.property("basicInformation");
+        expect(result).to.have.property("accessControl");
+    });
+
+    it("returns only the requested behavior when given { beh: true }", async () => {
+        const result = (await node.get({ basicInformation: true })) as Record<string, unknown>;
+        expect(Object.keys(result)).to.deep.equal(["basicInformation"]);
+        expect(result.basicInformation).to.be.an("object");
+    });
+
+    it("returns only the requested attributes when given an attribute list", async () => {
+        const result = (await node.get({ basicInformation: ["vendorId", "vendorName"] })) as Record<string, unknown>;
+        expect(Object.keys(result)).to.deep.equal(["basicInformation"]);
+        const bi = result.basicInformation as Record<string, unknown>;
+        expect(Object.keys(bi).sort()).to.deep.equal(["vendorId", "vendorName"]);
+        const state = node.state.basicInformation as unknown as Record<string, unknown>;
+        expect(bi.vendorId).to.equal(state.vendorId);
+        expect(bi.vendorName).to.equal(state.vendorName);
+    });
+
+    it("returns {} for empty selector {}", async () => {
+        const result = await node.get({});
+        expect(result).to.deep.equal({});
+    });
+
+    it("returns { beh: {} } for empty attribute list []", async () => {
+        const result = (await node.get({ basicInformation: [] })) as Record<string, unknown>;
+        expect(result).to.deep.equal({ basicInformation: {} });
+    });
+
+    it("throws EndpointBehaviorNotPresentError for an unknown behavior id", async () => {
+        let threw = false;
+        try {
+            await node.get({ unknownBehaviorXyz: true } as any);
+        } catch (e) {
+            threw = true;
+            expect(e).to.be.instanceof(EndpointBehaviorNotPresentError);
+        }
+        expect(threw).to.be.true;
+    });
+
+    it("throws AttributeNotPresentError for an unknown attribute name", async () => {
+        let threw = false;
+        try {
+            await node.get({ basicInformation: ["nonExistentAttribute"] } as any);
+        } catch (e) {
+            threw = true;
+            expect(e).to.be.instanceof(AttributeNotPresentError);
+        }
+        expect(threw).to.be.true;
+    });
+});

--- a/packages/node/test/endpoint/EndpointGetTypesTest.ts
+++ b/packages/node/test/endpoint/EndpointGetTypesTest.ts
@@ -67,10 +67,10 @@ describe("Endpoint get type helpers", () => {
         const _checkTrueSlice: _TrueSlice = {} as { fake: Immutable<Behavior.StateOf<FakeBehaviorType>> };
         void _checkTrueSlice;
 
-        // StateSliceOf with key selection produces a Pick slice
+        // StateSliceOf with key selection produces a Partial<Pick> slice (values may be absent)
         type _PickSlice = StateSliceOf<TestEndpoint, { fake: readonly ["value"] }>;
         const _checkPickSlice: _PickSlice = {} as {
-            fake: Immutable<Pick<Behavior.StateOf<FakeBehaviorType>, "value">>;
+            fake: Immutable<Partial<Pick<Behavior.StateOf<FakeBehaviorType>, "value">>>;
         };
         void _checkPickSlice;
     });

--- a/packages/node/test/endpoint/EndpointGetTypesTest.ts
+++ b/packages/node/test/endpoint/EndpointGetTypesTest.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Behavior } from "#behavior/Behavior.js";
+import type {
+    BehaviorAt,
+    BehaviorOf,
+    BehaviorSelection,
+    RawBehaviorSelection,
+    StateSelector,
+    StateSliceOf,
+} from "#endpoint/Endpoint.js";
+import type { EndpointType } from "#endpoint/type/EndpointType.js";
+import type { Immutable } from "@matter/general";
+
+type FakeState = { value: number; label: string };
+type FakeBehaviorType = Behavior.Type & { readonly State: new () => FakeState; readonly id: "fake" };
+
+// A minimal EndpointType shape for type-level testing
+type TestEndpoint = EndpointType & { behaviors: { fake: FakeBehaviorType } };
+
+describe("Endpoint get type helpers", () => {
+    it("compiles correctly (types validated at compile time)", () => {
+        // BehaviorOf resolves to a Behavior.Type union over behaviors
+        type _BehOf = BehaviorOf<TestEndpoint>;
+        const _checkBehOf: _BehOf = {} as FakeBehaviorType;
+        void _checkBehOf;
+
+        // BehaviorAt resolves to the specific behavior type at a key
+        type _BehAt = BehaviorAt<TestEndpoint, "fake">;
+        const _checkBehAt: _BehAt = {} as FakeBehaviorType;
+        void _checkBehAt;
+
+        // BehaviorSelection accepts `true`
+        const _selTrue: BehaviorSelection<FakeBehaviorType> = true;
+        void _selTrue;
+
+        // BehaviorSelection accepts a readonly array of state keys
+        const _selKeys: BehaviorSelection<FakeBehaviorType> = ["value"] as const;
+        void _selKeys;
+
+        // RawBehaviorSelection accepts `true`
+        const _rawTrue: RawBehaviorSelection = true;
+        void _rawTrue;
+
+        // RawBehaviorSelection accepts a readonly string array
+        const _rawArr: RawBehaviorSelection = ["value", "label"] as const;
+        void _rawArr;
+
+        // StateSelector accepts { fake: true }
+        const _selectorTrue: StateSelector<TestEndpoint> = { fake: true };
+        void _selectorTrue;
+
+        // StateSelector accepts { fake: readonly (keyof State)[] }
+        const _selectorKeys: StateSelector<TestEndpoint> = { fake: ["value"] as const };
+        void _selectorKeys;
+
+        // StateSelector accepts partial (no keys required)
+        const _selectorEmpty: StateSelector<TestEndpoint> = {};
+        void _selectorEmpty;
+
+        // StateSliceOf with { fake: true } produces a slice with full fake state
+        type _TrueSlice = StateSliceOf<TestEndpoint, { fake: true }>;
+        const _checkTrueSlice: _TrueSlice = {} as { fake: Immutable<Behavior.StateOf<FakeBehaviorType>> };
+        void _checkTrueSlice;
+
+        // StateSliceOf with key selection produces a Pick slice
+        type _PickSlice = StateSliceOf<TestEndpoint, { fake: readonly ["value"] }>;
+        const _checkPickSlice: _PickSlice = {} as {
+            fake: Immutable<Pick<Behavior.StateOf<FakeBehaviorType>, "value">>;
+        };
+        void _checkPickSlice;
+    });
+});

--- a/packages/node/test/endpoint/ErrorsTest.ts
+++ b/packages/node/test/endpoint/ErrorsTest.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    AttributeNotPresentError,
+    EndpointBehaviorNotPresentError,
+    EndpointReadFailedError,
+} from "#endpoint/errors.js";
+import { AttributeId, ClusterId, EndpointNumber, Status } from "@matter/types";
+
+describe("EndpointBehaviorNotPresentError", () => {
+    it("names the missing behavior", () => {
+        const err = new EndpointBehaviorNotPresentError("doesNotExist");
+        expect(err.message).to.match(/doesNotExist/);
+    });
+});
+
+describe("AttributeNotPresentError", () => {
+    it("names the missing attribute and its behavior", () => {
+        const err = new AttributeNotPresentError("basicInformation", "ghost");
+        expect(err.message).to.match(/basicInformation/);
+        expect(err.message).to.match(/ghost/);
+    });
+});
+
+describe("EndpointReadFailedError", () => {
+    it("carries failed paths and the partial slice", () => {
+        const failed = [
+            {
+                path: { endpointId: EndpointNumber(1), clusterId: ClusterId(0x28), attributeId: AttributeId(0x01) },
+                status: Status.UnsupportedAttribute,
+            },
+        ];
+        const partial = { basicInformation: {} };
+        const err = new EndpointReadFailedError({ failed, partial });
+        expect(err.failed).to.equal(failed);
+        expect(err.partial).to.equal(partial);
+        expect(err.message).to.match(/1 path/);
+    });
+});

--- a/packages/node/test/node/ClientGroupTest.ts
+++ b/packages/node/test/node/ClientGroupTest.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ClientGroup } from "#node/ClientGroup.js";
+import { InvalidGroupOperationError } from "#node/client/ClientGroupInteraction.js";
+
+describe("ClientGroup", () => {
+    it("throws InvalidGroupOperationError on get()", async () => {
+        // get() throws before accessing instance state, so we can exercise it via prototype
+        const group = Object.create(ClientGroup.prototype) as ClientGroup;
+        let threw = false;
+        try {
+            await group.get();
+        } catch (e) {
+            threw = true;
+            expect(e).to.be.instanceof(InvalidGroupOperationError);
+            expect((e as Error).message).to.equal("Groups do not support reading attributes");
+        }
+        expect(threw).to.be.true;
+    });
+
+    it("throws InvalidGroupOperationError on getStateOf()", async () => {
+        const group = Object.create(ClientGroup.prototype) as ClientGroup;
+        let threw = false;
+        try {
+            await group.getStateOf("someCluster");
+        } catch (e) {
+            threw = true;
+            expect(e).to.be.instanceof(InvalidGroupOperationError);
+            expect((e as Error).message).to.equal("Groups do not support reading attributes");
+        }
+        expect(threw).to.be.true;
+    });
+});

--- a/packages/protocol/src/action/request/Read.ts
+++ b/packages/protocol/src/action/request/Read.ts
@@ -329,6 +329,28 @@ export namespace Read {
         }
     }
 
+    /**
+     * Accumulates {@link AttributePath} entries for a batched Read, deduped and preserved in insertion order.
+     *
+     * Omitting fields applies wildcard semantics: omitting `attributeId` reads all attributes of a cluster;
+     * omitting `clusterId` reads all clusters of an endpoint.
+     */
+    export class AttributePaths {
+        readonly #seen = new Set<string>();
+        readonly #paths = new Array<AttributePath>();
+
+        add(path: AttributePath): void {
+            const key = `${path.endpointId ?? "*"}/${path.clusterId ?? "*"}/${path.attributeId ?? "*"}`;
+            if (this.#seen.has(key)) return;
+            this.#seen.add(key);
+            this.#paths.push(path);
+        }
+
+        get paths(): ReadonlyArray<AttributePath> {
+            return this.#paths;
+        }
+    }
+
     export namespace EventSelector {
         export interface Concrete<C extends Specifier.Cluster> {
             endpoint: Specifier.Endpoint;

--- a/packages/protocol/test/action/request/ReadAttributePathsTest.ts
+++ b/packages/protocol/test/action/request/ReadAttributePathsTest.ts
@@ -6,7 +6,6 @@
 
 import { Read } from "#action/request/Read.js";
 import { AttributeId, AttributePath, ClusterId, EndpointNumber } from "@matter/types";
-import { expect } from "chai";
 
 describe("Read.AttributePaths", () => {
     function path(endpointId: number, clusterId: number, attributeId: number): AttributePath {

--- a/packages/protocol/test/action/request/ReadAttributePathsTest.ts
+++ b/packages/protocol/test/action/request/ReadAttributePathsTest.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Read } from "#action/request/Read.js";
+import { AttributeId, AttributePath, ClusterId, EndpointNumber } from "@matter/types";
+import { expect } from "chai";
+
+describe("Read.AttributePaths", () => {
+    function path(endpointId: number, clusterId: number, attributeId: number): AttributePath {
+        return {
+            endpointId: EndpointNumber(endpointId),
+            clusterId: ClusterId(clusterId),
+            attributeId: AttributeId(attributeId),
+        };
+    }
+
+    it("retains paths in insertion order", () => {
+        const paths = new Read.AttributePaths();
+        paths.add(path(1, 0x28, 0x01));
+        paths.add(path(1, 0x06, 0x00));
+        expect([...paths.paths]).to.deep.equal([path(1, 0x28, 0x01), path(1, 0x06, 0x00)]);
+    });
+
+    it("dedupes by (endpointId, clusterId, attributeId)", () => {
+        const paths = new Read.AttributePaths();
+        paths.add(path(1, 0x28, 0x01));
+        paths.add(path(1, 0x28, 0x01));
+        expect(paths.paths.length).to.equal(1);
+    });
+
+    it("treats different endpoints / clusters / attributes as distinct", () => {
+        const paths = new Read.AttributePaths();
+        paths.add(path(1, 0x28, 0x01));
+        paths.add(path(2, 0x28, 0x01));
+        paths.add(path(1, 0x29, 0x01));
+        paths.add(path(1, 0x28, 0x02));
+        expect(paths.paths.length).to.equal(4);
+    });
+
+    it("dedupes cluster-level wildcard paths (no attributeId)", () => {
+        const paths = new Read.AttributePaths();
+        paths.add({ endpointId: EndpointNumber(1), clusterId: ClusterId(0x28) });
+        paths.add({ endpointId: EndpointNumber(1), clusterId: ClusterId(0x28) });
+        expect(paths.paths.length).to.equal(1);
+    });
+
+    it("dedupes endpoint-level wildcard paths (no clusterId or attributeId)", () => {
+        const paths = new Read.AttributePaths();
+        paths.add({ endpointId: EndpointNumber(1) });
+        paths.add({ endpointId: EndpointNumber(1) });
+        expect(paths.paths.length).to.equal(1);
+    });
+
+    it("treats cluster wildcard and specific attribute as distinct", () => {
+        const paths = new Read.AttributePaths();
+        paths.add({ endpointId: EndpointNumber(1), clusterId: ClusterId(0x28) });
+        paths.add(path(1, 0x28, 0x01));
+        expect(paths.paths.length).to.equal(2);
+    });
+});

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -44,7 +44,7 @@
     },
     "homepage": "https://github.com/matter-js/matter.js#readme",
     "dependencies": {
-        "@nacho-iot/js-tools": "*",
+        "@nacho-iot/js-tools": "0.1.4",
         "@types/express": "^5.0.6",
         "ansi-colors": "^4.1.3",
         "chai": "^4.5.0",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -44,7 +44,7 @@
     },
     "homepage": "https://github.com/matter-js/matter.js#readme",
     "dependencies": {
-        "@nacho-iot/js-tools": "0.1.4",
+        "@nacho-iot/js-tools": "^0.1.4",
         "@types/express": "^5.0.6",
         "ansi-colors": "^4.1.3",
         "chai": "^4.5.0",


### PR DESCRIPTION
## Summary

- **`Endpoint.get()` / `getStateOf()`**: new async read API on client and server endpoints
  - Client node: issues a single batched Matter Read request; optional `fabricFilter` control
  - Server node: returns a snapshot of local state (no network I/O)
  - Group node: throws `InvalidGroupOperationError("Groups do not support reading attributes")`
- **`nodeType: "server" | "client" | "group"`**: replaces scattered `isGroup` / `isLocalNode` boolean properties on `Node` with a typed discriminant literal
- **`Read.AttributePaths`**: renames `Read.Plan` to an honest, convention-consistent name (accumulates + deduplicates `AttributePath[]` for batched reads)

## Changes

| File | Change |
|------|--------|
| `packages/node/src/node/Node.ts` | `abstract readonly nodeType: "server" \| "client" \| "group"` |
| `packages/node/src/node/ServerNode.ts` | `nodeType = "server" as const` |
| `packages/node/src/node/ClientNode.ts` | `nodeType: "client" \| "group" = "client"` |
| `packages/node/src/node/ClientGroup.ts` | `nodeType = "group"`, `get()`/`getStateOf()` throw |
| `packages/node/src/endpoint/Endpoint.ts` | `get()`/`getStateOf()`, group guard, `AttributePaths` usage |
| `packages/protocol/src/action/request/Read.ts` | `Read.Plan` → `Read.AttributePaths` |
| `packages/node/src/behavior/system/network/NetworkClient.ts` | `isGroup` → `nodeType === "group"` |
| `packages/node/src/behavior/system/software-update/OtaAnnouncements.ts` | `isGroup` → `nodeType === "group"` |


🤖 Generated with [Claude Code](https://claude.com/claude-code)