### PR TITLE
fix: dispose service lifetimes on close to remove diagnostic leaks

### DIFF
--- a/packages/node/src/node/server/ServerEnvironment.ts
+++ b/packages/node/src/node/server/ServerEnvironment.ts
@@ -21,6 +21,7 @@ import {
     StorageService,
 } from "@matter/general";
 import {
+    CertificateAuthority,
     FabricAuthority,
     FabricManager,
     MdnsService,
@@ -84,7 +85,7 @@ export namespace ServerEnvironment {
     export async function close(node: ServerNode) {
         const { env } = node;
 
-        env.close(FabricManager);
+        await env.close(FabricManager);
         await env.close(PeerSet);
         await env.close(ChangeNotificationService);
         await env.close(SessionManager);
@@ -98,7 +99,8 @@ export namespace ServerEnvironment {
 
         await env.close(ServerNodeStore);
         await env.close(SharedNodeServices);
-        env.close(FabricAuthority);
+        await env.close(FabricAuthority);
+        await env.close(CertificateAuthority);
 
         // Release the env-held lock (from storage.lock) if one was acquired
         if (env.has(DatafileRoot.Lock)) {

--- a/packages/protocol/src/events/OccurrenceManager.ts
+++ b/packages/protocol/src/events/OccurrenceManager.ts
@@ -272,8 +272,11 @@ export class OccurrenceManager {
     }
 
     // For ServerNode usage the ServerEnvironment takes care to close the OccurrenceManager
-    close(): MaybePromise<void> {
-        return MaybePromise.then(this.#cull, () => this.#store.close());
+    async close() {
+        await this.#construction.close(async () => {
+            await this.#cull;
+            await this.#store.close();
+        });
     }
 
     add(occurrence: Occurrence): MaybePromise<NumberedOccurrence> {

--- a/packages/protocol/src/fabric/FabricManager.ts
+++ b/packages/protocol/src/fabric/FabricManager.ts
@@ -89,6 +89,10 @@ export class FabricManager {
         await this.construction;
     }
 
+    async close() {
+        await this.#construction.close();
+    }
+
     static [Environmental.create](env: Environment) {
         const instance = new FabricManager(env.get(Crypto), env.get(StorageManager).createContext("fabrics"));
         env.set(FabricManager, instance);

--- a/packages/protocol/src/session/SessionManager.ts
+++ b/packages/protocol/src/session/SessionManager.ts
@@ -750,13 +750,10 @@ export class SessionManager {
     }
 
     async close() {
-        if (this.#construction.status === Lifecycle.Status.Initializing) {
-            await this.#construction;
-        }
-
-        this.#observers.close();
-
-        await this.closeAllSessions();
+        await this.#construction.close(async () => {
+            this.#observers.close();
+            await this.closeAllSessions();
+        });
     }
 
     async clear() {


### PR DESCRIPTION
## Summary
- **FabricManager**: add `close()` so its Construction lifetime is disposed on shutdown.
- **SessionManager.close**: wrap existing teardown in `construction.close(destructor)` so the lifecycle transitions to Destroyed and the lifetime is disposed.
- **OccurrenceManager.close**: same `construction.close(destructor)` wrap.
- **ServerEnvironment.close**: add `CertificateAuthority` to the cascade and `await` `FabricAuthority` (previously fire-and-forget) so both lifetimes finish disposing before close returns; also `await` `FabricManager` now that it has an async close.

## Context
Follow-up to #3746.  After shutdown the diagnose dump still showed `fabric manager`, `session manager`, `occurrence manager`, `certificate authority`, `fabric authority` lifetimes alive — diagnostic-only noise (no handles), but distracting when triaging real hang causes.  Each of these services either lacked a `close()` method, had a `close()` that didn't trigger `Construction` teardown, or was missing from `ServerEnvironment.close()`.

## Test plan
- [x] `npm test -- -p packages/protocol` (842/842 ESM/CJS/Web)
- [x] `npm test -- -p packages/node` (1135/1135 ESM/CJS/Web)
- [x] `npm run format-verify`, `npm run lint`, `npm run build` — clean
- [ ] Manual: re-run matter-server shutdown diagnose and confirm these five lifetimes no longer show in the dump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)