### PR TITLE
fix: show human-readable feature names in cluster diagnostics

### DIFF
--- a/packages/matter.js/src/device/Endpoint.ts
+++ b/packages/matter.js/src/device/Endpoint.ts
@@ -14,6 +14,7 @@ import {
     NotImplementedError,
     Observable,
 } from "@matter/general";
+import { ClusterModel, Matter } from "@matter/model";
 import {
     Behavior,
     Endpoint as ClientEndpoint,
@@ -22,7 +23,6 @@ import {
     type GlobalAttributeState,
 } from "@matter/node";
 import { ClusterClientObj, Val } from "@matter/protocol";
-import { ClusterModel, Matter } from "@matter/model";
 import { ClusterId, ClusterType, DeviceTypeId, EndpointNumber, getClusterNameById } from "@matter/types";
 import { DeviceTypeDefinition } from "./DeviceTypes.js";
 

--- a/packages/matter.js/src/device/Endpoint.ts
+++ b/packages/matter.js/src/device/Endpoint.ts
@@ -22,6 +22,7 @@ import {
     type GlobalAttributeState,
 } from "@matter/node";
 import { ClusterClientObj, Val } from "@matter/protocol";
+import { ClusterModel, Matter } from "@matter/model";
 import { ClusterId, ClusterType, DeviceTypeId, EndpointNumber, getClusterNameById } from "@matter/types";
 import { DeviceTypeDefinition } from "./DeviceTypes.js";
 
@@ -443,7 +444,22 @@ export class Endpoint {
             if (features[featureName] === true) supportedFeatures.push(featureName);
         }
         if (supportedFeatures.length) {
-            elementDiagnostic.push([Diagnostic.strong("features"), supportedFeatures]);
+            const clusterModel = Matter.get(ClusterModel, client.id);
+            let displayFeatures: string[];
+            if (clusterModel) {
+                const titleMap = new Map<string, string>();
+                for (const f of clusterModel.features) {
+                    const title = f.title ?? f.name;
+                    titleMap.set(f.name, title);
+                    if (f.title) {
+                        titleMap.set(f.title.charAt(0).toLowerCase() + f.title.slice(1), title);
+                    }
+                }
+                displayFeatures = supportedFeatures.map(name => titleMap.get(name) ?? name);
+            } else {
+                displayFeatures = supportedFeatures;
+            }
+            elementDiagnostic.push([Diagnostic.strong("features"), displayFeatures]);
         }
 
         if (Object.keys(client.attributes).length) {

--- a/packages/node/src/endpoint/properties/Behaviors.ts
+++ b/packages/node/src/endpoint/properties/Behaviors.ts
@@ -28,7 +28,7 @@ import {
     MaybePromise,
     Transaction,
 } from "@matter/general";
-import { ClusterModel, FeatureSet } from "@matter/model";
+import { ClusterModel } from "@matter/model";
 import { ClusterTypeProtocol, Val } from "@matter/protocol";
 import type { ClusterType } from "@matter/types";
 import type { Agent } from "../Agent.js";
@@ -123,9 +123,15 @@ export class Behaviors {
             const elements = this.elementsOf(type);
             const elementDiagnostic = Array<unknown>();
 
-            const features = schema instanceof ClusterModel ? schema.supportedFeatures : new FeatureSet();
-            if (features.size) {
-                elementDiagnostic.push([Diagnostic.strong("features"), features]);
+            if (schema instanceof ClusterModel) {
+                const features = schema.supportedFeatures;
+                if (features.size) {
+                    const titleMap = new Map(schema.features.map(f => [f.name, f.title ?? f.name]));
+                    elementDiagnostic.push([
+                        Diagnostic.strong("features"),
+                        [...features].map(name => titleMap.get(name) ?? name),
+                    ]);
+                }
             }
 
             if (elements.attributes.size) {


### PR DESCRIPTION
## Summary

- Replace cluster feature short codes (`GN`, `LT`, `ADO`, `VDO`) with human-readable titles (`GroupNames`, `Lighting`, `Audio`, `Video`) in diagnostic output
- Applies to both server node (`Behaviors.ts`) and client node (`Endpoint.ts`) cluster logging
- Falls back to short code if no title is defined or cluster model is unknown

Before:
```
✓onOff id: 0x6
  features LT
✓cameraAvStreamManagement id: 0x551
  features ADO VDO SNP SPKR NV
```

After:
```
✓onOff id: 0x6
  features Lighting
✓cameraAvStreamManagement id: 0x551
  features Audio Video Snapshot Speaker NightVision
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)