### PR TITLE
fix(codegen): exclude disallowed clusters from device requirements

### DIFF
--- a/packages/model/src/aspects/Conformance.ts
+++ b/packages/model/src/aspects/Conformance.ts
@@ -100,6 +100,13 @@ export class Conformance extends Aspect<Conformance.Definition> {
     }
 
     /**
+     * Is the associated element disallowed?
+     */
+    get isDisallowed() {
+        return this.ast.type === Conformance.Flag.Disallowed;
+    }
+
+    /**
      * Perform limited conformance evaluation to determine whether this conformance is applicable given a feature
      * combination.
      *

--- a/packages/model/src/models/RequirementModel.ts
+++ b/packages/model/src/models/RequirementModel.ts
@@ -75,6 +75,13 @@ export class RequirementModel extends Model<RequirementElement, RequirementModel
         return this.conformance.isMandatory;
     }
 
+    /**
+     * Is the element disallowed?
+     */
+    get isDisallowed() {
+        return this.conformance.isDisallowed;
+    }
+
     constructor(
         definition: Model.Definition<RequirementModel>,
         ...children: Model.ChildDefinition<RequirementModel>[]

--- a/packages/model/src/standard/elements/occupancy-sensing.element.ts
+++ b/packages/model/src/standard/elements/occupancy-sensing.element.ts
@@ -17,7 +17,7 @@ import {
 
 export const OccupancySensing = Cluster(
     { name: "OccupancySensing", id: 0x406, classification: "application" },
-    Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 7 }),
+    Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 6 }),
 
     Attribute(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },

--- a/packages/node/src/devices/closure-panel.ts
+++ b/packages/node/src/devices/closure-panel.ts
@@ -9,8 +9,6 @@
 import {
     ClosureDimensionServer as BaseClosureDimensionServer
 } from "../behaviors/closure-dimension/ClosureDimensionServer.js";
-import { WindowCoveringServer as BaseWindowCoveringServer } from "../behaviors/window-covering/WindowCoveringServer.js";
-import { ClosureControlServer as BaseClosureControlServer } from "../behaviors/closure-control/ClosureControlServer.js";
 import { MutableEndpoint } from "../endpoint/type/MutableEndpoint.js";
 import { SupportedBehaviors } from "../endpoint/properties/SupportedBehaviors.js";
 import { Identity } from "@matter/general";
