### PR TITLE
chore(types): tighten TlvTaggedList encode path and doc-comments

### DIFF
--- a/packages/protocol/src/certificate/kinds/definitions/operational.ts
+++ b/packages/protocol/src/certificate/kinds/definitions/operational.ts
@@ -32,7 +32,6 @@ import { ExtensionKeyUsageBitmap } from "./base.js";
  */
 export const MAX_TLV_CERTIFICATE_SIZE = 400;
 
-// Order-preserving: extensions are part of the certificate's signed bytes; re-encode must reproduce wire order.
 export const TlvCertificateExtension = TlvTaggedListPreservingOrder({
     basicConstraints: TlvField(
         1,

--- a/packages/types/src/tlv/TlvObject.ts
+++ b/packages/types/src/tlv/TlvObject.ts
@@ -154,10 +154,8 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
     }
 
     /**
-     * Encode the object as List. Default emits in schema definition order (which matter.js declares in spec/tag order,
-     * satisfying Matter Core §10.6.1 for Interaction Model IBs). With
-     * {@link preserveDataOrdering}, caller-supplied property order is emitted first (used for certificate sub-lists
-     * whose signed bytes depend on original member order; §A.5.3), with any remaining schema fields appended after.
+     * Encode the object as List. Default emits in schema definition order. With {@link preserveDataOrdering},
+     * caller-supplied property order is emitted first, with any remaining schema fields appended after.
      */
     #encodeList(writer: TlvWriter, value: TypeFromFields<F>, options?: TlvEncodingOptions) {
         const valueKeys = Object.keys(value);
@@ -169,15 +167,19 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
                 );
             }
         }
-        const encodedFields = new Set<string>();
         if (this.preserveDataOrdering) {
+            const encodedFields = new Set<string>();
             for (const name of valueKeys) {
                 this.#encodeEntryToTlv(writer, name, value, options);
                 encodedFields.add(name);
             }
+            for (const name in this.fieldDefinitions) {
+                if (encodedFields.has(name)) continue;
+                this.#encodeEntryToTlv(writer, name, value, options);
+            }
+            return;
         }
         for (const name in this.fieldDefinitions) {
-            if (encodedFields.has(name)) continue;
             this.#encodeEntryToTlv(writer, name, value, options);
         }
     }
@@ -360,13 +362,11 @@ export const TlvObjectWithMaxSize = <F extends TlvFields>(fields: F, maxSize: nu
     new ObjectSchemaWithMaxSize(fields, maxSize, TlvType.Structure);
 
 /**
- * List TLV schema with all tagged entries. Members are emitted in schema definition order on encode; matter.js
- * declares fields in spec/tag order, which satisfies Matter Core §10.6.1 for Interaction Model IBs.
+ * List TLV schema with all tagged entries. Members are emitted in schema definition order on encode.
  * List entries that can appear multiple times can be defined using TlvRepeatedField/TlvOptionalRepeatedField and are
  * represented as Arrays.
  *
- * For lists whose wire order must reproduce caller-supplied order (e.g. signed certificate sub-lists), use
- * {@link TlvTaggedListPreservingOrder}.
+ * For lists whose wire order must reproduce caller-supplied order, use {@link TlvTaggedListPreservingOrder}.
  *
  * TODO: We represent Tlv Lists right now as named object properties. This formally does not match the spec, which
  *      defines a list as a sequence of TLV elements with optional tag where the order matters. That's ok for now

--- a/packages/types/test/tlv/TlvObjectTest.ts
+++ b/packages/types/test/tlv/TlvObjectTest.ts
@@ -519,6 +519,11 @@ describe("TlvObject tests", () => {
             );
         });
 
+        it("omits absent optional fields and emits remaining schema fields after caller-supplied ones", () => {
+            const expectedHex = "1724010624020118";
+            expect(Bytes.toHex(schemaPreserve.encode({ clusterId: 6, commandId: 1 }))).equal(expectedHex);
+        });
+
         it("throws ValidationDatatypeMismatchError on unknown fields", () => {
             expect(() =>
                 // @ts-expect-error test case


### PR DESCRIPTION
## Summary

Follow-up cleanup on #3748 (merged). Addresses internal review nits — no behavior change for callers.

## What changed

**`packages/types/src/tlv/TlvObject.ts`**
- `#encodeList`: allocate the encoded-fields tracking `Set` only inside the preserve-order branch. The default schema-order path (every CommandPathIB/AttributePathIB/EventPathIB/ClusterPathIB encode) no longer pays for an unused `Set` and unused `has` check on every call.
- Trim certificate-specific rationale from the private `#encodeList` JSDoc and the §10.6.1 IM-specific citation from the `TlvTaggedList` factory JSDoc. That domain detail belongs on `TlvTaggedListPreservingOrder` (already there) and at the call sites, not on the generic TLV encoder.

**`packages/protocol/src/certificate/kinds/definitions/operational.ts`**
- Drop the redundant `Order-preserving:` comment on `TlvCertificateExtension`; the factory name + JSDoc already convey the intent.
- Keep the comment on `TlvGenericMatterSubjectOrIssuerTaggedList` where the helper's purpose is less obvious from local context.

**`packages/types/test/tlv/TlvObjectTest.ts`**
- Add a regression test covering `TlvTaggedListPreservingOrder` with an absent optional field. Exercises the second loop that appends remaining schema fields after the caller-supplied ones — previously untested.

## Tests

- `format-verify`: clean
- `lint`: 0 warnings, 0 errors
- `@matter/types`: 315/315 ✓
- `@matter/protocol`: 842/842 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)