### PR TITLE
fix(model): preserve parentheses when serializing negated conformance groups

### DIFF
--- a/packages/model/src/aspects/Conformance.ts
+++ b/packages/model/src/aspects/Conformance.ts
@@ -418,7 +418,8 @@ export namespace Conformance {
                 return `${lhs} ${ast.type} ${rhs}`;
 
             case Operator.NOT:
-                return `!${serializeAtomic(ast.param)}`;
+                // NOT binds tighter than every binary operator, so a binary operand must be grouped
+                return isBinaryOperator(ast.param.type) ? `!(${serialize(ast.param)})` : `!${serialize(ast.param)}`;
 
             case Special.Empty:
                 return "";

--- a/packages/model/src/logic/cluster-variance/IllegalFeatureCombinations.ts
+++ b/packages/model/src/logic/cluster-variance/IllegalFeatureCombinations.ts
@@ -182,7 +182,11 @@ function addFeatureNode(
                 }
 
                 case Conformance.Operator.NOT: {
-                    add({ [feature.name]: true, [extractName(node.param.param)]: true });
+                    // [!X] disallows the feature whenever X holds; for [!(A | B)] each disjunct is independently illegal
+                    const disjuncts = extractDisjunctFeatures(node.param.param);
+                    for (const name in disjuncts) {
+                        add({ [feature.name]: true, [name]: disjuncts[name] });
+                    }
                     break;
                 }
 

--- a/packages/model/src/standard/elements/on-off.element.ts
+++ b/packages/model/src/standard/elements/on-off.element.ts
@@ -23,7 +23,7 @@ export const OnOff = Cluster(
         { name: "FeatureMap", id: 0xfffc, type: "FeatureMap" },
         Field({ name: "LT", conformance: "[!OFFONLY]", constraint: "0", title: "Lighting" }),
         Field({ name: "DF", conformance: "[!OFFONLY]", constraint: "1", title: "DeadFrontBehavior" }),
-        Field({ name: "OFFONLY", conformance: "[!LT | DF]", constraint: "2", title: "OffOnly" })
+        Field({ name: "OFFONLY", conformance: "[!(LT | DF)]", constraint: "2", title: "OffOnly" })
     ),
 
     Attribute({ name: "OnOff", id: 0x0, type: "bool", access: "R V", conformance: "M", quality: "N S" }),

--- a/packages/model/test/aspects/ConformanceTest.ts
+++ b/packages/model/test/aspects/ConformanceTest.ts
@@ -28,6 +28,10 @@ const TEST_DEFINITIONS = [
     "AX, WBL",
     "[WIRED]",
     "!AB",
+    "!(LT | DF)",
+    "[!(LT | DF)]",
+    "!(LT & DF)",
+    "!(A | B | C)",
     "AB.a",
     "AB.a+",
     "AB.a2",
@@ -65,6 +69,8 @@ const TEST_DEFINITIONS = [
 
 const TEST_DEFINITIONS2 = {
     "(AX | WBL)": "AX | WBL",
+    "[!(LT)]": "[!LT]",
+    "!((LT | DF))": "!(LT | DF)",
     "RequiresEncodedPixels == True": "RequiresEncodedPixels == true",
     "Enabled == False": "Enabled == false",
 };

--- a/packages/model/test/logic/ClusterVarianceTest.ts
+++ b/packages/model/test/logic/ClusterVarianceTest.ts
@@ -5,6 +5,7 @@
  */
 
 import { ClusterElement, ClusterModel, ClusterVariance, Conformance, FeatureMap, MatterModel } from "#index.js";
+import { IllegalFeatureCombinations } from "#logic/cluster-variance/IllegalFeatureCombinations.js";
 import { InferredComponent } from "#logic/cluster-variance/InferredComponents.js";
 import { VarianceCondition } from "#logic/cluster-variance/VarianceCondition.js";
 
@@ -122,7 +123,41 @@ describe("ClusterVariance", () => {
             });
         });
     });
