### PR TITLE
fix(model): default decorator-declared attributes to read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/model
     - Breaking: Type-specific Model subfields such as "clusters" and "attributes" no longer support array-like positional access; use `Matter.clusters.at(4)` instead of `Matter.clusters[4]`
-    - Breaking: Attributes declared by decorators (`@attribute(...)`) now default to read-only (`R V`); apply the `writable` decorator to attributes that must accept writes.
+    - Breaking: Attributes declared by decorators (`@attribute(...)`) now default to read-only (`R V`); apply the `writable` decorator to attributes that must accept writes
     - Enhancement: First Model preparations for Matter 1.5 and 1.5.1
     - Enhancement: The fluent API for manipulating the Matter data model is improved
     - Enhancement: Enhances decorator capabilities for attributes, clusters, and (matter and non-matter) commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/model
     - Breaking: Type-specific Model subfields such as "clusters" and "attributes" no longer support array-like positional access; use `Matter.clusters.at(4)` instead of `Matter.clusters[4]`
+    - Breaking: Attributes declared by decorators (`@attribute(...)`) now default to read-only (`R V`); apply the `writable` decorator to attributes that must accept writes.
     - Enhancement: First Model preparations for Matter 1.5 and 1.5.1
     - Enhancement: The fluent API for manipulating the Matter data model is improved
     - Enhancement: Enhances decorator capabilities for attributes, clusters, and (matter and non-matter) commands

--- a/packages/model/src/decoration/decorators/attribute.ts
+++ b/packages/model/src/decoration/decorators/attribute.ts
@@ -4,10 +4,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Access } from "#aspects/index.js";
+import { FieldSemantics } from "#decoration/semantics/FieldSemantics.js";
 import { AttributeModel } from "#models/AttributeModel.js";
+import { ValueModel } from "#models/ValueModel.js";
+import { Decorator } from "@matter/general";
 import { element } from "./element.js";
 
 /**
- * Decorates a property as a Matter attribute.
+ * Default access for decorator-declared attributes: read-only with View read privilege.  Matches the spec convention
+ * "R V" so decorator-declared attributes inherit the same default as spec-defined attributes.  Use the `writable`
+ * decorator to mark an attribute as writable.
  */
-export const attribute = element.property(AttributeModel);
+const defaultAttributeAccess = Decorator<Decorator.PropertyCollector>((_target, context) => {
+    const model = FieldSemantics.of(context).mutableModel;
+    if (model instanceof ValueModel && model.access.rw === undefined) {
+        model.access = new Access({ ...model.access, rw: Access.Rw.Read, readPriv: Access.Privilege.View });
+    }
+});
+
+/**
+ * Decorates a property as a Matter attribute.
+ *
+ * Decorator-declared attributes default to read-only.  Apply the `writable` decorator to mark an attribute as
+ * writable.
+ */
+export const attribute = (...modifiers: element.Modifier<Decorator.PropertyCollector>[]) =>
+    element(AttributeModel, defaultAttributeAccess, ...modifiers);

