### PR TITLE
fix(protocol): auto-detect Large Message Quality on client invoke

### DIFF
--- a/packages/protocol/src/action/client/ClientInteraction.ts
+++ b/packages/protocol/src/action/client/ClientInteraction.ts
@@ -8,6 +8,7 @@ import { ClientBdxRequest, ClientBdxResponse } from "#action/client/ClientBdx.js
 import { ClientRead } from "#action/client/ClientRead.js";
 import { Interactable, InteractionSession } from "#action/Interactable.js";
 import { ClientInvoke, Invoke } from "#action/request/Invoke.js";
+import { MalformedRequestError } from "#action/request/MalformedRequestError.js";
 import { Read } from "#action/request/Read.js";
 import { resolvePathForSpecifier } from "#action/request/Specifier.js";
 import { Subscribe } from "#action/request/Subscribe.js";
@@ -65,6 +66,32 @@ const MAX_COMMAND_REF = 0xffff;
 
 /** Higher processing time to give devices a bit more time to send updates. */
 const SUBSCRIPTION_PROCESSING_TIME = Seconds(10);
+
+/**
+ * Probe commands in a {@link ClientInvoke} for the Matter "Large Message Quality" ("L") flag.
+ *
+ * Legacy command requests carry no model reference, so callers using {@link Invoke.LegacyCommandRequest}
+ * must continue to set {@link ClientInvoke.largeMessage} explicitly.
+ *
+ * @internal — exported for unit testing.
+ */
+export function inferLargeMessage(request: ClientInvoke): boolean {
+    for (const cmd of request.commands.values()) {
+        if (Invoke.isLegacy(cmd)) {
+            continue;
+        }
+        try {
+            const command = Invoke.commandOf(cmd);
+            if (command.schema?.effectiveQuality?.largeMessage) {
+                return true;
+            }
+        } catch (error) {
+            // Swallow only resolution errors — downstream encode will surface them with full context.
+            MalformedRequestError.accept(error);
+        }
+    }
+    return false;
+}
 
 interface PendingCommand {
     request: Invoke.ConcreteCommandRequest<any>;
@@ -531,6 +558,10 @@ export class ClientInteraction<
      * when the device supports multiple invokes per exchange and the target is not endpoint 0.
      */
     async *invoke(request: ClientInvoke, session?: SessionT): DecodedInvokeResult {
+        if (request.largeMessage === undefined && inferLargeMessage(request)) {
+            request.largeMessage = true;
+        }
+
         // Large Message Quality commands must not be batched and require TCP
         if (request.largeMessage) {
             yield* this.#invokeSingle(request, session);

--- a/packages/protocol/src/action/client/ClientInteraction.ts
+++ b/packages/protocol/src/action/client/ClientInteraction.ts
@@ -562,20 +562,19 @@ export class ClientInteraction<
             request.largeMessage = true;
         }
 
-        // Large Message Quality commands must not be batched and require TCP
-        if (request.largeMessage) {
-            yield* this.#invokeSingle(request, session);
-            return;
-        }
-
         const maxPathsPerInvoke = this.#exchangeProvider.maxPathsPerInvoke ?? 1;
 
-        // Single command with batching support — auto-batch
-        if (request.invokeRequests.length === 1 && request.batchDuration !== false && maxPathsPerInvoke) {
-            const endpointId = request.invokeRequests[0].commandPath.endpointId;
-            if (endpointId !== undefined && endpointId !== 0 && !request.timedRequest) {
-                yield* this.#invokeWithBatching(request, session);
-                return;
+        // Large Message Quality commands must not be batched (per spec) but still respect the
+        // peer's MaxPathsPerInvoke — splitting propagates largeMessage to each sub-batch, which
+        // in turn forces TCP transport via #begin.
+        if (!request.largeMessage) {
+            // Single command with batching support — auto-batch
+            if (request.invokeRequests.length === 1 && request.batchDuration !== false && maxPathsPerInvoke) {
+                const endpointId = request.invokeRequests[0].commandPath.endpointId;
+                if (endpointId !== undefined && endpointId !== 0 && !request.timedRequest) {
+                    yield* this.#invokeWithBatching(request, session);
+                    return;
+                }
             }
         }
 

--- a/packages/protocol/test/action/InvokeLargeMessageTest.ts
+++ b/packages/protocol/test/action/InvokeLargeMessageTest.ts
@@ -285,4 +285,61 @@ describe("Invoke largeMessage flag", () => {
             expect(invoke.largeMessage).to.equal(false);
         });
     });
+
+    describe("ClientInteraction.invoke routing decision", () => {
+        // Mirror of the routing decision at ClientInteraction.invoke. Pins the contract that L
+        // commands skip batching (per spec) but still respect MaxPathsPerInvoke via splitting.
+        // Note: ClientInteraction.#invokeSingle does not enforce MaxPathsPerInvoke itself, so a
+        // multi-command L invoke routed directly to #invokeSingle would violate the peer limit.
+        type Route = "batched" | "split" | "single";
+        function decideRoute(request: ReturnType<typeof Invoke>, maxPathsPerInvoke: number): Route {
+            if (request.largeMessage === undefined && inferLargeMessage(request)) {
+                request.largeMessage = true;
+            }
+            if (!request.largeMessage) {
+                if (request.invokeRequests.length === 1 && request.batchDuration !== false && maxPathsPerInvoke) {
+                    const endpointId = request.invokeRequests[0].commandPath.endpointId;
+                    if (endpointId !== undefined && endpointId !== 0 && !request.timedRequest) {
+                        return "batched";
+                    }
+                }
+            }
+            return request.commands.size > maxPathsPerInvoke ? "split" : "single";
+        }
+
+        const provideOffer = () =>
+            Invoke.ConcreteCommandRequest({
+                endpoint: EndpointNumber(2),
+                cluster: WebRtcTransportProvider,
+                command: "provideOffer",
+                fields: {
+                    webRtcSessionId: null,
+                    sdp: "v=0",
+                    streamUsage: 3,
+                    originatingEndpointId: 2,
+                },
+            });
+
+        it("routes a single L command to #invokeSingle", () => {
+            const invoke = Invoke({ commands: [provideOffer()] });
+            expect(decideRoute(invoke, 1)).to.equal("single");
+        });
+
+        it("splits a multi-command L invoke when count exceeds MaxPathsPerInvoke", () => {
+            const invoke = Invoke({
+                commands: [
+                    { ...provideOffer(), commandRef: 0 },
+                    { ...provideOffer(), commandRef: 1 },
+                ],
+            });
+            expect(decideRoute(invoke, 1)).to.equal("split");
+        });
+
+        it("does not batch L commands even when batchable shape allows it", () => {
+            const invoke = Invoke({ commands: [provideOffer()] });
+            // Batching kicks in for a single non-timed command at endpoint != 0 with a peer that
+            // accepts batches. Verify the L flag suppresses that path.
+            expect(decideRoute(invoke, 8)).to.equal("single");
+        });
+    });
 });

