### PR TITLE
feat(matter.js): align legacy Endpoint/PairedNode API surface with modern

### DIFF
--- a/packages/matter.js/src/device/Endpoint.ts
+++ b/packages/matter.js/src/device/Endpoint.ts
@@ -5,7 +5,15 @@
  */
 
 import { SupportedAttributeClient, UnknownSupportedAttributeClient } from "#cluster/client/AttributeClient.js";
-import { AtLeastOne, Diagnostic, ImplementationError, InternalError, NotImplementedError } from "@matter/general";
+import {
+    AtLeastOne,
+    Diagnostic,
+    Immutable,
+    ImplementationError,
+    InternalError,
+    NotImplementedError,
+    Observable,
+} from "@matter/general";
 import { Behavior, Endpoint as ClientEndpoint } from "@matter/node";
 import { ClusterClientObj, Val } from "@matter/protocol";
 import { ClusterId, ClusterType, DeviceTypeId, EndpointNumber, getClusterNameById } from "@matter/types";
@@ -67,15 +75,38 @@ export class Endpoint {
     }
 
     /**
-     * Access to typed cached cluster state values
-     * Returns immutable cached attribute values from cluster clients
+     * Access cached state for a specific behavior ID.
+     *
+     * Be aware that using a string type does not provide type checking and does not enforce the correctness of the used
+     * Behavior type including all enabled features. Because of this the returned state is typed as a plain string
+     * indexed record (Val.Struct). Please ensure to have proper checks in place when using this method with string type.
      */
