### PR TITLE
refactor(protocol,matter.js): streaming InputChunk + DecodedDataReport relocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/general
     - Fix: `causedBy`/`asError`/`errorOf`/`repackErrorAs` no longer crash with "undefined is not an object" when invoked with `undefined`/`null` as error object
 
+- @matter/protocol
+    - Deprecation: Internally used `DecodedDataReport`, `DecodedAttributeReport{Value,Status,Entry}`, `DecodedEventReport{Value,Status,Entry}`, `DecodedEventData`, and the `normalize*` / `normalizeAndDecode*` helpers moved to `@project-chip/matter.js/cluster`. Scheduled for removal in 0.18
+    - Enhancement: `ReadResult.EventValue` exposes the four wire timestamp variants (`epochTimestamp`, `systemTimestamp`, `deltaEpochTimestamp`, `deltaSystemTimestamp`) alongside the existing collapsed `timestamp: number`
+    - Adjustment: `ReadResult.Chunk` and `InputChunk` are now async generators; should be only used internally
+    - Fix: Event reports are now decoded in wire (EventNumber) order
+
 ## 0.17.0 (2026-05-20)
 
 - Breaking: Matter 1.5/1.5.1 specification introduces some changes, as always with new Matter specification versions. You might need to adjust your code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/protocol
     - Deprecation: Internally used `DecodedDataReport`, `DecodedAttributeReport{Value,Status,Entry}`, `DecodedEventReport{Value,Status,Entry}`, `DecodedEventData`, and the `normalize*` / `normalizeAndDecode*` helpers moved to `@project-chip/matter.js/cluster`. Scheduled for removal in 0.18
     - Enhancement: `ReadResult.EventValue` exposes the four wire timestamp variants (`epochTimestamp`, `systemTimestamp`, `deltaEpochTimestamp`, `deltaSystemTimestamp`) alongside the existing collapsed `timestamp: number`
-    - Adjustment: `ReadResult.Chunk` and `InputChunk` are now async generators; should be only used internally
+    - Adjustment: `ReadResult.Chunk` may now be an async iterable (`InputChunk` is an async generator); consumers iterate chunk contents with `for await … of chunk`. Mainly internal
     - Fix: Event reports are now decoded in wire (EventNumber) order
 
 ## 0.17.0 (2026-05-20)

--- a/packages/matter.js/src/cluster/client/ClusterClient.ts
+++ b/packages/matter.js/src/cluster/client/ClusterClient.ts
@@ -6,7 +6,7 @@
 
 import { capitalize, Diagnostic, Duration, ImplementationError, Logger } from "@matter/general";
 import { AttributeModel } from "@matter/model";
