### PR TITLE
chore(ci): bump actions/download-artifact v4 → v8 in load-chip

### DIFF
--- a/.github/actions/load-chip/action.yml
+++ b/.github/actions/load-chip/action.yml
@@ -9,7 +9,7 @@ runs:
   using: 'composite'
   steps:
     - name: Install artifact image
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: chip-image
         path: /tmp


### PR DESCRIPTION
## Summary
- Bumps `actions/download-artifact` from v4 to v8 in `.github/actions/load-chip/action.yml`.
- Custom composite actions under `.github/actions/` aren't covered by dependabot's default scan, so this dependency had drifted four major versions behind.
- Audited every other pinned action across `.github/actions/` and `.github/workflows/` — all already on the current major.

## v4 → v8 notable changes
- **v5**: path consistency fix for downloads by `artifact-ids` (we download by `name:`, not affected).
- **v6**: Node 24 support added.
- **v7**: default runtime is Node 24, requires self-hosted runner ≥ 2.327.1 (we use `ubuntu-latest`, so fine).
- **v8**: ESM migration (transparent), hash mismatch now errors instead of warning, `Content-Type` checked before unzip. Pairs cleanly with `actions/upload-artifact@v7` zip uploads.

## Test plan
- [ ] CHIP test workflow runs through `Load CHIP from artifact` step successfully on this branch.