### PR TITLE
fix(general): drop broken MatterAggregateError[Symbol.hasInstance] override

### DIFF
--- a/packages/general/src/MatterError.ts
+++ b/packages/general/src/MatterError.ts
@@ -164,15 +164,6 @@ export class MatterError extends Error {
             }
         }
     }
-
-    // TODO - this is probably correct; MatterAggregateError should be typeof MatterError.  Need to diagnose some test
-    // breakage before enabling though
-    // static [Symbol.hasInstance](instance: unknown) {
-    //     if (instance instanceof MatterAggregateError) {
-    //         return true;
-    //     }
-    //     return Error[Symbol.hasInstance](instance);
-    // }
 }
 
 /**
@@ -248,14 +239,6 @@ export class MatterAggregateError extends AggregateError {
     addStackless(error: Error) {
         error.stack = undefined;
         this.errors.push(error);
-    }
-
-    // TODO - see comment on MatterError.  If that one is correct this is incorrect
-    static override [Symbol.hasInstance](instance: unknown) {
-        if (instance instanceof MatterError) {
-            return true;
-        }
-        return AggregateError[Symbol.hasInstance](instance);
     }
 
     /**

--- a/packages/general/test/MatterErrorTest.ts
+++ b/packages/general/test/MatterErrorTest.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MatterAggregateError, MatterError } from "#MatterError.js";
+import { ImplementationError, InternalError, MatterAggregateError, MatterError } from "#MatterError.js";
 import "../src/log/LogFormat.js";
 
 class SpecialError extends MatterError {}
@@ -129,5 +129,27 @@ describe("MatterError", () => {
         } finally {
             MatterError.formatterFor = originalFormatter;
         }
+    });
+
+    describe("MatterAggregateError instanceof", () => {
+        it("matches genuine MatterAggregateError instances", () => {
+            expect(new MatterAggregateError([]) instanceof MatterAggregateError).true;
+        });
+
+        it("matches subclasses of MatterAggregateError", () => {
+            class CustomAggregateError extends MatterAggregateError {}
+            expect(new CustomAggregateError([]) instanceof MatterAggregateError).true;
+        });
+
+        it("does not match non-aggregate MatterError subclasses", () => {
+            expect(new InternalError("x") instanceof MatterAggregateError).false;
+            expect(new ImplementationError("x") instanceof MatterAggregateError).false;
+            expect(new MatterError("x") instanceof MatterAggregateError).false;
+            expect(new SpecialError("x") instanceof MatterAggregateError).false;
+        });
+
+        it("does not match plain Error", () => {
+            expect(new Error("x") instanceof MatterAggregateError).false;
+        });
     });
 });

--- a/packages/node/src/behavior/system/controller/discovery/DiscoveryError.ts
+++ b/packages/node/src/behavior/system/controller/discovery/DiscoveryError.ts
@@ -6,13 +6,6 @@
 
 import { MatterAggregateError, MatterError } from "@matter/general";
 
-export class DiscoveryError extends MatterError {
-    static override [Symbol.hasInstance](instance: unknown) {
-        if (instance instanceof DiscoveryAggregateError) {
-            return true;
-        }
-        return super[Symbol.hasInstance](instance);
-    }
-}
+export class DiscoveryError extends MatterError {}
 
 export class DiscoveryAggregateError extends MatterAggregateError {}

--- a/packages/node/test/behavior/cluster/ClusterBehaviorTest.ts
+++ b/packages/node/test/behavior/cluster/ClusterBehaviorTest.ts
@@ -350,11 +350,11 @@ describe("ClusterBehavior", () => {
                 } as any);
                 throw new Error("MockEndpoint should have thrown FeatureMismatchError");
             } catch (e) {
-                expect(e instanceof MatterAggregateError);
+                expect(e instanceof MatterAggregateError).true;
                 const cause1 = (e as MatterAggregateError).errors[0];
-                expect(cause1 instanceof BehaviorInitializationError);
+                expect(cause1 instanceof BehaviorInitializationError).true;
                 const cause2 = cause1.cause;
-                expect(cause2) instanceof FeatureMismatchError;
+                expect(cause2 instanceof FeatureMismatchError).true;
                 expect(cause2.message).equals(
                     'The featureMap for node0.part0.myCluster does not match the implementation; please use MyClusterBehavior.with("FeatureName") to configure features',
                 );

--- a/packages/node/test/endpoint/EndpointVariableServiceTest.ts
+++ b/packages/node/test/endpoint/EndpointVariableServiceTest.ts
@@ -5,8 +5,8 @@
  */
 
 import { OnOffLightDevice } from "#devices/on-off-light";
