### PR TITLE
feat(protocol): selective test-cert validation in device attestation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: `causedBy`/`asError`/`errorOf`/`repackErrorAs` no longer crash with "undefined is not an object" when invoked with `undefined`/`null` as error object
 
 - @matter/protocol
+    - Feature: New `TrustedAsTestCertificate` attestation finding lets `onAttestationFailure` decide whether to accept devices whose PAA is only in the trust store as a test certificate; previously these failed with `PaaNotTrusted`. Adds per-call `considerTestCertificates` and `allowsTestCertificates` on `DclCertificateService`
+    - Feature: `OnAttestationFailure` callback may return a `string` (wraps the underlying error as `cause` of a new `CommissioningError`) or throw to propagate verbatim
+    - Adjustment: Default-accept policies (`onAttestationFailure === true`/`undefined`) now commission test-PAA-only devices that previously failed; upgrade the policy to keep rejecting
     - Deprecation: Internally used `DecodedDataReport`, `DecodedAttributeReport{Value,Status,Entry}`, `DecodedEventReport{Value,Status,Entry}`, `DecodedEventData`, and the `normalize*` / `normalizeAndDecode*` helpers moved to `@project-chip/matter.js/cluster`. Scheduled for removal in 0.18
     - Enhancement: `ReadResult.EventValue` exposes the four wire timestamp variants (`epochTimestamp`, `systemTimestamp`, `deltaEpochTimestamp`, `deltaSystemTimestamp`) alongside the existing collapsed `timestamp: number`
     - Adjustment: `ReadResult.Chunk` may now be an async iterable (`InputChunk` is an async generator); consumers iterate chunk contents with `for await … of chunk`. Mainly internal

--- a/packages/node/test/node/ClientAttestationTest.ts
+++ b/packages/node/test/node/ClientAttestationTest.ts
@@ -8,8 +8,10 @@ import { Bytes, Crypto, DerCodec, DerType, MockCrypto, MockFetch, ObjectId, Pem,
 import {
     AttestationFinding,
     CertificationDeclaration,
+    CommissioningError,
     DclCertificateService,
     DeviceAttestationCheck,
+    DeviceAttestationError,
     DeviceAttestationValidator,
     Paa,
     TestCert_PAA_FFF1_Cert,
@@ -135,8 +137,11 @@ interface AttestationTestOptions {
     /** The onAttestationFailure commissioning option. */
     onAttestationFailure?: DeviceAttestationValidator.OnAttestationFailure;
 
-    /** If set, commissioning is expected to be rejected with this pattern. */
-    expectRejection?: RegExp;
+    /**
+     * If set, commissioning is expected to be rejected. `RegExp` matches the thrown error's message;
+     * a function receives the thrown error for arbitrary inspection (instance type, `cause` chain, etc.).
+     */
+    expectRejection?: RegExp | ((err: unknown) => void | Promise<void>);
 
     /** Assertions to run on the findings captured by the callback (if callback was used). */
     assertFindings?: (findings: AttestationFinding[]) => void;
@@ -212,7 +217,18 @@ async function runAttestationTest(options: AttestationTestOptions) {
         );
 
         if (options.expectRejection !== undefined) {
-            await expect(commissionPromise).to.be.rejectedWith(options.expectRejection);
+            if (options.expectRejection instanceof RegExp) {
+                await expect(commissionPromise).to.be.rejectedWith(options.expectRejection);
+            } else {
+                let thrown: unknown;
+                try {
+                    await commissionPromise;
+                } catch (err) {
+                    thrown = err;
+                }
+                expect(thrown, "commissioning was expected to reject but resolved").to.not.be.undefined;
+                await options.expectRejection(thrown);
+            }
         } else {
             await commissionPromise;
         }
@@ -439,6 +455,49 @@ describe("device attestation during commissioning", () => {
                         0,
                         "Expected on-demand DCL revocation lookup during commissioning",
                     );
+                },
+            });
+        });
+    });
+
+    describe("onAttestationFailure callback contract", () => {
+        it("string return on success-path findings wraps the synthesized error as cause", () =>
+            runAttestationTest({
+                dclPaaCert: TestCert_PAA_NoVID_Cert,
+                onAttestationFailure: () => "operator declined: test attestation",
+                expectRejection: err => {
+                    expect(err).to.be.instanceOf(CommissioningError);
+                    expect((err as CommissioningError).message).to.equal("operator declined: test attestation");
+                    const cause = (err as Error).cause;
+                    expect(cause).to.be.instanceOf(CommissioningError);
+                    expect((cause as CommissioningError).message).to.match(/finding\(s\) and was rejected by policy/);
+                },
+            }));
+
+        it("string return on hard-error finding wraps the original DeviceAttestationError as cause", () =>
+            runAttestationTest({
+                dclPaaCert: TestCert_PAA_FFF1_Cert,
+                onAttestationFailure: () => "operator declined: untrusted PAA",
+                expectRejection: err => {
+                    expect(err).to.be.instanceOf(CommissioningError);
+                    expect((err as CommissioningError).message).to.equal("operator declined: untrusted PAA");
+                    const cause = (err as Error).cause;
+                    expect(cause).to.be.instanceOf(DeviceAttestationError);
+                    expect((cause as DeviceAttestationError).failure).to.equal(DeviceAttestationCheck.PaaNotTrusted);
+                },
+            }));
+
+        it("callback throw propagates verbatim (no wrapping)", () => {
+            class CustomRejection extends Error {}
+            return runAttestationTest({
+                dclPaaCert: TestCert_PAA_FFF1_Cert,
+                onAttestationFailure: () => {
+                    throw new CustomRejection("custom rejection");
+                },
+                expectRejection: err => {
+                    expect(err).to.be.instanceOf(CustomRejection);
+                    expect((err as Error).message).to.equal("custom rejection");
+                    expect((err as Error).cause).to.be.undefined;
                 },
             });
         });

--- a/packages/node/test/node/ClientAttestationTest.ts
+++ b/packages/node/test/node/ClientAttestationTest.ts
@@ -501,5 +501,49 @@ describe("device attestation during commissioning", () => {
                 },
             });
         });
+
+        it("callback throwing DeviceAttestationError on success-path findings propagates without re-invocation", () => {
+            let invocations = 0;
+            return runAttestationTest({
+                dclPaaCert: TestCert_PAA_NoVID_Cert,
+                onAttestationFailure: () => {
+                    invocations++;
+                    throw new DeviceAttestationError(
+                        DeviceAttestationCheck.AttestationSignatureInvalid,
+                        "from callback",
+                    );
+                },
+                expectRejection: err => {
+                    expect(err).to.be.instanceOf(DeviceAttestationError);
+                    expect((err as DeviceAttestationError).failure).to.equal(
+                        DeviceAttestationCheck.AttestationSignatureInvalid,
+                    );
+                    expect((err as Error).message).to.equal("from callback");
+                    expect(invocations).to.equal(1);
+                },
+            });
+        });
+
+        it("callback throwing DeviceAttestationError on hard-error finding propagates without re-invocation", () => {
+            let invocations = 0;
+            return runAttestationTest({
+                dclPaaCert: TestCert_PAA_FFF1_Cert,
+                onAttestationFailure: () => {
+                    invocations++;
+                    throw new DeviceAttestationError(
+                        DeviceAttestationCheck.AttestationSignatureInvalid,
+                        "from callback",
+                    );
+                },
+                expectRejection: err => {
+                    expect(err).to.be.instanceOf(DeviceAttestationError);
+                    expect((err as DeviceAttestationError).failure).to.equal(
+                        DeviceAttestationCheck.AttestationSignatureInvalid,
+                    );
+                    expect((err as Error).message).to.equal("from callback");
+                    expect(invocations).to.equal(1);
+                },
+            });
+        });
     });
 });

