### PR TITLE
fix(operational-credentials): roll back PASE session on AddNOC/UpdateNOC failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/general
     - Fix: `causedBy`/`asError`/`errorOf`/`repackErrorAs` no longer crash with "undefined is not an object" when invoked with `undefined`/`null` as error object
 
+- @matter/node
+  - Fix: Roll back assigned Fabric from PASE session on AddNOC/UpdateNOC failure
+
 - @matter/protocol
     - Deprecation: Internally used `DecodedDataReport`, `DecodedAttributeReport{Value,Status,Entry}`, `DecodedEventReport{Value,Status,Entry}`, `DecodedEventData`, and the `normalize*` / `normalizeAndDecode*` helpers moved to `@project-chip/matter.js/cluster`. Scheduled for removal in 0.18
     - Enhancement: `ReadResult.EventValue` exposes the four wire timestamp variants (`epochTimestamp`, `systemTimestamp`, `deltaEpochTimestamp`, `deltaSystemTimestamp`) alongside the existing collapsed `timestamp: number`

--- a/packages/general/src/transaction/Transaction.ts
+++ b/packages/general/src/transaction/Transaction.ts
@@ -65,6 +65,19 @@ export interface Transaction extends Lifetime.Owner {
     onShared(actor: () => void, once?: boolean): void;
 
     /**
+     * Schedule cleanup work to run after the transaction is finalized (i.e. after the next commit or rollback
+     * completes and locks are released).
+     *
+     * The actor runs OUTSIDE the transaction it was registered on: it does not participate in the transaction's
+     * commit/rollback and cannot acquire its locks.  This makes it safe for actors that would otherwise deadlock
+     * against the transaction's own lock-acquiring reactors.
+     *
+     * The actor may be synchronous or asynchronous.  Any error it throws or rejects with is logged and otherwise
+     * swallowed — it never propagates back to the transaction.
+     */
+    onFinalize(actor: () => MaybePromise<void>): void;
+
+    /**
      * Listen for {@link Transaction.status} close.
      */
     onClose(actor: () => void): void;

--- a/packages/general/src/transaction/Tx.ts
+++ b/packages/general/src/transaction/Tx.ts
@@ -162,7 +162,7 @@ class Tx implements Transaction, Transaction.Finalization {
             MaybePromise.then(actor, undefined, err => {
                 logger.warn(`Finalize actor on transaction ${this.via} failed:`, err);
             });
-        });
+        }, true);
     }
 
     onClose(listener: () => void) {

--- a/packages/general/src/transaction/Tx.ts
+++ b/packages/general/src/transaction/Tx.ts
@@ -157,6 +157,14 @@ class Tx implements Transaction, Transaction.Finalization {
         this.#shared[once ? "once" : "on"](listener);
     }
 
+    onFinalize(actor: () => MaybePromise<void>) {
+        this.onShared(() => {
+            MaybePromise.then(actor, undefined, err => {
+                logger.warn(`Finalize actor on transaction ${this.via} failed:`, err);
+            });
+        });
+    }
+
     onClose(listener: () => void) {
         if (this.status === Status.ReadOnly) {
             return;

--- a/packages/node/src/behaviors/operational-credentials/OperationalCredentialsServer.ts
+++ b/packages/node/src/behaviors/operational-credentials/OperationalCredentialsServer.ts
@@ -277,22 +277,19 @@ export class OperationalCredentialsServer extends OperationalCredentialsBase {
                     `FabricIndex ${fabric.fabricIndex} already exists in state. This should not happen`,
                 );
             }
+
+            // Spec: The receiver SHALL create and add a new Access Control Entry using the CaseAdminSubject field to grant
+            // subsequent Administer access to an Administrator member of the new Fabric.
+            // Order matters: ACL change event must be attributed to the new fabric, not PASE-default.
+            await this.endpoint.act(agent =>
+                agent.get(AccessControlServer).addDefaultCaseAcl(fabric, [caseAdminSubject]),
+            );
         } catch (e) {
-            // Fabric insertion into FabricManager is not currently transactional so we need to remove manually
-            await fabric.delete(this.context.exchange);
+            // Deferred: fabric.delete inline would deadlock against this transaction's lock:true reactors.
+            const exchange = this.context.exchange;
+            this.context.transaction.onFinalize(() => fabric.delete(exchange));
             throw e;
         }
-
-        // The receiver SHALL create and add a new Access Control Entry using the CaseAdminSubject field to grant
-        // subsequent Administer access to an Administrator member of the new Fabric.
-        await this.endpoint.act(agent => agent.get(AccessControlServer).addDefaultCaseAcl(fabric, [caseAdminSubject]));
-
-        // TODO The incoming IPKValue SHALL be stored in the Fabric-scoped slot within the Group Key Management cluster
-        //  (see KeySetWrite), for subsequent use during CASE.
-
-        // TODO If the current secure session was established with PASE, the receiver SHALL: a. Augment the secure
-        //  session context with the FabricIndex generated above, such that subsequent interactions have the proper
-        //  accessing fabric.
 
         logger.info(
             `addNoc success, adminVendorId ${adminVendorId}, caseAdminSubject ${SubjectId.strOf(caseAdminSubject)}`,
@@ -350,11 +347,14 @@ export class OperationalCredentialsServer extends OperationalCredentialsBase {
         }
 
         // Build a new Fabric with the updated NOC and ICAC
+        const oldFabric = timedOp.associatedFabric;
+        let replaced = false;
         try {
             const updatedFabric = await timedOp.buildUpdatedFabric(nocValue, icacValue);
 
             // update FabricManager and Resumption records but leave the current session intact
             await timedOp.replaceFabric(updatedFabric);
+            replaced = true;
 
             // close all sessions found to the old fabric and just leave the one with this exchange open to deliver response
             await timedOp.associatedFabric.replaced(this.context.exchange);
@@ -364,6 +364,11 @@ export class OperationalCredentialsServer extends OperationalCredentialsBase {
                 fabricIndex: updatedFabric.fabricIndex,
             };
         } catch (error) {
+            if (replaced && oldFabric !== undefined) {
+                // FabricManager swapped to new fabric, but a later step threw; restore old, so manager
+                // and current session stay in sync.  Deferred for the same reason as addNoc's catch.
+                this.context.transaction.onFinalize(() => timedOp.restoreFabric(oldFabric));
+            }
             logger.info("Building fabric for updateNoc failed", error);
             return this.#mapNocErrors(error);
         }

--- a/packages/node/test/behavior/ReactorTransactionDeadlockTest.ts
+++ b/packages/node/test/behavior/ReactorTransactionDeadlockTest.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { FabricManager, TestFabric } from "@matter/protocol";
+import { MockServerNode } from "../node/mock-server-node.js";
+
+describe("Deferred fabric.delete via transaction.onFinalize", () => {
+    it("completes cleanly when scheduled from inside a behavior transaction", async () => {
+        const node = new MockServerNode();
+        await node.start();
+        try {
+            const fabric = await TestFabric({ fabrics: node.env.get(FabricManager) });
+            expect(node.env.get(FabricManager).fabrics.length).to.equal(1);
+
+            const onlinePromise = Promise.resolve(
+                node.online({}, async agent => {
+                    agent.context.transaction.onFinalize(() => fabric.delete());
+                    throw new Error("simulated handler failure");
+                }),
+            ).catch((err: unknown) => err);
+
+            await MockTime.resolve(onlinePromise, { macrotasks: true });
+
+            await MockTime.resolve(
+                new Promise<void>(resolve => {
+                    const check = () => {
+                        if (node.env.get(FabricManager).fabrics.length === 0) {
+                            resolve();
+                        } else {
+                            void MockTime.advance(100).then(check);
+                        }
+                    };
+                    check();
+                }),
+                { macrotasks: true },
+            );
+
+            expect(node.env.get(FabricManager).fabrics.length).to.equal(0);
+        } finally {
+            await node.close();
+        }
+    });
+});

--- a/packages/node/test/node/FailsafeCommissioningTest.ts
+++ b/packages/node/test/node/FailsafeCommissioningTest.ts
@@ -19,6 +19,8 @@
  *    - No factory reset (state.commissioned was never true; handleFabricChange sees false→false, no state change).
  */
 
+import { AccessControlServer } from "#behaviors/access-control";
+import { OnOffLightDevice } from "#devices/on-off-light";
 import { ServerNode } from "#node/ServerNode.js";
 import { Crypto, Lifecycle, MockCrypto, Seconds } from "@matter/general";
 import {
@@ -29,6 +31,7 @@ import {
     FabricManager,
     ServiceDescription,
 } from "@matter/protocol";
+import { MockServerNode } from "./mock-server-node.js";
 import { MockSite } from "./mock-site.js";
 
 describe("Failsafe commissioning re-announcement", () => {
@@ -81,6 +84,12 @@ describe("Failsafe commissioning re-announcement", () => {
                 this.count++;
             }
             return undefined;
+        }
+    }
+
+    class FailingAccessControlServer extends AccessControlServer {
+        override addDefaultCaseAcl(): never {
+            throw new Error("Simulated ACL transaction failure (test)");
         }
     }
 
@@ -275,6 +284,41 @@ describe("Failsafe commissioning re-announcement", () => {
             // reaching the isPase guard.  Had the CASE close also triggered #startCommissioningAdvertisement,
             // the count would be 2 instead of 1.
             expect(adSpy.count).to.equal(1);
+        } finally {
+            await site.close();
+        }
+    });
+
+    it("recovers cleanly when initial ACL creation fails during addNOC", async () => {
+        const site = new MockSite();
+        try {
+            const controller = await site.addController();
+            const device = await site.addNode(MockServerNode.RootEndpoint.with(FailingAccessControlServer), {
+                device: OnOffLightDevice,
+            });
+
+            const disableEntropy = enableEntropy(controller, device);
+
+            const { passcode, discriminator } = device.state.commissioning;
+
+            const adSpy = new CommissioningAdSpy();
+            device.env.get(DeviceAdvertiser).addAdvertiser(adSpy);
+
+            let caughtError: unknown;
+            await MockTime.resolve(
+                controller.peers.commission({ passcode, discriminator, timeout: Seconds(90) }).catch(err => {
+                    caughtError = err;
+                }),
+                { macrotasks: true },
+            );
+
+            disableEntropy();
+
+            expect(caughtError).to.not.equal(undefined);
+            expect(device.env.get(FabricManager).fabrics.length).to.equal(0);
+            expect(adSpy.count).to.be.greaterThan(0);
+            expect(device.lifecycle.isOnline).to.equal(true);
+            expect(device.state.commissioning.commissioned).to.equal(false);
         } finally {
             await site.close();
         }

--- a/packages/protocol/src/fabric/Fabric.ts
+++ b/packages/protocol/src/fabric/Fabric.ts
@@ -85,6 +85,7 @@ export class Fabric {
     #persistCallback: ((isUpdate?: boolean) => MaybePromise<void>) | undefined;
     #storage?: StorageContext;
     #isDeleting?: boolean;
+    #deletePromise?: Promise<void>;
 
     /**
      * Create a fabric synchronously.
@@ -276,7 +277,7 @@ export class Fabric {
     }
 
     get isDeleting() {
-        return this.#isDeleting;
+        return !!this.#isDeleting;
     }
 
     get leaving() {
@@ -404,16 +405,30 @@ export class Fabric {
      *
      * Does not emit the leave event.
      */
-    async delete(currentExchange?: MessageExchange) {
+    async delete(currentExchange?: MessageExchange): Promise<void> {
+        if (this.#deletePromise !== undefined) {
+            // Lifecycle fires once; still honor this caller's currentExchange for session close.
+            await this.#closeSessions(currentExchange);
+            await this.#deletePromise;
+            return;
+        }
+
         this.#isDeleting = true;
 
-        await this.#deleting.emit();
+        this.#deletePromise = this.#delete(currentExchange);
+        await this.#deletePromise;
+    }
 
+    async #delete(currentExchange?: MessageExchange) {
+        await this.#deleting.emit();
+        await this.#closeSessions(currentExchange);
+        await this.#deleted.emit();
+    }
+
+    async #closeSessions(currentExchange?: MessageExchange) {
         for (const session of [...this.#sessions]) {
             await session.initiateForceClose({ cause: new FabricRemovedError(), currentExchange });
         }
-
-        await this.#deleted.emit();
     }
 
     persist(isUpdate = true) {

--- a/packages/protocol/src/fabric/FabricManager.ts
+++ b/packages/protocol/src/fabric/FabricManager.ts
@@ -250,6 +250,7 @@ export class FabricManager {
             await this.persistFabrics();
         }
         await fabric.storage?.clearAll();
+        await this.#events.deleted.emit(fabric);
     }
 
     [Symbol.iterator]() {


### PR DESCRIPTION
## Summary

Addresses [CHIP spec issue #13027](https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/13027): an AddNOC step that throws after PASE session augmentation must clean up the partially applied fabric and session. Same shape exists in UpdateNOC when the post-`replaceFabric` session reset throws.

- New `Transaction.onFinalize(actor)` primitive — schedules cleanup work (sync or async) to run after the transaction releases its locks; errors logged, never propagated.
- `OperationalCredentialsServer.addNoc`: ACL creation moved inside the existing try; catch schedules `fabric.delete` via `onFinalize`.
- `OperationalCredentialsServer.updateNoc`: tracks whether `replaceFabric` succeeded; on subsequent throw, schedules `FailsafeContext.restoreFabric` via `onFinalize`.
- `Fabric.delete`: idempotent across concurrent callers via in-flight promise. Each caller's `currentExchange` still honored for session close even on re-entrant call.
- `FabricManager.events.deleted`: now actually emitted (was declared but never fired).
- Stale TODOs in `addNoc` removed (PASE augment was already wired at line 269; IPK→GKM is wired operationally via `FabricGroups.keySets`).

## Why `onFinalize`

The naive approach (`await fabric.delete()` inline in the catch) deadlocks: the command transaction holds write locks that the `lock:true` reactors on `FabricManager` events need before they can fire, and the transaction commit/rollback waits for those reactors to complete. `onFinalize` defers the cleanup to run after the transaction transitions out of exclusive mode and locks are released.

Wraps the existing `onShared` signal under the hood, but with three additions worth surfacing:
- accepts `MaybePromise<void>` so the actor may be async
- errors are caught and logged (`logger.warn`), never propagated
- intent is named: "this is cleanup after the transaction"

🤖 Generated with [Claude Code](https://claude.com/claude-code)