### PR TITLE
feat(general): add LogFormat.format() convenience helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: Added locking to storage implementations to prevent concurrent access issues and data corruption
     - Enhancement: Split out Blob-Storage into its own `dir`-based BlobStorage implementation
     - Enhancement: Added Storage Migration logic that can generically migrate between different storage engines
-    - Enhancement: `LogFormat.format(value, format?)` renders any Diagnostic-loggable value to a string in the specified format (defaults to plain text)
+    - Enhancement: `LogFormat.format` renders any Diagnostic-loggable value to a string in the specified format (defaults to plain text)
 
 - @matter/\*:
     - Upgraded to Matter specification version 1.5
@@ -1198,7 +1198,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Deprecation: We've deprecated the hand-generated device type definitions used by the pre-0.8.0 API in DeviceTypes.ts. These device type definitions remain at Matter 1.1.
     - Removal: We removed old Scenes cluster implementation which was never fully implemented or used by any Matter controller
 - matter.js-react-native:
-    - Feature: Introduces new package to provides a React Native compatible platform Implementations for Matter.js. This package is still in development and not fully working and should be considered experimental for now! Currently it tries to support UDP, BLE, AsyncStorage, and Crypto platform features. See [README](./packages/matter.js-react-native/README.md) for more information.
+    - Feature: Introduces new package to provides a React Native compatible platform Implementations for Matter.js. This package is still in development and not fully working and should be considered experimental for now! Currently it tries to support UDP, BLE, AsyncStorage, and Crypto platform features. See [README](./packages/react-native/README.md) for more information.
 - matter.js chip and python Testing:
     - Includes updates and infrastructure improvements for Matter.js use of tests defined in [connectedhomeip](https://github.com/project-chip/connectedhomeip)
 
@@ -1609,7 +1609,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Breaking: Remove the exposed legacy API classes (MatterDevice/MatterController) and legacy examples from the exported lists
     - Feature: Autoregister Crypto, Time, and Network in their Node.js variants when including packages from @project-chip/matter-node.js root package but only if not yet registered (so can be overridden by the developer)
     - Examples/Reference implementations:
-        - The reference implementations are moved to the example directory and details moved into an own [README.md](./packages/matter-node.js-examples/README.md) file
+        - The reference implementations are moved to the example directory and details moved into an own [README.md](./examples/README.md) file
         - the "npm run matter" command got renamed to "npm run matter-device" (same for binary usage
         - Add hints for all imports in the examples to show what the corresponding "matter-node.js" import would be (because they cannot be used directly for build reasons)
         - Added the "npm run matter-\*" commands also to the base package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: Added locking to storage implementations to prevent concurrent access issues and data corruption
     - Enhancement: Split out Blob-Storage into its own `dir`-based BlobStorage implementation
     - Enhancement: Added Storage Migration logic that can generically migrate between different storage engines
+    - Enhancement: `LogFormat.format(value, format?)` renders any Diagnostic-loggable value to a string in the specified format (defaults to plain text)
 
 - @matter/\*:
     - Upgraded to Matter specification version 1.5
@@ -40,6 +41,8 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Feature: (@adeepn) Added `DclBehavior` for centralized DCL configuration via environment variables (`MATTER_DCL_*`), config files, or programmatic setup
     - Feature: `CommissioningClient.BaseCommissioningOptions` now accepts `wifiNetwork`, `threadNetwork`, `regulatoryLocation`, and `regulatoryCountryCode` for passing network credentials and regulatory configuration during commissioning
     - Feature: `onAttestationFailure` commissioning option for controlling attestation validation policy (true/false/callback with typed findings)
+    - Feature: ServerNode Network behavior options allow to set `tcp` (boolean) to enable TCP support for the server node
+    - Feature: ServerNode Network behavior options allow to set `transportPreference` ("udp"/"tcp") to define the preferred connection type when peers support both. "udp" is the default and fallback
     - Feature: DoorLockServer is fully implemented except for Aliro features
     - Feature: The new Supervision() factory allows for fine-grained control of validation for state, commands, and arbitrary JS values
     - Feature: Added `Endpoint.get()` and `Endpoint.getStateOf()` — async read API with optional `fabricFilter` control; on a client endpoint issues a single batched Matter Read; on a server endpoint returns a snapshot of local state
@@ -114,6 +117,9 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Feature: We've rewritten the typing system for clusters to make types simpler, consume less runtime memory and work better with IDEs
 
 - @project-chip/matter.js
+    - Feature: CommissioningController allows to set `tcp` (boolean) to enable TCP support for the controller
+    - Feature: CommissioningController allows to set `transportPreference` ("udp"/"tcp") to define the preferred connection type when devices support both. "udp" is the default and fallback
+    - Feature: CommissioningOptions when commission a new device allows to set an `onAttestationFailure` callback that gets called with attestation validation options and allows decisions to continue or block the commissioning. Default accepts but logs all failures.
     - Enhancement: `CommissioningController.commissionNode()` now uses the parallel PASE commissioning path for pre-discovered devices; WiFi/Thread/regulatory credentials and abort signal are fully propagated
     - Adjustment: The "Waiting for device discovery" node state is now bound to the availability of IP announcements from MDNS
     - Fix: Fixes inverted autoConnect logic in CommissioningController

--- a/packages/general/src/log/LogFormat.ts
+++ b/packages/general/src/log/LogFormat.ts
@@ -61,6 +61,13 @@ export namespace LogFormat {
      * Built in formatter that produces HTML.
      */
     export const HTML = "html";
+
+    /**
+     * Format a value to string using the specified format.
+     */
+    export function format(value: unknown, format: string | Formatter = PLAIN): string {
+        return LogFormat(format)(value);
+    }
 }
 
 export type DiagnosticProducer = () => string;

--- a/packages/general/test/log/LoggerTest.ts
+++ b/packages/general/test/log/LoggerTest.ts
@@ -438,6 +438,20 @@ describe("Logger", () => {
         });
     });
 
+    describe("LogFormat.format", () => {
+        it("renders plain string with default format", () => {
+            expect(LogFormat.format("hello")).equal("hello");
+        });
+
+        it("renders structured value to plain text", () => {
+            expect(LogFormat.format(Diagnostic.dict({ foo: "bar", biz: 1 }))).equal("foo: bar biz: 1");
+        });
+
+        it("renders with named format", () => {
+            expect(LogFormat.format(Diagnostic.strong("hello"), LogFormat.ANSI)).equal("[1mhello[0m");
+        });
+    });
+
     describe("setFormat", () => {
         it("throws if format is unknown", () => {
             let message;


### PR DESCRIPTION
## Summary

- Adds `LogFormat.format(value, format?)` to the `LogFormat` namespace in `@matter/general`
- Renders any Diagnostic-loggable value (Endpoint, Node, dict, list, error, …) directly to a string without going through the Logger
- Defaults to `LogFormat.PLAIN`; accepts any named format (`"ansi"`, `"html"`) or a custom `Formatter` function
- No circular dependency: lives in `LogFormat.ts` which already owns the formatting logic

## Usage

```typescript
import { LogFormat } from "@matter/general";

const plain = LogFormat.format(endpoint);
const ansi  = LogFormat.format(endpoint, LogFormat.ANSI);
const html  = LogFormat.format(endpoint, "html");
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)