### PR TITLE
fix(general): notify on operational TXT parameter changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/general
     - Fix: `causedBy`/`asError`/`errorOf`/`repackErrorAs` no longer crash with "undefined is not an object" when invoked with `undefined`/`null` as error object
+    - Fix: IpService now also emits changed event when the TXT reconrd changes to ensure updates of the descriptor
 
 - @matter/model
     - Fix: Remove invalid FabricIndex field from four commands

--- a/packages/general/src/net/dns-sd/IpService.ts
+++ b/packages/general/src/net/dns-sd/IpService.ts
@@ -11,6 +11,7 @@ import { ServerAddressSet } from "#net/ServerAddressSet.js";
 import { Duration } from "#time/Duration.js";
 import { Time } from "#time/Time.js";
 import { Abort } from "#util/Abort.js";
+import { Bytes } from "#util/Bytes.js";
 import { AsyncObservable, AsyncObservableValue, ObserverGroup } from "#util/Observable.js";
 import { DnssdName } from "./DnssdName.js";
 import { DnssdNames } from "./DnssdNames.js";
@@ -30,6 +31,7 @@ export class IpService {
     readonly #addresses = ServerAddressSet<ServerAddressIp>();
     #status = new IpServiceStatus(this);
     #notified?: Promise<void>;
+    #parameterSignature: string;
 
     constructor(name: string, via: string, names: DnssdNames) {
         this.#name = names.get(name);
@@ -45,6 +47,8 @@ export class IpService {
 
             this.#updateService(record.ttl, service);
         }
+
+        this.#parameterSignature = parameterSignatureOf(this.parameters);
     }
 
     /**
@@ -184,21 +188,35 @@ export class IpService {
     }
 
     #onServiceChanged = async ({ updated, deleted }: DnssdName.Changes) => {
+        // The address-change path never observes TXT records, so detect parameter changes here.
+        let txtUpdated = false;
+
         if (updated) {
             for (const record of updated) {
                 const service = serviceOf(record);
                 if (service) {
                     this.#updateService(record.ttl, service);
+                } else if (record.recordType === DnsRecordType.TXT) {
+                    txtUpdated = true;
                 }
             }
         }
 
+        // Deleted/expired TXT is intentionally ignored: keep the last known parameters as the best assumption.
         if (deleted) {
             for (const record of deleted) {
                 const service = serviceOf(record);
                 if (service) {
                     this.#deleteService(service);
                 }
+            }
+        }
+
+        if (txtUpdated) {
+            const signature = parameterSignatureOf(this.parameters);
+            if (signature !== this.#parameterSignature) {
+                this.#parameterSignature = signature;
+                this.#notify();
             }
         }
     };
@@ -333,6 +351,13 @@ function serviceOf(record: DnssdName.Record) {
     }
 
     return record.value;
+}
+
+function parameterSignatureOf(parameters: DnssdParameters): string {
+    return [...parameters.keys()]
+        .sort()
+        .map(key => `${key}=${Bytes.toHex(parameters.raw(key)!)}`)
+        .join("\0");
 }
 
 function hostKeyOf(name: string, port: number) {

--- a/packages/general/test/net/dns-sd/IpServiceTest.ts
+++ b/packages/general/test/net/dns-sd/IpServiceTest.ts
@@ -25,6 +25,47 @@ describe("IpService", () => {
         expectKvs(service);
     });
 
+    it("notifies on parameter changes but swallows identical re-announcements and TXT expiry", async () => {
+        await using site = new MockSite();
+        const { client, server } = await site.addPair();
+
+        const service = client.addService();
+
+        // Reachable means no active resolution runs; parameter changes must still arrive via passive announcements.
+        service.status.isReachable = true;
+
+        const changed = new Promise<void>(resolve => service.changed.once(resolve));
+        await server.broadcast(1, Hours(24));
+        await MockTime.resolve(changed);
+        expectKvs(service);
+
+        let changes = 0;
+        service.changed.on(() => {
+            changes++;
+        });
+
+        // Identical re-announcement: parameters did not change, so no notification.
+        await MockTime.resolve(server.broadcast(1, Hours(24)), { macrotasks: true });
+        await MockTime.advance(Minutes(1));
+        expect(changes).equals(0);
+
+        // Changed parameters: notify and reflect the new values.
+        const rechanged = new Promise<void>(resolve => service.changed.once(resolve));
+        await server.broadcast(1, Hours(24), undefined, ["foo=baz", "added=1"]);
+        await MockTime.resolve(rechanged);
+        expect(changes).equals(1);
+        const kvs = new Map([...service.parameters]);
+        expect(kvs.get("foo")).equals("baz");
+        expect(kvs.get("added")).equals("1");
+
+        // TXT expiry while the address persists: swallowed (last known parameters remain the best assumption).
+        await MockTime.resolve(server.broadcast(1, Hours(24), undefined, ["foo=baz", "added=1"], 0), {
+            macrotasks: true,
+        });
+        await MockTime.advance(Minutes(1));
+        expect(changes).equals(1);
+    });
+
     it("expires", async () => {
         await using site = new MockSite();
         const { client, server } = await site.addPair();

--- a/packages/general/test/net/dns-sd/dns-sd-helpers.ts
+++ b/packages/general/test/net/dns-sd/dns-sd-helpers.ts
@@ -118,7 +118,13 @@ export class MockHost {
     /**
      * Send MDNS message now.
      */
-    async broadcast(nameOrIndex: number | string = 1, ttl = Hours(1), ips?: string[]) {
+    async broadcast(
+        nameOrIndex: number | string = 1,
+        ttl = Hours(1),
+        ips?: string[],
+        txt = ["foo=bar", "flag"],
+        txtTtl = ttl,
+    ) {
         const qname = qnameOf(nameOrIndex);
 
         const answers: DnsRecord[] = [
@@ -138,9 +144,9 @@ export class MockHost {
             {
                 name: qname,
                 recordType: DnsRecordType.TXT,
-                ttl,
+                ttl: txtTtl,
                 recordClass: DnsRecordClass.IN,
-                value: ["foo=bar", "flag"],
+                value: txt,
             },
         ];
 


### PR DESCRIPTION
## Problem

`IpService` emitted its `changed` event only when **IP addresses** changed. Its DNS-SD name observer `#onServiceChanged` handled SRV records (driving address resolution, which notifies on address add/delete) but **ignored TXT records entirely**.

So when a peer re-announced operationally with the **same address but changed session parameters** (TXT: `SII`/`SAI`/`SAT`, TCP support `T`, `ICD`, …), `IpService.parameters` (a live read of the name) reflected the new values, but `changed` never fired. `Peer` copies `service.parameters` into the persisted `ClientNode` descriptor (`discoveryData`) on `changed`, so the descriptor went **stale** — the controller kept using outdated session/MRP parameters.

This matters specifically when connecting to a peer via a **known operational address**: no active resolution runs (`isReachable` short-circuits it), but the `Peer` still constructs an `IpService` that passively observes the mDNS name. Inbound re-announcements were ingested into the name cache but never propagated to the descriptor.

## Fix

`#onServiceChanged` now notifies on a TXT update — but only when the parameter **values actually changed**:

- An **updated** TXT recomputes an order-independent, binary-safe signature (`key=hex(rawValue)`, sorted) and notifies only if it differs from the last observed signature. Identical re-announcements are ignored.
- A **deleted or expired** TXT is **swallowed**: the last known parameters remain the best assumption, so the descriptor is neither wiped nor re-notified.

The signature is seeded in the constructor so parameters already present at construction don't trigger a spurious first notification.

## Test

`IpServiceTest` — a reachable (non-resolving) service:
- identical re-announcement → **0** notifications,
- changed TXT → **1** notification + new values exposed,
- TXT expiry (goodbye) while the address persists → **still 1** (swallowed).

Confirmed red/green (fails with the fix reverted). The `broadcast` test helper gained an additive `txtTtl` parameter (defaults to `ttl`) to send a TXT goodbye while keeping the address alive.

## Gates
- `@matter/general` suite 795/795 ✓
- format-verify ✓ · lint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)