### PR TITLE
fix(protocol): accept and emit cross-protocol StatusReport messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Do not announce devices as commissionable before the factory reset when the last fabric is removed
     - Fix: Fixes expiry logic where cached records for Commissionable devices could potentially never expire
     - Fix: For BDX cases also give the device the defined timeout of 5 minutes to ack/request the next packet
-    - Fix: Accept SecureChannel StatusReport messages on any protocol exchange (e.g. BDX) per Matter spec 4.10, and stamp the SecureChannel protocol id on outgoing StatusReports
+    - Fix: Accept SecureChannel StatusReport messages on any protocol exchange (e.g. BDX)
     - Fix: Ensures the Matter port on IPv4 is the same as on IPv6
 
 - @matter/react-native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Do not announce devices as commissionable before the factory reset when the last fabric is removed
     - Fix: Fixes expiry logic where cached records for Commissionable devices could potentially never expire
     - Fix: For BDX cases also give the device the defined timeout of 5 minutes to ack/request the next packet
+    - Fix: Accept SecureChannel StatusReport messages on any protocol exchange (e.g. BDX) per Matter spec 4.10, and stamp the SecureChannel protocol id on outgoing StatusReports
     - Fix: Ensures the Matter port on IPv4 is the same as on IPv6
 
 - @matter/react-native

--- a/packages/protocol/src/protocol/MessageExchange.ts
+++ b/packages/protocol/src/protocol/MessageExchange.ts
@@ -366,7 +366,8 @@ export class MessageExchange {
         } = message;
 
         const isStandaloneAck = SecureMessageType.isStandaloneAck(protocolId, messageType);
