### PR TITLE
fix(general): unref utility timer when utility set before start()

### DIFF
--- a/packages/general/src/time/StandardTime.ts
+++ b/packages/general/src/time/StandardTime.ts
@@ -121,6 +121,9 @@ export class StandardTimer implements Timer {
             }
             this.callback(lifetime);
         }, this.interval);
+        if (this.#utility) {
+            (this.#timerId as { unref?: () => void }).unref?.();
+        }
         return this;
     }
 

--- a/packages/general/test/time/StandardTimeTest.ts
+++ b/packages/general/test/time/StandardTimeTest.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { StandardTimer } from "#time/StandardTime.js";
+import { Millis } from "#time/TimeUnit.js";
+
+/**
+ * Replaces the global timer factories with stubs that return a shared fake timer whose ref/unref calls are counted,
+ * so we can observe whether {@link StandardTimer} unrefs the underlying timer.
+ */
+function withStubbedTimers(test: (counts: { ref: number; unref: number }) => void) {
+    const counts = { ref: 0, unref: 0 };
+    const fake = {
+        ref() {
+            counts.ref++;
+        },
+        unref() {
+            counts.unref++;
+        },
+    };
+    const original = { setTimeout: globalThis.setTimeout, setInterval: globalThis.setInterval };
+    globalThis.setTimeout = (() => fake) as unknown as typeof setTimeout;
+    globalThis.setInterval = (() => fake) as unknown as typeof setInterval;
+    try {
+        test(counts);
+    } finally {
+        globalThis.setTimeout = original.setTimeout;
+        globalThis.setInterval = original.setInterval;
+    }
+}
+
+describe("StandardTimer", () => {
+    describe("utility/unref", () => {
+        it("unrefs the timer when utility is set before start (non-periodic)", () => {
+            withStubbedTimers(counts => {
+                const timer = new StandardTimer("test", Millis(1000), () => {}, false);
+                timer.utility = true;
+                timer.start();
+                expect(counts.unref).equal(1);
+                timer.stop();
+            });
+        });
+
+        it("unrefs the timer when utility is set before start (periodic)", () => {
+            withStubbedTimers(counts => {
+                const timer = new StandardTimer("test", Millis(1000), () => {}, true);
+                timer.utility = true;
+                timer.start();
+                expect(counts.unref).equal(1);
+                timer.stop();
+            });
+        });
+
+        it("does not unref a non-utility timer", () => {
+            withStubbedTimers(counts => {
+                const timer = new StandardTimer("test", Millis(1000), () => {}, false);
+                timer.start();
+                expect(counts.unref).equal(0);
+                timer.stop();
+            });
+        });
+
+        it("unrefs the timer when utility is set after start", () => {
+            withStubbedTimers(counts => {
+                const timer = new StandardTimer("test", Millis(1000), () => {}, false);
+                timer.start();
+                expect(counts.unref).equal(0);
+                timer.utility = true;
+                expect(counts.unref).equal(1);
+                timer.stop();
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Problem

`StandardTimer.utility` setter only calls `timerId.unref()` when `#timerId` is already set (timer already running). If `utility = true` is set **before** `start()`, the flag is stored but `unref()` is never applied to the timer created by `start()`.

Result: utility timers (e.g. matter-server's reconnect timeout, which sets `timer.utility = true` before `timer.start()`) keep a ref on the event loop and can prevent clean Node.js process exit.

Found during matterjs-server availability debugging.

## Fix

`start()` now calls `unref()` on the freshly created timer when `#utility` is set, mirroring the existing setter pattern.

## Test

New `StandardTimeTest.ts` stubs the global timer factories and asserts:
- utility-before-start → unref (periodic + non-periodic)
- non-utility → no unref
- utility-after-start → unref (regression guard)

Verified failing pre-fix (the two before-start cases), passing post-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)