### PR TITLE
feat(types): make Interaction Model interactionModelRevision optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Breaking: We have removed the deprecated device type definitions in DeviceTypes that have not received updates since Matter 1.1
     - Breaking: A number of semi-internal implementation details of cluster metadata have changed.  The general API shape remains the same but some advanced use cases may require updates
     - Breaking: Removed some special pre-bound TLV string/byte-string schema exports, including `TlvHardwareAddress`
+    - Breaking: `interactionModelRevision` on all Interaction Model message schemas is now optional (`number | undefined`); chip SDK already treats it as optional per-message and cannot disambiguate revisions when absent, so consumers must handle `undefined` rather than receive a synthetic default
     - Feature: We've rewritten the typing system for clusters to simplify types, consume less runtime memory and work better with IDEs
     - Enhancement: Increases Matter TlvString/TlvByteString default maximum length to 65536 to cover WebRTC cases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,6 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Breaking: We have removed the deprecated device type definitions in DeviceTypes that have not received updates since Matter 1.1
     - Breaking: A number of semi-internal implementation details of cluster metadata have changed.  The general API shape remains the same but some advanced use cases may require updates
     - Breaking: Removed some special pre-bound TLV string/byte-string schema exports, including `TlvHardwareAddress`
-    - Breaking: `interactionModelRevision` on all Interaction Model message schemas is now optional (`number | undefined`); chip SDK already treats it as optional per-message and cannot disambiguate revisions when absent, so consumers must handle `undefined` rather than receive a synthetic default
     - Feature: We've rewritten the typing system for clusters to simplify types, consume less runtime memory and work better with IDEs
     - Enhancement: Increases Matter TlvString/TlvByteString default maximum length to 65536 to cover WebRTC cases
 

--- a/packages/node/src/node/server/InteractionServer.ts
+++ b/packages/node/src/node/server/InteractionServer.ts
@@ -242,6 +242,16 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
         };
     }
 
+    #checkSenderRevision(interactionModelRevision: number | undefined) {
+        if (interactionModelRevision === undefined) {
+            logger.debug("Sender omitted interaction model revision");
+        } else if (interactionModelRevision > Specification.INTERACTION_MODEL_REVISION) {
+            logger.debug(
+                `Interaction model revision of sender ${interactionModelRevision} is higher than supported ${Specification.INTERACTION_MODEL_REVISION}`,
+            );
+        }
+    }
+
     /**
      * Returns an iterator that yields the data reports and events data for the given read request.
      */
@@ -284,11 +294,7 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
             }),
         ]);
 
-        if (interactionModelRevision > Specification.INTERACTION_MODEL_REVISION) {
-            logger.debug(
-                `Interaction model revision of sender ${interactionModelRevision} is higher than supported ${Specification.INTERACTION_MODEL_REVISION}.`,
-            );
-        }
+        this.#checkSenderRevision(interactionModelRevision);
         if (attributeRequests === undefined && eventRequests === undefined) {
             return {
                 dataReport: {
@@ -339,11 +345,7 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
             );
         }
 
-        if (interactionModelRevision > Specification.INTERACTION_MODEL_REVISION) {
-            logger.debug(
-                `Interaction model revision of sender ${interactionModelRevision} is higher than supported ${Specification.INTERACTION_MODEL_REVISION}.`,
-            );
-        }
+        this.#checkSenderRevision(interactionModelRevision);
 
         const receivedWithinTimedInteraction = exchange.hasActiveTimedInteraction();
 
@@ -529,11 +531,7 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
             }),
         ]);
 
-        if (interactionModelRevision > Specification.INTERACTION_MODEL_REVISION) {
-            logger.debug(
-                `Interaction model revision of sender ${interactionModelRevision} is higher than supported ${Specification.INTERACTION_MODEL_REVISION}.`,
-            );
-        }
+        this.#checkSenderRevision(interactionModelRevision);
 
         if (message.packetHeader.sessionType !== SessionType.Unicast) {
             throw new StatusResponseError(
@@ -834,11 +832,7 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
             }),
         ]);
 