-        if (protocolId !== this.#protocolId && !isStandaloneAck) {
+        const isStatusReport = SecureMessageType.isStatusReport(protocolId, messageType);
+        if (protocolId !== this.#protocolId && !isStandaloneAck && !isStatusReport) {
             throw new MatterFlowError(
                 `Drop received a message for an unexpected protocol. Expected: ${this.#protocolId}, received: ${protocolId}`,
             );
@@ -485,8 +486,10 @@ export class MessageExchange {
             requiresAck = false;
         }
 
-        // Standalone acks are always sent via the SECURE_CHANNEL_PROTOCOL_ID
-        const protocolId = isStandaloneAck ? SECURE_CHANNEL_PROTOCOL_ID : this.#protocolId;
+        // StandaloneAck and StatusReport are SecureChannel messages and are always sent via SECURE_CHANNEL_PROTOCOL_ID
+        // regardless of the exchange's protocol (Matter spec 4.10).
+        const isStatusReport = messageType === SecureMessageType.StatusReport;
+        const protocolId = isStandaloneAck || isStatusReport ? SECURE_CHANNEL_PROTOCOL_ID : this.#protocolId;
         if (isStandaloneAck) {
             if (!this.session.usesMrp) {
                 return;

--- a/packages/protocol/test/protocol/MessageExchangeTest.ts
+++ b/packages/protocol/test/protocol/MessageExchangeTest.ts
@@ -8,8 +8,8 @@ import { Message } from "#codec/MessageCodec.js";
 import { MessageExchange } from "#protocol/MessageExchange.js";
 import { ProtocolMocks } from "#protocol/ProtocolMocks.js";
 import { SessionParameters } from "#session/SessionParameters.js";
-import { Bytes, Millis, NetworkError } from "@matter/general";
-import { SECURE_CHANNEL_PROTOCOL_ID } from "@matter/types";
+import { Bytes, MatterFlowError, Millis, NetworkError } from "@matter/general";
+import { BDX_PROTOCOL_ID, SECURE_CHANNEL_PROTOCOL_ID, SecureMessageType } from "@matter/types";
 
 /**
  * Creates a NodeSession whose channel send() throws to simulate a hard network failure.
@@ -28,7 +28,7 @@ function makeThrowingSession(): ProtocolMocks.NodeSession {
 /**
  * Creates a MessageExchange with a trackable peerLost spy.
  */
-function createExchange(session: ProtocolMocks.NodeSession) {
+function createExchange(session: ProtocolMocks.NodeSession, protocolId: number = SECURE_CHANNEL_PROTOCOL_ID) {
     const peerLostCalled = { value: false };
     const exchange = MessageExchange.initiate(
         {
@@ -40,7 +40,7 @@ function createExchange(session: ProtocolMocks.NodeSession) {
             retry() {},
         },
         1,
-        SECURE_CHANNEL_PROTOCOL_ID,
+        protocolId,
     );
     return { exchange, peerLostCalled };
 }
@@ -50,18 +50,23 @@ function createExchange(session: ProtocolMocks.NodeSession) {
  * - requiresAck: false so no ack send is triggered on the channel
  * - protocolId matches the exchange protocol to pass the protocol check
  */
-function fakeInboundMessage(): Message {
+function fakeInboundMessage(overrides?: {
+    messageId?: number;
+    protocolId?: number;
+    messageType?: number;
+    payload?: Bytes;
+}): Message {
     return {
-        packetHeader: { messageId: 1 },
+        packetHeader: { messageId: overrides?.messageId ?? 1 },
         payloadHeader: {
-            protocolId: SECURE_CHANNEL_PROTOCOL_ID,
-            messageType: 1,
+            protocolId: overrides?.protocolId ?? SECURE_CHANNEL_PROTOCOL_ID,
+            messageType: overrides?.messageType ?? 1,
             exchangeId: 1,
             isInitiatorMessage: false,
             requiresAck: false,
             ackedMessageId: undefined,
         },
-        payload: Bytes.empty,
+        payload: overrides?.payload ?? Bytes.empty,
     } as unknown as Message;
 }
 
@@ -109,6 +114,81 @@ describe("MessageExchange", () => {
 
                 expect(peerLostCalled.value).to.be.false;
             });
+        });
+    });
+
+    describe("cross-protocol StatusReport", () => {
+        it("accepts SecureChannel StatusReport on a non-SecureChannel exchange and delivers it to the consumer", async () => {
+            // Reproduces the case where a peer sends a spec-compliant StatusReport (protocolId=0, type=0x40)
+            // within an exchange that runs a different protocol (here: BDX, protocolId=2).
+            const session = new ProtocolMocks.NodeSession();
+            const { exchange } = createExchange(session, BDX_PROTOCOL_ID);
+
+            // Payload bytes from a real BDX TransferFailedUnknownError StatusReport
+            // (generalStatus=Failure, protocolId=BDX, protocolStatus=0x1f).
+            const statusReportPayload = new Uint8Array([0x01, 0x00, 0x02, 0x00, 0x00, 0x00, 0x1f, 0x00]);
+            const message = fakeInboundMessage({
+                protocolId: SECURE_CHANNEL_PROTOCOL_ID,
+                messageType: SecureMessageType.StatusReport,
+                payload: statusReportPayload,
+            });
+
+            await exchange.onMessageReceived(message);
+
+            const received = await exchange.nextMessage({ timeout: Millis(0) });
+            expect(received.payloadHeader.protocolId).equals(SECURE_CHANNEL_PROTOCOL_ID);
+            expect(received.payloadHeader.messageType).equals(SecureMessageType.StatusReport);
+            expect(received.payload).deep.equals(statusReportPayload);
+        });
+
+        it("still rejects non-StatusReport SecureChannel messages on a non-SecureChannel exchange", async () => {
+            const session = new ProtocolMocks.NodeSession();
+            const { exchange } = createExchange(session, BDX_PROTOCOL_ID);
+
+            const message = fakeInboundMessage({
+                protocolId: SECURE_CHANNEL_PROTOCOL_ID,
+                messageType: SecureMessageType.PbkdfParamRequest,
+            });
+
+            await expect(exchange.onMessageReceived(message)).to.be.rejectedWith(MatterFlowError);
+        });
+
+        it("stamps the SecureChannel protocol id on outgoing StatusReports from a non-SecureChannel exchange", async () => {
+            const session = new ProtocolMocks.NodeSession();
+            const sentMessages = new Array<Message>();
+            (session.channel as any).send = async (message: Message): Promise<void> => {
+                sentMessages.push(message);
+            };
+            const { exchange } = createExchange(session, BDX_PROTOCOL_ID);
+
+            // Send a StatusReport via exchange.send() on a BDX exchange (protocolId=2).
+            // The outgoing message must carry SECURE_CHANNEL_PROTOCOL_ID per Matter spec 4.10.
+            await exchange.send(
+                SecureMessageType.StatusReport,
+                new Uint8Array([0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00]),
+                { requiresAck: false, disableMrpLogic: true },
+            );
+
+            expect(sentMessages.length).equals(1);
+            expect(sentMessages[0].payloadHeader.protocolId).equals(SECURE_CHANNEL_PROTOCOL_ID);
+            expect(sentMessages[0].payloadHeader.messageType).equals(SecureMessageType.StatusReport);
+        });
+
+        it("keeps the exchange's protocol id on non-StatusReport outgoing messages", async () => {
+            const session = new ProtocolMocks.NodeSession();
+            const sentMessages = new Array<Message>();
+            (session.channel as any).send = async (message: Message): Promise<void> => {
+                sentMessages.push(message);
+            };
+            const { exchange } = createExchange(session, BDX_PROTOCOL_ID);
+
+            // Use a BDX BlockQuery (opcode 0x10, shares value with StandaloneAck) to also guard
+            // against accidentally treating it as a standalone-ack-style cross-protocol message.
+            await exchange.send(0x10, new Uint8Array([0x00]), { requiresAck: false, disableMrpLogic: true });
+
+            expect(sentMessages.length).equals(1);
+            expect(sentMessages[0].payloadHeader.protocolId).equals(BDX_PROTOCOL_ID);
+            expect(sentMessages[0].payloadHeader.messageType).equals(0x10);
         });
     });
 });

--- a/packages/types/src/protocol/definitions/secure-channel.ts
+++ b/packages/types/src/protocol/definitions/secure-channel.ts
@@ -88,4 +88,12 @@ export namespace SecureMessageType {
     export function isStandaloneAck(protocolId: number, messageType: number) {
         return protocolId === SECURE_CHANNEL_PROTOCOL_ID && messageType === SecureMessageType.StandaloneAck;
     }
+
+    /**
+     * StatusReport messages are SecureChannel messages but may flow within an exchange of any protocol per Matter spec
+     * 4.10 (Status Report Messages).
+     */
+    export function isStatusReport(protocolId: number, messageType: number) {
+        return protocolId === SECURE_CHANNEL_PROTOCOL_ID && messageType === SecureMessageType.StatusReport;
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes BDX (and any non-SecureChannel exchange) rejecting peer-sent `StatusReport` messages with `[flow] Drop received a message for an unexpected protocol. Expected: 2, received: 0`. Per Matter Core Spec §4.10, `StatusReport` is a SecureChannel message but may flow inside an exchange of any protocol.
- Also fixes a symmetric send-side spec violation: outgoing `StatusReport`s were stamped with the exchange's protocolId instead of `SECURE_CHANNEL_PROTOCOL_ID`. Latent since refactor `e7b40bab4` removed the per-call `protocolId` override option.
- Adds `SecureMessageType.isStatusReport(protocolId, messageType)` helper.

## Why the tests missed it

The existing BDX tests use `ProtocolMocks.Exchange`, which overrides `nextMessage()` and bypasses `MessageExchange.onMessageReceived()` — so the protocolId check at the wire boundary was never exercised. New tests use real `MessageExchange.initiate(...)` and call `onMessageReceived` / `send` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)