### PR TITLE
fix(protocol): correct BTP handshake decoder version nibble order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Adjustment: `ReadResult.Chunk` may now be an async iterable (`InputChunk` is an async generator); consumers iterate chunk contents with `for await … of chunk`. Mainly internal
     - Fix: Event reports are now decoded in wire (EventNumber) order
     - Fix: Allows CSRs with an empty subject as per Matter spec
+    - Fix: Corrects BTP handshake decoding of version field
 
 - @matter/types
     - Fix: Remove invalid FabricIndex field from four commands

--- a/packages/protocol/src/codec/BtpCodec.ts
+++ b/packages/protocol/src/codec/BtpCodec.ts
@@ -185,20 +185,20 @@ export class BtpCodec {
         }
 
         const ver: number[] = [];
-        ver[0] = (version & 0xf0) >> 4;
-        ver[1] = version & 0x0f;
+        ver[1] = (version & 0xf0) >> 4;
+        ver[0] = version & 0x0f;
 
         version = reader.readUInt8();
-        ver[2] = (version & 0xf0) >> 4;
-        ver[3] = version & 0x0f;
+        ver[3] = (version & 0xf0) >> 4;
+        ver[2] = version & 0x0f;
 
         version = reader.readUInt8();
-        ver[4] = (version & 0xf0) >> 4;
-        ver[5] = version & 0x0f;
+        ver[5] = (version & 0xf0) >> 4;
+        ver[4] = version & 0x0f;
 
         version = reader.readUInt8();
-        ver[6] = (version & 0xf0) >> 4;
-        ver[7] = version & 0x0f;
+        ver[7] = (version & 0xf0) >> 4;
+        ver[6] = version & 0x0f;
 
         const versions = ver.filter(v => v !== 0);
         if (versions.length === 0) {

--- a/packages/protocol/test/codec/BtpCodecTest.ts
+++ b/packages/protocol/test/codec/BtpCodecTest.ts
@@ -206,9 +206,18 @@ describe("BtpCodec", () => {
         });
 
         it("decodes a valid request handshake message with multiple versions", () => {
-            const result = BtpCodec.decodeBtpHandshakeRequest(Bytes.fromHex("656c04560000b90006"));
+            // BTP wire packs even version index in the low nibble, odd index in the high nibble:
+            // [4,5,6] => bytes 54 06 00 00.
+            const result = BtpCodec.decodeBtpHandshakeRequest(Bytes.fromHex("656c54060000b90006"));
 
             expect(result).deep.equal(DECODED_HANDSHAKE_REQUEST_WITH_MULTIPLE_VERSIONS);
+        });
+
+        it("round-trips multiple versions preserving index order", () => {
+            const encoded = BtpCodec.encodeBtpHandshakeRequest(DECODED_HANDSHAKE_REQUEST_WITH_MULTIPLE_VERSIONS);
+            const decoded = BtpCodec.decodeBtpHandshakeRequest(encoded);
+
+            expect(decoded.versions).deep.equal(DECODED_HANDSHAKE_REQUEST_WITH_MULTIPLE_VERSIONS.versions);
         });
 
         it("decodes a valid btp packet", () => {


### PR DESCRIPTION
## Problem

`BtpCodec.decodeHandshakeRequestPayload` assigned version nibbles to the wrong array indices vs the Matter BTP wire spec.

Wire convention (matches CHIP SDK `BleLayer.cpp::SetSupportedProtocolVersion` and matter.js's own encoder at `BtpCodec.ts:93-96`, `(versions[1] << 4) | versions[0]`):
- even index → **low** nibble
- odd index → **high** nibble

The decoder did the opposite:
```ts
ver[0] = (version & 0xf0) >> 4;   // HIGH → ver[0]  WRONG
ver[1] = version & 0x0f;          // LOW  → ver[1]  WRONG
```

For wire byte `0x54` (`{4 at index 0, 5 at index 1}`) the decoder produced `[5, 4]` instead of `[4, 5]`. After `.filter(v => v !== 0)` the version *set* is still correct, so today's consumers (`BtpSessionHandler` negotiates via `versions.includes(...)`) work despite the bug. Any future positional consumer (`versions[0]` as "preferred version") would silently break.

## Fix

Swap the index assignments in all four byte pairs so the decoder mirrors the encoder. Round-trip is now identity-preserving for version order.

## Test

- Corrected the multi-version fixture wire `656c04560000b90006` → `656c54060000b90006`. The old vector only round-tripped *because* the decoder was broken; the new vector is the correct encoding of `[4, 5, 6]`.
- Added an encode↔decode round-trip test asserting index order is preserved.

## Follow-up (non-blocking)

End-to-end BLE commissioning against a real CHIP commissioner with byte-level logs would be a nice confirmation. No interop bug is expected today since negotiation is set-based.

## Gates
- `@matter/protocol` suite 870/870 ✓
- format-verify ✓ · lint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)