### PR TITLE
fix(protocol): preserve EventNumber order in normalizeEventData

### DIFF
--- a/packages/protocol/src/interaction/EventDataDecoder.ts
+++ b/packages/protocol/src/interaction/EventDataDecoder.ts
@@ -74,20 +74,15 @@ export function normalizeAndDecodeReadEventReport(data: TypeFromSchema<typeof Tl
 export function normalizeEventData(
     data: TypeFromSchema<typeof TlvEventData>[],
 ): TypeFromSchema<typeof TlvEventData>[][] {
-    // Put all returned values into a map to group by path
-    const responseList = new Map<string, TypeFromSchema<typeof TlvEventData>[]>(); // TODO CHECK
-    data.forEach(value => {
-        if (!value) return;
-        const {
-            path: { nodeId, endpointId, clusterId, eventId },
-        } = value;
-        const mapId = `${nodeId}-${endpointId}-${clusterId}-${eventId}`;
-        const list = responseList.get(mapId) || [];
-        list.push(value);
-        responseList.set(mapId, list);
-    });
-
-    return Array.from(responseList.values());
+    // One occurrence per outer entry, preserving wire (EventNumber) order
+    // per Matter Core §10.7.3.1. Earlier code regrouped by path tuple,
+    // which broke ordered event cycles such as Generic Switch multi-press.
+    const result: TypeFromSchema<typeof TlvEventData>[][] = [];
+    for (const value of data) {
+        if (!value) continue;
+        result.push([value]);
+    }
+    return result;
 }
 
 export function normalizeAndDecodeEventData(

--- a/packages/protocol/test/protocol/interaction/EventDataDecoderTest.ts
+++ b/packages/protocol/test/protocol/interaction/EventDataDecoderTest.ts
@@ -62,7 +62,7 @@ describe("EventDataDecoder", () => {
             ]);
         });
 
-        it("normalize data with all paths given for multiple events", () => {
+        it("preserves wire (EventNumber) order across interleaved event types", () => {
             const data: TypeFromSchema<typeof TlvEventData>[] = [
                 {
                     path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0) },
@@ -89,33 +89,7 @@ describe("EventDataDecoder", () => {
 
             const normalized = normalizeEventData(data);
 
-            expect(normalized).deep.equal([
-                [
-                    {
-                        path: data[0].path,
-                        eventNumber: data[0].eventNumber,
-                        priority: data[0].priority,
-                        epochTimestamp: data[0].epochTimestamp,
-                        data: data[0].data,
-                    },
-                    {
-                        path: data[0].path,
-                        eventNumber: data[2].eventNumber,
-                        priority: data[2].priority,
-                        epochTimestamp: data[2].epochTimestamp,
-                        data: data[2].data,
-                    },
-                ],
-                [
-                    {
-                        path: data[1].path,
-                        eventNumber: data[1].eventNumber,
-                        priority: data[1].priority,
-                        epochTimestamp: data[1].epochTimestamp,
-                        data: data[1].data,
-                    },
-                ],
-            ]);
+            expect(normalized).deep.equal([[data[0]], [data[1]], [data[2]]]);
         });
     });
 
@@ -192,7 +166,7 @@ describe("EventDataDecoder", () => {
             ]);
         });
 
-        it("normalize and decode data with all paths given for multiple events", () => {
+        it("preserves wire (EventNumber) order across interleaved event types", () => {
             const data: TypeFromSchema<typeof TlvEventData>[] = [
                 {
                     path: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x28), eventId: EventId(0) },
@@ -228,58 +202,40 @@ describe("EventDataDecoder", () => {
 
             const normalized = normalizeAndDecodeEventData(data);
 
+            const startUpPath = {
+                endpointId: EndpointNumber(0),
+                clusterId: ClusterId(0x28),
+                eventId: EventId(0),
+                nodeId: undefined,
+                eventName: "startUp",
+            };
+            const shutDownPath = {
+                endpointId: EndpointNumber(0),
+                clusterId: ClusterId(0x28),
+                eventId: EventId(1),
+                nodeId: undefined,
+                eventName: "shutDown",
+            };
+            const baseOccurrence = {
+                priority: 1,
+                epochTimestamp: 0,
+                systemTimestamp: undefined,
+                deltaEpochTimestamp: undefined,
+                deltaSystemTimestamp: undefined,
+                path: undefined,
+            };
             expect(normalized).deep.equal([
                 {
-                    path: {
-                        endpointId: EndpointNumber(0),
-                        clusterId: ClusterId(0x28),
-                        eventId: EventId(0),
-                        nodeId: undefined,
-                        eventName: "startUp",
-                    },
-                    events: [
-                        {
-                            eventNumber: EventNumber(1),
-                            priority: 1,
-                            epochTimestamp: 0,
-                            systemTimestamp: undefined,
-                            deltaEpochTimestamp: undefined,
-                            deltaSystemTimestamp: undefined,
-                            data: { softwareVersion: 1 },
-                            path: undefined,
-                        },
-                        {
-                            eventNumber: EventNumber(3),
-                            priority: 1,
-                            epochTimestamp: 0,
-                            systemTimestamp: undefined,
-                            deltaEpochTimestamp: undefined,
-                            deltaSystemTimestamp: undefined,
-                            data: { softwareVersion: 3 },
-                            path: undefined,
-                        },
-                    ],
+                    path: startUpPath,
+                    events: [{ ...baseOccurrence, eventNumber: EventNumber(1), data: { softwareVersion: 1 } }],
                 },
                 {
-                    path: {
-                        endpointId: EndpointNumber(0),
-                        clusterId: ClusterId(0x28),
-                        eventId: EventId(1),
-                        nodeId: undefined,
-                        eventName: "shutDown",
-                    },
-                    events: [
-                        {
-                            eventNumber: EventNumber(2),
-                            priority: 1,
-                            epochTimestamp: 0,
-                            systemTimestamp: undefined,
-                            deltaEpochTimestamp: undefined,
-                            deltaSystemTimestamp: undefined,
-                            data: undefined,
-                            path: undefined,
-                        },
-                    ],
+                    path: shutDownPath,
+                    events: [{ ...baseOccurrence, eventNumber: EventNumber(2), data: undefined }],
+                },
+                {
+                    path: startUpPath,
+                    events: [{ ...baseOccurrence, eventNumber: EventNumber(3), data: { softwareVersion: 3 } }],
                 },
             ]);
         });


### PR DESCRIPTION
Fixes #3785.

`normalizeEventData` grouped occurrences by `(nodeId, endpointId, clusterId, eventId)` into a Map and returned `Array.from(map.values())`, so the outer iteration became "first occurrence per path". `InputChunk` walks outer-then-inner, which destroyed wire (EventNumber) order whenever the same path repeated within a single `ReportData`.

Matter Core 1.5.1 §10.7.3.1 emits `EventReports` in EventNumber order (the EventNumber-omitted compression rule depends on it), and Application Cluster 1.5.1 §1.13 defines the Generic Switch cycle (`InitialPress → MultiPressOngoing → ShortRelease → … → MultiPressComplete`) as an ordered sequence; the CHIP Python SDK's `SubscriptionTransaction.SetEventUpdateCallback` API contract delivers per-event in arrival order.

This change returns one occurrence per outer entry, in wire order. `normalizeAndDecodeEventData` and `InputChunk` work unchanged; their outer/inner iteration now simply flattens to wire order. The previous grouping was a decode-cache optimization with no spec basis. Tests that codified the broken behavior are updated.

Test results: protocol 842/842 ESM, 1147/1147 node ESM.
