### PR TITLE
feat(logging): standardize log levels across packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 ## __WORK IN PROGRESS__
 
+- @matter/\*
+    - Enhancement: Standardized log levels across all packages against a new logging guideline (see `docs/LOGGING.md`)
+
 - @matter/general
     - Fix: `causedBy`/`asError`/`errorOf`/`repackErrorAs` no longer crash with "undefined is not an object" when invoked with `undefined`/`null` as error object
 

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -1,0 +1,164 @@
+# Logging Levels
+
+How to choose a log level in matter.js. The goal is consistency: the same kind of
+event should always land on the same level, and each level should mean one thing.
+
+matter.js is a library. Its logs are read by two audiences:
+
+- **Developers / integrators** diagnosing behavior — mostly at `debug`, sometimes `info`.
+- **Operators / end users** running a deployment — at `notice` and above by default.
+
+## The six levels
+
+| Level    | Value | Audience        | One-line meaning                                             |
+| -------- | ----- | --------------- | ------------------------------------------------------------ |
+| `debug`  | 0     | developer       | Full internal detail.                                        |
+| `info`   | 1     | developer/ops   | Normal narrative + dev-relevant hints.                       |
+| `notice` | 2     | operator/user   | Operator-significant event, within normal operation.         |
+| `warn`   | 3     | operator/user   | Anomaly contained to a single operation.                     |
+| `error`  | 4     | operator/user   | A whole feature/subsystem is broken.                         |
+| `fatal`  | 5     | operator/user   | The runtime itself cannot continue.                          |
+
+## Two questions decide the level
+
+The scheme uses **one discriminator per boundary**, so each border is a single yes/no.
+
+**1. Audience gate — who is this for?**
+
+- For a developer reading internals → `debug`, or `info` if it is normal high-level
+  progress worth seeing during active monitoring.
+- For an operator/user running the system → `notice` and above.
+
+**2. Blast radius — within the user-facing band, how much is affected?**
+
+- One operation → `warn`
+- A whole feature/subsystem → `error`
+- The whole runtime → `fatal`
+
+Blast radius decides severity **within** the anomaly band (`warn`/`error`/`fatal`); it is
+not affected by "who must fix it." The **`notice`↔`warn` border is the exception**: there
+the question is whether the condition implies someone (developer / user / config) should
+investigate or fix it. If nobody can — the cause is external/operational, or we
+auto-recover on a known schedule, and it is handled — it is not a `warn`.
+
+Two more levers shape the result:
+
+- **Volume.** High-frequency or environmentally-caused conditions drop a level to avoid
+  spam: a per-operation anomaly that can fire in bulk (wrong network interface, session
+  churn) belongs at `info`/`debug`, not `warn`/`notice` — unless a single occurrence
+  explains a user-observable symptom, in which case keep it at `notice` (de-duplicated).
+- **Audience.** `debug`/`info` are for developers; `notice`+ are seen by operators.
+
+```
+DEBUG → INFO   : pure wire/diagnostic detail  vs  worth a dev seeing on a healthy run
+INFO  → NOTICE : dev-facing / high-volume     vs  operator-significant, lower-volume
+NOTICE→ WARN   : nobody-can-fix, handled      vs  someone should investigate/fix
+WARN  → ERROR  : single operation             vs  whole feature/subsystem
+ERROR → FATAL  : a feature dead               vs  the whole runtime dead
+```
+
+## Per-level definitions
+
+### `fatal` (5)
+
+The owning runtime/process/node cannot continue and will stop (or already stopped).
+Whole-instance death.
+
+- **Test:** after this, does this runtime keep doing useful work? If no → `fatal`.
+- Reserve it. If anything keeps running, it is `error`. A single dead node in a
+  multi-node server is `error`, not `fatal`.
+- Examples: an unhandled error reaching the top-level reporter; the shared storage
+  backend corrupt or unwritable so nothing can persist; a required network/FS
+  permission denied at startup so the service cannot run.
+
+### `error` (4)
+
+A whole feature or subsystem is broken and stays broken until someone (the integrating
+developer or the operator) acts. matter.js cannot fix it itself. Blast radius is a
+functionality, not the process.
+
+- Examples: a node fails to come up; API misuse that disables a capability; an
+  OS/environment error that kills a subsystem but not the process.
+- Persistent broad degradation lands here once the user is left with a broken
+  experience — even when the root cause is external and we keep retrying.
+
+### `warn` (3)
+
+Something anomalous happened, contained to a single operation, and either recovered or
+failed without taking down the surrounding feature. It hints at a latent problem worth
+a look.
+
+- Examples: a transient socket send failure on one message; a DCL rate-limit we backed
+  off from; one command rejected for malformed input; a retryable timeout.
+- Border to `error` = blast radius. Border to `notice` = **does it imply someone should
+  investigate or fix it?** If nobody can (external/operational, or we auto-recover on a
+  schedule) and it is handled, it drops to `notice` — or to `info` if it is high-volume
+  or purely dev-diagnostic.
+
+### `notice` (2)
+
+An operationally significant event the operator should see **even at reduced production
+verbosity**, within matter.js's normal operating envelope, where **no fix by us, the
+developer, or the user is implied** — because nothing is wrong, the cause is
+external/operational, or we auto-recover on a known schedule. Use it also for a handled
+condition that **explains a user-observable symptom** (e.g. dropped events) so the cause
+is visible.
+
+- Examples: node commissioned/decommissioned; fabric added/removed; subscription
+  created/cancelled; a commissioning attempt the device legitimately rejected (wrong
+  passcode); an announce/update that failed but will be retried on schedule; events
+  dropped because a cluster is unmodeled (de-duplicated).
+- **Significance- and volume-gated.** Not every state change is `notice`. High-frequency
+  operational traffic — e.g. sessions establishing/ending — belongs at `info`; reserve
+  `notice` for rarer, operator-significant lifecycle (commissioning, fabric/identity,
+  subscriptions).
+- **Not for internal process or control-flow mechanism** (a failsafe timer expiring, a
+  retry limit reached, a reconnect attempt) → `debug`/`info`. Log the operator-relevant
+  *outcome* at `notice`; the mechanism lower.
+
+### `info` (1)
+
+The normal-operation narrative plus anything a developer should be able to see on a
+healthy run without dropping to `debug`:
+
+- High-level progress and lifecycle (sessions establishing/ending, connection steps).
+- **Dev-actionable hints** — e.g. a performance note worth acting on.
+- **Known/handled conditions we cannot fix** that are too frequent for `notice` but should
+  not be buried in `debug` — e.g. a CASE session that fails because the peer is not on our
+  fabric (the controller's choice; we handle it, but a developer asking "why won't this
+  device connect?" needs to see it).
+- **Test:** would an operator running at `notice` want every one of these? If no, but a
+  developer watching a healthy system would → `info`.
+
+### `debug` (0)
+
+Pure internal/diagnostic detail: wire traffic, state transitions, internal decisions, and
+**routine protocol mechanics** (status responses, BUSY, retransmits, acks) that need no
+developer attention. The default home for high-volume "expected" noise. (A handled
+operation-level failure a developer may need to explain behavior belongs at `info`, not
+here.)
+
+## Cross-cutting practices
+
+These are best practice in all new code. Their status as *binding* (must-fix in existing
+code) is still under review.
+
+1. **The level reflects how the code HANDLES the situation, not how scary the underlying
+   error looks.** A transient timeout we retry is `warn`, even though "timeout" sounds
+   bad.
+2. **Log where you handle/swallow, not where you throw or rethrow.** No log-and-throw —
+   that double-reports, and the caller owns the severity decision.
+3. **One event → one line at one level.** Don't re-log the same failure at each stack
+   frame.
+4. **Routine protocol mechanics** (status responses, BUSY, retransmits) are `debug`, never
+   `warn`+. A handled operation-level failure a developer may need to explain behavior can
+   sit at `info`.
+5. **Attach the error/cause object when it adds diagnostic value.** A message alone is fine
+   when the cause object adds nothing.
+6. **Phrase for the audience.** A `notice`+ line is read by users — clear, no internal
+   jargon. A `debug`/`info` line may use developer shorthand.
+7. **Volume is a downgrade lever.** Drop high-frequency or environmentally-caused
+   conditions to `info`/`debug` to avoid spam — unless a single occurrence explains a
+   user-observable symptom (then `notice`, de-duplicated).
+8. **Shutdown path.** Failures while the runtime is intentionally shutting down are at most
+   `warn` — nothing meaningful is broken.

--- a/packages/general/src/environment/RuntimeService.ts
+++ b/packages/general/src/environment/RuntimeService.ts
@@ -281,7 +281,7 @@ export class RuntimeService {
 
     #crash(cause?: Error) {
         if (cause) {
-            logger.error(cause);
+            logger.fatal(cause);
         }
         this.crashed.emit(cause);
         this.cancel();

--- a/packages/general/src/fs/FileHandleTracker.ts
+++ b/packages/general/src/fs/FileHandleTracker.ts
@@ -24,7 +24,7 @@ export namespace FileHandleTracker {
     const openHandles = new Set<WeakRef<File.Handle>>();
 
     const registry = new FinalizationRegistry<HandleInfo>(info => {
-        logger.error(`File handle GC'd without close: "${info.purpose}" for ${info.path}`);
+        logger.warn(`File handle GC'd without close: "${info.purpose}" for ${info.path}`);
     });
 
     /**

--- a/packages/general/src/net/dns-sd/DnssdSolicitor.ts
+++ b/packages/general/src/net/dns-sd/DnssdSolicitor.ts
@@ -260,7 +260,7 @@ export class QueryMulticaster implements DnssdSolicitor {
                     }),
                 );
             } catch (e) {
-                logger.error("Unhandled error soliciting DNS-SD names:", e);
+                logger.warn("Unhandled error soliciting DNS-SD names:", e);
             }
         }
     }

--- a/packages/general/src/net/dns-sd/IpServiceStatus.ts
+++ b/packages/general/src/net/dns-sd/IpServiceStatus.ts
@@ -138,7 +138,7 @@ export class IpServiceStatus {
                 if (!this.#connecting.size) {
                     this.#connectionInitiatedAt = undefined;
                 }
-                logger.error(this.#service.via, "Connection error:", asError(error));
+                logger.warn(this.#service.via, "Connection error:", asError(error));
                 this.isReachable = false;
             },
         );

--- a/packages/general/src/net/http/HttpEndpointGroup.ts
+++ b/packages/general/src/net/http/HttpEndpointGroup.ts
@@ -36,7 +36,7 @@ export class HttpEndpointGroup implements HttpEndpoint {
         try {
             await MatterAggregateError.allSettled(this.#endpoints.map(endpoint => endpoint.close()));
         } catch (e) {
-            logger.error("Error closing HTTP endpoints", e);
+            logger.warn("Error closing HTTP endpoints", e);
         }
         this.#endpoints = [];
     }

--- a/packages/general/src/net/http/HttpSharedEndpoint.ts
+++ b/packages/general/src/net/http/HttpSharedEndpoint.ts
@@ -44,7 +44,7 @@ export class HttpSharedEndpoint {
                     try {
                         await (await this.#target)?.close();
                     } catch (e) {
-                        logger.error("Error closing HTTP endpoint", e);
+                        logger.warn("Error closing HTTP endpoint", e);
                     } finally {
                         this.#target = undefined;
                     }

--- a/packages/general/src/storage/StorageService.ts
+++ b/packages/general/src/storage/StorageService.ts
@@ -605,7 +605,7 @@ export class StorageService {
                 const skipNote =
                     result.otherTypeKeysSkipped > 0 ? `, ${result.otherTypeKeysSkipped} non-matching keys skipped` : "";
                 if (result.success) {
-                    logger.info(
+                    logger.notice(
                         `${label} migration complete: ${result.migratedCount} migrated, ${result.skippedCount} skipped${skipNote}`,
                     );
                 } else {

--- a/packages/general/src/transaction/Tx.ts
+++ b/packages/general/src/transaction/Tx.ts
@@ -96,7 +96,7 @@ class Tx implements Transaction, Transaction.Finalization {
                 break;
 
             default:
-                logger.error(this.via, "Disposed", this.via, "while", this.status);
+                logger.warn(this.via, "Disposed", this.via, "while", this.status);
                 break;
         }
 
@@ -348,7 +348,7 @@ class Tx implements Transaction, Transaction.Finalization {
             throw cause;
         }
 
-        logger.error("Rolling back", this.via, "due to error:", Diagnostic.weak(asError(cause).message));
+        logger.warn("Rolling back", this.via, "due to error:", Diagnostic.weak(asError(cause).message));
 
         try {
             const result = this.rollback();
@@ -530,7 +530,7 @@ class Tx implements Transaction, Transaction.Finalization {
         let cycles = 1;
 
         const errorRollback = (error?: any) => {
-            logger.error(
+            logger.warn(
                 "Rolling back",
                 this.via,
                 "due to pre-commit error:",
@@ -655,7 +655,7 @@ class Tx implements Transaction, Transaction.Finalization {
         let asyncCommits: undefined | Promise<void>[];
         for (const participant of this.participants) {
             const handleParticipantError = (error: any) => {
-                logger.error(`Error committing ${participant} (phase one):`, error);
+                logger.warn(`Error committing ${participant} (phase one):`, error);
                 needRollback = true;
             };
 

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -382,7 +382,7 @@ export class PairedNode {
                 if (this.#options.autoSubscribe === false) {
                     // No subscription desired -- do a one-time wildcard read to populate state
                     this.#initializeWithRead().catch(error => {
-                        logger.info(this.#peerAddress, `Error during read-only initialization`, error);
+                        logger.warn(this.#peerAddress, `Error during read-only initialization`, error);
                     });
                 } else {
                     // Activate the sustained subscription on NetworkClient
@@ -496,7 +496,7 @@ export class PairedNode {
         try {
             await this.#commissioningController.validateAndUpdateFabricLabel(this.nodeId);
         } catch (error) {
-            logger.info(this.#peerAddress, `Error updating fabric label`, error);
+            logger.warn(this.#peerAddress, `Error updating fabric label`, error);
         }
     }
 
@@ -515,7 +515,7 @@ export class PairedNode {
         }
         if (this.#options.autoSubscribe === false) {
             this.#initializeWithRead().catch(error => {
-                logger.info(this.#peerAddress, `Error during read-only initialization`, error);
+                logger.warn(this.#peerAddress, `Error during read-only initialization`, error);
             });
         } else {
             this.#activateSubscription();
@@ -768,7 +768,7 @@ export class PairedNode {
                 try {
                     await this.#commissioningController.validateAndUpdateFabricLabel(this.nodeId);
                 } catch (error) {
-                    logger.info(this.#peerAddress, `Error updating fabric label`, error);
+                    logger.warn(this.#peerAddress, `Error updating fabric label`, error);
                 }
             }
         } else if (this.#connectionState === NodeStates.Connected) {
@@ -904,13 +904,13 @@ export class PairedNode {
             return;
         }
         if (!this.#clientNode.endpoints.has(endpointId)) {
-            logger.info(this.#peerAddress, `Endpoint ${endpointId} not found on node. Ignoring endpoint ...`);
+            logger.debug(this.#peerAddress, `Endpoint ${endpointId} not found on node. Ignoring endpoint ...`);
             return;
         }
         const endpoint = this.#clientNode.endpoints.for(endpointId);
         const descriptorData = endpoint.maybeStateOf(DescriptorClient);
         if (descriptorData === undefined) {
-            logger.info(`Descriptor data for endpoint ${endpointId} not found in structure! Ignoring endpoint ...`);
+            logger.debug(`Descriptor data for endpoint ${endpointId} not found in structure! Ignoring endpoint ...`);
             return;
         }
         collectedData.set(endpointId, endpoint);
@@ -1170,7 +1170,7 @@ export class PairedNode {
             return deviceTypeDefinition;
         });
         if (deviceTypes.length === 0) {
-            logger.info(this.#peerAddress, `No device type found for endpoint ${endpointId}, ignore`);
+            logger.debug(this.#peerAddress, `No device type found for endpoint ${endpointId}, ignore`);
             throw new MatterError(`NodeId ${this.nodeId}: No device type found for endpoint`);
         }
 

--- a/packages/node/src/behavior/Events.ts
+++ b/packages/node/src/behavior/Events.ts
@@ -159,7 +159,7 @@ export class OnlineEvent<T extends any[] = any[], S extends ValueModel = ValueMo
     #occurrenceTrigger?: (payload: any) => void;
 
     protected override handleError(error: Error, observer: Observer) {
-        logger.error(`Error in ${descriptionOf(this, observer)}`, error);
+        logger.warn(`Error in ${descriptionOf(this, observer)}`, error);
     }
 
     constructor(schema: S, owner: Events) {

--- a/packages/node/src/behavior/context/server/LocalActorContext.ts
+++ b/packages/node/src/behavior/context/server/LocalActorContext.ts
@@ -67,7 +67,7 @@ export const LocalActorContext = {
         // Must fire after commit but before transaction disposal so datasource references remain valid.
         context.transaction.onShared(() => {
             function handleErr(err: unknown) {
-                logger.error("interactionComplete observer failed", Diagnostic.error(err));
+                logger.warn("interactionComplete observer failed", Diagnostic.error(err));
             }
             if (interactionComplete.isObserved) {
                 try {

--- a/packages/node/src/behavior/context/server/RemoteActorContext.ts
+++ b/packages/node/src/behavior/context/server/RemoteActorContext.ts
@@ -186,7 +186,7 @@ export function RemoteActorContext(options: RemoteActorContext.Options) {
                 exchange.closing.off(notifyInteractionComplete);
                 exchangeCompleteEvents.delete(exchange);
                 function handleErr(err: unknown) {
-                    logger.error("interactionComplete observer failed", Diagnostic.error(err));
+                    logger.warn("interactionComplete observer failed", Diagnostic.error(err));
                 }
                 if (context.interactionComplete?.isObserved) {
                     try {

--- a/packages/node/src/behavior/internal/BehaviorBacking.ts
+++ b/packages/node/src/behavior/internal/BehaviorBacking.ts
@@ -329,7 +329,7 @@ export abstract class BehaviorBacking {
                 MaybePromise.then(
                     () => behavior?.[Symbol.asyncDispose](),
                     undefined,
-                    e => logger.error(`Destroying ${this}:`, e),
+                    e => logger.warn(`Destroying ${this}:`, e),
                 ),
             () => this.#events?.[Symbol.dispose](),
         );

--- a/packages/node/src/behavior/state/managed/Datasource.ts
+++ b/packages/node/src/behavior/state/managed/Datasource.ts
@@ -424,7 +424,7 @@ class DatasourceImpl implements Datasource, Datasource.ExternallyMutableStore.Co
         const location = this.location;
 
         function handleObserverError(error: any) {
-            logger.error(`Error in ${location.path} observer:`, error);
+            logger.warn(`Error in ${location.path} observer:`, error);
         }
 
         if (this.events?.interactionEnd?.isObserved) {
@@ -602,7 +602,7 @@ class RootReference implements ValReference<Val.Struct>, Transaction.Participant
                 try {
                     this.rollback();
                 } catch (e) {
-                    logger.error(
+                    logger.warn(
                         `Error resetting reference to ${this.#internals.location.path} after reset of transaction ${transaction.via}:`,
                         e,
                     );
@@ -654,7 +654,7 @@ class RootReference implements ValReference<Val.Struct>, Transaction.Participant
                 this.#expired = true;
                 this.#refreshSubrefs();
             } catch (e) {
-                logger.error(
+                logger.warn(
                     `Error detaching reference to ${this.#internals.location.path} from closed transaction ${transaction.via}:`,
                     e,
                 );
@@ -893,7 +893,7 @@ class RootReference implements ValReference<Val.Struct>, Transaction.Participant
             if (emitBegin && this.#internals.events?.interactionBegin?.isObserved) {
                 const location = this.#internals.location;
                 function handleBeginObserverError(error: any) {
-                    logger.error(`Error in ${location.path} observer:`, error);
+                    logger.warn(`Error in ${location.path} observer:`, error);
                 }
                 try {
                     const result = this.#internals.events?.interactionBegin?.emit(this.#session);

--- a/packages/node/src/behavior/system/controller/discovery/ParallelPaseDiscovery.ts
+++ b/packages/node/src/behavior/system/controller/discovery/ParallelPaseDiscovery.ts
@@ -131,7 +131,7 @@ export abstract class ParallelPaseDiscovery<W> extends Discovery<W> {
                     logger.debug("Failed parallel commissioning attempt:", Diagnostic.errorMessage(error));
                 } else {
                     this.#attemptErrors.push(error);
-                    logger.info("Unexpected error from parallel commissioning attempt:", error);
+                    logger.warn("Unexpected error from parallel commissioning attempt:", error);
                 }
                 return undefined;
             })
@@ -162,7 +162,7 @@ export abstract class ParallelPaseDiscovery<W> extends Discovery<W> {
             // Await loser cleanup (canceled PASE sessions, etc.).  All losers resolve to undefined
             // so rejections here would indicate an unexpected bug — log but don't mask the winner error.
             await MatterAggregateError.allSettled([...this.#pending], this.cleanupLabel).catch(error => {
-                logger.error("Unexpected error during parallel attempt cleanup:", error);
+                logger.warn("Unexpected error during parallel attempt cleanup:", error);
             });
         }
 

--- a/packages/node/src/behavior/system/http/HttpInterface.ts
+++ b/packages/node/src/behavior/system/http/HttpInterface.ts
@@ -286,14 +286,14 @@ function adaptError(e: unknown) {
 }
 
 function logSuccess(request: Request, response: Response) {
-    logger.notice(diagnosticHeaderFor(request, response));
+    logger.info(diagnosticHeaderFor(request, response));
 }
 
 function logError(request: Request, response: Response, error: unknown) {
     if (response.status >= 500 && response.status < 600) {
-        logger.error(diagnosticHeaderFor(request, response), error);
+        logger.warn(diagnosticHeaderFor(request, response), error);
     } else if (error instanceof MatterError) {
-        logger.error(diagnosticHeaderFor(request, response), Diagnostic.errorMessage(error), error.message);
+        logger.warn(diagnosticHeaderFor(request, response), Diagnostic.errorMessage(error));
     } else {
         logger.warn(diagnosticHeaderFor(request, response), asError(error).message);
     }

--- a/packages/node/src/behavior/system/network/ServerNetworkRuntime.ts
+++ b/packages/node/src/behavior/system/network/ServerNetworkRuntime.ts
@@ -172,7 +172,7 @@ export class ServerNetworkRuntime extends NetworkRuntime {
                 );
             } catch (error) {
                 NoAddressAvailableError.accept(error);
-                logger.info(`IPv6 UDP interface not created because IPv6 is not available, but required by Matter.`);
+                logger.warn(`IPv6 UDP interface not created because IPv6 is not available, but required by Matter.`);
                 throw error;
             }
 

--- a/packages/node/src/behavior/system/remote/RemoteInterface.ts
+++ b/packages/node/src/behavior/system/remote/RemoteInterface.ts
@@ -105,7 +105,7 @@ export abstract class RemoteInterface {
         try {
             await this.stop();
         } catch (e) {
-            logger.error(`Error terminating API endpoint ${this.address}`);
+            logger.error(`Error terminating API endpoint ${this.address}`, e);
         }
     }
 

--- a/packages/node/src/behavior/system/software-update/OtaAnnouncements.ts
+++ b/packages/node/src/behavior/system/software-update/OtaAnnouncements.ts
@@ -144,7 +144,7 @@ export class OtaAnnouncements {
             this.#currentAnnouncementPromise = this.#announceOtaProvider(peerAddress);
             await this.#currentAnnouncementPromise;
         } catch (error) {
-            logger.error(`Error announcing OTA provider to ${peerAddress}`, error);
+            logger.warn(`Error announcing OTA provider to ${peerAddress}`, error);
         } finally {
             this.#currentAnnouncementPromise = undefined;
         }
@@ -207,7 +207,7 @@ export class OtaAnnouncements {
                 // the device when there is any update. So let's not do this here automatically.
             } catch (error) {
                 // Just log, if anything failed, we try again in 24h
-                logger.info("Could not set default OTA provider", error);
+                logger.notice("Could not set default OTA provider", error);
             }
         }
     }

--- a/packages/node/src/behavior/system/software-update/SoftwareUpdateManager.ts
+++ b/packages/node/src/behavior/system/software-update/SoftwareUpdateManager.ts
@@ -221,7 +221,7 @@ export class SoftwareUpdateManager extends Behavior {
         try {
             await this.#checkAvailableUpdates();
         } catch (error) {
-            logger.error(`Error during initial OTA update check:`, error);
+            logger.notice(`Error during initial OTA update check:`, error);
         }
 
         this.internal.checkForUpdateTimer.stop();
@@ -822,7 +822,7 @@ export class SoftwareUpdateManager extends Behavior {
         const nextEntry = this.internal.updateQueue[0];
         if (nextEntry) {
             this.#triggerUpdateOnNode(nextEntry).catch(error => {
-                logger.error(`Error while triggering OTA update on node ${nextEntry.peerAddress.toString()}:`, error);
+                logger.warn(`Error while triggering OTA update on node ${nextEntry.peerAddress.toString()}:`, error);
             });
             if (!this.internal.updateQueueTimer?.isRunning) {
                 // Start a periodic timer to check for stalled updates
@@ -866,7 +866,7 @@ export class SoftwareUpdateManager extends Behavior {
                 entry.lastProgressUpdateTime = Time.nowMs;
             }
         } catch (error) {
-            logger.error(`Failed to announce OTA provider to node ${peerAddress.toString()}:`, error);
+            logger.warn(`Failed to announce OTA provider to node ${peerAddress.toString()}:`, error);
             // Reset entry state so the queue doesn't stay blocked
             entry.lastProgressUpdateTime = undefined;
             entry.lastProgressStatus = OtaUpdateStatus.Unknown;

--- a/packages/node/src/behaviors/access-control/AccessControlServer.ts
+++ b/packages/node/src/behaviors/access-control/AccessControlServer.ts
@@ -153,7 +153,7 @@ export class AccessControlServer extends AccessControlBehavior.with("Extension")
             if (delayedChangeExchange !== undefined && delayedChangeExchange !== context.exchange) {
                 // We are in a delayed ACL update with another exchange, so we do not process this one with Busy error
                 // This is formally not in specification, but chip also does this that way
-                logger.warn(
+                logger.debug(
                     "Decline parallel ACL changes from multiple exchanges",
                     context.exchange.id,
                     "vs.",

--- a/packages/node/src/behaviors/binding/BindingManager.ts
+++ b/packages/node/src/behaviors/binding/BindingManager.ts
@@ -148,7 +148,7 @@ export class BindingManager {
         try {
             await rec.server.events.removed.emit(resolution);
         } catch (err) {
-            logger.error(
+            logger.warn(
                 "Binding removed handler failed",
                 Diagnostic.dict({ endpoint: rec.server.endpoint.number, kind: resolution.kind }),
                 Diagnostic.error(err),
@@ -305,7 +305,7 @@ export class BindingManager {
         try {
             await canonicalServer.events.established.emit(resolution);
         } catch (err) {
-            logger.error(
+            logger.warn(
                 "Binding established handler failed",
                 Diagnostic.dict({ endpoint: sourceEp.number, kind: resolution.kind }),
                 Diagnostic.error(err),

--- a/packages/node/src/behaviors/general-commissioning/GeneralCommissioningServer.ts
+++ b/packages/node/src/behaviors/general-commissioning/GeneralCommissioningServer.ts
@@ -254,7 +254,7 @@ export class GeneralCommissioningServer extends GeneralCommissioningBehavior {
         // 5. The Breadcrumb attribute SHALL be reset to zero.
         this.state.breadcrumb = BigInt(0);
 
-        logger.info(
+        logger.notice(
             "Commissioned",
             Diagnostic.dict({
                 fabric: `${hex.fixed(fabric.globalId, 16)} (#${fabric.fabricIndex})`,

--- a/packages/node/src/behaviors/groups/GroupsServer.ts
+++ b/packages/node/src/behaviors/groups/GroupsServer.ts
@@ -103,7 +103,7 @@ export class GroupsServer extends GroupsBase {
                 gkm.addEndpointForGroup(fabric, groupId, endpointNumber, groupName),
             );
         } catch (error) {
-            logger.error(error);
+            logger.debug("Could not add group", error);
             StatusResponseError.accept(error);
             return { status: error.code, groupId };
         }

--- a/packages/node/src/behaviors/operational-credentials/VendorIdVerification.ts
+++ b/packages/node/src/behaviors/operational-credentials/VendorIdVerification.ts
@@ -123,21 +123,21 @@ export namespace VendorIdVerification {
             }
         } catch (error) {
             ReceivedStatusResponseError.accept(error);
-            logger.error("Could not verify VendorId", error);
+            logger.warn("Could not verify VendorId: peer rejected the signing request", error);
             return undefined;
         }
 
         const peerAddress = node.peerAddress;
         if (!peerAddress) {
             // Should not happen when above command was successful
-            logger.error("Could not verify VendorId: Node is not a commissioned peer");
+            logger.warn("Could not verify VendorId: Node is not a commissioned peer");
             return undefined;
         }
 
         const sessions = node.env.maybeGet(PeerSet)?.get(peerAddress)?.sessions;
         if (!sessions?.size) {
             // Should not happen when above command was successful
-            logger.error("Could not verify VendorId: Node has no session established");
+            logger.warn("Could not verify VendorId: Node has no session established");
             return undefined;
         }
 
@@ -216,7 +216,7 @@ export namespace VendorIdVerification {
             await nocCert.verify(crypto, rootCert, icaCert);
         } catch (error) {
             CryptoError.accept(error);
-            logger.error("Could not verify VendorId", error);
+            logger.warn("Could not verify VendorId: certificate chain verification failed", error);
             return false;
         }
 

--- a/packages/node/src/behaviors/ota-software-update-provider/OtaSoftwareUpdateProviderServer.ts
+++ b/packages/node/src/behaviors/ota-software-update-provider/OtaSoftwareUpdateProviderServer.ts
@@ -109,7 +109,7 @@ export class OtaSoftwareUpdateProviderServer extends OtaSoftwareUpdateProviderBe
         const ownFabric = fabricAuthority.fabrics[0];
         if (!ownFabric) {
             // Can only happen if the SoftwareUpdateManager is used without any commissioned nodes
-            logger.error(`No owning fabric, delay initialization`);
+            logger.info(`No owning fabric, delay initialization`);
             fabricAuthority.fabricAdded.once(() => this.#nodeOnline());
             return;
         }

--- a/packages/node/src/behaviors/ota-software-update-requestor/OtaSoftwareUpdateRequestorServer.ts
+++ b/packages/node/src/behaviors/ota-software-update-requestor/OtaSoftwareUpdateRequestorServer.ts
@@ -544,7 +544,7 @@ export class OtaSoftwareUpdateRequestorServer extends OtaSoftwareUpdateRequestor
             try {
                 otaHeader = await this.validateUpdateFile();
             } catch (error) {
-                logger.error(`OTA update file is invalid:`, error);
+                logger.notice(`OTA update file is invalid:`, error);
 
                 await downloadLocation.delete();
                 otaHeader = undefined; // Should be the case anyway, but let's make sure
@@ -756,7 +756,7 @@ export class OtaSoftwareUpdateRequestorServer extends OtaSoftwareUpdateRequestor
 
             return await this.#validateApplyUpdate(applyRequest, ep, fileDesignator);
         } else if (action !== OtaSoftwareUpdateProvider.ApplyUpdateAction.Proceed) {
-            logger.error(`Invalid OTA Provider applyUpdateRequest response: unknown Action ${action}`);
+            logger.notice(`Invalid OTA Provider applyUpdateRequest response: unknown Action ${action}`);
             this.#resetStateToIdle(OtaSoftwareUpdateRequestor.ChangeReason.Failure);
             return false;
         }
@@ -861,7 +861,7 @@ export class OtaSoftwareUpdateRequestorServer extends OtaSoftwareUpdateRequestor
             fileDesignator = await this.#handleDownload(ep, imageUri, newSoftwareVersion);
         } catch (error) {
             MatterError.accept(error);
-            logger.info(`OTA download failed:`, error);
+            logger.notice(`OTA download failed:`, error);
             if (error instanceof OtaDownloadError) {
                 this.#emitDownloadErrorEvent(newSoftwareVersion, error.bytesTransferred, error.code);
             }

--- a/packages/node/src/behaviors/thermostat/AtomicWriteHandler.ts
+++ b/packages/node/src/behaviors/thermostat/AtomicWriteHandler.ts
@@ -10,7 +10,17 @@ import type { ClusterState } from "#behavior/cluster/ClusterState.js";
 import { ActionContext } from "#behavior/context/ActionContext.js";
 import { ValueSupervisor } from "#behavior/supervision/ValueSupervisor.js";
 import { Endpoint } from "#endpoint/Endpoint.js";
-import { BasicSet, Environment, Environmental, InternalError, Logger, ObserverGroup, serialize } from "@matter/general";
+import {
+    asError,
+    BasicSet,
+    Diagnostic,
+    Environment,
+    Environmental,
+    InternalError,
+    Logger,
+    ObserverGroup,
+    serialize,
+} from "@matter/general";
 import { DataModelPath } from "@matter/model";
 import {
     AccessControl,
@@ -265,7 +275,10 @@ export class AtomicWriteHandler {
                 await context.transaction?.commit();
             } catch (error) {
                 await context.transaction?.rollback();
-                logger.info(`Failed to write attribute ${attr} during atomic write commit: ${error}`);
+                logger.info(
+                    `Failed to write attribute ${attr} during atomic write commit:`,
+                    Diagnostic.errorMessage(asError(error)),
+                );
                 statusCode = StatusResponseError.of(error)?.code ?? Status.Failure;
                 // If one fails with ConstraintError, the whole command should return ConstraintError, otherwise Failure
                 commandStatusCode =

--- a/packages/node/src/behaviors/thermostat/ThermostatServer.ts
+++ b/packages/node/src/behaviors/thermostat/ThermostatServer.ts
@@ -1289,7 +1289,7 @@ export class ThermostatBaseServer extends ThermostatBehaviorLogicBase {
         const newPresetHandles = new Set<string>();
         for (const preset of newPresets) {
             if (preset.presetHandle === null) {
-                logger.error("Preset is missing presetHandle, generating a new one");
+                logger.debug("Preset is missing presetHandle, generating a new one");
                 preset.presetHandle = entropy.randomBytes(16);
                 changed = true;
             }
@@ -1356,7 +1356,7 @@ export class ThermostatBaseServer extends ThermostatBehaviorLogicBase {
         }
 
         if (changed) {
-            logger.error("PresetHandles or BuiltIn flags were updated, updating persistedPresets");
+            logger.debug("PresetHandles or BuiltIn flags were updated, updating persistedPresets");
             this.state.persistedPresets = newPresets;
         }
     }

--- a/packages/node/src/node/Node.ts
+++ b/packages/node/src/node/Node.ts
@@ -148,7 +148,7 @@ export abstract class Node<T extends Node.CommonRootEndpoint = Node.CommonRootEn
 
                 // We intentionally do not track this promise because it is likely to hang
                 runtime.close().catch(e => {
-                    logger.info("Error closing network runtime", asError(e));
+                    logger.warn("Error closing network runtime", asError(e));
                 });
             }
             this.env.runtime.delete(this);

--- a/packages/node/src/node/client/ClientEventEmitter.ts
+++ b/packages/node/src/node/client/ClientEventEmitter.ts
@@ -128,7 +128,7 @@ function getNames(matter: MatterModel, { path: { clusterId, eventId } }: ReadRes
     const cluster = matter.clusters(clusterId);
     if (cluster === undefined) {
         if (!warnedForUnknown.has(clusterId)) {
-            logger.warn(`Ignoring events for unknown cluster #${clusterId}`);
+            logger.notice(`Ignoring events for unknown cluster #${clusterId}`);
             warnedForUnknown.add(clusterId);
             matterCache[key] = undefined;
         }
@@ -138,7 +138,7 @@ function getNames(matter: MatterModel, { path: { clusterId, eventId } }: ReadRes
     const event = cluster.events(eventId);
     if (event === undefined) {
         if (!warnedForUnknown.has(key)) {
-            logger.warn(`Ignoring unknown event #${eventId} for ${cluster.name} cluster`);
+            logger.notice(`Ignoring unknown event #${eventId} for ${cluster.name} cluster`);
             warnedForUnknown.add(key);
             matterCache[key] = undefined;
         }

--- a/packages/node/src/node/client/ClientNodeInteraction.ts
+++ b/packages/node/src/node/client/ClientNodeInteraction.ts
@@ -208,7 +208,7 @@ export class ClientNodeInteraction implements Interactable<ActionContext> {
         }
 
         const closed = this.#interactable.close(reason).catch(e => {
-            logger.error(`Unhandled error closing client interaction`, e);
+            logger.warn(`Unhandled error closing client interaction`, e);
         });
 
         this.#interactable = undefined;

--- a/packages/node/src/node/client/ClientStructure.ts
+++ b/packages/node/src/node/client/ClientStructure.ts
@@ -845,7 +845,7 @@ export class ClientStructure {
         try {
             await endpoint.delete();
         } catch (e) {
-            logger.error(`Error erasing peer endpoint ${endpoint}:`, e);
+            logger.warn(`Error erasing peer endpoint ${endpoint}:`, e);
         }
     }
 
@@ -876,7 +876,7 @@ export class ClientStructure {
                         ).erase?.(),
                     );
                 } catch (e) {
-                    logger.error("Error clearing cluster storage:", e);
+                    logger.warn("Error clearing cluster storage:", e);
                 }
 
                 this.#pendingStructureEvents.push({

--- a/packages/node/src/node/client/Peers.ts
+++ b/packages/node/src/node/client/Peers.ts
@@ -387,7 +387,7 @@ export class Peers extends EndpointContainer<ClientNode> {
         this.#mutex.run(() =>
             this.#cullExpiredNodesAndAddresses()
                 .catch(error => {
-                    logger.error("Error culling expired nodes", error);
+                    logger.warn("Error culling expired nodes", error);
                 })
                 .finally(() => {
                     this.#manageExpiration();

--- a/packages/node/src/node/integration/ProtocolService.ts
+++ b/packages/node/src/node/integration/ProtocolService.ts
@@ -704,12 +704,11 @@ function invokeCommand(
                                 outerResolve,
                             );
                         } catch (e) {
-                            logger.error(
-                                "Response validation error for",
-                                command.name,
-                                Diagnostic.errorMessage(asError(e)),
+                            const error = new StatusResponse.FailureError(
+                                `Response validation failed for ${command.name}: ${asError(e).message}`,
                             );
-                            throw new StatusResponse.FailureError(`Response validation failed for ${command.name}`);
+                            error.cause = e;
+                            throw error;
                         }
                     }
                     if (isObject(result)) {
@@ -735,8 +734,11 @@ function invokeCommand(
                         outerResolve,
                     );
                 } catch (e) {
-                    logger.error("Response validation error for", command.name, Diagnostic.errorMessage(asError(e)));
-                    throw new StatusResponse.FailureError(`Response validation failed for ${command.name}`);
+                    const error = new StatusResponse.FailureError(
+                        `Response validation failed for ${command.name}: ${asError(e).message}`,
+                    );
+                    error.cause = e;
+                    throw error;
                 }
             }
             if (isObject(result)) {

--- a/packages/node/src/node/server/InteractionServer.ts
+++ b/packages/node/src/node/server/InteractionServer.ts
@@ -630,7 +630,7 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
                 message,
             );
         } catch (error) {
-            logger.error(
+            logger.warn(
                 `Subscription ${Subscription.idStrOf(subscriptionId)} for session ${session.via}: Error while sending initial data reports:`,
                 error instanceof MatterError ? error.message : error,
             );
@@ -715,7 +715,7 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
             throw error;
         }
 
-        logger.info(
+        logger.notice(
             "Subscribe successful",
             Mark.OUTBOUND,
             exchange.via,
@@ -789,7 +789,7 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
             );
             subscription.activate();
 
-            logger.info(
+            logger.notice(
                 `Subscription successfully reestablished`,
                 Mark.OUTBOUND,
                 exchange.via,

--- a/packages/node/src/node/server/ServerSubscription.ts
+++ b/packages/node/src/node/server/ServerSubscription.ts
@@ -800,7 +800,7 @@ export class ServerSubscription implements Subscription {
             }
         } catch (error) {
             if (StatusResponseError.is(error, Status.InvalidSubscription, Status.Failure)) {
-                logger.info(`Subscription ${this.idStr} cancelled by peer`);
+                logger.notice(`Subscription ${this.idStr} cancelled by peer`);
                 this.#isCanceledByPeer = true;
             } else {
                 StatusResponseError.accept(error);

--- a/packages/node/src/storage/client/ClientCacheBuffer.ts
+++ b/packages/node/src/storage/client/ClientCacheBuffer.ts
@@ -162,7 +162,7 @@ export class ClientCacheBuffer {
                 // Run the actual flush through the mutex so it serializes with explicit flush calls
                 await this.#mutex.produce(() => this.#doFlush());
             } catch (e) {
-                logger.error("Periodic cache flush failed:", e);
+                logger.warn("Periodic cache flush failed:", e);
             }
         }
     }

--- a/packages/nodejs-ble/src/BlenoBleServer.ts
+++ b/packages/nodejs-ble/src/BlenoBleServer.ts
@@ -52,7 +52,7 @@ function initializeBleno(server: BlenoBleServer, hciId?: number) {
                 server.handleC1WriteRequest(data, offset, withoutResponse);
                 callback(this.RESULT_SUCCESS);
             } catch (e) {
-                logger.error(`C1 write request failed: ${e}`);
+                logger.warn("C1 write request failed", e);
                 callback(this.RESULT_UNLIKELY_ERROR);
             }
         }
@@ -392,7 +392,7 @@ export class BlenoBleServer extends BleChannel<Bytes> {
 
     async btpHandshakeTimeoutTriggered() {
         await this.disconnect();
-        logger.error("Timeout for handshake subscribe request on C2 reached, disconnecting.");
+        logger.warn("Timeout for handshake subscribe request on C2 reached, disconnecting.");
     }
 
     onClose(listener: () => void): Transport.Listener {

--- a/packages/nodejs-ble/src/NobleBleChannel.ts
+++ b/packages/nodejs-ble/src/NobleBleChannel.ts
@@ -204,7 +204,7 @@ export class NobleBleCentralInterface implements Transport {
                         // so chance is high also disconnect does not work reliably for now
                         peripheral
                             .disconnectAsync()
-                            .catch(error => logger.error(`Ignored error while disconnecting`, error));
+                            .catch(error => logger.debug(`Ignored error while disconnecting`, error));
                     }
                     rejectOnce(new BleError(`Timeout while interviewing peripheral ${peripheralAddress}`));
                 }),
@@ -451,7 +451,7 @@ export class NobleBleCentralInterface implements Transport {
                 logger.debug(`Peripheral ${peripheral.address}: Disconnect from peripheral while closing central`);
                 peripheral
                     .disconnectAsync()
-                    .catch(error => logger.error(`Peripheral ${peripheral.address}: Error while disconnecting`, error));
+                    .catch(error => logger.warn(`Peripheral ${peripheral.address}: Error while disconnecting`, error));
             }
         }
         this.#openChannels.clear();
@@ -509,7 +509,7 @@ export class NobleBleChannel extends BleChannel<Bytes> {
             if (peripheral.state === "connected") {
                 await characteristicC2ForSubscribe.unsubscribeAsync().catch(error => {
                     if (!isNobleDisconnectError(error)) {
-                        logger.error(`Peripheral ${peripheralAddress}: Error while unsubscribing`, error);
+                        logger.warn(`Peripheral ${peripheralAddress}: Error while unsubscribing`, error);
                     }
                 });
             }
@@ -727,7 +727,7 @@ export class NobleBleChannel extends BleChannel<Bytes> {
         if (this.connected) {
             this.peripheral.disconnectAsync().catch(error => {
                 if (!isNobleDisconnectError(error)) {
-                    logger.error(`Peripheral ${this.peripheral.address}: Error while disconnecting`, error);
+                    logger.warn(`Peripheral ${this.peripheral.address}: Error while disconnecting`, error);
                 }
             });
         }

--- a/packages/nodejs-shell/src/app.ts
+++ b/packages/nodejs-shell/src/app.ts
@@ -177,7 +177,7 @@ process.on("message", function (message) {
 
     switch (message) {
         case "exit":
-            exit().catch(error => logger.error(error));
+            exit().catch(error => logger.error("Error during exit", error));
     }
 });
 

--- a/packages/nodejs/src/net/NodeJsHttpEndpoint.ts
+++ b/packages/nodejs/src/net/NodeJsHttpEndpoint.ts
@@ -200,7 +200,7 @@ export class NodeJsHttpEndpoint implements HttpEndpoint {
 
         this.#httpListener = (req, res) => {
             this.#handleHttp(req, res).catch(error => {
-                logger.error("Unhandled error in HTTP endpoint handler", error);
+                logger.warn("Unhandled error in HTTP endpoint handler", error);
                 respondError(res, 500);
             });
         };
@@ -232,7 +232,7 @@ export class NodeJsHttpEndpoint implements HttpEndpoint {
 
         this.#wsListener = (req, socket, head) => {
             this.#handleUpgrade(adapter, req, socket, head).catch(error => {
-                logger.error("Unhandled error WebSocket endpoint", error);
+                logger.warn("Unhandled error WebSocket endpoint", error);
             });
         };
 
@@ -267,7 +267,7 @@ export class NodeJsHttpEndpoint implements HttpEndpoint {
         const nodeBodyStream = ReadStream.fromWeb(response.body as NodeReadableStream);
 
         nodeBodyStream.on("error", error => {
-            logger.error("Error transmitting HTTP body", error);
+            logger.warn("Error transmitting HTTP body", error);
             respondError(res, 500);
         });
 

--- a/packages/nodejs/src/net/NodeJsUdpSocket.ts
+++ b/packages/nodejs/src/net/NodeJsUdpSocket.ts
@@ -75,7 +75,7 @@ function createDgramSocket(host: string | undefined, port: number | undefined, o
                 }),
             );
             socket.removeListener("error", handleBindError);
-            socket.on("error", error => logger.error(error));
+            socket.on("error", error => logger.error("UDP socket error", error));
 
             resolve(socket);
         });

--- a/packages/nodejs/src/storage/fs/FileStorageDriver.ts
+++ b/packages/nodejs/src/storage/fs/FileStorageDriver.ts
@@ -195,7 +195,7 @@ export class FileStorageDriver extends FilesystemStorageDriver implements Legacy
         try {
             return fromJson(value) as T;
         } catch (error) {
-            logger.error(`Failed to parse storage value for key ${key} in context ${contexts.join(".")}`);
+            logger.warn(`Failed to parse storage value for key ${key} in context ${contexts.join(".")}`, error);
         }
     }
 

--- a/packages/protocol/src/action/client/InputChunk.ts
+++ b/packages/protocol/src/action/client/InputChunk.ts
@@ -204,13 +204,11 @@ function decodeAttributeGroup(
             path: { nodeId, endpointId, clusterId, attributeId },
             tlv: TlvAny,
             value,
-            // Wire `dataVersion` is optional per TlvAttributeReportData; substitute 0 when the publisher omits
-            // it so the chunk honors its `version: number` contract. In practice spec-compliant publishers
-            // always include dataVersion for AttributeData reports.
+            // dataVersion is optional on the wire; default to 0 to satisfy the version: number contract
             version: dataVersion ?? 0,
         };
     } catch (error) {
-        // Swallow wire-decode failures (malformed TLV, schema mismatch); unrelated errors bubble.
+        // Skip a malformed entry; unrelated errors re-throw.
         UnexpectedDataError.accept(error);
         logger.warn(
             `Error decoding attribute ${endpointId}/${Diagnostic.hex(clusterId)}/${Diagnostic.hex(attributeId)}: ${error.message}`,
@@ -295,9 +293,9 @@ function decodeEventValue(eventData: TypeFromSchema<typeof TlvEventData>): ReadR
             tlv: TlvAny,
         };
     } catch (error) {
-        // Swallow wire-decode failures; unrelated errors bubble.
+        // Skip a malformed entry; unrelated errors re-throw.
         UnexpectedDataError.accept(error);
-        logger.error(
+        logger.warn(
             `Error decoding event ${endpointId}/${Diagnostic.hex(clusterId)}/${Diagnostic.hex(eventId)}: ${error.message}`,
         );
         return undefined;

--- a/packages/protocol/src/bdx/BdxProtocol.ts
+++ b/packages/protocol/src/bdx/BdxProtocol.ts
@@ -135,7 +135,7 @@ export class BdxProtocol implements ProtocolHandler {
                     try {
                         await bdxSession.processTransfer();
                     } catch (error) {
-                        logger.error(`Error processing BDX transfer:`, error);
+                        logger.warn(`Error processing BDX transfer:`, error);
                     }
                 } catch (error) {
                     BdxError.accept(error);

--- a/packages/protocol/src/bdx/BdxSession.ts
+++ b/packages/protocol/src/bdx/BdxSession.ts
@@ -142,8 +142,6 @@ export class BdxSession {
                     logger.info(`Failed to send BDX error status to peer:`, Diagnostic.errorMessage(sendError));
                 });
 
-                logger.warn(`BDX session failed with error:`, error);
-
                 error.bytesTransferred = this.#transferFlow?.transferredBytes ?? 0;
                 error.totalBytesLength = this.#transferFlow?.dataLength;
             }

--- a/packages/protocol/src/ble/BtpSessionHandler.ts
+++ b/packages/protocol/src/ble/BtpSessionHandler.ts
@@ -290,7 +290,7 @@ export class BtpSessionHandler {
                 await this.handleMatterMessagePayload(payloadToProcess);
             }
         } catch (error) {
-            logger.error(`Error while handling incoming BTP data: ${error}`);
+            logger.warn(`Error while handling incoming BTP data:`, error);
             await this.close();
 
             // If no BTP protocol error, rethrow

--- a/packages/protocol/src/common/BleScanner.ts
+++ b/packages/protocol/src/common/BleScanner.ts
@@ -359,7 +359,7 @@ export class BleScanner implements Scanner {
                 this.#finishWaiter(queryKey, true);
             },
             cause => {
-                logger.error("Unexpected error canceling commissioning", cause);
+                logger.warn("Unexpected error canceling commissioning", cause);
             },
         );
 

--- a/packages/protocol/src/common/FailsafeTimer.ts
+++ b/packages/protocol/src/common/FailsafeTimer.ts
@@ -95,7 +95,7 @@ export class FailsafeTimer {
 
     #startFailsafeTimer(expiry: Duration) {
         return Time.getTimer("Failsafe expiration", expiry, () =>
-            this.expire().catch(e => logger.error("Error during failsafe expiration", e)),
+            this.expire().catch(e => logger.warn("Error during failsafe expiration", e)),
         ).start();
     }
 }

--- a/packages/protocol/src/dcl/DclCertificateService.ts
+++ b/packages/protocol/src/dcl/DclCertificateService.ts
@@ -467,7 +467,7 @@ export class DclCertificateService {
                 this.#certificateIndex.set(metadata.subjectKeyId, metadata);
                 validCount++;
             } else {
-                logger.info(
+                logger.warn(
                     `Certificate referenced in index but not found in storage`,
                     Diagnostic.dict({ skid: metadata.subjectKeyId }),
                 );
@@ -904,12 +904,12 @@ export class DclCertificateService {
                     });
                     inserted.push(skidFromDer);
                 } catch (err) {
-                    logger.error("seed: malformed entry, aborting stream", Diagnostic.errorMessage(asError(err)));
+                    logger.warn("seed: malformed entry, aborting stream", Diagnostic.errorMessage(asError(err)));
                     break;
                 }
             }
         } catch (err) {
-            logger.error("seed: stream failed", Diagnostic.errorMessage(asError(err)));
+            logger.warn("seed: stream failed", Diagnostic.errorMessage(asError(err)));
         }
 
         if (inserted.length > 0) {

--- a/packages/protocol/src/dcl/DclVendorInfoService.ts
+++ b/packages/protocol/src/dcl/DclVendorInfoService.ts
@@ -416,15 +416,12 @@ export class DclVendorInfoService {
                         creator: entry.creator ?? "",
                     });
                 } catch (err) {
-                    logger.error(
-                        "seed: malformed vendor entry, aborting stream",
-                        Diagnostic.errorMessage(asError(err)),
-                    );
+                    logger.warn("seed: malformed vendor entry, aborting stream", Diagnostic.errorMessage(asError(err)));
                     break;
                 }
             }
         } catch (err) {
-            logger.error("seed: vendor stream failed", Diagnostic.errorMessage(asError(err)));
+            logger.warn("seed: vendor stream failed", Diagnostic.errorMessage(asError(err)));
             return;
         }
 

--- a/packages/protocol/src/events/NonvolatileEventStore.ts
+++ b/packages/protocol/src/events/NonvolatileEventStore.ts
@@ -73,7 +73,7 @@ export class NonvolatileEventStore extends BaseEventStore {
                     conversion,
                     () => summary,
                     error => {
-                        console.warn("Error clearing volatile event number reservation", error);
+                        logger.warn("Error clearing volatile event number reservation", error);
                         return summary;
                     },
                 );
@@ -102,7 +102,7 @@ export class NonvolatileEventStore extends BaseEventStore {
         if (this.#iops.size) {
             return MatterAggregateError.allSettled(this.#iops, "Error closing event store")
                 .then(() => {})
-                .catch(error => logger.error(error));
+                .catch(error => logger.warn("Error settling event store on close:", error));
         }
     }
 

--- a/packages/protocol/src/events/OccurrenceManager.ts
+++ b/packages/protocol/src/events/OccurrenceManager.ts
@@ -395,7 +395,7 @@ export class OccurrenceManager {
         if (asyncDrops.length) {
             return MatterAggregateError.allSettled(asyncDrops, "Error dropping occurrences")
                 .then(() => {})
-                .catch(error => logger.error(error));
+                .catch(error => logger.warn("Error dropping occurrences:", error));
         }
     }
 }

--- a/packages/protocol/src/fabric/Fabric.ts
+++ b/packages/protocol/src/fabric/Fabric.ts
@@ -231,7 +231,7 @@ export class Fabric {
                 this.#vvsc = vvsc;
             }
         }
-        logger.info(
+        logger.notice(
             "Updated Vendor Verification Data for Fabric",
             this.#rootVendorId,
             this.#vidVerificationStatement,

--- a/packages/protocol/src/fabric/FabricAuthority.ts
+++ b/packages/protocol/src/fabric/FabricAuthority.ts
@@ -191,7 +191,7 @@ export class FabricAuthority {
             fabric.intermediateCACert,
         );
         const newFabric = await builder.build(fabric.fabricIndex);
-        logger.info(`Rotated NOC for fabric ${fabric.fabricIndex}`);
+        logger.notice(`Rotated NOC for fabric ${fabric.fabricIndex}`);
 
         await this.#fabrics.replaceFabric(newFabric);
 

--- a/packages/protocol/src/interaction/EventDataDecoder.ts
+++ b/packages/protocol/src/interaction/EventDataDecoder.ts
@@ -151,7 +151,7 @@ export function normalizeAndDecodeEventData(
                 events,
             });
         } catch (error: any) {
-            logger.error(`Error decoding event ${endpointId}/${clusterId}/${eventId}: ${error.message}`);
+            logger.warn(`Error decoding event ${endpointId}/${clusterId}/${eventId}: ${error.message}`);
         }
     });
     return result;
@@ -188,7 +188,7 @@ export function normalizeEventStatus(data: TypeFromSchema<typeof TlvEventStatus>
                 clusterStatus: status.clusterStatus,
             });
         } catch (error: any) {
-            logger.error(`Error decoding event ${endpointId}/${clusterId}/${eventId}: ${error.message}`);
+            logger.warn(`Error decoding event ${endpointId}/${clusterId}/${eventId}: ${error.message}`);
         }
     });
     return result;

--- a/packages/protocol/src/mdns/CommissionableMdnsScanner.ts
+++ b/packages/protocol/src/mdns/CommissionableMdnsScanner.ts
@@ -321,7 +321,7 @@ export class CommissionableMdnsScanner implements Scanner {
                                 this.#speculativeTargets.delete(targetKey);
                                 target.off(this.#speculativeObserver);
                                 if (!(error instanceof AbortedError)) {
-                                    logger.error(`Speculative discovery for ${target.qname} failed:`, error);
+                                    logger.warn(`Speculative discovery for ${target.qname} failed:`, error);
                                 }
                             });
                     }

--- a/packages/protocol/src/mdns/MdnsServer.ts
+++ b/packages/protocol/src/mdns/MdnsServer.ts
@@ -223,7 +223,7 @@ export class MdnsServer {
                 }
             }),
             "Error announcing MDNS messages",
-        ).catch(error => logger.error(error));
+        ).catch(error => logger.error("Error announcing MDNS messages", error));
     }
 
     async expireAnnouncements(...services: string[]) {
@@ -250,7 +250,7 @@ export class MdnsServer {
                 }
             }),
             "Error happened when expiring MDNS announcements",
-        ).catch(error => logger.error(error));
+        ).catch(error => logger.warn("Error happened when expiring MDNS announcements", error));
         await this.#resetServices();
     }
 

--- a/packages/protocol/src/mdns/MdnsService.ts
+++ b/packages/protocol/src/mdns/MdnsService.ts
@@ -100,7 +100,7 @@ export class MdnsService {
                     "Error disposing MDNS services",
                 );
             } catch (e) {
-                logger.error(e);
+                logger.warn("Error disposing MDNS services", e);
             }
 
             if (this.#socket) {

--- a/packages/protocol/src/peer/ControllerCommissioner.ts
+++ b/packages/protocol/src/peer/ControllerCommissioner.ts
@@ -537,7 +537,7 @@ export class ControllerCommissioner {
                             // Already-closed races with our force-close — the session shut down
                             // via another path, no action needed.  Anything else is a real bug.
                             if (error instanceof SessionClosedError) return;
-                            logger.error("Error while force-closing PASE session on BLE close", error);
+                            logger.warn("Error while force-closing PASE session on BLE close", error);
                         });
                 });
             }

--- a/packages/protocol/src/peer/PeerConnection.ts
+++ b/packages/protocol/src/peer/PeerConnection.ts
@@ -597,13 +597,13 @@ export async function PeerConnection(
                 );
                 break;
             case "peer":
-                error(address, `Peer error (retry in ${Duration.format(delay!)}):`, Diagnostic.errorMessage(e));
+                warn(address, `Peer error (retry in ${Duration.format(delay!)}):`, Diagnostic.errorMessage(e));
                 break;
             case "network":
-                error(address, `Connection error (retry in ${Duration.format(delay!)}):`, Diagnostic.errorMessage(e));
+                warn(address, `Connection error (retry in ${Duration.format(delay!)}):`, Diagnostic.errorMessage(e));
                 break;
             case "general":
-                error(address, `General connection error (retry in ${Duration.format(delay!)}):`, e);
+                warn(address, `General connection error (retry in ${Duration.format(delay!)}):`, e);
                 break;
         }
 

--- a/packages/protocol/src/protocol/ExchangeManager.ts
+++ b/packages/protocol/src/protocol/ExchangeManager.ts
@@ -418,7 +418,7 @@ export class ExchangeManager implements Transport.Provider {
             return;
         }
 
-        logger.error(Message.via(exchange, message), "Unhandled error handling incoming message:", error);
+        logger.warn(Message.via(exchange, message), "Unhandled error handling incoming message:", error);
     }
 
     deleteExchange(exchangeIndex: number) {
@@ -637,7 +637,7 @@ export class ExchangeManager implements Transport.Provider {
             await messenger.sendCloseSession();
             await messenger.close();
         } catch (error) {
-            logger.error(exchange.via, "Error closing session:", error);
+            logger.warn(exchange.via, "Error closing session:", error);
         }
     }
 }

--- a/packages/protocol/src/protocol/MessageExchange.ts
+++ b/packages/protocol/src/protocol/MessageExchange.ts
@@ -199,7 +199,7 @@ export class MessageExchange {
             this.#receivedMessageToAck = undefined;
             // TODO await
             this.sendStandaloneAckForMessage(messageToAck).catch(error =>
-                logger.error("An error happened when sending a standalone ack", error),
+                logger.warn("An error happened when sending a standalone ack", error),
             );
         }
     });
@@ -742,7 +742,7 @@ export class MessageExchange {
             if (this.#closeTimer !== undefined) {
                 // All resubmissions done and in closing, no need to wait further
                 // TODO await
-                this.#close().catch(error => logger.error("Error closing exchange", error));
+                this.#close().catch(error => logger.warn("Error closing exchange", error));
             }
             return;
         }
@@ -767,9 +767,9 @@ export class MessageExchange {
             })
             .then(() => this.#initializeResubmission(message, resubmissionBackoffTime, expectedProcessingTime))
             .catch(error => {
-                logger.error(`Error retransmitting ${Message.via(this, message)}:`, error);
+                logger.warn(`Error retransmitting ${Message.via(this, message)}:`, error);
                 if (error instanceof SessionClosedError) {
-                    this.#close().catch(error => logger.error("An error happened when closing the exchange", error));
+                    this.#close().catch(error => logger.warn("An error happened when closing the exchange", error));
                 } else {
                     this.#initializeResubmission(message, resubmissionBackoffTime, expectedProcessingTime);
                 }
@@ -798,7 +798,7 @@ export class MessageExchange {
             try {
                 await this.sendStandaloneAckForMessage(messageToAck);
             } catch (error) {
-                logger.error("An error happened when closing the exchange", error);
+                logger.warn("An error happened when closing the exchange", error);
             }
         }
         await this.#close();
@@ -896,7 +896,7 @@ export class MessageExchange {
                 using _acking = closing.join("acking");
                 await this.sendStandaloneAckForMessage(messageToAck);
             } catch (error) {
-                logger.error(this.via, `Unhandled error closing exchange`, error);
+                logger.warn(this.via, `Unhandled error closing exchange`, error);
             }
             if (cause || this.#sentMessageToAck === undefined) {
                 // We have sent the Ack and there's nothing left waiting for a peer ack, close directly

--- a/packages/protocol/src/session/SessionManager.ts
+++ b/packages/protocol/src/session/SessionManager.ts
@@ -796,7 +796,7 @@ export class SessionManager {
             }
         }
         await MatterAggregateError.allSettled(closePromises, "Error closing sessions").catch(error =>
-            logger.error(error),
+            logger.warn("Error closing sessions:", error),
         );
     }
 

--- a/packages/protocol/src/session/case/CaseServer.ts
+++ b/packages/protocol/src/session/case/CaseServer.ts
@@ -74,9 +74,9 @@ export class CaseServer implements ProtocolHandler {
                     ShutdownError,
                 )
             ) {
-                logger.error(messenger.via, "Error establishing CASE session:", Diagnostic.errorMessage(error));
+                logger.info(messenger.via, "Error establishing CASE session:", Diagnostic.errorMessage(error));
             } else {
-                logger.error(messenger.via, "Error establishing CASE session:", error);
+                logger.warn(messenger.via, "Error establishing CASE session:", error);
             }
 
             if (exchange.considerClosed) {

--- a/packages/protocol/src/transport/tcp/TcpChannel.ts
+++ b/packages/protocol/src/transport/tcp/TcpChannel.ts
@@ -209,7 +209,7 @@ export class TcpChannel implements IpNetworkChannel<Bytes>, ConnectedChannel {
 
         // Receive buffer cap — prevent memory exhaustion from slow/malicious peers
         if (this.#receiveLength > this.#maxReceiveBufferSize) {
-            logger.error(
+            logger.warn(
                 `Receive buffer exceeded ${this.#maxReceiveBufferSize} bytes without completing a message, closing`,
             );
             this.#workers.add(this.close());
@@ -260,7 +260,7 @@ export class TcpChannel implements IpNetworkChannel<Bytes>, ConnectedChannel {
             }
 
             if (messageLength > this.maxMessageSize) {
-                logger.error(`Received TCP message of ${messageLength} bytes exceeds limit of ${this.maxMessageSize}`);
+                logger.warn(`Received TCP message of ${messageLength} bytes exceeds limit of ${this.maxMessageSize}`);
                 // TODO: Send MESSAGE_TOO_LARGE status report before closing (spec §4.15.2.3)
                 this.#workers.add(this.close());
                 return;

--- a/packages/react-native/src/ble/ReactNativeBleClient.ts
+++ b/packages/react-native/src/ble/ReactNativeBleClient.ts
@@ -84,14 +84,14 @@ export class ReactNativeBleClient {
                 (error, peripheral) => {
                     if (error !== null || peripheral === null) {
                         this.isScanning = false;
-                        logger.error("Error while scanning for BLE devices", error);
+                        logger.warn("Error while scanning for BLE devices", error);
                         if (this.shouldScan) {
                             this.startScanning().catch(error =>
-                                logger.error("Error while restarting scanning after error", error),
+                                logger.warn("Error while restarting scanning after error", error),
                             );
                         } else {
                             this.stopScanning().catch(error =>
-                                logger.error("Error while stopping scanning after error", error),
+                                logger.warn("Error while stopping scanning after error", error),
                             );
                         }
                         return;

--- a/packages/react-native/src/net/UdpSocketReactNative.ts
+++ b/packages/react-native/src/net/UdpSocketReactNative.ts
@@ -100,7 +100,7 @@ function createDgramSocket(host: string | undefined, port: number | undefined, o
                 }),
             );
             socket.removeListener("error", handleBindError);
-            socket.on("error", (error: Error) => logger.error(error));
+            socket.on("error", (error: Error) => logger.error("UDP socket error", error));
             resolve(socket);
         });
     });


### PR DESCRIPTION
## Summary

Introduces a log-level guideline (`docs/LOGGING.md`) and re-levels ~90 internal `logger.*` statements across packages for consistency.

### The guideline
- **Blast radius** decides severity in the anomaly band: one operation → `warn`, whole feature/subsystem → `error`, whole runtime → `fatal`.
- **`notice`↔`warn` = actionability**: someone should investigate/fix → `warn`; nobody can (external/operational, or we auto-recover on a schedule) and it's handled → `notice`.
- **Volume** is a downgrade lever (high-frequency/env-caused → `info`/`debug` to avoid spam, unless it explains a user-visible symptom → `notice`, deduped).
- **Audience**: `debug`/`info` for developers, `notice`+ for operators.
- Cross-cutting: log-where-handled (no log-and-throw), one-event-one-line, attach cause when it adds value, phrase `notice`+ for users, shutdown-path failures → at most `warn`.

### Re-leveling highlights
- Single-operation cleanup/teardown failures `error` → `warn`.
- Transient/retried errors → `warn`.
- Routine protocol mechanics → `debug`; CASE establishment failures (peer not on our fabric, etc.) → `info`.
- Lifecycle/identity events (commissioned, subscriptions, NOC rotation) → `notice`.
- `RuntimeService.#crash` → `fatal`.
- Removed a BDX double-log; transported validation-error cause through `ProtocolService` `FailureError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)