-    stateOf<T extends Behavior.Type>(type: T) {
-        return this.#endpoint.stateOf(type);
+    stateOf(type: string): Immutable<Val.Struct>;
+
+    /**
+     * Access cached state for a specific behavior.
+     *
+     * This is the recommended way to access state for a specific behavior because it provides proper type checking
+     * and enforces the correctness of the used Behavior type including all enabled features.
+     */
+    stateOf<T extends Behavior.Type>(type: T): Immutable<Behavior.StateOf<T>>;
+
+    stateOf(type: Behavior.Type | string) {
+        return this.#endpoint.stateOf(type as any);
     }
 
-    maybeStateOf<T extends Behavior.Type>(type: T) {
-        return this.#endpoint.maybeStateOf(type);
+    /**
+     * Version of {@link stateOf} that returns undefined instead of throwing if the requested behavior is unsupported.
+     */
+    maybeStateOf(type: string): Immutable<Val.Struct> | undefined;
+
+    /**
+     * Version of {@link stateOf} that returns undefined instead of throwing if the requested behavior is unsupported.
+     */
+    maybeStateOf<T extends Behavior.Type>(type: T): Immutable<Behavior.StateOf<T>> | undefined;
+
+    maybeStateOf(type: Behavior.Type | string) {
+        return this.#endpoint.maybeStateOf(type as any);
     }
 
     /**
@@ -115,6 +146,27 @@ export class Endpoint {
      */
     commandsOf<T extends Behavior.Type>(type: T) {
         return this.#endpoint.commandsOf(type);
+    }
+
+    /**
+     * Events for a specific behavior ID.
+     *
+     * Be aware that using a string type does not provide type checking and does not enforce the correctness of the used
+     * Behavior type including all enabled features. Because of this each event is typed as Observable | undefined.
+     * Please ensure to have proper checks in place when using this method with string type.
+     */
+    eventsOf(type: string): Immutable<Record<string, Observable | undefined>>;
+
+    /**
+     * Events for a specific behavior.
+     *
+     * This is the recommended way to access events for a specific behavior because it provides proper type checking
+     * and enforces the correctness of the used Behavior type including all enabled features.
+     */
+    eventsOf<T extends Behavior.Type>(type: T): Behavior.EventsOf<T>;
+
+    eventsOf(type: Behavior.Type | string): unknown {
+        return this.#endpoint.eventsOf(type as any);
     }
 
     get behaviors() {

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -1468,11 +1468,38 @@ export class PairedNode {
     }
 
     /**
-     * Access to typed cached cluster state values of the root endpoint
-     * Returns immutable cached attribute values from cluster clients
+     * Access cached state of the root endpoint for a specific behavior ID.
+     *
+     * Be aware that using a string type does not provide type checking and does not enforce the correctness of the used
+     * Behavior type including all enabled features. Because of this the returned state is typed as a plain string
+     * indexed record (Val.Struct). Please ensure to have proper checks in place when using this method with string type.
      */
-    stateOf<T extends Behavior.Type>(type: T) {
-        return this.#clientNode.stateOf(type);
+    stateOf(type: string): Immutable<Val.Struct>;
+
+    /**
+     * Access cached state of the root endpoint for a specific behavior.
+     *
+     * This is the recommended way to access state for a specific behavior because it provides proper type checking
+     * and enforces the correctness of the used Behavior type including all enabled features.
+     */
+    stateOf<T extends Behavior.Type>(type: T): Immutable<Behavior.StateOf<T>>;
+
+    stateOf(type: Behavior.Type | string) {
+        return this.#clientNode.stateOf(type as any);
+    }
+
+    /**
+     * Version of {@link stateOf} that returns undefined instead of throwing if the requested behavior is unsupported.
+     */
+    maybeStateOf(type: string): Immutable<Val.Struct> | undefined;
+
+    /**
+     * Version of {@link stateOf} that returns undefined instead of throwing if the requested behavior is unsupported.
+     */
+    maybeStateOf<T extends Behavior.Type>(type: T): Immutable<Behavior.StateOf<T>> | undefined;
+
+    maybeStateOf(type: Behavior.Type | string) {
+        return this.#clientNode.maybeStateOf(type as any);
     }
 
     /**
@@ -1481,6 +1508,31 @@ export class PairedNode {
      */
     commandsOf<T extends Behavior.Type>(type: T): Commands.OfBehavior<T> {
         return this.#clientNode.commandsOf(type);
+    }
+
+    /**
+     * Events of the root endpoint for a specific behavior ID.
+     *
+     * Be aware that using a string type does not provide type checking and does not enforce the correctness of the used
+     * Behavior type including all enabled features. Because of this each event is typed as Observable | undefined.
+     * Please ensure to have proper checks in place when using this method with string type.
+     *
+     * Note: this exposes per-behavior events of the root endpoint. The {@link events} field on this class is the
+     * lifecycle event bus of the {@link PairedNode} itself ({@link PairedNode.Events}) and unrelated to behavior
+     * events.
+     */
+    eventsOf(type: string): Immutable<Record<string, Observable | undefined>>;
+
+    /**
+     * Events of the root endpoint for a specific behavior.
+     *
+     * This is the recommended way to access events for a specific behavior because it provides proper type checking
+     * and enforces the correctness of the used Behavior type including all enabled features.
+     */
+    eventsOf<T extends Behavior.Type>(type: T): Behavior.EventsOf<T>;
+
+    eventsOf(type: Behavior.Type | string): unknown {
+        return this.#clientNode.eventsOf(type as any);
     }
 }
 

--- a/packages/matter.js/test/device/EndpointGetTypesTest.ts
+++ b/packages/matter.js/test/device/EndpointGetTypesTest.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Endpoint } from "#device/Endpoint.js";
+import type { Immutable, Observable } from "@matter/general";
+import { Behavior, Commands } from "@matter/node";
+import type { Val } from "@matter/protocol";
+
+type FakeState = { value: number; label: string };
+type FakeBehaviorType = Behavior.Type & { readonly State: new () => FakeState; readonly id: "fake" };
+
+type _AssertEqual<A, B> = (<T>() => T extends A ? 1 : 0) extends <T>() => T extends B ? 1 : 0 ? true : false;
+
+describe("Legacy Endpoint get type helpers", () => {
+    it("compiles correctly (parity with modern Endpoint, types validated at compile time)", () => {
+        // The body never executes at runtime; the boolean cast defeats the
+        // unreachable-code check so the type assertions still get checked.
+        if ((false as boolean) === true) {
+            const ep = null as unknown as Endpoint;
+            const fakeBeh = null as unknown as FakeBehaviorType;
+
+            // stateOf(string) → Immutable<Val.Struct>
+            const _stateString: Immutable<Val.Struct> = ep.stateOf("anyId");
+            const _stateStringExact: _AssertEqual<typeof _stateString, Immutable<Val.Struct>> = true;
+            void _stateString;
+            void _stateStringExact;
+
+            // stateOf<T>(T) → Immutable<Behavior.StateOf<T>>
+            const _stateTyped = ep.stateOf(fakeBeh);
+            const _stateTypedExact: _AssertEqual<typeof _stateTyped, Immutable<FakeState>> = true;
+            void _stateTyped;
+            void _stateTypedExact;
+
+            // maybeStateOf(string) → Immutable<Val.Struct> | undefined
+            const _maybeString = ep.maybeStateOf("anyId");
+            const _maybeStringExact: _AssertEqual<typeof _maybeString, Immutable<Val.Struct> | undefined> = true;
+            void _maybeString;
+            void _maybeStringExact;
+
+            // maybeStateOf<T>(T) → Immutable<Behavior.StateOf<T>> | undefined
+            const _maybeTyped = ep.maybeStateOf(fakeBeh);
+            const _maybeTypedExact: _AssertEqual<typeof _maybeTyped, Immutable<FakeState> | undefined> = true;
+            void _maybeTyped;
+            void _maybeTypedExact;
+
+            // commandsOf<T>(T) → Commands.OfBehavior<T>
+            const _commandsTyped = ep.commandsOf(fakeBeh);
+            const _commandsTypedExact: _AssertEqual<
+                typeof _commandsTyped,
+                Commands.OfBehavior<FakeBehaviorType>
+            > = true;
+            void _commandsTyped;
+            void _commandsTypedExact;
+
+            // eventsOf(string) → Immutable<Record<string, Observable | undefined>>
+            const _eventsString = ep.eventsOf("anyId");
+            const _eventsStringExact: _AssertEqual<
+                typeof _eventsString,
+                Immutable<Record<string, Observable | undefined>>
+            > = true;
+            void _eventsString;
+            void _eventsStringExact;
+
+            // eventsOf<T>(T) → Behavior.EventsOf<T>
+            const _eventsTyped = ep.eventsOf(fakeBeh);
+            const _eventsTypedExact: _AssertEqual<typeof _eventsTyped, Behavior.EventsOf<FakeBehaviorType>> = true;
+            void _eventsTyped;
+            void _eventsTypedExact;
+
+            // setStateOf(string, Val.Struct) → Promise<void>
+            const _setString: Promise<void> = ep.setStateOf("anyId", { foo: 1 });
+            void _setString;
+
+            // setStateOf<T>(T, Behavior.PatchStateOf<T>) → Promise<void>
+            const _setTyped: Promise<void> = ep.setStateOf(fakeBeh, { value: 2 });
+            void _setTyped;
+
+            // Negative cases — must fail to type-check.
+
+            // @ts-expect-error - number is not a valid behavior type or id
+            ep.stateOf(42);
+
+            // @ts-expect-error - number is not a valid behavior type or id
+            ep.maybeStateOf(42);
+
+            // @ts-expect-error - number is not a valid behavior type or id
+            ep.eventsOf(42);
+
+            // @ts-expect-error - patch shape must match FakeState (value: number)
+            ep.setStateOf(fakeBeh, { value: "not a number" });
+
+            // @ts-expect-error - unknown attribute on typed patch
+            ep.setStateOf(fakeBeh, { missing: 1 });
+        }
+    });
+});

--- a/packages/matter.js/test/device/EndpointGetTypesTest.ts
+++ b/packages/matter.js/test/device/EndpointGetTypesTest.ts
@@ -90,10 +90,10 @@ describe("Legacy Endpoint get type helpers", () => {
             ep.eventsOf(42);
 
             // @ts-expect-error - patch shape must match FakeState (value: number)
-            ep.setStateOf(fakeBeh, { value: "not a number" });
+            void ep.setStateOf(fakeBeh, { value: "not a number" });
 
             // @ts-expect-error - unknown attribute on typed patch
-            ep.setStateOf(fakeBeh, { missing: 1 });
+            void ep.setStateOf(fakeBeh, { missing: 1 });
         }
     });
 });

