### PR TITLE
fix(node): expose subscriptions on ClientNodeInteraction wrapper

### DIFF
--- a/packages/node/src/node/client/ClientNodeInteraction.ts
+++ b/packages/node/src/node/client/ClientNodeInteraction.ts
@@ -18,6 +18,7 @@ import {
     ClientRead,
     ClientSubscribe,
     ClientSubscription,
+    ClientSubscriptions,
     ClientWrite,
     DecodedInvokeResult,
     Interactable,
@@ -163,6 +164,10 @@ export class ClientNodeInteraction implements Interactable<ActionContext> {
 
     async probe(options?: ClientProbeOptions): Promise<boolean> {
         return this.#interaction.probe(options);
+    }
+
+    get subscriptions(): ClientSubscriptions {
+        return this.#node.env.get(ClientSubscriptions);
     }
 
     get #interaction() {

--- a/packages/protocol/src/action/client/ClientInteraction.ts
+++ b/packages/protocol/src/action/client/ClientInteraction.ts
@@ -108,7 +108,7 @@ const DEFAULT_MINIMUM_RESPONSE_TIMEOUT_WITH_FAILSAFE = Seconds(30);
 export class ClientInteraction<
     SessionT extends InteractionSession = InteractionSession,
 > implements Interactable<SessionT> {
-    protected readonly environment: Environment;
+    readonly #environment: Environment;
     readonly #lifetime: Lifetime;
     readonly #exchangeProvider: ExchangeProvider;
     readonly #interactions = new BasicSet<Read | Write | Invoke | Subscribe | ClientBdxRequest>();
@@ -125,7 +125,7 @@ export class ClientInteraction<
     #nextCommandRef = 1;
 
     constructor({ environment, abort, sustainRetries, exchangeProvider, address, network }: ClientInteractionContext) {
-        this.environment = environment;
+        this.#environment = environment;
         this.#exchangeProvider = exchangeProvider ?? environment.get(ExchangeProvider);
         if (environment.has(ClientSubscriptions)) {
             this.#subscriptions = environment.get(ClientSubscriptions);
@@ -180,7 +180,7 @@ export class ClientInteraction<
 
     get subscriptions() {
         if (this.#subscriptions === undefined) {
-            this.#subscriptions = this.environment.get(ClientSubscriptions);
+            this.#subscriptions = this.#environment.get(ClientSubscriptions);
         }
         return this.#subscriptions;
     }


### PR DESCRIPTION
## Summary
- `CommissioningClient` casts `node.interaction` to `ClientInteraction` and assigns it to `peer.interaction`, but the runtime value is a `ClientNodeInteraction` wrapper which did not expose `subscriptions`. `PeerAddressMonitor` crashed at `interaction.subscriptions.closeForPeer(...)` whenever an address migration succeeded.
- Add a `subscriptions` getter on `ClientNodeInteraction` that resolves `ClientSubscriptions` from the node environment — same singleton the inner `ClientInteraction` would return, without forcing lazy interactable creation.
- Tighten `ClientInteraction.environment` from `protected` to `#environment` since no subclass needs it.

Observed crash:
```
ERROR  Multiplex            Error: Cannot read properties of undefined (reading 'closeForPeer')
  at PeerAddressMonitor.#check (packages/protocol/src/peer/PeerAddressMonitor.ts:186:43)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)