--- a/packages/protocol/test/action/InvokeLargeMessageTest.ts
+++ b/packages/protocol/test/action/InvokeLargeMessageTest.ts
@@ -250,12 +250,10 @@ describe("Invoke largeMessage flag", () => {
     });
 
     describe("ClientInteraction.invoke inference policy", () => {
-        // The auto-detect at ClientInteraction.invoke entry is a two-line gate:
-        //   if (request.largeMessage === undefined && inferLargeMessage(request)) {
-        //       request.largeMessage = true;
-        //   }
-        // This block pins the precedence so a future "simplification" cannot silently override
-        // an explicit caller decision.
+        // Mirrors the first two statements of ClientInteraction.invoke() in
+        // packages/protocol/src/action/client/ClientInteraction.ts. KEEP IN SYNC if the
+        // production gate changes. Pins the precedence: an explicit largeMessage decision must
+        // win over the inference, otherwise callers cannot opt out of TCP routing.
         function applyInferencePolicy(request: ReturnType<typeof Invoke>) {
             if (request.largeMessage === undefined && inferLargeMessage(request)) {
                 request.largeMessage = true;
@@ -287,10 +285,12 @@ describe("Invoke largeMessage flag", () => {
     });
 
     describe("ClientInteraction.invoke routing decision", () => {
-        // Mirror of the routing decision at ClientInteraction.invoke. Pins the contract that L
-        // commands skip batching (per spec) but still respect MaxPathsPerInvoke via splitting.
-        // Note: ClientInteraction.#invokeSingle does not enforce MaxPathsPerInvoke itself, so a
-        // multi-command L invoke routed directly to #invokeSingle would violate the peer limit.
+        // Mirrors the dispatch logic in ClientInteraction.invoke() at
+        // packages/protocol/src/action/client/ClientInteraction.ts (post-inference block through
+        // the splitting/single fall-through). KEEP IN SYNC. The contract pinned here is: L
+        // commands skip batching but still split on MaxPathsPerInvoke — #invokeSingle does not
+        // enforce the path limit itself, so routing a multi-command L invoke directly there
+        // would violate the peer limit.
         type Route = "batched" | "split" | "single";
         function decideRoute(request: ReturnType<typeof Invoke>, maxPathsPerInvoke: number): Route {
             if (request.largeMessage === undefined && inferLargeMessage(request)) {

--- a/packages/protocol/test/action/InvokeLargeMessageTest.ts
+++ b/packages/protocol/test/action/InvokeLargeMessageTest.ts
@@ -4,10 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { inferLargeMessage } from "#action/client/ClientInteraction.js";
 import { Invoke } from "#action/request/Invoke.js";
 import { CommandModel, Quality } from "@matter/model";
-import { EndpointNumber } from "@matter/types";
+import { ClusterId, CommandId, EndpointNumber, TlvNoArguments } from "@matter/types";
 import { OnOffCluster } from "@matter/types/clusters/on-off";
+import { WebRtcTransportProvider } from "@matter/types/clusters/web-rtc-transport-provider";
 
 /**
  * Tests for the largeMessage flag on Invoke requests.
@@ -96,6 +98,191 @@ describe("Invoke largeMessage flag", () => {
             const noModel = undefined as CommandModel | undefined;
             const flagNone = !!noModel?.effectiveQuality.largeMessage;
             expect(flagNone).to.equal(false);
+        });
+    });
+
+    describe("inferLargeMessage", () => {
+        it("detects L quality on a concrete command request", () => {
+            const invoke = Invoke({
+                commands: [
+                    Invoke.ConcreteCommandRequest({
+                        endpoint: EndpointNumber(2),
+                        cluster: WebRtcTransportProvider,
+                        command: "provideOffer",
+                        fields: {
+                            webRtcSessionId: null,
+                            sdp: "v=0",
+                            streamUsage: 3,
+                            originatingEndpointId: 2,
+                        },
+                    }),
+                ],
+            });
+
+            expect(inferLargeMessage(invoke)).to.equal(true);
+        });
+
+        it("returns false for a command without L quality", () => {
+            const invoke = Invoke({
+                commands: [
+                    Invoke.ConcreteCommandRequest({
+                        endpoint: EndpointNumber(1),
+                        cluster: OnOffCluster,
+                        command: "toggle",
+                    }),
+                ],
+            });
+
+            expect(inferLargeMessage(invoke)).to.equal(false);
+        });
+
+        it("flags the whole invoke when any one command carries L quality", () => {
+            const invoke = Invoke({
+                commands: [
+                    Invoke.ConcreteCommandRequest({
+                        endpoint: EndpointNumber(1),
+                        cluster: OnOffCluster,
+                        command: "toggle",
+                        commandRef: 0,
+                    }),
+                    Invoke.ConcreteCommandRequest({
+                        endpoint: EndpointNumber(2),
+                        cluster: WebRtcTransportProvider,
+                        command: "provideOffer",
+                        fields: {
+                            webRtcSessionId: null,
+                            sdp: "v=0",
+                            streamUsage: 3,
+                            originatingEndpointId: 2,
+                        },
+                        commandRef: 1,
+                    }),
+                ],
+            });
+
+            expect(inferLargeMessage(invoke)).to.equal(true);
+        });
+
+        it("ignores legacy command requests (no model link)", () => {
+            const invoke = Invoke({
+                commands: [
+                    {
+                        endpoint: EndpointNumber(1),
+                        cluster: { id: ClusterId(0x1234), name: "Custom" },
+                        command: {
+                            requestId: CommandId(0x05),
+                            requestSchema: TlvNoArguments,
+                            responseSchema: TlvNoArguments,
+                            timed: false,
+                        },
+                    },
+                ],
+            });
+
+            expect(inferLargeMessage(invoke)).to.equal(false);
+        });
+
+        it("detects L quality on a wildcard command request", () => {
+            const invoke = Invoke({
+                commands: [
+                    Invoke.WildcardCommandRequest({
+                        cluster: WebRtcTransportProvider,
+                        command: "provideOffer",
+                        fields: {
+                            webRtcSessionId: null,
+                            sdp: "v=0",
+                            streamUsage: 3,
+                            originatingEndpointId: 2,
+                        },
+                    }),
+                ],
+            });
+
+            expect(inferLargeMessage(invoke)).to.equal(true);
+        });
+
+        it("swallows MalformedRequestError when cluster/command unresolved", () => {
+            // Build via the factory then replace with an unresolvable specifier — the factory itself
+            // rejects unresolvable specifiers up-front, so we bypass it to exercise the catch path.
+            const invoke = Invoke({
+                commands: [
+                    Invoke.ConcreteCommandRequest({
+                        endpoint: EndpointNumber(1),
+                        cluster: OnOffCluster,
+                        command: "toggle",
+                    }),
+                ],
+            });
+            invoke.commands.clear();
+            invoke.commands.set(0, {
+                endpoint: EndpointNumber(1),
+                cluster: { id: ClusterId(0x1234), name: "Unknown" },
+                command: "nonexistent",
+            } as unknown as Invoke.ConcreteCommandRequest);
+
+            expect(inferLargeMessage(invoke)).to.equal(false);
+        });
+
+        it("rethrows non-MalformedRequestError raised during model probing", () => {
+            const invoke = Invoke({
+                commands: [
+                    Invoke.ConcreteCommandRequest({
+                        endpoint: EndpointNumber(1),
+                        cluster: OnOffCluster,
+                        command: "toggle",
+                    }),
+                ],
+            });
+            invoke.commands.set(0, {
+                endpoint: EndpointNumber(1),
+                cluster: { id: ClusterId(0x1234), name: "Custom" },
+                command: {
+                    // Non-legacy (no requestId), non-string — commandOf returns this object as-is,
+                    // then the schema access throws an unrelated error which must propagate.
+                    get schema(): never {
+                        throw new TypeError("simulated bug");
+                    },
+                },
+            } as unknown as Invoke.ConcreteCommandRequest);
+
+            expect(() => inferLargeMessage(invoke)).to.throw(TypeError, "simulated bug");
+        });
+    });
+
+    describe("ClientInteraction.invoke inference policy", () => {
+        // The auto-detect at ClientInteraction.invoke entry is a two-line gate:
+        //   if (request.largeMessage === undefined && inferLargeMessage(request)) {
+        //       request.largeMessage = true;
+        //   }
+        // This block pins the precedence so a future "simplification" cannot silently override
+        // an explicit caller decision.
+        function applyInferencePolicy(request: ReturnType<typeof Invoke>) {
+            if (request.largeMessage === undefined && inferLargeMessage(request)) {
+                request.largeMessage = true;
+            }
+        }
+
+        it("preserves an explicit largeMessage:false on a command with L quality", () => {
+            const invoke = Invoke({
+                commands: [
+                    Invoke.ConcreteCommandRequest({
+                        endpoint: EndpointNumber(2),
+                        cluster: WebRtcTransportProvider,
+                        command: "provideOffer",
+                        fields: {
+                            webRtcSessionId: null,
+                            sdp: "v=0",
+                            streamUsage: 3,
+                            originatingEndpointId: 2,
+                        },
+                    }),
+                ],
+            });
+            invoke.largeMessage = false;
+
+            applyInferencePolicy(invoke);
+
+            expect(invoke.largeMessage).to.equal(false);
         });
     });
 });


### PR DESCRIPTION
## Summary
- `ClientInteraction.invoke()` now inspects `effectiveQuality.largeMessage` on each command at entry and sets `request.largeMessage = true` when any command carries the "L" flag — unless the caller already set the flag explicitly (true or false), which is preserved.
- Closes the gap where direct `ClientInteraction.invoke()` callers (legacy `InteractionClient.#invoke`, controller WebSocket handlers, `ControllerCommissioningFlow.#invokeCommand`, custom code building `Invoke` objects) silently sent oversized payloads over UDP and tripped `MessageChannel maxPayloadSize` warnings — e.g. `WebRtcTransportProvider.ProvideOffer` with a multi-KB SDP.
- `ClientCommandMethod` path is unaffected: it still sets the flag explicitly, taking the fast path.
- Legacy command requests carry no model reference and continue to require an explicit `largeMessage` setting from the caller.

New tests cover: concrete L command, no-L baseline, mixed-batch (one L flips whole invoke), legacy fall-through, wildcard L command, `MalformedRequestError` swallow on unresolved cluster/command, narrowing rethrows non-`MalformedRequestError`, and explicit `largeMessage: false` preservation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)