### PR TITLE
fix(codegen): handle 'Field ID' header in command param tables

### DIFF
--- a/packages/model/src/standard/elements/audio-output.element.ts
+++ b/packages/model/src/standard/elements/audio-output.element.ts
@@ -27,8 +27,15 @@ export const AudioOutput = Cluster(
         Field({ name: "entry", type: "OutputInfoStruct" })
     ),
     Attribute({ name: "CurrentOutput", id: 0x1, type: "uint8", access: "R V", conformance: "M" }),
-    Command({ name: "SelectOutput", id: 0x0, access: "O", conformance: "M", direction: "request", response: "status" }),
-    Command({ name: "RenameOutput", id: 0x1, access: "M", conformance: "NU", direction: "request", response: "status" }),
+    Command(
+        { name: "SelectOutput", id: 0x0, access: "O", conformance: "M", direction: "request", response: "status" },
+        Field({ name: "Index", id: 0x0, type: "uint8", conformance: "M" })
+    ),
+    Command(
+        { name: "RenameOutput", id: 0x1, access: "M", conformance: "NU", direction: "request", response: "status" },
+        Field({ name: "Index", id: 0x0, type: "uint8", conformance: "M" }),
+        Field({ name: "Name", id: 0x1, type: "string", conformance: "M", constraint: "max 32" })
+    ),
 
     Datatype(
         { name: "OutputTypeEnum", type: "enum8" },

--- a/packages/model/src/standard/resources/audio-output.resource.ts
+++ b/packages/model/src/standard/resources/audio-output.resource.ts
@@ -43,7 +43,13 @@ Resource.add({
                 "\n" +
                 "Note that when the current output is set to an output of type HDMI, adjustments to volume via a " +
                 "Speaker endpoint on the same node may cause HDMI volume up/down commands to be sent to the given " +
-                "HDMI output."
+                "HDMI output.",
+
+            children: [{
+                tag: "field", name: "Index", xref: "cluster§6.5.7.1.1",
+                details: "This shall indicate the index field of the OutputInfoStruct from the OutputList attribute in which " +
+                    "to change to."
+            }]
         },
 
         {

--- a/packages/types/src/clusters/audio-output.d.ts
+++ b/packages/types/src/clusters/audio-output.d.ts
@@ -102,7 +102,7 @@ export declare namespace AudioOutput {
          *
          * @see {@link MatterSpecification.v151.Cluster} § 6.5.7.1
          */
-        selectOutput(): MaybePromise;
+        selectOutput(request: SelectOutputRequest): MaybePromise;
     }
 
     /**
@@ -117,7 +117,7 @@ export declare namespace AudioOutput {
          *
          * @see {@link MatterSpecification.v151.Cluster} § 6.5.7.2
          */
-        renameOutput(): MaybePromise;
+        renameOutput(request: RenameOutputRequest): MaybePromise;
     }
 
     /**
@@ -176,6 +176,40 @@ export declare namespace AudioOutput {
          *
          * @see {@link MatterSpecification.v151.Cluster} § 6.5.5.2.3
          */
+        name: string;
+    };
+
+    /**
+     * Upon receipt, this shall change the output on the device to the output at a specific index in the Output List.
+     *
+     * Note that when the current output is set to an output of type HDMI, adjustments to volume via a Speaker endpoint
+     * on the same node may cause HDMI volume up/down commands to be sent to the given HDMI output.
+     *
+     * @see {@link MatterSpecification.v151.Cluster} § 6.5.7.1
+     */
+    export declare class SelectOutputRequest {
+        constructor(values?: Partial<SelectOutputRequest>);
+
+        /**
+         * This shall indicate the index field of the OutputInfoStruct from the OutputList attribute in which to change
+         * to.
+         *
+         * @see {@link MatterSpecification.v151.Cluster} § 6.5.7.1.1
+         */
+        index: number;
+    };
+
+    /**
+     * Upon receipt, this shall rename the output at a specific index in the Output List.
+     *
+     * Updates to the output name shall appear in the device's settings menus. Name updates may automatically be sent to
+     * the actual device to which the output connects.
+     *
+     * @see {@link MatterSpecification.v151.Cluster} § 6.5.7.2
+     */
+    export declare class RenameOutputRequest {
+        constructor(values?: Partial<RenameOutputRequest>);
+        index: number;
         name: string;
     };
 

--- a/support/codegen/src/mom/spec/translate-datatype.ts
+++ b/support/codegen/src/mom/spec/translate-datatype.ts
@@ -134,7 +134,7 @@ function hasColumn(definition: SpecReference, ...names: string[]) {
 }
 
 const FieldSchema = {
-    id: Integer,
+    id: Alias(Integer, "fieldid"),
     name: Alias(Identifier, "field"),
 
     // Not really optional, but we want to process rows even if missing

--- a/support/models/src/v1.5.1/spec.ts
+++ b/support/models/src/v1.5.1/spec.ts
@@ -16273,26 +16273,39 @@ export const SpecMatter = Matter(
             details: "This attribute contains the value of the index field of the currently selected OutputInfoStruct."
         }),
 
-        Command({
-            name: "SelectOutput", id: 0x0, access: "O", conformance: "M", direction: "request",
-            response: "status", xref: "cluster§6.5.7.1",
+        Command(
+            {
+                name: "SelectOutput", id: 0x0, access: "O", conformance: "M", direction: "request",
+                response: "status", xref: "cluster§6.5.7.1",
 
-            details: "Upon receipt, this shall change the output on the device to the output at a specific index in the " +
-                "Output List." +
-                "\n" +
-                "Note that when the current output is set to an output of type HDMI, adjustments to volume via a " +
-                "Speaker endpoint on the same node may cause HDMI volume up/down commands to be sent to the given " +
-                "HDMI output."
-        }),
+                details: "Upon receipt, this shall change the output on the device to the output at a specific index in the " +
+                    "Output List." +
+                    "\n" +
+                    "Note that when the current output is set to an output of type HDMI, adjustments to volume via a " +
+                    "Speaker endpoint on the same node may cause HDMI volume up/down commands to be sent to the given " +
+                    "HDMI output."
+            },
 
-        Command({
-            name: "RenameOutput", id: 0x1, access: "M", conformance: "NU", direction: "request",
-            response: "status", xref: "cluster§6.5.7.2",
-            details: "Upon receipt, this shall rename the output at a specific index in the Output List." +
-                "\n" +
-                "Updates to the output name shall appear in the device's settings menus. Name updates may " +
-                "automatically be sent to the actual device to which the output connects."
-        }),
+            Field({
+                name: "Index", id: 0x0, type: "uint8", conformance: "M", xref: "cluster§6.5.7.1.1",
+                details: "This shall indicate the index field of the OutputInfoStruct from the OutputList attribute in which " +
+                    "to change to."
+            })
+        ),
+
+        Command(
+            {
+                name: "RenameOutput", id: 0x1, access: "M", conformance: "NU", direction: "request",
+                response: "status", xref: "cluster§6.5.7.2",
+                details: "Upon receipt, this shall rename the output at a specific index in the Output List." +
+                    "\n" +
+                    "Updates to the output name shall appear in the device's settings menus. Name updates may " +
+                    "automatically be sent to the actual device to which the output connects."
+            },
+
+            Field({ name: "Index", id: 0x0, type: "uint8", conformance: "M" }),
+            Field({ name: "Name", id: 0x1, type: "string", conformance: "M", constraint: "max 32" })
+        ),
 
         Datatype(
             {


### PR DESCRIPTION
## Summary
- Matter 1.5.1 AudioOutput cluster (`06-05-audio-output-cluster.md`) is the only spec file using `| Field ID |` as the column header for command parameter tables — every other cluster uses `| ID |`. Header normalization stripped non-word chars and lowercased, producing column key `fieldid`. `FieldSchema.id` in `translate-datatype.ts` was bare `Integer` (no alias), so the lookup failed and SelectOutput / RenameOutput generated with no parameters.
- Added `Alias(Integer, "fieldid")` so the parser recognizes the variant header. Regenerated `support/models/src/v1.5.1/spec.ts` and the standard model — `AudioOutput.SelectOutput` now has `Index`, `AudioOutput.RenameOutput` now has `Index` + `Name`, and `packages/types/src/clusters/audio-output.d.ts` exposes `SelectOutputRequest` / `RenameOutputRequest` with the proper signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)