### PR TITLE
fix(node): accept FabricIndex.OMIT_FABRIC on ClientNode fabric-scoped struct writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Properly cancels subscriptions that were canceled by the peer but were still in resubmission state
     - Fix: Preserves clusters in the structure even if they are not specified in the serverList of the endpoint but are reported in data ("Schrödinger's cluster")
     - Fix: You can now assign bare objects composed of managed values to state properties
+    - Fix: ClientNode `setStateOf` accepts `FabricIndex.OMIT_FABRIC` for fabric-scoped struct entries (Matter §7.13.6) and substitutes the peer's assigned fabric index so the local cache mirrors what the peer stores
 
 - @matter/nodejs-ble
     - Fix: Fixes several crash or blocking cases around BLE and the usage in commissioning

--- a/packages/node/src/behavior/context/server/LocalActorContext.ts
+++ b/packages/node/src/behavior/context/server/LocalActorContext.ts
@@ -139,7 +139,10 @@ export namespace LocalActorContext {
     /**
      * {@link LocalActorContext} configuration options.
      */
-    export interface Options extends Omit<InteractionSettings, "transaction"> {
+    export interface Options
+        extends
+            Omit<InteractionSettings, "transaction">,
+            Pick<ValueSupervisor.SupervisionSettings, "clientPeerContext"> {
         lifetime?: Lifetime.Owner;
         command?: boolean;
         activity?: NodeActivity;

--- a/packages/node/src/behavior/state/validation/FabricIndexSentinel.ts
+++ b/packages/node/src/behavior/state/validation/FabricIndexSentinel.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { FabricIndex as FabricIndexElement, FieldModel, ValueModel } from "@matter/model";
+
+const FIELD_ID = FabricIndexElement.id;
+const FIELD_NAME = FabricIndexElement.name;
+
+/**
+ * True when `schema` is the spec-defined fabric-scoped struct FabricIndex sentinel field — same id/name match
+ * `ObjectSchema.encodeEntryToTlv` uses to gate the wire-level strip (Matter §7.13.6).  Per spec the id+name
+ * combination is reserved for this purpose; no other struct field can re-use it.
+ */
+export function isFabricIndexSentinel(schema: ValueModel): boolean {
+    return schema instanceof FieldModel && schema.id === FIELD_ID && schema.name === FIELD_NAME;
+}

--- a/packages/node/src/behavior/state/validation/ValueValidator.ts
+++ b/packages/node/src/behavior/state/validation/ValueValidator.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { camelize, InternalError } from "@matter/general";
+import { camelize, InternalError, Logger } from "@matter/general";
 import type { Schema } from "@matter/model";
 import { AttributeModel, ClusterModel, DataModelPath, FeatureMap, Metatype, ValueModel } from "@matter/model";
 import { ConformanceError, DatatypeError, SchemaImplementationError, Val } from "@matter/protocol";
-import { Status } from "@matter/types";
+import { FabricIndex, Status } from "@matter/types";
 import { RootSupervisor } from "../../supervision/RootSupervisor.js";
 import { maybeConfigOf } from "../../supervision/SupervisionConfig.js";
 import type { ValueSupervisor } from "../../supervision/ValueSupervisor.js";
@@ -25,7 +25,10 @@ import {
 } from "./assertions.js";
 import { createConformanceValidator } from "./conformance.js";
 import { createConstraintValidator } from "./constraint.js";
+import { isFabricIndexSentinel } from "./FabricIndexSentinel.js";
 import { ValidationLocation } from "./location.js";
+
+const logger = Logger.get("ValueValidator");
 
 /**
  * Generate a function that performs data validation.
@@ -245,7 +248,33 @@ function createIntegerValidator(schema: ValueModel, supervisor: RootSupervisor, 
         throw new InternalError(`No integer assertion implemented for integer type ${name}`);
     }
 
-    return createSimpleValidator(schema, supervisor, assertion);
+    const inner = createSimpleValidator(schema, supervisor, assertion);
+
+    // OMIT_FABRIC handling for the fabric-scoped struct FabricIndex sentinel (Matter §7.13.6).  Mutation of
+    // `siblings.fabricIndex` is an intentional bend of the read-only validator contract — covers both the
+    // per-field StructManager setter path AND the ListManager.writeEntry path (which writes raw entry objects
+    // bypassing per-field setters).  One mechanism handles every setStateOf path.
+    if (isFabricIndexSentinel(schema)) {
+        const fabricSentinelOrSubstitute: ValueSupervisor.Validate = (value, session, location) => {
+            const peerContext = session.clientPeerContext;
+            if (value !== FabricIndex.OMIT_FABRIC || peerContext === undefined) {
+                inner(value, session, location);
+                return;
+            }
+            const siblings = location.siblings as Val.Struct | undefined;
+            if (siblings !== undefined && peerContext.fabricIndexOnPeer !== undefined) {
+                siblings.fabricIndex = peerContext.fabricIndexOnPeer;
+                return;
+            }
+            logger.debug(
+                "fabricIndex was not replaced with the peer's fabric index because it is not yet known; local cache will hold the OMIT_FABRIC sentinel (-1) until the peer's subscription delivers the real value at",
+                location.path,
+            );
+        };
+        return fabricSentinelOrSubstitute;
+    }
+
+    return inner;
 }
 
 function createStructValidator(schema: Schema, supervisor: RootSupervisor): ValueSupervisor.Validate {

--- a/packages/node/src/behavior/supervision/ValueSupervisor.ts
+++ b/packages/node/src/behavior/supervision/ValueSupervisor.ts
@@ -7,6 +7,7 @@
 import type { AsyncObservable, Transaction } from "@matter/general";
 import { DataModelPath, Schema } from "@matter/model";
 import type { AccessControl, InteractionSettings, Val } from "@matter/protocol";
+import type { FabricIndex } from "@matter/types";
 import type { ValReference } from "../state/managed/ValReference.js";
 import type { ValidationLocation } from "../state/validation/location.js";
 import type { RootSupervisor } from "./RootSupervisor.js";
@@ -81,6 +82,16 @@ export namespace ValueSupervisor {
          * deferred.
          */
         acceptInvalid?: boolean;
+
+        /**
+         * Present on contexts rooted at a ClientNode (peer node).  Drives substitution of the
+         * {@link FabricIndex.OMIT_FABRIC} sentinel on fabric-scoped struct writes (Matter §7.13.6) so the local
+         * cache mirrors the post-write peer state.
+         */
+        clientPeerContext?: {
+            /** Fabric index the peer assigned to our identity, when known. */
+            fabricIndexOnPeer?: FabricIndex;
+        };
 
         /**
          * Controls how per-instance supervision config is scoped.

--- a/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
+++ b/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
@@ -234,9 +234,10 @@ export class CommissioningClient extends Behavior {
         }
 
         try {
-            await commissioner.commission(commissioningOptions);
+            const { fabricIndexOnPeer } = await commissioner.commission(commissioningOptions);
             this.state.peerAddress = address;
             this.state.commissionedAt = Time.nowMs;
+            this.state.fabricIndexOnPeer = fabricIndexOnPeer;
 
             // Apply changes from the peer
             await this.#update(this.env.get(PeerSet).for(address));
@@ -312,6 +313,7 @@ export class CommissioningClient extends Behavior {
 
         this.state.peerAddress = undefined;
         this.state.commissionedAt = undefined;
+        this.state.fabricIndexOnPeer = undefined;
 
         await this.context.transaction.commit();
 
@@ -343,7 +345,29 @@ export class CommissioningClient extends Behavior {
 
     #initializeNode() {
         const endpoint = this.endpoint as ClientNode;
+        this.#backfillFabricIndexOnPeer();
+
+        // If the synchronous backfill missed (OpCreds subscription still in-flight), self-heal on the next
+        // currentFabricIndex update.  Reactor is idempotent — once state is filled it short-circuits.
+        if (this.state.fabricIndexOnPeer === undefined && this.endpoint.behaviors.has(OperationalCredentialsClient)) {
+            this.reactTo(
+                this.endpoint.eventsOf(OperationalCredentialsClient).currentFabricIndex$Changed,
+                this.#backfillFabricIndexOnPeer,
+            );
+        }
+
         endpoint.lifecycle.initialized.emit(this.state.peerAddress !== undefined);
+    }
+
+    /** Recover `state.fabricIndexOnPeer` from `OperationalCredentialsClient.currentFabricIndex` when missing. */
+    #backfillFabricIndexOnPeer() {
+        if (this.state.peerAddress === undefined || this.state.fabricIndexOnPeer !== undefined) {
+            return;
+        }
+        const value = this.endpoint.maybeStateOf(OperationalCredentialsClient)?.currentFabricIndex;
+        if (value !== undefined && value !== FabricIndex.NO_FABRIC) {
+            this.state.fabricIndexOnPeer = value;
+        }
     }
 
     #operationalAddressesChanged(newAddresses: ServerAddress[] | undefined, oldAddresses: ServerAddress[] | undefined) {
@@ -664,6 +688,16 @@ export namespace CommissioningClient {
          */
         @field(systimeMs, nonvolatile)
         commissionedAt?: Timestamp;
+
+        /**
+         * Fabric index the peer assigned to our identity (from the AddNoc response).  Substituted for the
+         * {@link FabricIndex.OMIT_FABRIC} sentinel on fabric-scoped struct writes so the local cache mirrors
+         * the value the peer will store.
+         *
+         * Distinct from {@link peerAddress.fabricIndex} which is our local fabric index.
+         */
+        @field(fabricIdx, nonvolatile)
+        fabricIndexOnPeer?: FabricIndex;
 
         /**
          * The TTL of the discovery record if applicable (in seconds).

--- a/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
+++ b/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
@@ -108,6 +108,16 @@ export class CommissioningClient extends Behavior {
             this.state.discoveredAt = Time.nowMs;
         }
 
+        // Defends against storage corruption / direct state manipulation; backfill from
+        // OperationalCredentialsClient recovers on partsReady.
+        const persistedFabricIndexOnPeer = this.state.fabricIndexOnPeer;
+        if (persistedFabricIndexOnPeer !== undefined && !FabricIndex.isValid(persistedFabricIndexOnPeer)) {
+            logger.warn(
+                `Discarding invalid persisted fabricIndexOnPeer ${persistedFabricIndexOnPeer} for ${this.endpoint}`,
+            );
+            this.state.fabricIndexOnPeer = undefined;
+        }
+
         if (this.state.peerAddress !== undefined) {
             // And ensure we are coupled to the Peer instance
             this.#bindPeer(this.state.peerAddress);

--- a/packages/node/src/endpoint/Endpoint.ts
+++ b/packages/node/src/endpoint/Endpoint.ts
@@ -28,7 +28,7 @@ import {
 } from "@matter/general";
 import { ClusterModel, DataModelPath } from "@matter/model";
 import { Read, Val } from "@matter/protocol";
-import { AttributeId, ClusterId, EndpointNumber, Status } from "@matter/types";
+import { AttributeId, ClusterId, EndpointNumber, FabricIndex, Status } from "@matter/types";
 import { RootEndpoint } from "../endpoints/root.js";
 import { Agent } from "./Agent.js";
 import {
@@ -785,13 +785,41 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
             this.#activity = this.env.get(NodeActivity);
         }
 
+        const clientPeerContext = this.#resolveClientPeerContext();
         return LocalActorContext.act(
             purpose,
             context => {
                 return actor(this.agentFor(context));
             },
-            { activity: this.#activity, lifetime: this.construction },
+            {
+                activity: this.#activity,
+                lifetime: this.construction,
+                clientPeerContext,
+            },
         );
+    }
+
+    #resolveClientPeerContext(): { fabricIndexOnPeer?: FabricIndex } | undefined {
+        const root = this.ownerOfType(RootEndpoint);
+        if (root === undefined || (root as unknown as Node<any>).nodeType !== "client") {
+            return undefined;
+        }
+        // String-keyed lookup avoids importing CommissioningClient/OperationalCredentialsClient: that would
+        // form a cycle (Endpoint → CommissioningClient → ClientNode → Node → Endpoint).
+        const commissioning = root.behaviors.maybeStateOf("commissioning") as
+            | { fabricIndexOnPeer?: FabricIndex }
+            | undefined;
+        if (commissioning?.fabricIndexOnPeer !== undefined) {
+            return { fabricIndexOnPeer: commissioning.fabricIndexOnPeer };
+        }
+        const opcreds = root.behaviors.maybeStateOf("operationalCredentials") as
+            | { currentFabricIndex?: FabricIndex }
+            | undefined;
+        const fallback = opcreds?.currentFabricIndex;
+        if (fallback !== undefined && fallback !== FabricIndex.NO_FABRIC) {
+            return { fabricIndexOnPeer: fallback };
+        }
+        return {};
     }
 
     /**

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -6,8 +6,10 @@
 
 import { ClusterBehavior } from "#behavior/cluster/ClusterBehavior.js";
 import { GlobalAttributeState } from "#behavior/cluster/ClusterState.js";
+import { CommissioningClient } from "#behavior/system/commissioning/CommissioningClient.js";
 import { ControllerBehavior } from "#behavior/system/controller/ControllerBehavior.js";
 import { DiscoveryError } from "#behavior/system/controller/discovery/DiscoveryError.js";
+import { AccessControlClient } from "#behaviors/access-control";
 import { BasicInformationBehavior, BasicInformationServer } from "#behaviors/basic-information";
 import {
     BooleanStateConfigurationClient,
@@ -41,7 +43,8 @@ import {
 } from "@matter/general";
 import { Specification } from "@matter/model";
 import { ControllerCommissioner, FabricAuthority, FabricManager, PeerSet, Val } from "@matter/protocol";
-import { FabricIndex, Status, StatusResponseError } from "@matter/types";
+import { FabricIndex, NodeId, Status, StatusResponseError } from "@matter/types";
+import { AccessControl } from "@matter/types/clusters/access-control";
 import { WindowCovering } from "@matter/types/clusters/window-covering";
 import { MyBehavior } from "../behavior/cluster/cluster-behavior-test-util.js";
 import { MockSite } from "./mock-site.js";
@@ -817,6 +820,123 @@ describe("ClientNode", () => {
         });
     });
 
+    describe("writes a fabric-scoped struct attribute via setStateOf", () => {
+        // Matter §7.13.6: callers pass OMIT_FABRIC for the mandatory FabricIndex field; the validator
+        // substitutes the peer's assigned index (or skips on a relaxed remote-write context).
+
+        it("accepts FabricIndex.OMIT_FABRIC as the mandatory placeholder", async () => {
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair();
+            const peer1 = await subscribedPeer(controller, "peer1");
+
+            const newSubject = NodeId(BigInt(0x55));
+
+            await MockTime.resolve(
+                peer1.setStateOf(AccessControlClient, {
+                    acl: [
+                        {
+                            privilege: AccessControl.AccessControlEntryPrivilege.Administer,
+                            authMode: AccessControl.AccessControlEntryAuthMode.Case,
+                            subjects: [newSubject],
+                            targets: null,
+                            fabricIndex: FabricIndex.OMIT_FABRIC,
+                        },
+                    ],
+                }),
+            );
+
+            const aclOnServer = device.state.accessControl.acl;
+            const written = aclOnServer.find(entry => entry.subjects?.[0] === newSubject);
+            expect(written, "server-side ACL entry written by peer is missing").to.be.ok;
+            expect(written!.fabricIndex).greaterThan(0);
+            expect(written!.fabricIndex).lessThan(255);
+
+            const aclOnPeerCache = peer1.stateOf(AccessControlClient).acl;
+            const cached = aclOnPeerCache.find(entry => entry.subjects?.[0] === newSubject);
+            expect(cached, "local ClientNode cache is missing the written ACL entry").to.be.ok;
+            expect(cached!.fabricIndex).equals(written!.fabricIndex);
+        });
+
+        it("rejects FabricIndex.NO_FABRIC (0)", async () => {
+            // Matter §7.5.2: fabric-scoped data SHALL NOT use fabric-index 0.  Caller bug surface preserved.
+
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair();
+            const peer1 = await subscribedPeer(controller, "peer1");
+
+            const caught = await captureRejection(() =>
+                peer1.setStateOf(AccessControlClient, {
+                    acl: [
+                        {
+                            privilege: AccessControl.AccessControlEntryPrivilege.Administer,
+                            authMode: AccessControl.AccessControlEntryAuthMode.Case,
+                            subjects: [NodeId(BigInt(0x56))],
+                            targets: null,
+                            fabricIndex: FabricIndex.NO_FABRIC,
+                        },
+                    ],
+                }),
+            );
+
+            expect((caught as Error)?.message).match(/Constraint .*Value 0 is not within bounds/);
+        });
+
+        it("does not relax server-side fabricIndex validation", async () => {
+            // Guards against leakage of `underClientNode` onto server-rooted contexts.
+
+            await using site = new MockSite();
+            const { device } = await site.addCommissionedPair();
+
+            const caught = await captureRejection(() =>
+                device.setStateOf("accessControl", {
+                    acl: [
+                        {
+                            privilege: AccessControl.AccessControlEntryPrivilege.Administer,
+                            authMode: AccessControl.AccessControlEntryAuthMode.Case,
+                            subjects: [NodeId(BigInt(0x57))],
+                            targets: null,
+                            fabricIndex: FabricIndex.OMIT_FABRIC,
+                        },
+                    ],
+                }),
+            );
+
+            expect((caught as Error)?.message).match(/Value -1 is below the uint8 minimum/);
+        });
+    });
+
+    describe("captures and backfills the peer-assigned fabric index", () => {
+        it("captures fabricIndexOnPeer at commissioning", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair();
+            const peer1 = controller.peers.get("peer1")!;
+
+            const captured = peer1.state.commissioning.fabricIndexOnPeer;
+            expect(captured).is.a("number");
+            expect(captured).greaterThan(0);
+            expect(captured).lessThan(255);
+        });
+
+        it("backfills fabricIndexOnPeer from operational credentials on reload when state was cleared", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair();
+            const peer1 = await subscribedPeer(controller, "peer1");
+            const captured = peer1.state.commissioning.fabricIndexOnPeer;
+            expect(captured).is.a("number");
+
+            // Simulate a peer commissioned before this field existed: clear and persist.
+            await peer1.setStateOf(CommissioningClient, { fabricIndexOnPeer: undefined });
+            expect(peer1.state.commissioning.fabricIndexOnPeer).equals(undefined);
+
+            // Close + reload — partsReady triggers backfill from OperationalCredentialsClient.currentFabricIndex.
+            await site.close();
+            const controllerB = await site.addNode(undefined, { id: "controller1", index: 1 });
+            const peer1b = controllerB.peers.get("peer1")!;
+
+            expect(peer1b.state.commissioning.fabricIndexOnPeer).equals(captured);
+        });
+    });
+
     it("emits Matter events", async () => {
         // *** SETUP ***
 
@@ -1426,6 +1546,7 @@ const PEER1_STATE = {
         ],
         caseAuthenticatedTags: undefined,
         commissionedAt: expect.NUMBER,
+        fabricIndexOnPeer: expect.NUMBER,
         discoveredAt: expect.NUMBER,
         onlineAt: undefined,
         offlineAt: undefined,

--- a/packages/protocol/src/peer/ControllerCommissioner.ts
+++ b/packages/protocol/src/peer/ControllerCommissioner.ts
@@ -45,7 +45,7 @@ import {
     ServerAddress,
     TransportSet,
 } from "@matter/general";
-import { NodeId, SECURE_CHANNEL_PROTOCOL_ID, SecureChannelStatusCode } from "@matter/types";
+import { FabricIndex, NodeId, SECURE_CHANNEL_PROTOCOL_ID, SecureChannelStatusCode } from "@matter/types";
 import { GeneralCommissioning } from "@matter/types/clusters/general-commissioning";
 import { DclCertificateService } from "../dcl/DclCertificateService.js";
 import { PeerAddress } from "./PeerAddress.js";
@@ -209,7 +209,7 @@ export class ControllerCommissioner {
     /**
      * Commission a previously discovered node.
      */
-    async commission(options: LocatedNodeCommissioningOptions): Promise<PeerAddress> {
+    async commission(options: LocatedNodeCommissioningOptions): Promise<CommissionResult> {
         const {
             passcode,
             addresses,
@@ -470,7 +470,7 @@ export class ControllerCommissioner {
         ephemeralSession: NodeSession,
         options: CommissioningOptions,
         discoveryData?: DiscoveryData,
-    ): Promise<PeerAddress> {
+    ): Promise<CommissionResult> {
         const {
             fabric,
             finalizeCommissioning: performCaseCommissioning,
@@ -606,8 +606,12 @@ export class ControllerCommissioner {
             },
         );
 
+        let fabricIndexOnPeer: FabricIndex | undefined;
         try {
             await commissioner.executeCommissioning();
+            const captured = commissioner.fabricIndexOnPeer;
+            // Treat the spec-invalid NO_FABRIC (0) as "unknown" so callers don't have to filter it again.
+            fabricIndexOnPeer = captured === FabricIndex.NO_FABRIC ? undefined : captured;
         } catch (error) {
             // We might have added data for an operational address that we need to cleanup
             await this.#context.peers.get(address)?.delete();
@@ -627,6 +631,15 @@ export class ControllerCommissioner {
             });
         }
 
-        return address;
+        return { address, fabricIndexOnPeer };
     }
+}
+
+/** Result of a successful commissioning operation. */
+export interface CommissionResult {
+    /** Controller-side {@link PeerAddress} (interned). */
+    address: PeerAddress;
+
+    /** Fabric index the peer assigned to our identity, from the AddNoc response. */
+    fabricIndexOnPeer?: FabricIndex;
 }

--- a/packages/protocol/src/peer/ControllerCommissioningFlow.ts
+++ b/packages/protocol/src/peer/ControllerCommissioningFlow.ts
@@ -313,6 +313,14 @@ export class ControllerCommissioningFlow {
     }
 
     /**
+     * Fabric index assigned to our identity by the peer device, captured from the AddNoc response.  Defined
+     * after `executeCommissioning()` resolves successfully.
+     */
+    get fabricIndexOnPeer(): FabricIndex | undefined {
+        return this.collectedCommissioningData.fabricIndex;
+    }
+
+    /**
      * Execute the commissioning process in the defined order. The steps are sorted before execution based on the step
      * number and sub step number.
      * If >50% of the failsafe time has passed, the failsafe timer is re-armed (50% of 60s default are 30s and each

--- a/packages/types/src/datatype/FabricIndex.ts
+++ b/packages/types/src/datatype/FabricIndex.ts
@@ -27,6 +27,14 @@ export function FabricIndex(value: number): FabricIndex {
 export namespace FabricIndex {
     export const NO_FABRIC = 0 as FabricIndex;
     export const OMIT_FABRIC = -1 as FabricIndex;
+
+    /**
+     * True when `value` is a real fabric index in the spec range for fabric-scoped data (1..254 per Matter
+     * §7.5.2).  Excludes the {@link NO_FABRIC} and {@link OMIT_FABRIC} sentinels.
+     */
+    export const isValid = (value: unknown): value is FabricIndex => {
+        return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 254;
+    };
 }
 
 class FabricIndexTlvWrapper extends TlvWrapper<FabricIndex, number | undefined> {


### PR DESCRIPTION
## Summary
- Validator now accepts `FabricIndex.OMIT_FABRIC` for the fabric-scoped struct's mandatory FabricIndex field (id 0xFE) on contexts rooted at a `ClientNode`, per Matter §7.13.6 (server-derived; clients omit on write). TS types still mandate the field, so callers pass the sentinel.
- Substitutes the peer's assigned fabric index (captured at commissioning into `CommissioningClient.State.fabricIndexOnPeer`, self-heals from `OperationalCredentialsClient.currentFabricIndex` via reactor) so the local cache mirrors the post-write peer state. Single mechanism covers per-field StructManager.set and ListManager.writeEntry paths.
- `NO_FABRIC` (0) stays rejected per Matter §7.5.2.
- `ControllerCommissioner.commission()` returns `CommissionResult { address, fabricIndexOnPeer? }` (was bare `PeerAddress`); `NO_FABRIC` normalized to `undefined` at the boundary.
- `SupervisionSettings.clientPeerContext?: { fabricIndexOnPeer? }` threads through `LocalActorContext.Options` via `Pick<>`.

## Test plan
- [x] Three new ClientNode tests in `packages/node/test/node/ClientNodeTest.ts`:
  - `accepts FabricIndex.OMIT_FABRIC as the mandatory placeholder` — peer ACL write reflects substituted fabric index in both server and local cache
  - `rejects FabricIndex.NO_FABRIC (0)` — caller bug surface preserved
  - `does not relax server-side fabricIndex validation` — guards against `clientPeerContext` leakage
- [x] Two persistence tests:
  - `captures fabricIndexOnPeer at commissioning` — state captured immediately post-commission
  - `backfills fabricIndexOnPeer from operational credentials on reload when state was cleared` — covers stale-on-upgrade migration
- [x] Full repo test sweep clean (`npm test`)
- [x] `npm run format-verify` clean
- [x] Build clean across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)