--- a/packages/matter.js/test/device/PairedNodeGetTypesTest.ts
+++ b/packages/matter.js/test/device/PairedNodeGetTypesTest.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PairedNode } from "#device/PairedNode.js";
+import type { Immutable, Observable } from "@matter/general";
+import { Behavior, Commands } from "@matter/node";
+import type { Val } from "@matter/protocol";
+
+type FakeState = { value: number; label: string };
+type FakeBehaviorType = Behavior.Type & { readonly State: new () => FakeState; readonly id: "fake" };
+
+type _AssertEqual<A, B> = (<T>() => T extends A ? 1 : 0) extends <T>() => T extends B ? 1 : 0 ? true : false;
+
+describe("Legacy PairedNode get type helpers", () => {
+    it("compiles correctly (parity with modern Endpoint, types validated at compile time)", () => {
+        if ((false as boolean) === true) {
+            const node = null as unknown as PairedNode;
+            const fakeBeh = null as unknown as FakeBehaviorType;
+
+            // stateOf(string) → Immutable<Val.Struct>
+            const _stateString = node.stateOf("anyId");
+            const _stateStringExact: _AssertEqual<typeof _stateString, Immutable<Val.Struct>> = true;
+            void _stateString;
+            void _stateStringExact;
+
+            // stateOf<T>(T) → Immutable<Behavior.StateOf<T>>
+            const _stateTyped = node.stateOf(fakeBeh);
+            const _stateTypedExact: _AssertEqual<typeof _stateTyped, Immutable<FakeState>> = true;
+            void _stateTyped;
+            void _stateTypedExact;
+
+            // maybeStateOf(string) → Immutable<Val.Struct> | undefined
+            const _maybeString = node.maybeStateOf("anyId");
+            const _maybeStringExact: _AssertEqual<typeof _maybeString, Immutable<Val.Struct> | undefined> = true;
+            void _maybeString;
+            void _maybeStringExact;
+
+            // maybeStateOf<T>(T) → Immutable<Behavior.StateOf<T>> | undefined
+            const _maybeTyped = node.maybeStateOf(fakeBeh);
+            const _maybeTypedExact: _AssertEqual<typeof _maybeTyped, Immutable<FakeState> | undefined> = true;
+            void _maybeTyped;
+            void _maybeTypedExact;
+
+            // commandsOf<T>(T) → Commands.OfBehavior<T>
+            const _commandsTyped = node.commandsOf(fakeBeh);
+            const _commandsTypedExact: _AssertEqual<
+                typeof _commandsTyped,
+                Commands.OfBehavior<FakeBehaviorType>
+            > = true;
+            void _commandsTyped;
+            void _commandsTypedExact;
+
+            // eventsOf(string) → Immutable<Record<string, Observable | undefined>>
+            const _eventsString = node.eventsOf("anyId");
+            const _eventsStringExact: _AssertEqual<
+                typeof _eventsString,
+                Immutable<Record<string, Observable | undefined>>
+            > = true;
+            void _eventsString;
+            void _eventsStringExact;
+
+            // eventsOf<T>(T) → Behavior.EventsOf<T>
+            const _eventsTyped = node.eventsOf(fakeBeh);
+            const _eventsTypedExact: _AssertEqual<typeof _eventsTyped, Behavior.EventsOf<FakeBehaviorType>> = true;
+            void _eventsTyped;
+            void _eventsTypedExact;
+
+            // PairedNode.events is the lifecycle bus (not behavior events).
+            // Asserts the conflict the team accepted: same-name field with different shape.
+            const _lifecycleEvents = node.events;
+            const _lifecycleIsBus: _AssertEqual<typeof _lifecycleEvents, PairedNode.Events> = true;
+            void _lifecycleEvents;
+            void _lifecycleIsBus;
+
+            // Negative cases — must fail to type-check.
+
+            // @ts-expect-error - number is not a valid behavior type or id
+            node.stateOf(42);
+
+            // @ts-expect-error - number is not a valid behavior type or id
+            node.maybeStateOf(42);
+
+            // @ts-expect-error - number is not a valid behavior type or id
+            node.eventsOf(42);
+        }
+    });
+});