-import { EndpointBehaviorsError } from "#endpoint/errors.js";
 import { Environment } from "@matter/general";
+import { UnsupportedCastError } from "@matter/model";
 import { MockServerNode } from "../node/mock-server-node.js";
 import { MockEndpoint } from "./mock-endpoint.js";
 
@@ -44,7 +44,7 @@ describe("EndpointVariableService", () => {
             const environment = new Environment("test");
             environment.vars.addUnixEnvStyle({ MATTER_NODES_NODE0_BASICINFORMATION_VENDORSPECIES: "Frog" });
             await expect(MockServerNode.create(MockServerNode.RootEndpoint, { environment })).rejectedWith(
-                EndpointBehaviorsError,
+                UnsupportedCastError,
             );
         });
     });
@@ -93,7 +93,7 @@ describe("EndpointVariableService", () => {
             const environment = new Environment("test");
             environment.vars.addUnixEnvStyle({ MATTER_NODES_NODE0_PARTS_PART0_ONOFF_ONTIME: "Fred" });
 
-            await expect(MockEndpoint.create(OnOffLightDevice, { environment })).rejectedWith(EndpointBehaviorsError);
+            await expect(MockEndpoint.create(OnOffLightDevice, { environment })).rejectedWith(UnsupportedCastError);
         });
     });
 });

--- a/packages/node/test/node/ServerNodeTest.ts
+++ b/packages/node/test/node/ServerNodeTest.ts
@@ -12,14 +12,13 @@ import { LightSensorDevice } from "#devices/light-sensor";
 import { OnOffLightDevice } from "#devices/on-off-light";
 import { PumpDevice } from "#devices/pump";
 import { Endpoint } from "#endpoint/Endpoint.js";
