### PR TITLE
fix(protocol): align session eviction and Busy send with Matter spec

### DIFF
--- a/packages/protocol/src/securechannel/SecureChannelMessenger.ts
+++ b/packages/protocol/src/securechannel/SecureChannelMessenger.ts
@@ -148,7 +148,7 @@ export class SecureChannelMessenger {
             GeneralStatusCode.Busy,
             SecureChannelStatusCode.Busy,
             abort,
-            undefined,
+            false,
             writer.toByteArray(),
         );
     }

--- a/packages/protocol/src/session/SessionManager.ts
+++ b/packages/protocol/src/session/SessionManager.ts
@@ -368,7 +368,7 @@ export class SessionManager {
 
         let oldestSession: NodeSession | undefined = undefined;
         for (const session of this.#sessions) {
-            if (!oldestSession || session.activeTimestamp < oldestSession.activeTimestamp) {
+            if (!oldestSession || session.timestamp < oldestSession.timestamp) {
                 oldestSession = session;
             }
         }


### PR DESCRIPTION
## Summary

Two small Matter spec-compliance fixes in the Secure Channel protocol, found during the 1.6.0 spec↔implementation verification:

- **Session eviction (§4.11.1.1):** `SessionManager.findOldestInactiveSession()` now selects the LRU victim by `session.timestamp` (updated on send **or** receive — matching the spec's `SessionTimestamp`) instead of `session.activeTimestamp` (receive-only). Previously a session the local node only sent on (e.g. server pushing subscription reports) kept a stale `activeTimestamp` and could be wrongly evicted during session-id exhaustion while genuinely older idle sessions survived. CHIP's `SecureSessionTable` sorts eviction by `GetLastActivityTime()`, which updates on both TX and RX.

- **Busy StatusReport (§4.11.1.5):** `SecureChannelMessenger.sendBusy()` now sends with `requiresAck: false` (R Flag = 0) as the spec mandates, matching the existing `sendCloseSession()` behavior. Latent fix — `sendBusy` currently has no caller, but any future responder-side Busy emit would have gone out reliable over UDP.

## Testing

- `packages/protocol` test suite passes (1075/1075)
- Format + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)