+
+    describe("illegal feature combinations", () => {
+        // OnOff: OFFONLY conformance "[!(LT | DF)]" is disallowed whenever LT or DF is enabled
+        it("supports negated disjunction over features", () => {
+            expect(
+                illegalCombinations(
+                    { name: "LT", conformance: "[!OFFONLY]" },
+                    { name: "DF", conformance: "[!OFFONLY]" },
+                    { name: "OFFONLY", conformance: "[!(LT | DF)]" },
+                ),
+            ).deep.equal([
+                { LT: true, OFFONLY: true },
+                { DF: true, OFFONLY: true },
+            ]);
+        });
+    });
 });
+
+function illegalCombinations(...features: { name: string; conformance: string }[]) {
+    const cluster = new ClusterModel({
+        id: 1,
+        name: "Cluster",
+        children: [
+            {
+                tag: "attribute",
+                id: FeatureMap.id,
+                name: "FeatureMap",
+                type: "FeatureMap",
+                children: features.map(f => ({ tag: "field", ...f })),
+            },
+        ],
+    });
+    new MatterModel({ name: "Matter", children: [cluster] });
+    return IllegalFeatureCombinations(cluster).illegal;
+}
 
 type AttributeDefinition = { name: string; conformance: Conformance.Definition } | string[];
 

--- a/support/models/src/v1.5.1/spec.ts
+++ b/support/models/src/v1.5.1/spec.ts
@@ -1090,7 +1090,7 @@ export const SpecMatter = Matter(
             }),
 
             Field({
-                name: "OFFONLY", conformance: "[!LT | DF]", constraint: "2", title: "OffOnly",
+                name: "OFFONLY", conformance: "[!(LT | DF)]", constraint: "2", title: "OffOnly",
                 xref: "cluster§1.5.4.3",
 
                 details: "When this feature is supported, the Off command shall be supported and the On and Toggle commands " +


### PR DESCRIPTION
## Problem

`OnOff` feature `OFFONLY` had conformance `[!LT | DF]` in `v1.5.1/spec.ts`, but the spec markdown says `[!(LT | DF)]`. The dropped parentheses invert the meaning: `!(LT | DF)` (NOT lighting and NOT dead-front) vs `(!LT) | DF`.

## Root cause

Not the scraper — the markdown parser produces `[!(LT | DF)]` correctly. The `Conformance` aspect parses the conformance into an AST and **re-serializes** it during codegen, and `Conformance.serialize`'s `Operator.NOT` case emitted its operand with no parentheses:

```js
case Operator.NOT:
    return `!${serializeAtomic(ast.param)}`;   // otherOperator omitted → never parenthesizes
```

`!` binds tighter than every binary operator, so `NOT(OR(LT, DF))` serialized to `!LT | DF`, which re-parses as `(!LT) | DF`. The binary-operator serialization path *does* parenthesize correctly (e.g. `[MS & (MSR | AS)]` survives), so only operands of unary `!` were affected. The mangled output matched the already-committed value, so regeneration produced no diff and the bug looked baked-in.

## Fix

1. **`Conformance.ts`** — parenthesize NOT's operand when it is a binary operator.
2. **`IllegalFeatureCombinations.ts`** — the fix surfaced a second gap: the feature-variance generator's `OptionalIf → NOT` rule only handled `!Name` (`extractName` threw on a group), so `generate-clusters` aborted with *"New rule required to support OnOff.state.featureMap.OFFONLY conformance"*. Generalized via `extractDisjunctFeatures`: `[!(A | B)]` makes the feature illegal in combination with each disjunct (correct polarity, including nested `!`). The `!Name` case is unchanged.
3. Regenerated `v1.5.1/spec.ts` + `on-off.element.ts` — `OFFONLY` is the only `!(group)` feature conformance in 1.5.1, so the regen diff is a single line each.

Older spec versions (1.1–1.4.2) left as-is — 1.5.1 is the current baseline and the runtime model derives from it.

## Tests

- `ConformanceTest`: round-trip cases for `!(A | B)`, `[!(LT | DF)]`, `!(A & B)`, plus redundant-paren normalization (`[!(LT)]` → `[!LT]`).
- `ClusterVarianceTest`: regression for negated-disjunction feature conformance (the case that previously threw).

## Verification

- `npm run build -- --clean` ✓
- `format-verify` ✓ · `lint` ✓
- Tests: model 442/442, types 315/315, node 1158/1158 (ESM/CJS/Web)
- 1.5.1 codegen validation baseline unchanged (7 errors / 4 invalid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)