@@ -46,26 +44,9 @@ export namespace ClosurePanelRequirements {
     export const ClosureDimensionServer = BaseClosureDimensionServer;
 
     /**
-     * The WindowCovering cluster is optional per the Matter specification.
-     *
-     * We provide this alias to the default implementation {@link WindowCoveringServer} for convenience.
-     */
-    export const WindowCoveringServer = BaseWindowCoveringServer;
-
-    /**
-     * The ClosureControl cluster is optional per the Matter specification.
-     *
-     * We provide this alias to the default implementation {@link ClosureControlServer} for convenience.
-     */
-    export const ClosureControlServer = BaseClosureControlServer;
-
-    /**
      * An implementation for each server cluster supported by the endpoint per the Matter specification.
      */
-    export const server = {
-        mandatory: { ClosureDimension: ClosureDimensionServer },
-        optional: { WindowCovering: WindowCoveringServer, ClosureControl: ClosureControlServer }
-    };
+    export const server = { mandatory: { ClosureDimension: ClosureDimensionServer } };
 }
 
 export const ClosurePanelDeviceDefinition = MutableEndpoint({

--- a/packages/node/src/devices/closure.ts
+++ b/packages/node/src/devices/closure.ts
@@ -8,10 +8,6 @@
 
 import { IdentifyServer as BaseIdentifyServer } from "../behaviors/identify/IdentifyServer.js";
 import { ClosureControlServer as BaseClosureControlServer } from "../behaviors/closure-control/ClosureControlServer.js";
-import { WindowCoveringServer as BaseWindowCoveringServer } from "../behaviors/window-covering/WindowCoveringServer.js";
-import {
-    ClosureDimensionServer as BaseClosureDimensionServer
-} from "../behaviors/closure-dimension/ClosureDimensionServer.js";
 import { MutableEndpoint } from "../endpoint/type/MutableEndpoint.js";
 import { SupportedBehaviors } from "../endpoint/properties/SupportedBehaviors.js";
 import { Identity } from "@matter/general";
@@ -47,26 +43,9 @@ export namespace ClosureRequirements {
     export const ClosureControlServer = BaseClosureControlServer;
 
     /**
-     * The WindowCovering cluster is optional per the Matter specification.
-     *
-     * We provide this alias to the default implementation {@link WindowCoveringServer} for convenience.
-     */
-    export const WindowCoveringServer = BaseWindowCoveringServer;
-
-    /**
-     * The ClosureDimension cluster is optional per the Matter specification.
-     *
-     * We provide this alias to the default implementation {@link ClosureDimensionServer} for convenience.
-     */
-    export const ClosureDimensionServer = BaseClosureDimensionServer;
-
-    /**
      * An implementation for each server cluster supported by the endpoint per the Matter specification.
      */
-    export const server = {
-        mandatory: { Identify: IdentifyServer, ClosureControl: ClosureControlServer },
-        optional: { WindowCovering: WindowCoveringServer, ClosureDimension: ClosureDimensionServer }
-    };
+    export const server = { mandatory: { Identify: IdentifyServer, ClosureControl: ClosureControlServer } };
 }
 
 export const ClosureDeviceDefinition = MutableEndpoint({

--- a/packages/node/src/devices/door-lock.ts
+++ b/packages/node/src/devices/door-lock.ts
@@ -8,10 +8,6 @@
 
 import { IdentifyServer as BaseIdentifyServer } from "../behaviors/identify/IdentifyServer.js";
 import { DoorLockServer as BaseDoorLockServer } from "../behaviors/door-lock/DoorLockServer.js";
-import { GroupsServer as BaseGroupsServer } from "../behaviors/groups/GroupsServer.js";
-import {
-    ScenesManagementServer as BaseScenesManagementServer
-} from "../behaviors/scenes-management/ScenesManagementServer.js";
 import { MutableEndpoint } from "../endpoint/type/MutableEndpoint.js";
 import { SupportedBehaviors } from "../endpoint/properties/SupportedBehaviors.js";
 import { Identity } from "@matter/general";
@@ -40,26 +36,9 @@ export namespace DoorLockRequirements {
     export const DoorLockServer = BaseDoorLockServer;
 
     /**
-     * The Groups cluster is optional per the Matter specification.
-     *
-     * We provide this alias to the default implementation {@link GroupsServer} for convenience.
-     */
-    export const GroupsServer = BaseGroupsServer;
-
-    /**
-     * The ScenesManagement cluster is optional per the Matter specification.
-     *
-     * We provide this alias to the default implementation {@link ScenesManagementServer} for convenience.
-     */
-    export const ScenesManagementServer = BaseScenesManagementServer;
-
-    /**
      * An implementation for each server cluster supported by the endpoint per the Matter specification.
      */
-    export const server = {
-        mandatory: { Identify: IdentifyServer, DoorLock: DoorLockServer },
-        optional: { Groups: GroupsServer, ScenesManagement: ScenesManagementServer }
-    };
+    export const server = { mandatory: { Identify: IdentifyServer, DoorLock: DoorLockServer } };
 }
 
 export const DoorLockDeviceDefinition = MutableEndpoint({

--- a/packages/node/src/devices/window-covering.ts
+++ b/packages/node/src/devices/window-covering.ts
@@ -9,10 +9,6 @@
 import { IdentifyServer as BaseIdentifyServer } from "../behaviors/identify/IdentifyServer.js";
 import { WindowCoveringServer as BaseWindowCoveringServer } from "../behaviors/window-covering/WindowCoveringServer.js";
 import { GroupsServer as BaseGroupsServer } from "../behaviors/groups/GroupsServer.js";
-import { ClosureControlServer as BaseClosureControlServer } from "../behaviors/closure-control/ClosureControlServer.js";
-import {
-    ClosureDimensionServer as BaseClosureDimensionServer
-} from "../behaviors/closure-dimension/ClosureDimensionServer.js";
 import { MutableEndpoint } from "../endpoint/type/MutableEndpoint.js";
 import { SupportedBehaviors } from "../endpoint/properties/SupportedBehaviors.js";
 import { Identity } from "@matter/general";
@@ -50,29 +46,11 @@ export namespace WindowCoveringRequirements {
     export const GroupsServer = BaseGroupsServer;
 
     /**
-     * The ClosureControl cluster is optional per the Matter specification.
-     *
-     * We provide this alias to the default implementation {@link ClosureControlServer} for convenience.
-     */
-    export const ClosureControlServer = BaseClosureControlServer;
-
-    /**
-     * The ClosureDimension cluster is optional per the Matter specification.
-     *
-     * We provide this alias to the default implementation {@link ClosureDimensionServer} for convenience.
-     */
-    export const ClosureDimensionServer = BaseClosureDimensionServer;
-
-    /**
      * An implementation for each server cluster supported by the endpoint per the Matter specification.
      */
     export const server = {
         mandatory: { Identify: IdentifyServer, WindowCovering: WindowCoveringServer },
-        optional: {
-            Groups: GroupsServer,
-            ClosureControl: ClosureControlServer,
-            ClosureDimension: ClosureDimensionServer
-        }
+        optional: { Groups: GroupsServer }
     };
 }
 

--- a/packages/types/src/clusters/occupancy-sensing.d.ts
+++ b/packages/types/src/clusters/occupancy-sensing.d.ts
@@ -32,7 +32,7 @@ export declare namespace OccupancySensing {
     /**
      * The cluster revision assigned by {@link MatterSpecification.v151.Cluster}.
      */
-    export const revision: 7;
+    export const revision: 6;
 
     /**
      * Canonical metadata for the OccupancySensing cluster.

--- a/support/codegen/src/endpoints/RequirementGenerator.ts
+++ b/support/codegen/src/endpoints/RequirementGenerator.ts
@@ -61,6 +61,10 @@ export class RequirementGenerator {
                 continue;
             }
 
+            if (requirement.isDisallowed) {
+                continue;
+            }
+
             if (requirement.isMandatory || requirement.name === "Descriptor") {
                 const variance = ClusterVariance(definition);
                 if (variance.requiresFeatures) {

--- a/support/models/src/v1.5.1/spec.ts
+++ b/support/models/src/v1.5.1/spec.ts
@@ -4914,7 +4914,7 @@ export const SpecMatter = Matter(
                 "sensing modalities, including configuration and provision of notifications of occupancy status."
         },
 
-        Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 7 }),
+        Attribute({ name: "ClusterRevision", id: 0xfffd, type: "ClusterRevision", default: 6 }),
 
         Attribute(
             { name: "FeatureMap", id: 0xfffc, type: "FeatureMap", xref: "cluster§2.7.4" },


### PR DESCRIPTION
## Summary
- Codegen treated conformance "X" (forbidden) the same as missing M, so `ClosureControl` / `ClosureDimension` / `WindowCovering` / `Groups` / `ScenesManagement` were emitted into the `optional` map of several device-type requirement files. Added `isDisallowed` getters to `Conformance` and `RequirementModel`, then skip disallowed requirements in `RequirementGenerator` before the mandatory/optional split.
- Regenerated affected devices: `window-covering`, `closure`, `closure-panel`, `door-lock`.
- Bumped OccupancySensing cluster revision 7→6 to match the 1.5.1 spec (touches spec source + regenerated element + cluster `.d.ts`).

Thanks @Luligu for catching it

🤖 Generated with [Claude Code](https://claude.com/claude-code)