### PR TITLE
fix(node): serialize Peers.forAddress creation to avoid duplicate ClientNodes

### DIFF
--- a/packages/node/src/node/client/Peers.ts
+++ b/packages/node/src/node/client/Peers.ts
@@ -255,8 +255,20 @@ export class Peers extends EndpointContainer<ClientNode> {
             throw new ImplementationError("Cannot register a peer address for a fabric we do not belong to");
         }
 
-        let node = this.get(peerAddress);
-        if (!node) {
+        const existing = this.get(peerAddress);
+        if (existing) {
+            return existing;
+        }
+
+        // Serialize creation through the same mutex the cull/leave paths use. Two concurrent callers for the same
+        // address would otherwise both pass the check and both create a ClientNode (the awaits below yield between
+        // the check and the add).
+        return this.#mutex.produce(async () => {
+            let node = this.get(peerAddress);
+            if (node) {
+                return node;
+            }
+
             if (options.id !== undefined) {
                 // We want to initialize a node with a provided id. This could be an injected node, so ensure the
                 // ClientNodeStore is constructed. Without id the storage is empty anyway because id is newly assigned
@@ -276,9 +288,9 @@ export class Peers extends EndpointContainer<ClientNode> {
             await node.set({
                 commissioning: { peerAddress: PeerAddress(peerAddress) },
             });
-        }
 
-        return node;
+            return node;
+        });
     }
 
     override async close() {

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -1113,6 +1113,25 @@ describe("ClientNode", () => {
         await MockTime.resolve(ep1.commandsOf(OnOffClient).offWithEffect({ effectIdentifier: 0, effectVariant: 0 }));
     });
 
+    it("forAddress returns the same node for concurrent calls", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+
+        const peerAddress = controller.peers.get("peer1")!.peerAddress!;
+        expect(peerAddress).not.undefined;
+
+        await MockTime.resolve(controller.peers.get("peer1")!.delete());
+        expect(controller.peers.size).equals(0);
+
+        const [a, b] = await MockTime.resolve(
+            Promise.all([controller.peers.forAddress(peerAddress), controller.peers.forAddress(peerAddress)]),
+            { macrotasks: true },
+        );
+
+        expect(a).equals(b);
+        expect(controller.peers.size).equals(1);
+    });
+
     it("properly supports unknown clusters", async () => {
         // *** SETUP ***
 


### PR DESCRIPTION
## Problem

`Peers.forAddress` (`packages/node/src/node/client/Peers.ts`) did a check-then-create with `await` points between the initial `this.get(peerAddress)` check and the `this.add(node)` write (`await node.construction`, `await node.set(...)`), without taking the `#mutex` that the cull (`#onExpirationIntervalElapsed`) and leave (`#onLeave`) paths use.

Two concurrent `forAddress(sameAddress)` callers both pass the `get()` check, both create a new `ClientNode`, both `add()` — divergent peer state, subscription duplication, address-resolution churn.

A reproduction test created `peer2` **and** `peer3` for a single address (`a !== b`).

## Fix

- Early-return if the node already exists (common-case fast path).
- Otherwise wrap the create-and-add path in the existing `#mutex.produce(...)`, re-checking `this.get(peerAddress)` inside the critical section so a second caller returns the cached node.

`#mutex.produce<T>` returns the callback's value, so `forAddress` still returns the `ClientNode`.

### No deadlock

`forAddress` is never reached from inside a code path that already holds `#mutex`: cull and leave operate on existing nodes (they don't call `forAddress`), and `runCommissioning` holds the mutex only for its busy-registration — its `fn()` runs outside the lock. Verified by inspection and by the full node test suite.

### Cull interaction

Because creation now goes through the same `#mutex` the cull uses, `forAddress` creation and the expired-node cull are mutually exclusive by construction.

## Test

`forAddress returns the same node for concurrent calls`: commission a pair, delete `peer1` (peers empty), then `Promise.all` two `forAddress(sameAddress)` calls. Asserts the two results are identity-equal and `peers.size === 1`. Fails on the pre-fix code (two distinct nodes), passes with the fix.

A cull-specific test was considered but deliberately not added: `forAddress` and the cull share the identical `#mutex`, so the concurrent-`forAddress` test already exercises that lock; and the cull never deletes a commissioned / in-creation node (it `continue`s on `addresses === undefined` and only deletes uncommissioned nodes), so a "culled mid-create" scenario is not reachable to drive a red/green test.

## Gates
- `@matter/node` suite 1157/1157 ✓
- format-verify ✓ · lint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)