### PR TITLE
feat(main): expose runtime version from @matter/main

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -116,6 +116,10 @@ jobs:
         if: steps.automerge.outputs.mergeResult == 'merged'
         run: npm run version -- --apply
 
+      - name: Stamp runtime version constant
+        if: steps.automerge.outputs.mergeResult == 'merged'
+        run: node tools/set-version.mjs
+
       - name: Publish npm
         if: steps.automerge.outputs.mergeResult == 'merged'
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,8 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Several previous "Zigbee only" features, attributes and commands were removed because they were never allowed for Matter
 
 - @matter/\*
+    - Upgraded to Matter specification version 1.5
     - 20%–50% RAM usage reductions and improvements
-
-- @matter/model
-    - Breaking: Type-specific Model subfields such as "clusters" and "attributes" no longer support array-like positional access; use `Matter.clusters.at(4)` instead of `Matter.clusters[4]`
-    - Breaking: Attributes declared by decorators (`@attribute(...)`) now default to read-only (`R V`); apply the `writable` decorator to attributes that must accept writes
-    - Enhancement: First Model preparations for Matter 1.5 and 1.5.1
-    - Enhancement: The fluent API for manipulating the Matter data model is improved
-    - Enhancement: Enhances decorator capabilities for attributes, clusters, and (matter and non-matter) commands
 
 - @matter/general
     - Breaking: Blob/File-related storage methods were removed from the normal Storage implementation
@@ -35,8 +29,15 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: Added Storage Migration logic that can generically migrate between different storage engines
     - Enhancement: `LogFormat.format` renders any Diagnostic-loggable value to a string in the specified format (defaults to plain text)
 
-- @matter/\*:
-    - Upgraded to Matter specification version 1.5
+- @matter/main
+    - Feature: Added `version` string export that exposes the published matter.js version
+
+- @matter/model
+    - Breaking: Type-specific Model subfields such as "clusters" and "attributes" no longer support array-like positional access; use `Matter.clusters.at(4)` instead of `Matter.clusters[4]`
+    - Breaking: Attributes declared by decorators (`@attribute(...)`) now default to read-only (`R V`); apply the `writable` decorator to attributes that must accept writes
+    - Enhancement: First Model preparations for Matter 1.5 and 1.5.1
+    - Enhancement: The fluent API for manipulating the Matter data model is improved
+    - Enhancement: Enhances decorator capabilities for attributes, clusters, and (matter and non-matter) commands
 
 - @matter/node
     - Feature: (@adeepn) Added `DclBehavior` for centralized DCL configuration via environment variables (`MATTER_DCL_*`), config files, or programmatic setup

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -10,3 +10,4 @@ export { Environment } from "@matter/general";
 export { Matter } from "@matter/model";
 export * from "@matter/node";
 export * from "@matter/types/datatype";
+export { version } from "./version.js";

--- a/packages/main/src/version.ts
+++ b/packages/main/src/version.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const version: string = "0.0.0-git";

--- a/tools/set-version.mjs
+++ b/tools/set-version.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Stamps the runtime version constant for @matter/main.
+ *
+ * Reads the target version from argv[2] or, if absent, from version.txt at
+ * repo root. Replaces the literal "0.0.0-git" with the stamped value in:
+ *   - packages/main/src/version.ts
+ *   - packages/main/dist/esm/version.js
+ *   - packages/main/dist/cjs/version.js
+ *
+ * Each target file must contain the placeholder exactly once. If the
+ * placeholder is missing, the script exits non-zero — that means a prior
+ * run already stamped the tree (or the file shape changed unexpectedly).
+ *
+ * The script is invoked by the release workflow only. Local developers
+ * never run it.
+ */
+
+import { readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const PLACEHOLDER = "0.0.0-git";
+const VERSION_RE = /^(?:\d+\.\d+\.\d+(?:-[a-z0-9.-]+)?|[a-z]+)$/;
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const TARGETS = [
+    "packages/main/src/version.ts",
+    "packages/main/dist/esm/version.js",
+    "packages/main/dist/cjs/version.js",
+];
+
+async function readTargetVersion() {
+    if (process.argv[2]) {
+        return process.argv[2].trim();
+    }
+    const text = await readFile(resolve(repoRoot, "version.txt"), "utf8");
+    const trimmed = text.trim();
+    if (!trimmed) {
+        throw new Error("version.txt is empty");
+    }
+    return trimmed;
+}
+
+async function stamp(relPath, version) {
+    const abs = resolve(repoRoot, relPath);
+    const original = await readFile(abs, "utf8");
+    const literal = `"${PLACEHOLDER}"`;
+    const occurrences = original.split(literal).length - 1;
+    if (occurrences !== 1) {
+        throw new Error(
+            `Expected exactly one occurrence of ${literal} in ${relPath}, found ${occurrences}. ` +
+                `Either the placeholder was already stamped or the file shape changed.`,
+        );
+    }
+    const updated = original.replace(literal, `"${version}"`);
+    await writeFile(abs, updated);
+    console.log(`stamped ${relPath} -> ${version}`);
+}
+
+async function main() {
+    const version = await readTargetVersion();
+    if (!VERSION_RE.test(version)) {
+        throw new Error(`Version ${version} is invalid (must match ${VERSION_RE}).`);
+    }
+    for (const target of TARGETS) {
+        await stamp(target, version);
+    }
+}
+
+main().catch(err => {
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add `version` string export to `@matter/main`, backed by a placeholder source file that ships `"0.0.0-git"` in git.
- Add `tools/set-version.mjs` to stamp the placeholder at release time (mirrors the existing `package.json` version-bump pattern — source file in git always stays at the placeholder, the release runner mutates it transiently).
- Wire the script into `.github/workflows/release-npm.yml` between `npm run version --apply` and `npm publish --workspaces`.

Consumers can now:

```ts
import { version } from "@matter/main";
console.log(version); // e.g. "0.17.0-alpha.0-20260515-..."
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)