--- a/packages/matter.js/test/tsconfig.json
+++ b/packages/matter.js/test/tsconfig.json
@@ -1,0 +1,35 @@
+// Managed by nacho-build.  Nacho will update references automatically but otherwise preserves your edits.
+// Use `nacho-build configure` to overwrite with defaults.
+{
+    "extends": "../../../tsc/tsconfig.test.json",
+    "compilerOptions": {
+        "types": [
+            "mocha",
+            "node",
+            "@matter/testing"
+        ]
+    },
+    "references": [
+        {
+            "path": "../../general/src"
+        },
+        {
+            "path": "../../model/src"
+        },
+        {
+            "path": "../../node/src"
+        },
+        {
+            "path": "../../protocol/src"
+        },
+        {
+            "path": "../../testing/src"
+        },
+        {
+            "path": "../../types/src"
+        },
+        {
+            "path": "../src"
+        }
+    ]
+}

--- a/packages/matter.js/tsconfig.json
+++ b/packages/matter.js/tsconfig.json
@@ -1,5 +1,5 @@
 {
     "compilerOptions": { "composite": true },
     "files": [],
-    "references": [{ "path": "src" }]
+    "references": [{ "path": "src" }, { "path": "test" }]
 }

--- a/packages/node/src/endpoint/Endpoint.ts
+++ b/packages/node/src/endpoint/Endpoint.ts
@@ -459,7 +459,7 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
      * This is the recommended way to access events for a specific behavior because it provides proper type checking
      * and enforces the correctness of the used Behavior type including all enabled features.
      */
