### PR TITLE
feat(shell): add fabric-filtered flag to attribute read commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/types
     - Fix: Remove invalid FabricIndex field from four commands
 
+- @matter/nodejs-shell
+    - Feature: Added `--fabric-filtered` flag (default `true`) to the attribute read commands to control fabric filtering
+
 ## 0.17.0 (2026-05-20)
 
 - Breaking: Matter 1.5/1.5.1 specification introduces some changes, as always with new Matter specification versions. You might need to adjust your code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/node
   - Fix: Roll back assigned Fabric from PASE session on AddNOC/UpdateNOC failure
 
+- @matter/nodejs-shell
+    - Feature: Added `--fabric-filtered` flag (default `true`) to the attribute read commands to control fabric filtering
+
 - @matter/protocol
     - Feature: New `TrustedAsTestCertificate` attestation finding lets `onAttestationFailure` decide whether to accept devices whose PAA is only in the trust store as a test certificate; previously these failed with `PaaNotTrusted`. Adds per-call `considerTestCertificates` and a separate `acceptTestCertificates` trust policy on `DclCertificateService`
     - Feature: `OnAttestationFailure` callback may return a `string` (wraps the underlying error as `cause` of a new `CommissioningError`) or throw to propagate verbatim
@@ -39,9 +42,6 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/types
     - Fix: Remove invalid FabricIndex field from four commands
-
-- @matter/nodejs-shell
-    - Feature: Added `--fabric-filtered` flag (default `true`) to the attribute read commands to control fabric filtering
 
 ## 0.17.0 (2026-05-20)
 

--- a/packages/nodejs-ble/src/NobleBleClient.ts
+++ b/packages/nodejs-ble/src/NobleBleClient.ts
@@ -146,9 +146,10 @@ export class NobleBleClient {
             return;
         }
         this.#closing = true;
