### PR TITLE
fix(model): don't add implicit FabricIndex to fabric-scoped command structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,17 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/general
     - Fix: `causedBy`/`asError`/`errorOf`/`repackErrorAs` no longer crash with "undefined is not an object" when invoked with `undefined`/`null` as error object
 
+- @matter/model
+    - Fix: Remove invalid FabricIndex field from four commands
+
 - @matter/protocol
     - Deprecation: Internally used `DecodedDataReport`, `DecodedAttributeReport{Value,Status,Entry}`, `DecodedEventReport{Value,Status,Entry}`, `DecodedEventData`, and the `normalize*` / `normalizeAndDecode*` helpers moved to `@project-chip/matter.js/cluster`. Scheduled for removal in 0.18
     - Enhancement: `ReadResult.EventValue` exposes the four wire timestamp variants (`epochTimestamp`, `systemTimestamp`, `deltaEpochTimestamp`, `deltaSystemTimestamp`) alongside the existing collapsed `timestamp: number`
     - Adjustment: `ReadResult.Chunk` may now be an async iterable (`InputChunk` is an async generator); consumers iterate chunk contents with `for await … of chunk`. Mainly internal
     - Fix: Event reports are now decoded in wire (EventNumber) order
+
+- @matter/types
+    - Fix: Remove invalid FabricIndex field from four commands
 
 ## 0.17.0 (2026-05-20)
 

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -926,7 +926,6 @@ export class CommissioningController {
             try {
                 await node.node.commandsOf(OperationalCredentialsClient).updateFabricLabel({
                     label,
-                    fabricIndex: fabric.fabricIndex,
                 });
             } catch (error) {
                 const sre = StatusResponseError.of(error);

--- a/packages/model/src/standard/elements/operational-credentials.element.ts
+++ b/packages/model/src/standard/elements/operational-credentials.element.ts
@@ -103,8 +103,7 @@ export const OperationalCredentials = Cluster(
     Command(
         { name: "UpdateNoc", id: 0x7, access: "F A", conformance: "M", direction: "request", response: "NocResponse" },
         Field({ name: "NocValue", id: 0x0, type: "octstr", access: "F", conformance: "M", constraint: "max 400" }),
-        Field({ name: "IcacValue", id: 0x1, type: "octstr", access: "F", conformance: "O", constraint: "max 400" }),
-        Field({ name: "FabricIndex", id: 0xfe, type: "FabricIndex" })
+        Field({ name: "IcacValue", id: 0x1, type: "octstr", access: "F", conformance: "O", constraint: "max 400" })
     ),
 
     Command(
@@ -122,8 +121,7 @@ export const OperationalCredentials = Cluster(
             name: "UpdateFabricLabel", id: 0x9, access: "F A", conformance: "M", direction: "request",
             response: "NocResponse"
         },
-        Field({ name: "Label", id: 0x0, type: "string", access: "F", conformance: "M", constraint: "max 32" }),
-        Field({ name: "FabricIndex", id: 0xfe, type: "FabricIndex" })
+        Field({ name: "Label", id: 0x0, type: "string", access: "F", conformance: "M", constraint: "max 32" })
     ),
 
     Command(

--- a/packages/model/src/standard/elements/ota-software-update-requestor.element.ts
+++ b/packages/model/src/standard/elements/ota-software-update-requestor.element.ts
@@ -69,8 +69,7 @@ export const OtaSoftwareUpdateRequestor = Cluster(
         Field({ name: "VendorId", id: 0x1, type: "vendor-id", access: "F", conformance: "M" }),
         Field({ name: "AnnouncementReason", id: 0x2, type: "AnnouncementReasonEnum", access: "F", conformance: "M" }),
         Field({ name: "MetadataForNode", id: 0x3, type: "octstr", access: "F", conformance: "O", constraint: "max 512" }),
-        Field({ name: "Endpoint", id: 0x4, type: "endpoint-no", access: "F", conformance: "M" }),
-        Field({ name: "FabricIndex", id: 0xfe, type: "FabricIndex" })
+        Field({ name: "Endpoint", id: 0x4, type: "endpoint-no", access: "F", conformance: "M" })
     ),
 
     Datatype(

--- a/packages/model/src/standard/elements/time-synchronization.element.ts
+++ b/packages/model/src/standard/elements/time-synchronization.element.ts
@@ -106,8 +106,7 @@ export const TimeSynchronization = Cluster(
         Field({
             name: "TrustedTimeSource", id: 0x0, type: "FabricScopedTrustedTimeSourceStruct", access: "F",
             conformance: "M", quality: "X"
-        }),
-        Field({ name: "FabricIndex", id: 0xfe, type: "FabricIndex" })
+        })
     ),
 
     Command(

--- a/packages/model/test/standard/MatterDefinitionTest.ts
+++ b/packages/model/test/standard/MatterDefinitionTest.ts
@@ -44,4 +44,18 @@ describe("MatterDefinition", () => {
     it("has not decreased in scope", () => {
         expect(validate().elementCount).least(3582);
     });
+
+    // Commands are not fabric-scoped data (Core § 7.5.3) so their structs must never carry the implicit global
+    // FabricIndex field (id 0xfe, Core § 7.13.6); the accessing fabric is derived from the command invocation context.
+    it("does not add the implicit FabricIndex field to commands", () => {
+        const offenders = new Array<string>();
+        for (const cluster of instantiate().clusters) {
+            for (const command of cluster.commands) {
+                if (command.children.some(field => field.id === 0xfe)) {
+                    offenders.push(`${cluster.name}.${command.name}`);
+                }
+            }
+        }
+        expect(offenders).deep.equal([]);
+    });
 });

--- a/packages/node/src/behavior/system/software-update/OtaAnnouncements.ts
+++ b/packages/node/src/behavior/system/software-update/OtaAnnouncements.ts
@@ -273,7 +273,6 @@ export class OtaAnnouncements {
             await endpoint.commandsOf(OtaSoftwareUpdateRequestorClient).announceOtaProvider({
                 providerNodeId: this.#ownNodeId,
                 vendorId: this.#ownVendorId,
-                fabricIndex: this.#ownFabricIndex,
                 announcementReason,
                 endpoint: this.#otaProviderEndpoint,
             });

--- a/packages/protocol/src/action/request/Invoke.ts
+++ b/packages/protocol/src/action/request/Invoke.ts
@@ -11,7 +11,6 @@ import {
     ClusterType,
     CommandData,
     CommandId,
-    FabricIndex,
     InvokeRequest,
     ObjectSchema,
     TlvOfModel,
@@ -224,15 +223,10 @@ export namespace Invoke {
         const { commandRef } = request;
 
         let fields: any = "fields" in request ? request.fields : undefined;
-        if (requestSchema instanceof ObjectSchema) {
-            if (fields === undefined) {
-                // If developer did not provide a request object, create an empty one if it needs to be an object
-                // This can happen when all object properties are optional
-                fields = {};
-            }
-            if (requestSchema.isFabricScoped && fields.fabricIndex === undefined) {
-                fields.fabricIndex = FabricIndex.NO_FABRIC;
-            }
+        if (requestSchema instanceof ObjectSchema && fields === undefined) {
+            // If developer did not provide a request object, create an empty one if it needs to be an object
+            // This can happen when all object properties are optional
+            fields = {};
         }
 
         if (!skipValidation) {

--- a/packages/protocol/src/peer/ControllerCommissioningFlow.ts
+++ b/packages/protocol/src/peer/ControllerCommissioningFlow.ts
@@ -1379,7 +1379,6 @@ export class ControllerCommissioningFlow {
                     command: "updateFabricLabel",
                     fields: {
                         label: this.fabric.label,
-                        fabricIndex,
                     },
                 }),
             );

--- a/packages/types/src/clusters/operational-credentials.d.ts
+++ b/packages/types/src/clusters/operational-credentials.d.ts
@@ -825,7 +825,6 @@ export declare namespace OperationalCredentials {
         constructor(values?: Partial<UpdateNocRequest>);
         nocValue: Bytes;
         icacValue?: Bytes;
-        fabricIndex: FabricIndex;
     }
 
     /**
@@ -854,8 +853,6 @@ export declare namespace OperationalCredentials {
          * @see {@link MatterSpecification.v151.Core} § 11.18.6.11.1
          */
         label: string;
-
-        fabricIndex: FabricIndex;
     }
 
     /**

--- a/packages/types/src/clusters/ota-software-update-requestor.d.ts
+++ b/packages/types/src/clusters/ota-software-update-requestor.d.ts
@@ -410,8 +410,6 @@ export declare namespace OtaSoftwareUpdateRequestor {
          * @see {@link MatterSpecification.v151.Core} § 11.20.7.6.1.5
          */
         endpoint: EndpointNumber;
-
-        fabricIndex: FabricIndex;
     }
 
     /**

--- a/packages/types/src/clusters/time-synchronization.d.ts
+++ b/packages/types/src/clusters/time-synchronization.d.ts
@@ -1055,8 +1055,6 @@ export declare namespace TimeSynchronization {
          * @see {@link MatterSpecification.v151.Core} § 11.17.9.2.1
          */
         trustedTimeSource: FabricScopedTrustedTimeSource | null;
-
-        fabricIndex: FabricIndex;
     }
 
     /**

--- a/support/codegen/src/mom/spec/translate-datatype.ts
+++ b/support/codegen/src/mom/spec/translate-datatype.ts
@@ -159,6 +159,7 @@ export function translateFields<T extends AnyElement.Type<FieldRecord>>(
     type: T,
     fields?: SpecReference,
     withAccessNotes = true,
+    addImplicitFabricIndex = true,
 ): ReturnType<T>[] | undefined {
     let records = translateTable(type.Tag, fields, FieldSchema);
 
@@ -171,7 +172,7 @@ export function translateFields<T extends AnyElement.Type<FieldRecord>>(
     });
 
     if (withAccessNotes) {
-        applyAccessModifier(fields, records);
+        applyAccessModifier(fields, records, addImplicitFabricIndex);
     }
 
     return translateRecordsToMatter(type.Tag, records, type) as ReturnType<T>[] | undefined;
@@ -287,7 +288,9 @@ export function translateValueChildren(
         }
 
         case Metatype.object:
-            return translateFields(FieldElement, definition, parent?.type !== "event");
+            // Commands are not fabric-scoped data (Core § 7.5.3), so their request/response structs must not carry the
+            // implicit global FabricIndex field (Core § 7.13.6); the accessing fabric is derived from the invocation.
+            return translateFields(FieldElement, definition, parent?.type !== "event", tag !== "command");
     }
 }
 
@@ -326,10 +329,11 @@ export function accessModifierOf(details?: SpecReference) {
 // For some reason, "default" fabric access appears in an informational row instead of the access column in many of the
 // core definitions.  Fix this.
 //
-// We also use the presence of this record to add the implicit FabrixIndex field
+// When addImplicitFabricIndex is set we also use the presence of this record to add the implicit FabricIndex field.
 function applyAccessModifier(
     fields?: SpecReference,
     records?: { id: number; name?: string; type?: string; access?: string; conformance?: string }[],
+    addImplicitFabricIndex = true,
 ) {
     if (!records) {
         return;
@@ -355,7 +359,7 @@ function applyAccessModifier(
     }
 
     // Add the FabricIndex field if not already present
-    if (!haveFabricIndex) {
+    if (addImplicitFabricIndex && !haveFabricIndex) {
         records.push({
             id: FabricIndex.id as number,
             name: FabricIndex.name,

--- a/support/models/src/v1.5.1/spec.ts
+++ b/support/models/src/v1.5.1/spec.ts
@@ -38658,8 +38658,7 @@ export const SpecMatter = Matter(
                 name: "TrustedTimeSource", id: 0x0, type: "FabricScopedTrustedTimeSourceStruct", access: "F",
                 conformance: "M", quality: "X", xref: "core§11.17.9.2.1",
                 details: "This field contains the Node ID and endpoint of a trusted time source on the accessing fabric."
-            }),
-            Field({ name: "FabricIndex", id: 0xfe, type: "FabricIndex" })
+            })
         ),
 
         Command(
@@ -39283,8 +39282,7 @@ export const SpecMatter = Matter(
             },
 
             Field({ name: "NocValue", id: 0x0, type: "octstr", access: "F", conformance: "M", constraint: "max 400" }),
-            Field({ name: "IcacValue", id: 0x1, type: "octstr", access: "F", conformance: "O", constraint: "max 400" }),
-            Field({ name: "FabricIndex", id: 0xfe, type: "FabricIndex" })
+            Field({ name: "IcacValue", id: 0x1, type: "octstr", access: "F", conformance: "O", constraint: "max 400" })
         ),
 
         Command(
@@ -39352,8 +39350,7 @@ export const SpecMatter = Matter(
                 name: "Label", id: 0x0, type: "string", access: "F", conformance: "M", constraint: "max 32",
                 xref: "core§11.18.6.11.1",
                 details: "This field shall contain the label to set for the fabric associated with the current secure session."
-            }),
-            Field({ name: "FabricIndex", id: 0xfe, type: "FabricIndex" })
+            })
         ),
 
         Command(
@@ -40626,9 +40623,7 @@ export const SpecMatter = Matter(
                     "Update Provider cluster server on the ProviderNodeID. This is provided to avoid having to do " +
                     "discovery of the location of that endpoint by walking over all endpoints and checking their " +
                     "Descriptor Cluster."
-            }),
-
-            Field({ name: "FabricIndex", id: 0xfe, type: "FabricIndex" })
+            })
         ),
 
         Datatype(


### PR DESCRIPTION
## Problem

Fixes #3800.

Fabric-scoped **command** request structs were carrying the implicit global FabricIndex field (TLV tag 254 / id `0xfe`), so the controller sent a spurious fabric index on the wire when invoking e.g. `UpdateFabricLabel`.

Per Matter Core spec:
- **§ 7.5.3** — fabric-scoped *data* is limited to lists of fabric-scoped structs + fabric-sensitive events. Commands are neither.
- **§ 7.13.6 / § 7.19 (L567–572)** — the implicit FabricIndex field must not be indicated by the client in write interactions *or* command payloads; the server derives it from the accessing fabric.

So a fabric-scoped *command* envelope must never carry the implicit FabricIndex field.

## Root cause

The spec code generator (`translate-datatype.ts` → `applyAccessModifier`) injected the implicit FabricIndex field into **any** element whose field table had a fabric-scoped access note — including command request structs, not just data structs/events.

## Fix

- **Codegen**: thread `addImplicitFabricIndex` through `translateFields` → `applyAccessModifier`; at the `metatype.object` branch pass `tag !== "command"`. Data structs and fabric-sensitive events still get the implicit field; commands no longer do.
- **Regenerated** model — the field is removed from **4** commands:
  - `OperationalCredentials.UpdateNoc`
  - `OperationalCredentials.UpdateFabricLabel` (the reported case)
  - `OtaSoftwareUpdateRequestor.AnnounceOtaProvider`
  - `TimeSynchronization.SetTrustedTimeSource`
- **Call sites**: dropped the now-invalid `fabricIndex` arguments (`CommissioningController`, `ControllerCommissioningFlow`, `OtaAnnouncements`).
- **Invoke encoder**: removed the now-dead `isFabricScoped → fabricIndex = NO_FABRIC` injection.
- **Guard test** in `MatterDefinitionTest` asserting no command struct (request or response) carries the id-`0xfe` field.

## Notes

- Server handlers were already correct — they derive the fabric from the session context, not the request struct.
- Legitimate fabric fields are untouched: `NocResponse.FabricIndex` (id `0x1`), `RemoveFabric.FabricIndex` (id `0x0`), and data structs like `NOCStruct` / `FabricDescriptorStruct` (id `0xfe`, valid per § 7.5.3).

## Verification

Clean build · model/types/protocol/node/matter.js test suites · format-verify · lint — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)