--- a/packages/node/test/node/ClientAttestationTest.ts
+++ b/packages/node/test/node/ClientAttestationTest.ts
@@ -134,6 +134,12 @@ interface AttestationTestOptions {
     /** PAA cert to register in DCL trust store. undefined = no DclCertificateService. */
     dclPaaCert?: Bytes;
 
+    /**
+     * When true, inject `dclPaaCert` directly as a test-only PAA (isProduction: false) and
+     * skip the production DCL fetch mock. Used to exercise the `TrustedAsTestCertificate` finding.
+     */
+    paaAsTestOnly?: boolean;
+
     /** The onAttestationFailure commissioning option. */
     onAttestationFailure?: DeviceAttestationValidator.OnAttestationFailure;
 
@@ -166,7 +172,13 @@ async function runAttestationTest(options: AttestationTestOptions) {
 
     try {
         if (options.dclPaaCert !== undefined && options.setupBeforeCommission === undefined) {
-            setupDclFetchMock(fetchMock, options.dclPaaCert);
+            if (options.paaAsTestOnly) {
+                fetchMock.addResponse("/dcl/pki/root-certificates", {
+                    approvedRootCertificates: { schemaVersion: 0, certs: [] },
+                });
+            } else {
+                setupDclFetchMock(fetchMock, options.dclPaaCert);
+            }
             fetchMock.install();
         }
 
@@ -181,6 +193,9 @@ async function runAttestationTest(options: AttestationTestOptions) {
         if (options.dclPaaCert !== undefined) {
             dclService = new DclCertificateService(controller.env, { updateInterval: null });
             await dclService.construction;
+            if (options.paaAsTestOnly) {
+                await dclService.addCertificate(options.dclPaaCert, "PAA", { isProduction: false });
+            }
             // Inject the Matter test CD signer so CD signature verification works for test CDs
             await dclService.addCertificate(CertificationDeclaration.testSignerCertificate(), "CDSigner");
         }
@@ -343,6 +358,36 @@ describe("device attestation during commissioning", () => {
                 dclPaaCert: TestCert_PAA_NoVID_Cert,
                 onAttestationFailure: false,
                 expectRejection: /finding\(s\) and was rejected by policy/,
+            }));
+    });
+
+    describe("with DCL trust store (test-only PAA)", () => {
+        it("emits TrustedAsTestCertificate finding, callback rejects", () =>
+            runAttestationTest({
+                dclPaaCert: TestCert_PAA_NoVID_Cert,
+                paaAsTestOnly: true,
+                onAttestationFailure: () => false,
+                expectRejection: /finding\(s\) and was rejected by policy/,
+                assertFindings: findings => {
+                    const trusted = findings.find(f => f.type === DeviceAttestationCheck.TrustedAsTestCertificate);
+                    expect(trusted).to.not.be.undefined;
+                    expect(trusted!.level).equals("error");
+                },
+            }));
+
+        it("emits TrustedAsTestCertificate finding, callback accepts → commissioning proceeds", () =>
+            runAttestationTest({
+                dclPaaCert: TestCert_PAA_NoVID_Cert,
+                paaAsTestOnly: true,
+                onAttestationFailure: () => true,
+                assertFindings: findings => {
+                    const types = findings.map(f => f.type);
+                    expect(types).to.include(DeviceAttestationCheck.TrustedAsTestCertificate);
+                },
+                assertResult: (device, peers) => {
+                    expect(device.state.commissioning.commissioned).equals(true);
+                    expect(peers).equals(1);
+                },
             }));
     });
 

--- a/packages/protocol/src/certificate/DeviceAttestationValidator.ts
+++ b/packages/protocol/src/certificate/DeviceAttestationValidator.ts
@@ -31,11 +31,12 @@ export enum DeviceAttestationCheck {
     CdSignerVerificationSkipped = "CdSignerVerificationSkipped",
     PaaTrustStoreTimeMismatch = "PaaTrustStoreTimeMismatch",
     DclServiceUnavailable = "DclServiceUnavailable",
+    TrustedAsTestCertificate = "TrustedAsTestCertificate",
 }
 
 /** A single finding from the attestation validation process. */
 export interface AttestationFinding {
-    /** Severity: "error" stops validation immediately, "warning"/"info" are collected. */
+    /** Severity. "error" aborts validation unless the check is recoverable (collected instead). */
     level: "error" | "warning" | "info";
 
     /** The specific check that produced this finding. */
@@ -159,14 +160,24 @@ export namespace DeviceAttestationValidator {
                     "Register DclCertificateService in the environment for full attestation.",
             });
         } else {
-            // Step 2: PAA Trust Store lookup
+            // Step 2: PAA Trust Store lookup — probe both production and test scope
             const paiAkid = pai.cert.extensions.authorityKeyIdentifier;
-            const paaMetadata = dclCertificateService.getCertificate(paiAkid);
+            const paaMetadata = dclCertificateService.getCertificate(paiAkid, { considerTestCertificates: true });
             if (paaMetadata === undefined) {
                 throw new DeviceAttestationError(
                     DeviceAttestationCheck.PaaNotTrusted,
                     `PAA not found in trust store for authority key identifier ${Bytes.toHex(paiAkid)}`,
                 );
+            }
+
+            if (!paaMetadata.isProduction && !dclCertificateService.allowsTestCertificates) {
+                findings.push({
+                    level: "error",
+                    type: DeviceAttestationCheck.TrustedAsTestCertificate,
+                    message:
+                        `PAA ${Bytes.toHex(paiAkid)} is a test/development certificate; ` +
+                        `device presented a valid test attestation but production trust policy is in effect`,
+                });
             }
 
             // Step 2b: Time-based trust store check (SHOULD per spec 6.2.3.1)
@@ -185,7 +196,7 @@ export namespace DeviceAttestationValidator {
             }
 
             // Step 3: Certificate chain signature verification
-            const paaDer = await dclCertificateService.getCertificateAsDer(paiAkid);
+            const paaDer = await dclCertificateService.getCertificateAsDer(paiAkid, { considerTestCertificates: true });
             paa = Paa.fromAsn1(paaDer);
 
             try {

--- a/packages/protocol/src/certificate/DeviceAttestationValidator.ts
+++ b/packages/protocol/src/certificate/DeviceAttestationValidator.ts
@@ -109,8 +109,10 @@ export namespace DeviceAttestationValidator {
      * (PAA trust store, chain verification, revocation) only run when dclCertificateService
      * is provided.
      *
-     * Errors (hard failures) throw immediately via {@link DeviceAttestationError}.
-     * Warnings and info findings are collected and returned for the caller to evaluate.
+     * Most error-level failures throw immediately via {@link DeviceAttestationError}. A small
+     * set of recoverable error cases (currently {@link DeviceAttestationCheck.TrustedAsTestCertificate})
+     * are collected in `findings` so the caller can decide via `onFailure` whether to proceed.
+     * Warning and info findings are always collected.
      */
     export async function validate(context: Context, data: DeviceAttestationData): Promise<ValidationResult> {
         const { crypto, dclCertificateService } = context;

--- a/packages/protocol/src/certificate/DeviceAttestationValidator.ts
+++ b/packages/protocol/src/certificate/DeviceAttestationValidator.ts
@@ -88,12 +88,19 @@ export namespace DeviceAttestationValidator {
 
     /**
      * Controls behavior when attestation findings occur.
-     * - `true`: always proceed (warnings/info are logged)
-     * - `false`: reject on any finding (error, warning, or info)
+     * - `true`: always proceed (warnings/info logged)
+     * - `false`: reject on any finding
      * - `undefined`: backward-compatible accept with logging
-     * - function: receives all findings, returns whether to proceed
+     * - function: receives all findings; may
+     *     - return `true` to proceed
+     *     - return `false` to reject with the underlying error (the original
+     *       {@link DeviceAttestationError} on hard-failure findings, or a fresh
+     *       {@link CommissioningError} on collected-finding rejection)
+     *     - return a `string` to reject with a new {@link CommissioningError} whose message is
+     *       that string and whose `cause` is the underlying error
+     *     - throw any error to reject by rethrowing that error verbatim (no wrapping)
      */
-    export type OnAttestationFailure = boolean | ((findings: AttestationFinding[]) => MaybePromise<boolean>);
+    export type OnAttestationFailure = boolean | ((findings: AttestationFinding[]) => MaybePromise<boolean | string>);
 
     /**
      * Validates device attestation per Matter spec Section 6.2.3.1.

--- a/packages/protocol/src/dcl/DclCertificateService.ts
+++ b/packages/protocol/src/dcl/DclCertificateService.ts
@@ -124,20 +124,21 @@ export class DclCertificateService {
      */
     #isRelevant(
         metadata: DclCertificateService.CertificateMetadata,
-        considerTestCertificates = this.allowsTestCertificates,
+        options?: DclCertificateService.GetCertificateOptions,
     ) {
         const kind = metadata.kind ?? "PAA";
+        const considerTestCertificates = options?.considerTestCertificates ?? this.allowsTestCertificates;
         return kind !== "PAA" || metadata.isProduction || considerTestCertificates;
     }
 
     /**
      * Get certificate metadata by subject key identifier. Returns undefined if not found or if the
-     * entry is a test certificate while `fetchTestCertificates` is disabled.
+     * entry is filtered by the effective trust policy.
      */
-    getCertificate(subjectKeyId: Bytes | string) {
+    getCertificate(subjectKeyId: Bytes | string, options?: DclCertificateService.GetCertificateOptions) {
         this.construction.assert();
         const metadata = this.#certificateIndex.get(this.#normalizeSubjectKeyId(subjectKeyId));
-        if (metadata === undefined || !this.#isRelevant(metadata)) {
+        if (metadata === undefined || !this.#isRelevant(metadata, options)) {
             return undefined;
         }
         return metadata;

--- a/packages/protocol/src/dcl/DclCertificateService.ts
+++ b/packages/protocol/src/dcl/DclCertificateService.ts
@@ -1099,6 +1099,8 @@ export class DclCertificateService {
         if (signerAkid !== undefined) {
             const signerAkidNorm = this.#normalizeSubjectKeyId(signerAkid);
 
+            // CRL signer trust anchor honors test PAAs that the validator already accepted upstream.
+            const trustAllPaas: DclCertificateService.GetCertificateOptions = { considerTestCertificates: true };
             let issuerPublicKey: Bytes | undefined;
             if (delegatorCert !== undefined) {
                 // Delegated signer: verify delegator is signed by a trusted PAA
@@ -1109,7 +1111,7 @@ export class DclCertificateService {
                 ) {
                     throw new MatterDclError("CRLSignerDelegator chain cannot be anchored to trusted PAA");
                 }
-                const paaDer = await this.#getCertificateDer(delegatorAkid);
+                const paaDer = await this.#getCertificateDer(delegatorAkid, trustAllPaas);
                 const paa = Paa.fromAsn1(paaDer);
                 await this.#crypto.verifyEcdsa(
                     PublicKey(paa.cert.ellipticCurvePublicKey),
@@ -1118,7 +1120,7 @@ export class DclCertificateService {
                 );
                 issuerPublicKey = delegatorCert.cert.ellipticCurvePublicKey;
             } else if (this.#certificateIndex.has(signerAkidNorm)) {
-                const paaDer = await this.#getCertificateDer(signerAkid);
+                const paaDer = await this.#getCertificateDer(signerAkid, trustAllPaas);
                 const paa = Paa.fromAsn1(paaDer);
                 issuerPublicKey = paa.cert.ellipticCurvePublicKey;
             }

--- a/packages/protocol/src/dcl/DclCertificateService.ts
+++ b/packages/protocol/src/dcl/DclCertificateService.ts
@@ -253,39 +253,36 @@ export class DclCertificateService {
     }
 
     /**
-     * Get certificate metadata by subject key identifier, fetching from DCL if not in local storage. Returns
-     * undefined if not found.
+     * Get certificate metadata by subject key identifier, fetching from DCL if not in local storage.
+     * Returns undefined if not found or if the entry is filtered by the effective trust policy.
      */
     async getOrFetchCertificate(
         subjectKeyId: Bytes | string,
-        options?: DclClient.Options & { isProduction?: boolean },
+        options?: DclClient.Options & { isProduction?: boolean } & DclCertificateService.GetCertificateOptions,
     ) {
         this.construction.assert();
 
         const normalizedId = this.#normalizeSubjectKeyId(subjectKeyId);
 
-        // First check if certificate is in the index
         const existing = this.#certificateIndex.get(normalizedId);
-        if (existing) {
+        if (existing && this.#isRelevant(existing, options)) {
             return existing;
         }
 
         if (this.#fetchPromise !== undefined) {
-            // Wait for ongoing fetch process to complete, return whatever is in the index afterward
             await this.#fetchPromise;
-            return this.#certificateIndex.get(normalizedId);
+            const afterFetch = this.#certificateIndex.get(normalizedId);
+            return afterFetch && this.#isRelevant(afterFetch, options) ? afterFetch : undefined;
         }
 
         try {
             const isProduction = options?.isProduction ?? true;
-            // Fetch the root certificate list to find the certificate reference
             const config = isProduction
                 ? (this.#options.dclConfig ?? DclConfig.production)
                 : (this.#options.testDclConfig ?? DclConfig.test);
             const dclClient = new DclClient(config);
             const certRefs = await dclClient.fetchRootCertificateList(options);
 
-            // Find the certificate reference with matching subject key ID (with colons for comparison)
             const subjectKeyIdWithColons = normalizedId
                 .match(/.{1,2}/g)
                 ?.join(":")
@@ -300,7 +297,6 @@ export class DclCertificateService {
                 return;
             }
 
-            // Use existing method to fetch and store the certificate
             await this.#fetchAndStoreCertificate(
                 this.#storage!,
                 dclClient,
@@ -310,7 +306,6 @@ export class DclCertificateService {
                 options ?? this.#options,
             );
 
-            // After fetching, retrieve from index (it should be there now if fetch was successful)
             const fetched = this.#certificateIndex.get(normalizedId);
             if (fetched) {
                 await this.#saveIndex();
@@ -319,7 +314,7 @@ export class DclCertificateService {
                     Diagnostic.dict({ skid: normalizedId, prod: isProduction }),
                 );
             }
-            return fetched;
+            return fetched && this.#isRelevant(fetched, options) ? fetched : undefined;
         } catch (error) {
             MatterDclError.accept(error);
             logger.debug(`Failed to fetch certificate ${normalizedId} from DCL: ${error.message}`);

--- a/packages/protocol/src/dcl/DclCertificateService.ts
+++ b/packages/protocol/src/dcl/DclCertificateService.ts
@@ -160,18 +160,17 @@ export class DclCertificateService {
 
     /**
      * Get certificate as PEM string.
-     * @throws {MatterDclError} if certificate not found
+     * @throws {MatterDclError} if certificate not found or filtered by trust policy
      */
-    async getCertificateAsPem(subjectKeyId: Bytes | string) {
+    async getCertificateAsPem(subjectKeyId: Bytes | string, options?: DclCertificateService.GetCertificateOptions) {
         this.construction.assert();
 
         const normalizedId = this.#normalizeSubjectKeyId(subjectKeyId);
         const metadata = this.#certificateIndex.get(normalizedId);
-        if (!metadata || !this.#isRelevant(metadata)) {
+        if (!metadata || !this.#isRelevant(metadata, options)) {
             throw new MatterDclError(`Certificate not found`, Diagnostic.dict({ skid: normalizedId }));
         }
 
-        // Retrieve DER certificate from storage
         const derBytes = await this.#storage!.get<Bytes>(normalizedId);
         if (!derBytes || derBytes.byteLength === 0) {
             throw new MatterDclError(`Certificate data not found in storage`, Diagnostic.dict({ skid: normalizedId }));

--- a/packages/protocol/src/dcl/DclCertificateService.ts
+++ b/packages/protocol/src/dcl/DclCertificateService.ts
@@ -182,18 +182,18 @@ export class DclCertificateService {
 
     /**
      * Get certificate as DER bytes.
-     * @throws {MatterDclError} if certificate not found
+     * @throws {MatterDclError} if certificate not found or filtered by trust policy
      */
-    async getCertificateAsDer(subjectKeyId: Bytes | string) {
+    async getCertificateAsDer(subjectKeyId: Bytes | string, options?: DclCertificateService.GetCertificateOptions) {
         this.construction.assert();
-        return this.#getCertificateDer(subjectKeyId);
+        return this.#getCertificateDer(subjectKeyId, options);
     }
 
     /** Internal DER retrieval without construction assert (safe during init). */
-    async #getCertificateDer(subjectKeyId: Bytes | string) {
+    async #getCertificateDer(subjectKeyId: Bytes | string, options?: DclCertificateService.GetCertificateOptions) {
         const normalizedId = this.#normalizeSubjectKeyId(subjectKeyId);
         const metadata = this.#certificateIndex.get(normalizedId);
-        if (!metadata || !this.#isRelevant(metadata)) {
+        if (!metadata || !this.#isRelevant(metadata, options)) {
             throw new MatterDclError(`Certificate not found`, Diagnostic.dict({ skid: normalizedId }));
         }
 

--- a/packages/protocol/src/dcl/DclCertificateService.ts
+++ b/packages/protocol/src/dcl/DclCertificateService.ts
@@ -119,14 +119,15 @@ export class DclCertificateService {
 
     /**
      * Whether a stored entry is relevant under the current trust policy. Production certificates
-     * are always relevant. Test PAAs are only relevant when `fetchTestCertificates` is enabled,
-     * so cached test PAAs left in storage from a previous run are ignored once the option is
-     * turned off without requiring a storage purge. CD signer certificates are managed
-     * separately and are always relevant.
+     * are always relevant. Test PAAs are only relevant when the test-certificate policy allows
+     * them. CD signer certificates are managed separately and are always relevant.
      */
-    #isRelevant(metadata: DclCertificateService.CertificateMetadata) {
+    #isRelevant(
+        metadata: DclCertificateService.CertificateMetadata,
+        considerTestCertificates = this.allowsTestCertificates,
+    ) {
         const kind = metadata.kind ?? "PAA";
-        return kind !== "PAA" || metadata.isProduction || !!this.#options.fetchTestCertificates;
+        return kind !== "PAA" || metadata.isProduction || considerTestCertificates;
     }
 
     /**
@@ -149,6 +150,11 @@ export class DclCertificateService {
     get certificates() {
         this.construction.assert();
         return Array.from(this.#certificateIndex.values());
+    }
+
+    /** Whether the service is configured to fetch and trust test (non-production) certificates. */
+    get allowsTestCertificates(): boolean {
+        return this.#options.fetchTestCertificates ?? false;
     }
 
     /**
@@ -1291,6 +1297,15 @@ export class DclCertificateService {
 }
 
 export namespace DclCertificateService {
+    /** Per-call options for certificate retrieval. */
+    export interface GetCertificateOptions {
+        /**
+         * Whether the lookup should also return test (non-production) certificates.
+         * Defaults to the service-wide `fetchTestCertificates` flag passed at construction.
+         */
+        considerTestCertificates?: boolean;
+    }
+
     export interface Options {
         /** Whether to fetch test certificates in addition to production ones. Default is false. */
         fetchTestCertificates?: boolean;

--- a/packages/protocol/src/peer/ControllerCommissioningFlow.ts
+++ b/packages/protocol/src/peer/ControllerCommissioningFlow.ts
@@ -1173,6 +1173,8 @@ export class ControllerCommissioningFlow {
 
         const { attestation } = this.commissioningOptions;
 
+        let findings: AttestationFinding[] = [];
+        let baseError: Error | undefined;
         try {
             const result = await DeviceAttestationValidator.validate(
                 {
@@ -1190,41 +1192,27 @@ export class ControllerCommissioningFlow {
                     productId: this.collectedCommissioningData.productId!,
                 },
             );
-
-            if (result.findings.length > 0) {
-                const decision = await this.#resolveAttestationFindings(result.findings);
-                if (!decision.proceed) {
-                    const baseError = new CommissioningError(
-                        `Device attestation produced ${result.findings.length} finding(s) and was rejected by policy`,
-                    );
-                    if (decision.reason !== undefined) {
-                        throw new CommissioningError(decision.reason, { cause: baseError });
-                    }
-                    throw baseError;
-                }
-                logger.info(
-                    `Device attestation successfully verified with ${result.findings.length} accepted finding(s)`,
-                );
-            } else {
-                logger.info("Device attestation successfully verified");
-            }
+            findings = result.findings;
         } catch (error) {
-            if (error instanceof DeviceAttestationError) {
-                const errorFinding: AttestationFinding = {
-                    level: "error",
-                    type: error.failure,
-                    message: error.message,
-                };
-                const decision = await this.#resolveAttestationFindings([errorFinding]);
-                if (!decision.proceed) {
-                    if (decision.reason !== undefined) {
-                        throw new CommissioningError(decision.reason, { cause: error });
-                    }
-                    throw error;
+            DeviceAttestationError.accept(error);
+            findings = [{ level: "error", type: error.failure, message: error.message }];
+            baseError = error;
+        }
+
+        if (findings.length > 0) {
+            const decision = await this.#resolveAttestationFindings(findings);
+            if (!decision.proceed) {
+                baseError ??= new CommissioningError(
+                    `Device attestation produced ${findings.length} finding(s) and was rejected by policy`,
+                );
+                if (decision.reason !== undefined) {
+                    throw new CommissioningError(decision.reason, { cause: baseError });
                 }
-            } else {
-                throw error;
+                throw baseError;
             }
+            logger.info(`Device attestation successfully verified with ${findings.length} accepted finding(s)`);
+        } else {
+            logger.info("Device attestation successfully verified");
         }
 
         // Extract DAC public key for CSR signature verification in #certificates()

--- a/packages/protocol/src/peer/ControllerCommissioningFlow.ts
+++ b/packages/protocol/src/peer/ControllerCommissioningFlow.ts
@@ -24,7 +24,6 @@ import {
     ImplementationError,
     Instant,
     Logger,
-    MaybePromise,
     Millis,
     Minutes,
     NoResponseTimeoutError,
@@ -144,6 +143,8 @@ export type ControllerCommissioningFlowOptions = {
         onFailure?: DeviceAttestationValidator.OnAttestationFailure;
     };
 };
+
+type AttestationDecision = { proceed: true } | { proceed: false; reason?: string };
 
 /** Types representation of a general commissioning response. */
 type CommissioningSuccessFailureResponse = {
@@ -1191,11 +1192,15 @@ export class ControllerCommissioningFlow {
             );
 
             if (result.findings.length > 0) {
-                const proceed = await this.#resolveAttestationFindings(result.findings);
-                if (!proceed) {
-                    throw new CommissioningError(
+                const decision = await this.#resolveAttestationFindings(result.findings);
+                if (!decision.proceed) {
+                    const baseError = new CommissioningError(
                         `Device attestation produced ${result.findings.length} finding(s) and was rejected by policy`,
                     );
+                    if (decision.reason !== undefined) {
+                        throw new CommissioningError(decision.reason, { cause: baseError });
+                    }
+                    throw baseError;
                 }
                 logger.info(
                     `Device attestation successfully verified with ${result.findings.length} accepted finding(s)`,
@@ -1210,8 +1215,11 @@ export class ControllerCommissioningFlow {
                     type: error.failure,
                     message: error.message,
                 };
-                const proceed = await this.#resolveAttestationFindings([errorFinding]);
-                if (!proceed) {
+                const decision = await this.#resolveAttestationFindings([errorFinding]);
+                if (!decision.proceed) {
+                    if (decision.reason !== undefined) {
+                        throw new CommissioningError(decision.reason, { cause: error });
+                    }
                     throw error;
                 }
             } else {
@@ -1229,11 +1237,15 @@ export class ControllerCommissioningFlow {
     }
 
     /** Resolve attestation findings according to the configured policy. */
-    #resolveAttestationFindings(findings: AttestationFinding[]): MaybePromise<boolean> {
+    async #resolveAttestationFindings(findings: AttestationFinding[]): Promise<AttestationDecision> {
         const policy = this.commissioningOptions.attestation.onFailure;
 
         if (typeof policy === "function") {
-            return policy(findings);
+            // Throws from the callback propagate to the caller unchanged.
+            const result = await policy(findings);
+            if (result === true) return { proceed: true };
+            if (typeof result === "string") return { proceed: false, reason: result };
+            return { proceed: false };
         }
 
         for (const f of findings) {
@@ -1251,7 +1263,7 @@ export class ControllerCommissioningFlow {
             }
         }
 
-        return policy !== false;
+        return { proceed: policy !== false };
     }
 
     // TODO consider Distributed Compliance Ledger Info about Commissioning Flow

--- a/packages/protocol/src/peer/ControllerCommissioningFlow.ts
+++ b/packages/protocol/src/peer/ControllerCommissioningFlow.ts
@@ -1173,7 +1173,7 @@ export class ControllerCommissioningFlow {
 
         const { attestation } = this.commissioningOptions;
 
-        let findings: AttestationFinding[] = [];
+        let findings: AttestationFinding[];
         let baseError: Error | undefined;
         try {
             const result = await DeviceAttestationValidator.validate(

--- a/packages/protocol/src/peer/ControllerCommissioningFlow.ts
+++ b/packages/protocol/src/peer/ControllerCommissioningFlow.ts
@@ -127,7 +127,12 @@ export type ControllerCommissioningFlowOptions = {
          * Controls behavior when attestation produces findings.
          * - `false`: reject on any finding
          * - `true`: always accept with info logging
-         * - callback: receives `AttestationFinding[]`, return `true` to proceed, `false` to reject
+         * - callback: receives `AttestationFinding[]` and decides the outcome; may
+         *   - return `true` to proceed
+         *   - return `false` to reject with the underlying error
+         *   - return a `string` to reject with a new {@link CommissioningError} whose message is
+         *     that string and whose `cause` is the underlying error
+         *   - throw any error to reject by rethrowing that error verbatim (no wrapping)
          * - `undefined`: accept with warning logging (backward compatibility)
          *
          * The callback receives either:
@@ -135,8 +140,8 @@ export type ControllerCommissioningFlowOptions = {
          *   certificate, untrusted PAA, DCL service unavailable). The commissioner must decide
          *   whether to proceed despite the failure.
          * - One or more warning/info-level findings after successful validation (e.g. provisional
-         *   CD, test CD, skipped CD signer verification, no revocation data). These are
-         *   informational and the commissioner can inspect them for detailed decisions.
+         *   CD, test CD, skipped CD signer verification, no revocation data, test-cert-only PAA).
+         *   These are informational and the commissioner can inspect them for detailed decisions.
          *
          * TODO: Make required in next breaking version and remove undefined backward-compatible accept
          */

--- a/packages/protocol/test/certificate/DeviceAttestationValidatorTest.ts
+++ b/packages/protocol/test/certificate/DeviceAttestationValidatorTest.ts
@@ -624,4 +624,62 @@ describe("DeviceAttestationValidator", () => {
             expect(finding).to.be.undefined;
         });
     });
+
+    describe("test-certificate PAA detection", () => {
+        it("emits TrustedAsTestCertificate when PAA is test-only and service disallows test certs", async () => {
+            fetchMock.addResponse("/dcl/pki/root-certificates", {
+                approvedRootCertificates: { schemaVersion: 0, certs: [] },
+            });
+            fetchMock.install();
+
+            service = new DclCertificateService(environment, { updateInterval: null });
+            await service.construction;
+
+            await service.addCertificate(TestCert_PAA_NoVID_Cert, "PAA", { isProduction: false });
+            await service.addCertificate(CertificationDeclaration.testSignerCertificate(), "CDSigner");
+
+            const result = await DeviceAttestationValidator.validate(buildContext(service), buildData());
+
+            const finding = result.findings.find(f => f.type === DeviceAttestationCheck.TrustedAsTestCertificate);
+            expect(finding).to.not.be.undefined;
+            expect(finding!.level).to.equal("error");
+        });
+
+        it("does NOT emit TrustedAsTestCertificate when service allowsTestCertificates is true", async () => {
+            fetchMock.addResponse("on.dcl.csa-iot.org/dcl/pki/root-certificates", {
+                approvedRootCertificates: { schemaVersion: 0, certs: [] },
+            });
+            fetchMock.addResponse("on.test-net.dcl.csa-iot.org/dcl/pki/root-certificates", {
+                approvedRootCertificates: { schemaVersion: 0, certs: [] },
+            });
+            fetchMock.addResponse(
+                "api.github.com/repos/project-chip/connectedhomeip/contents/credentials/development/paa-root-certs",
+                [],
+            );
+            fetchMock.install();
+
+            service = new DclCertificateService(environment, {
+                updateInterval: null,
+                fetchTestCertificates: true,
+            });
+            await service.construction;
+
+            await service.addCertificate(TestCert_PAA_NoVID_Cert, "PAA", { isProduction: false });
+            await service.addCertificate(CertificationDeclaration.testSignerCertificate(), "CDSigner");
+
+            const result = await DeviceAttestationValidator.validate(buildContext(service), buildData());
+
+            const finding = result.findings.find(f => f.type === DeviceAttestationCheck.TrustedAsTestCertificate);
+            expect(finding).to.be.undefined;
+        });
+
+        it("does NOT emit TrustedAsTestCertificate when the PAA is a production cert", async () => {
+            const dclService = await setupDclService();
+
+            const result = await DeviceAttestationValidator.validate(buildContext(dclService), buildData());
+
+            const finding = result.findings.find(f => f.type === DeviceAttestationCheck.TrustedAsTestCertificate);
+            expect(finding).to.be.undefined;
+        });
+    });
 });

--- a/packages/protocol/test/certificate/DeviceAttestationValidatorTest.ts
+++ b/packages/protocol/test/certificate/DeviceAttestationValidatorTest.ts
@@ -17,7 +17,7 @@ import { TlvAttestation } from "#common/OperationalCredentialsTypes.js";
 import { DclCertificateService } from "#dcl/DclCertificateService.js";
 import { Bytes, Crypto, Environment, MockFetch, MockStorageService, PrivateKey, StandardCrypto } from "@matter/general";
 import { VendorId } from "@matter/types";
-import { pemEncode, setupDclFetchMock } from "./TestHelpers.js";
+import { buildTestCrl, pemEncode, setupDclFetchMock } from "./TestHelpers.js";
 
 describe("DeviceAttestationValidator", () => {
     const crypto = new StandardCrypto();
@@ -680,6 +680,54 @@ describe("DeviceAttestationValidator", () => {
 
             const finding = result.findings.find(f => f.type === DeviceAttestationCheck.TrustedAsTestCertificate);
             expect(finding).to.be.undefined;
+        });
+
+        it("runs revocation against a test-only PAA: a revoked DAC still throws CertificateRevoked", async () => {
+            const dac = Dac.fromAsn1(dacDer);
+            const dacSerial = Bytes.toHex(dac.cert.serialNumber).toUpperCase();
+            const dacAkid = Bytes.toHex(dac.cert.extensions.authorityKeyIdentifier).toUpperCase();
+
+            fetchMock.addResponse("/dcl/pki/root-certificates", {
+                approvedRootCertificates: { schemaVersion: 0, certs: [] },
+            });
+            fetchMock.addResponse(`/dcl/pki/revocation-points/${dacAkid}`, {
+                pkiRevocationDistributionPointsByIssuerSubjectKeyID: {
+                    issuerSubjectKeyID: dacAkid,
+                    points: [
+                        {
+                            vid: 0xfff1,
+                            pid: 0,
+                            isPAA: false,
+                            label: "test-revocation",
+                            crlSignerDelegator: "",
+                            crlSignerCertificate: pemEncode(TestCert_PAA_NoVID_Cert),
+                            issuerSubjectKeyID: dacAkid,
+                            dataURL: "https://example.com/test.crl",
+                            dataFileSize: "",
+                            dataDigest: "",
+                            dataDigestType: 0,
+                            revocationType: 1,
+                            schemaVersion: 0,
+                        },
+                    ],
+                    schemaVersion: 0,
+                },
+            });
+            fetchMock.addResponse("https://example.com/test.crl", buildTestCrl([dacSerial], dac.cert.issuerDer), {
+                binary: true,
+            });
+            fetchMock.install();
+
+            service = new DclCertificateService(environment, { updateInterval: null });
+            await service.construction;
+
+            await service.addCertificate(TestCert_PAA_NoVID_Cert, "PAA", { isProduction: false });
+            await service.addCertificate(CertificationDeclaration.testSignerCertificate(), "CDSigner");
+
+            await expect(DeviceAttestationValidator.validate(buildContext(service), buildData())).to.be.rejectedWith(
+                DeviceAttestationError,
+                /Device Attestation Certificate has been revoked/,
+            );
         });
     });
 });

--- a/packages/protocol/test/dcl/DclCertificateServiceTest.ts
+++ b/packages/protocol/test/dcl/DclCertificateServiceTest.ts
@@ -1817,6 +1817,15 @@ describe("DclCertificateService", () => {
                     svc.getCertificateAsDer(TEST_PAA_NOVID_SKID, { considerTestCertificates: false }),
                 ).to.be.rejectedWith(/Certificate not found/);
             });
+
+            it("getCertificateAsPem returns PEM when override is true", async () => {
+                await seedStorageWithTestPaas();
+                const svc = await openServiceAfterSeed(false);
+
+                await expect(svc.getCertificateAsPem(TEST_PAA_NOVID_SKID)).to.be.rejectedWith(/Certificate not found/);
+                const pem = await svc.getCertificateAsPem(TEST_PAA_NOVID_SKID, { considerTestCertificates: true });
+                expect(pem).to.include("-----BEGIN CERTIFICATE-----");
+            });
         });
     });
 });

--- a/packages/protocol/test/dcl/DclCertificateServiceTest.ts
+++ b/packages/protocol/test/dcl/DclCertificateServiceTest.ts
@@ -1836,6 +1836,33 @@ describe("DclCertificateService", () => {
                     await svc.getOrFetchCertificate(TEST_PAA_NOVID_SKID, { considerTestCertificates: true }),
                 ).to.deep.include({ isProduction: false });
             });
+
+            it("getOrFetchCertificate filters a post-fetch test cert per the considerTestCertificates override", async () => {
+                fetchMock.addResponse(PROD_ROOT_LIST_URL, EMPTY_DCL_CERT_LIST);
+                fetchMock.addResponse(TEST_ROOT_LIST_URL, mockDclRootCertificateList);
+                fetchMock.addResponse(
+                    "on.test-net.dcl.csa-iot.org/dcl/pki/certificates/MDAxGDAWBgNVBAMMD01hdHRlciBUZXN0IFBBQQ%3D%3D/78%3A5C%3AE7%3A05%3AB8%3A6B%3A8F%3A4E%3A6F%3AC7%3A93%3AAA%3A60%3ACB%3A43%3AEA%3A69%3A68%3A82%3AD5",
+                    mockDclCertificateNoVID,
+                );
+                fetchMock.install();
+
+                service = new DclCertificateService(environment, {
+                    fetchTestCertificates: false,
+                    updateInterval: null,
+                });
+                await service.construction;
+
+                expect(service.getCertificate(TEST_PAA_NOVID_SKID, { considerTestCertificates: true })).to.be.undefined;
+
+                expect(await service.getOrFetchCertificate(TEST_PAA_NOVID_SKID, { isProduction: false })).to.be
+                    .undefined;
+                expect(
+                    await service.getOrFetchCertificate(TEST_PAA_NOVID_SKID, {
+                        isProduction: false,
+                        considerTestCertificates: true,
+                    }),
+                ).to.deep.include({ isProduction: false });
+            });
         });
     });
 });

--- a/packages/protocol/test/dcl/DclCertificateServiceTest.ts
+++ b/packages/protocol/test/dcl/DclCertificateServiceTest.ts
@@ -1826,6 +1826,16 @@ describe("DclCertificateService", () => {
                 const pem = await svc.getCertificateAsPem(TEST_PAA_NOVID_SKID, { considerTestCertificates: true });
                 expect(pem).to.include("-----BEGIN CERTIFICATE-----");
             });
+
+            it("getOrFetchCertificate respects the considerTestCertificates override on local hits", async () => {
+                await seedStorageWithTestPaas();
+                const svc = await openServiceAfterSeed(false);
+
+                expect(await svc.getOrFetchCertificate(TEST_PAA_NOVID_SKID)).to.be.undefined;
+                expect(
+                    await svc.getOrFetchCertificate(TEST_PAA_NOVID_SKID, { considerTestCertificates: true }),
+                ).to.deep.include({ isProduction: false });
+            });
         });
     });
 });

--- a/packages/protocol/test/dcl/DclCertificateServiceTest.ts
+++ b/packages/protocol/test/dcl/DclCertificateServiceTest.ts
@@ -1799,6 +1799,24 @@ describe("DclCertificateService", () => {
                 expect(svc.getCertificate(TEST_PAA_NOVID_SKID)).to.not.be.undefined;
                 expect(svc.getCertificate(TEST_PAA_NOVID_SKID, { considerTestCertificates: false })).to.be.undefined;
             });
+
+            it("getCertificateAsDer returns DER when override is true", async () => {
+                await seedStorageWithTestPaas();
+                const svc = await openServiceAfterSeed(false);
+
+                await expect(svc.getCertificateAsDer(TEST_PAA_NOVID_SKID)).to.be.rejectedWith(/Certificate not found/);
+                const der = await svc.getCertificateAsDer(TEST_PAA_NOVID_SKID, { considerTestCertificates: true });
+                expect(der.byteLength).to.be.greaterThan(0);
+            });
+
+            it("getCertificateAsDer throws when explicit override is false even if fetchTestCertificates is on", async () => {
+                await seedStorageWithTestPaas();
+                const svc = await openServiceAfterSeed(true);
+
+                await expect(
+                    svc.getCertificateAsDer(TEST_PAA_NOVID_SKID, { considerTestCertificates: false }),
+                ).to.be.rejectedWith(/Certificate not found/);
+            });
         });
     });
 });

--- a/packages/protocol/test/dcl/DclCertificateServiceTest.ts
+++ b/packages/protocol/test/dcl/DclCertificateServiceTest.ts
@@ -1681,12 +1681,23 @@ describe("DclCertificateService", () => {
         const TEST_PAA_NOVID_SKID = "785CE705B86B8F4E6FC793AA60CB43EA696882D5";
         const TEST_PAA_FFF1_SKID = "6AFD22771F511FECBF1641976710DCDC31A1717E";
 
+        const EMPTY_DCL_CERT_LIST = { approvedRootCertificates: { schemaVersion: 0, certs: [] } };
+        const PROD_ROOT_LIST_URL = "on.dcl.csa-iot.org/dcl/pki/root-certificates";
+        const TEST_ROOT_LIST_URL = "on.test-net.dcl.csa-iot.org/dcl/pki/root-certificates";
+        const GITHUB_PAA_DIR_URL =
+            "api.github.com/repos/project-chip/connectedhomeip/contents/credentials/development/paa-root-certs";
+
+        let service: DclCertificateService | undefined;
+
+        afterEach(async () => {
+            await service?.close();
+            service = undefined;
+        });
+
         // Set up storage with two test PAAs cached from a prior `fetchTestCertificates: true` run.
         async function seedStorageWithTestPaas() {
-            fetchMock.addResponse("on.dcl.csa-iot.org/dcl/pki/root-certificates", {
-                approvedRootCertificates: { schemaVersion: 0, certs: [] },
-            });
-            fetchMock.addResponse("on.test-net.dcl.csa-iot.org/dcl/pki/root-certificates", mockDclRootCertificateList);
+            fetchMock.addResponse(PROD_ROOT_LIST_URL, EMPTY_DCL_CERT_LIST);
+            fetchMock.addResponse(TEST_ROOT_LIST_URL, mockDclRootCertificateList);
             fetchMock.addResponse(
                 "on.test-net.dcl.csa-iot.org/dcl/pki/certificates/MDAxGDAWBgNVBAMMD01hdHRlciBUZXN0IFBBQQ%3D%3D/78%3A5C%3AE7%3A05%3AB8%3A6B%3A8F%3A4E%3A6F%3AC7%3A93%3AAA%3A60%3ACB%3A43%3AEA%3A69%3A68%3A82%3AD5",
                 mockDclCertificateNoVID,
@@ -1695,10 +1706,7 @@ describe("DclCertificateService", () => {
                 "on.test-net.dcl.csa-iot.org/dcl/pki/certificates/MDAEFjAUBgorBgEEAYKefAIBDARGRkYx/6A%3AFD%3A22%3A77%3A1F%3A51%3A1F%3AEC%3ABF%3A16%3A41%3A97%3A67%3A10%3ADC%3ADC%3A31%3AA1%3A71%3A7E",
                 mockDclCertificateFFF1,
             );
-            fetchMock.addResponse(
-                "api.github.com/repos/project-chip/connectedhomeip/contents/credentials/development/paa-root-certs",
-                [],
-            );
+            fetchMock.addResponse(GITHUB_PAA_DIR_URL, []);
             fetchMock.install();
 
             const seed = new DclCertificateService(environment, { fetchTestCertificates: true });
@@ -1711,70 +1719,51 @@ describe("DclCertificateService", () => {
             fetchMock = new MockFetch();
         }
 
-        it("hides cached test certificates from getCertificate when fetchTestCertificates is disabled", async () => {
-            await seedStorageWithTestPaas();
-
-            // Reopen with test fetching disabled — cached test certs must not surface.
-            fetchMock.addResponse("on.dcl.csa-iot.org/dcl/pki/root-certificates", {
-                approvedRootCertificates: { schemaVersion: 0, certs: [] },
-            });
+        // Open the service after seeding. Mocks empty DCL endpoints so the construction-time
+        // update completes without populating the store. The caller-supplied `fetchTestCertificates`
+        // flag determines which endpoints are reached and therefore which mocks are required.
+        async function openServiceAfterSeed(fetchTestCertificates: boolean) {
+            fetchMock.addResponse(PROD_ROOT_LIST_URL, EMPTY_DCL_CERT_LIST);
+            if (fetchTestCertificates) {
+                fetchMock.addResponse(TEST_ROOT_LIST_URL, EMPTY_DCL_CERT_LIST);
+                fetchMock.addResponse(GITHUB_PAA_DIR_URL, []);
+            }
             fetchMock.install();
 
-            const service = new DclCertificateService(environment, { fetchTestCertificates: false });
+            service = new DclCertificateService(environment, { fetchTestCertificates });
             await service.construction;
+            return service;
+        }
 
-            expect(service.getCertificate(TEST_PAA_NOVID_SKID)).to.be.undefined;
-            expect(service.getCertificate(TEST_PAA_FFF1_SKID)).to.be.undefined;
+        it("hides cached test certificates from getCertificate when fetchTestCertificates is disabled", async () => {
+            await seedStorageWithTestPaas();
+            const svc = await openServiceAfterSeed(false);
+
+            expect(svc.getCertificate(TEST_PAA_NOVID_SKID)).to.be.undefined;
+            expect(svc.getCertificate(TEST_PAA_FFF1_SKID)).to.be.undefined;
             // Raw enumeration still exposes the cached entries for management commands.
-            expect(service.certificates.length).to.equal(2);
-
-            await service.close();
+            expect(svc.certificates.length).to.equal(2);
         });
 
         it("returns cached test certificates again when fetchTestCertificates is re-enabled", async () => {
             await seedStorageWithTestPaas();
+            const svc = await openServiceAfterSeed(true);
 
-            fetchMock.addResponse("on.dcl.csa-iot.org/dcl/pki/root-certificates", {
-                approvedRootCertificates: { schemaVersion: 0, certs: [] },
-            });
-            fetchMock.addResponse("on.test-net.dcl.csa-iot.org/dcl/pki/root-certificates", {
-                approvedRootCertificates: { schemaVersion: 0, certs: [] },
-            });
-            fetchMock.addResponse(
-                "api.github.com/repos/project-chip/connectedhomeip/contents/credentials/development/paa-root-certs",
-                [],
-            );
-            fetchMock.install();
-
-            const service = new DclCertificateService(environment, { fetchTestCertificates: true });
-            await service.construction;
-
-            expect(service.getCertificate(TEST_PAA_NOVID_SKID)?.isProduction).to.be.false;
-            expect(service.getCertificate(TEST_PAA_FFF1_SKID)?.isProduction).to.be.false;
-
-            await service.close();
+            expect(svc.getCertificate(TEST_PAA_NOVID_SKID)?.isProduction).to.be.false;
+            expect(svc.getCertificate(TEST_PAA_FFF1_SKID)?.isProduction).to.be.false;
         });
 
         it("rejects DER/PEM lookups for hidden test certificates", async () => {
             await seedStorageWithTestPaas();
+            const svc = await openServiceAfterSeed(false);
 
-            fetchMock.addResponse("on.dcl.csa-iot.org/dcl/pki/root-certificates", {
-                approvedRootCertificates: { schemaVersion: 0, certs: [] },
-            });
-            fetchMock.install();
-
-            const service = new DclCertificateService(environment, { fetchTestCertificates: false });
-            await service.construction;
-
-            await expect(service.getCertificateAsDer(TEST_PAA_NOVID_SKID)).to.be.rejectedWith(/Certificate not found/);
-            await expect(service.getCertificateAsPem(TEST_PAA_NOVID_SKID)).to.be.rejectedWith(/Certificate not found/);
-
-            await service.close();
+            await expect(svc.getCertificateAsDer(TEST_PAA_NOVID_SKID)).to.be.rejectedWith(/Certificate not found/);
+            await expect(svc.getCertificateAsPem(TEST_PAA_NOVID_SKID)).to.be.rejectedWith(/Certificate not found/);
         });
 
         it("does not affect production certificates", async () => {
             // Seed a production cert (no test fetching needed).
-            fetchMock.addResponse("on.dcl.csa-iot.org/dcl/pki/root-certificates", mockDclRootCertificateList);
+            fetchMock.addResponse(PROD_ROOT_LIST_URL, mockDclRootCertificateList);
             fetchMock.addResponse(
                 "on.dcl.csa-iot.org/dcl/pki/certificates/MDAxGDAWBgNVBAMMD01hdHRlciBUZXN0IFBBQQ%3D%3D/78%3A5C%3AE7%3A05%3AB8%3A6B%3A8F%3A4E%3A6F%3AC7%3A93%3AAA%3A60%3ACB%3A43%3AEA%3A69%3A68%3A82%3AD5",
                 mockDclCertificateNoVID,
@@ -1785,13 +1774,31 @@ describe("DclCertificateService", () => {
             );
             fetchMock.install();
 
-            const service = new DclCertificateService(environment, { fetchTestCertificates: false });
+            service = new DclCertificateService(environment, { fetchTestCertificates: false });
             await service.construction;
 
             expect(service.getCertificate(TEST_PAA_NOVID_SKID)?.isProduction).to.be.true;
             expect(service.getCertificate(TEST_PAA_FFF1_SKID)?.isProduction).to.be.true;
+        });
 
-            await service.close();
+        describe("considerTestCertificates per-call override", () => {
+            it("returns cached test certificate when override is true and fetchTestCertificates is disabled", async () => {
+                await seedStorageWithTestPaas();
+                const svc = await openServiceAfterSeed(false);
+
+                expect(svc.getCertificate(TEST_PAA_NOVID_SKID)).to.be.undefined;
+                expect(svc.getCertificate(TEST_PAA_NOVID_SKID, { considerTestCertificates: true })).to.deep.include({
+                    isProduction: false,
+                });
+            });
+
+            it("filters cached test certificate when override is false even if fetchTestCertificates is enabled", async () => {
+                await seedStorageWithTestPaas();
+                const svc = await openServiceAfterSeed(true);
+
+                expect(svc.getCertificate(TEST_PAA_NOVID_SKID)).to.not.be.undefined;
+                expect(svc.getCertificate(TEST_PAA_NOVID_SKID, { considerTestCertificates: false })).to.be.undefined;
+            });
         });
     });
 });


### PR DESCRIPTION
## Summary

- Add per-call `considerTestCertificates` option to all four public `DclCertificateService` getters (`getCertificate`, `getCertificateAsDer`, `getCertificateAsPem`, `getOrFetchCertificate`) so the device attestation validator can probe test PAAs without flipping the service-wide trust policy. New `allowsTestCertificates` accessor exposes the service's policy flag.
- Device attestation validator now emits a new `TrustedAsTestCertificate` error-level finding (instead of throwing `PaaNotTrusted`) when the only matching PAA in the trust store is a test/development certificate and the service's `fetchTestCertificates` is off. Full validation (chain signatures, expiry, revocation, CD checks) still runs against the test PAA; the consolidated findings array reaches the caller via the existing `onFailure` callback.
- Widen `OnAttestationFailure` callback return contract. The function form may now return `string` (rejects with `new CommissioningError(reason, { cause: underlyingError })`) or throw any error (propagates verbatim). Boolean / undefined behavior is unchanged.

## Behavior shift to call out

Previously a device whose PAA was cached locally as a test cert and whose service was configured for production-only trust would fail commissioning with `PaaNotTrusted`. After this change, validation completes and the application receives a `TrustedAsTestCertificate` error finding through the existing `onFailure` callback. **Applications that default-accept findings (`onFailure === true` or `undefined`) will now silently commission these devices unless they upgrade their policy.** Configure `onFailure: false` or a function callback to reject `TrustedAsTestCertificate` if you want production-only trust.

Internal fix: split the single try/catch around `DeviceAttestationValidator.validate()` so a callback that throws `DeviceAttestationError` on the success path (collected findings) propagates verbatim instead of being re-caught and re-invoking the callback with a fabricated finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)