### PR TITLE
fix(node): recover Connected state when subscription data flows during reconnect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12026,7 +12026,7 @@
             "version": "0.0.0-git",
             "license": "Apache-2.0",
             "dependencies": {
-                "@craftzdog/react-native-buffer": "^6.1.2",
+                "@craftzdog/react-native-buffer": "6.1.2",
                 "@matter/general": "*",
                 "@matter/nodejs": "*",
                 "@matter/protocol": "*",

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -729,7 +729,9 @@ export class PairedNode {
      * Handles structure update scheduling, device info updates, and connectionAlive events.
      */
     #handleSubscriptionAlive() {
-        this.#setConnectionState(NodeStates.Connected);
+        if (this.#remoteInitializationDone && !this.#closing && !this.#decommissioned) {
+            this.#setConnectionState(NodeStates.Connected);
+        }
 
         // Schedule endpoint structure update if needed
         if (

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -729,6 +729,8 @@ export class PairedNode {
      * Handles structure update scheduling, device info updates, and connectionAlive events.
      */
     #handleSubscriptionAlive() {
+        this.#setConnectionState(NodeStates.Connected);
+
         // Schedule endpoint structure update if needed
         if (
             this.#remoteInitializationDone &&


### PR DESCRIPTION
## Summary

- `PairedNode` transitions to `Reconnecting` on TCP session drop but had no path back to `Connected` unless `SustainedSubscription` completed a full re-subscribe cycle
- After a device-initiated CASE Resume (e.g. OTA reboot), the existing `PeerSubscription` keeps delivering data — `#handleSubscriptionAlive` fires — but `stateChanged(Connected)` was never emitted
- Consumers (e.g. matterjs-server) were left stuck on their reconnect timers until they declared the node unavailable after 3 minutes

## Root cause

`#handleSubscriptionAlive()` in `PairedNode` scheduled endpoint structure updates and emitted `connectionAlive`, but never restored the `Connected` state. The only path back to `Connected` was `SustainedSubscription.active.emit(true)` after a successful `#subscribe()` cycle — which doesn't happen when the existing subscription continues uninterrupted through a session resume.

## Fix

Call `#setConnectionState(NodeStates.Connected)` at the start of `#handleSubscriptionAlive()`. Arriving subscription data is direct proof the device is reachable; restoring `Connected` immediately is correct.

## Test plan

- [ ] Node reconnects after TCP session drop + device-initiated CASE Resume (OTA scenario)
- [ ] `stateChanged(Connected)` fires within one subscription keepalive interval of the reconnect
- [ ] No state regression for normal subscribe/unsubscribe lifecycle
- [ ] No double `Connected` emission when already connected (guarded by `#setConnectionState` dedup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)