### PR TITLE
fix(protocol): bounds-check message/secured extensions length on decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: An empty mDNS TXT record is now encoded as a single zero byte as required by RFC 6763 §6.1
 
 - @matter/protocol
+    - Enhancement: SII/SAI/SAT keys are now omitted from advertised DNS-SD TXT records when at their default values, matching CHIP SDK behavior
     - Fix: Corrected the Session Active Threshold limit to 65535 milliseconds (was wrongly checked against 65535 seconds)
     - Fix: Invalid or out-of-range SII/SAI/SAT values in discovered DNS-SD TXT records are now ignored so MRP defaults apply, as required by the Matter spec
-    - Enhancement: SII/SAI/SAT keys are now omitted from advertised DNS-SD TXT records when at their default values, matching CHIP SDK behavior
+    - Fix: Added size checks for Message Extensions and Secured Extensions length fields on message decode
 
 ## 0.17.1 (2026-06-03)
 

--- a/packages/protocol/src/codec/MessageCodec.ts
+++ b/packages/protocol/src/codec/MessageCodec.ts
@@ -173,6 +173,11 @@ export class MessageCodec {
         let messageExtension: Bytes | undefined = undefined;
         if (header.hasMessageExtensions) {
             const extensionLength = reader.readUInt16();
+            if (extensionLength > reader.remainingBytesCount) {
+                throw new UnexpectedDataError(
+                    `Message extension length ${extensionLength} exceeds remaining message size ${reader.remainingBytesCount}.`,
+                );
+            }
             messageExtension = reader.readByteArray(extensionLength);
         }
 
@@ -190,6 +195,11 @@ export class MessageCodec {
         let securityExtension: Bytes | undefined = undefined;
         if (payloadHeader.hasSecuredExtension) {
             const extensionLength = reader.readUInt16();
+            if (extensionLength > reader.remainingBytesCount) {
+                throw new UnexpectedDataError(
+                    `Secured extension length ${extensionLength} exceeds remaining message size ${reader.remainingBytesCount}.`,
+                );
+            }
             securityExtension = reader.readByteArray(extensionLength);
         }
 
@@ -324,7 +334,9 @@ export class MessageCodec {
             sessionType === SessionType.Group &&
             (destGroupId === undefined || sourceNodeId === undefined || destNodeId !== undefined)
         ) {
-            throw new InternalError(`Group session must have destination group id or source node id.`);
+            throw new InternalError(
+                `Group session must have a destination group id and a source node id and no destination node id.`,
+            );
         }
         const writer = new DataWriter(Endian.Little);
         const flags =

--- a/packages/protocol/test/codec/MessageCodecTest.ts
+++ b/packages/protocol/test/codec/MessageCodecTest.ts
@@ -108,6 +108,17 @@ describe("MessageCodec", () => {
             });
         });
 
+        it("rejects message extension length exceeding remaining bytes", () => {
+            // Same as ENCODED_WITH_PRIVACY_EXTENSION but extension length field set to 0xffff
+            const malformed = Bytes.of(ENCODED_WITH_PRIVACY_EXTENSION).slice();
+            malformed[16] = 0xff;
+            malformed[17] = 0xff;
+
+            expect(() => MessageCodec.decodePacket(malformed)).throws(
+                /Message extension length \d+ exceeds remaining message size \d+\./,
+            );
+        });
+
         it("decodes message with secured extension", () => {
             const result = MessageCodec.decodePayload(MessageCodec.decodePacket(ENCODED_WITH_SECURED_EXTENSION));
 
@@ -121,6 +132,17 @@ describe("MessageCodec", () => {
             };
 
             expect(result).deep.equal(DECODED_WITH_SECURED_EXTENSION);
+        });
+
+        it("rejects secured extension length exceeding remaining bytes", () => {
+            // Same as ENCODED_WITH_SECURED_EXTENSION but extension length field set to 0xffff
+            const malformed = Bytes.of(ENCODED_WITH_SECURED_EXTENSION).slice();
+            malformed[22] = 0xff;
+            malformed[23] = 0xff;
+
+            expect(() => MessageCodec.decodePayload(MessageCodec.decodePacket(malformed))).throws(
+                /Secured extension length \d+ exceeds remaining message size \d+\./,
+            );
         });
     });
 


### PR DESCRIPTION
## Summary

- Validate the Message Extensions / Secured Extensions length field against the remaining buffer before skipping; malformed lengths now cleanly reject the message with `UnexpectedDataError` (message dropped) instead of silently truncating the extension and emptying the payload. Matches CHIP `MessageHeader.cpp` (`mxLength <= reader.Remaining()`).
- Fix misleading group-session encode guard error message: said "or", but the code enforces destination group id AND source node id AND no destination node id.

Source: Matter 1.6.0 spec↔impl verification, Message Frame Format findings F-02 and Q-01.

## Testing

- Two new rejection tests with malformed length fields (`0xffff`) for both extension types
- Full `@matter/protocol` suite green (1086/1086 ESM+CJS), format + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)