-        if (interactionModelRevision > Specification.INTERACTION_MODEL_REVISION) {
-            logger.debug(
-                `Interaction model revision of sender ${interactionModelRevision} is higher than supported ${Specification.INTERACTION_MODEL_REVISION}.`,
-            );
-        }
+        this.#checkSenderRevision(interactionModelRevision);
 
         const receivedWithinTimedInteraction = exchange.hasActiveTimedInteraction();
         if (exchange.hasExpiredTimedInteraction()) {
@@ -994,11 +988,7 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
             }),
         ]);
 
-        if (interactionModelRevision > Specification.INTERACTION_MODEL_REVISION) {
-            logger.debug(
-                `Interaction model revision of sender ${interactionModelRevision} is higher than supported ${Specification.INTERACTION_MODEL_REVISION}.`,
-            );
-        }
+        this.#checkSenderRevision(interactionModelRevision);
 
         exchange.startTimedInteraction(interval);
     }

--- a/packages/protocol/src/action/client/subscription/ClientSubscription.ts
+++ b/packages/protocol/src/action/client/subscription/ClientSubscription.ts
@@ -20,7 +20,7 @@ export abstract class ClientSubscription implements ActiveSubscription {
     readonly request: Subscribe;
     readonly peer: PeerAddress;
     abstract maxInterval: number;
-    abstract interactionModelRevision: number;
+    abstract interactionModelRevision: number | undefined;
 
     /**
      * If the subscription has an async worker, this is the promise associated with the worker.

--- a/packages/protocol/src/action/client/subscription/PeerSubscription.ts
+++ b/packages/protocol/src/action/client/subscription/PeerSubscription.ts
@@ -13,7 +13,7 @@ import { ClientSubscription } from "./ClientSubscription.js";
  * A Matter protocol-level subscription established with a peer.
  */
 export class PeerSubscription extends ClientSubscription {
-    readonly interactionModelRevision: number;
+    readonly interactionModelRevision: number | undefined;
     readonly maxInterval: number;
     readonly #maxPeerResponseTime: Duration;
     isReading = false;

--- a/packages/protocol/src/action/client/subscription/SustainedSubscription.ts
+++ b/packages/protocol/src/action/client/subscription/SustainedSubscription.ts
@@ -24,7 +24,6 @@ import {
     Seconds,
     Time,
 } from "@matter/general";
-import { Specification } from "@matter/model";
 import { SubscribeResponse } from "@matter/types";
 import { ClientSubscription } from "./ClientSubscription.js";
 import { PeerSubscription } from "./PeerSubscription.js";
@@ -197,7 +196,7 @@ export class SustainedSubscription extends ClientSubscription {
     }
 
     get interactionModelRevision() {
-        return this.#subscription?.interactionModelRevision ?? Specification.INTERACTION_MODEL_REVISION;
+        return this.#subscription?.interactionModelRevision;
     }
 
     get maxInterval() {

--- a/packages/protocol/src/interaction/InteractionMessenger.ts
+++ b/packages/protocol/src/interaction/InteractionMessenger.ts
@@ -363,7 +363,7 @@ export class InteractionServerMessenger extends InteractionMessenger {
         const dataReport: TypeFromSchema<typeof TlvDataReportForSend> = {
             subscriptionId,
             suppressResponse,
-            interactionModelRevision,
+            interactionModelRevision: interactionModelRevision ?? Specification.INTERACTION_MODEL_REVISION,
             attributeReports: undefined,
             eventReports: undefined,
         };

--- a/packages/types/src/protocol/messages/TlvDataReport.ts
+++ b/packages/types/src/protocol/messages/TlvDataReport.ts
@@ -8,7 +8,7 @@ import { TypeFromSchema } from "#tlv/TlvSchema.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvBoolean } from "../../tlv/TlvBoolean.js";
 import { TlvUInt32, TlvUInt8 } from "../../tlv/TlvNumber.js";
-import { TlvField, TlvObject, TlvOptionalField } from "../../tlv/TlvObject.js";
+import { TlvObject, TlvOptionalField } from "../../tlv/TlvObject.js";
 import { TlvAttributeReport } from "../types/TlvAttributeReport.js";
 import { TlvEventReport } from "../types/TlvEventReport.js";
 
@@ -27,7 +27,7 @@ export const TlvDataReport = TlvObject({
 
     /** Do not send a response to this action. */
     suppressResponse: TlvOptionalField(4, TlvBoolean),
-    interactionModelRevision: TlvField(0xff, TlvUInt8),
+    interactionModelRevision: TlvOptionalField(0xff, TlvUInt8),
 });
 
 export type DataReport = TypeFromSchema<typeof TlvDataReport>;

--- a/packages/types/src/protocol/messages/TlvInvokeRequest.ts
+++ b/packages/types/src/protocol/messages/TlvInvokeRequest.ts
@@ -8,7 +8,7 @@ import { TypeFromSchema } from "#tlv/TlvSchema.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvBoolean } from "../../tlv/TlvBoolean.js";
 import { TlvUInt8 } from "../../tlv/TlvNumber.js";
-import { TlvField, TlvObject } from "../../tlv/TlvObject.js";
+import { TlvField, TlvObject, TlvOptionalField } from "../../tlv/TlvObject.js";
 import { TlvCommandData } from "../types/TlvCommandData.js";
 
 /** @see {@link MatterSpecification.v13.Core}, section 10.7.9 */
@@ -22,7 +22,7 @@ export const TlvInvokeRequest = TlvObject({
 
     /** Cluster command(s) to invoke. */
     invokeRequests: TlvField(2, TlvArray(TlvCommandData)),
-    interactionModelRevision: TlvField(0xff, TlvUInt8),
+    interactionModelRevision: TlvOptionalField(0xff, TlvUInt8),
 });
 
 export type InvokeRequest = TypeFromSchema<typeof TlvInvokeRequest>;

--- a/packages/types/src/protocol/messages/TlvInvokeResponse.ts
+++ b/packages/types/src/protocol/messages/TlvInvokeResponse.ts
@@ -20,7 +20,7 @@ export const TlvInvokeResponse = TlvObject({
     /** Command response or status. */
     invokeResponses: TlvField(1, TlvArray(TlvInvokeResponseData)),
     moreChunkedMessages: TlvOptionalField(2, TlvBoolean),
-    interactionModelRevision: TlvField(0xff, TlvUInt8),
+    interactionModelRevision: TlvOptionalField(0xff, TlvUInt8),
 });
 
 export type InvokeResponse = TypeFromSchema<typeof TlvInvokeResponse>;

--- a/packages/types/src/protocol/messages/TlvReadRequest.ts
+++ b/packages/types/src/protocol/messages/TlvReadRequest.ts
@@ -31,7 +31,7 @@ export const TlvReadRequest = TlvObject({
 
     /** A list of zero or more cluster instance data versions. */
     dataVersionFilters: TlvOptionalField(4, TlvArray(TlvDataVersionFilter)),
-    interactionModelRevision: TlvField(0xff, TlvUInt8),
+    interactionModelRevision: TlvOptionalField(0xff, TlvUInt8),
 });
 
 export type ReadRequest = TypeFromSchema<typeof TlvReadRequest>;

--- a/packages/types/src/protocol/messages/TlvStatusResponse.ts
+++ b/packages/types/src/protocol/messages/TlvStatusResponse.ts
@@ -6,12 +6,12 @@
 
 import { StatusCode } from "../../common/StatusCode.js";
 import { TlvEnum, TlvUInt8 } from "../../tlv/TlvNumber.js";
-import { TlvField, TlvObject } from "../../tlv/TlvObject.js";
+import { TlvField, TlvObject, TlvOptionalField } from "../../tlv/TlvObject.js";
 
 /** @see {@link MatterSpecification.v13.Core}, section 10.7.1 */
 
 export const TlvStatusResponse = TlvObject({
     /** A status code (@see Status Codes {@link MatterSpecification.v13.Core} section 7.10.7) */
     status: TlvField(0, TlvEnum<StatusCode>()),
-    interactionModelRevision: TlvField(0xff, TlvUInt8),
+    interactionModelRevision: TlvOptionalField(0xff, TlvUInt8),
 });

--- a/packages/types/src/protocol/messages/TlvSubscribeRequest.ts
+++ b/packages/types/src/protocol/messages/TlvSubscribeRequest.ts
@@ -40,7 +40,7 @@ export const TlvSubscribeRequest = TlvObject({
 
     /** A list of zero or more cluster instance data versions. */
     dataVersionFilters: TlvOptionalField(8, TlvArray(TlvDataVersionFilter)),
-    interactionModelRevision: TlvField(0xff, TlvUInt8),
+    interactionModelRevision: TlvOptionalField(0xff, TlvUInt8),
 });
 
 export type SubscribeRequest = TypeFromSchema<typeof TlvSubscribeRequest>;

--- a/packages/types/src/protocol/messages/TlvSubscribeResponse.ts
+++ b/packages/types/src/protocol/messages/TlvSubscribeResponse.ts
@@ -6,7 +6,7 @@
 
 import { TypeFromSchema } from "#tlv/TlvSchema.js";
 import { TlvUInt16, TlvUInt32, TlvUInt8 } from "../../tlv/TlvNumber.js";
-import { TlvField, TlvObject } from "../../tlv/TlvObject.js";
+import { TlvField, TlvObject, TlvOptionalField } from "../../tlv/TlvObject.js";
 
 /** @see {@link MatterSpecification.v13.Core}, section 10.7.5 */
 
@@ -17,7 +17,7 @@ export const TlvSubscribeResponse = TlvObject({
     /** The final maximum interval for the subscription in seconds. */
     maxInterval: TlvField(2, TlvUInt16),
 
-    interactionModelRevision: TlvField(0xff, TlvUInt8),
+    interactionModelRevision: TlvOptionalField(0xff, TlvUInt8),
 });
 
 export type SubscribeResponse = TypeFromSchema<typeof TlvSubscribeResponse>;

--- a/packages/types/src/protocol/messages/TlvTimedRequest.ts
+++ b/packages/types/src/protocol/messages/TlvTimedRequest.ts
@@ -6,14 +6,14 @@
 
 import { TypeFromSchema } from "#tlv/TlvSchema.js";
 import { TlvUInt16, TlvUInt8 } from "../../tlv/TlvNumber.js";
-import { TlvField, TlvObject } from "../../tlv/TlvObject.js";
+import { TlvField, TlvObject, TlvOptionalField } from "../../tlv/TlvObject.js";
 
 /** @see {@link MatterSpecification.v13.Core}, section 10.7.8 */
 
 export const TlvTimedRequest = TlvObject({
     /** An interval, in milliseconds, to expect a following action. */
     timeout: TlvField(0, TlvUInt16),
-    interactionModelRevision: TlvField(0xff, TlvUInt8),
+    interactionModelRevision: TlvOptionalField(0xff, TlvUInt8),
 });
 
 export type TimedRequest = TypeFromSchema<typeof TlvTimedRequest>;

--- a/packages/types/src/protocol/messages/TlvWriteRequest.ts
+++ b/packages/types/src/protocol/messages/TlvWriteRequest.ts
@@ -23,7 +23,7 @@ export const TlvWriteRequest = TlvObject({
     /** A list of one or more path and data tuples. */
     writeRequests: TlvField(2, TlvArray(TlvAttributeData)),
     moreChunkedMessages: TlvOptionalField(3, TlvBoolean),
-    interactionModelRevision: TlvField(0xff, TlvUInt8),
+    interactionModelRevision: TlvOptionalField(0xff, TlvUInt8),
 });
 
 export type WriteRequest = TypeFromSchema<typeof TlvWriteRequest>;

--- a/packages/types/src/protocol/messages/TlvWriteResponse.ts
+++ b/packages/types/src/protocol/messages/TlvWriteResponse.ts
@@ -7,7 +7,7 @@
 import { TypeFromSchema } from "#tlv/TlvSchema.js";
 import { TlvArray } from "../../tlv/TlvArray.js";
 import { TlvUInt8 } from "../../tlv/TlvNumber.js";
-import { TlvField, TlvObject } from "../../tlv/TlvObject.js";
+import { TlvField, TlvObject, TlvOptionalField } from "../../tlv/TlvObject.js";
 import { TlvAttributeStatus } from "../types/TlvAttributeStatus.js";
 
 /** @see {@link MatterSpecification.v13.Core}, section 10.7.7 */
@@ -15,7 +15,7 @@ import { TlvAttributeStatus } from "../types/TlvAttributeStatus.js";
 export const TlvWriteResponse = TlvObject({
     /** A list of zero or more concrete paths indicating errors or successes. */
     writeResponses: TlvField(0, TlvArray(TlvAttributeStatus)),
-    interactionModelRevision: TlvField(0xff, TlvUInt8),
+    interactionModelRevision: TlvOptionalField(0xff, TlvUInt8),
 });
 
 export type WriteResponse = TypeFromSchema<typeof TlvWriteResponse>;


### PR DESCRIPTION
## Summary

All 10 incoming Interaction Model message schemas now declare `interactionModelRevision` as `TlvOptionalField` instead of `TlvField`. Type narrows from `number` to `number | undefined`. No synthetic default is applied on decode — consumers see `undefined` when the peer omitted the field.

## Why

Per a deep dive into the chip C++ SDK (`src/app/MessageDef/`), the field is treated as optional per-message everywhere it appears: `GetSimpleValue()` returns `CHIP_END_OF_TLV` when the tag is absent (`Parser.h:118`); `CheckInteractionModelRevision()` only logs under `CHIP_CONFIG_IM_PRETTY_PRINT` and is the only consumer (`MessageParser.cpp:40-50`); the public `GetInteractionModelRevision()` getter is never called anywhere in chip's codebase. The session-layer comment at `src/messaging/SessionParameters.h:99-100` explicitly notes that an absent revision could mean 10 or 11 and cannot be disambiguated.

matter.js currently rejects messages from spec-compliant peers that omit the field (mandatory `TlvField` throws `ValidationMandatoryFieldMissingError` on decode). This PR aligns the wire-level contract with chip's behavior. Because there is no reliable default, we expose `undefined` to consumers rather than substitute our own revision.

see also #3747 

## What changed

**Schemas (`@matter/types`, 10 incoming + 2 outgoing kept as-is)**

`TlvField(0xff, TlvUInt8)` → `TlvOptionalField(0xff, TlvUInt8)` on:
- `TlvReadRequest`, `TlvWriteRequest`, `TlvWriteResponse`
- `TlvInvokeRequest`, `TlvInvokeResponse`
- `TlvSubscribeRequest`, `TlvSubscribeResponse`
- `TlvTimedRequest`, `TlvStatusResponse`, `TlvDataReport`

Kept mandatory (we always know our own revision when sending):
- `TlvDataReportForSend`, `TlvInvokeResponseForSend`

**Server (`@matter/node`)**

`InteractionServer.ts` consolidates the five identical sender-revision check sites into a single `#checkSenderRevision` helper. The helper now DEBUG-logs both the existing "higher than supported" branch and a new "sender omitted interaction model revision" branch.

**Protocol (`@matter/protocol`)**

- `ClientSubscription.interactionModelRevision`, `PeerSubscription.interactionModelRevision`, `SustainedSubscription.interactionModelRevision` are typed `number | undefined`.
- `SustainedSubscription` no longer falls back to `Specification.INTERACTION_MODEL_REVISION` when the peer omitted the value; the getter returns `undefined`.
- `InteractionMessenger.ts` forwarding path substitutes our own revision when the source `baseDataReport.interactionModelRevision` is undefined (we always include it when sending).

## Not changed

- 16 producer/encode sites still write `Specification.INTERACTION_MODEL_REVISION` — we know our own revision and always include it.
- PASE `SessionParameters.interactionModelRevision` (separate handshake schema) was already optional with its own fallback (`11`) and is untouched.
- Session-level revision tracking in `Session.ts` / `NodeSession.ts` (sourced from PASE handshake) is untouched.

## Backwards compatibility

External consumers reading `interactionModelRevision` from incoming `ReadRequest`/`WriteRequest`/etc. or from `ClientSubscription`/`PeerSubscription`/`SustainedSubscription` need to handle `undefined`. matter.js's own outbound encodes are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)