### PR TITLE
fix(node): log enabled client clusters per endpoint

### DIFF
--- a/packages/node/src/behaviors/descriptor/DescriptorServer.ts
+++ b/packages/node/src/behaviors/descriptor/DescriptorServer.ts
@@ -40,14 +40,11 @@ export class DescriptorServer extends DescriptorBehavior {
         this.state.serverList = this.#serverList;
         this.state.clientList = this.#clientList;
 
-        const mandatoryClients = this.endpoint.type.requirements.client?.mandatory;
-        if (mandatoryClients) {
-            const active = Object.keys(mandatoryClients).filter(k => k in this.endpoint.type.clientClusters);
-            if (active.length) {
-                logger.debug(
-                    `Active mandatory client cluster(s) [${active.join(", ")}] for endpoint ${this.endpoint.id} (device type ${this.endpoint.type.name})`,
-                );
-            }
+        const enabledClientClusters = Object.keys(this.endpoint.type.clientClusters ?? {});
+        if (enabledClientClusters.length) {
+            logger.debug(
+                `Enabled client cluster(s) [${enabledClientClusters.join(", ")}] for endpoint ${this.endpoint.id} (device type ${this.endpoint.type.name})`,
+            );
         }
 
         // Initialize DeviceTypeList


### PR DESCRIPTION
## Summary
Follow-up to #3769. Replace the "Active mandatory client cluster(s)" debug line in `DescriptorServer.initialize()` with a simpler "Enabled client cluster(s) [...] for endpoint <id> (device type <name>)" — logs every client cluster on the endpoint at activation regardless of origin (explicitly supplied vs auto-merged from `requirements.client.mandatory`).
