### PR TITLE
fix(node): reject commissioning a NodeId already in use

### DIFF
--- a/packages/node/src/behavior/system/controller/ControllerBehavior.ts
+++ b/packages/node/src/behavior/system/controller/ControllerBehavior.ts
@@ -7,7 +7,7 @@
 import { Behavior } from "#behavior/Behavior.js";
 import { BasicInformationBehavior } from "#behaviors/basic-information";
 import { Node } from "#node/Node.js";
-import { IdentityService } from "#node/server/IdentityService.js";
+import { IdentityConflictError, IdentityService } from "#node/server/IdentityService.js";
 import {
     Crypto,
     DnsRecordType,
@@ -130,6 +130,13 @@ export class ControllerBehavior extends Behavior {
                 // Lock early to act as semaphor for address assignment
                 await agent.context.transaction.addResources(controller);
                 await agent.context.transaction.begin();
+
+                // A caller-supplied NodeId bypasses the allocation loop below, so check it for collisions here.
+                if (nodeId !== undefined && identity.peerAddressInUse({ fabricIndex, nodeId })) {
+                    throw new IdentityConflictError(
+                        `Cannot assign NodeId ${nodeId} on fabric ${fabricIndex}: the peer address is already in use`,
+                    );
+                }
 
                 const useSequentialIds = controller.state.nodeIdAssignment !== "random";
                 let nextNodeId: NodeId = controller.state.nextNodeId ?? NodeId(1);

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -1113,6 +1113,17 @@ describe("ClientNode", () => {
         await MockTime.resolve(ep1.commandsOf(OnOffClient).offWithEffect({ effectIdentifier: 0, effectVariant: 0 }));
     });
 
+    it("refuses to allocate a peer address whose NodeId is already in use", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+
+        const { fabricIndex, nodeId } = controller.peers.get("peer1")!.peerAddress!;
+
+        await expect(
+            controller.act(agent => agent.get(ControllerBehavior).allocatePeerAddress(fabricIndex, nodeId)),
+        ).rejectedWith(/already in use/i);
+    });
+
     it("properly supports unknown clusters", async () => {
         // *** SETUP ***
 


### PR DESCRIPTION
## Problem

`ControllerBehavior.allocatePeerAddress(fabricIndex, nodeId?)` only guarded against NodeId collisions while **auto-allocating**: the `while (nodeId === undefined)` loop re-rolls when `identity.peerAddressInUse(...)` is true.

When the caller **supplies** a NodeId (e.g. `CommissioningClient` passes `opts.nodeId`), that loop is skipped and the code goes straight to `identity.reservePeerAddress(address)` — a bare `Set.add` with no collision check. Commissioning with a NodeId already in use on the fabric therefore silently double-reserves the address and corrupts peer state (the collision is only noticed later, if at all).

Reproduced: allocating an already-commissioned peer's NodeId again resolved successfully instead of failing.

## Fix

Inside the allocation transaction (so it is race-safe against concurrent allocations, matching the auto-allocation loop), reject a caller-supplied NodeId that is already in use:

```ts
if (nodeId !== undefined && identity.peerAddressInUse({ fabricIndex, nodeId })) {
    throw new IdentityConflictError(
        `Cannot assign NodeId ${nodeId} on fabric ${fabricIndex}: the peer address is already in use`,
    );
}
```

`IdentityConflictError` is the existing error type for this class of conflict (e.g. duplicate endpoint numbers).

No regression for re-commissioning: re-pairing decommissions first, which releases the reserved address before a new allocation.

## Test

`refuses to allocate a peer address whose NodeId is already in use`: commission a pair, then call `allocatePeerAddress(fabricIndex, peer1NodeId)` and assert it rejects with `/already in use/`. Fails on pre-fix code (the call resolves), passes with the fix.

## Note (out of scope)

`IdentityService.reservePeerAddress` adds to its `Set<PeerAddress>` without `PeerAddress(...)` normalization, while `peerAddressInUse`/`releasePeerAddress` normalize. Harmless today because all callers pass interned `PeerAddress` instances, but normalizing on insert would make it robust. Not changed here.

## Gates
- `@matter/node` suite 1157/1157 ✓
- format-verify ✓ · lint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)