### PR TITLE
fix(protocol): spec-compliant 32-bit message counter wrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Deprecation: Internally used `DecodedDataReport`, `DecodedAttributeReport{Value,Status,Entry}`, `DecodedEventReport{Value,Status,Entry}`, `DecodedEventData`, and the `normalize*` / `normalizeAndDecode*` helpers moved to `@project-chip/matter.js/cluster`. Scheduled for removal in 0.18
     - Enhancement: `ReadResult.EventValue` exposes the four wire timestamp variants (`epochTimestamp`, `systemTimestamp`, `deltaEpochTimestamp`, `deltaSystemTimestamp`) alongside the existing collapsed `timestamp: number`
     - Adjustment: `ReadResult.Chunk` may now be an async iterable (`InputChunk` is an async generator); consumers iterate chunk contents with `for await … of chunk`. Mainly internal
+    - Fix: Fixes message counter rollover logic
     - Fix: Event reports are now decoded in wire (EventNumber) order
     - Fix: Allows CSRs with an empty subject as per Matter spec
 

--- a/packages/protocol/src/protocol/MessageCounter.ts
+++ b/packages/protocol/src/protocol/MessageCounter.ts
@@ -6,8 +6,8 @@
 
 import { Construction, Crypto, InternalError, StorageContext, asyncNew } from "@matter/general";
 
-/** Maximum 32 bit counter value. */
-export const MAX_COUNTER_VALUE_32BIT = 0xfffffffe;
+/** Maximum 32 bit counter value. Per Matter spec the counter wraps from 0xFFFFFFFF to 0. */
+export const MAX_COUNTER_VALUE_32BIT = 0xffffffff;
 
 /** Default number of messages before a rollover callback is called. */
 const ROLLOVER_INFO_DIFFERENCE = 1000;

--- a/packages/protocol/src/protocol/MessageReceptionState.ts
+++ b/packages/protocol/src/protocol/MessageReceptionState.ts
@@ -198,7 +198,7 @@ export class MessageReceptionStateUnencryptedWithRollover extends MessageRecepti
         } else if (diff < 0) {
             // negative value means the new message counter is smaller than the current maximum
             if (diff < -MSG_COUNTER_WINDOW_SIZE) {
-                return MAX_COUNTER_VALUE_32BIT + diff;
+                return MAX_COUNTER_VALUE_32BIT + 1 + diff;
             }
             return diff;
         }

--- a/packages/protocol/test/protocol/MessageCounterTest.ts
+++ b/packages/protocol/test/protocol/MessageCounterTest.ts
@@ -94,6 +94,18 @@ describe("MessageCounter", () => {
             );
         });
 
+        it("emits 0xFFFFFFFF before rolling over to 0", async () => {
+            await testStorageContext.set("counter", 0xfffffffe);
+            const messageCounter = await PersistedMessageCounter.create(
+                crypto,
+                testStorageContext,
+                "counter",
+                async () => {},
+            );
+            expect(await messageCounter.getIncrementedCounter()).equals(0xffffffff);
+            expect(await messageCounter.getIncrementedCounter()).equals(0);
+        });
+
         it("Message counter rolls over if allowed", async () => {
             await testStorageContext.set("counter", MAX_COUNTER_VALUE_32BIT);
             const messageCounter = await PersistedMessageCounter.create(

--- a/packages/protocol/test/protocol/MessageReceptionStateTest.ts
+++ b/packages/protocol/test/protocol/MessageReceptionStateTest.ts
@@ -289,6 +289,11 @@ describe("MessageReceptionState", () => {
                 expect(() => state.updateMessageCounter(MAX_COUNTER_VALUE_32BIT - 33)).throws(DuplicateMessageError);
                 state.updateMessageCounter(MAX_COUNTER_VALUE_32BIT - 32);
             });
+
+            it("accepts a peer counter of 0xFFFFFFFF (maximum valid value)", () => {
+                const state = new MessageReceptionStateEncryptedWithoutRollover();
+                expect(() => state.updateMessageCounter(0xffffffff)).not.throw();
+            });
         });
     });
 
@@ -469,7 +474,7 @@ describe("MessageReceptionState", () => {
                     state,
                     103 + MAX_COUNTER_INCREASE_2POW31, // same as (max_message_counter - 2^31) % 2^32
                     true,
-                    -MAX_COUNTER_INCREASE_2POW31 + 1, // +1 because of 0 on rollover
+                    -MAX_COUNTER_INCREASE_2POW31,
                 );
             });
 
