### PR TITLE
fix(protocol): detach FailsafeContext closedByPeer listener on close

### DIFF
--- a/packages/protocol/src/common/FailsafeContext.ts
+++ b/packages/protocol/src/common/FailsafeContext.ts
@@ -47,6 +47,7 @@ export abstract class FailsafeContext {
     #forUpdateNoc?: boolean;
     #fabricBuilder?: FabricBuilder;
     #rootCertSet = false;
+    #detachClosedByPeer?: () => void;
 
     #commissioned = AsyncObservable<[], void>();
 
@@ -75,12 +76,15 @@ export abstract class FailsafeContext {
             logger.debug(`Arm failSafe timer for ${Duration.format(expiryLength)}`);
 
             // When the PASE session used to arm the Fail-Safe timer is terminated by peer, the Fail-Safe timer SHALL
-            // be considered expired and do the relevant cleanup actions.
-            session.closedByPeer.on(() => {
+            // be considered expired and do the relevant cleanup actions. closedByPeer is reusable, so detach on close
+            // to avoid leaking this context across commission retries.
+            const closedByPeer = () => {
                 if (!this.#failsafe?.completed) {
                     return this.#failSafeExpired();
                 }
-            });
+            };
+            session.closedByPeer.on(closedByPeer);
+            this.#detachClosedByPeer = () => session.closedByPeer.off(closedByPeer);
         });
     }
 
@@ -190,6 +194,8 @@ export abstract class FailsafeContext {
 
     async close(currentExchange?: MessageExchange) {
         await this.#construction.close(async () => {
+            this.#detachClosedByPeer?.();
+            this.#detachClosedByPeer = undefined;
             if (this.#failsafe) {
                 await this.#failsafe.close();
                 this.#failsafe = undefined;

--- a/packages/protocol/test/common/FailsafeContextTest.ts
+++ b/packages/protocol/test/common/FailsafeContextTest.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { FailsafeContext } from "#common/FailsafeContext.js";
+import { FabricManager } from "#fabric/FabricManager.js";
+import { SessionParameters } from "#index.js";
+import { NodeSession } from "#session/NodeSession.js";
+import { SessionManager } from "#session/SessionManager.js";
+import { b$, MemoryStorageDriver, Seconds, StandardCrypto, StorageContext } from "@matter/general";
+import { NodeId } from "@matter/types";
+
+const KEY = b$`66951379d0a6d151cf5472cccf13f360`;
+
+class TestFailsafeContext extends FailsafeContext {
+    override async storeEndpointState() {}
+    override async restoreNetworkState() {}
+    override async restoreBreadcrumb() {}
+}
+
+describe("FailsafeContext", () => {
+    function setup() {
+        const crypto = new StandardCrypto();
+        const storage = new MemoryStorageDriver();
+        storage.initialize();
+        const fabrics = new FabricManager(crypto);
+        const sessions = new SessionManager({
+            parameters: {} as SessionParameters,
+            fabrics,
+            storage: new StorageContext(storage, ["context"]),
+        });
+        const session = new NodeSession({
+            crypto,
+            id: 1,
+            fabric: undefined,
+            peerNodeId: NodeId.UNSPECIFIED_NODE_ID,
+            peerSessionId: 1,
+            decryptKey: KEY,
+            encryptKey: KEY,
+            attestationKey: new Uint8Array(),
+            isInitiator: true,
+        });
+        return { sessions, fabrics, session };
+    }
+
+    it("detaches its closedByPeer listener on close", async () => {
+        const { sessions, fabrics, session } = setup();
+
+        expect(session.closedByPeer.isObserved).false;
+
+        const context = new TestFailsafeContext({
+            sessions,
+            fabrics,
+            session,
+            expiryLength: Seconds(60),
+            maxCumulativeFailsafe: Seconds(900),
+        });
+        await context.construction.ready;
+
+        expect(session.closedByPeer.isObserved).true;
+
+        await context.close();
+
+        expect(session.closedByPeer.isObserved).false;
+    });
+});


### PR DESCRIPTION
## Problem

`FailsafeContext` registered a handler on the session's `closedByPeer` observable in its construction without capturing the disposer:

```ts
session.closedByPeer.on(() => { ... });  // disposer discarded
```

`closedByPeer` is a reusable `AsyncObservableValue` on `NodeSession` (not one-shot). Across repeated commission attempts, each new `FailsafeContext` attaches another handler that never detaches. The handler closure keeps the closed `FailsafeContext` reachable — a slow leak proportional to the commission failure/retry count.

## Fix

- Name the handler and capture its disposer: `this.#detachClosedByPeer = () => session.closedByPeer.off(handler)`.
- Invoke it in `close()` (inside the `#construction.close(...)` destructor), then clear the field.

Safe in the edge cases:
- **Re-entrancy:** the handler calls `#failSafeExpired()` → `close()` → `off(handler)` while the handler is mid-emit. `Observable.emit` iterates a *cloned* observer array, so removing from the Set during emit is safe.
- **Double close:** second call finds `#detachClosedByPeer` undefined → no-op.
- **Construction failed before attach:** field stays undefined → detach skipped harmlessly.

## Test

`packages/protocol/test/common/FailsafeContextTest.ts` builds a real `NodeSession` + `FabricManager` + `SessionManager` and a minimal `FailsafeContext` subclass, then asserts `session.closedByPeer.isObserved` is `false` initially, `true` after construction, and `false` after `close()`. Fails on the pre-fix code (`expected true to be false`), passes with the fix.

## Gates
- `@matter/protocol` suite 870/870 ✓
- format-verify ✓ · lint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)