-import { EndpointBehaviorsError, EndpointPartsError } from "#endpoint/errors.js";
+import { EndpointPartsError } from "#endpoint/errors.js";
 import { AggregatorEndpoint } from "#endpoints/aggregator";
 import { LocalActorContext } from "#index.js";
 import { ServerEnvironment } from "#node/server/ServerEnvironment.js";
 import { ServerNode } from "#node/ServerNode.js";
 import {
     Bytes,
-    CrashedDependenciesError,
     Crypto,
     DnsCodec,
     DnsMessage,
@@ -34,7 +33,7 @@ import {
     StorageManager,
     StorageService,
 } from "@matter/general";
-import { AccessLevel, BasicInformation, ElementTag, FeatureMap } from "@matter/model";
+import { AccessLevel, BasicInformation, ElementTag, FeatureMap, UnsupportedCastError } from "@matter/model";
 import {
     AttestationCertificateManager,
     CertificationDeclaration,
@@ -486,7 +485,7 @@ describe("ServerNode", () => {
             it("from root behavior error", async () => {
                 await expect(
                     MockServerNode.create(MockServerNode.RootEndpoint, { environment: badNodeEnv }),
-                ).rejectedWith(EndpointBehaviorsError);
+                ).rejectedWith(UnsupportedCastError);
             });
 
             it("from behavior error on child during node create", async () => {
@@ -500,7 +499,7 @@ describe("ServerNode", () => {
 
             it("from behavior on child after node create", async () => {
                 const node = await MockServerNode.create(MockServerNode.RootEndpoint, { environment: badEndpointEnv });
-                await expect(node.add(new Endpoint(LightSensorDevice))).rejectedWith(EndpointBehaviorsError);
+                await expect(node.add(new Endpoint(LightSensorDevice))).rejectedWith(UnsupportedCastError);
             });
         });
 
@@ -512,7 +511,7 @@ describe("ServerNode", () => {
                         environment: badNodeEnv,
                         device: undefined,
                     }),
-                ).rejectedWith(EndpointBehaviorsError, 'Cannot convert "not a number" to an integer');
+                ).rejectedWith(UnsupportedCastError, 'Cannot convert "not a number" to an integer');
             });
 
             it("from behavior error on child during startup", async () => {
@@ -523,7 +522,7 @@ describe("ServerNode", () => {
                         id: "foo",
                         device: LightSensorDevice,
                     }),
-                ).rejectedWith(EndpointBehaviorsError, 'Property "diet" is unsupported');
+                ).rejectedWith(UnsupportedCastError, 'Property "diet" is unsupported');
             });
 
             it("from behavior error on child added after startup", async () => {
@@ -533,7 +532,7 @@ describe("ServerNode", () => {
                     device: undefined,
                 });
                 await expect(node.add(LightSensorDevice)).rejectedWith(
-                    CrashedDependenciesError,
+                    UnsupportedCastError,
                     'Property "diet" is unsupported',
                 );
             });


### PR DESCRIPTION
## Summary

- Remove the broken `static [Symbol.hasInstance]` override on `MatterAggregateError` that caused **any** `MatterError` to be wrongly identified as a `MatterAggregateError`. Callers reading `.errors` on the falsely-matched error then crashed (originally hit in `ControllerCommandHandler#writeAttribute` when a single-attribute write failed: `WriteResult.assertSuccess` throws a single `PathError`, but `error instanceof MatterAggregateError` returned `true` and `error.errors.find(...)` blew up because `PathError` has no `errors` field).
- Remove the same anti-pattern from `DiscoveryError` (which made any `DiscoveryAggregateError` match `instanceof DiscoveryError`). Investigated: zero production callers do `instanceof DiscoveryError`; only one test (`ClientNodeTest.ts:72`) and it hits the bare-throw path.
- Remove the dormant commented-out reciprocal block + TODO on `MatterError` — it described an experiment never carried out and the premise was infeasible (a class can't extend both `AggregateError` and `MatterError`).
- Add tests in `MatterErrorTest.ts` asserting the contract in both directions: genuine aggregates and aggregate subclasses match; non-aggregate `MatterError` subclasses, plain `Error`, and base `MatterError` do not.
- Fix latent false-positive assertions in `ServerNodeTest.ts` and `EndpointVariableServiceTest.ts`. They asserted `rejectedWith(EndpointBehaviorsError)` / `rejectedWith(CrashedDependenciesError)` while production actually throws the bare underlying `UnsupportedCastError` on the single-failure path. Tests passed only because of the broken `hasInstance`. Migrated to `rejectedWith(UnsupportedCastError, ...)` matching the actual contract (single failure → single error; multiple failures → aggregate — same shape as `WriteResult.assertSuccess`).
- Fix three no-op `instanceof` assertions in `ClusterBehaviorTest.ts:353-357`. `expect(... instanceof X);` returns an Assertion without asserting; line 357 (`expect(cause2) instanceof FeatureMismatchError;`) was worse — `instanceof` applied to the Assertion wrapper, not the value. All three now properly assert `.true`.

## Why native `instanceof` is now correct

`MatterAggregateError extends AggregateError` and `DiscoveryError extends MatterError` — the prototype chain alone gives correct `instanceof` semantics. The overrides only short-circuited that to fake a sibling-class relationship. Removing them restores the JS-native behavior callers expect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)