-        logger.debug("Stopping Noble");
 
         if (this.nobleState === "poweredOn") {
+            logger.debug("Stopping Noble");
+
             // noble.stop() hangs when BLE isn't powered on (https://github.com/stoprocent/noble/issues/30).
             // Only attempt the full stop sequence when BLE is actually available.
             try {
@@ -170,7 +171,7 @@ export class NobleBleClient {
             // Defer listener removal so noble.stop() can finish its internal event roundtrip
             Time.getTimer("noble-cleanup", Instant, () => noble.removeAllListeners()).start();
         } else {
-            logger.debug(`Skipping noble.stop() because state is "${this.nobleState}"`);
+            logger.debug(`Skip stopping noble because state is "${this.nobleState}"`);
 
             // No stop needed — remove listeners immediately to release the event loop
             noble.removeAllListeners();

--- a/packages/nodejs-shell/src/shell/cmd_cluster-attributes.ts
+++ b/packages/nodejs-shell/src/shell/cmd_cluster-attributes.ts
@@ -41,9 +41,16 @@ function generateAllAttributeHandlersForCluster(yargs: Argv, theNode: MatterNode
                     describe: "endpoint id to read",
                     type: "number",
                     demandOption: true,
+                })
+                .options({
+                    "fabric-filtered": {
+                        describe: "request fabric-filtered data (only data visible to the accessing fabric)",
+                        default: true,
+                        type: "boolean",
+                    },
                 }),
         async argv => {
-            const { nodeId, endpointId, clusterId, attributeId: rawAttributeId } = argv;
+            const { nodeId, endpointId, clusterId, attributeId: rawAttributeId, fabricFiltered } = argv;
             const attributeId = rawAttributeId === "*" ? undefined : parseInt(rawAttributeId);
             const node = (await theNode.connectAndGetNodes(nodeId))[0];
 
@@ -57,6 +64,7 @@ function generateAllAttributeHandlersForCluster(yargs: Argv, theNode: MatterNode
                             attributeId: attributeId !== undefined ? AttributeId(attributeId) : undefined,
                         },
                     ],
+                    isFabricFiltered: fabricFiltered,
                 });
                 console.log(
                     `Attribute values for cluster ${node.nodeId.toString()}/${endpointId}/${clusterId}/${attributeId}:`,
@@ -115,11 +123,17 @@ function generateClusterAttributeHandlers(yargs: Argv, cluster: ClusterModel, th
                                         default: false,
                                         type: "boolean",
                                     },
+                                    "fabric-filtered": {
+                                        describe:
+                                            "request fabric-filtered data (only data visible to the accessing fabric)",
+                                        default: true,
+                                        type: "boolean",
+                                    },
                                 });
                         },
                         async argv => {
                             const clusterId = cluster.id;
-                            const { nodeId, endpointId, remote } = argv;
+                            const { nodeId, endpointId, remote, fabricFiltered } = argv;
                             const requestRemote = remote ? true : undefined;
                             const node = (await theNode.connectAndGetNodes(nodeId))[0];
 
@@ -138,11 +152,14 @@ function generateClusterAttributeHandlers(yargs: Argv, cluster: ClusterModel, th
                             for (const attribute of cluster.attributes) {
                                 const attributeName = attribute.propertyName;
                                 const attributeClient = clusterClient.attributes[attributeName];
-                                if (!remote && !(attributeClient instanceof SupportedAttributeClient)) {
+                                if (
+                                    attributeClient === undefined ||
+                                    (!remote && !(attributeClient instanceof SupportedAttributeClient))
+                                ) {
                                     continue;
                                 }
                                 console.log(
-                                    `    ${attributeName} (${attribute.id}): ${Diagnostic.json(await attributeClient.get(requestRemote))}`,
+                                    `    ${attributeName} (${attribute.id}): ${Diagnostic.json(await attributeClient.get(requestRemote, fabricFiltered))}`,
                                 );
                             }
                         },
@@ -217,9 +234,14 @@ function generateAttributeReadHandler(
                         default: false,
                         type: "boolean",
                     },
+                    "fabric-filtered": {
+                        describe: "request fabric-filtered data (only data visible to the accessing fabric)",
+                        default: true,
+                        type: "boolean",
+                    },
                 }),
         async argv => {
-            const { nodeId, endpointId, remote } = argv;
+            const { nodeId, endpointId, remote, fabricFiltered } = argv;
             const requestRemote = remote ? true : undefined;
             const node = (await theNode.connectAndGetNodes(nodeId))[0];
 
@@ -229,7 +251,7 @@ function generateAttributeReadHandler(
                 return;
             }
             const attributeClient = clusterClient.attributes[attributeName];
-            if (!remote && !(attributeClient instanceof SupportedAttributeClient)) {
+            if (attributeClient === undefined || (!remote && !(attributeClient instanceof SupportedAttributeClient))) {
                 console.log(
                     `ERROR: Attribute ${node.nodeId.toString()}/${endpointId}/${clusterId}/${attribute.id} not supported by the device.`,
                 );
@@ -237,7 +259,7 @@ function generateAttributeReadHandler(
             }
             try {
                 console.log(
-                    `Attribute value for ${attributeName} ${node.nodeId.toString()}/${endpointId}/${clusterId}/${attribute.id}: ${Diagnostic.json(await attributeClient.get(requestRemote))}`,
+                    `Attribute value for ${attributeName} ${node.nodeId.toString()}/${endpointId}/${clusterId}/${attribute.id}: ${Diagnostic.json(await attributeClient.get(requestRemote, fabricFiltered))}`,
                 );
             } catch (error) {
                 console.log(`ERROR: Could not get attribute ${attribute.name}: ${error}`);

--- a/packages/protocol/src/common/BleScanner.ts
+++ b/packages/protocol/src/common/BleScanner.ts
@@ -103,7 +103,7 @@ export class BleScanner implements Scanner {
         }
         this.#recordWaiters.set(queryId, { resolver, timer, resolveOnUpdatedRecords, cancelResolver });
         logger.debug(
-            `Registered waiter for query ${queryId} with timeout ${timeout === undefined ? "(none)" : Duration.format(timeout)} ${
+            `Registered waiter for query ${queryId} with timeout ${timeout === undefined ? "(none)" : Duration.format(timeout)}${
                 resolveOnUpdatedRecords ? "" : " (not resolving on updated records)"
             }`,
         );


### PR DESCRIPTION
## What

Adds a `--fabric-filtered` boolean flag (default `true`, preserving current behavior) to the shell attribute **read** commands, so reads can be requested with or without fabric filtering:

- `by-id <cluster-id> read <attr-id> <node> <ep>` → forwards to `getMultipleAttributes({ isFabricFiltered })`
- `<cluster> read * <node> <ep>` / `all` → `attributeClient.get(remote, fabricFiltered)`
- `<cluster> read <attr> <node> <ep>` → `attributeClient.get(remote, fabricFiltered)`

Usage: append `--no-fabric-filtered` for an unfiltered (wildcard-fabric) read.

## Also: crash fix

Pre-existing bug surfaced while testing: `read all` (and single-attribute read) crashed with `Cannot read properties of undefined (reading 'get')` when an attribute from the model is unknown to the cluster client (`clusterClient.attributes[name]` is `undefined`). The old guard only skipped such attributes when `!remote`, so `.get` ran on `undefined`. Now both paths skip/error when `attributeClient === undefined` regardless of `remote`.

## Notes

- Write path untouched (read-only flag).
- Verified: `npm run build -p packages/nodejs-shell`, `format-verify`, `lint` all green. (nodejs-shell has no test suite.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)