### PR TITLE
fix(general): make error utilities undefined/null safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The main work (all changes without a GitHub username in brackets in the below li
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+
+- @matter/general
+    - Fix: `causedBy`/`asError`/`errorOf`/`repackErrorAs` no longer crash with "undefined is not an object" when invoked with `undefined`/`null` as error object
+
 ## 0.17.0 (2026-05-20)
 
 - Breaking: Matter 1.5/1.5.1 specification introduces some changes, as always with new Matter specification versions. You might need to adjust your code.

--- a/packages/general/src/util/Error.ts
+++ b/packages/general/src/util/Error.ts
@@ -10,7 +10,7 @@ import { ClassExtends } from "./Type.js";
 
 /** If the cause has a "message" field, treat as an Error */
 function considerAsError(error: unknown): error is Error {
-    return (error as Error).message !== undefined;
+    return typeof error === "object" && error !== null && (error as { message?: unknown }).message !== undefined;
 }
 
 export function asError(e: any): Error {

--- a/packages/general/test/util/ErrorTest.ts
+++ b/packages/general/test/util/ErrorTest.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { asError, causedBy, errorOf, repackErrorAs } from "#util/Error.js";
+
+class FooError extends Error {}
+
+describe("Error utils", () => {
+    describe("asError", () => {
+        it("returns Error with 'Unknown error' for undefined", () => {
+            const e = asError(undefined);
+            expect(e).instanceof(Error);
+            expect(e.message).equal("Unknown error");
+        });
+
+        it("returns Error with 'Unknown error' for null", () => {
+            const e = asError(null);
+            expect(e).instanceof(Error);
+            expect(e.message).equal("Unknown error");
+        });
+
+        it("wraps strings as Error", () => {
+            const e = asError("boom");
+            expect(e).instanceof(Error);
+            expect(e.message).equal("boom");
+        });
+
+        it("passes through real Errors", () => {
+            const original = new FooError("x");
+            expect(asError(original)).equal(original);
+        });
+    });
+
+    describe("causedBy", () => {
+        it("returns false for undefined error without throwing", () => {
+            expect(causedBy(undefined, FooError)).false;
+        });
+
+        it("returns false for null error without throwing", () => {
+            expect(causedBy(null, FooError)).false;
+        });
+
+        it("detects direct cause match", () => {
+            expect(causedBy(new FooError("x"), FooError)).true;
+        });
+
+        it("detects nested cause match", () => {
+            const inner = new FooError("inner");
+            const outer = new Error("outer");
+            outer.cause = inner;
+            expect(causedBy(outer, FooError)).true;
+        });
+    });
+
+    describe("errorOf", () => {
+        it("returns 'Unknown error' for undefined", () => {
+            expect(errorOf(undefined).message).equal("Unknown error");
+        });
+
+        it("returns 'Unknown error' for null", () => {
+            expect(errorOf(null).message).equal("Unknown error");
+        });
+    });
+
+    describe("repackErrorAs", () => {
+        it("throws TypeError when repackaging undefined", () => {
+            expect(() => repackErrorAs(undefined, FooError)).throws(TypeError);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- `considerAsError` dereferenced `.message` on the raw input, so `causedBy(undefined, ...)` (and any `asError`/`repackErrorAs` call with a non-object throw value) crashed with `"undefined is not an object (evaluating 'error.message')"`. This masked the real PASE failure in `PaseServer.onNewExchange` whenever something threw `undefined`.
- Tightened the type guard to properly narrow `unknown -> Error` via `typeof`/`null`/structural-message checks — no more lying `as Error` cast.
- Added regression tests for `asError`, `causedBy`, `errorOf`, `repackErrorAs` covering `undefined`/`null` and non-Error inputs.

## Repro (from user report)
```
ERROR  PaseServer       An error occurred during PASE commissioning (1/20): 2↔1 undefined
ERROR  ExchangeManager  Unhandled error handling incoming message: undefined is not an object (evaluating 'error.message')
  at considerAsError (.../util/Error.js:8:10)
  at asError       (.../util/Error.js:11:7)
  at causedBy      (.../util/Error.js:35:13)
  at onNewExchange (.../session/pase/PaseServer.js:77:28)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)