### PR TITLE
fix(node): retain PhysicalDeviceProperties through teardown and stop/start

### DIFF
--- a/packages/node/src/node/NodePhysicalProperties.ts
+++ b/packages/node/src/node/NodePhysicalProperties.ts
@@ -56,8 +56,9 @@ function inspectEndpoint(endpoint: Endpoint, properties: PhysicalDevicePropertie
 
     // Battery power
     const powerSourceFeatures = endpoint.maybeFeaturesOf(PowerSourceClient);
-    if (powerSourceFeatures) {
-        const status = endpoint.stateOf(PowerSourceClient).status;
+    const powerSourceState = powerSourceFeatures ? endpoint.maybeStateOf(PowerSourceClient) : undefined;
+    if (powerSourceFeatures && powerSourceState) {
+        const { status } = powerSourceState;
         if (powerSourceFeatures.wired) {
             if (status === PowerSource.PowerSourceStatus.Active) {
                 // Should we only consider A/C "mains" powered?  What is a DC adapter?  What is an external battery?
@@ -82,14 +83,14 @@ function inspectEndpoint(endpoint: Endpoint, properties: PhysicalDevicePropertie
 
     // Sleepy thread device
     const threadNetworkDiagnostics = endpoint.behaviors.typeFor(ThreadNetworkDiagnosticsClient);
-    if (threadNetworkDiagnostics) {
-        const tnd = endpoint.stateOf(threadNetworkDiagnostics);
+    const tnd = threadNetworkDiagnostics ? endpoint.maybeStateOf(threadNetworkDiagnostics) : undefined;
+    if (tnd) {
         if (tnd.routingRole === ThreadNetworkDiagnostics.RoutingRole.SleepyEndDevice) {
             properties.isThreadSleepyEndDevice = true;
         }
         if (tnd.extendedPanId !== undefined && tnd.extendedPanId !== null) {
             properties.threadActive = true;
-            properties.threadPan = tnd.extendedPanId === undefined ? undefined : BigInt(tnd.extendedPanId);
+            properties.threadPan = BigInt(tnd.extendedPanId);
             properties.threadChannel = tnd.channel ?? undefined;
         } else {
             properties.threadActive = false;

--- a/packages/node/src/node/client/ClientNodePhysicalProperties.ts
+++ b/packages/node/src/node/client/ClientNodePhysicalProperties.ts
@@ -7,6 +7,7 @@
 import { EndpointInitializer } from "#endpoint/properties/EndpointInitializer.js";
 import { ClientNode } from "#node/ClientNode.js";
 import { NodePhysicalProperties } from "#node/NodePhysicalProperties.js";
+import { deepCopy } from "@matter/general";
 import { PhysicalDeviceProperties } from "@matter/protocol";
 import { ClientEndpointInitializer } from "./ClientEndpointInitializer.js";
 
@@ -22,6 +23,7 @@ export function ClientNodePhysicalProperties(node: ClientNode) {
     }
 
     let properties: PhysicalDeviceProperties | undefined;
+    let frozen = false;
 
     const result: PhysicalDeviceProperties = {
         get supportsThread() {
@@ -72,11 +74,22 @@ export function ClientNodePhysicalProperties(node: ClientNode) {
     cache.set(node, result);
 
     const structure = (node.env.get(EndpointInitializer) as ClientEndpointInitializer).structure;
-    structure.changed.on(() => (properties = undefined));
+    structure.changed.on(() => {
+        if (frozen) return;
+        properties = undefined;
+    });
+
+    // Snapshot before runtime close detaches behavior state; cleared again if the node comes back online.
+    node.lifecycle.goingOffline.on(() => freeze());
+    node.lifecycle.online.on(() => {
+        frozen = false;
+        properties = undefined;
+    });
 
     // WeakMap entries are GC'd automatically but appear as strong references in heap snapshots, causing false
-    // positives in leak detection.  Explicit deletion avoids this
+    // positives in leak detection.  Explicit deletion avoids this.
     node.lifecycle.destroyed.once(() => {
+        freeze();
         cache.delete(node);
     });
 
@@ -87,5 +100,11 @@ export function ClientNodePhysicalProperties(node: ClientNode) {
             properties = NodePhysicalProperties(node);
         }
         return properties;
+    }
+
+    function freeze() {
+        if (frozen) return;
+        properties = deepCopy(props());
+        frozen = true;
     }
 }

--- a/packages/node/test/node/ClientNodePhysicalPropertiesTest.ts
+++ b/packages/node/test/node/ClientNodePhysicalPropertiesTest.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ClientNodePhysicalProperties } from "#node/client/ClientNodePhysicalProperties.js";
+import { MockSite } from "./mock-site.js";
+import { subscribedPeer } from "./node-helpers.js";
+
+describe("ClientNodePhysicalProperties", () => {
+    before(() => {
+        MockTime.init();
+    });
+
+    it("retains last-known properties after the node is torn down", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+        const peer1 = await subscribedPeer(controller, "peer1");
+
+        const properties = ClientNodePhysicalProperties(peer1);
+
+        // Force evaluation while the node is fully online so the snapshot is populated.
+        const initialServers = [...properties.rootEndpointServerList];
+        const initialThread = properties.supportsThread;
+        const initialBattery = properties.isBatteryPowered;
+
+        expect(initialServers.length).greaterThan(0);
+
+        // Close the peer.  Teardown emits goingOffline (freezing the snapshot) then proceeds with
+        // structure mutations that previously invalidated the cache and re-evaluated against
+        // torn-down behavior state.
+        const destroyed = new Promise<void>(resolve => peer1.lifecycle.destroyed.once(() => resolve()));
+        await MockTime.resolve(peer1.close(), { macrotasks: true });
+        await MockTime.resolve(destroyed);
+
+        // Held reference must keep returning the snapshot captured before teardown.
+        expect(properties.rootEndpointServerList).deep.equals(initialServers);
+        expect(properties.supportsThread).equals(initialThread);
+        expect(properties.isBatteryPowered).equals(initialBattery);
+    });
+
+    it("detaches the snapshot from live behavior state at freeze", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+        const peer1 = await subscribedPeer(controller, "peer1");
+
+        const properties = ClientNodePhysicalProperties(peer1);
+        const liveList = properties.rootEndpointServerList;
+        expect(liveList.length).greaterThan(0);
+
+        const destroyed = new Promise<void>(resolve => peer1.lifecycle.destroyed.once(() => resolve()));
+        await MockTime.resolve(peer1.close(), { macrotasks: true });
+        await MockTime.resolve(destroyed);
+
+        // After freeze the snapshot array is the deepCopy result — same contents, distinct identity from the
+        // live array captured pre-teardown.
+        const frozenList = properties.rootEndpointServerList;
+        expect(frozenList).deep.equals(liveList);
+        expect(frozenList).not.equals(liveList);
+    });
+
+    it("re-evaluates after the node comes back online", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+        const peer1 = await subscribedPeer(controller, "peer1");
+
+        const properties = ClientNodePhysicalProperties(peer1);
+
+        // Capture a live snapshot and freeze it by stopping the peer.
+        const initialList = [...properties.rootEndpointServerList];
+        expect(initialList.length).greaterThan(0);
+
+        await MockTime.resolve(peer1.stop(), { macrotasks: true });
+
+        // Frozen — reading returns the captured snapshot.
+        expect(properties.rootEndpointServerList).deep.equals(initialList);
+
+        // Bringing the peer back online must unfreeze and force re-evaluation.  We do not assert that the value
+        // changes (the test environment is stable), only that the snapshot identity changes — i.e. the getter
+        // produced a fresh evaluation rather than returning the frozen copy.
+        const frozenSnapshot = properties.rootEndpointServerList;
+        await MockTime.resolve(peer1.start(), { macrotasks: true });
+
+        const refreshedSnapshot = properties.rootEndpointServerList;
+        expect(refreshedSnapshot).not.equals(frozenSnapshot);
+        expect(refreshedSnapshot).deep.equals(initialList);
+    });
+});


### PR DESCRIPTION
## Summary

- `ClientNodePhysicalProperties` getters re-evaluated `NodePhysicalProperties(node)` on every read via `structure.changed` cache invalidation. During teardown, structure mutations triggered re-evaluation while behavior backings were closing, throwing inside diagnostic snapshot reads (e.g. `endpoint.get` slice assembly).
- Snapshot a `deepCopy` of the last good `NodePhysicalProperties` output on `goingOffline`; ignore late `structure.changed` events while frozen. Clear the freeze on `online` so `stop()`/`start()` cycles refresh against current state.
- In `NodePhysicalProperties`, replace `endpoint.stateOf(PowerSourceClient)` / `endpoint.stateOf(threadNetworkDiagnostics)` with `endpoint.maybeStateOf(...)` gated by the matching `maybeFeaturesOf` / `typeFor` check, so partial-teardown behavior state degrades gracefully instead of throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)