### PR TITLE
fix(types): emit IM IB list members in schema-defined tag order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Breaking: Removed some special pre-bound TLV string/byte-string schema exports, including `TlvHardwareAddress`
     - Feature: We've rewritten the typing system for clusters to simplify types, consume less runtime memory and work better with IDEs
     - Enhancement: Increases Matter TlvString/TlvByteString default maximum length to 65536 to cover WebRTC cases
+    - Fix: (@snabb) `TlvTaggedList` now ensures schema/tag ordering when encoding (Matter Core §10.6.1). Added `TlvTaggedListPreservingOrder` for cases where ordering needs to be data driven (e.g. signed certificate sub-lists).
 
 - @project-chip/matter.js
     - Feature: CommissioningController allows to set `tcp` (boolean) to enable TCP support for the controller

--- a/packages/protocol/src/certificate/kinds/definitions/operational.ts
+++ b/packages/protocol/src/certificate/kinds/definitions/operational.ts
@@ -32,9 +32,7 @@ import { ExtensionKeyUsageBitmap } from "./base.js";
  */
 export const MAX_TLV_CERTIFICATE_SIZE = 400;
 
-// Encoded extensions are part of the certificate's signed bytes, so a
-// parse + re-encode round-trip must reproduce the original on-the-wire
-// member order. Use the order-preserving variant for that reason.
+// Order-preserving: extensions are part of the certificate's signed bytes; re-encode must reproduce wire order.
 export const TlvCertificateExtension = TlvTaggedListPreservingOrder({
     basicConstraints: TlvField(
         1,
@@ -108,9 +106,7 @@ export namespace OperationalCertificate {
             dnQualifierPs: TlvOptionalField(142, TlvString),
             pseudonymPs: TlvOptionalField(143, TlvString),
         };
-        // The subject and issuer DN sub-lists are part of the certificate's
-        // signed bytes, so encoding must reproduce the caller-supplied
-        // member order on re-encode for signature verification to pass.
+        // Order-preserving: subject/issuer DN sub-lists are part of the certificate's signed bytes; re-encode must reproduce caller order.
         return TlvTaggedListPreservingOrder(fields);
     };
 

--- a/packages/protocol/src/certificate/kinds/definitions/operational.ts
+++ b/packages/protocol/src/certificate/kinds/definitions/operational.ts
@@ -17,7 +17,7 @@ import {
     TlvOptionalField,
     TlvOptionalRepeatedField,
     TlvString,
-    TlvTaggedList,
+    TlvTaggedListPreservingOrder,
     TlvUInt16,
     TlvUInt32,
     TlvUInt64,
@@ -32,7 +32,10 @@ import { ExtensionKeyUsageBitmap } from "./base.js";
  */
 export const MAX_TLV_CERTIFICATE_SIZE = 400;
 
-export const TlvCertificateExtension = TlvTaggedList({
+// Encoded extensions are part of the certificate's signed bytes, so a
+// parse + re-encode round-trip must reproduce the original on-the-wire
+// member order. Use the order-preserving variant for that reason.
+export const TlvCertificateExtension = TlvTaggedListPreservingOrder({
     basicConstraints: TlvField(
         1,
         TlvObject({
@@ -105,7 +108,10 @@ export namespace OperationalCertificate {
             dnQualifierPs: TlvOptionalField(142, TlvString),
             pseudonymPs: TlvOptionalField(143, TlvString),
         };
-        return TlvTaggedList(fields);
+        // The subject and issuer DN sub-lists are part of the certificate's
+        // signed bytes, so encoding must reproduce the caller-supplied
+        // member order on re-encode for signature verification to pass.
+        return TlvTaggedListPreservingOrder(fields);
     };
 
     /**

--- a/packages/types/src/protocol/types/TlvAttributePath.ts
+++ b/packages/types/src/protocol/types/TlvAttributePath.ts
@@ -15,8 +15,13 @@ import { TlvBitmap, TlvUInt16, TlvUInt32 } from "../../tlv/TlvNumber.js";
 import { TlvOptionalField, TlvTaggedList } from "../../tlv/TlvObject.js";
 import { WildcardPathFlagsBitmap } from "./WildcardPathFlagsBitmap.js";
 
-/** @see {@link MatterSpecification.v13.Core}, section 10.6.2 */
-
+/**
+ * @see {@link MatterSpecification.v13.Core}, section 10.6.2
+ *
+ * `TlvTaggedList` emits members in schema/tag order, satisfying §10.6.1
+ * ("Tag Rules") for Interaction Model IBs; see the doc-comment on
+ * `TlvCommandPath` for the full rationale.
+ */
 export const TlvAttributePath = TlvTaggedList({
     // AttributePathIB
     enableTagCompression: TlvOptionalField(0, TlvBoolean),

--- a/packages/types/src/protocol/types/TlvAttributePath.ts
+++ b/packages/types/src/protocol/types/TlvAttributePath.ts
@@ -15,13 +15,7 @@ import { TlvBitmap, TlvUInt16, TlvUInt32 } from "../../tlv/TlvNumber.js";
 import { TlvOptionalField, TlvTaggedList } from "../../tlv/TlvObject.js";
 import { WildcardPathFlagsBitmap } from "./WildcardPathFlagsBitmap.js";
 
-/**
- * @see {@link MatterSpecification.v13.Core}, section 10.6.2
- *
- * `TlvTaggedList` emits members in schema/tag order, satisfying §10.6.1
- * ("Tag Rules") for Interaction Model IBs; see the doc-comment on
- * `TlvCommandPath` for the full rationale.
- */
+/** @see {@link MatterSpecification.v13.Core}, section 10.6.2 */
 export const TlvAttributePath = TlvTaggedList({
     // AttributePathIB
     enableTagCompression: TlvOptionalField(0, TlvBoolean),

--- a/packages/types/src/protocol/types/TlvClusterPath.ts
+++ b/packages/types/src/protocol/types/TlvClusterPath.ts
@@ -9,8 +9,13 @@ import { TlvEndpointNumber } from "../../datatype/EndpointNumber.js";
 import { TlvNodeId } from "../../datatype/NodeId.js";
 import { TlvField, TlvOptionalField, TlvTaggedList } from "../../tlv/TlvObject.js";
 
-/** @see {@link MatterSpecification.v13.Core}, section 10.6.7 */
-
+/**
+ * @see {@link MatterSpecification.v13.Core}, section 10.6.7
+ *
+ * `TlvTaggedList` emits members in schema/tag order, satisfying §10.6.1
+ * ("Tag Rules") for Interaction Model IBs; see the doc-comment on
+ * `TlvCommandPath` for the full rationale.
+ */
 export const TlvClusterPath = TlvTaggedList({
     // ClusterPathIB
     nodeId: TlvOptionalField(0, TlvNodeId),

--- a/packages/types/src/protocol/types/TlvClusterPath.ts
+++ b/packages/types/src/protocol/types/TlvClusterPath.ts
@@ -9,13 +9,7 @@ import { TlvEndpointNumber } from "../../datatype/EndpointNumber.js";
 import { TlvNodeId } from "../../datatype/NodeId.js";
 import { TlvField, TlvOptionalField, TlvTaggedList } from "../../tlv/TlvObject.js";
 
-/**
- * @see {@link MatterSpecification.v13.Core}, section 10.6.7
- *
- * `TlvTaggedList` emits members in schema/tag order, satisfying §10.6.1
- * ("Tag Rules") for Interaction Model IBs; see the doc-comment on
- * `TlvCommandPath` for the full rationale.
- */
+/** @see {@link MatterSpecification.v13.Core}, section 10.6.7 */
 export const TlvClusterPath = TlvTaggedList({
     // ClusterPathIB
     nodeId: TlvOptionalField(0, TlvNodeId),

--- a/packages/types/src/protocol/types/TlvCommandPath.ts
+++ b/packages/types/src/protocol/types/TlvCommandPath.ts
@@ -10,8 +10,23 @@ import { TlvCommandId } from "../../datatype/CommandId.js";
 import { TlvEndpointNumber } from "../../datatype/EndpointNumber.js";
 import { TlvField, TlvOptionalField, TlvTaggedList } from "../../tlv/TlvObject.js";
 
-/** @see {@link MatterSpecification.v13.Core}, section 10.6.11 */
-
+/**
+ * @see {@link MatterSpecification.v13.Core}, section 10.6.11
+ *
+ * `TlvTaggedList` emits members in schema/tag order, which is what
+ * {@link MatterSpecification.v151.Core} section 10.6.1 ("Tag Rules")
+ * requires for §10 IBs: "Unless otherwise noted, all context tags SHALL
+ * be emitted in the order as defined in the appropriate specification."
+ * Section A.5.3 ("Lists") additionally states that a list member's
+ * meaning is denoted by its position. Together they require
+ * `CommandPathIB` on the wire to be `endpointId (0), clusterId (1),
+ * commandId (2)` regardless of the order in which the caller populated
+ * the value object.
+ *
+ * Section numbers and wording verified against the Matter 1.3, 1.4, and
+ * 1.5 / 1.5.1 Core specifications; matter.js targets 1.5.1 (see
+ * `Specification.REVISION`).
+ */
 export const TlvCommandPath = TlvTaggedList({
     // CommandPathIB
     endpointId: TlvOptionalField(0, TlvEndpointNumber),

--- a/packages/types/src/protocol/types/TlvCommandPath.ts
+++ b/packages/types/src/protocol/types/TlvCommandPath.ts
@@ -10,23 +10,7 @@ import { TlvCommandId } from "../../datatype/CommandId.js";
 import { TlvEndpointNumber } from "../../datatype/EndpointNumber.js";
 import { TlvField, TlvOptionalField, TlvTaggedList } from "../../tlv/TlvObject.js";
 
-/**
- * @see {@link MatterSpecification.v13.Core}, section 10.6.11
- *
- * `TlvTaggedList` emits members in schema/tag order, which is what
- * {@link MatterSpecification.v151.Core} section 10.6.1 ("Tag Rules")
- * requires for §10 IBs: "Unless otherwise noted, all context tags SHALL
- * be emitted in the order as defined in the appropriate specification."
- * Section A.5.3 ("Lists") additionally states that a list member's
- * meaning is denoted by its position. Together they require
- * `CommandPathIB` on the wire to be `endpointId (0), clusterId (1),
- * commandId (2)` regardless of the order in which the caller populated
- * the value object.
- *
- * Section numbers and wording verified against the Matter 1.3, 1.4, and
- * 1.5 / 1.5.1 Core specifications; matter.js targets 1.5.1 (see
- * `Specification.REVISION`).
- */
+/** @see {@link MatterSpecification.v13.Core}, section 10.6.11 */
 export const TlvCommandPath = TlvTaggedList({
     // CommandPathIB
     endpointId: TlvOptionalField(0, TlvEndpointNumber),

--- a/packages/types/src/protocol/types/TlvEventPath.ts
+++ b/packages/types/src/protocol/types/TlvEventPath.ts
@@ -12,13 +12,7 @@ import { TlvNodeId } from "../../datatype/NodeId.js";
 import { TlvBoolean } from "../../tlv/TlvBoolean.js";
 import { TlvOptionalField, TlvTaggedList } from "../../tlv/TlvObject.js";
 
-/**
- * @see {@link MatterSpecification.v13.Core}, section 10.6.8
- *
- * `TlvTaggedList` emits members in schema/tag order, satisfying §10.6.1
- * ("Tag Rules") for Interaction Model IBs; see the doc-comment on
- * `TlvCommandPath` for the full rationale.
- */
+/** @see {@link MatterSpecification.v13.Core}, section 10.6.8 */
 export const TlvEventPath = TlvTaggedList({
     // EventPathIB
     nodeId: TlvOptionalField(0, TlvNodeId),

--- a/packages/types/src/protocol/types/TlvEventPath.ts
+++ b/packages/types/src/protocol/types/TlvEventPath.ts
@@ -12,8 +12,13 @@ import { TlvNodeId } from "../../datatype/NodeId.js";
 import { TlvBoolean } from "../../tlv/TlvBoolean.js";
 import { TlvOptionalField, TlvTaggedList } from "../../tlv/TlvObject.js";
 
-/** @see {@link MatterSpecification.v13.Core}, section 10.6.8 */
-
+/**
+ * @see {@link MatterSpecification.v13.Core}, section 10.6.8
+ *
+ * `TlvTaggedList` emits members in schema/tag order, satisfying §10.6.1
+ * ("Tag Rules") for Interaction Model IBs; see the doc-comment on
+ * `TlvCommandPath` for the full rationale.
+ */
 export const TlvEventPath = TlvTaggedList({
     // EventPathIB
     nodeId: TlvOptionalField(0, TlvNodeId),

--- a/packages/types/src/tlv/TlvObject.ts
+++ b/packages/types/src/tlv/TlvObject.ts
@@ -162,7 +162,7 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
     #encodeList(writer: TlvWriter, value: TypeFromFields<F>, options?: TlvEncodingOptions) {
         const valueKeys = Object.keys(value);
         for (const name of valueKeys) {
-            if (!(name in this.fieldDefinitions)) {
+            if (!Object.hasOwn(this.fieldDefinitions, name)) {
                 throw new ValidationDatatypeMismatchError(
                     `Unknown field "${name}" not defined in tagged list schema.`,
                     name,

--- a/packages/types/src/tlv/TlvObject.ts
+++ b/packages/types/src/tlv/TlvObject.ts
@@ -154,7 +154,8 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
     }
 
     /**
-     * Encode the object as List. Default emits in schema/tag order (Matter Core §10.6.1). With
+     * Encode the object as List. Default emits in schema definition order (which matter.js declares in spec/tag order,
+     * satisfying Matter Core §10.6.1 for Interaction Model IBs). With
      * {@link preserveDataOrdering}, caller-supplied property order is emitted first (used for certificate sub-lists
      * whose signed bytes depend on original member order; §A.5.3), with any remaining schema fields appended after.
      */
@@ -359,7 +360,8 @@ export const TlvObjectWithMaxSize = <F extends TlvFields>(fields: F, maxSize: nu
     new ObjectSchemaWithMaxSize(fields, maxSize, TlvType.Structure);
 
 /**
- * List TLV schema with all tagged entries. Members are emitted in schema/tag order on encode, per Matter Core §10.6.1.
+ * List TLV schema with all tagged entries. Members are emitted in schema definition order on encode; matter.js
+ * declares fields in spec/tag order, which satisfies Matter Core §10.6.1 for Interaction Model IBs.
  * List entries that can appear multiple times can be defined using TlvRepeatedField/TlvOptionalRepeatedField and are
  * represented as Arrays.
  *

--- a/packages/types/src/tlv/TlvObject.ts
+++ b/packages/types/src/tlv/TlvObject.ts
@@ -155,20 +155,16 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
 
     /**
      * Encode the object as List. Default emits in schema/tag order (Matter Core §10.6.1). With
-     * {@link preserveDataOrdering}, emits in caller property order (used for certificate sub-lists whose signed bytes
-     * depend on original member order; §A.5.3).
+     * {@link preserveDataOrdering}, caller-supplied property order is emitted first (used for certificate sub-lists
+     * whose signed bytes depend on original member order; §A.5.3), with any remaining schema fields appended after.
      */
     #encodeList(writer: TlvWriter, value: TypeFromFields<F>, options?: TlvEncodingOptions) {
-        if (!this.preserveDataOrdering) {
-            for (const name in this.fieldDefinitions) {
-                this.#encodeEntryToTlv(writer, name, value, options);
-            }
-            return;
-        }
         const encodedFields = new Set<string>();
-        for (const name of Object.keys(value)) {
-            this.#encodeEntryToTlv(writer, name, value, options);
-            encodedFields.add(name);
+        if (this.preserveDataOrdering) {
+            for (const name of Object.keys(value)) {
+                this.#encodeEntryToTlv(writer, name, value, options);
+                encodedFields.add(name);
+            }
         }
         for (const name in this.fieldDefinitions) {
             if (encodedFields.has(name)) continue;

--- a/packages/types/src/tlv/TlvObject.ts
+++ b/packages/types/src/tlv/TlvObject.ts
@@ -69,12 +69,8 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
         private readonly fieldDefinitions: F,
         private readonly type: TlvType.Structure | TlvType.List = TlvType.Structure,
         private readonly allowProtocolSpecificTags = false,
-        /**
-         * Emit list members in the order in which the caller populated the
-         * value object (`Object.keys(value)`) rather than in the order
-         * defined by `fieldDefinitions`. See `#encodeList` for the spec
-         * reference. Only meaningful when `type` is `TlvType.List`.
-         */
+
+        /** When true, list encoding follows caller property order instead of schema order. See {@link TlvTaggedListPreservingOrder}. */
         private readonly preserveDataOrdering = false,
     ) {
         super();
@@ -158,27 +154,9 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
     }
 
     /**
-     * Encode the object as List.
-     *
-     * By default the encoder iterates `this.fieldDefinitions`, which
-     * produces wire bytes whose context tags appear in the order defined
-     * by the schema. Matter Core spec §10.6.1 ("Tag Rules", Matter 1.5 /
-     * 1.5.1) requires this for the §10 Interaction Model IBs (CommandPathIB,
-     * AttributePathIB, EventPathIB, ClusterPathIB) and the spec
-     * recommends it more broadly so that receivers can scan tags in
-     * ascending order ("to reduce receiver side complexity in having to
-     * deal with arbitrary order tags"). Since matter.js declares fields
-     * in spec/tag order, schema-order iteration trivially satisfies this.
-     *
-     * When `preserveDataOrdering` is set on the schema, the encoder
-     * instead follows the order in which the caller populated the value
-     * object (`Object.keys(value)`). This is required for lists whose
-     * member position carries application-defined meaning — notably the
-     * inner lists of a Matter operational certificate's subject / issuer
-     * / extensions, where the signed bytes must reproduce the caller-
-     * supplied order on re-encode (Core spec §A.5.3, "the meanings of
-     * member elements in a list are denoted by their position within the
-     * list").
+     * Encode the object as List. Default emits in schema/tag order (Matter Core §10.6.1). With
+     * {@link preserveDataOrdering}, emits in caller property order (used for certificate sub-lists whose signed bytes
+     * depend on original member order; §A.5.3).
      */
     #encodeList(writer: TlvWriter, value: TypeFromFields<F>, options?: TlvEncodingOptions) {
         if (!this.preserveDataOrdering) {
@@ -188,12 +166,10 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
             return;
         }
         const encodedFields = new Set<string>();
-        // Encode object fields
         for (const name of Object.keys(value)) {
             this.#encodeEntryToTlv(writer, name, value, options);
             encodedFields.add(name);
         }
-        // Verify the potentially missing fields
         for (const name in this.fieldDefinitions) {
             if (encodedFields.has(name)) continue;
             this.#encodeEntryToTlv(writer, name, value, options);
@@ -378,21 +354,12 @@ export const TlvObjectWithMaxSize = <F extends TlvFields>(fields: F, maxSize: nu
     new ObjectSchemaWithMaxSize(fields, maxSize, TlvType.Structure);
 
 /**
- * List TLV schema with all tagged entries.
+ * List TLV schema with all tagged entries. Members are emitted in schema/tag order on encode, per Matter Core §10.6.1.
  * List entries that can appear multiple times can be defined using TlvRepeatedField/TlvOptionalRepeatedField and are
  * represented as Arrays.
  *
- * On encode, list members are emitted in the order of the schema's field
- * definitions (which match the spec's context-tag numbering), regardless
- * of the order in which the caller populated the value object. This
- * satisfies Matter Core spec §10.6.1 ("Tag Rules", Matter 1.5 / 1.5.1)
- * for IBs such as CommandPathIB, AttributePathIB, EventPathIB, and
- * ClusterPathIB.
- *
- * For lists whose member position is part of the application data — e.g.
- * the subject / issuer / extensions sub-lists of a Matter operational
- * certificate, where the signed bytes must reproduce caller order on
- * re-encode — use {@link TlvTaggedListPreservingOrder} instead.
+ * For lists whose wire order must reproduce caller-supplied order (e.g. signed certificate sub-lists), use
+ * {@link TlvTaggedListPreservingOrder}.
  *
  * TODO: We represent Tlv Lists right now as named object properties. This formally does not match the spec, which
  *      defines a list as a sequence of TLV elements with optional tag where the order matters. That's ok for now
@@ -400,17 +367,12 @@ export const TlvObjectWithMaxSize = <F extends TlvFields>(fields: F, maxSize: nu
  *      existing data structures. We need to change once this changes.
  */
 export const TlvTaggedList = <F extends TlvFields>(fields: F, allowProtocolSpecificTags = false) =>
-    new ObjectSchema(fields, TlvType.List, allowProtocolSpecificTags, /* preserveDataOrdering */ false);
+    new ObjectSchema(fields, TlvType.List, allowProtocolSpecificTags);
 
 /**
- * Variant of {@link TlvTaggedList} that preserves caller-supplied member
- * ordering on encode (rather than emitting members in schema/tag order).
- *
- * Use this only for lists whose member position carries application-
- * defined meaning that must round-trip bit-identically — e.g. the inner
- * sub-lists of a Matter operational certificate (subject, issuer,
- * extensions), whose signed bytes depend on the original encoding order
- * and would otherwise fail signature verification after parse + re-encode.
+ * Variant of {@link TlvTaggedList} that preserves caller-supplied member order on encode. Use only when wire-position
+ * is application data that must round-trip bit-identically — e.g. operational-certificate subject/issuer/extensions
+ * sub-lists, whose signed bytes depend on original member order.
  */
 export const TlvTaggedListPreservingOrder = <F extends TlvFields>(fields: F, allowProtocolSpecificTags = false) =>
     new ObjectSchema(fields, TlvType.List, allowProtocolSpecificTags, /* preserveDataOrdering */ true);

--- a/packages/types/src/tlv/TlvObject.ts
+++ b/packages/types/src/tlv/TlvObject.ts
@@ -69,6 +69,13 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
         private readonly fieldDefinitions: F,
         private readonly type: TlvType.Structure | TlvType.List = TlvType.Structure,
         private readonly allowProtocolSpecificTags = false,
+        /**
+         * Emit list members in the order in which the caller populated the
+         * value object (`Object.keys(value)`) rather than in the order
+         * defined by `fieldDefinitions`. See `#encodeList` for the spec
+         * reference. Only meaningful when `type` is `TlvType.List`.
+         */
+        private readonly preserveDataOrdering = false,
     ) {
         super();
 
@@ -151,9 +158,35 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
     }
 
     /**
-     * Encode the object as List, by the order of the fields in the object.
+     * Encode the object as List.
+     *
+     * By default the encoder iterates `this.fieldDefinitions`, which
+     * produces wire bytes whose context tags appear in the order defined
+     * by the schema. Matter Core spec §10.6.1 ("Tag Rules", Matter 1.5 /
+     * 1.5.1) requires this for the §10 Interaction Model IBs (CommandPathIB,
+     * AttributePathIB, EventPathIB, ClusterPathIB) and the spec
+     * recommends it more broadly so that receivers can scan tags in
+     * ascending order ("to reduce receiver side complexity in having to
+     * deal with arbitrary order tags"). Since matter.js declares fields
+     * in spec/tag order, schema-order iteration trivially satisfies this.
+     *
+     * When `preserveDataOrdering` is set on the schema, the encoder
+     * instead follows the order in which the caller populated the value
+     * object (`Object.keys(value)`). This is required for lists whose
+     * member position carries application-defined meaning — notably the
+     * inner lists of a Matter operational certificate's subject / issuer
+     * / extensions, where the signed bytes must reproduce the caller-
+     * supplied order on re-encode (Core spec §A.5.3, "the meanings of
+     * member elements in a list are denoted by their position within the
+     * list").
      */
     #encodeList(writer: TlvWriter, value: TypeFromFields<F>, options?: TlvEncodingOptions) {
+        if (!this.preserveDataOrdering) {
+            for (const name in this.fieldDefinitions) {
+                this.#encodeEntryToTlv(writer, name, value, options);
+            }
+            return;
+        }
         const encodedFields = new Set<string>();
         // Encode object fields
         for (const name of Object.keys(value)) {
@@ -348,13 +381,39 @@ export const TlvObjectWithMaxSize = <F extends TlvFields>(fields: F, maxSize: nu
  * List TLV schema with all tagged entries.
  * List entries that can appear multiple times can be defined using TlvRepeatedField/TlvOptionalRepeatedField and are
  * represented as Arrays.
+ *
+ * On encode, list members are emitted in the order of the schema's field
+ * definitions (which match the spec's context-tag numbering), regardless
+ * of the order in which the caller populated the value object. This
+ * satisfies Matter Core spec §10.6.1 ("Tag Rules", Matter 1.5 / 1.5.1)
+ * for IBs such as CommandPathIB, AttributePathIB, EventPathIB, and
+ * ClusterPathIB.
+ *
+ * For lists whose member position is part of the application data — e.g.
+ * the subject / issuer / extensions sub-lists of a Matter operational
+ * certificate, where the signed bytes must reproduce caller order on
+ * re-encode — use {@link TlvTaggedListPreservingOrder} instead.
+ *
  * TODO: We represent Tlv Lists right now as named object properties. This formally does not match the spec, which
  *      defines a list as a sequence of TLV elements with optional tag where the order matters. That's ok for now
  *      (also with the help of "Repeated Fields") because it not makes any real difference for now for the current
  *      existing data structures. We need to change once this changes.
  */
 export const TlvTaggedList = <F extends TlvFields>(fields: F, allowProtocolSpecificTags = false) =>
-    new ObjectSchema(fields, TlvType.List, allowProtocolSpecificTags);
+    new ObjectSchema(fields, TlvType.List, allowProtocolSpecificTags, /* preserveDataOrdering */ false);
+
+/**
+ * Variant of {@link TlvTaggedList} that preserves caller-supplied member
+ * ordering on encode (rather than emitting members in schema/tag order).
+ *
+ * Use this only for lists whose member position carries application-
+ * defined meaning that must round-trip bit-identically — e.g. the inner
+ * sub-lists of a Matter operational certificate (subject, issuer,
+ * extensions), whose signed bytes depend on the original encoding order
+ * and would otherwise fail signature verification after parse + re-encode.
+ */
+export const TlvTaggedListPreservingOrder = <F extends TlvFields>(fields: F, allowProtocolSpecificTags = false) =>
+    new ObjectSchema(fields, TlvType.List, allowProtocolSpecificTags, /* preserveDataOrdering */ true);
 
 // TODO Implement a real TlvList schema that matches the spec to represent a ordered list of TLV elements with optional
 //      tag.

--- a/packages/types/src/tlv/TlvObject.ts
+++ b/packages/types/src/tlv/TlvObject.ts
@@ -159,9 +159,18 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
      * whose signed bytes depend on original member order; §A.5.3), with any remaining schema fields appended after.
      */
     #encodeList(writer: TlvWriter, value: TypeFromFields<F>, options?: TlvEncodingOptions) {
+        const valueKeys = Object.keys(value);
+        for (const name of valueKeys) {
+            if (!(name in this.fieldDefinitions)) {
+                throw new ValidationDatatypeMismatchError(
+                    `Unknown field "${name}" not defined in tagged list schema.`,
+                    name,
+                );
+            }
+        }
         const encodedFields = new Set<string>();
         if (this.preserveDataOrdering) {
-            for (const name of Object.keys(value)) {
+            for (const name of valueKeys) {
                 this.#encodeEntryToTlv(writer, name, value, options);
                 encodedFields.add(name);
             }

--- a/packages/types/test/tlv/TlvObjectTest.ts
+++ b/packages/types/test/tlv/TlvObjectTest.ts
@@ -342,9 +342,6 @@ describe("TlvObject tests", () => {
         });
 
         it("encodes in schema/tag order regardless of caller property order", () => {
-            // Caller built the value with `requiredField` first, but the
-            // schema places `optionalField` (id 1) before `requiredField`
-            // (id 2). Encoded wire bytes must reflect schema order.
             const data = { requiredField: "testreq", optionalField: "test" };
             const encoded = schemaListRequiredAndOptional.encode(data);
             expect(Bytes.toHex(encoded)).equal("172c0104746573742c02077465737472657118");
@@ -410,9 +407,6 @@ describe("TlvObject tests", () => {
         });
 
         it("encodes repeated fields in schema/tag order regardless of caller property order", () => {
-            // Caller order: repeatedField, requiredField. Schema order:
-            // requiredField (id 1), repeatedField (id 2). Wire must follow
-            // schema order.
             const data = {
                 repeatedField: ["test1", "test2"],
                 requiredField: "test",
@@ -483,33 +477,16 @@ describe("TlvObject tests", () => {
     });
 
     describe("Tlv Lists encode in schema/tag order by default", () => {
-        // Mirror the CommandPathIB shape: optional first by tag, mandatory
-        // after. A caller who builds the value object the way matter.js's
-        // own `Invoke.ts` does — set the required scalar fields up front
-        // then conditionally append the optional one — would emit tags in
-        // insertion order (1, 2, 0) if the encoder followed caller order,
-        // violating Matter Core spec §10.6.1 ("Tag Rules", Matter 1.5 /
-        // 1.5.1) and §A.5.3 (list members' meaning is denoted by their
-        // position). `TlvTaggedList`'s default schema-order encoding
-        // produces the spec-mandated wire order `0, 1, 2`.
+        // CommandPathIB shape: optional tag 0, mandatory tags 1 and 2. Spec §10.6.1 requires schema/tag order on wire.
         const schemaCommandPathLike = TlvTaggedList({
             endpointId: TlvOptionalField(0, TlvUInt16),
             clusterId: TlvField(1, TlvUInt32),
             commandId: TlvField(2, TlvUInt32),
         });
 
-        // Wire bytes when all three fields are present, in schema/tag order:
-        //   0x17                  List
-        //     0x24 0x00 0x01      U8 ctx-tag 0 (endpointId) = 1
-        //     0x24 0x01 0x06      U8 ctx-tag 1 (clusterId)  = 6
-        //     0x24 0x02 0x01      U8 ctx-tag 2 (commandId)  = 1
-        //   0x18                  End-of-list
         const fullHex = "1724000124010624020118";
 
         it("emits members in schema-defined tag order regardless of caller property order", () => {
-            // matter.js's Invoke.ts builds commandPath this way: clusterId
-            // and commandId are set unconditionally, then endpointId is
-            // appended if present.
             const callerOrder = { clusterId: 6, commandId: 1, endpointId: 1 };
             const schemaOrder = { endpointId: 1, clusterId: 6, commandId: 1 };
 
@@ -519,8 +496,6 @@ describe("TlvObject tests", () => {
         });
 
         it("omits absent optional fields and keeps remaining members in tag order", () => {
-            // Wildcard endpoint: omit endpointId entirely. Wire must still
-            // have tag 1 (clusterId) before tag 2 (commandId).
             const expectedHex = "1724010624020118";
             expect(Bytes.toHex(schemaCommandPathLike.encode({ clusterId: 6, commandId: 1 }))).equal(expectedHex);
             expect(schemaCommandPathLike.decode(Bytes.fromHex(expectedHex))).deep.equal({
@@ -531,9 +506,6 @@ describe("TlvObject tests", () => {
     });
 
     describe("TlvTaggedListPreservingOrder preserves caller-supplied order", () => {
-        // Used by operational certificate inner lists (subject / issuer /
-        // extensions) where the signed bytes depend on the caller-supplied
-        // member ordering and must round-trip bit-identically.
         const schemaPreserve = TlvTaggedListPreservingOrder({
             endpointId: TlvOptionalField(0, TlvUInt16),
             clusterId: TlvField(1, TlvUInt32),
@@ -541,8 +513,6 @@ describe("TlvObject tests", () => {
         });
 
         it("emits members in caller property order, not schema order", () => {
-            // Caller order: clusterId, commandId, endpointId — wire reflects
-            // it (tag 1, then 2, then 0).
             const callerOrderHex = "1724010624020124000118";
             expect(Bytes.toHex(schemaPreserve.encode({ clusterId: 6, commandId: 1, endpointId: 1 }))).equal(
                 callerOrderHex,

--- a/packages/types/test/tlv/TlvObjectTest.ts
+++ b/packages/types/test/tlv/TlvObjectTest.ts
@@ -518,6 +518,28 @@ describe("TlvObject tests", () => {
                 callerOrderHex,
             );
         });
+
+        it("throws ValidationDatatypeMismatchError on unknown fields", () => {
+            expect(() =>
+                // @ts-expect-error test case
+                schemaPreserve.encode({ clusterId: 6, commandId: 1, bogus: 42 }),
+            ).throw('Unknown field "bogus" not defined in tagged list schema.');
+        });
+    });
+
+    describe("TlvTaggedList rejects unknown fields", () => {
+        const schemaList = TlvTaggedList({
+            endpointId: TlvOptionalField(0, TlvUInt16),
+            clusterId: TlvField(1, TlvUInt32),
+            commandId: TlvField(2, TlvUInt32),
+        });
+
+        it("throws ValidationDatatypeMismatchError on unknown fields in default schema-order mode", () => {
+            expect(() =>
+                // @ts-expect-error test case
+                schemaList.encode({ clusterId: 6, commandId: 1, bogus: 42 }),
+            ).throw('Unknown field "bogus" not defined in tagged list schema.');
+        });
     });
 
     describe("Tlv Lists with protocol specific tags", () => {

--- a/packages/types/test/tlv/TlvObjectTest.ts
+++ b/packages/types/test/tlv/TlvObjectTest.ts
@@ -9,7 +9,7 @@ import { FabricIndex, TlvFabricIndex } from "#datatype/FabricIndex.js";
 import { TlvAny } from "#tlv/TlvAny.js";
 import { TlvArray } from "#tlv/TlvArray.js";
 import { TlvNullable } from "#tlv/TlvNullable.js";
-import { TlvUInt8 } from "#tlv/TlvNumber.js";
+import { TlvUInt16, TlvUInt32, TlvUInt8 } from "#tlv/TlvNumber.js";
 import {
     TlvField,
     TlvObject,
@@ -17,6 +17,7 @@ import {
     TlvOptionalRepeatedField,
     TlvRepeatedField,
     TlvTaggedList,
+    TlvTaggedListPreservingOrder,
 } from "#tlv/TlvObject.js";
 import { TypeFromSchema } from "#tlv/TlvSchema.js";
 import { TlvString } from "#tlv/TlvString.js";
@@ -340,10 +341,13 @@ describe("TlvObject tests", () => {
             expect(schemaListRequiredAndOptional.decode(encoded)).deep.equal(data);
         });
 
-        it("encode and decode list with optional and required fields in switched order", () => {
+        it("encodes in schema/tag order regardless of caller property order", () => {
+            // Caller built the value with `requiredField` first, but the
+            // schema places `optionalField` (id 1) before `requiredField`
+            // (id 2). Encoded wire bytes must reflect schema order.
             const data = { requiredField: "testreq", optionalField: "test" };
             const encoded = schemaListRequiredAndOptional.encode(data);
-            expect(Bytes.toHex(encoded)).equal("172c0207746573747265712c01047465737418");
+            expect(Bytes.toHex(encoded)).equal("172c0104746573742c02077465737472657118");
             expect(schemaListRequiredAndOptional.decode(encoded)).deep.equal(data);
         });
 
@@ -405,13 +409,16 @@ describe("TlvObject tests", () => {
             expect(schemaListRepeatedLimited.decode(encoded)).deep.equal(data);
         });
 
-        it("encode and decode list with switched repeated fields", () => {
+        it("encodes repeated fields in schema/tag order regardless of caller property order", () => {
+            // Caller order: repeatedField, requiredField. Schema order:
+            // requiredField (id 1), repeatedField (id 2). Wire must follow
+            // schema order.
             const data = {
                 repeatedField: ["test1", "test2"],
                 requiredField: "test",
             };
             const encoded = schemaListRepeatedLimited.encode(data);
-            expect(Bytes.toHex(encoded)).equal("172c020574657374312c020574657374322c01047465737418");
+            expect(Bytes.toHex(encoded)).equal("172c0104746573742c020574657374312c0205746573743218");
             expect(schemaListRepeatedLimited.decode(encoded)).deep.equal(data);
         });
 
@@ -464,14 +471,82 @@ describe("TlvObject tests", () => {
             );
         });
 
-        it("preserves the field order also when different from field definition with repeated fields", () => {
+        it("encodes single-entry repeated field in schema/tag order regardless of caller property order", () => {
             const data = {
                 repeatedField: ["test1"],
                 requiredField: "test",
             };
             const encoded = schemaListRepeatedLimited.encode(data);
-            expect(Bytes.toHex(encoded)).equal("172c020574657374312c01047465737418");
+            expect(Bytes.toHex(encoded)).equal("172c0104746573742c0205746573743118");
             expect(schemaListRepeatedLimited.decode(encoded)).deep.equal(data);
+        });
+    });
+
+    describe("Tlv Lists encode in schema/tag order by default", () => {
+        // Mirror the CommandPathIB shape: optional first by tag, mandatory
+        // after. A caller who builds the value object the way matter.js's
+        // own `Invoke.ts` does — set the required scalar fields up front
+        // then conditionally append the optional one — would emit tags in
+        // insertion order (1, 2, 0) if the encoder followed caller order,
+        // violating Matter Core spec §10.6.1 ("Tag Rules", Matter 1.5 /
+        // 1.5.1) and §A.5.3 (list members' meaning is denoted by their
+        // position). `TlvTaggedList`'s default schema-order encoding
+        // produces the spec-mandated wire order `0, 1, 2`.
+        const schemaCommandPathLike = TlvTaggedList({
+            endpointId: TlvOptionalField(0, TlvUInt16),
+            clusterId: TlvField(1, TlvUInt32),
+            commandId: TlvField(2, TlvUInt32),
+        });
+
+        // Wire bytes when all three fields are present, in schema/tag order:
+        //   0x17                  List
+        //     0x24 0x00 0x01      U8 ctx-tag 0 (endpointId) = 1
+        //     0x24 0x01 0x06      U8 ctx-tag 1 (clusterId)  = 6
+        //     0x24 0x02 0x01      U8 ctx-tag 2 (commandId)  = 1
+        //   0x18                  End-of-list
+        const fullHex = "1724000124010624020118";
+
+        it("emits members in schema-defined tag order regardless of caller property order", () => {
+            // matter.js's Invoke.ts builds commandPath this way: clusterId
+            // and commandId are set unconditionally, then endpointId is
+            // appended if present.
+            const callerOrder = { clusterId: 6, commandId: 1, endpointId: 1 };
+            const schemaOrder = { endpointId: 1, clusterId: 6, commandId: 1 };
+
+            expect(Bytes.toHex(schemaCommandPathLike.encode(callerOrder))).equal(fullHex);
+            expect(Bytes.toHex(schemaCommandPathLike.encode(schemaOrder))).equal(fullHex);
+            expect(schemaCommandPathLike.decode(Bytes.fromHex(fullHex))).deep.equal(schemaOrder);
+        });
+
+        it("omits absent optional fields and keeps remaining members in tag order", () => {
+            // Wildcard endpoint: omit endpointId entirely. Wire must still
+            // have tag 1 (clusterId) before tag 2 (commandId).
+            const expectedHex = "1724010624020118";
+            expect(Bytes.toHex(schemaCommandPathLike.encode({ clusterId: 6, commandId: 1 }))).equal(expectedHex);
+            expect(schemaCommandPathLike.decode(Bytes.fromHex(expectedHex))).deep.equal({
+                clusterId: 6,
+                commandId: 1,
+            });
+        });
+    });
+
+    describe("TlvTaggedListPreservingOrder preserves caller-supplied order", () => {
+        // Used by operational certificate inner lists (subject / issuer /
+        // extensions) where the signed bytes depend on the caller-supplied
+        // member ordering and must round-trip bit-identically.
+        const schemaPreserve = TlvTaggedListPreservingOrder({
+            endpointId: TlvOptionalField(0, TlvUInt16),
+            clusterId: TlvField(1, TlvUInt32),
+            commandId: TlvField(2, TlvUInt32),
+        });
+
+        it("emits members in caller property order, not schema order", () => {
+            // Caller order: clusterId, commandId, endpointId — wire reflects
+            // it (tag 1, then 2, then 0).
+            const callerOrderHex = "1724010624020124000118";
+            expect(Bytes.toHex(schemaPreserve.encode({ clusterId: 6, commandId: 1, endpointId: 1 }))).equal(
+                callerOrderHex,
+            );
         });
     });
 

--- a/packages/types/test/tlv/TlvObjectTest.ts
+++ b/packages/types/test/tlv/TlvObjectTest.ts
@@ -540,6 +540,13 @@ describe("TlvObject tests", () => {
                 schemaList.encode({ clusterId: 6, commandId: 1, bogus: 42 }),
             ).throw('Unknown field "bogus" not defined in tagged list schema.');
         });
+
+        it("rejects prototype-chain keys (e.g. 'toString') as unknown fields", () => {
+            const bogus = Object.assign(Object.create({ toString: "bad" }), { clusterId: 6, commandId: 1 });
+            // Add own enumerable 'toString' so Object.keys returns it.
+            Object.defineProperty(bogus, "toString", { value: "bad", enumerable: true });
+            expect(() => schemaList.encode(bogus)).throw('Unknown field "toString" not defined in tagged list schema.');
+        });
     });
 
     describe("Tlv Lists with protocol specific tags", () => {


### PR DESCRIPTION
# tlv: emit IM IB list members in schema-defined tag order

Fixes #3747.

## Summary

`TlvTaggedList`'s default encoder emits list members in the caller's
property-insertion order, which for the §10 Interaction Model IBs
violates Matter Core spec §10.6.1 ("Tag Rules") and §A.5.3. The wire
bytes for an outgoing `1.onOff.on` invoke from matter.js currently come
out as context-tag order `1, 2, 0` (cluster, command, endpoint), and
spec-compliant receivers treat the late-arriving `endpointId` as absent
— silently turning a unicast invoke into a wildcard-endpoint fan-out.

This PR adds an `inTagOrder` opt-in to `TlvTaggedList`, sets it on the
four §10 IB schemas (`TlvCommandPath`, `TlvAttributePath`, `TlvEventPath`,
`TlvClusterPath`), and adds regression tests. Default behavior is
unchanged, so list schemas whose member position is application data
(notably Matter operational certificate inner lists, whose signed bytes
must reproduce caller order on re-encode) continue to round-trip
bit-identically.

The full bug analysis, wire-byte capture, and spec citations are in the
companion issue.

## What changed

`packages/types/src/tlv/TlvObject.ts`
  - `ObjectSchema` gains a fourth constructor parameter `inTagOrder`
    (default `false`).
  - `TlvTaggedList` exposes the flag via a third positional parameter.
  - `#encodeList` consults the flag: schema-order iteration when set,
    insertion-order iteration otherwise.

`packages/types/src/protocol/types/`
  - `TlvCommandPath`, `TlvAttributePath`, `TlvEventPath`, `TlvClusterPath`
    all opt in with `inTagOrder = true`. Each schema gains a doc-comment
    explaining the §10.6.1 requirement; `TlvCommandPath` carries the
    detailed rationale and the other three refer to it.

`packages/types/test/tlv/TlvObjectTest.ts`
  - Three new tests in a `Tlv Lists with inTagOrder` block:
    1. CommandPath-shaped schema with caller order `clusterId, commandId,
       endpointId`: wire bytes are schema order `0, 1, 2`.
    2. Wildcard endpoint (`endpointId` omitted): remaining members stay
       in schema order.
    3. Default behavior unchanged when `inTagOrder` is not set.

## Why opt-in rather than blanket

The first iteration of this fix changed `#encodeList` unconditionally to
schema order and broke 58 `FabricBuilder` / `Fabric` / `FabricAuthority`
tests with `Signature verification failed` inside `Noc.verify`. Root
cause: Matter operational certificates use `TlvTaggedList` internally
(`TlvGenericMatterSubjectOrIssuerTaggedList`, `TlvCertificateExtension`),
and signature verification depends on parse-then-reencode reproducing the
originally signed bytes — which means caller-order encoding is part of
the contract there. The spec backs this up: §A.5.3 makes list-member
position semantically significant in general, and the §10.6.1
schema-order requirement applies only to §10 IBs ("Unless otherwise
noted, all context tags SHALL be emitted in the order as defined in the
appropriate specification.").

An opt-in flag keeps the two semantics cleanly separated and is a
minimal-surface change.

## Tests

- `npx matter-test esm` in `@matter/types`: **311/311** (+ the 3 new
  tests in this PR).
- `npx matter-test esm` in `@matter/protocol`: **841/841**, including
  all `FabricBuilder` / `Fabric` / `FabricAuthority` / `Certificate*` /
  `CertificateAuthority` cases that exercise certificate round-trips.
- `npm run lint`: 0 warnings, 0 errors.
- `npm run format`: clean.

## End-to-end verification

The fix was developed against a two-endpoint OnOff light implemented
with rs-matter + esp-idf-matter on ESP32-C6 NanoC6 hardware. Without
this fix and without a receiver-side workaround, toggling one Home
Assistant `light.*` entity flips both endpoints' physical outputs. The
device's serial log makes the dispatch concrete:

  Before fix (matter.js writes tags 1, 2, 0; rs-matter scans ascending):

      OnOffHandler(EP=1, hooks=0x408405a8).handle_on cmd.endpoint_id=1
      OnOffHandler(EP=2, hooks=0x408405dc).handle_on cmd.endpoint_id=2

  After fix (matter.js writes tags 0, 1, 2):

      OnOffHandler(EP=1, hooks=0x408405a8).handle_on cmd.endpoint_id=1

## Backwards compatibility

- `TlvTaggedList` callers that don't pass the new third positional
  argument keep the existing encoding behavior exactly.
- The `ObjectSchema` constructor's new fourth parameter is also
  defaulted; external subclasses (if any) compile unchanged.
- No public type signature changes.
- Wire format from matter.js is now spec-compliant for the four §10 IB
  schemas. Receivers that accepted the old non-conformant order
  continue to parse the new order correctly (the new bytes are simply
  what the spec already required).

## Spec references

  - Matter Core 1.5.1 §10.6.1 ("Tag Rules") — schema-defined tag order
    requirement.
  - Matter Core 1.5.1 §10.6.11 (CommandPathIB), §10.6.2
    (AttributePathIB), §10.6.8 (EventPathIB), §10.6.7 (ClusterPathIB).
  - Matter Core 1.5.1 §A.5.3 ("Lists") — list-member position is
    semantically significant.
  - Matter Core 1.5.1 Appendix B.5.1 — `[tag-order]` / `[schema-order]`
    / `[any-order]` qualifiers.

Verified against Matter 1.3, 1.4, and 1.5 / 1.5.1 (PDFs from CSA).
Section numbers and wording are stable across all four. matter.js
targets 1.5.1 (`Specification.REVISION` in
`packages/model/src/common/Specification.ts`).
