### PR TITLE
fix(node): log mandatory client clusters at endpoint activation

### DIFF
--- a/packages/node/src/behaviors/descriptor/DescriptorServer.ts
+++ b/packages/node/src/behaviors/descriptor/DescriptorServer.ts
@@ -7,11 +7,13 @@
 import { IndexBehavior } from "#behavior/system/index/IndexBehavior.js";
 import { Endpoint } from "#endpoint/Endpoint.js";
 import { EndpointLifecycle } from "#endpoint/properties/EndpointLifecycle.js";
-import { ImplementationError, isDeepEqual } from "@matter/general";
+import { ImplementationError, isDeepEqual, Logger } from "@matter/general";
 import { Matter } from "@matter/model";
 import { ClusterId, DeviceTypeId, EndpointNumber, Semtag } from "@matter/types";
 import { Descriptor } from "@matter/types/clusters/descriptor";
 import { DescriptorBehavior } from "./DescriptorBehavior.js";
+
+const logger = Logger.get("DescriptorServer");
 
 /**
  * This is the default server implementation of DescriptorBehavior.
@@ -37,6 +39,16 @@ export class DescriptorServer extends DescriptorBehavior {
 
         this.state.serverList = this.#serverList;
         this.state.clientList = this.#clientList;
+
+        const mandatoryClients = this.endpoint.type.requirements.client?.mandatory;
+        if (mandatoryClients) {
+            const active = Object.keys(mandatoryClients).filter(k => k in this.endpoint.type.clientClusters);
+            if (active.length) {
+                logger.debug(
+                    `Active mandatory client cluster(s) [${active.join(", ")}] for endpoint ${this.endpoint.id} (device type ${this.endpoint.type.name})`,
+                );
+            }
+        }
 
         // Initialize DeviceTypeList
         this.#initializeDeviceTypeList();

--- a/packages/node/src/endpoint/type/MutableEndpoint.ts
+++ b/packages/node/src/endpoint/type/MutableEndpoint.ts
@@ -6,12 +6,9 @@
 
 import { Behavior } from "#behavior/Behavior.js";
 import { isClientBehavior } from "#behavior/cluster/cluster-behavior-utils.js";
-import { Logger } from "@matter/general";
 import { SupportedBehaviors } from "../properties/SupportedBehaviors.js";
 import { SupportedClientClusters } from "../properties/SupportedClientClusters.js";
 import { EndpointType } from "./EndpointType.js";
-
-const logger = Logger.get("MutableEndpoint");
 
 /**
  * A MutableEndpoint is an EndpointType with factory functions that make it convenient to reconfigure the endpoint.
@@ -58,12 +55,8 @@ export function MutableEndpoint<const T extends EndpointType.Options>(options: T
     const mandatoryClients: SupportedBehaviors = options.requirements?.client?.mandatory ?? {};
     if (Object.keys(mandatoryClients).length > 0) {
         const merged = SupportedClientClusters.extend(clientClusters, Object.values(mandatoryClients));
-        const added = Object.keys(merged).filter(k => !(k in clientClusters));
-        if (added.length > 0) {
+        if (Object.keys(merged).some(k => !(k in clientClusters))) {
             clientClusters = merged;
-            logger.debug(
-                `Auto-registered mandatory client cluster(s) [${added.join(", ")}] for device type ${type.name}`,
-            );
         }
     }
 


### PR DESCRIPTION
## Summary
- Move `"Auto-registered mandatory client cluster(s) ..."` debug log out of `MutableEndpoint` factory (fired at device-type module import — before any endpoint exists) into `DescriptorServer.initialize()`, so it fires per endpoint activation and includes the endpoint id.
- Compute active set directly as `requirements.client.mandatory ∩ clientClusters` — no new field on `EndpointType` needed.
- Message reworded to `"Active mandatory client cluster(s) [...] for endpoint <id> (device type <name>)"`.
