### PR TITLE
fix(protocol): persist fabrics atomically with multi-key storage set

### DIFF
--- a/packages/protocol/src/fabric/FabricManager.ts
+++ b/packages/protocol/src/fabric/FabricManager.ts
@@ -182,14 +182,10 @@ export class FabricManager {
 
         this.#construction.assert();
 
-        const storeResult = this.#storage.set(
-            "fabrics",
-            this.fabrics.map(fabric => fabric.config),
-        );
-        if (MaybePromise.is(storeResult)) {
-            return storeResult.then(() => this.#storage!.set("nextFabricIndex", this.#nextFabricIndex));
-        }
-        return this.#storage.set("nextFabricIndex", this.#nextFabricIndex);
+        return this.#storage.set({
+            fabrics: this.fabrics.map(fabric => fabric.config),
+            nextFabricIndex: this.#nextFabricIndex,
+        });
     }
 
     addFabric(fabric: Fabric) {


### PR DESCRIPTION
## Problem

`FabricManager.persistFabrics` wrote `"fabrics"` and `"nextFabricIndex"` in two separate `storage.set(key, value)` calls with an `await`/`.then(...)` gap between them:

```ts
const storeResult = this.#storage.set("fabrics", ...);
if (MaybePromise.is(storeResult)) {
    return storeResult.then(() => this.#storage!.set("nextFabricIndex", ...));
}
return this.#storage.set("nextFabricIndex", ...);
```

If a fabric is added/removed during the gap, the two persisted snapshots describe different points in time. On restart this yields duplicate or skipped fabric indices.

## Fix

Use the existing multi-key `StorageContext.set({ ... })` overload so both values are written together:

```ts
return this.#storage.set({
    fabrics: this.fabrics.map(fabric => fabric.config),
    nextFabricIndex: this.#nextFabricIndex,
});
```

- `WalStorageDriver` wraps multi-key set in `begin()`/`commit()` — atomic per WAL transaction.
- `MemoryStorageDriver` loops synchronously — no async gap.

No test added: this is pure storage-API usage; the atomicity guarantee belongs to the storage layer, which is covered there.

## Gates
- `@matter/protocol` suite 870/870 ✓
- format-verify ✓ · lint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)