### PR TITLE
fix(node): tighten StateSelector to typed behavior keys

### DIFF
--- a/packages/node/src/endpoint/Endpoint.ts
+++ b/packages/node/src/endpoint/Endpoint.ts
@@ -1347,10 +1347,12 @@ export type BehaviorSelection<B extends Behavior.Type> = true | readonly (keyof 
 
 export type RawBehaviorSelection = true | readonly string[];
 
-// TODO: use BehaviorSelection<BehaviorAt<T, K>> — blocked by SupportedBehaviors index sig (Record<string,...>
-// makes keyof=string → BehaviorAt→Behavior.Type → keyof {}=never). Fix: remove index sig. getStateOf() is ok.
 export type StateSelector<T extends EndpointType> = {
-    [K in keyof T["behaviors"]]?: RawBehaviorSelection;
+    [K in keyof T["behaviors"]]?: string extends K
+        ? RawBehaviorSelection
+        : T["behaviors"][K] extends Behavior.Type
+          ? BehaviorSelection<T["behaviors"][K]>
+          : RawBehaviorSelection;
 };
 
 export type StateSliceOf<T extends EndpointType, S> = S extends undefined

--- a/packages/node/test/endpoint/EndpointGetTypesTest.ts
+++ b/packages/node/test/endpoint/EndpointGetTypesTest.ts
@@ -67,6 +67,16 @@ describe("Endpoint get type helpers", () => {
         const _selectorBadKey: StateSelector<TestEndpoint> = { fake: ["missing"] as const };
         void _selectorBadKey;
 
+        // Fallback branch: unbound `T extends EndpointType` widens `keyof T["behaviors"]` to `string`
+        // via the SupportedBehaviors index signature, so values must accept RawBehaviorSelection
+        // (arbitrary string-keyed attribute lists) for backward compatibility with generic code.
+        type _GenericValue = NonNullable<StateSelector<EndpointType>[string]>;
+        type _AssertEqual<A, B> = (<T>() => T extends A ? 1 : 0) extends <T>() => T extends B ? 1 : 0 ? true : false;
+        const _genericValueIsRaw: _AssertEqual<_GenericValue, RawBehaviorSelection> = true;
+        void _genericValueIsRaw;
+        const _genericSelector: StateSelector<EndpointType> = { someBehavior: ["arbitraryAttr"] as const };
+        void _genericSelector;
+
         // StateSliceOf with { fake: true } produces a slice with full fake state
         type _TrueSlice = StateSliceOf<TestEndpoint, { fake: true }>;
         const _checkTrueSlice: _TrueSlice = {} as { fake: Immutable<Behavior.StateOf<FakeBehaviorType>> };

--- a/packages/node/test/endpoint/EndpointGetTypesTest.ts
+++ b/packages/node/test/endpoint/EndpointGetTypesTest.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Behavior } from "#behavior/Behavior.js";
+import { Behavior } from "#behavior/Behavior.js";
 import type {
     BehaviorAt,
     BehaviorOf,
@@ -13,7 +13,8 @@ import type {
     StateSelector,
     StateSliceOf,
 } from "#endpoint/Endpoint.js";
-import type { EndpointType } from "#endpoint/type/EndpointType.js";
+import { SupportedBehaviors } from "#endpoint/properties/SupportedBehaviors.js";
+import { EndpointType } from "#endpoint/type/EndpointType.js";
 import type { Immutable } from "@matter/general";
 
 type FakeState = { value: number; label: string };
@@ -76,6 +77,37 @@ describe("Endpoint get type helpers", () => {
         void _genericValueIsRaw;
         const _genericSelector: StateSelector<EndpointType> = { someBehavior: ["arbitraryAttr"] as const };
         void _genericSelector;
+
+        // Real factory path: exercise EndpointType(...) + SupportedBehaviors(...) + MapOf<>, not a
+        // hand-built intersection. Catches regressions in EndpointType.For<T> / MapOf<T> that would
+        // widen `keyof T["behaviors"]` back to `string` and silently drop the per-behavior tightening.
+        class FactoryTestBehavior extends Behavior {
+            static override readonly id = "factoryTest";
+            static override readonly State = class FactoryTestState {
+                value = 0;
+                label = "";
+            };
+        }
+        const FactoryTestEndpoint = EndpointType({
+            name: "FactoryTest",
+            deviceType: 0xfff1,
+            deviceRevision: 1,
+            behaviors: SupportedBehaviors(FactoryTestBehavior),
+        });
+        type _FactoryTestType = typeof FactoryTestEndpoint;
+
+        // Behavior keys must remain narrow (literal "factoryTest"), not widened to `string`.
+        type _FactoryKeys = keyof _FactoryTestType["behaviors"];
+        const _factoryKeysNarrow: string extends _FactoryKeys ? false : true = true;
+        void _factoryKeysNarrow;
+
+        // Typed attribute key accepted on factory-built endpoint
+        const _factoryGood: StateSelector<_FactoryTestType> = { factoryTest: ["value"] as const };
+        void _factoryGood;
+
+        // @ts-expect-error - "missing" is not a key of FactoryTestBehavior State
+        const _factoryBad: StateSelector<_FactoryTestType> = { factoryTest: ["missing"] as const };
+        void _factoryBad;
 
         // StateSliceOf with { fake: true } produces a slice with full fake state
         type _TrueSlice = StateSliceOf<TestEndpoint, { fake: true }>;

--- a/packages/node/test/endpoint/EndpointGetTypesTest.ts
+++ b/packages/node/test/endpoint/EndpointGetTypesTest.ts
@@ -62,6 +62,11 @@ describe("Endpoint get type helpers", () => {
         const _selectorEmpty: StateSelector<TestEndpoint> = {};
         void _selectorEmpty;
 
+        // StateSelector rejects attribute keys that are not in the behavior's State for typed endpoints.
+        // @ts-expect-error - "missing" is not a key of FakeState
+        const _selectorBadKey: StateSelector<TestEndpoint> = { fake: ["missing"] as const };
+        void _selectorBadKey;
+
         // StateSliceOf with { fake: true } produces a slice with full fake state
         type _TrueSlice = StateSliceOf<TestEndpoint, { fake: true }>;
         const _checkTrueSlice: _TrueSlice = {} as { fake: Immutable<Behavior.StateOf<FakeBehaviorType>> };


### PR DESCRIPTION
## Summary
- Resolves TODO from 2d9d35f32 — `StateSelector<T>` now produces typed attribute keys per behavior for concrete `EndpointType.For<T>` callers (autocomplete + rejection of unknown attribute names) while keeping `RawBehaviorSelection` as the fallback for unbound generic `T extends EndpointType`.
- Discriminator `string extends K` inside the mapped type detects the widened-key case (index-sig path) vs the narrow literal-keyed case from `MapOf<>`. No changes to `SupportedBehaviors` itself.
- Adds a `@ts-expect-error` type-level test asserting unknown attribute keys are rejected.

The earlier TODO claimed the `SupportedBehaviors = Record<string, Behavior.Type>` index signature blocked the tightening; investigation showed concrete `EndpointType.For<T>["behaviors"]` is already the literal `MapOf<>` shape (no index sig), so `keyof` is narrow there. The conditional handles both shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)