### PR TITLE
fix: nullable attribute encoding in TlvOfModel and chip-testing controller

### DIFF
--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -45,6 +45,7 @@ import { Specification } from "@matter/model";
 import { ControllerCommissioner, FabricAuthority, FabricManager, PeerSet, Val } from "@matter/protocol";
 import { FabricIndex, NodeId, Status, StatusResponseError } from "@matter/types";
 import { AccessControl } from "@matter/types/clusters/access-control";
+import { OnOff } from "@matter/types/clusters/on-off";
 import { WindowCovering } from "@matter/types/clusters/window-covering";
 import { MyBehavior } from "../behavior/cluster/cluster-behavior-test-util.js";
 import { MockSite } from "./mock-site.js";
@@ -474,6 +475,54 @@ describe("ClientNode", () => {
         const ep1Server = device.parts.get(1) as Endpoint<OnOffLightDevice>;
         expect(ep1Server.state.onOff.onTime).equals(20);
         expect(ep1Server.state.identify.identifyTime).equals(5);
+    });
+
+    it("writes nullable attribute: null, 0 and 2", async () => {
+        await using site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair();
+
+        const peer1 = controller.peers.get("peer1")!;
+        const ep1Client = peer1.parts.get("ep1")!;
+        const ep1Server = device.parts.get(1) as Endpoint<OnOffLightDevice>;
+
+        await MockTime.resolve(
+            ep1Client.act(agent => {
+                agent.get(OnOffClient).state.startUpOnOff = null;
+            }),
+        );
+        expect(ep1Server.state.onOff.startUpOnOff).equals(null);
+
+        await MockTime.resolve(
+            ep1Client.act(agent => {
+                agent.get(OnOffClient).state.startUpOnOff = OnOff.StartUpOnOff.Off;
+            }),
+        );
+        expect(ep1Server.state.onOff.startUpOnOff).equals(OnOff.StartUpOnOff.Off);
+
+        await MockTime.resolve(
+            ep1Client.act(agent => {
+                agent.get(OnOffClient).state.startUpOnOff = OnOff.StartUpOnOff.Toggle;
+            }),
+        );
+        expect(ep1Server.state.onOff.startUpOnOff).equals(OnOff.StartUpOnOff.Toggle);
+    });
+
+    it("writes nullable attribute via setStateOf: null, 0 and 2", async () => {
+        await using site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair();
+
+        const peer1 = controller.peers.get("peer1")!;
+        const ep1Client = peer1.parts.get("ep1")!;
+        const ep1Server = device.parts.get(1) as Endpoint<OnOffLightDevice>;
+
+        await MockTime.resolve(ep1Client.setStateOf("onOff", { startUpOnOff: null }));
+        expect(ep1Server.state.onOff.startUpOnOff).equals(null);
+
+        await MockTime.resolve(ep1Client.setStateOf("onOff", { startUpOnOff: OnOff.StartUpOnOff.Off }));
+        expect(ep1Server.state.onOff.startUpOnOff).equals(OnOff.StartUpOnOff.Off);
+
+        await MockTime.resolve(ep1Client.setStateOf("onOff", { startUpOnOff: OnOff.StartUpOnOff.Toggle }));
+        expect(ep1Server.state.onOff.startUpOnOff).equals(OnOff.StartUpOnOff.Toggle);
     });
 
     describe("writes attribute whose constraint references a sibling attribute", () => {

--- a/packages/types/src/tlv/TlvOfModel.ts
+++ b/packages/types/src/tlv/TlvOfModel.ts
@@ -174,7 +174,7 @@ function generateTlv(model: ClusterModel | ValueModel): TlvSchema<unknown> {
 
         let tlv: TlvSchema<unknown> = generateStruct(model);
 
-        if (model.quality.nullable) {
+        if (model.nullable) {
             tlv = TlvNullable(tlv);
         }
 
@@ -238,7 +238,7 @@ function generateTlv(model: ClusterModel | ValueModel): TlvSchema<unknown> {
             throw new InternalError(`No TLV mapping for model ${model.name}`);
     }
 
-    if (model.quality.nullable) {
+    if (model.nullable) {
         tlv = TlvNullable(tlv);
     }
 

--- a/packages/types/test/tlv/TlvOfModelTest.ts
+++ b/packages/types/test/tlv/TlvOfModelTest.ts
@@ -52,9 +52,13 @@ describe("TlvOfModel", () => {
     });
 
     describe("nullable quality on extended models", () => {
-        // Simulates the PeerBehavior.generateDiscoveredType() path where attrSupportOverrides
-        // creates extended attribute models via attr.extend({ operationalIsSupported: true }).
-        // The extended model has no local quality, so nullable must be resolved via effectiveQuality.
+        // PeerBehavior.generateDiscoveredType() calls maybeOverrideSupport() for every attribute.
+        // That function adds an attribute to attrSupportOverrides whenever the attribute is supported
+        // AND its conformance applicability is not Mandatory (i.e. all conditional/optional attributes).
+        // It then calls attr.extend({ operationalIsSupported: true }) for each override.
+        // The extended model carries no local quality, so nullable must be resolved via effectiveQuality.
+        // This affects ALL nullable conditional/optional attributes on peer devices — not just ones
+        // where the relevant feature appears absent.
         describe("scalar (enum) attribute", () => {
             const onOff = Matter.clusters("OnOff")!;
             const startUpOnOff = onOff.attributes("StartUpOnOff")!;
@@ -85,6 +89,22 @@ describe("TlvOfModel", () => {
                     exportedResetTimestamp: MATTER_EPOCH_OFFSET_S + 2000,
                 };
                 expect(roundTrip(extended, value)).deep.equal(value);
+            });
+        });
+
+        describe("non-nullable conditional attribute", () => {
+            // GlobalSceneControl has conformance "LT" (conditional) but no nullable quality.
+            // Extending it must NOT add TlvNullable — the fix must be precise.
+            const onOff = Matter.clusters("OnOff")!;
+            const globalSceneControl = onOff.attributes("GlobalSceneControl")!;
+            const extended = globalSceneControl.extend({ operationalIsSupported: true });
+
+            it("round-trips false", () => {
+                expect(roundTrip(extended, false)).equal(false);
+            });
+
+            it("round-trips true", () => {
+                expect(roundTrip(extended, true)).equal(true);
             });
         });
     });

--- a/packages/types/test/tlv/TlvOfModelTest.ts
+++ b/packages/types/test/tlv/TlvOfModelTest.ts
@@ -51,6 +51,44 @@ describe("TlvOfModel", () => {
         });
     });
 
+    describe("nullable quality on extended models", () => {
+        // Simulates the PeerBehavior.generateDiscoveredType() path where attrSupportOverrides
+        // creates extended attribute models via attr.extend({ operationalIsSupported: true }).
+        // The extended model has no local quality, so nullable must be resolved via effectiveQuality.
+        describe("scalar (enum) attribute", () => {
+            const onOff = Matter.clusters("OnOff")!;
+            const startUpOnOff = onOff.attributes("StartUpOnOff")!;
+            const extended = startUpOnOff.extend({ operationalIsSupported: true });
+
+            it("round-trips null", () => {
+                expect(roundTrip(extended, null)).equal(null);
+            });
+
+            it("round-trips non-null values", () => {
+                expect(roundTrip(extended, 0)).equal(0);
+                expect(roundTrip(extended, 2)).equal(2);
+            });
+        });
+
+        describe("struct attribute", () => {
+            const eem = Matter.clusters("ElectricalEnergyMeasurement")!;
+            const cumulativeEnergyReset = eem.attributes("CumulativeEnergyReset")!;
+            const extended = cumulativeEnergyReset.extend({ operationalIsSupported: true });
+
+            it("round-trips null", () => {
+                expect(roundTrip(extended, null)).equal(null);
+            });
+
+            it("round-trips non-null value", () => {
+                const value = {
+                    importedResetTimestamp: MATTER_EPOCH_OFFSET_S + 1000,
+                    exportedResetTimestamp: MATTER_EPOCH_OFFSET_S + 2000,
+                };
+                expect(roundTrip(extended, value)).deep.equal(value);
+            });
+        });
+    });
+
     describe("unknown attribute", () => {
         it("returns TlvAny for attribute typed as any", () => {
             const model = new AttributeModel({ id: 1, name: "unknown_1", type: "any", access: "RW" });

--- a/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
+++ b/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
@@ -634,7 +634,7 @@ export class LegacyControllerCommandHandler extends CommandHandler {
 
 function inferAttrModel(id: number, value: unknown): AttributeModel {
     let type: string;
-    if (value instanceof Uint8Array) type = "octstr";
+    if (Bytes.isBytes(value)) type = "octstr";
     else if (typeof value === "bigint") type = "uint64";
     else if (typeof value === "string") type = "string";
     else if (typeof value === "boolean") type = "bool";

--- a/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
+++ b/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
@@ -638,7 +638,7 @@ function inferAttrModel(id: number, value: unknown): AttributeModel {
     else if (typeof value === "bigint") type = "uint64";
     else if (typeof value === "string") type = "string";
     else if (typeof value === "boolean") type = "bool";
-    else type = "uint32";
+    else type = "int32";
     return new AttributeModel({
         id,
         name: `attr_${id}`,

--- a/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
+++ b/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
@@ -437,8 +437,7 @@ export class LegacyControllerCommandHandler extends CommandHandler {
         logger.info("Writing attribute", attributeId, "with value", value);
 
         const realAttr = Matter.clusters(clusterId)?.attributes(attributeId);
-        const attrModel =
-            realAttr ?? new AttributeModel({ id: attributeId, name: `attr_${attributeId}`, access: "RW" });
+        const attrModel = realAttr ?? inferAttrModel(attributeId, value);
 
         await client.setAttribute({
             attributeData: {
@@ -631,4 +630,20 @@ export class LegacyControllerCommandHandler extends CommandHandler {
             };
         });
     }
+}
+
+function inferAttrModel(id: number, value: unknown): AttributeModel {
+    let type: string;
+    if (value instanceof Uint8Array) type = "octstr";
+    else if (typeof value === "bigint") type = "uint64";
+    else if (typeof value === "string") type = "string";
+    else if (typeof value === "boolean") type = "bool";
+    else type = "uint32";
+    return new AttributeModel({
+        id,
+        name: `attr_${id}`,
+        type,
+        quality: value === null ? "X" : undefined,
+        access: "RW",
+    });
 }

--- a/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
+++ b/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
@@ -25,12 +25,6 @@ import {
     ManualPairingCodeCodec,
     QrPairingCodeCodec,
     SecureChannelStatusCode,
-    TlvBoolean,
-    TlvByteString,
-    TlvInt32,
-    TlvNullable,
-    TlvString,
-    TlvUInt64,
     VendorId,
 } from "@matter/main/types";
 import { AttributeModel, CommandModel, Matter } from "@matter/model";
@@ -442,32 +436,6 @@ export class LegacyControllerCommandHandler extends CommandHandler {
 
         logger.info("Writing attribute", attributeId, "with value", value);
 
-        let tlvValue: any;
-
-        if (value === null) {
-            tlvValue = TlvNullable(TlvBoolean).encodeTlv(value); // Boolean is just a placeholder here
-        } else if (Bytes.isBytes(value)) {
-            tlvValue = TlvByteString.encodeTlv(value);
-        } else {
-            switch (typeof value) {
-                case "boolean":
-                    tlvValue = TlvBoolean.encodeTlv(value);
-                    break;
-                case "number":
-                    tlvValue = TlvInt32.encodeTlv(value);
-                    break;
-                case "bigint":
-                    tlvValue = TlvUInt64.encodeTlv(value);
-                    break;
-                case "string":
-                    tlvValue = TlvString.encodeTlv(value);
-                    break;
-                default:
-                    throw new Error("Unsupported value type for Any encoding");
-            }
-        }
-
-        // Try to look up the real model for proper encoding
         const realAttr = Matter.clusters(clusterId)?.attributes(attributeId);
         const attrModel =
             realAttr ?? new AttributeModel({ id: attributeId, name: `attr_${attributeId}`, access: "RW" });
@@ -477,7 +445,7 @@ export class LegacyControllerCommandHandler extends CommandHandler {
                 endpointId,
                 clusterId,
                 attribute: { id: attributeId, name: attrModel.name, schema: attrModel },
-                value: tlvValue,
+                value,
             },
         });
     }

--- a/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
+++ b/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
@@ -638,7 +638,8 @@ function inferAttrModel(id: number, value: unknown): AttributeModel {
     else if (typeof value === "bigint") type = "uint64";
     else if (typeof value === "string") type = "string";
     else if (typeof value === "boolean") type = "bool";
-    else type = "int32";
+    else if (typeof value === "number" || value === null) type = "int32";
+    else throw new Error(`Cannot infer TLV type for unknown attribute ${id} from value of type ${typeof value}`);
     return new AttributeModel({
         id,
         name: `attr_${id}`,


### PR DESCRIPTION
## Summary

### fix(types): TlvOfModel uses effectiveQuality for nullable check

`generateTlv` checked `model.quality.nullable` which reads only the **local** quality field.

**Root cause**: `PeerBehavior.generateDiscoveredType()` calls `maybeOverrideSupport()` for every attribute. That function adds an attribute to `attrSupportOverrides` whenever `isSupported && applicability !== Mandatory` — i.e., every non-mandatory (conditional/optional) attribute the device supports gets `attr.extend({ operationalIsSupported: true })`. This is correct behavior — it marks "this optional attribute is present on this device".

`startUpOnOff` has conformance `"LT"` (conditional on Lighting) → not Mandatory → always extended via `attr.extend(...)` when the device reports it, **regardless of FeatureMap**. The extended model carries no local quality (only `operationalIsSupported: true`), so `model.quality.nullable` returned `false` even though the original attribute is `nullable`.

Fix: use `model.nullable` which calls `effectiveQuality`, traversing the `operationalBase` inheritance chain back to the original attribute definition where `nullable = true`.

This affects **all nullable conditional/optional attributes** on peer devices, not just attributes whose feature appears absent.

Adds `TlvOfModel` round-trip tests for nullable scalar (enum) and struct attributes on extended models.

### fix(chip-testing): fix double-encode bug writing nullable attributes

`LegacyControllerCommandHandler.handleWriteAttributeById` pre-encoded values to `TlvStream` before passing to the old `InteractionClient`, which then re-encoded using the attribute schema via `TlvOfModel`.

For nullable enums (e.g. `startUpOnOff`), the second encode received a `TlvElement[]` array instead of `null` → `Number(array) = NaN → 0` → `UnsignedInt(0)` on the wire.

Fix: pass raw `value` directly; `InteractionClient` encodes once via `TlvOfModel` with correct nullable schema. For unknown attributes (not in the Matter model), `inferAttrModel` builds a typed `AttributeModel` from the JS value type so `TlvOfModel` produces a concrete schema instead of `TlvAny` (which requires a pre-encoded `TlvStream`).

Adds `ClientNode` tests covering `null`/`0`/`2` writes for a nullable enum attribute via both `agent.state` assignment and `setStateOf` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)