### PR TITLE
fix(protocol): close abandoned TCP channels after failed CASE attempts

### DIFF
--- a/packages/general/src/net/Network.ts
+++ b/packages/general/src/net/Network.ts
@@ -12,7 +12,7 @@ import type { Transport } from "./Transport.js";
 import type { UdpSocket, UdpSocketOptions } from "./udp/UdpSocket.js";
 
 /** Options for {@link Network.connectTcp}. */
-export interface TcpConnectOptions extends Transport.ConnectOptions {
+export interface TcpConnectOptions extends Transport.OpenChannelOptions {
     /** Per-call timeout in milliseconds. Defaults to TCP_CONNECTION_TIMEOUT_MS. */
     timeout?: number;
 }

--- a/packages/general/src/net/Network.ts
+++ b/packages/general/src/net/Network.ts
@@ -99,7 +99,11 @@ export abstract class Network {
     }
 
     /** Connect to a remote TCP endpoint. Override in platform implementations that support TCP. */
-    connectTcp(_host: string, _port: number, _options?: { timeout?: number }): Promise<TcpConnection> {
+    connectTcp(
+        _host: string,
+        _port: number,
+        _options?: { timeout?: number; abort?: AbortSignal },
+    ): Promise<TcpConnection> {
         throw new NetworkError("TCP client not supported on this platform");
     }
 

--- a/packages/general/src/net/Network.ts
+++ b/packages/general/src/net/Network.ts
@@ -8,7 +8,14 @@ import { MatterError } from "../MatterError.js";
 import { repackErrorAs } from "../util/Error.js";
 import type { MaybePromise } from "../util/Promises.js";
 import type { TcpConnection, TcpListener, TcpListenerOptions } from "./tcp/TcpConnection.js";
+import type { Transport } from "./Transport.js";
 import type { UdpSocket, UdpSocketOptions } from "./udp/UdpSocket.js";
+
+/** Options for {@link Network.connectTcp}. */
+export interface TcpConnectOptions extends Transport.ConnectOptions {
+    /** Per-call timeout in milliseconds. Defaults to TCP_CONNECTION_TIMEOUT_MS. */
+    timeout?: number;
+}
 
 export class NetworkError extends MatterError {}
 
@@ -99,11 +106,7 @@ export abstract class Network {
     }
 
     /** Connect to a remote TCP endpoint. Override in platform implementations that support TCP. */
-    connectTcp(
-        _host: string,
-        _port: number,
-        _options?: { timeout?: number; abort?: AbortSignal },
-    ): Promise<TcpConnection> {
+    connectTcp(_host: string, _port: number, _options?: TcpConnectOptions): Promise<TcpConnection> {
         throw new NetworkError("TCP client not supported on this platform");
     }
 

--- a/packages/general/src/net/Transport.ts
+++ b/packages/general/src/net/Transport.ts
@@ -18,12 +18,18 @@ export interface Transport {
     onData(listener: (socket: Channel<Bytes>, data: Bytes) => void): Transport.Listener;
     close(): Promise<void>;
     supports(type: ChannelType, address?: string): boolean;
-    openChannel(address: ServerAddress, abort?: AbortSignal): Promise<Channel<Bytes>>;
+    openChannel(address: ServerAddress, options?: Transport.ConnectOptions): Promise<Channel<Bytes>>;
 }
 
 export namespace Transport {
     export interface Listener {
         close(): Promise<void>;
+    }
+
+    /** Options accepted by transport connect operations. */
+    export interface ConnectOptions {
+        /** Aborts an in-flight connect; the transport tears down any partial state on signal. */
+        abort?: AbortSignal;
     }
 
     export interface Provider<T extends Transport = Transport> {

--- a/packages/general/src/net/Transport.ts
+++ b/packages/general/src/net/Transport.ts
@@ -18,7 +18,7 @@ export interface Transport {
     onData(listener: (socket: Channel<Bytes>, data: Bytes) => void): Transport.Listener;
     close(): Promise<void>;
     supports(type: ChannelType, address?: string): boolean;
-    openChannel(address: ServerAddress, options?: Transport.ConnectOptions): Promise<Channel<Bytes>>;
+    openChannel(address: ServerAddress, options?: Transport.OpenChannelOptions): Promise<Channel<Bytes>>;
 }
 
 export namespace Transport {
@@ -26,9 +26,12 @@ export namespace Transport {
         close(): Promise<void>;
     }
 
-    /** Options accepted by transport connect operations. */
-    export interface ConnectOptions {
-        /** Aborts an in-flight connect; the transport tears down any partial state on signal. */
+    /**
+     * Options accepted by {@link Transport.openChannel}. Connectionless transports (UDP) ignore
+     * fields that only apply to connect-oriented setup.
+     */
+    export interface OpenChannelOptions {
+        /** Aborts an in-flight channel open; the transport tears down any partial state on signal. */
         abort?: AbortSignal;
     }
 

--- a/packages/general/src/net/Transport.ts
+++ b/packages/general/src/net/Transport.ts
@@ -18,7 +18,7 @@ export interface Transport {
     onData(listener: (socket: Channel<Bytes>, data: Bytes) => void): Transport.Listener;
     close(): Promise<void>;
     supports(type: ChannelType, address?: string): boolean;
-    openChannel(address: ServerAddress): Promise<Channel<Bytes>>;
+    openChannel(address: ServerAddress, abort?: AbortSignal): Promise<Channel<Bytes>>;
 }
 
 export namespace Transport {

--- a/packages/general/src/net/udp/UdpTransport.ts
+++ b/packages/general/src/net/udp/UdpTransport.ts
@@ -33,7 +33,7 @@ export class UdpTransport implements Transport {
         return this.#server.supports(type, address);
     }
 
-    async openChannel(address: ServerAddress, _options?: Transport.ConnectOptions) {
+    async openChannel(address: ServerAddress, _options?: Transport.OpenChannelOptions) {
         if (!ServerAddress.isIp(address)) {
             throw new NetworkError(`Unsupported address type for UDP interface`);
         }

--- a/packages/general/src/net/udp/UdpTransport.ts
+++ b/packages/general/src/net/udp/UdpTransport.ts
@@ -33,7 +33,7 @@ export class UdpTransport implements Transport {
         return this.#server.supports(type, address);
     }
 
-    async openChannel(address: ServerAddress) {
+    async openChannel(address: ServerAddress, _abort?: AbortSignal) {
         if (!ServerAddress.isIp(address)) {
             throw new NetworkError(`Unsupported address type for UDP interface`);
         }

--- a/packages/general/src/net/udp/UdpTransport.ts
+++ b/packages/general/src/net/udp/UdpTransport.ts
@@ -33,7 +33,7 @@ export class UdpTransport implements Transport {
         return this.#server.supports(type, address);
     }
 
-    async openChannel(address: ServerAddress, _abort?: AbortSignal) {
+    async openChannel(address: ServerAddress, _options?: Transport.ConnectOptions) {
         if (!ServerAddress.isIp(address)) {
             throw new NetworkError(`Unsupported address type for UDP interface`);
         }

--- a/packages/nodejs-ble/src/NobleBleChannel.ts
+++ b/packages/nodejs-ble/src/NobleBleChannel.ts
@@ -94,7 +94,7 @@ export class NobleBleCentralInterface implements Transport {
         this.#bleScanner = bleScanner;
     }
 
-    openChannel(address: ServerAddress, _abort?: AbortSignal): Promise<Channel<Bytes>> {
+    openChannel(address: ServerAddress, _options?: Transport.ConnectOptions): Promise<Channel<Bytes>> {
         return this.#openChannel(address, 1);
     }
 

--- a/packages/nodejs-ble/src/NobleBleChannel.ts
+++ b/packages/nodejs-ble/src/NobleBleChannel.ts
@@ -94,7 +94,7 @@ export class NobleBleCentralInterface implements Transport {
         this.#bleScanner = bleScanner;
     }
 
-    openChannel(address: ServerAddress, _options?: Transport.ConnectOptions): Promise<Channel<Bytes>> {
+    openChannel(address: ServerAddress, _options?: Transport.OpenChannelOptions): Promise<Channel<Bytes>> {
         return this.#openChannel(address, 1);
     }
 

--- a/packages/nodejs-ble/src/NobleBleChannel.ts
+++ b/packages/nodejs-ble/src/NobleBleChannel.ts
@@ -94,7 +94,11 @@ export class NobleBleCentralInterface implements Transport {
         this.#bleScanner = bleScanner;
     }
 
-    openChannel(address: ServerAddress, tryCount = 1): Promise<Channel<Bytes>> {
+    openChannel(address: ServerAddress, _abort?: AbortSignal): Promise<Channel<Bytes>> {
+        return this.#openChannel(address, 1);
+    }
+
+    #openChannel(address: ServerAddress, tryCount: number): Promise<Channel<Bytes>> {
         if (this.#closed) {
             throw new NetworkError("Network interface is closed");
         }
@@ -233,7 +237,7 @@ export class NobleBleCentralInterface implements Transport {
                 }
 
                 // Try again and chain promises
-                this.openChannel(address, tryCount + 1)
+                this.#openChannel(address, tryCount + 1)
                     .then(resolveOnce)
                     .catch(rejectOnce);
             };

--- a/packages/nodejs/src/net/NodeJsNetwork.ts
+++ b/packages/nodejs/src/net/NodeJsNetwork.ts
@@ -192,13 +192,21 @@ export class NodeJsNetwork extends Network {
         return NodeJsTcpListener.create(options);
     }
 
-    override async connectTcp(host: string, port: number, options?: { timeout?: number }): Promise<TcpConnection> {
+    override async connectTcp(
+        host: string,
+        port: number,
+        options?: { timeout?: number; abort?: AbortSignal },
+    ): Promise<TcpConnection> {
+        if (options?.abort?.aborted) {
+            throw new NetworkError("TCP connect aborted");
+        }
         return new Promise((resolve, reject) => {
             let settled = false;
 
             const settle = (fn: () => void) => {
                 if (!settled) {
                     settled = true;
+                    options?.abort?.removeEventListener("abort", onAbort);
                     fn();
                 }
             };
@@ -215,12 +223,15 @@ export class NodeJsNetwork extends Network {
                     reject(error);
                 });
 
+            const onAbort = () => rejectOnce(new NetworkError("TCP connect aborted"));
+
             socket.setTimeout(options?.timeout ?? TCP_CONNECTION_TIMEOUT_MS);
             socket.once("timeout", () => {
                 socket.destroy();
                 settle(() => reject(new NetworkError("TCP connection timeout")));
             });
             socket.on("error", rejectOnce);
+            options?.abort?.addEventListener("abort", onAbort, { once: true });
         });
     }
 }

--- a/packages/nodejs/src/net/NodeJsNetwork.ts
+++ b/packages/nodejs/src/net/NodeJsNetwork.ts
@@ -202,11 +202,12 @@ export class NodeJsNetwork extends Network {
         }
         return new Promise((resolve, reject) => {
             let settled = false;
+            let onAbort: (() => void) | undefined;
 
             const settle = (fn: () => void) => {
                 if (!settled) {
                     settled = true;
-                    options?.abort?.removeEventListener("abort", onAbort);
+                    if (onAbort) options?.abort?.removeEventListener("abort", onAbort);
                     fn();
                 }
             };
@@ -223,7 +224,7 @@ export class NodeJsNetwork extends Network {
                     reject(error);
                 });
 
-            const onAbort = () => rejectOnce(new NetworkError("TCP connect aborted"));
+            onAbort = () => rejectOnce(new NetworkError("TCP connect aborted"));
 
             socket.setTimeout(options?.timeout ?? TCP_CONNECTION_TIMEOUT_MS);
             socket.once("timeout", () => {

--- a/packages/nodejs/src/net/NodeJsNetwork.ts
+++ b/packages/nodejs/src/net/NodeJsNetwork.ts
@@ -17,6 +17,7 @@ import {
     onSameNetwork,
     TCP_CONNECTION_TIMEOUT_MS,
     TcpConnection,
+    TcpConnectOptions,
     TcpListener,
     TcpListenerOptions,
     UdpSocket,
@@ -192,24 +193,27 @@ export class NodeJsNetwork extends Network {
         return NodeJsTcpListener.create(options);
     }
 
-    override async connectTcp(
-        host: string,
-        port: number,
-        options?: { timeout?: number; abort?: AbortSignal },
-    ): Promise<TcpConnection> {
+    override async connectTcp(host: string, port: number, options?: TcpConnectOptions): Promise<TcpConnection> {
         if (options?.abort?.aborted) {
             throw new NetworkError("TCP connect aborted");
         }
         return new Promise((resolve, reject) => {
             let settled = false;
-            let onAbort: (() => void) | undefined;
+            // Captured by reference so settle() can detach the listener regardless of which path settles first.
+            let abortListener: (() => void) | undefined;
+
+            const detachAbort = () => {
+                if (abortListener !== undefined) {
+                    options?.abort?.removeEventListener("abort", abortListener);
+                    abortListener = undefined;
+                }
+            };
 
             const settle = (fn: () => void) => {
-                if (!settled) {
-                    settled = true;
-                    if (onAbort) options?.abort?.removeEventListener("abort", onAbort);
-                    fn();
-                }
+                if (settled) return;
+                settled = true;
+                detachAbort();
+                fn();
             };
 
             const socket = createConnection({ host, port, noDelay: true }, () => {
@@ -224,7 +228,7 @@ export class NodeJsNetwork extends Network {
                     reject(error);
                 });
 
-            onAbort = () => rejectOnce(new NetworkError("TCP connect aborted"));
+            abortListener = () => rejectOnce(new NetworkError("TCP connect aborted"));
 
             socket.setTimeout(options?.timeout ?? TCP_CONNECTION_TIMEOUT_MS);
             socket.once("timeout", () => {
@@ -232,7 +236,7 @@ export class NodeJsNetwork extends Network {
                 settle(() => reject(new NetworkError("TCP connection timeout")));
             });
             socket.on("error", rejectOnce);
-            options?.abort?.addEventListener("abort", onAbort, { once: true });
+            options?.abort?.addEventListener("abort", abortListener, { once: true });
         });
     }
 }

--- a/packages/nodejs/src/net/NodeJsTcpConnection.ts
+++ b/packages/nodejs/src/net/NodeJsTcpConnection.ts
@@ -6,6 +6,7 @@
 
 import {
     Bytes,
+    Logger,
     Seconds,
     TCP_KEEP_ALIVE_INITIAL_DELAY_MS,
     TcpConnection,
@@ -14,6 +15,8 @@ import {
     withTimeout,
 } from "@matter/general";
 import type { Socket } from "node:net";
+
+const logger = Logger.get("NodeJsTcpConnection");
 
 /** Time to wait for graceful close before force-destroying the socket. */
 const TCP_CLOSE_TIMEOUT = Seconds(5);
@@ -29,6 +32,7 @@ export class NodeJsTcpConnection implements TcpConnection {
 
     readonly #socket: Socket;
     #ended = false;
+    #closePromise?: Promise<void>;
 
     /** Queued chunks waiting for the async iterator to consume. */
     #chunks = new Array<Uint8Array>();
@@ -131,22 +135,38 @@ export class NodeJsTcpConnection implements TcpConnection {
         };
     }
 
-    async close(): Promise<void> {
-        if (this.#socket.destroyed) {
-            return;
-        }
+    close(): Promise<void> {
+        // Memoize so concurrent callers share one teardown — each `await close()` waits for actual shutdown.
+        return (this.#closePromise ??= this.#doClose());
+    }
 
+    async #doClose(): Promise<void> {
+        const alreadyClosed = this.#ended || this.#socket.destroyed;
         this.#ended = true;
         this.#waiter?.({ value: undefined as unknown as Bytes, done: true });
         this.#waiter = undefined;
 
-        const closed = new Promise<void>(resolve => {
-            this.#socket.once("close", () => resolve());
-            this.#socket.end();
-        });
+        // Already closed externally; a fresh "close" listener wouldn't fire and would stall #closePromise.
+        if (alreadyClosed) {
+            return;
+        }
 
-        await withTimeout(TCP_CLOSE_TIMEOUT, closed, () => {
-            this.#socket.destroy();
-        });
+        try {
+            const closed = new Promise<void>(resolve => {
+                this.#socket.once("close", () => resolve());
+                this.#socket.end();
+            });
+
+            await withTimeout(TCP_CLOSE_TIMEOUT, closed, () => {
+                this.#socket.destroy();
+            });
+        } catch (error) {
+            logger.warn(`Error closing TCP connection ${this.remoteAddress}:${this.remotePort}:`, error);
+            try {
+                this.#socket.destroy();
+            } catch (destroyError) {
+                logger.debug(`Error destroying TCP socket ${this.remoteAddress}:${this.remotePort}:`, destroyError);
+            }
+        }
     }
 }

--- a/packages/nodejs/test/net/NodeJsTcpConnectionTest.ts
+++ b/packages/nodejs/test/net/NodeJsTcpConnectionTest.ts
@@ -7,6 +7,7 @@
 import { Bytes } from "@matter/general";
 import * as assert from "node:assert";
 import * as net from "node:net";
+import { NodeJsNetwork } from "../../src/net/NodeJsNetwork.js";
 import { NodeJsTcpConnection } from "../../src/net/NodeJsTcpConnection.js";
 
 describe("NodeJsTcpConnection", () => {
@@ -166,6 +167,30 @@ describe("NodeJsTcpConnection", () => {
         } finally {
             rawServer.destroy();
         }
+    });
+
+    describe("connectTcp abort handling", () => {
+        it("rejects immediately when abort signal is pre-fired", async () => {
+            const network = new NodeJsNetwork();
+            const controller = new AbortController();
+            controller.abort();
+
+            await assert.rejects(network.connectTcp("127.0.0.1", serverPort, { abort: controller.signal }), /aborted/i);
+        });
+
+        it("destroys the socket and rejects when abort fires during connect", async () => {
+            const network = new NodeJsNetwork();
+            const controller = new AbortController();
+
+            // TEST-NET-1 (RFC 5737) — guaranteed non-routable; SYN will hang until aborted.
+            const connectPromise = network.connectTcp("192.0.2.1", 5540, {
+                abort: controller.signal,
+                timeout: 10_000,
+            });
+            setImmediate(() => controller.abort());
+
+            await assert.rejects(connectPromise, /aborted/i);
+        });
     });
 
     it("close after peer-initiated close completes without hanging", async () => {

--- a/packages/nodejs/test/net/NodeJsTcpConnectionTest.ts
+++ b/packages/nodejs/test/net/NodeJsTcpConnectionTest.ts
@@ -146,4 +146,43 @@ describe("NodeJsTcpConnection", () => {
         // Should not hang
         await clientSocket.close();
     });
+
+    it("concurrent close calls share one teardown promise", async () => {
+        const { clientSocket, rawServer } = await connectClient();
+        try {
+            let endCount = 0;
+            rawServer.on("end", () => {
+                endCount++;
+            });
+
+            const [a, b, c] = await Promise.all([clientSocket.close(), clientSocket.close(), clientSocket.close()]);
+
+            assert.equal(a, undefined);
+            assert.equal(b, undefined);
+            assert.equal(c, undefined);
+            // The single underlying socket end should produce at most one "end" event on the peer.
+            // (Some platforms may not deliver it before the server destroys; assertion is upper-bound.)
+            assert.ok(endCount <= 1, `expected ≤1 server-side "end" event, got ${endCount}`);
+        } finally {
+            rawServer.destroy();
+        }
+    });
+
+    it("close after peer-initiated close completes without hanging", async () => {
+        const { clientSocket, rawServer } = await connectClient();
+
+        // Trigger close from peer side and wait for it to propagate to the client wrapper.
+        const peerClosed = new Promise<void>(resolve => {
+            clientSocket.onClose(() => resolve());
+        });
+        rawServer.end();
+        rawServer.destroy();
+        await peerClosed;
+
+        // Awaiting close() must resolve promptly even though the underlying socket already emitted "close".
+        await Promise.race([
+            clientSocket.close(),
+            new Promise((_, reject) => setTimeout(() => reject(new Error("close() hung")), 1000)),
+        ]);
+    });
 });

--- a/packages/protocol/src/action/client/subscription/SustainedSubscription.ts
+++ b/packages/protocol/src/action/client/subscription/SustainedSubscription.ts
@@ -149,7 +149,7 @@ export class SustainedSubscription extends ClientSubscription {
                     if (!causedBy(e, AbortedError) || !this.abort.aborted) {
                         // Subscription failed not by timeout but because could not be established, so we have a new session anyway
                         sessionTrusted = true;
-                        logger.error(
+                        logger.info(
                             `Failed to establish subscription to ${this.peer}, retry in ${Duration.format(retry)}:`,
                             Diagnostic.errorMessage(asError(e)),
                         );

--- a/packages/protocol/src/peer/PeerConnection.ts
+++ b/packages/protocol/src/peer/PeerConnection.ts
@@ -626,7 +626,7 @@ export namespace PeerConnection {
         /**
          * Open byte channel to a specific address.
          */
-        openSocket(address: ServerAddressIp, abort: AbortSignal): Promise<Channel<Bytes> | void>;
+        openSocket(address: ServerAddressIp, abort: AbortSignal): Promise<Channel<Bytes> | undefined>;
 
         timing: PeerTimingParameters;
 

--- a/packages/protocol/src/peer/PeerConnection.ts
+++ b/packages/protocol/src/peer/PeerConnection.ts
@@ -436,89 +436,103 @@ export async function PeerConnection(
             }
         }
 
-        // When we try the fallback address, and it is not the first one, then we directly use a higher MRP interval
-        const isFallback = attemptingFallback && addrsAttempted > 1;
-
-        await using unsecuredSession = context.sessions.createUnsecuredSession({
-            channel: socket,
-            sessionParameters: peer.sessionParameters,
-            isInitiator: true,
-        });
-
-        await using exchange = PeerConnection.createExchange(peer, context.exchanges, unsecuredSession, network);
-
-        info(
-            Diagnostic.via(`${peer.address.toString()}${exchange.via}`),
-            address,
-            "Connecting",
-            Diagnostic.dict({
-                "addr #": addrNo,
-                "attempt #": attemptNo,
-                "connect time": Duration.format(Timestamp.delta(lifetime.startedAt)),
-                "addr time": Duration.format(Timestamp.delta(attemptLifetime.startedAt)),
-            }),
-            Diagnostic.asFlags({
-                [network.id]: true,
-                fallback: address === attemptingFallback,
-            }),
-        );
-
-        const caseClient = new CaseClient(context.sessions);
-
-        const fabric = context.sessions.fabricFor(peer.address);
-
-        let kick: Disposable | undefined;
-
-        // localAbort wraps addressAbort; firing it aborts only this single attempt so connect() can
-        // loop back and open a fresh exchange (fresh MRP backoff) without aborting the address entirely.
-        using localAbort = new Abort({ abort: addressAbort });
+        // MessageChannel.close skips TCP — sessions own that lifecycle. If pair fails before a session
+        // takes over we must close the channel ourselves. UDP close is a no-op so this is safe for both.
+        let socketOwned = true;
 
         try {
-            using _pairing = attemptLifetime.join("pairing");
+            // When we try the fallback address, and it is not the first one, then we directly use a higher MRP interval
+            const isFallback = attemptingFallback && addrsAttempted > 1;
 
-            kick = kicker?.use((origin: KickOrigin) => {
-                if (exchange.retransmissionCount < context.timing.kickMinRetransmissions) {
+            await using unsecuredSession = context.sessions.createUnsecuredSession({
+                channel: socket,
+                sessionParameters: peer.sessionParameters,
+                isInitiator: true,
+            });
+
+            await using exchange = PeerConnection.createExchange(peer, context.exchanges, unsecuredSession, network);
+
+            info(
+                Diagnostic.via(`${peer.address.toString()}${exchange.via}`),
+                address,
+                "Connecting",
+                Diagnostic.dict({
+                    "addr #": addrNo,
+                    "attempt #": attemptNo,
+                    "connect time": Duration.format(Timestamp.delta(lifetime.startedAt)),
+                    "addr time": Duration.format(Timestamp.delta(attemptLifetime.startedAt)),
+                }),
+                Diagnostic.asFlags({
+                    [network.id]: true,
+                    fallback: address === attemptingFallback,
+                }),
+            );
+
+            const caseClient = new CaseClient(context.sessions);
+
+            const fabric = context.sessions.fabricFor(peer.address);
+
+            let kick: Disposable | undefined;
+
+            // localAbort wraps addressAbort; firing it aborts only this single attempt so connect() can
+            // loop back and open a fresh exchange (fresh MRP backoff) without aborting the address entirely.
+            using localAbort = new Abort({ abort: addressAbort });
+
+            try {
+                using _pairing = attemptLifetime.join("pairing");
+
+                kick = kicker?.use((origin: KickOrigin) => {
+                    if (exchange.retransmissionCount < context.timing.kickMinRetransmissions) {
+                        return;
+                    }
+
+                    const threshold =
+                        origin === "discover"
+                            ? context.timing.kickRestartCooldown.addressChange
+                            : context.timing.kickRestartCooldown.connect;
+
+                    if (lastRestartAt === undefined || Timestamp.delta(lastRestartAt) >= threshold) {
+                        info(via, address, `Restarting exchange on "${origin}" kick`);
+                        lastRestartAt = Time.nowMs;
+                        localAbort();
+                    } else {
+                        debug(
+                            via,
+                            address,
+                            `Suppressing "${origin}" kick, last restart was ${Duration.format(Timestamp.delta(lastRestartAt))} ago`,
+                        );
+                    }
+                });
+
+                const { session } = await caseClient.pair(exchange, fabric, peer.address.nodeId, {
+                    ...options,
+                    abort: localAbort,
+                    caseAuthenticatedTags: peer.descriptor.caseAuthenticatedTags,
+                    maxInitialRetransmissions: Infinity,
+                    maxInitialRetransmissionTime: timing.maxDelayBetweenInitialContactRetries,
+                    initialRetransmissionTime: isFallback ? timing.maxDelayBetweenInitialContactRetries : undefined,
+                });
+
+                outputSession = session;
+                socketOwned = false;
+                overallAbort();
+            } catch (e) {
+                if (AbortedError.is(e)) {
                     return;
                 }
 
-                const threshold =
-                    origin === "discover"
-                        ? context.timing.kickRestartCooldown.addressChange
-                        : context.timing.kickRestartCooldown.connect;
-
-                if (lastRestartAt === undefined || Timestamp.delta(lastRestartAt) >= threshold) {
-                    info(via, address, `Restarting exchange on "${origin}" kick`);
-                    lastRestartAt = Time.nowMs;
-                    localAbort();
-                } else {
-                    debug(
-                        via,
-                        address,
-                        `Suppressing "${origin}" kick, last restart was ${Duration.format(Timestamp.delta(lastRestartAt))} ago`,
-                    );
-                }
-            });
-
-            const { session } = await caseClient.pair(exchange, fabric, peer.address.nodeId, {
-                ...options,
-                abort: localAbort,
-                caseAuthenticatedTags: peer.descriptor.caseAuthenticatedTags,
-                maxInitialRetransmissions: Infinity,
-                maxInitialRetransmissionTime: timing.maxDelayBetweenInitialContactRetries,
-                initialRetransmissionTime: isFallback ? timing.maxDelayBetweenInitialContactRetries : undefined,
-            });
-
-            // Success
-            outputSession = session;
-            overallAbort();
-        } catch (e) {
-            if (AbortedError.is(e)) {
-                return;
+                throw e;
+            } finally {
+                kick?.[Symbol.dispose]();
             }
-
-            throw e;
         } finally {
-            kick?.[Symbol.dispose]();
+            if (socketOwned) {
+                try {
+                    await socket.close();
+                } catch (e) {
+                    warn(address, "Error closing abandoned channel:", Diagnostic.errorMessage(asError(e)));
+                }
+            }
         }
     }
 

--- a/packages/protocol/src/peer/PeerSet.ts
+++ b/packages/protocol/src/peer/PeerSet.ts
@@ -283,7 +283,9 @@ export class PeerSet implements ImmutableSet<Peer>, ObservableSet<Peer> {
             );
         }
 
-        return await Abort.race(abort, operationalInterface.openChannel(address));
+        // Plumb the abort signal into openChannel so an aborted TCP connect is destroyed at the
+        // socket level — prevents an orphan TcpChannel being registered after the caller gives up.
+        return await Abort.race(abort, operationalInterface.openChannel(address, abort));
     }
 
     addKnownPeer(descriptor: PeerDescriptor) {

--- a/packages/protocol/src/peer/PeerSet.ts
+++ b/packages/protocol/src/peer/PeerSet.ts
@@ -285,7 +285,17 @@ export class PeerSet implements ImmutableSet<Peer>, ObservableSet<Peer> {
 
         // Plumb the abort signal into openChannel so an aborted TCP connect is destroyed at the
         // socket level — prevents an orphan TcpChannel being registered after the caller gives up.
-        return await Abort.race(abort, operationalInterface.openChannel(address, abort));
+        // The openChannel path may reject with an abort error before Abort.race's listener wins
+        // the EventTarget callback ordering; convert that to undefined to preserve the
+        // race-returns-undefined-on-abort contract that PeerConnection relies on.
+        if (abort.aborted) return undefined;
+        try {
+            const result = await Abort.race(abort, operationalInterface.openChannel(address, abort));
+            return result === undefined ? undefined : result;
+        } catch (e) {
+            if (abort.aborted) return undefined;
+            throw e;
+        }
     }
 
     addKnownPeer(descriptor: PeerDescriptor) {

--- a/packages/protocol/src/peer/PeerSet.ts
+++ b/packages/protocol/src/peer/PeerSet.ts
@@ -290,7 +290,7 @@ export class PeerSet implements ImmutableSet<Peer>, ObservableSet<Peer> {
         // race-returns-undefined-on-abort contract that PeerConnection relies on.
         if (abort.aborted) return undefined;
         try {
-            const result = await Abort.race(abort, operationalInterface.openChannel(address, abort));
+            const result = await Abort.race(abort, operationalInterface.openChannel(address, { abort }));
             return result === undefined ? undefined : result;
         } catch (e) {
             if (abort.aborted) return undefined;

--- a/packages/protocol/src/session/case/CaseClient.ts
+++ b/packages/protocol/src/session/case/CaseClient.ts
@@ -326,13 +326,21 @@ export class CaseClient {
             this.#sessions.sessions.add(secureSession);
         }
 
-        // These are not abortable
+        // Not abortable; errors must not propagate — session is already adopted at this point.
         try {
             await messenger.close();
         } catch (e) {
             logger.error(messenger.via, "Unhandled error closing CASE messenger:", e);
         }
-        await this.#sessions.saveResumptionRecord(resumptionRecord);
+        try {
+            await this.#sessions.saveResumptionRecord(resumptionRecord);
+        } catch (e) {
+            logger.error(
+                messenger.via,
+                "Failed to save resumption record; session is usable but cannot be resumed:",
+                e,
+            );
+        }
 
         return { session: secureSession, resumed };
     }

--- a/packages/protocol/src/session/case/CaseClient.ts
+++ b/packages/protocol/src/session/case/CaseClient.ts
@@ -326,13 +326,17 @@ export class CaseClient {
             this.#sessions.sessions.add(secureSession);
         }
 
-        // These are not abortable
+        // Not abortable; errors must not propagate — session is already adopted at this point.
         try {
             await messenger.close();
         } catch (e) {
             logger.error(messenger.via, "Unhandled error closing CASE messenger:", e);
         }
-        await this.#sessions.saveResumptionRecord(resumptionRecord);
+        try {
+            await this.#sessions.saveResumptionRecord(resumptionRecord);
+        } catch (e) {
+            logger.warn(messenger.via, "Failed to save resumption record; session is usable but cannot be resumed:", e);
+        }
 
         return { session: secureSession, resumed };
     }

--- a/packages/protocol/src/session/case/CaseClient.ts
+++ b/packages/protocol/src/session/case/CaseClient.ts
@@ -326,21 +326,13 @@ export class CaseClient {
             this.#sessions.sessions.add(secureSession);
         }
 
-        // Not abortable; errors must not propagate — session is already adopted at this point.
+        // These are not abortable
         try {
             await messenger.close();
         } catch (e) {
             logger.error(messenger.via, "Unhandled error closing CASE messenger:", e);
         }
-        try {
-            await this.#sessions.saveResumptionRecord(resumptionRecord);
-        } catch (e) {
-            logger.error(
-                messenger.via,
-                "Failed to save resumption record; session is usable but cannot be resumed:",
-                e,
-            );
-        }
+        await this.#sessions.saveResumptionRecord(resumptionRecord);
 
         return { session: secureSession, resumed };
     }

--- a/packages/protocol/src/transport/tcp/TcpTransport.ts
+++ b/packages/protocol/src/transport/tcp/TcpTransport.ts
@@ -146,7 +146,7 @@ export class TcpTransport implements ConnectionOrientedTransport {
         return type === ChannelType.TCP;
     }
 
-    async openChannel(address: ServerAddress, abort?: AbortSignal): Promise<Channel<Bytes>> {
+    async openChannel(address: ServerAddress, options?: Transport.ConnectOptions): Promise<Channel<Bytes>> {
         if (!ServerAddress.isIp(address)) {
             throw new NetworkError(`TcpTransport does not support non-IP addresses`);
         }
@@ -163,7 +163,7 @@ export class TcpTransport implements ConnectionOrientedTransport {
         }
 
         // Deduplicate concurrent connect attempts for the same address
-        const promise = this.#connect(address, abort);
+        const promise = this.#connect(address, options?.abort);
         this.#connecting.set(key, promise);
         return promise.finally(() => this.#connecting.delete(key));
     }

--- a/packages/protocol/src/transport/tcp/TcpTransport.ts
+++ b/packages/protocol/src/transport/tcp/TcpTransport.ts
@@ -146,27 +146,29 @@ export class TcpTransport implements ConnectionOrientedTransport {
         return type === ChannelType.TCP;
     }
 
-    async openChannel(address: ServerAddress): Promise<Channel<Bytes>> {
+    async openChannel(address: ServerAddress, abort?: AbortSignal): Promise<Channel<Bytes>> {
         if (!ServerAddress.isIp(address)) {
             throw new NetworkError(`TcpTransport does not support non-IP addresses`);
         }
 
         const key = `${address.ip}:${address.port}`;
 
-        // Return existing channel or in-flight connection for this address
+        // Return existing channel or in-flight connection for this address. Shared connects ignore
+        // per-caller abort; aborting one caller must not tear down a connect another caller still
+        // needs. Callers that want a fresh, abortable connect must use a distinct address tuple.
         const existing = this.#channels.get(key) ?? this.#connecting.get(key);
         if (existing) {
             return existing;
         }
 
         // Deduplicate concurrent connect attempts for the same address
-        const promise = this.#connect(address);
+        const promise = this.#connect(address, abort);
         this.#connecting.set(key, promise);
         return promise.finally(() => this.#connecting.delete(key));
     }
 
-    async #connect(address: ServerAddressIp): Promise<Channel<Bytes>> {
-        const socket = await this.#network.connectTcp(address.ip, address.port);
+    async #connect(address: ServerAddressIp, abort?: AbortSignal): Promise<Channel<Bytes>> {
+        const socket = await this.#network.connectTcp(address.ip, address.port, { abort });
         const channel = new TcpChannel(socket, this.#maxMessageSize);
         this.#registerChannel(channel);
         return channel;

--- a/packages/protocol/src/transport/tcp/TcpTransport.ts
+++ b/packages/protocol/src/transport/tcp/TcpTransport.ts
@@ -153,9 +153,10 @@ export class TcpTransport implements ConnectionOrientedTransport {
 
         const key = `${address.ip}:${address.port}`;
 
-        // Return existing channel or in-flight connection for this address. Shared connects ignore
-        // per-caller abort; aborting one caller must not tear down a connect another caller still
-        // needs. Callers that want a fresh, abortable connect must use a distinct address tuple.
+        // The first caller's abort signal governs an in-flight connect; subsequent callers awaiting
+        // the same promise will see it reject if the first aborts. PeerConnection dedupes attempts
+        // per (peer, address) at a higher level, so concurrent sharing for the same ip:port is rare
+        // and the simpler shared-promise contract is acceptable.
         const existing = this.#channels.get(key) ?? this.#connecting.get(key);
         if (existing) {
             return existing;
@@ -170,6 +171,12 @@ export class TcpTransport implements ConnectionOrientedTransport {
     async #connect(address: ServerAddressIp, abort?: AbortSignal): Promise<Channel<Bytes>> {
         const socket = await this.#network.connectTcp(address.ip, address.port, { abort });
         const channel = new TcpChannel(socket, this.#maxMessageSize);
+        // Abort can fire in the microtask window between connectTcp resolving and us getting here.
+        // Close the channel without registering so it never enters #channels as an orphan.
+        if (abort?.aborted) {
+            await channel.close();
+            throw new NetworkError("TCP connect aborted after socket established");
+        }
         this.#registerChannel(channel);
         return channel;
     }

--- a/packages/protocol/src/transport/tcp/TcpTransport.ts
+++ b/packages/protocol/src/transport/tcp/TcpTransport.ts
@@ -146,7 +146,7 @@ export class TcpTransport implements ConnectionOrientedTransport {
         return type === ChannelType.TCP;
     }
 
-    async openChannel(address: ServerAddress, options?: Transport.ConnectOptions): Promise<Channel<Bytes>> {
+    async openChannel(address: ServerAddress, options?: Transport.OpenChannelOptions): Promise<Channel<Bytes>> {
         if (!ServerAddress.isIp(address)) {
             throw new NetworkError(`TcpTransport does not support non-IP addresses`);
         }

--- a/packages/protocol/test/peer/PeerConnectionSocketOwnershipTest.ts
+++ b/packages/protocol/test/peer/PeerConnectionSocketOwnershipTest.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    AbortedError,
+    Bytes,
+    Channel,
+    ChannelType,
+    Observable,
+    ServerAddressIp,
+    ServerAddressTcp,
+    ServerAddressUdp,
+} from "@matter/general";
+
+/**
+ * Tests for the socket-ownership cleanup contract in `PeerConnection.attemptOnce`.
+ *
+ * The full function is a closure inside `PeerConnection()` requiring sessions/exchanges/peer wiring,
+ * so these tests validate the composable invariant that protects against leaked TCP channels:
+ *
+ * - If `pair()` succeeds, the channel is adopted by the secure session and must NOT be closed here.
+ * - If `pair()` throws, the channel must be closed (no session bound).
+ * - If `pair()` throws AbortedError, the channel must still be closed.
+ * - The same logic applies regardless of channel type (UDP `close()` is a no-op, TCP needs real close).
+ *
+ * Regression target: a TCP channel opened by `openSocket` but never adopted by a `SecureSession` would
+ * otherwise stay registered in `TcpTransport` forever (MessageChannel.close skips TCP teardown).
+ */
+
+function mockChannel(type: ChannelType.TCP | ChannelType.UDP): Channel<Bytes> & { closed: boolean } {
+    let closed = false;
+    return {
+        get type() {
+            return type;
+        },
+        get name() {
+            return `${type}://mock`;
+        },
+        get isReliable() {
+            return type === ChannelType.TCP;
+        },
+        send: async () => {},
+        close: async () => {
+            closed = true;
+        },
+        get networkAddress(): ServerAddressTcp | ServerAddressUdp {
+            return type === ChannelType.TCP
+                ? ({ type: "tcp", ip: "127.0.0.1", port: 5540 } satisfies ServerAddressTcp)
+                : ({ type: "udp", ip: "127.0.0.1", port: 5540 } satisfies ServerAddressUdp);
+        },
+        networkAddressChanged: Observable<[ServerAddressIp]>(),
+        get closed() {
+            return closed;
+        },
+    } as unknown as Channel<Bytes> & { closed: boolean };
+}
+
+/**
+ * Mirror of the ownership pattern in `PeerConnection.attemptOnce`:
+ *  - socket obtained from openSocket
+ *  - flag flipped to false ONLY on successful pair()
+ *  - finally closes the channel iff still owned
+ */
+async function runAttemptPattern(channel: Channel<Bytes>, pairOutcome: "success" | "throw" | "abort"): Promise<void> {
+    let socketOwned = true;
+    try {
+        if (pairOutcome === "success") {
+            socketOwned = false;
+        } else if (pairOutcome === "abort") {
+            throw new AbortedError("aborted");
+        } else {
+            throw new Error("pair failed");
+        }
+    } catch (e) {
+        if (AbortedError.is(e)) {
+            return;
+        }
+        throw e;
+    } finally {
+        if (socketOwned) {
+            await channel.close();
+        }
+    }
+}
+
+describe("PeerConnection socket ownership", () => {
+    describe("TCP", () => {
+        it("does not close the channel when pair() succeeds (session adopts it)", async () => {
+            const channel = mockChannel(ChannelType.TCP);
+            await runAttemptPattern(channel, "success");
+            expect(channel.closed).false;
+        });
+
+        it("closes the channel when pair() throws", async () => {
+            const channel = mockChannel(ChannelType.TCP);
+            await expect(runAttemptPattern(channel, "throw")).eventually.rejectedWith("pair failed");
+            expect(channel.closed).true;
+        });
+
+        it("closes the channel when pair() throws AbortedError", async () => {
+            const channel = mockChannel(ChannelType.TCP);
+            await runAttemptPattern(channel, "abort");
+            expect(channel.closed).true;
+        });
+    });
+
+    describe("UDP", () => {
+        it("does not close on success (session adopts the channel)", async () => {
+            const channel = mockChannel(ChannelType.UDP);
+            await runAttemptPattern(channel, "success");
+            expect(channel.closed).false;
+        });
+
+        it("invokes close on failure (harmless because real UdpChannel.close is a no-op)", async () => {
+            const channel = mockChannel(ChannelType.UDP);
+            await expect(runAttemptPattern(channel, "throw")).eventually.rejectedWith("pair failed");
+            expect(channel.closed).true;
+        });
+    });
+});

--- a/packages/protocol/test/peer/PeerConnectionSocketOwnershipTest.ts
+++ b/packages/protocol/test/peer/PeerConnectionSocketOwnershipTest.ts
@@ -105,6 +105,25 @@ describe("PeerConnection socket ownership", () => {
             await runAttemptPattern(channel, "abort");
             expect(channel.closed).true;
         });
+
+        it("does not close the channel when a later step throws after ownership transferred", async () => {
+            // Models the edge case where the secure session is adopted (socketOwned=false) and a
+            // subsequent statement throws. Cleanup must respect prior ownership transfer.
+            const channel = mockChannel(ChannelType.TCP);
+            const run = async () => {
+                let socketOwned = true;
+                try {
+                    socketOwned = false; // session adopted
+                    throw new Error("late failure after adoption");
+                } finally {
+                    if (socketOwned) {
+                        await channel.close();
+                    }
+                }
+            };
+            await expect(run()).eventually.rejectedWith("late failure after adoption");
+            expect(channel.closed).false;
+        });
     });
 
     describe("UDP", () => {

--- a/packages/react-native/src/ble/ReactNativeBleChannel.ts
+++ b/packages/react-native/src/ble/ReactNativeBleChannel.ts
@@ -37,7 +37,7 @@ export class ReactNativeBleCentralInterface implements Transport {
         this.#ble = ble;
     }
 
-    async openChannel(address: ServerAddress, _options?: Transport.ConnectOptions): Promise<Channel<Bytes>> {
+    async openChannel(address: ServerAddress, _options?: Transport.OpenChannelOptions): Promise<Channel<Bytes>> {
         if (!ServerAddress.isBle(address)) {
             throw new InternalError(`Unsupported address type for BLE channel.`);
         }

--- a/packages/react-native/src/ble/ReactNativeBleChannel.ts
+++ b/packages/react-native/src/ble/ReactNativeBleChannel.ts
@@ -37,7 +37,7 @@ export class ReactNativeBleCentralInterface implements Transport {
         this.#ble = ble;
     }
 
-    async openChannel(address: ServerAddress, _abort?: AbortSignal): Promise<Channel<Bytes>> {
+    async openChannel(address: ServerAddress, _options?: Transport.ConnectOptions): Promise<Channel<Bytes>> {
         if (!ServerAddress.isBle(address)) {
             throw new InternalError(`Unsupported address type for BLE channel.`);
         }

--- a/packages/react-native/src/ble/ReactNativeBleChannel.ts
+++ b/packages/react-native/src/ble/ReactNativeBleChannel.ts
@@ -37,7 +37,7 @@ export class ReactNativeBleCentralInterface implements Transport {
         this.#ble = ble;
     }
 
-    async openChannel(address: ServerAddress): Promise<Channel<Bytes>> {
+    async openChannel(address: ServerAddress, _abort?: AbortSignal): Promise<Channel<Bytes>> {
         if (!ServerAddress.isBle(address)) {
             throw new InternalError(`Unsupported address type for BLE channel.`);
         }

--- a/packages/react-native/src/net/NetworkReactNative.ts
+++ b/packages/react-native/src/net/NetworkReactNative.ts
@@ -192,7 +192,11 @@ export class NetworkReactNative extends Network {
         return TcpListenerReactNative.create(options);
     }
 
-    override async connectTcp(host: string, port: number): Promise<TcpConnection> {
-        return connectReactNativeTcp(host, port);
+    override async connectTcp(
+        host: string,
+        port: number,
+        options?: { timeout?: number; abort?: AbortSignal },
+    ): Promise<TcpConnection> {
+        return connectReactNativeTcp(host, port, options?.abort);
     }
 }

--- a/packages/react-native/src/net/NetworkReactNative.ts
+++ b/packages/react-native/src/net/NetworkReactNative.ts
@@ -31,6 +31,7 @@ import {
     NetworkInterfaceDetails,
     onSameNetwork,
     TcpConnection,
+    TcpConnectOptions,
     TcpListener,
     TcpListenerOptions,
     UdpSocket,
@@ -192,11 +193,7 @@ export class NetworkReactNative extends Network {
         return TcpListenerReactNative.create(options);
     }
 
-    override async connectTcp(
-        host: string,
-        port: number,
-        options?: { timeout?: number; abort?: AbortSignal },
-    ): Promise<TcpConnection> {
+    override async connectTcp(host: string, port: number, options?: TcpConnectOptions): Promise<TcpConnection> {
         return connectReactNativeTcp(host, port, options?.abort, options?.timeout);
     }
 }

--- a/packages/react-native/src/net/NetworkReactNative.ts
+++ b/packages/react-native/src/net/NetworkReactNative.ts
@@ -197,6 +197,6 @@ export class NetworkReactNative extends Network {
         port: number,
         options?: { timeout?: number; abort?: AbortSignal },
     ): Promise<TcpConnection> {
-        return connectReactNativeTcp(host, port, options?.abort);
+        return connectReactNativeTcp(host, port, options?.abort, options?.timeout);
     }
 }

--- a/packages/react-native/src/net/TcpConnectionReactNative.ts
+++ b/packages/react-native/src/net/TcpConnectionReactNative.ts
@@ -133,15 +133,12 @@ export class TcpConnectionReactNative implements TcpConnection {
             return;
         }
 
+        // react-native-tcp-socket Socket type lacks `once`; install a named handler and detach it manually.
+        let onClose: (() => void) | undefined;
         try {
-            // react-native-tcp-socket Socket type lacks `once`; dedupe manually.
             const closed = new Promise<void>(resolve => {
-                let resolved = false;
-                this.#socket.on("close", () => {
-                    if (resolved) return;
-                    resolved = true;
-                    resolve();
-                });
+                onClose = () => resolve();
+                this.#socket.on("close", onClose);
                 this.#socket.end();
             });
             await withTimeout(Seconds(5), closed, () => {
@@ -154,19 +151,32 @@ export class TcpConnectionReactNative implements TcpConnection {
             } catch (destroyError) {
                 logger.debug(`Error destroying TCP socket ${this.remoteAddress}:${this.remotePort}:`, destroyError);
             }
+        } finally {
+            if (onClose) {
+                this.#socket.off("close", onClose);
+            }
         }
     }
 }
 
 /** Create a client TCP connection using react-native-tcp-socket. */
-export function connectReactNativeTcp(host: string, port: number): Promise<TcpConnectionReactNative> {
+export function connectReactNativeTcp(
+    host: string,
+    port: number,
+    abort?: AbortSignal,
+): Promise<TcpConnectionReactNative> {
+    if (abort?.aborted) {
+        return Promise.reject(new NetworkError("TCP connect aborted"));
+    }
     let socket: RnSocket | undefined;
+    let onAbort: (() => void) | undefined;
 
     const connected = new Promise<TcpConnectionReactNative>((resolve, reject) => {
         let settled = false;
         const settle = (fn: () => void) => {
             if (!settled) {
                 settled = true;
+                if (onAbort) abort?.removeEventListener("abort", onAbort);
                 fn();
             }
         };
@@ -178,10 +188,20 @@ export function connectReactNativeTcp(host: string, port: number): Promise<TcpCo
         socket.on("error", (err: Error) => {
             settle(() => reject(tcpErrorFrom(err)));
         });
+
+        onAbort = () =>
+            settle(() => {
+                socket?.destroy();
+                reject(new NetworkError("TCP connect aborted"));
+            });
+        abort?.addEventListener("abort", onAbort, { once: true });
     });
 
     return withTimeout(TCP_CONNECT_TIMEOUT, connected, () => {
         socket?.destroy();
         throw new NetworkError("TCP connection timeout");
+    }).finally(() => {
+        // withTimeout's timeout path doesn't run settle; detach the abort listener defensively.
+        if (onAbort) abort?.removeEventListener("abort", onAbort);
     });
 }

--- a/packages/react-native/src/net/TcpConnectionReactNative.ts
+++ b/packages/react-native/src/net/TcpConnectionReactNative.ts
@@ -123,7 +123,9 @@ export class TcpConnectionReactNative implements TcpConnection {
     }
 
     async #doClose(): Promise<void> {
-        const alreadyClosed = this.#ended || this.#socket.destroyed;
+        // react-native-tcp-socket's exported Socket type does not surface `destroyed`, so we rely on
+        // #ended (set by the constructor's "close"/"error" handlers) to detect external closure.
+        const alreadyClosed = this.#ended;
         this.#ended = true;
         this.#waiter?.({ value: undefined as unknown as Bytes, done: true });
         this.#waiter = undefined;

--- a/packages/react-native/src/net/TcpConnectionReactNative.ts
+++ b/packages/react-native/src/net/TcpConnectionReactNative.ts
@@ -172,16 +172,22 @@ export function connectReactNativeTcp(
         return Promise.reject(new NetworkError("TCP connect aborted"));
     }
     let socket: RnSocket | undefined;
-    let onAbort: (() => void) | undefined;
+    let abortListener: (() => void) | undefined;
+
+    const detachAbort = () => {
+        if (abortListener !== undefined) {
+            abort?.removeEventListener("abort", abortListener);
+            abortListener = undefined;
+        }
+    };
 
     const connected = new Promise<TcpConnectionReactNative>((resolve, reject) => {
         let settled = false;
         const settle = (fn: () => void) => {
-            if (!settled) {
-                settled = true;
-                if (onAbort) abort?.removeEventListener("abort", onAbort);
-                fn();
-            }
+            if (settled) return;
+            settled = true;
+            detachAbort();
+            fn();
         };
 
         socket = createConnection({ host, port }, () => {
@@ -192,20 +198,17 @@ export function connectReactNativeTcp(
             settle(() => reject(tcpErrorFrom(err)));
         });
 
-        onAbort = () =>
+        abortListener = () =>
             settle(() => {
                 socket?.destroy();
                 reject(new NetworkError("TCP connect aborted"));
             });
-        abort?.addEventListener("abort", onAbort, { once: true });
+        abort?.addEventListener("abort", abortListener, { once: true });
     });
 
     const timeout = timeoutMs !== undefined ? Seconds(timeoutMs / 1000) : TCP_CONNECT_TIMEOUT;
     return withTimeout(timeout, connected, () => {
         socket?.destroy();
         throw new NetworkError("TCP connection timeout");
-    }).finally(() => {
-        // withTimeout's timeout path doesn't run settle; detach the abort listener defensively.
-        if (onAbort) abort?.removeEventListener("abort", onAbort);
-    });
+    }).finally(detachAbort);
 }

--- a/packages/react-native/src/net/TcpConnectionReactNative.ts
+++ b/packages/react-native/src/net/TcpConnectionReactNative.ts
@@ -123,7 +123,7 @@ export class TcpConnectionReactNative implements TcpConnection {
     }
 
     async #doClose(): Promise<void> {
-        const alreadyClosed = this.#ended;
+        const alreadyClosed = this.#ended || this.#socket.destroyed;
         this.#ended = true;
         this.#waiter?.({ value: undefined as unknown as Bytes, done: true });
         this.#waiter = undefined;
@@ -164,6 +164,7 @@ export function connectReactNativeTcp(
     host: string,
     port: number,
     abort?: AbortSignal,
+    timeoutMs?: number,
 ): Promise<TcpConnectionReactNative> {
     if (abort?.aborted) {
         return Promise.reject(new NetworkError("TCP connect aborted"));
@@ -197,7 +198,8 @@ export function connectReactNativeTcp(
         abort?.addEventListener("abort", onAbort, { once: true });
     });
 
-    return withTimeout(TCP_CONNECT_TIMEOUT, connected, () => {
+    const timeout = timeoutMs !== undefined ? Seconds(timeoutMs / 1000) : TCP_CONNECT_TIMEOUT;
+    return withTimeout(timeout, connected, () => {
         socket?.destroy();
         throw new NetworkError("TCP connection timeout");
     }).finally(() => {

--- a/packages/react-native/src/net/TcpConnectionReactNative.ts
+++ b/packages/react-native/src/net/TcpConnectionReactNative.ts
@@ -6,6 +6,7 @@
 
 import {
     Bytes,
+    Logger,
     NetworkError,
     Seconds,
     TCP_CONNECTION_TIMEOUT_MS,
@@ -16,6 +17,8 @@ import {
     type TcpConnection,
 } from "@matter/general";
 import { createConnection, type Socket as RnSocket } from "react-native-tcp-socket";
+
+const logger = Logger.get("TcpConnectionReactNative");
 
 /** Connection timeout as Duration for withTimeout. */
 const TCP_CONNECT_TIMEOUT = Seconds(TCP_CONNECTION_TIMEOUT_MS / 1000);
@@ -30,6 +33,7 @@ export class TcpConnectionReactNative implements TcpConnection {
     readonly localPort: number;
     readonly #socket: RnSocket;
     #ended = false;
+    #closePromise?: Promise<void>;
     #chunks = new Array<Bytes>();
     #waiter?: (value: IteratorResult<Bytes>) => void;
 
@@ -113,19 +117,44 @@ export class TcpConnectionReactNative implements TcpConnection {
         };
     }
 
-    async close(): Promise<void> {
-        if (this.#ended) return;
+    close(): Promise<void> {
+        // Memoize so concurrent callers share one teardown — each `await close()` waits for actual shutdown.
+        return (this.#closePromise ??= this.#doClose());
+    }
+
+    async #doClose(): Promise<void> {
+        const alreadyClosed = this.#ended;
         this.#ended = true;
         this.#waiter?.({ value: undefined as unknown as Bytes, done: true });
         this.#waiter = undefined;
 
-        const closed = new Promise<void>(resolve => {
-            this.#socket.on("close", () => resolve());
-            this.#socket.end();
-        });
-        await withTimeout(Seconds(5), closed, () => {
-            this.#socket.destroy();
-        });
+        // Already closed externally; a fresh "close" listener wouldn't fire and would stall #closePromise.
+        if (alreadyClosed) {
+            return;
+        }
+
+        try {
+            // react-native-tcp-socket Socket type lacks `once`; dedupe manually.
+            const closed = new Promise<void>(resolve => {
+                let resolved = false;
+                this.#socket.on("close", () => {
+                    if (resolved) return;
+                    resolved = true;
+                    resolve();
+                });
+                this.#socket.end();
+            });
+            await withTimeout(Seconds(5), closed, () => {
+                this.#socket.destroy();
+            });
+        } catch (error) {
+            logger.warn(`Error closing TCP connection ${this.remoteAddress}:${this.remotePort}:`, error);
+            try {
+                this.#socket.destroy();
+            } catch (destroyError) {
+                logger.debug(`Error destroying TCP socket ${this.remoteAddress}:${this.remotePort}:`, destroyError);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Staggered CASE could leak TCP sockets when a connection attempt opened a socket but failed/aborted before `CaseClient.pair()` established a secure session. `MessageChannel.close` deliberately skips TCP teardown (the comment at `MessageChannel.ts:189` states sessions own that lifecycle), so the abandoned channel stayed registered in `TcpTransport` until the peer eventually dropped it via keepalive `ETIMEDOUT`.

Observed in a controller log where a peer's link-local fe80 TCP socket emitted `ETIMEDOUT` ~98s after CASE actually succeeded on the peer's ULA fdb8 address — no Matter session was ever bound to fe80, only fdb8.

## Changes

- **PeerConnection.attemptOnce** — Track socket ownership with a `socketOwned` flag; flip to `false` only when `pair()` returns successfully. Outer `finally` closes the channel when no secure session adopted it. UDP close is a no-op so the path is safe for both transports.
- **CaseClient.pair** — Make `saveResumptionRecord` non-fatal (mirrors the existing `messenger.close` try/catch pattern). A persistence failure must not reject `pair()` after the session has already been adopted into the manager, since that would leave callers to tear down a channel under a live session.
- **NodeJsTcpConnection / TcpConnectionReactNative `close()`** — Memoize the close promise so concurrent callers share one teardown and every `await close()` waits for the real shutdown. Early-return when the socket has already closed externally (`#ended` set by constructor's close/error handler, or `socket.destroyed` on Node) so the close promise never stalls waiting on a `"close"` event that already fired.
- **SustainedSubscription** — Downgrade the transient "failed to establish subscription, retry in N" message from `error` to `info`. This is a retry-with-backoff path; an error log here is misleading.

## Verification of scope

- BLE / BTP unaffected: PASE+BLE goes through \`ControllerCommissioner.ts:349\` calling \`ble.openChannel(address)\` directly. \`PeerSet.#openSocket\` only routes \`ChannelType.TCP | ChannelType.UDP\`; BLE never traverses \`attemptOnce\` either.
- Cross-reviewed by codex (gpt-5.3-codex, xhigh reasoning) twice. Findings from first pass: (1) earlier \`PeerSet.#openSocket\` cleanup was unsafe for shared TcpTransport channels — reverted; (2) \`socketOwned\` flipped too late vs. \`saveResumptionRecord\` — addressed in CaseClient; (3) \`close()\` lost close-as-barrier semantics for concurrent callers — fixed via promise memoization. Second pass found a deadlock risk if socket closed before \`close()\` invoked — fixed via early-return on \`#ended\`/\`destroyed\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)