--- a/packages/model/src/decoration/decorators/attribute.ts
+++ b/packages/model/src/decoration/decorators/attribute.ts
@@ -12,9 +12,15 @@ import { Decorator } from "@matter/general";
 import { element } from "./element.js";
 
 /**
- * Default access for decorator-declared attributes: read-only with View read privilege.  Matches the spec convention
- * "R V" so decorator-declared attributes inherit the same default as spec-defined attributes.  Use the `writable`
- * decorator to mark an attribute as writable.
+ * Default access for decorator-declared attributes: read-only with View read privilege ("R V"), the Matter spec
+ * convention for read-only attributes.
+ *
+ * `readPriv` must be set alongside `rw: Read`: without it, `Access.isEmpty` reports true and `Access.extend` discards
+ * the value during effective-access resolution, causing `Access.Default` (`RW V O`) to win and silently reverting
+ * this default.
+ *
+ * The `writable` decorator overrides `rw` to `ReadWrite`; the resulting access then extends against `Access.Default`
+ * to recover `writePriv: Operate`.
  */
 const defaultAttributeAccess = Decorator<Decorator.PropertyCollector>((_target, context) => {
     const model = FieldSemantics.of(context).mutableModel;

--- a/packages/model/src/decoration/decorators/attribute.ts
+++ b/packages/model/src/decoration/decorators/attribute.ts
@@ -11,17 +11,6 @@ import { ValueModel } from "#models/ValueModel.js";
 import { Decorator } from "@matter/general";
 import { element } from "./element.js";
 
-/**
- * Default access for decorator-declared attributes: read-only with View read privilege ("R V"), the Matter spec
- * convention for read-only attributes.
- *
- * `readPriv` must be set alongside `rw: Read`: without it, `Access.isEmpty` reports true and `Access.extend` discards
- * the value during effective-access resolution, causing `Access.Default` (`RW V O`) to win and silently reverting
- * this default.
- *
- * The `writable` decorator overrides `rw` to `ReadWrite`; the resulting access then extends against `Access.Default`
- * to recover `writePriv: Operate`.
- */
 const defaultAttributeAccess = Decorator<Decorator.PropertyCollector>((_target, context) => {
     const model = FieldSemantics.of(context).mutableModel;
     if (model instanceof ValueModel && model.access.rw === undefined) {
@@ -32,8 +21,13 @@ const defaultAttributeAccess = Decorator<Decorator.PropertyCollector>((_target, 
 /**
  * Decorates a property as a Matter attribute.
  *
- * Decorator-declared attributes default to read-only.  Apply the `writable` decorator to mark an attribute as
- * writable.
+ * Decorator-declared attributes default to read-only access (`R V`) — the Matter spec convention for read-only
+ * attributes.  Apply the `writable` decorator to mark an attribute as writable; that yields `RW V O` via
+ * `Access.Default` extension.
+ *
+ * `readPriv: View` must be set alongside `rw: Read` in the default: without it `Access.isEmpty` reports true and
+ * `Access.extend` discards the value during effective-access resolution, silently reinstating `Access.Default`
+ * (`RW V O`).
  */
 export const attribute = (...modifiers: element.Modifier<Decorator.PropertyCollector>[]) =>
     element(AttributeModel, defaultAttributeAccess, ...modifiers);

--- a/packages/model/test/decoration/semantics/FieldSemanticsTest.ts
+++ b/packages/model/test/decoration/semantics/FieldSemanticsTest.ts
@@ -81,6 +81,21 @@ describe("FieldSemantics", () => {
         expect(bar!.access.writable).false;
     });
 
+    it("defaults attributes to read-only", () => {
+        class Foo {
+            @attribute(0x1, uint32)
+            bar = 4;
+        }
+
+        const schema = Schema.Required(Foo);
+        expect(schema.children.length).equals(1);
+        const bar = schema.get(AttributeModel, "bar");
+        expect(bar).not.undefined;
+        expect(bar!.access.readable).true;
+        expect(bar!.access.writable).false;
+        expect(bar!.writable).false;
+    });
+
     it("sets writable", () => {
         class Foo {
             @attribute(0x1, uint32, writable)
@@ -95,6 +110,7 @@ describe("FieldSemantics", () => {
         expect(bar!.quality.nonvolatile).not.true;
         expect(bar!.access.readable).true;
         expect(bar!.access.writable).true;
+        expect(bar!.writable).true;
     });
 
     it("merges with base class", () => {


### PR DESCRIPTION
## Summary

- `@attribute(...)` previously left the model's access aspect empty, so `effectiveAccess` fell through to `Access.Default` (`RW V O`).  `AttributeModel.writable`, `AccessControl.limitsFor`, generated descriptions and the client-side `AttributeClient.set` guard all then reported the attribute as writable regardless of intent.
- The decorator now injects `{rw: Read, readPriv: View}` (= `R V`).  `readPriv` is load-bearing — without it `Access.isEmpty` would treat the value as empty and `Access.extend` would discard it during effective-access resolution, silently reinstating `Access.Default`.
- The existing `writable` decorator still flips `rw` to `ReadWrite`; the resulting access then extends against `Access.Default` to recover `writePriv: Operate`.

Breaking for any decorator-declared attribute that relied on the previous RW default — apply `writable` explicitly to attributes that must accept writes.

Supersedes the original motivation for #3192: that PR only mutated raw access and had no effect on `effectiveAccess`-based gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)