-import { ClusterClientObj, DecodedEventData } from "@matter/protocol";
+import { ClusterClientObj } from "@matter/protocol";
 import {
     AttributeId,
     ClusterId,
@@ -22,6 +22,7 @@ import {
 } from "@matter/types";
 import { TlvVoid } from "@matter/types/tlv";
 import { createAttributeClient } from "./AttributeClient.js";
+import { DecodedEventData } from "./DecodedDataReport.js";
 import { createEventClient } from "./EventClient.js";
 import { InteractionClient } from "./InteractionClient.js";
 

--- a/packages/matter.js/src/cluster/client/ClusterClient.ts
+++ b/packages/matter.js/src/cluster/client/ClusterClient.ts
@@ -6,7 +6,6 @@
 
 import { capitalize, Diagnostic, Duration, ImplementationError, Logger } from "@matter/general";
 import { AttributeModel } from "@matter/model";
-import { ClusterClientObj } from "@matter/protocol";
 import {
     AttributeId,
     ClusterId,
@@ -22,6 +21,7 @@ import {
 } from "@matter/types";
 import { TlvVoid } from "@matter/types/tlv";
 import { createAttributeClient } from "./AttributeClient.js";
+import { ClusterClientObj } from "./ClusterClientTypes.js";
 import { DecodedEventData } from "./DecodedDataReport.js";
 import { createEventClient } from "./EventClient.js";
 import { InteractionClient } from "./InteractionClient.js";

--- a/packages/matter.js/src/cluster/client/ClusterClientTypes.ts
+++ b/packages/matter.js/src/cluster/client/ClusterClientTypes.ts
@@ -16,7 +16,7 @@ import {
     TlvEventFilter,
     TypeFromSchema,
 } from "@matter/types";
-import { DecodedEventData } from "../../interaction/EventDataDecoder.js";
+import { DecodedEventData } from "./DecodedDataReport.js";
 
 export interface AttributeClientObj<T = any> {
     readonly id: AttributeId;

--- a/packages/matter.js/src/cluster/client/DecodedDataReport.ts
+++ b/packages/matter.js/src/cluster/client/DecodedDataReport.ts
@@ -98,16 +98,16 @@ export interface DecodedDataReport extends DataReport {
  *
  * For new code prefer consuming the chunk stream directly.
  */
-export function decodeDataReport(
+export async function decodeDataReport(
     report: DataReport,
     leftoverAttributeReports?: TypeFromSchema<typeof TlvAttributeReport>[],
-): DecodedDataReport {
+): Promise<DecodedDataReport> {
     const attributeReports = new Array<DecodedAttributeReportValue<any>>();
     const attributeStatus = new Array<DecodedAttributeReportStatus>();
     const eventReports = new Array<DecodedEventReportValue<any>>();
     const eventStatus = new Array<DecodedEventReportStatus>();
 
-    for (const chunk of InputChunk(report, leftoverAttributeReports)) {
+    for await (const chunk of InputChunk(report, leftoverAttributeReports)) {
         switch (chunk.kind) {
             case "attr-value":
                 attributeReports.push(toDecodedAttributeReportValue(chunk));

--- a/packages/matter.js/src/cluster/client/DecodedDataReport.ts
+++ b/packages/matter.js/src/cluster/client/DecodedDataReport.ts
@@ -110,38 +110,16 @@ export function decodeDataReport(
     for (const chunk of InputChunk(report, leftoverAttributeReports)) {
         switch (chunk.kind) {
             case "attr-value":
-                attributeReports.push({
-                    path: resolveAttributePath(chunk.path),
-                    version: chunk.version,
-                    value: chunk.value,
-                });
+                attributeReports.push(toDecodedAttributeReportValue(chunk));
                 break;
             case "attr-status":
-                attributeStatus.push({
-                    path: resolveAttributePath(chunk.path),
-                    status: chunk.status,
-                    clusterStatus: chunk.clusterStatus,
-                });
+                attributeStatus.push(toDecodedAttributeReportStatus(chunk));
                 break;
             case "event-value":
-                eventReports.push({
-                    path: resolveEventPath(chunk.path),
-                    events: [
-                        {
-                            eventNumber: chunk.number,
-                            priority: chunk.priority,
-                            epochTimestamp: chunk.timestamp,
-                            data: chunk.value,
-                        },
-                    ],
-                });
+                eventReports.push(toDecodedEventReportValue(chunk));
                 break;
             case "event-status":
-                eventStatus.push({
-                    path: resolveEventPath(chunk.path),
-                    status: chunk.status,
-                    clusterStatus: chunk.clusterStatus,
-                });
+                eventStatus.push(toDecodedEventReportStatus(chunk));
                 break;
         }
     }
@@ -152,6 +130,51 @@ export function decodeDataReport(
         attributeStatus: attributeStatus.length > 0 ? attributeStatus : undefined,
         eventReports,
         eventStatus: eventStatus.length > 0 ? eventStatus : undefined,
+    };
+}
+
+/** Build a legacy {@link DecodedAttributeReportValue} from a streaming chunk. */
+export function toDecodedAttributeReportValue(chunk: ReadResult.AttributeValue): DecodedAttributeReportValue<any> {
+    return {
+        path: resolveAttributePath(chunk.path),
+        version: chunk.version,
+        value: chunk.value,
+    };
+}
+
+/** Build a legacy {@link DecodedAttributeReportStatus} from a streaming chunk. */
+export function toDecodedAttributeReportStatus(chunk: ReadResult.AttributeStatus): DecodedAttributeReportStatus {
+    return {
+        path: resolveAttributePath(chunk.path),
+        status: chunk.status,
+        clusterStatus: chunk.clusterStatus,
+    };
+}
+
+/** Build a legacy {@link DecodedEventReportValue} from a streaming chunk; forwards all four wire timestamp variants. */
+export function toDecodedEventReportValue(chunk: ReadResult.EventValue): DecodedEventReportValue<any> {
+    return {
+        path: resolveEventPath(chunk.path),
+        events: [
+            {
+                eventNumber: chunk.number,
+                priority: chunk.priority,
+                epochTimestamp: chunk.epochTimestamp,
+                systemTimestamp: chunk.systemTimestamp,
+                deltaEpochTimestamp: chunk.deltaEpochTimestamp,
+                deltaSystemTimestamp: chunk.deltaSystemTimestamp,
+                data: chunk.value,
+            },
+        ],
+    };
+}
+
+/** Build a legacy {@link DecodedEventReportStatus} from a streaming chunk. */
+export function toDecodedEventReportStatus(chunk: ReadResult.EventStatus): DecodedEventReportStatus {
+    return {
+        path: resolveEventPath(chunk.path),
+        status: chunk.status,
+        clusterStatus: chunk.clusterStatus,
     };
 }
 

--- a/packages/matter.js/src/cluster/client/DecodedDataReport.ts
+++ b/packages/matter.js/src/cluster/client/DecodedDataReport.ts
@@ -41,7 +41,7 @@ export type DecodedAttributeReportValue<T> = DecodedAttributeReportEntry & {
 
 /** Represents a fully qualified and decoded attribute status from a received DataReport. */
 export type DecodedAttributeReportStatus = DecodedAttributeReportEntry & {
-    status?: Status;
+    status: Status;
     clusterStatus?: number;
 };
 
@@ -72,7 +72,7 @@ export type DecodedEventReportValue<T> = DecodedEventReportEntry & {
 
 /** Represents a fully qualified and decoded event status from a received DataReport. */
 export type DecodedEventReportStatus = DecodedEventReportEntry & {
-    status?: Status;
+    status: Status;
     clusterStatus?: number;
 };
 

--- a/packages/matter.js/src/cluster/client/DecodedDataReport.ts
+++ b/packages/matter.js/src/cluster/client/DecodedDataReport.ts
@@ -1,0 +1,193 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Diagnostic, Logger, UnexpectedDataError } from "@matter/general";
+import { Matter } from "@matter/model";
+import { InputChunk, ReadResult } from "@matter/protocol";
+import {
+    AttributeId,
+    ClusterId,
+    DataReport,
+    EndpointNumber,
+    EventId,
+    EventNumber,
+    NodeId,
+    Priority,
+    Status,
+    TlvAttributeReport,
+    TypeFromSchema,
+} from "@matter/types";
+
+const logger = Logger.get("DecodedDataReport");
+
+export type DecodedAttributeReportEntry = {
+    path: {
+        nodeId?: NodeId;
+        endpointId: EndpointNumber;
+        clusterId: ClusterId;
+        attributeId: AttributeId;
+        attributeName: string;
+    };
+};
+
+/** Represents a fully qualified and decoded attribute value from a received DataReport. */
+export type DecodedAttributeReportValue<T> = DecodedAttributeReportEntry & {
+    version: number;
+    value: T;
+};
+
+/** Represents a fully qualified and decoded attribute status from a received DataReport. */
+export type DecodedAttributeReportStatus = DecodedAttributeReportEntry & {
+    status?: Status;
+    clusterStatus?: number;
+};
+
+export type DecodedEventData<T> = {
+    eventNumber: EventNumber;
+    priority: Priority;
+    epochTimestamp?: number | bigint;
+    systemTimestamp?: number | bigint;
+    deltaEpochTimestamp?: number | bigint;
+    deltaSystemTimestamp?: number | bigint;
+    data?: T;
+};
+
+export type DecodedEventReportEntry = {
+    path: {
+        nodeId?: NodeId;
+        endpointId: EndpointNumber;
+        clusterId: ClusterId;
+        eventId: EventId;
+        eventName: string;
+    };
+};
+
+/** Represents a fully qualified and decoded event value from a received DataReport. */
+export type DecodedEventReportValue<T> = DecodedEventReportEntry & {
+    events: DecodedEventData<T>[];
+};
+
+/** Represents a fully qualified and decoded event status from a received DataReport. */
+export type DecodedEventReportStatus = DecodedEventReportEntry & {
+    status?: Status;
+    clusterStatus?: number;
+};
+
+/**
+ * Legacy 4-array shape produced by {@link decodeDataReport}. Inherits wire-level fields (`moreChunkedMessages`,
+ * `subscriptionId`, `interactionModelRevision`, `suppressResponse`) from {@link DataReport}; callers that want only
+ * the decoded payload should strip them via `Omit<DecodedDataReport, …>`.
+ *
+ * Kept here in the matter.js package while the legacy `InteractionClient` / `ClusterClient` / `EventClient` /
+ * `PairedNode` callbacks consume it. The modern path consumes `ReadResult.Chunk` directly via {@link InputChunk}.
+ */
+export interface DecodedDataReport extends DataReport {
+    attributeReports: DecodedAttributeReportValue<any>[];
+    attributeStatus?: DecodedAttributeReportStatus[];
+    eventReports: DecodedEventReportValue<any>[];
+    eventStatus?: DecodedEventReportStatus[];
+}
+
+/**
+ * Build the legacy 4-array shape from a wire {@link DataReport} by collecting the streamed {@link ReadResult.Chunk}s
+ * produced by {@link InputChunk}. Honors the same `leftoverAttributeReports` handoff for chunked-array tails that
+ * span multiple incoming reports.
+ *
+ * For new code prefer consuming the chunk stream directly.
+ */
+export function decodeDataReport(
+    report: DataReport,
+    leftoverAttributeReports?: TypeFromSchema<typeof TlvAttributeReport>[],
+): DecodedDataReport {
+    const attributeReports = new Array<DecodedAttributeReportValue<any>>();
+    const attributeStatus = new Array<DecodedAttributeReportStatus>();
+    const eventReports = new Array<DecodedEventReportValue<any>>();
+    const eventStatus = new Array<DecodedEventReportStatus>();
+
+    for (const chunk of InputChunk(report, leftoverAttributeReports)) {
+        switch (chunk.kind) {
+            case "attr-value":
+                attributeReports.push({
+                    path: resolveAttributePath(chunk.path),
+                    version: chunk.version,
+                    value: chunk.value,
+                });
+                break;
+            case "attr-status":
+                attributeStatus.push({
+                    path: resolveAttributePath(chunk.path),
+                    status: chunk.status,
+                    clusterStatus: chunk.clusterStatus,
+                });
+                break;
+            case "event-value":
+                eventReports.push({
+                    path: resolveEventPath(chunk.path),
+                    events: [
+                        {
+                            eventNumber: chunk.number,
+                            priority: chunk.priority,
+                            epochTimestamp: chunk.timestamp,
+                            data: chunk.value,
+                        },
+                    ],
+                });
+                break;
+            case "event-status":
+                eventStatus.push({
+                    path: resolveEventPath(chunk.path),
+                    status: chunk.status,
+                    clusterStatus: chunk.clusterStatus,
+                });
+                break;
+        }
+    }
+
+    return {
+        ...report,
+        attributeReports,
+        attributeStatus: attributeStatus.length > 0 ? attributeStatus : undefined,
+        eventReports,
+        eventStatus: eventStatus.length > 0 ? eventStatus : undefined,
+    };
+}
+
+function resolveAttributePath(path: ReadResult.ConcreteAttributePath): DecodedAttributeReportEntry["path"] {
+    const { nodeId, endpointId, clusterId, attributeId } = path;
+    if (endpointId === undefined || clusterId === undefined || attributeId === undefined) {
+        throw new UnexpectedDataError(`Invalid attribute path ${endpointId}/${clusterId}/${attributeId}`);
+    }
+    const clusterModel = Matter.clusters(clusterId);
+    const attributeModel = clusterModel?.attributes(attributeId) ?? Matter.attributes(attributeId);
+    if (attributeModel === undefined) {
+        logger.debug(
+            `Unresolved attribute path ${endpointId}/${Diagnostic.hex(clusterId)}/${Diagnostic.hex(attributeId)} — reporting with placeholder name.`,
+        );
+    }
+    return {
+        nodeId,
+        endpointId,
+        clusterId,
+        attributeId,
+        attributeName: attributeModel?.propertyName ?? `Unknown (${Diagnostic.hex(attributeId)})`,
+    };
+}
+
+function resolveEventPath(path: ReadResult.ConcreteEventPath): DecodedEventReportEntry["path"] {
+    const { nodeId, endpointId, clusterId, eventId } = path;
+    if (endpointId === undefined || clusterId === undefined || eventId === undefined) {
+        throw new UnexpectedDataError(`Invalid event path ${endpointId}/${clusterId}/${eventId}`);
+    }
+    const clusterModel = Matter.clusters(clusterId);
+    const eventModel = clusterModel?.events(eventId);
+    return {
+        nodeId,
+        endpointId,
+        clusterId,
+        eventId,
+        eventName: eventModel?.propertyName ?? `Unknown (${Diagnostic.hex(eventId)})`,
+    };
+}

--- a/packages/matter.js/src/cluster/client/EventClient.ts
+++ b/packages/matter.js/src/cluster/client/EventClient.ts
@@ -5,8 +5,8 @@
  */
 
 import { Duration, ImplementationError } from "@matter/general";
-import { DecodedEventData } from "@matter/protocol";
 import { ClusterId, ClusterType, EndpointNumber, EventId, EventNumber } from "@matter/types";
+import { DecodedEventData } from "./DecodedDataReport.js";
 import { InteractionClient } from "./InteractionClient.js";
 
 /**

--- a/packages/matter.js/src/cluster/client/InteractionClient.ts
+++ b/packages/matter.js/src/cluster/client/InteractionClient.ts
@@ -22,12 +22,6 @@ import type { ServerNode } from "@matter/node";
 import { ClientNodeInteraction } from "@matter/node";
 import {
     ClientInteraction,
-    DecodedAttributeReportStatus,
-    DecodedAttributeReportValue,
-    DecodedDataReport,
-    DecodedEventData,
-    DecodedEventReportStatus,
-    DecodedEventReportValue,
     DedicatedChannelExchangeProvider,
     DiscoveryData,
     ExchangeManager,
@@ -62,6 +56,14 @@ import {
     TypeFromSchema,
 } from "@matter/types";
 import { AccessControl } from "@matter/types/clusters/access-control";
+import {
+    DecodedAttributeReportStatus,
+    DecodedAttributeReportValue,
+    DecodedDataReport,
+    DecodedEventData,
+    DecodedEventReportStatus,
+    DecodedEventReportValue,
+} from "./DecodedDataReport.js";
 
 const REQUEST_ALL = [{}];
 const DEFAULT_TIMED_REQUEST_TIMEOUT = Seconds(10);

--- a/packages/matter.js/src/cluster/client/InteractionClient.ts
+++ b/packages/matter.js/src/cluster/client/InteractionClient.ts
@@ -63,6 +63,10 @@ import {
     DecodedEventData,
     DecodedEventReportStatus,
     DecodedEventReportValue,
+    toDecodedAttributeReportStatus,
+    toDecodedAttributeReportValue,
+    toDecodedEventReportStatus,
+    toDecodedEventReportValue,
 } from "./DecodedDataReport.js";
 
 const REQUEST_ALL = [{}];
@@ -474,33 +478,6 @@ export class InteractionClient {
         return await this.#processReadResult(read, { attributeListener });
     }
 
-    #convertAttributePath(entry: ReadResult.ConcreteAttributePath) {
-        const { endpointId, clusterId, attributeId } = entry;
-
-        const clusterModel = Matter.clusters(clusterId);
-        const attribute = clusterModel?.attributes(attributeId);
-
-        return {
-            endpointId,
-            clusterId,
-            attributeId,
-            attributeName: attribute ? attribute.propertyName : `Unknown (${Diagnostic.hex(attributeId)})`,
-        };
-    }
-
-    #convertEventPath(entry: ReadResult.ConcreteEventPath) {
-        const { endpointId, clusterId, eventId } = entry;
-        const clusterModel = Matter.clusters(clusterId);
-        const event = clusterModel?.events(eventId);
-
-        return {
-            endpointId,
-            clusterId,
-            eventId,
-            eventName: event ? event.propertyName : `Unknown (${Diagnostic.hex(eventId)})`,
-        };
-    }
-
     async #processReadResult(
         report: ReadResult<ReadResult.Chunk>,
         listeners: {
@@ -518,49 +495,23 @@ export class InteractionClient {
             for (const entry of chunks) {
                 switch (entry.kind) {
                     case "attr-value": {
-                        const { path, value, version } = entry;
-                        const reportValue: DecodedAttributeReportValue<any> = {
-                            path: this.#convertAttributePath(path),
-                            value,
-                            version,
-                        };
+                        const reportValue = toDecodedAttributeReportValue(entry);
                         attributeReports.push(reportValue);
                         attributeListener?.(reportValue);
                         break;
                     }
-
-                    case "attr-status": {
-                        const { path, status, clusterStatus } = entry;
-                        const reportStatus: DecodedAttributeReportStatus = {
-                            path: this.#convertAttributePath(path),
-                            status,
-                            clusterStatus,
-                        };
-                        attributeStatus.push(reportStatus);
+                    case "attr-status":
+                        attributeStatus.push(toDecodedAttributeReportStatus(entry));
                         break;
-                    }
-
                     case "event-value": {
-                        const { path, number, timestamp, priority, value } = entry;
-                        const reportValue: DecodedEventReportValue<any> = {
-                            path: this.#convertEventPath(path),
-                            events: [{ eventNumber: number, epochTimestamp: timestamp, priority, data: value }],
-                        };
+                        const reportValue = toDecodedEventReportValue(entry);
                         eventReports.push(reportValue);
                         eventListener?.(reportValue);
                         break;
                     }
-
-                    case "event-status": {
-                        const { path, status, clusterStatus } = entry;
-                        const reportStatus: DecodedEventReportStatus = {
-                            path: this.#convertEventPath(path),
-                            status,
-                            clusterStatus,
-                        };
-                        eventStatus.push(reportStatus);
+                    case "event-status":
+                        eventStatus.push(toDecodedEventReportStatus(entry));
                         break;
-                    }
                 }
             }
         }

--- a/packages/matter.js/src/cluster/client/InteractionClient.ts
+++ b/packages/matter.js/src/cluster/client/InteractionClient.ts
@@ -492,7 +492,7 @@ export class InteractionClient {
         const eventStatus = new Array<DecodedEventReportStatus>();
 
         for await (const chunks of report) {
-            for (const entry of chunks) {
+            for await (const entry of chunks) {
                 switch (entry.kind) {
                     case "attr-value": {
                         const reportValue = toDecodedAttributeReportValue(entry);

--- a/packages/matter.js/src/cluster/client/index.ts
+++ b/packages/matter.js/src/cluster/client/index.ts
@@ -6,5 +6,6 @@
 
 export * from "./AttributeClient.js";
 export * from "./ClusterClient.js";
+export * from "./DecodedDataReport.js";
 export * from "./EventClient.js";
 export * from "./InteractionClient.js";

--- a/packages/matter.js/src/cluster/client/index.ts
+++ b/packages/matter.js/src/cluster/client/index.ts
@@ -6,6 +6,7 @@
 
 export * from "./AttributeClient.js";
 export * from "./ClusterClient.js";
+export * from "./ClusterClientTypes.js";
 export * from "./DecodedDataReport.js";
 export * from "./EventClient.js";
 export * from "./InteractionClient.js";

--- a/packages/matter.js/src/device/Device.ts
+++ b/packages/matter.js/src/device/Device.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ClusterClientObj } from "#cluster/client/ClusterClientTypes.js";
 import { AtLeastOne, HandlerFunction, NamedHandler, NotImplementedError } from "@matter/general";
 import { RootNodeDt } from "@matter/model";
 import { Endpoint as NodeEndpoint } from "@matter/node";
-import { ClusterClientObj } from "@matter/protocol";
 import { ClusterType, EndpointNumber } from "@matter/types";
 import { DeviceClasses, DeviceTypeDefinition, getDeviceTypeDefinitionFromModelByCode } from "./DeviceTypes.js";
 import { Endpoint, EndpointOptions } from "./Endpoint.js";

--- a/packages/matter.js/src/device/Endpoint.ts
+++ b/packages/matter.js/src/device/Endpoint.ts
@@ -5,6 +5,7 @@
  */
 
 import { SupportedAttributeClient, UnknownSupportedAttributeClient } from "#cluster/client/AttributeClient.js";
+import { ClusterClientObj } from "#cluster/client/ClusterClientTypes.js";
 import {
     AtLeastOne,
     Diagnostic,
@@ -22,7 +23,7 @@ import {
     Commands,
     type GlobalAttributeState,
 } from "@matter/node";
-import { ClusterClientObj, Val } from "@matter/protocol";
+import { Val } from "@matter/protocol";
 import { ClusterId, ClusterType, DeviceTypeId, EndpointNumber, getClusterNameById } from "@matter/types";
 import { DeviceTypeDefinition } from "./DeviceTypes.js";
 

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -5,6 +5,7 @@
  */
 
 import { ClusterClient } from "#cluster/client/ClusterClient.js";
+import { ClusterClientObj } from "#cluster/client/ClusterClientTypes.js";
 import { DecodedAttributeReportValue, DecodedEventReportValue } from "#cluster/client/DecodedDataReport.js";
 import { InteractionClient, UnknownNodeError } from "#cluster/client/InteractionClient.js";
 import {
@@ -46,7 +47,7 @@ import {
     type GlobalAttributeState,
 } from "@matter/node";
 import { DescriptorClient } from "@matter/node/behaviors/descriptor";
-import { ClusterClientObj, PaseClient, Peer, PeerAddress, Read, SustainedSubscription, Val } from "@matter/protocol";
+import { PaseClient, Peer, PeerAddress, Read, SustainedSubscription, Val } from "@matter/protocol";
 import {
     AttributeId,
     CaseAuthenticatedTag,

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -5,6 +5,7 @@
  */
 
 import { ClusterClient } from "#cluster/client/ClusterClient.js";
+import { DecodedAttributeReportValue, DecodedEventReportValue } from "#cluster/client/DecodedDataReport.js";
 import { InteractionClient, UnknownNodeError } from "#cluster/client/InteractionClient.js";
 import {
     AsyncObservable,
@@ -45,17 +46,7 @@ import {
     type GlobalAttributeState,
 } from "@matter/node";
 import { DescriptorClient } from "@matter/node/behaviors/descriptor";
-import {
-    ClusterClientObj,
-    DecodedAttributeReportValue,
-    DecodedEventReportValue,
-    PaseClient,
-    Peer,
-    PeerAddress,
-    Read,
-    SustainedSubscription,
-    Val,
-} from "@matter/protocol";
+import { ClusterClientObj, PaseClient, Peer, PeerAddress, Read, SustainedSubscription, Val } from "@matter/protocol";
 import {
     AttributeId,
     CaseAuthenticatedTag,

--- a/packages/matter.js/src/device/TypeHelpers.ts
+++ b/packages/matter.js/src/device/TypeHelpers.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ClusterClientObj, ClusterClientObjInternal } from "@matter/protocol";
+import { ClusterClientObj, ClusterClientObjInternal } from "#cluster/client/ClusterClientTypes.js";
 
 export function asClusterClientInternal(obj: ClusterClientObj): ClusterClientObjInternal {
     if (obj._type !== "ClusterClient") {

--- a/packages/matter.js/test/cluster/client/DecodedDataReportTest.ts
+++ b/packages/matter.js/test/cluster/client/DecodedDataReportTest.ts
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { decodeDataReport } from "#cluster/client/DecodedDataReport.js";
+import {
+    AttributeId,
+    ClusterId,
+    DataReport,
+    EndpointNumber,
+    EventId,
+    EventNumber,
+    Status,
+    TlvOfModel,
+    TlvUInt32,
+    TlvVoid,
+} from "@matter/types";
+import { BasicInformation } from "@matter/types/clusters/basic-information";
+
+const TlvStartUpEvent = TlvOfModel(BasicInformation.events.startUp);
+
+function buildReport(input: Partial<DataReport>): DataReport {
+    return { ...input };
+}
+
+describe("decodeDataReport", () => {
+    it("decodes a single attribute into the legacy 4-array shape with resolved name", () => {
+        const report = buildReport({
+            attributeReports: [
+                {
+                    attributeData: {
+                        path: {
+                            endpointId: EndpointNumber(0),
+                            clusterId: ClusterId(BasicInformation.id),
+                            attributeId: AttributeId(BasicInformation.attributes.dataModelRevision.id),
+                        },
+                        dataVersion: 17,
+                        data: TlvUInt32.encodeTlv(1),
+                    },
+                },
+            ],
+        });
+
+        const decoded = decodeDataReport(report);
+
+        expect(decoded.attributeReports).has.length(1);
+        expect(decoded.attributeReports[0].path.attributeName).equal("dataModelRevision");
+        expect(decoded.attributeReports[0].value).equal(1);
+        expect(decoded.attributeReports[0].version).equal(17);
+        expect(decoded.attributeStatus).equal(undefined);
+    });
+
+    it("preserves wire (EventNumber) order across interleaved event types (#3785 regression)", () => {
+        const startUp = EventId(BasicInformation.events.startUp.id);
+        const shutDown = EventId(BasicInformation.events.shutDown.id);
+        const clusterId = ClusterId(BasicInformation.id);
+        const report = buildReport({
+            eventReports: [
+                {
+                    eventData: {
+                        path: { endpointId: EndpointNumber(0), clusterId, eventId: startUp },
+                        eventNumber: EventNumber(1),
+                        priority: 1,
+                        epochTimestamp: 0,
+                        data: TlvStartUpEvent.encodeTlv({ softwareVersion: 1 }),
+                    },
+                },
+                {
+                    eventData: {
+                        path: { endpointId: EndpointNumber(0), clusterId, eventId: shutDown },
+                        eventNumber: EventNumber(2),
+                        priority: 1,
+                        epochTimestamp: 0,
+                        data: TlvVoid.encodeTlv(),
+                    },
+                },
+                {
+                    eventData: {
+                        path: { endpointId: EndpointNumber(0), clusterId, eventId: startUp },
+                        eventNumber: EventNumber(3),
+                        priority: 1,
+                        epochTimestamp: 0,
+                        data: TlvStartUpEvent.encodeTlv({ softwareVersion: 3 }),
+                    },
+                },
+            ],
+        });
+
+        const decoded = decodeDataReport(report);
+
+        expect(decoded.eventReports).has.length(3);
+        expect(decoded.eventReports.map(r => r.events[0].eventNumber)).deep.equal([
+            EventNumber(1),
+            EventNumber(2),
+            EventNumber(3),
+        ]);
+        expect(decoded.eventReports.map(r => r.path.eventId)).deep.equal([startUp, shutDown, startUp]);
+        expect(decoded.eventReports.map(r => r.path.eventName)).deep.equal(["startUp", "shutDown", "startUp"]);
+    });
+
+    it("populates attributeStatus for failed attribute reads", () => {
+        const report = buildReport({
+            attributeReports: [
+                {
+                    attributeStatus: {
+                        path: {
+                            endpointId: EndpointNumber(0),
+                            clusterId: ClusterId(BasicInformation.id),
+                            attributeId: AttributeId(BasicInformation.attributes.vendorId.id),
+                        },
+                        status: { status: Status.UnsupportedAttribute },
+                    },
+                },
+            ],
+        });
+
+        const decoded = decodeDataReport(report);
+
+        expect(decoded.attributeReports).has.length(0);
+        expect(decoded.attributeStatus).has.length(1);
+        expect(decoded.attributeStatus![0].status).equal(Status.UnsupportedAttribute);
+        expect(decoded.attributeStatus![0].path.attributeName).equal("vendorId");
+    });
+});

--- a/packages/matter.js/test/cluster/client/DecodedDataReportTest.ts
+++ b/packages/matter.js/test/cluster/client/DecodedDataReportTest.ts
@@ -26,7 +26,7 @@ function buildReport(input: Partial<DataReport>): DataReport {
 }
 
 describe("decodeDataReport", () => {
-    it("decodes a single attribute into the legacy 4-array shape with resolved name", () => {
+    it("decodes a single attribute into the legacy 4-array shape with resolved name", async () => {
         const report = buildReport({
             attributeReports: [
                 {
@@ -43,7 +43,7 @@ describe("decodeDataReport", () => {
             ],
         });
 
-        const decoded = decodeDataReport(report);
+        const decoded = await decodeDataReport(report);
 
         expect(decoded.attributeReports).has.length(1);
         expect(decoded.attributeReports[0].path.attributeName).equal("dataModelRevision");
@@ -52,7 +52,7 @@ describe("decodeDataReport", () => {
         expect(decoded.attributeStatus).equal(undefined);
     });
 
-    it("preserves wire (EventNumber) order across interleaved event types (#3785 regression)", () => {
+    it("preserves wire (EventNumber) order across interleaved event types (#3785 regression)", async () => {
         const startUp = EventId(BasicInformation.events.startUp.id);
         const shutDown = EventId(BasicInformation.events.shutDown.id);
         const clusterId = ClusterId(BasicInformation.id);
@@ -88,7 +88,7 @@ describe("decodeDataReport", () => {
             ],
         });
 
-        const decoded = decodeDataReport(report);
+        const decoded = await decodeDataReport(report);
 
         expect(decoded.eventReports).has.length(3);
         expect(decoded.eventReports.map(r => r.events[0].eventNumber)).deep.equal([
@@ -100,7 +100,7 @@ describe("decodeDataReport", () => {
         expect(decoded.eventReports.map(r => r.path.eventName)).deep.equal(["startUp", "shutDown", "startUp"]);
     });
 
-    it("populates attributeStatus for failed attribute reads", () => {
+    it("populates attributeStatus for failed attribute reads", async () => {
         const report = buildReport({
             attributeReports: [
                 {
@@ -116,7 +116,7 @@ describe("decodeDataReport", () => {
             ],
         });
 
-        const decoded = decodeDataReport(report);
+        const decoded = await decodeDataReport(report);
 
         expect(decoded.attributeReports).has.length(0);
         expect(decoded.attributeStatus).has.length(1);

--- a/packages/node/src/endpoint/Endpoint.ts
+++ b/packages/node/src/endpoint/Endpoint.ts
@@ -1198,7 +1198,7 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
                 : baseRequest;
             const readValues = new Map<string, Map<string, unknown>>();
             for await (const chunk of node.interaction.read(request, undefined)) {
-                for (const report of chunk) {
+                for await (const report of chunk) {
                     if (report.kind === "attr-value") {
                         const info = clusterLookup.get(report.path.clusterId);
                         if (info !== undefined) {
@@ -1234,7 +1234,7 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
 
         const collectFailures = async (stream: ReturnType<typeof node.interaction.read>) => {
             for await (const chunk of stream) {
-                for (const report of chunk) {
+                for await (const report of chunk) {
                     if (report.kind === "attr-status" && report.status !== Status.Success) {
                         failed.push({ path: report.path, status: report.status, clusterStatus: report.clusterStatus });
                     }

--- a/packages/node/src/node/client/ClientStructure.ts
+++ b/packages/node/src/node/client/ClientStructure.ts
@@ -219,7 +219,7 @@ export class ClientStructure {
         const scope = ReadScope(request);
         for await (const chunk of changes) {
             const chunkData = new Array<ReadResult.Report>();
-            for (const change of chunk) {
+            for await (const change of chunk) {
                 chunkData.push(change);
                 switch (change.kind) {
                     case "attr-value":

--- a/packages/node/src/node/server/InteractionServer.ts
+++ b/packages/node/src/node/server/InteractionServer.ts
@@ -258,7 +258,7 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
         const readContext = this.#prepareOnlineContext(exchange, message, readRequest.isFabricFiltered);
 
         for await (const chunk of this.#serverInteraction.read(readRequest, readContext)) {
-            for (const report of chunk) {
+            for await (const report of chunk) {
                 yield InteractionServerMessenger.convertServerInteractionReport(report);
             }
         }

--- a/packages/node/src/node/server/ServerSubscription.ts
+++ b/packages/node/src/node/server/ServerSubscription.ts
@@ -541,7 +541,7 @@ export class ServerSubscription implements Subscription {
             if (Read.containsAttribute(request)) {
                 const attributeReader = new AttributeReadResponse(this.#context.node.protocol, session);
                 for (const chunk of attributeReader.process(request)) {
-                    for (const report of chunk) {
+                    for await (const report of chunk) {
                         if (report.kind === "attr-status") {
                             if (suppressStatusReports) {
                                 continue;
@@ -575,7 +575,7 @@ export class ServerSubscription implements Subscription {
             if (Read.containsEvent(request)) {
                 const eventReader = new EventReadResponse(this.#context.node.protocol, session);
                 for await (const chunk of eventReader.process(request)) {
-                    for (const report of chunk) {
+                    for await (const report of chunk) {
                         if (report.kind === "event-status") {
                             if (suppressStatusReports) {
                                 continue;
@@ -728,7 +728,7 @@ export class ServerSubscription implements Subscription {
                     attributeFilter,
                 );
                 for (const chunk of attributeReader.process(request)) {
-                    for (const report of chunk) {
+                    for await (const report of chunk) {
                         // No need to filter out status responses because AttributeSubscriptionResponse does that already
                         yield InteractionServerMessenger.convertServerInteractionReport(report);
                     }
@@ -741,7 +741,7 @@ export class ServerSubscription implements Subscription {
 
                 const eventReader = new EventReadResponse(this.#context.node.protocol, session);
                 for await (const chunk of eventReader.process(request)) {
-                    for (const report of chunk) {
+                    for await (const report of chunk) {
                         if (report.kind === "event-status") {
                             continue;
                         }

--- a/packages/node/test/endpoint/server/ProtocolServiceTest.ts
+++ b/packages/node/test/endpoint/server/ProtocolServiceTest.ts
@@ -373,7 +373,7 @@ describe("ProtocolServiceTest", () => {
 
         let encoded = 0;
         for (const chunk of data) {
-            for (const report of chunk) {
+            for await (const report of chunk) {
                 if (report.kind !== "attr-value") {
                     continue;
                 }

--- a/packages/node/test/endpoints/ClusterClientIntegrationTest.ts
+++ b/packages/node/test/endpoints/ClusterClientIntegrationTest.ts
@@ -17,7 +17,7 @@ import { Identify } from "@matter/types/clusters/identify";
 import { MockSite } from "../node/mock-site.js";
 
 async function readDescriptorAttribute(
-    peer: { interaction: { read(req: Read): AsyncIterable<Iterable<ReadResult.Report>> } },
+    peer: { interaction: { read(req: Read): AsyncIterable<ReadResult.Chunk> } },
     endpoint: EndpointNumber,
     attribute: "clientList" | "serverList",
 ): Promise<ClusterId[]> {
@@ -31,7 +31,7 @@ async function readDescriptorAttribute(
 
     const reports = new Array<ReadResult.Report>();
     for await (const chunk of peer.interaction.read(readRequest)) {
-        for (const report of chunk) {
+        for await (const report of chunk) {
             reports.push(report);
         }
     }

--- a/packages/node/test/node/AttributeReadResponseTest.ts
+++ b/packages/node/test/node/AttributeReadResponseTest.ts
@@ -164,7 +164,7 @@ describe("AttributeReadResponse", () => {
             }),
         );
 
-        expect(countAttrs(response.data)).deep.equals({
+        expect(await countAttrs(response.data)).deep.equals({
             0: {
                 40: 21,
             },
@@ -177,7 +177,7 @@ describe("AttributeReadResponse", () => {
             await MockServerNode.createOnline(MockServerNode.RootEndpoint, { device: undefined }),
             Read.Attribute(),
         );
-        expect(countAttrs(response.data)).deep.equals({
+        expect(await countAttrs(response.data)).deep.equals({
             0: ROOT_ENDPOINT_FULL_CLUSTER_LIST,
         });
     });
@@ -188,7 +188,7 @@ describe("AttributeReadResponse", () => {
         const endpoint = await node.add(OnOffLightDevice);
 
         const responseWithLight = await readAttr(node, Read.Attribute());
-        expect(countAttrs(responseWithLight.data)).deep.equals({
+        expect(await countAttrs(responseWithLight.data)).deep.equals({
             0: ROOT_ENDPOINT_FULL_CLUSTER_LIST,
             1: {
                 3: 7,
@@ -206,7 +206,7 @@ describe("AttributeReadResponse", () => {
         await endpoint.close();
 
         const responseAfterRemove = await readAttr(node, Read.Attribute());
-        expect(countAttrs(responseAfterRemove.data)).deep.equals({
+        expect(await countAttrs(responseAfterRemove.data)).deep.equals({
             0: ROOT_ENDPOINT_FULL_CLUSTER_LIST,
         });
         expect(responseAfterRemove.counts).deep.equals({
@@ -223,7 +223,7 @@ describe("AttributeReadResponse", () => {
                 attributes: "attributeList",
             }),
         );
-        expect(countAttrs(response.data)).deep.equals({
+        expect(await countAttrs(response.data)).deep.equals({
             0: {
                 29: 1,
                 31: 1,

--- a/packages/node/test/node/AttributeSubscriptionResponseTest.ts
+++ b/packages/node/test/node/AttributeSubscriptionResponseTest.ts
@@ -74,7 +74,7 @@ describe("AttributeSubscriptionResponse", () => {
             }),
         );
 
-        expect(countAttrs(response.data)).deep.equals({
+        expect(await countAttrs(response.data)).deep.equals({
             0: {
                 40: 5,
             },

--- a/packages/node/test/node/ClientChunkedListTest.ts
+++ b/packages/node/test/node/ClientChunkedListTest.ts
@@ -95,7 +95,7 @@ describe("ClientChunkedList", () => {
         await MockTime.resolve(
             (async () => {
                 for await (const chunk of peer1.interaction.read(readRequest)) {
-                    for (const report of chunk) {
+                    for await (const report of chunk) {
                         reports.push(report);
                     }
                 }

--- a/packages/node/test/node/EventReadResponseTest.ts
+++ b/packages/node/test/node/EventReadResponseTest.ts
@@ -299,7 +299,7 @@ describe("EventReadResponse", () => {
             }),
         );
 
-        expect(countEvents(response.data)).deep.equals({
+        expect(await countEvents(response.data)).deep.equals({
             0: {
                 40: 1,
             },
@@ -320,7 +320,7 @@ describe("EventReadResponse", () => {
             }),
         );
 
-        expect(countEvents(response.data)).deep.equals({
+        expect(await countEvents(response.data)).deep.equals({
             0: {
                 40: 2,
             },
@@ -332,7 +332,7 @@ describe("EventReadResponse", () => {
         const node = await MockServerNode.createOnline();
         await node.act(agent => node.events.basicInformation.startUp.emit({ softwareVersion: 2 }, agent.context));
         const response = await readEv(node, false, Read.Event({}));
-        expect(countEvents(response.data)).deep.equals({
+        expect(await countEvents(response.data)).deep.equals({
             0: ROOT_ENDPOINT_FULL_CLUSTER_LIST,
         });
         expect(response.counts).deep.equals({
@@ -442,10 +442,10 @@ export async function readEvRaw(node: MockServerNode, data: Partial<Read.Events>
     });
 }
 
-export function countEvents(chunks: ReadResult.Chunk[]) {
+export async function countEvents(chunks: ReadResult.Chunk[]) {
     const counts = {} as Record<EndpointNumber, Record<ClusterId, number>>;
     for (const chunk of chunks) {
-        for (const report of chunk) {
+        for await (const report of chunk) {
             if (report.kind !== "event-value") {
                 throw new Error("Only attribute values expected");
             }

--- a/packages/node/test/node/read-helpers.ts
+++ b/packages/node/test/node/read-helpers.ts
@@ -53,10 +53,10 @@ export async function readAllAttrs(node: MockServerNode) {
     });
 }
 
-export function countAttrs(chunks: ReadResult.Chunk[]) {
+export async function countAttrs(chunks: ReadResult.Chunk[]) {
     const counts = {} as Record<EndpointNumber, Record<ClusterId, number>>;
     for (const chunk of chunks) {
-        for (const report of chunk) {
+        for await (const report of chunk) {
             if (report.kind !== "attr-value") {
                 throw new Error("Only attribute values expected");
             }

--- a/packages/protocol/src/action/client/InputChunk.ts
+++ b/packages/protocol/src/action/client/InputChunk.ts
@@ -5,78 +5,317 @@
  */
 
 import { ReadResult } from "#action/response/ReadResult.js";
-import { DecodedDataReport } from "#interaction/DecodedDataReport.js";
-import { DataReport, Status, TlvAny, TlvAttributeReport, TypeFromSchema } from "@matter/types";
+import { decodeAttributeValueWithSchema, decodeUnknownAttributeValue } from "#interaction/AttributeDataDecoder.js";
+import { decodeUnknownEventValue } from "#interaction/EventDataDecoder.js";
+import { Diagnostic, Logger, UnexpectedDataError } from "@matter/general";
+import { Matter } from "@matter/model";
+import {
+    AttributeId,
+    ClusterId,
+    DataReport,
+    EndpointNumber,
+    NodeId,
+    Status,
+    TlvAny,
+    TlvAttributeData,
+    TlvAttributeReport,
+    TlvAttributeStatus,
+    TlvEventData,
+    TlvEventStatus,
+    TlvOfModel,
+    TlvType,
+    TypeFromSchema,
+} from "@matter/types";
+
+const logger = Logger.get("InputChunk");
+
+interface ResolvedAttributePath {
+    nodeId?: NodeId;
+    endpointId: EndpointNumber;
+    clusterId: ClusterId;
+    attributeId: AttributeId;
+    dataVersion?: number;
+}
+
+interface AttributeDataGroup {
+    path: ResolvedAttributePath;
+    dataVersion?: number;
+    entries: TypeFromSchema<typeof TlvAttributeData>[];
+}
 
 /**
  * Converts a {@link DataReport} into a {@link ReadResult.Chunk}.
+ *
+ * Wire order is preserved end-to-end. Adjacent `attributeData` entries sharing a full path accumulate so chunked
+ * arrays reassemble into a single decoded value; an `attributeStatus` or a path change flushes the pending group.
+ * Each `attributeStatus` emits one chunk directly. Each event emits one chunk per occurrence (#3785).
+ * Tag-compressed paths inherit from the last fully-qualified entry per Matter Core §10.7.5.
+ *
+ * When `report.moreChunkedMessages` is set and the trailing data group looks like the head of an open chunked
+ * array (last entry has a list-action `listIndex`, or is a bare array TLV that could still be growing), its raw
+ * entries are stashed in `leftoverAttributeReports` for the next report. Spec basis: Matter Core §8.5.6.3
+ * requires array chunks for the same path to be contiguous.
  */
 export function* InputChunk(
     input: DataReport,
     leftoverAttributeReports?: TypeFromSchema<typeof TlvAttributeReport>[],
 ): ReadResult.Chunk {
-    const report = DecodedDataReport(input, leftoverAttributeReports);
+    yield* emitAttributes(input, leftoverAttributeReports);
+    yield* emitEvents(input);
+}
 
-    for (const attr of report.attributeReports) {
-        yield {
+function* emitAttributes(
+    input: DataReport,
+    leftover: TypeFromSchema<typeof TlvAttributeReport>[] | undefined,
+): Generator<ReadResult.AttributeValue | ReadResult.AttributeStatus> {
+    let attrs = input.attributeReports;
+    if (leftover?.length) {
+        attrs = attrs === undefined ? [...leftover] : [...leftover, ...attrs];
+        leftover.length = 0;
+    }
+    if (attrs === undefined || attrs.length === 0) {
+        return;
+    }
+
+    let lastPath: ResolvedAttributePath | undefined;
+    let group: AttributeDataGroup | undefined;
+
+    for (const entry of attrs) {
+        if (entry.attributeData !== undefined) {
+            const data = entry.attributeData;
+            const resolved = resolvePath(data.path, lastPath);
+            if (
+                data.path.enableTagCompression &&
+                data.dataVersion === undefined &&
+                lastPath?.dataVersion !== undefined
+            ) {
+                data.dataVersion = lastPath.dataVersion;
+            }
+            if (!data.path.enableTagCompression) {
+                lastPath = { ...resolved, dataVersion: data.dataVersion };
+            }
+            if (group !== undefined && !samePath(group.path, resolved)) {
+                yield* flushDataGroup(group);
+                group = undefined;
+            }
+            if (group === undefined) {
+                group = { path: resolved, dataVersion: data.dataVersion, entries: [data] };
+            } else {
+                group.entries.push(data);
+                if (group.dataVersion === undefined) group.dataVersion = data.dataVersion;
+            }
+        } else if (entry.attributeStatus !== undefined) {
+            const statusSrc = entry.attributeStatus;
+            const resolved = resolvePath(statusSrc.path, lastPath);
+            // Status entry has no dataVersion of its own; preserve whatever the previous data entry installed.
+            if (!statusSrc.path.enableTagCompression) {
+                lastPath = { ...resolved, dataVersion: lastPath?.dataVersion };
+            }
+            if (group !== undefined) {
+                yield* flushDataGroup(group);
+                group = undefined;
+            }
+            const status = buildAttrStatus(resolved, statusSrc);
+            if (status !== undefined) yield status;
+        }
+    }
+
+    if (
+        group !== undefined &&
+        input.moreChunkedMessages &&
+        leftover !== undefined &&
+        looksLikeChunkedArrayHead(group.entries[group.entries.length - 1])
+    ) {
+        for (const d of group.entries) leftover.push({ attributeData: d });
+        return;
+    }
+    if (group !== undefined) {
+        yield* flushDataGroup(group);
+    }
+}
+
+function* flushDataGroup(group: AttributeDataGroup): Generator<ReadResult.AttributeValue> {
+    const value = decodeAttributeGroup(group.path, group.dataVersion, group.entries);
+    if (value !== undefined) yield value;
+}
+
+function resolvePath(
+    path: TypeFromSchema<typeof TlvAttributeData>["path"],
+    lastPath: ResolvedAttributePath | undefined,
+): ResolvedAttributePath {
+    if (path.enableTagCompression) {
+        if (lastPath === undefined) {
+            throw new UnexpectedDataError("Tag compression enabled, but no previous path");
+        }
+        if (path.nodeId === undefined && lastPath.nodeId !== undefined) path.nodeId = lastPath.nodeId;
+        if (path.endpointId === undefined) path.endpointId = lastPath.endpointId;
+        if (path.clusterId === undefined) path.clusterId = lastPath.clusterId;
+        if (path.attributeId === undefined) path.attributeId = lastPath.attributeId;
+    } else if (path.endpointId === undefined || path.clusterId === undefined || path.attributeId === undefined) {
+        throw new UnexpectedDataError("Tag compression disabled, but path is incomplete: " + Diagnostic.json(path));
+    }
+    return {
+        nodeId: path.nodeId,
+        endpointId: path.endpointId!,
+        clusterId: path.clusterId!,
+        attributeId: path.attributeId!,
+    };
+}
+
+function samePath(a: ResolvedAttributePath, b: ResolvedAttributePath): boolean {
+    return (
+        a.nodeId === b.nodeId &&
+        a.endpointId === b.endpointId &&
+        a.clusterId === b.clusterId &&
+        a.attributeId === b.attributeId
+    );
+}
+
+function looksLikeChunkedArrayHead(data: TypeFromSchema<typeof TlvAttributeData>): boolean {
+    // True if this entry could be the head of a chunked array whose tail continues in the next message.
+    if (data.path.listIndex !== undefined) return true;
+    const tlvData = data.data;
+    return Array.isArray(tlvData) && tlvData.length > 1 && tlvData[0].typeLength.type === TlvType.Array;
+}
+
+function decodeAttributeGroup(
+    path: ResolvedAttributePath,
+    dataVersion: number | undefined,
+    entries: TypeFromSchema<typeof TlvAttributeData>[],
+): ReadResult.AttributeValue | undefined {
+    const { nodeId, endpointId, clusterId, attributeId } = path;
+
+    try {
+        const clusterModel = Matter.clusters(clusterId);
+        const attributeModel = clusterModel?.attributes(attributeId) ?? Matter.attributes(attributeId);
+
+        let value: unknown;
+        if (attributeModel === undefined) {
+            value = decodeUnknownAttributeValue(entries);
+        } else {
+            let schema;
+            try {
+                schema = TlvOfModel(attributeModel);
+            } catch {
+                // Attribute is known but has no schema (e.g. deprecated global attributes) — decode as unknown
+                schema = undefined;
+            }
+            value =
+                schema === undefined
+                    ? decodeUnknownAttributeValue(entries)
+                    : decodeAttributeValueWithSchema(schema, entries);
+        }
+        return {
             kind: "attr-value",
+            path: { nodeId, endpointId, clusterId, attributeId },
             tlv: TlvAny,
-            ...attr,
+            value,
+            // Type declares version required; wire-decoded dataVersion may be absent — preserve historical behavior.
+            version: dataVersion as number,
         };
+    } catch (error: any) {
+        logger.warn(
+            `Error decoding attribute ${endpointId}/${Diagnostic.hex(clusterId)}/${Diagnostic.hex(attributeId)}: ${error.message}`,
+        );
+        return undefined;
     }
+}
 
-    if (report.attributeStatus) {
-        for (const attr of report.attributeStatus) {
-            yield {
-                kind: "attr-status",
-                path: attr.path,
-                status: attr.status ?? Status.Failure, // TODO - attr.status shouldn't be optional?
-                clusterStatus: attr.clusterStatus,
-            };
+function buildAttrStatus(
+    path: ResolvedAttributePath,
+    src: TypeFromSchema<typeof TlvAttributeStatus>,
+): ReadResult.AttributeStatus | undefined {
+    const { nodeId, endpointId, clusterId, attributeId } = path;
+    return {
+        kind: "attr-status",
+        path: { nodeId, endpointId, clusterId, attributeId },
+        status: src.status.status ?? Status.Failure,
+        clusterStatus: src.status.clusterStatus,
+    };
+}
+
+function* emitEvents(input: DataReport): Generator<ReadResult.EventValue | ReadResult.EventStatus> {
+    const events = input.eventReports;
+    if (events === undefined || events.length === 0) return;
+
+    for (const entry of events) {
+        if (entry.eventData !== undefined) {
+            const value = decodeEventValue(entry.eventData);
+            if (value !== undefined) yield value;
+        } else if (entry.eventStatus !== undefined) {
+            const status = buildEventStatus(entry.eventStatus);
+            if (status !== undefined) yield status;
         }
     }
+}
 
-    for (const event of report.eventReports) {
-        for (const occurrence of event.events) {
-            yield {
-                kind: "event-value",
-                path: event.path,
-                value: occurrence.data,
-                number: occurrence.eventNumber,
-                priority: occurrence.priority,
-                timestamp: Number(
-                    // TODO - this may not be useful, need to determine correct form
-                    occurrence.epochTimestamp ??
-                        occurrence.systemTimestamp ??
-                        occurrence.deltaEpochTimestamp ??
-                        occurrence.deltaSystemTimestamp ??
-                        0,
-                ),
+function decodeEventValue(eventData: TypeFromSchema<typeof TlvEventData>): ReadResult.EventValue | undefined {
+    const {
+        path: { nodeId, endpointId, clusterId, eventId },
+        eventNumber,
+        priority,
+        epochTimestamp,
+        systemTimestamp,
+        deltaEpochTimestamp,
+        deltaSystemTimestamp,
+        data,
+    } = eventData;
 
-                // TODO - temporary, field will be removed
-                tlv: TlvAny,
-            };
-        }
+    if (endpointId === undefined || clusterId === undefined || eventId === undefined) {
+        throw new UnexpectedDataError(`Invalid event path ${endpointId}/${clusterId}/${eventId}`);
     }
 
-    if (report.eventStatus) {
-        for (const event of report.eventStatus) {
-            if (event.status !== undefined) {
-                yield {
-                    kind: "event-status",
-                    path: event.path,
-                    status: event.status,
-                    clusterStatus: event.clusterStatus,
-                };
-            }
-            if (event.clusterStatus !== undefined) {
-                yield {
-                    kind: "event-status",
-                    path: event.path,
-                    status: event.status ?? Status.Failure,
-                    clusterStatus: event.clusterStatus,
-                };
-            }
+    try {
+        const clusterModel = Matter.clusters(clusterId);
+        const eventModel = clusterModel?.events(eventId);
+
+        let value: unknown;
+        if (eventModel === undefined) {
+            logger.debug(
+                `Decode unknown event ${Diagnostic.hex(clusterId)}/${Diagnostic.hex(eventId)} via the AnySchema.`,
+            );
+            value = data === undefined ? undefined : decodeUnknownEventValue(data);
+        } else {
+            const schema = TlvOfModel(eventModel);
+            value = data === undefined ? undefined : schema.decodeTlv(data);
         }
+
+        // TODO - timestamp collapses four distinct wire variants (absolute/delta × epoch/system).
+        //   Add discriminated/explicit fields in a follow-up so callers can recover the original semantics.
+        const timestamp = Number(epochTimestamp ?? systemTimestamp ?? deltaEpochTimestamp ?? deltaSystemTimestamp ?? 0);
+
+        return {
+            kind: "event-value",
+            path: { nodeId, endpointId, clusterId, eventId },
+            value,
+            number: eventNumber,
+            priority,
+            timestamp,
+            tlv: TlvAny,
+        };
+    } catch (error: any) {
+        logger.error(
+            `Error decoding event ${endpointId}/${Diagnostic.hex(clusterId)}/${Diagnostic.hex(eventId)}: ${error.message}`,
+        );
+        return undefined;
     }
+}
+
+function buildEventStatus(src: TypeFromSchema<typeof TlvEventStatus>): ReadResult.EventStatus | undefined {
+    const {
+        path: { nodeId, endpointId, clusterId, eventId },
+        status,
+    } = src;
+    if (endpointId === undefined || clusterId === undefined || eventId === undefined) {
+        throw new UnexpectedDataError(`Invalid event path ${endpointId}/${clusterId}/${eventId}`);
+    }
+    if (status.status === undefined && status.clusterStatus === undefined) {
+        return undefined;
+    }
+    return {
+        kind: "event-status",
+        path: { nodeId, endpointId, clusterId, eventId },
+        status: status.status ?? Status.Failure,
+        clusterStatus: status.clusterStatus,
+    };
 }

--- a/packages/protocol/src/action/client/InputChunk.ts
+++ b/packages/protocol/src/action/client/InputChunk.ts
@@ -51,10 +51,10 @@ interface AttributeDataGroup {
  * and `moreChunkedMessages` is set, the trailing entries are stashed in `leftoverAttributeReports` for the next
  * report. See #3785 for event-order semantics.
  */
-export function* InputChunk(
+export async function* InputChunk(
     input: DataReport,
     leftoverAttributeReports?: TypeFromSchema<typeof TlvAttributeReport>[],
-): ReadResult.Chunk {
+): AsyncGenerator<ReadResult.Report> {
     yield* emitAttributes(input, leftoverAttributeReports);
     yield* emitEvents(input);
 }

--- a/packages/protocol/src/action/client/InputChunk.ts
+++ b/packages/protocol/src/action/client/InputChunk.ts
@@ -110,8 +110,7 @@ function* emitAttributes(
                 yield* flushDataGroup(group);
                 group = undefined;
             }
-            const status = buildAttrStatus(resolved, statusSrc);
-            if (status !== undefined) yield status;
+            yield buildAttrStatus(resolved, statusSrc);
         }
     }
 
@@ -205,8 +204,10 @@ function decodeAttributeGroup(
             path: { nodeId, endpointId, clusterId, attributeId },
             tlv: TlvAny,
             value,
-            // Type declares version required; wire-decoded dataVersion may be absent — preserve historical behavior.
-            version: dataVersion as number,
+            // Wire `dataVersion` is optional per TlvAttributeReportData; substitute 0 when the publisher omits
+            // it so the chunk honors its `version: number` contract. In practice spec-compliant publishers
+            // always include dataVersion for AttributeData reports.
+            version: dataVersion ?? 0,
         };
     } catch (error) {
         // Swallow wire-decode failures (malformed TLV, schema mismatch); unrelated errors bubble.
@@ -221,7 +222,7 @@ function decodeAttributeGroup(
 function buildAttrStatus(
     path: ResolvedAttributePath,
     src: TypeFromSchema<typeof TlvAttributeStatus>,
-): ReadResult.AttributeStatus | undefined {
+): ReadResult.AttributeStatus {
     const { nodeId, endpointId, clusterId, attributeId } = path;
     return {
         kind: "attr-status",

--- a/packages/protocol/src/action/client/InputChunk.ts
+++ b/packages/protocol/src/action/client/InputChunk.ts
@@ -44,17 +44,12 @@ interface AttributeDataGroup {
 }
 
 /**
- * Converts a {@link DataReport} into a {@link ReadResult.Chunk}.
+ * Streaming decode of a {@link DataReport} into a {@link ReadResult.Chunk}.
  *
- * Wire order is preserved end-to-end. Adjacent `attributeData` entries sharing a full path accumulate so chunked
- * arrays reassemble into a single decoded value; an `attributeStatus` or a path change flushes the pending group.
- * Each `attributeStatus` emits one chunk directly. Each event emits one chunk per occurrence (#3785).
- * Tag-compressed paths inherit from the last fully-qualified entry per Matter Core §10.7.5.
- *
- * When `report.moreChunkedMessages` is set and the trailing data group looks like the head of an open chunked
- * array (last entry has a list-action `listIndex`, or is a bare array TLV that could still be growing), its raw
- * entries are stashed in `leftoverAttributeReports` for the next report. Spec basis: Matter Core §8.5.6.3
- * requires array chunks for the same path to be contiguous.
+ * Adjacent same-path `attributeData` entries accumulate for chunked-array reassembly per Matter Core §8.5.6.3.
+ * Tag compression resolves against the last fully-qualified path per §10.7.5. When the report ends mid-chunked-array
+ * and `moreChunkedMessages` is set, the trailing entries are stashed in `leftoverAttributeReports` for the next
+ * report. See #3785 for event-order semantics.
  */
 export function* InputChunk(
     input: DataReport,
@@ -124,7 +119,7 @@ function* emitAttributes(
         group !== undefined &&
         input.moreChunkedMessages &&
         leftover !== undefined &&
-        looksLikeChunkedArrayHead(group.entries[group.entries.length - 1])
+        mayContinueInNextReport(group.entries[group.entries.length - 1])
     ) {
         for (const d of group.entries) leftover.push({ attributeData: d });
         return;
@@ -171,8 +166,8 @@ function samePath(a: ResolvedAttributePath, b: ResolvedAttributePath): boolean {
     );
 }
 
-function looksLikeChunkedArrayHead(data: TypeFromSchema<typeof TlvAttributeData>): boolean {
-    // True if this entry could be the head of a chunked array whose tail continues in the next message.
+function mayContinueInNextReport(data: TypeFromSchema<typeof TlvAttributeData>): boolean {
+    // Two signals: a list-action `listIndex` (definitely chunked) or a bare array-typed value (could still grow).
     if (data.path.listIndex !== undefined) return true;
     const tlvData = data.data;
     return Array.isArray(tlvData) && tlvData.length > 1 && tlvData[0].typeLength.type === TlvType.Array;
@@ -213,7 +208,9 @@ function decodeAttributeGroup(
             // Type declares version required; wire-decoded dataVersion may be absent — preserve historical behavior.
             version: dataVersion as number,
         };
-    } catch (error: any) {
+    } catch (error) {
+        // Swallow wire-decode failures (malformed TLV, schema mismatch); unrelated errors bubble.
+        UnexpectedDataError.accept(error);
         logger.warn(
             `Error decoding attribute ${endpointId}/${Diagnostic.hex(clusterId)}/${Diagnostic.hex(attributeId)}: ${error.message}`,
         );
@@ -296,7 +293,9 @@ function decodeEventValue(eventData: TypeFromSchema<typeof TlvEventData>): ReadR
             deltaSystemTimestamp,
             tlv: TlvAny,
         };
-    } catch (error: any) {
+    } catch (error) {
+        // Swallow wire-decode failures; unrelated errors bubble.
+        UnexpectedDataError.accept(error);
         logger.error(
             `Error decoding event ${endpointId}/${Diagnostic.hex(clusterId)}/${Diagnostic.hex(eventId)}: ${error.message}`,
         );

--- a/packages/protocol/src/action/client/InputChunk.ts
+++ b/packages/protocol/src/action/client/InputChunk.ts
@@ -280,8 +280,7 @@ function decodeEventValue(eventData: TypeFromSchema<typeof TlvEventData>): ReadR
             value = data === undefined ? undefined : schema.decodeTlv(data);
         }
 
-        // TODO - timestamp collapses four distinct wire variants (absolute/delta × epoch/system).
-        //   Add discriminated/explicit fields in a follow-up so callers can recover the original semantics.
+        // `timestamp` is a lossy convenience: callers needing the specific wire variant read the explicit field below.
         const timestamp = Number(epochTimestamp ?? systemTimestamp ?? deltaEpochTimestamp ?? deltaSystemTimestamp ?? 0);
 
         return {
@@ -291,6 +290,10 @@ function decodeEventValue(eventData: TypeFromSchema<typeof TlvEventData>): ReadR
             number: eventNumber,
             priority,
             timestamp,
+            epochTimestamp,
+            systemTimestamp,
+            deltaEpochTimestamp,
+            deltaSystemTimestamp,
             tlv: TlvAny,
         };
     } catch (error: any) {

--- a/packages/protocol/src/action/response/ReadResult.ts
+++ b/packages/protocol/src/action/response/ReadResult.ts
@@ -30,7 +30,12 @@ import type {
 export interface ReadResult<Chunk = ReadResult.Chunk> extends AsyncIterable<Chunk> {}
 
 export namespace ReadResult {
-    export type Chunk = Iterable<Report>;
+    /**
+     * One block of reports yielded by a {@link ReadResult}. Async-iterable producers (e.g. wire-decode pipelines)
+     * can interleave work between reports; sync producers (e.g. small in-memory yields) keep their literal array
+     * shape. Consumers iterate with `for await … of chunk` either way.
+     */
+    export type Chunk = AsyncIterable<Report> | Iterable<Report>;
 
     export type Report = AttributeValue | AttributeStatus | EventValue | EventStatus;
 

--- a/packages/protocol/src/action/response/ReadResult.ts
+++ b/packages/protocol/src/action/response/ReadResult.ts
@@ -67,7 +67,25 @@ export namespace ReadResult {
         kind: "event-value";
         path: ConcreteEventPath;
         number: EventNumber;
+
+        /**
+         * Collapsed numeric form of whichever wire timestamp variant the publisher sent. Convenience for callers
+         * that don't care about the distinction; the specific variant is in the four fields below.
+         */
         timestamp: number;
+
+        /** Absolute Posix epoch timestamp (milliseconds). Per Matter Core §10.7 exactly one of the four is set. */
+        epochTimestamp?: number | bigint;
+
+        /** Absolute system-time timestamp (milliseconds). */
+        systemTimestamp?: number | bigint;
+
+        /** Relative epoch-time delta from the previous event (milliseconds). */
+        deltaEpochTimestamp?: number | bigint;
+
+        /** Relative system-time delta from the previous event (milliseconds). */
+        deltaSystemTimestamp?: number | bigint;
+
         priority: Priority;
         value: unknown;
         tlv: TlvSchema<unknown>;

--- a/packages/protocol/src/cluster/client/index.ts
+++ b/packages/protocol/src/cluster/client/index.ts
@@ -1,7 +1,0 @@
-/**
- * @license
- * Copyright 2022-2026 Matter.js Authors
- * SPDX-License-Identifier: Apache-2.0
- */
-
-export * from "./ClusterClientTypes.js";

--- a/packages/protocol/src/cluster/index.ts
+++ b/packages/protocol/src/cluster/index.ts
@@ -1,7 +1,0 @@
-/**
- * @license
- * Copyright 2022-2026 Matter.js Authors
- * SPDX-License-Identifier: Apache-2.0
- */
-
-export * from "./client/index.js";

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -12,7 +12,6 @@ export * from "./advertisement/index.js";
 export * from "./bdx/index.js";
 export * from "./ble/index.js";
 export * from "./certificate/index.js";
-export * from "./cluster/index.js";
 export * from "./codec/index.js";
 export * from "./common/index.js";
 export * from "./dcl/index.js";

--- a/packages/protocol/src/interaction/AttributeDataDecoder.ts
+++ b/packages/protocol/src/interaction/AttributeDataDecoder.ts
@@ -47,13 +47,10 @@ export type DecodedAttributeReportStatus = DecodedAttributeReportEntry & {
     clusterStatus?: number;
 };
 
-/** Represents a decoded attribute value from a received DataReport where data version could be optional. */
-export type DecodedAttributeValue<T> = Omit<DecodedAttributeReportValue<T>, "version"> & {
+/** Internal — like {@link DecodedAttributeReportValue} but with optional version. */
+type DecodedAttributeValue<T> = Omit<DecodedAttributeReportValue<T>, "version"> & {
     version?: number;
 };
-
-/** Structured representation of read attribute data as endpointId/clusterId/attributeName objects */
-export type StructuredReadAttributeData = { [key: number]: { [key: number]: { [key: string]: any } } };
 
 /**
  * Parses, normalizes (e.g. un-chunk arrays and resolve Tag compression if used) and decodes the attribute data from
@@ -344,28 +341,4 @@ export function decodeUnknownAttributeValue(values: TypeFromSchema<typeof TlvAtt
         );
         return tlvEncoded.map(element => schema.decodeAnyTlvStream(element));
     }
-}
-
-/** Structure the data of a received DataReport into an endpointId/clusterId/attributeName object structure. */
-export function structureReadAttributeDataToClusterObject(data: DecodedAttributeReportValue<any>[]) {
-    const structure: StructuredReadAttributeData = {};
-    for (const {
-        path: { endpointId, clusterId, attributeName },
-        value,
-    } of data) {
-        if (structure[endpointId] === undefined) {
-            if ((endpointId as any) === "__proto__") {
-                continue;
-            }
-            structure[endpointId] = {};
-        }
-        if (structure[endpointId][clusterId] === undefined) {
-            if ((clusterId as any) === "__proto__") {
-                continue;
-            }
-            structure[endpointId][clusterId] = {};
-        }
-        structure[endpointId][clusterId][attributeName] = value;
-    }
-    return structure;
 }

--- a/packages/protocol/src/interaction/AttributeDataDecoder.ts
+++ b/packages/protocol/src/interaction/AttributeDataDecoder.ts
@@ -25,7 +25,7 @@ import {
 
 const logger = Logger.get("AttributeDataDecoder");
 
-/** @deprecated removed in 0.18. Import from `@project-chip/matter.js/cluster` instead. */
+/** @deprecated since 0.17 — will be removed in 0.18. Import from `@project-chip/matter.js/cluster` instead. */
 export type DecodedAttributeReportEntry = {
     path: {
         nodeId?: NodeId;
@@ -39,7 +39,7 @@ export type DecodedAttributeReportEntry = {
 /**
  * Represents a fully qualified and decoded attribute value from a received DataReport.
  *
- * @deprecated removed in 0.18. Import from `@project-chip/matter.js/cluster` instead.
+ * @deprecated since 0.17 — will be removed in 0.18. Import from `@project-chip/matter.js/cluster` instead.
  */
 export type DecodedAttributeReportValue<T> = DecodedAttributeReportEntry & {
     version: number;
@@ -49,7 +49,7 @@ export type DecodedAttributeReportValue<T> = DecodedAttributeReportEntry & {
 /**
  * Represents a fully qualified and decoded attribute status from a received DataReport.
  *
- * @deprecated removed in 0.18. Import from `@project-chip/matter.js/cluster` instead.
+ * @deprecated since 0.17 — will be removed in 0.18. Import from `@project-chip/matter.js/cluster` instead.
  */
 export type DecodedAttributeReportStatus = DecodedAttributeReportEntry & {
     status?: Status;
@@ -65,7 +65,7 @@ type DecodedAttributeValue<T> = Omit<DecodedAttributeReportValue<T>, "version"> 
  * Parses, normalizes (e.g. un-chunk arrays and resolve Tag compression if used) and decodes the attribute data from
  * a received DataReport.
  *
- * @deprecated removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from
+ * @deprecated since 0.17 — will be removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from
  *   `@project-chip/matter.js/cluster`.
  */
 export function normalizeAndDecodeReadAttributeReport(
@@ -156,7 +156,7 @@ export function expandPathsInAttributeData(
  * Normalizes (e.g. prepare data for array un-chunking and resolve Tag compression if used) the attribute details from
  * a received DataReport.
  *
- * @deprecated removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from `@project-chip/matter.js/cluster`.
+ * @deprecated since 0.17 — will be removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from `@project-chip/matter.js/cluster`.
  */
 export function normalizeAttributeData(
     data: TypeFromSchema<typeof TlvAttributeData>[],
@@ -183,7 +183,7 @@ export function normalizeAttributeData(
  * Normalizes (e.g. un-chunk arrays and resolve Tag compression if used) and decodes the attribute data from a received
  * DataReport.
  *
- * @deprecated removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from `@project-chip/matter.js/cluster`.
+ * @deprecated since 0.17 — will be removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from `@project-chip/matter.js/cluster`.
  */
 export function normalizeAttributeStatus(
     data: TypeFromSchema<typeof TlvAttributeStatus>[],
@@ -228,7 +228,7 @@ export function normalizeAttributeStatus(
  * Normalizes (e.g. un-chunk arrays and resolve Tag compression if used) and decodes the attribute data from a received
  * DataReport.
  *
- * @deprecated removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from `@project-chip/matter.js/cluster`.
+ * @deprecated since 0.17 — will be removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from `@project-chip/matter.js/cluster`.
  */
 export function normalizeAndDecodeAttributeData(
     data: TypeFromSchema<typeof TlvAttributeData>[],

--- a/packages/protocol/src/interaction/AttributeDataDecoder.ts
+++ b/packages/protocol/src/interaction/AttributeDataDecoder.ts
@@ -25,6 +25,7 @@ import {
 
 const logger = Logger.get("AttributeDataDecoder");
 
+/** @deprecated removed in 0.18. Import from `@project-chip/matter.js/cluster` instead. */
 export type DecodedAttributeReportEntry = {
     path: {
         nodeId?: NodeId;
@@ -35,13 +36,21 @@ export type DecodedAttributeReportEntry = {
     };
 };
 
-/** Represents a fully qualified and decoded attribute value from a received DataReport */
+/**
+ * Represents a fully qualified and decoded attribute value from a received DataReport.
+ *
+ * @deprecated removed in 0.18. Import from `@project-chip/matter.js/cluster` instead.
+ */
 export type DecodedAttributeReportValue<T> = DecodedAttributeReportEntry & {
     version: number;
     value: T;
 };
 
-/** Represents a fully qualified and decoded attribute status from a received DataReport */
+/**
+ * Represents a fully qualified and decoded attribute status from a received DataReport.
+ *
+ * @deprecated removed in 0.18. Import from `@project-chip/matter.js/cluster` instead.
+ */
 export type DecodedAttributeReportStatus = DecodedAttributeReportEntry & {
     status?: Status;
     clusterStatus?: number;
@@ -55,7 +64,9 @@ type DecodedAttributeValue<T> = Omit<DecodedAttributeReportValue<T>, "version"> 
 /**
  * Parses, normalizes (e.g. un-chunk arrays and resolve Tag compression if used) and decodes the attribute data from
  * a received DataReport.
- * TODO: Convert into a Generator function once we migrate Reading Data for controller to also be streaming
+ *
+ * @deprecated removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from
+ *   `@project-chip/matter.js/cluster`.
  */
 export function normalizeAndDecodeReadAttributeReport(
     data: TypeFromSchema<typeof TlvAttributeReport>[],
@@ -144,6 +155,8 @@ export function expandPathsInAttributeData(
 /**
  * Normalizes (e.g. prepare data for array un-chunking and resolve Tag compression if used) the attribute details from
  * a received DataReport.
+ *
+ * @deprecated removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from `@project-chip/matter.js/cluster`.
  */
 export function normalizeAttributeData(
     data: TypeFromSchema<typeof TlvAttributeData>[],
@@ -169,6 +182,8 @@ export function normalizeAttributeData(
 /**
  * Normalizes (e.g. un-chunk arrays and resolve Tag compression if used) and decodes the attribute data from a received
  * DataReport.
+ *
+ * @deprecated removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from `@project-chip/matter.js/cluster`.
  */
 export function normalizeAttributeStatus(
     data: TypeFromSchema<typeof TlvAttributeStatus>[],
@@ -212,6 +227,8 @@ export function normalizeAttributeStatus(
 /**
  * Normalizes (e.g. un-chunk arrays and resolve Tag compression if used) and decodes the attribute data from a received
  * DataReport.
+ *
+ * @deprecated removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from `@project-chip/matter.js/cluster`.
  */
 export function normalizeAndDecodeAttributeData(
     data: TypeFromSchema<typeof TlvAttributeData>[],

--- a/packages/protocol/src/interaction/DecodedDataReport.ts
+++ b/packages/protocol/src/interaction/DecodedDataReport.ts
@@ -16,6 +16,9 @@ import {
     normalizeAndDecodeReadEventReport,
 } from "./EventDataDecoder.js";
 
+/**
+ * @deprecated removed in 0.18. Import `DecodedDataReport` from `@project-chip/matter.js/cluster` instead.
+ */
 export interface DecodedDataReport extends DataReport {
     isNormalized: true;
     attributeReports: DecodedAttributeReportValue<any>[];
@@ -25,6 +28,10 @@ export interface DecodedDataReport extends DataReport {
     subscriptionId?: number;
 }
 
+/**
+ * @deprecated removed in 0.18. Use `decodeDataReport` from `@project-chip/matter.js/cluster`, or consume the
+ *   streaming `InputChunk` API directly.
+ */
 export function DecodedDataReport(
     report: DataReport,
     leftoverAttributeReports?: TypeFromSchema<typeof TlvAttributeReport>[],

--- a/packages/protocol/src/interaction/DecodedDataReport.ts
+++ b/packages/protocol/src/interaction/DecodedDataReport.ts
@@ -17,7 +17,7 @@ import {
 } from "./EventDataDecoder.js";
 
 /**
- * @deprecated removed in 0.18. Import `DecodedDataReport` from `@project-chip/matter.js/cluster` instead.
+ * @deprecated since 0.17 — will be removed in 0.18. Import `DecodedDataReport` from `@project-chip/matter.js/cluster` instead.
  */
 export interface DecodedDataReport extends DataReport {
     isNormalized: true;
@@ -29,7 +29,7 @@ export interface DecodedDataReport extends DataReport {
 }
 
 /**
- * @deprecated removed in 0.18. Use `decodeDataReport` from `@project-chip/matter.js/cluster`, or consume the
+ * @deprecated since 0.17 — will be removed in 0.18. Use `decodeDataReport` from `@project-chip/matter.js/cluster`, or consume the
  *   streaming `InputChunk` API directly.
  */
 export function DecodedDataReport(

--- a/packages/protocol/src/interaction/EventDataDecoder.ts
+++ b/packages/protocol/src/interaction/EventDataDecoder.ts
@@ -25,6 +25,7 @@ import {
 
 const logger = Logger.get("EventDataDecoder");
 
+/** @deprecated removed in 0.18. Import from `@project-chip/matter.js/cluster` instead. */
 export type DecodedEventData<T> = {
     eventNumber: EventNumber;
     priority: Priority;
@@ -35,6 +36,7 @@ export type DecodedEventData<T> = {
     data?: T;
 };
 
+/** @deprecated removed in 0.18. Import from `@project-chip/matter.js/cluster` instead. */
 export type DecodedEventReportEntry = {
     path: {
         nodeId?: NodeId;
@@ -45,18 +47,28 @@ export type DecodedEventReportEntry = {
     };
 };
 
-/** Represents a fully qualified and decoded attribute value from a received DataReport */
+/**
+ * Represents a fully qualified and decoded event value from a received DataReport.
+ *
+ * @deprecated removed in 0.18. Import from `@project-chip/matter.js/cluster` instead.
+ */
 export type DecodedEventReportValue<T> = DecodedEventReportEntry & {
     events: DecodedEventData<T>[];
 };
 
-/** Represents a fully qualified and decoded attribute status from a received DataReport */
+/**
+ * Represents a fully qualified and decoded event status from a received DataReport.
+ *
+ * @deprecated removed in 0.18. Import from `@project-chip/matter.js/cluster` instead.
+ */
 export type DecodedEventReportStatus = DecodedEventReportEntry & {
     status?: Status;
     clusterStatus?: number;
 };
 
-// TODO: Convert into a Generator function once we migrate Reading Data for controller to also be streaming
+/**
+ * @deprecated removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from `@project-chip/matter.js/cluster`.
+ */
 export function normalizeAndDecodeReadEventReport(data: TypeFromSchema<typeof TlvEventReport>[]): {
     eventData: DecodedEventReportValue<any>[];
     eventStatus: DecodedEventReportStatus[];
@@ -71,6 +83,9 @@ export function normalizeAndDecodeReadEventReport(data: TypeFromSchema<typeof Tl
     };
 }
 
+/**
+ * @deprecated removed in 0.18. Use the streaming `InputChunk` API instead.
+ */
 export function normalizeEventData(
     data: TypeFromSchema<typeof TlvEventData>[],
 ): TypeFromSchema<typeof TlvEventData>[][] {
@@ -90,6 +105,9 @@ export function normalizeEventData(
     return Array.from(responseList.values());
 }
 
+/**
+ * @deprecated removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from `@project-chip/matter.js/cluster`.
+ */
 export function normalizeAndDecodeEventData(
     data: TypeFromSchema<typeof TlvEventData>[],
 ): DecodedEventReportValue<any>[] {
@@ -139,6 +157,9 @@ export function normalizeAndDecodeEventData(
     return result;
 }
 
+/**
+ * @deprecated removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from `@project-chip/matter.js/cluster`.
+ */
 export function normalizeEventStatus(data: TypeFromSchema<typeof TlvEventStatus>[]): DecodedEventReportStatus[] {
     const result = new Array<DecodedEventReportStatus>();
     data.forEach(entry => {

--- a/packages/protocol/src/interaction/EventDataDecoder.ts
+++ b/packages/protocol/src/interaction/EventDataDecoder.ts
@@ -25,7 +25,7 @@ import {
 
 const logger = Logger.get("EventDataDecoder");
 
-/** @deprecated removed in 0.18. Import from `@project-chip/matter.js/cluster` instead. */
+/** @deprecated since 0.17 — will be removed in 0.18. Import from `@project-chip/matter.js/cluster` instead. */
 export type DecodedEventData<T> = {
     eventNumber: EventNumber;
     priority: Priority;
@@ -36,7 +36,7 @@ export type DecodedEventData<T> = {
     data?: T;
 };
 
-/** @deprecated removed in 0.18. Import from `@project-chip/matter.js/cluster` instead. */
+/** @deprecated since 0.17 — will be removed in 0.18. Import from `@project-chip/matter.js/cluster` instead. */
 export type DecodedEventReportEntry = {
     path: {
         nodeId?: NodeId;
@@ -50,7 +50,7 @@ export type DecodedEventReportEntry = {
 /**
  * Represents a fully qualified and decoded event value from a received DataReport.
  *
- * @deprecated removed in 0.18. Import from `@project-chip/matter.js/cluster` instead.
+ * @deprecated since 0.17 — will be removed in 0.18. Import from `@project-chip/matter.js/cluster` instead.
  */
 export type DecodedEventReportValue<T> = DecodedEventReportEntry & {
     events: DecodedEventData<T>[];
@@ -59,7 +59,7 @@ export type DecodedEventReportValue<T> = DecodedEventReportEntry & {
 /**
  * Represents a fully qualified and decoded event status from a received DataReport.
  *
- * @deprecated removed in 0.18. Import from `@project-chip/matter.js/cluster` instead.
+ * @deprecated since 0.17 — will be removed in 0.18. Import from `@project-chip/matter.js/cluster` instead.
  */
 export type DecodedEventReportStatus = DecodedEventReportEntry & {
     status?: Status;
@@ -67,7 +67,7 @@ export type DecodedEventReportStatus = DecodedEventReportEntry & {
 };
 
 /**
- * @deprecated removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from `@project-chip/matter.js/cluster`.
+ * @deprecated since 0.17 — will be removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from `@project-chip/matter.js/cluster`.
  */
 export function normalizeAndDecodeReadEventReport(data: TypeFromSchema<typeof TlvEventReport>[]): {
     eventData: DecodedEventReportValue<any>[];
@@ -84,7 +84,7 @@ export function normalizeAndDecodeReadEventReport(data: TypeFromSchema<typeof Tl
 }
 
 /**
- * @deprecated removed in 0.18. Use the streaming `InputChunk` API instead.
+ * @deprecated since 0.17 — will be removed in 0.18. Use the streaming `InputChunk` API instead.
  */
 export function normalizeEventData(
     data: TypeFromSchema<typeof TlvEventData>[],
@@ -106,7 +106,7 @@ export function normalizeEventData(
 }
 
 /**
- * @deprecated removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from `@project-chip/matter.js/cluster`.
+ * @deprecated since 0.17 — will be removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from `@project-chip/matter.js/cluster`.
  */
 export function normalizeAndDecodeEventData(
     data: TypeFromSchema<typeof TlvEventData>[],
@@ -158,7 +158,7 @@ export function normalizeAndDecodeEventData(
 }
 
 /**
- * @deprecated removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from `@project-chip/matter.js/cluster`.
+ * @deprecated since 0.17 — will be removed in 0.18. Use the streaming `InputChunk` API or `decodeDataReport` from `@project-chip/matter.js/cluster`.
  */
 export function normalizeEventStatus(data: TypeFromSchema<typeof TlvEventStatus>[]): DecodedEventReportStatus[] {
     const result = new Array<DecodedEventReportStatus>();

--- a/packages/protocol/src/peer/ControllerCommissioningFlow.ts
+++ b/packages/protocol/src/peer/ControllerCommissioningFlow.ts
@@ -433,7 +433,7 @@ export class ControllerCommissioningFlow {
             attributeMap.set(`${endpointId}-${clusterId}-${attributeId}`, undefined);
         }
         for await (const data of this.interaction.read(request)) {
-            for (const entry of data) {
+            for await (const entry of data) {
                 if (entry.kind !== "attr-value") {
                     continue;
                 }
@@ -743,7 +743,7 @@ export class ControllerCommissioningFlow {
         const otaRequestors = new Array<EndpointNumber>();
 
         for await (const data of networkData) {
-            for (const entry of data) {
+            for await (const entry of data) {
                 if (entry.kind !== "attr-value") {
                     continue;
                 }

--- a/packages/protocol/src/peer/ControllerCommissioningFlow.ts
+++ b/packages/protocol/src/peer/ControllerCommissioningFlow.ts
@@ -62,7 +62,6 @@ import {
     DeviceAttestationValidator,
 } from "../certificate/DeviceAttestationValidator.js";
 import { Dac } from "../certificate/kinds/AttestationCertificates.js";
-import { ClusterClientObj } from "../cluster/client/ClusterClientTypes.js";
 import { TlvCertSigningRequest } from "../common/OperationalCredentialsTypes.js";
 import { DclCertificateService } from "../dcl/DclCertificateService.js";
 import { Fabric } from "../fabric/Fabric.js";
@@ -270,7 +269,6 @@ export class ControllerCommissioningFlow {
     protected readonly commissioningOptions: ControllerCommissioningFlowOptions;
     protected readonly commissioningSteps = new Array<CommissioningStep>();
     protected readonly commissioningStepResults = new Map<string, CommissioningStepResult>();
-    readonly #clusterClients = new Map<ClusterId, ClusterClientObj>();
     #commissioningStartedTime: Timestamp | undefined;
     #commissioningExpiryTime: Timestamp | undefined;
     #currentFailSafeEndTime: Timestamp | undefined;
@@ -1884,8 +1882,6 @@ export class ControllerCommissioningFlow {
 
         await this.interaction.close();
         this.interaction = transitionResult;
-
-        this.#clusterClients.clear();
 
         logger.debug("Successfully reconnected with device ...");
 

--- a/packages/protocol/test/action/client/InputChunkTest.ts
+++ b/packages/protocol/test/action/client/InputChunkTest.ts
@@ -440,6 +440,37 @@ describe("InputChunk", () => {
             ]);
         });
 
+        it("propagates the wire timestamp variant fields onto the chunk", () => {
+            // Publisher chose the systemTimestamp variant; only that field carries the value, the others stay
+            // undefined. `timestamp` reflects the collapsed convenience.
+            const eventId = EventId(BasicInformation.events.startUp.id);
+            const clusterId = ClusterId(BasicInformation.id);
+            const report = buildReport({
+                eventReports: [
+                    {
+                        eventData: {
+                            path: { endpointId: EndpointNumber(0), clusterId, eventId },
+                            eventNumber: EventNumber(1),
+                            priority: 1,
+                            systemTimestamp: 1234,
+                            data: TlvStartUpEvent.encodeTlv({ softwareVersion: 1 }),
+                        },
+                    },
+                ],
+            });
+
+            const chunks = collect(report);
+            expect(chunks).has.length(1);
+            const ev = chunks[0];
+            expect(ev.kind).equal("event-value");
+            if (ev.kind !== "event-value") return;
+            expect(ev.systemTimestamp).equal(1234);
+            expect(ev.epochTimestamp).equal(undefined);
+            expect(ev.deltaEpochTimestamp).equal(undefined);
+            expect(ev.deltaSystemTimestamp).equal(undefined);
+            expect(ev.timestamp).equal(1234);
+        });
+
         it("emits a single event-status chunk when both status and clusterStatus are set (B2 regression)", () => {
             // clusterStatus is wire-typed as uint8 but the TLV schema uses the Status enum; cluster-specific codes
             // are not Status enum members, so cast to satisfy the (overly narrow) type.

--- a/packages/protocol/test/action/client/InputChunkTest.ts
+++ b/packages/protocol/test/action/client/InputChunkTest.ts
@@ -1,0 +1,504 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InputChunk } from "#action/client/InputChunk.js";
+import {
+    AttributeId,
+    ClusterId,
+    DataReport,
+    EndpointNumber,
+    EventId,
+    EventNumber,
+    Status,
+    TlvArray,
+    TlvAttributeReport,
+    TlvBoolean,
+    TlvEventData,
+    TlvOfModel,
+    TlvUInt32,
+    TlvVoid,
+    TypeFromSchema,
+} from "@matter/types";
+import { BasicInformation } from "@matter/types/clusters/basic-information";
+import { OnOff } from "@matter/types/clusters/on-off";
+
+const TlvStartUpEvent = TlvOfModel(BasicInformation.events.startUp);
+
+function buildReport(input: Partial<DataReport>): DataReport {
+    return {
+        ...input,
+    };
+}
+
+function collect(report: DataReport, leftover?: TypeFromSchema<typeof TlvAttributeReport>[]) {
+    return Array.from(InputChunk(report, leftover));
+}
+
+describe("InputChunk", () => {
+    describe("attributes", () => {
+        it("yields one attr-value per fully-qualified path entry", () => {
+            const report = buildReport({
+                attributeReports: [
+                    {
+                        attributeData: {
+                            path: {
+                                endpointId: EndpointNumber(0),
+                                clusterId: ClusterId(BasicInformation.id),
+                                attributeId: AttributeId(BasicInformation.attributes.dataModelRevision.id),
+                            },
+                            dataVersion: 100,
+                            data: TlvUInt32.encodeTlv(17),
+                        },
+                    },
+                ],
+            });
+
+            const chunks = collect(report);
+
+            expect(chunks).deep.equal([
+                {
+                    kind: "attr-value",
+                    path: {
+                        nodeId: undefined,
+                        endpointId: EndpointNumber(0),
+                        clusterId: ClusterId(BasicInformation.id),
+                        attributeId: AttributeId(BasicInformation.attributes.dataModelRevision.id),
+                    },
+                    tlv: chunks[0].kind === "attr-value" ? chunks[0].tlv : undefined,
+                    value: 17,
+                    version: 100,
+                },
+            ]);
+        });
+
+        it("preserves cross-path order (A.1, B.1, A.2, B.2 → same order out)", () => {
+            const vendorId = ClusterId(BasicInformation.id);
+            const otherId = ClusterId(OnOff.id);
+            const report = buildReport({
+                attributeReports: [
+                    {
+                        attributeData: {
+                            path: {
+                                endpointId: EndpointNumber(0),
+                                clusterId: vendorId,
+                                attributeId: AttributeId(BasicInformation.attributes.dataModelRevision.id),
+                            },
+                            dataVersion: 1,
+                            data: TlvUInt32.encodeTlv(11),
+                        },
+                    },
+                    {
+                        attributeData: {
+                            path: {
+                                endpointId: EndpointNumber(1),
+                                clusterId: otherId,
+                                attributeId: AttributeId(OnOff.attributes.onOff.id),
+                            },
+                            dataVersion: 2,
+                            data: TlvBoolean.encodeTlv(true),
+                        },
+                    },
+                    {
+                        attributeData: {
+                            path: {
+                                endpointId: EndpointNumber(0),
+                                clusterId: vendorId,
+                                attributeId: AttributeId(BasicInformation.attributes.vendorId.id),
+                            },
+                            dataVersion: 1,
+                            data: TlvUInt32.encodeTlv(0xfff1),
+                        },
+                    },
+                ],
+            });
+
+            const chunks = collect(report);
+            const summary = chunks.map(c =>
+                c.kind === "attr-value"
+                    ? {
+                          endpointId: c.path.endpointId,
+                          clusterId: c.path.clusterId,
+                          attributeId: c.path.attributeId,
+                          value: c.value,
+                      }
+                    : null,
+            );
+
+            expect(summary).deep.equal([
+                {
+                    endpointId: EndpointNumber(0),
+                    clusterId: vendorId,
+                    attributeId: AttributeId(BasicInformation.attributes.dataModelRevision.id),
+                    value: 11,
+                },
+                {
+                    endpointId: EndpointNumber(1),
+                    clusterId: otherId,
+                    attributeId: AttributeId(OnOff.attributes.onOff.id),
+                    value: true,
+                },
+                {
+                    endpointId: EndpointNumber(0),
+                    clusterId: vendorId,
+                    attributeId: AttributeId(BasicInformation.attributes.vendorId.id),
+                    value: 0xfff1,
+                },
+            ]);
+        });
+
+        it("restores tag-compressed paths from the previous fully-qualified entry", () => {
+            const clusterId = ClusterId(BasicInformation.id);
+            const report = buildReport({
+                attributeReports: [
+                    {
+                        attributeData: {
+                            path: {
+                                endpointId: EndpointNumber(0),
+                                clusterId,
+                                attributeId: AttributeId(BasicInformation.attributes.dataModelRevision.id),
+                            },
+                            dataVersion: 200,
+                            data: TlvUInt32.encodeTlv(1),
+                        },
+                    },
+                    {
+                        attributeData: {
+                            // Only attributeId given; endpoint/cluster/dataVersion inherit
+                            path: {
+                                enableTagCompression: true,
+                                attributeId: AttributeId(BasicInformation.attributes.vendorId.id),
+                            },
+                            data: TlvUInt32.encodeTlv(0xfff1),
+                        },
+                    },
+                ],
+            });
+
+            const chunks = collect(report);
+            expect(chunks).has.length(2);
+            const second = chunks[1];
+            expect(second.kind).equal("attr-value");
+            if (second.kind !== "attr-value") return;
+            expect(second.path.endpointId).equal(EndpointNumber(0));
+            expect(second.path.clusterId).equal(clusterId);
+            expect(second.path.attributeId).equal(AttributeId(BasicInformation.attributes.vendorId.id));
+            expect(second.value).equal(0xfff1);
+            expect(second.version).equal(200);
+        });
+
+        it("emits attr-value then attr-status when a different-path status follows data", () => {
+            // Different paths → path change → flush data group, then status emits as its own chunk.
+            const clusterId = ClusterId(BasicInformation.id);
+            const attrId = AttributeId(BasicInformation.attributes.dataModelRevision.id);
+            const statusAttrId = AttributeId(BasicInformation.attributes.vendorId.id);
+            const report = buildReport({
+                attributeReports: [
+                    {
+                        attributeData: {
+                            path: { endpointId: EndpointNumber(0), clusterId, attributeId: attrId },
+                            dataVersion: 1,
+                            data: TlvUInt32.encodeTlv(7),
+                        },
+                    },
+                    {
+                        attributeStatus: {
+                            path: { endpointId: EndpointNumber(0), clusterId, attributeId: statusAttrId },
+                            status: { status: Status.UnsupportedAttribute },
+                        },
+                    },
+                ],
+            });
+
+            const chunks = collect(report);
+            expect(chunks.map(c => c.kind)).deep.equal(["attr-value", "attr-status"]);
+            expect(chunks[1].kind === "attr-status" && chunks[1].status).equal(Status.UnsupportedAttribute);
+        });
+
+        it("keeps adjacent same-cluster different-attribute entries from being lumped", () => {
+            // Three attrs of the same cluster, interleaved data and status. Each entry has its own attribute path
+            // → each flushes on path change, emitted in wire order. A status entry must not cause the next-path
+            // data entry to be skipped or reordered.
+            const clusterId = ClusterId(BasicInformation.id);
+            const a1 = AttributeId(BasicInformation.attributes.dataModelRevision.id);
+            const a2 = AttributeId(BasicInformation.attributes.vendorId.id);
+            const a3 = AttributeId(BasicInformation.attributes.productId.id);
+            const report = buildReport({
+                attributeReports: [
+                    {
+                        attributeData: {
+                            path: { endpointId: EndpointNumber(0), clusterId, attributeId: a1 },
+                            dataVersion: 1,
+                            data: TlvUInt32.encodeTlv(11),
+                        },
+                    },
+                    {
+                        attributeStatus: {
+                            path: { endpointId: EndpointNumber(0), clusterId, attributeId: a2 },
+                            status: { status: Status.UnsupportedAttribute },
+                        },
+                    },
+                    {
+                        attributeData: {
+                            path: { endpointId: EndpointNumber(0), clusterId, attributeId: a3 },
+                            dataVersion: 1,
+                            data: TlvUInt32.encodeTlv(33),
+                        },
+                    },
+                ],
+            });
+
+            const chunks = collect(report);
+            expect(chunks.map(c => c.kind)).deep.equal(["attr-value", "attr-status", "attr-value"]);
+            const ids = chunks.map(c =>
+                c.kind === "attr-value" || c.kind === "attr-status" ? c.path.attributeId : undefined,
+            );
+            expect(ids).deep.equal([a1, a2, a3]);
+        });
+
+        it("emits data and status for the same path in wire order", () => {
+            // Spec-pathological (data + status for the same attribute), but the streamer flushes on kind change
+            // within a path so the output preserves wire order: value first, status second.
+            const clusterId = ClusterId(BasicInformation.id);
+            const attrId = AttributeId(BasicInformation.attributes.dataModelRevision.id);
+            const report = buildReport({
+                attributeReports: [
+                    {
+                        attributeData: {
+                            path: { endpointId: EndpointNumber(0), clusterId, attributeId: attrId },
+                            dataVersion: 1,
+                            data: TlvUInt32.encodeTlv(5),
+                        },
+                    },
+                    {
+                        attributeStatus: {
+                            path: { endpointId: EndpointNumber(0), clusterId, attributeId: attrId },
+                            status: { status: Status.Failure },
+                        },
+                    },
+                ],
+            });
+
+            const chunks = collect(report);
+            expect(chunks.map(c => c.kind)).deep.equal(["attr-value", "attr-status"]);
+        });
+
+        it("stashes a chunked-array tail (listIndex entries) when moreChunkedMessages is set", () => {
+            // Initial value entry + listIndex=null append entry, same path. The append-action listIndex marks the
+            // tail as chunked, so the whole group is stashed for the next report.
+            const clusterId = ClusterId(BasicInformation.id);
+            const attrId = AttributeId(BasicInformation.attributes.capabilityMinima.id);
+            const basePath = { endpointId: EndpointNumber(0), clusterId, attributeId: attrId };
+
+            const reportN = buildReport({
+                moreChunkedMessages: true,
+                attributeReports: [
+                    {
+                        attributeData: {
+                            path: { ...basePath },
+                            dataVersion: 5,
+                            data: TlvUInt32.encodeTlv(1),
+                        },
+                    },
+                    {
+                        attributeData: {
+                            path: { ...basePath, listIndex: null },
+                            data: TlvUInt32.encodeTlv(2),
+                        },
+                    },
+                ],
+            });
+
+            const leftover = new Array<TypeFromSchema<typeof TlvAttributeReport>>();
+            const chunksN = collect(reportN, leftover);
+
+            expect(chunksN).has.length(0);
+            expect(leftover).has.length(2);
+        });
+
+        it("stashes a chunked-array tail (single array-typed initial value) when moreChunkedMessages is set", () => {
+            // Exercises the second branch of isChunkedArrayTail: single entry, no listIndex, but the TLV stream
+            // starts with an Array container and carries >1 inner element. Matches the publisher pattern where the
+            // first chunk of a multi-report list comes as the bare array.
+            const clusterId = ClusterId(BasicInformation.id);
+            const attrId = AttributeId(BasicInformation.attributes.capabilityMinima.id);
+            const TlvU32Array = TlvArray(TlvUInt32);
+
+            const reportN = buildReport({
+                moreChunkedMessages: true,
+                attributeReports: [
+                    {
+                        attributeData: {
+                            path: { endpointId: EndpointNumber(0), clusterId, attributeId: attrId },
+                            dataVersion: 11,
+                            data: TlvU32Array.encodeTlv([1, 2, 3]),
+                        },
+                    },
+                ],
+            });
+
+            const leftover = new Array<TypeFromSchema<typeof TlvAttributeReport>>();
+            const chunksN = collect(reportN, leftover);
+
+            expect(chunksN).has.length(0);
+            expect(leftover).has.length(1);
+        });
+
+        it("prepends leftover into the next call and clears the leftover buffer", () => {
+            // The leftover-merge step does not decode by itself, but we can verify the buffer flow: the next call
+            // sees the prepended entries and drains the buffer regardless of what it then chooses to do with them.
+            const clusterId = ClusterId(BasicInformation.id);
+            const attrId = AttributeId(BasicInformation.attributes.capabilityMinima.id);
+            const basePath = { endpointId: EndpointNumber(0), clusterId, attributeId: attrId };
+
+            const leftover: TypeFromSchema<typeof TlvAttributeReport>[] = [
+                { attributeData: { path: { ...basePath }, dataVersion: 5, data: TlvUInt32.encodeTlv(1) } },
+                { attributeData: { path: { ...basePath, listIndex: null }, data: TlvUInt32.encodeTlv(2) } },
+            ];
+
+            // Final report — moreChunkedMessages false, leftover gets consumed.
+            const reportFinal = buildReport({
+                moreChunkedMessages: false,
+                attributeReports: [],
+            });
+            collect(reportFinal, leftover);
+
+            expect(leftover).has.length(0);
+        });
+
+        it("flushes (not stashes) when moreChunkedMessages is false", () => {
+            const clusterId = ClusterId(BasicInformation.id);
+            const attrId = AttributeId(BasicInformation.attributes.dataModelRevision.id);
+            const report = buildReport({
+                moreChunkedMessages: false,
+                attributeReports: [
+                    {
+                        attributeData: {
+                            path: { endpointId: EndpointNumber(0), clusterId, attributeId: attrId },
+                            dataVersion: 9,
+                            data: TlvUInt32.encodeTlv(3),
+                        },
+                    },
+                ],
+            });
+
+            const leftover = new Array<TypeFromSchema<typeof TlvAttributeReport>>();
+            const chunks = collect(report, leftover);
+            expect(chunks).has.length(1);
+            expect(leftover).has.length(0);
+        });
+    });
+
+    describe("events", () => {
+        it("preserves wire (EventNumber) order across interleaved event types (#3785)", () => {
+            // Mimic Generic-Switch-style alternating sequence on a single path:
+            //   startUp(en=1), shutDown(en=2), startUp(en=3) → must come out in that exact order.
+            const startUp = EventId(BasicInformation.events.startUp.id);
+            const shutDown = EventId(BasicInformation.events.shutDown.id);
+            const clusterId = ClusterId(BasicInformation.id);
+            const data: TypeFromSchema<typeof TlvEventData>[] = [
+                {
+                    path: { endpointId: EndpointNumber(0), clusterId, eventId: startUp },
+                    eventNumber: EventNumber(1),
+                    priority: 1,
+                    epochTimestamp: 0,
+                    data: TlvStartUpEvent.encodeTlv({ softwareVersion: 1 }),
+                },
+                {
+                    path: { endpointId: EndpointNumber(0), clusterId, eventId: shutDown },
+                    eventNumber: EventNumber(2),
+                    priority: 1,
+                    epochTimestamp: 0,
+                    data: TlvVoid.encodeTlv(),
+                },
+                {
+                    path: { endpointId: EndpointNumber(0), clusterId, eventId: startUp },
+                    eventNumber: EventNumber(3),
+                    priority: 1,
+                    epochTimestamp: 0,
+                    data: TlvStartUpEvent.encodeTlv({ softwareVersion: 3 }),
+                },
+            ];
+
+            const report = buildReport({
+                eventReports: data.map(eventData => ({ eventData })),
+            });
+
+            const chunks = collect(report);
+            expect(chunks).has.length(3);
+            expect(chunks.map(c => (c.kind === "event-value" ? c.number : undefined))).deep.equal([
+                EventNumber(1),
+                EventNumber(2),
+                EventNumber(3),
+            ]);
+            expect(chunks.map(c => (c.kind === "event-value" ? c.path.eventId : undefined))).deep.equal([
+                startUp,
+                shutDown,
+                startUp,
+            ]);
+        });
+
+        it("emits a single event-status chunk when both status and clusterStatus are set (B2 regression)", () => {
+            // clusterStatus is wire-typed as uint8 but the TLV schema uses the Status enum; cluster-specific codes
+            // are not Status enum members, so cast to satisfy the (overly narrow) type.
+            const clusterStatus = 42 as Status;
+            const report = buildReport({
+                eventReports: [
+                    {
+                        eventStatus: {
+                            path: {
+                                endpointId: EndpointNumber(0),
+                                clusterId: ClusterId(BasicInformation.id),
+                                eventId: EventId(BasicInformation.events.startUp.id),
+                            },
+                            status: { status: Status.Failure, clusterStatus },
+                        },
+                    },
+                ],
+            });
+
+            const chunks = collect(report);
+            expect(chunks).has.length(1);
+            const only = chunks[0];
+            expect(only.kind).equal("event-status");
+            if (only.kind !== "event-status") return;
+            expect(only.status).equal(Status.Failure);
+            expect(only.clusterStatus).equal(clusterStatus);
+        });
+    });
+
+    describe("ordering across attributes and events", () => {
+        it("yields attributes first, then events (matches wire layout)", () => {
+            const clusterId = ClusterId(BasicInformation.id);
+            const attrId = AttributeId(BasicInformation.attributes.dataModelRevision.id);
+            const eventId = EventId(BasicInformation.events.startUp.id);
+            const report = buildReport({
+                attributeReports: [
+                    {
+                        attributeData: {
+                            path: { endpointId: EndpointNumber(0), clusterId, attributeId: attrId },
+                            dataVersion: 1,
+                            data: TlvUInt32.encodeTlv(1),
+                        },
+                    },
+                ],
+                eventReports: [
+                    {
+                        eventData: {
+                            path: { endpointId: EndpointNumber(0), clusterId, eventId },
+                            eventNumber: EventNumber(1),
+                            priority: 1,
+                            epochTimestamp: 0,
+                            data: TlvStartUpEvent.encodeTlv({ softwareVersion: 1 }),
+                        },
+                    },
+                ],
+            });
+
+            const chunks = collect(report);
+            expect(chunks.map(c => c.kind)).deep.equal(["attr-value", "event-value"]);
+        });
+    });
+});

--- a/packages/protocol/test/action/client/InputChunkTest.ts
+++ b/packages/protocol/test/action/client/InputChunkTest.ts
@@ -5,6 +5,7 @@
  */
 
 import { InputChunk } from "#action/client/InputChunk.js";
+import { ReadResult } from "#action/response/ReadResult.js";
 import {
     AttributeId,
     ClusterId,
@@ -33,13 +34,15 @@ function buildReport(input: Partial<DataReport>): DataReport {
     };
 }
 
-function collect(report: DataReport, leftover?: TypeFromSchema<typeof TlvAttributeReport>[]) {
-    return Array.from(InputChunk(report, leftover));
+async function collect(report: DataReport, leftover?: TypeFromSchema<typeof TlvAttributeReport>[]) {
+    const out = new Array<ReadResult.Report>();
+    for await (const chunk of InputChunk(report, leftover)) out.push(chunk);
+    return out;
 }
 
 describe("InputChunk", () => {
     describe("attributes", () => {
-        it("yields one attr-value per fully-qualified path entry", () => {
+        it("yields one attr-value per fully-qualified path entry", async () => {
             const report = buildReport({
                 attributeReports: [
                     {
@@ -56,7 +59,7 @@ describe("InputChunk", () => {
                 ],
             });
 
-            const chunks = collect(report);
+            const chunks = await collect(report);
 
             expect(chunks).deep.equal([
                 {
@@ -74,7 +77,7 @@ describe("InputChunk", () => {
             ]);
         });
 
-        it("preserves cross-path order (A.1, B.1, A.2, B.2 → same order out)", () => {
+        it("preserves cross-path order (A.1, B.1, A.2, B.2 → same order out)", async () => {
             const vendorId = ClusterId(BasicInformation.id);
             const otherId = ClusterId(OnOff.id);
             const report = buildReport({
@@ -115,7 +118,7 @@ describe("InputChunk", () => {
                 ],
             });
 
-            const chunks = collect(report);
+            const chunks = await collect(report);
             const summary = chunks.map(c =>
                 c.kind === "attr-value"
                     ? {
@@ -149,7 +152,7 @@ describe("InputChunk", () => {
             ]);
         });
 
-        it("restores tag-compressed paths from the previous fully-qualified entry", () => {
+        it("restores tag-compressed paths from the previous fully-qualified entry", async () => {
             const clusterId = ClusterId(BasicInformation.id);
             const report = buildReport({
                 attributeReports: [
@@ -177,7 +180,7 @@ describe("InputChunk", () => {
                 ],
             });
 
-            const chunks = collect(report);
+            const chunks = await collect(report);
             expect(chunks).has.length(2);
             const second = chunks[1];
             expect(second.kind).equal("attr-value");
@@ -189,7 +192,7 @@ describe("InputChunk", () => {
             expect(second.version).equal(200);
         });
 
-        it("emits attr-value then attr-status when a different-path status follows data", () => {
+        it("emits attr-value then attr-status when a different-path status follows data", async () => {
             // Different paths → path change → flush data group, then status emits as its own chunk.
             const clusterId = ClusterId(BasicInformation.id);
             const attrId = AttributeId(BasicInformation.attributes.dataModelRevision.id);
@@ -212,12 +215,12 @@ describe("InputChunk", () => {
                 ],
             });
 
-            const chunks = collect(report);
+            const chunks = await collect(report);
             expect(chunks.map(c => c.kind)).deep.equal(["attr-value", "attr-status"]);
             expect(chunks[1].kind === "attr-status" && chunks[1].status).equal(Status.UnsupportedAttribute);
         });
 
-        it("keeps adjacent same-cluster different-attribute entries from being lumped", () => {
+        it("keeps adjacent same-cluster different-attribute entries from being lumped", async () => {
             // Three attrs of the same cluster, interleaved data and status. Each entry has its own attribute path
             // → each flushes on path change, emitted in wire order. A status entry must not cause the next-path
             // data entry to be skipped or reordered.
@@ -250,7 +253,7 @@ describe("InputChunk", () => {
                 ],
             });
 
-            const chunks = collect(report);
+            const chunks = await collect(report);
             expect(chunks.map(c => c.kind)).deep.equal(["attr-value", "attr-status", "attr-value"]);
             const ids = chunks.map(c =>
                 c.kind === "attr-value" || c.kind === "attr-status" ? c.path.attributeId : undefined,
@@ -258,7 +261,7 @@ describe("InputChunk", () => {
             expect(ids).deep.equal([a1, a2, a3]);
         });
 
-        it("emits data and status for the same path in wire order", () => {
+        it("emits data and status for the same path in wire order", async () => {
             // Spec-pathological (data + status for the same attribute), but the streamer flushes on kind change
             // within a path so the output preserves wire order: value first, status second.
             const clusterId = ClusterId(BasicInformation.id);
@@ -281,11 +284,11 @@ describe("InputChunk", () => {
                 ],
             });
 
-            const chunks = collect(report);
+            const chunks = await collect(report);
             expect(chunks.map(c => c.kind)).deep.equal(["attr-value", "attr-status"]);
         });
 
-        it("stashes a chunked-array tail (listIndex entries) when moreChunkedMessages is set", () => {
+        it("stashes a chunked-array tail (listIndex entries) when moreChunkedMessages is set", async () => {
             // Initial value entry + listIndex=null append entry, same path. The append-action listIndex marks the
             // tail as chunked, so the whole group is stashed for the next report.
             const clusterId = ClusterId(BasicInformation.id);
@@ -312,13 +315,13 @@ describe("InputChunk", () => {
             });
 
             const leftover = new Array<TypeFromSchema<typeof TlvAttributeReport>>();
-            const chunksN = collect(reportN, leftover);
+            const chunksN = await collect(reportN, leftover);
 
             expect(chunksN).has.length(0);
             expect(leftover).has.length(2);
         });
 
-        it("stashes a chunked-array tail (single array-typed initial value) when moreChunkedMessages is set", () => {
+        it("stashes a chunked-array tail (single array-typed initial value) when moreChunkedMessages is set", async () => {
             // Exercises the second branch of isChunkedArrayTail: single entry, no listIndex, but the TLV stream
             // starts with an Array container and carries >1 inner element. Matches the publisher pattern where the
             // first chunk of a multi-report list comes as the bare array.
@@ -340,13 +343,13 @@ describe("InputChunk", () => {
             });
 
             const leftover = new Array<TypeFromSchema<typeof TlvAttributeReport>>();
-            const chunksN = collect(reportN, leftover);
+            const chunksN = await collect(reportN, leftover);
 
             expect(chunksN).has.length(0);
             expect(leftover).has.length(1);
         });
 
-        it("prepends leftover into the next call and clears the leftover buffer", () => {
+        it("prepends leftover into the next call and clears the leftover buffer", async () => {
             // The leftover-merge step does not decode by itself, but we can verify the buffer flow: the next call
             // sees the prepended entries and drains the buffer regardless of what it then chooses to do with them.
             const clusterId = ClusterId(BasicInformation.id);
@@ -363,12 +366,12 @@ describe("InputChunk", () => {
                 moreChunkedMessages: false,
                 attributeReports: [],
             });
-            collect(reportFinal, leftover);
+            await collect(reportFinal, leftover);
 
             expect(leftover).has.length(0);
         });
 
-        it("flushes (not stashes) when moreChunkedMessages is false", () => {
+        it("flushes (not stashes) when moreChunkedMessages is false", async () => {
             const clusterId = ClusterId(BasicInformation.id);
             const attrId = AttributeId(BasicInformation.attributes.dataModelRevision.id);
             const report = buildReport({
@@ -385,14 +388,14 @@ describe("InputChunk", () => {
             });
 
             const leftover = new Array<TypeFromSchema<typeof TlvAttributeReport>>();
-            const chunks = collect(report, leftover);
+            const chunks = await collect(report, leftover);
             expect(chunks).has.length(1);
             expect(leftover).has.length(0);
         });
     });
 
     describe("events", () => {
-        it("preserves wire (EventNumber) order across interleaved event types (#3785)", () => {
+        it("preserves wire (EventNumber) order across interleaved event types (#3785)", async () => {
             // Mimic Generic-Switch-style alternating sequence on a single path:
             //   startUp(en=1), shutDown(en=2), startUp(en=3) → must come out in that exact order.
             const startUp = EventId(BasicInformation.events.startUp.id);
@@ -426,7 +429,7 @@ describe("InputChunk", () => {
                 eventReports: data.map(eventData => ({ eventData })),
             });
 
-            const chunks = collect(report);
+            const chunks = await collect(report);
             expect(chunks).has.length(3);
             expect(chunks.map(c => (c.kind === "event-value" ? c.number : undefined))).deep.equal([
                 EventNumber(1),
@@ -440,7 +443,7 @@ describe("InputChunk", () => {
             ]);
         });
 
-        it("propagates the wire timestamp variant fields onto the chunk", () => {
+        it("propagates the wire timestamp variant fields onto the chunk", async () => {
             // Publisher chose the systemTimestamp variant; only that field carries the value, the others stay
             // undefined. `timestamp` reflects the collapsed convenience.
             const eventId = EventId(BasicInformation.events.startUp.id);
@@ -459,7 +462,7 @@ describe("InputChunk", () => {
                 ],
             });
 
-            const chunks = collect(report);
+            const chunks = await collect(report);
             expect(chunks).has.length(1);
             const ev = chunks[0];
             expect(ev.kind).equal("event-value");
@@ -471,7 +474,7 @@ describe("InputChunk", () => {
             expect(ev.timestamp).equal(1234);
         });
 
-        it("emits a single event-status chunk when both status and clusterStatus are set (B2 regression)", () => {
+        it("emits a single event-status chunk when both status and clusterStatus are set (B2 regression)", async () => {
             // clusterStatus is wire-typed as uint8 but the TLV schema uses the Status enum; cluster-specific codes
             // are not Status enum members, so cast to satisfy the (overly narrow) type.
             const clusterStatus = 42 as Status;
@@ -490,7 +493,7 @@ describe("InputChunk", () => {
                 ],
             });
 
-            const chunks = collect(report);
+            const chunks = await collect(report);
             expect(chunks).has.length(1);
             const only = chunks[0];
             expect(only.kind).equal("event-status");
@@ -501,7 +504,7 @@ describe("InputChunk", () => {
     });
 
     describe("ordering across attributes and events", () => {
-        it("yields attributes first, then events (matches wire layout)", () => {
+        it("yields attributes first, then events (matches wire layout)", async () => {
             const clusterId = ClusterId(BasicInformation.id);
             const attrId = AttributeId(BasicInformation.attributes.dataModelRevision.id);
             const eventId = EventId(BasicInformation.events.startUp.id);
@@ -528,7 +531,7 @@ describe("InputChunk", () => {
                 ],
             });
 
-            const chunks = collect(report);
+            const chunks = await collect(report);
             expect(chunks.map(c => c.kind)).deep.equal(["attr-value", "event-value"]);
         });
     });


### PR DESCRIPTION
## Summary

- Rewrites `@matter/protocol`'s DataReport decode pipeline as a streaming async generator (`InputChunk` → `ReadResult.Chunk`). Decode runs per fully-qualified attribute path; chunked-array reassembly and tag compression stay spec-compliant; events stream per-occurrence in wire (EventNumber) order. Fixes #3785 (Generic Switch multi-press cycle was destroyed by the previous Map-based grouping). Thanks to @snabb for the diagnosis and original fix proposal in #3786 — this PR supersedes it with a wider refactor.
- Relocates the legacy 4-array `DecodedDataReport` shape (interface + `Decoded*` types + `normalize*` helpers) into `@project-chip/matter.js/cluster` where the only consumers live (legacy `InteractionClient`, `PairedNode`, `ClusterClient`, `EventClient`). Protocol-side copies stay with `@deprecated` JSDoc for one release and are scheduled for hard removal in 0.18.
- `ReadResult.Chunk` is now `AsyncIterable<Report> | Iterable<Report>`. Sync server-side producers (`AttributeReadResponse.process` et al.) keep their `yield [report]` shape; the streaming wire-decode producer uses async to let TCP transports deliver large DataReports without blocking the event loop.
- `ReadResult.EventValue` gains the four explicit wire timestamp variants (`epochTimestamp`, `systemTimestamp`, `deltaEpochTimestamp`, `deltaSystemTimestamp`) alongside the existing collapsed `timestamp: number` (Matter Core §10.7).
- Bug fixes folded in: `attr-status` / `event-status` no longer double-emit when both `status` and `clusterStatus` are set; chunked-array leftover handoff no longer mutates the caller's `attributeReports` array via splice; dead exports removed.

Closes #3785. Supersedes #3786.

## Commits

1. Streaming `InputChunk` + dead-code cleanup
2. matter.js `DecodedDataReport` adapter + consumer rewires + `@deprecated` shims
3. Stale `#clusterClients` field deleted from `ControllerCommissioningFlow`
4. Type tightening: status fields required, four timestamp variants on `EventValue`
5. `ClusterClientTypes.ts` relocated to matter.js
6. Greg-review fixes: shared chunk-to-decoded helpers, narrowed `UnexpectedDataError` catches, naming, deprecation tag wording
7. `ReadResult.Chunk` → async-iterable; `InputChunk` → async generator
8. Changelog entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)