-    eventsOf<T extends Behavior.Type>(type: T | string): Behavior.EventsOf<T>;
+    eventsOf<T extends Behavior.Type>(type: T): Behavior.EventsOf<T>;
 
     eventsOf(type: Behavior.Type | string): unknown {
         if (typeof type === "string") {


### PR DESCRIPTION
## Summary
- Add string-key overloads to legacy `Endpoint.stateOf` / `maybeStateOf` and legacy `PairedNode.stateOf` to match the modern `Endpoint` API surface.
- Add missing `maybeStateOf` and new `eventsOf` (typed + string overloads) on both legacy `Endpoint` and `PairedNode`. JSDoc on `PairedNode.eventsOf` documents the accepted name collision with the existing `events` lifecycle bus.
- Tighten modern `Endpoint.eventsOf<T>` typed overload from `T | string` to `T`. The string branch is already covered by the separate `eventsOf(type: string)` overload; `T | string` was causing wrong-shape inference when explicit `<T>` was passed with a string arg.
- Add a typing regression suite for the legacy classes (`EndpointGetTypesTest`, `PairedNodeGetTypesTest`) mirroring `packages/node/test/endpoint/EndpointGetTypesTest`. Asserts both positive return shapes and `@ts-expect-error` negative cases.
- Wire `packages/matter.js/test/` into nacho-build via a `{ "path": "test" }` reference so the test-types build stage runs and `matter-test` can discover the compiled tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)