@@ -687,7 +692,7 @@ describe("MessageReceptionState", () => {
                 const prototype = MessageReceptionStateUnencryptedWithRollover.prototype;
                 state.updateMessageCounter(1);
                 state.updateMessageCounter(103);
-                assertMessageWindowUpdate(prototype, state, 70, 0b0, false, MAX_COUNTER_VALUE_32BIT - 33); // outside window is always new and moves the window
+                assertMessageWindowUpdate(prototype, state, 70, 0b0, false, MAX_COUNTER_VALUE_32BIT - 32); // outside window is always new and moves the window
 
                 assertMessageWindowUpdate(prototype, state, 71, 0b1, false, 1);
                 assertMessageWindowUpdate(prototype, state, 105, 0b0, false, 34);
@@ -724,6 +729,24 @@ describe("MessageReceptionState", () => {
                     false,
                     MAX_COUNTER_VALUE_32BIT - 32,
                 ); // window moved
+            });
+
+            it("treats the exact counter rollover (MAX -> 0) as new and detects replays", () => {
+                const state = new MessageReceptionStateUnencryptedWithRollover();
+                const prototype = MessageReceptionStateUnencryptedWithRollover.prototype;
+                state.updateMessageCounter(MAX_COUNTER_VALUE_32BIT - 1);
+                state.updateMessageCounter(MAX_COUNTER_VALUE_32BIT); // max = MAX
+
+                // The counter rolls over to 0, which is one step ahead of MAX: new, and advances max.
+                assertMessageWindowDifference(prototype, state, 0, false, 1);
+
+                // 0 is now the maximum, so a replay of 0 is a duplicate.
+                expect(() => state.updateMessageCounter(0)).throws(DuplicateMessageError);
+                // MAX is one behind max=0 (within the window) and was already seen: duplicate.
+                expect(() => state.updateMessageCounter(MAX_COUNTER_VALUE_32BIT)).throws(DuplicateMessageError);
+
+                // Counting continues forward past the rollover.
+                assertMessageWindowDifference(prototype, state, 1, false, 1);
             });
         });
     });


### PR DESCRIPTION
## Problem

Two coupled defects in the Matter message counter wrap, both confirmed against the CHIP SDK (`src/transport/MessageCounter.h`: `kMessageCounterMax = 0xFFFFFFFF`, rolls over at that value) and Matter 1.5.1 §4.6 ("the message counter wraps around from `0xFFFF_FFFF` to `0x0000_0000`"):

### 1. `MAX_COUNTER_VALUE_32BIT` was `0xFFFFFFFE` (one below the spec maximum)

- **Receiver bug:** a spec-legal counter of `0xFFFFFFFF` from a peer was rejected — `messageCounter > 0xFFFFFFFE` threw `InternalError("Invalid message counter value")`. An interop failure whenever a compliant peer's counter reaches exactly `0xFFFFFFFF`.
- **Sender bug:** the emitter rolled over one counter early, never emitting `0xFFFFFFFF`.
- The constant's own comment ("Maximum 32 bit counter value") did not match its value.

### 2. Forward-wrap off-by-one in `MessageReceptionStateUnencryptedWithRollover`

`calculateDiff` returned `MAX_COUNTER_VALUE_32BIT + diff` for the forward-wrap case, leaving the wrap modulus at `2^32 - 1` instead of `2^32`. The backward-wrap branch (`diff - MAX - 1`) and the `…EncryptedWithRollover` sibling (`diff + MAX + 1`) already used `MAX + 1`.

At the exact rollover (`max = MAX`, `new = 0`) the buggy branch returned `0`. Downstream, `updateMessageCounterAndBitmap` gates on `diff > 0 || diff < -WINDOW`, so `0` advanced neither `max` nor the bitmap — counter `0` was silently swallowed and a **replayed `0` was not detected as a duplicate**.

## Fix

1. `MAX_COUNTER_VALUE_32BIT` → `0xFFFFFFFF`.
2. Forward-wrap returns `MAX_COUNTER_VALUE_32BIT + 1 + diff`.

Together the wrap modulus becomes a true `2^32`. Evidence this was the right model: a legacy test expectation carried a `+1 because of 0 on rollover` workaround that compensated for the old wrong modulus — it now collapses to the clean `-2^31`.

## Tests

- `emits 0xFFFFFFFF before rolling over to 0` and `accepts a peer counter of 0xFFFFFFFF` — absolute-value tests that **fail on the old constant**.
- `treats the exact counter rollover (MAX -> 0) as new and detects replays` — covers the forward-wrap fix end to end.
- Updated two legacy diagnostic-diff expectations (`-2^31+1` → `-2^31`; `MAX-33` → `MAX-32`); duplicate/new + bitmap behavior unchanged.

## Scope

`MAX_COUNTER_VALUE_32BIT` is referenced only in `MessageCounter.ts` and `MessageReceptionState.ts` (repo-wide grep). Group-session and MCSP counters use the same shared `PersistedMessageCounter` / `MessageReceptionStateEncryptedWithRollover` classes and inherit the fix.

## Gates
- `@matter/protocol` suite 872/872 ✓
- `npm run build -- --clean` ✓ (no dependent breakage)
- format-verify ✓ · lint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)