### PR TITLE
fix(protocol): never drop mDNS records on packet overflow

### DIFF
--- a/packages/general/src/net/ServerAddress.ts
+++ b/packages/general/src/net/ServerAddress.ts
@@ -175,8 +175,8 @@ export namespace ServerAddress {
         NOT_IP = 3,
     }
 
-    /** True when `ip` is an IPv6 link-local address (fe80::/10).  Assumes lowercase — DNS codec output is. */
-    const IPV6_LINK_LOCAL_PATTERN = /^fe[89ab]/;
+    /** True when `ip` is an IPv6 link-local address (fe80::/10). */
+    const IPV6_LINK_LOCAL_PATTERN = /^fe[89ab]/i;
     export function isIpv6LinkLocal(ip: string): boolean {
         return IPV6_LINK_LOCAL_PATTERN.test(ip);
     }
@@ -189,10 +189,11 @@ export namespace ServerAddress {
         return selectionPreferenceOfIp(address.ip);
     }
 
-    /** Assumes lowercase `ip` like {@link isIpv6LinkLocal}. */
+    /** RFC 4193 ULA is fc00::/7.  Case-insensitive — OS-provided addresses are not guaranteed lowercase. */
+    const IPV6_ULA_PATTERN = /^f[cd]/i;
+
     export function selectionPreferenceOfIp(ip: string) {
-        // RFC 4193 ULA is fc00::/7
-        if (ip.startsWith("fd") || ip.startsWith("fc")) {
+        if (IPV6_ULA_PATTERN.test(ip)) {
             return SelectionPreference.IPV6_ULA;
         }
 

--- a/packages/general/src/net/ServerAddress.ts
+++ b/packages/general/src/net/ServerAddress.ts
@@ -163,11 +163,13 @@ export namespace ServerAddress {
     /**
      * Network address desirability from a Matter communication perspective.
      *
-     * Lower values indicate higher preference.  This is not a standard "happy eyeballs" ranking but works similarly.
+     * Lower values indicate higher preference.  This is not a standard "happy eyeballs" ranking: link-local is most
+     * likely reachable (same link, immune to prefix changes), and ULA ranks above global because Matter ULAs are
+     * typically Thread mesh addresses routed via the border router while globals may rotate.
      */
     export enum SelectionPreference {
-        IPV6_ULA,
         IPV6_LINK_LOCAL,
+        IPV6_ULA,
         IPV6,
         IPV4,
         NOT_IP = 3,
@@ -184,8 +186,13 @@ export namespace ServerAddress {
             return SelectionPreference.NOT_IP;
         }
 
-        const ip = address.ip;
-        if (ip.startsWith("fd")) {
+        return selectionPreferenceOfIp(address.ip);
+    }
+
+    /** Assumes lowercase `ip` like {@link isIpv6LinkLocal}. */
+    export function selectionPreferenceOfIp(ip: string) {
+        // RFC 4193 ULA is fc00::/7
+        if (ip.startsWith("fd") || ip.startsWith("fc")) {
             return SelectionPreference.IPV6_ULA;
         }
 

--- a/packages/general/src/net/dns-sd/MdnsSocket.ts
+++ b/packages/general/src/net/dns-sd/MdnsSocket.ts
@@ -153,14 +153,23 @@ export class MdnsSocket {
             chunk.answers.push(answerEncoded);
         }
 
-        // Add "additional records"...  We include these but only if they fit
-        const additionalRecords = message.additionalRecords ?? [];
-        for (const additionalRecord of additionalRecords) {
+        // Add "additional records", also splitting as necessary.  RFC 6762 §6 would allow omitting them on
+        // overflow, but Matter peers rely on the A/AAAA records carried here, so spill into follow-up packets
+        // instead
+        for (const additionalRecord of message.additionalRecords ?? []) {
             const additionalRecordEncoded = DnsCodec.encodeRecord(additionalRecord);
-            chunkSize += additionalRecordEncoded.byteLength;
-            if (chunkSize > MAX_MDNS_MESSAGE_SIZE) {
-                break;
+
+            if (chunkSize + additionalRecordEncoded.byteLength > MAX_MDNS_MESSAGE_SIZE) {
+                await this.#send(chunk, intf, unicastDest);
+
+                chunk.queries.length = 0;
+                chunk.answers.length = 0;
+                chunk.additionalRecords.length = 0;
+                chunkSize = DnsCodec.encode(chunk).byteLength + additionalRecordEncoded.byteLength;
+            } else {
+                chunkSize += additionalRecordEncoded.byteLength;
             }
+
             chunk.additionalRecords.push(additionalRecordEncoded);
         }
 

--- a/packages/general/test/net/ServerAddressTest.ts
+++ b/packages/general/test/net/ServerAddressTest.ts
@@ -75,6 +75,15 @@ describe("ServerAddress", () => {
             );
         });
 
+        it("classifies uppercase addresses", () => {
+            expect(ServerAddress.selectionPreferenceOf(udp("FE80::1"))).to.equal(
+                ServerAddress.SelectionPreference.IPV6_LINK_LOCAL,
+            );
+            expect(ServerAddress.selectionPreferenceOf(udp("FD29::1"))).to.equal(
+                ServerAddress.SelectionPreference.IPV6_ULA,
+            );
+        });
+
         it("does not mistake fec0 (deprecated site-local) for link-local", () => {
             expect(ServerAddress.selectionPreferenceOf(udp("fec0::1"))).to.equal(
                 ServerAddress.SelectionPreference.IPV6,

--- a/packages/general/test/net/ServerAddressTest.ts
+++ b/packages/general/test/net/ServerAddressTest.ts
@@ -62,6 +62,19 @@ describe("ServerAddress", () => {
             );
         });
 
+        it("prefers link-local over ULA over global over IPv4", () => {
+            const { SelectionPreference } = ServerAddress;
+            expect(SelectionPreference.IPV6_LINK_LOCAL).lessThan(SelectionPreference.IPV6_ULA);
+            expect(SelectionPreference.IPV6_ULA).lessThan(SelectionPreference.IPV6);
+            expect(SelectionPreference.IPV6).lessThan(SelectionPreference.IPV4);
+        });
+
+        it("classifies the fc00::/8 half of ULA space", () => {
+            expect(ServerAddress.selectionPreferenceOf(udp("fc29::1"))).to.equal(
+                ServerAddress.SelectionPreference.IPV6_ULA,
+            );
+        });
+
         it("does not mistake fec0 (deprecated site-local) for link-local", () => {
             expect(ServerAddress.selectionPreferenceOf(udp("fec0::1"))).to.equal(
                 ServerAddress.SelectionPreference.IPV6,

--- a/packages/general/test/net/dns-sd/MdnsSocketTest.ts
+++ b/packages/general/test/net/dns-sd/MdnsSocketTest.ts
@@ -440,7 +440,7 @@ describe("MdnsSocket", () => {
             expect(collector.messages[0].answers.length).to.be.greaterThan(0);
         });
 
-        it("omits additional records that do not fit", async () => {
+        it("spills additional records that do not fit into follow-up messages", async () => {
             const collector = collectSentMessages(env);
 
             // Create a response that fills up most of the message size with answers
@@ -453,11 +453,16 @@ describe("MdnsSocket", () => {
 
             await collector.stop();
 
-            // Calculate total additional records included
+            // All additional records are delivered across multiple messages
             const totalAdditional = collector.messages.reduce((sum, msg) => sum + msg.additionalRecords.length, 0);
+            expect(totalAdditional).to.equal(5);
 
-            // Should have fewer additional records than requested due to size constraints
-            expect(totalAdditional).to.be.lessThan(5);
+            expect(collector.messages.length).to.be.greaterThan(1);
+
+            // Each message stays within the size limit
+            for (const msg of collector.messages) {
+                expect(DnsCodec.encode(msg).byteLength).to.be.at.most(MAX_MDNS_MESSAGE_SIZE);
+            }
         });
     });
 

--- a/packages/node/test/node/ServerNodeTest.ts
+++ b/packages/node/test/node/ServerNodeTest.ts
@@ -187,16 +187,16 @@ describe("ServerNode", () => {
 
         function answer(name: string) {
             for (const answer of (advertisement as DnsMessage).answers) {
-                if (answer.value.startsWith(name)) {
+                if (typeof answer.value === "string" && answer.value.startsWith(name)) {
                     return answer.value.split(".")[0].substring(name.length);
                 }
             }
         }
 
-        function additional(recordType: DnsRecordType) {
-            for (const additional of (advertisement as DnsMessage).additionalRecords) {
-                if (additional.recordType === recordType) {
-                    return additional.value;
+        function record(recordType: DnsRecordType) {
+            for (const record of (advertisement as DnsMessage).answers) {
+                if (record.recordType === recordType) {
+                    return record.value;
                 }
             }
         }
@@ -207,9 +207,9 @@ describe("ServerNode", () => {
         expect(answer("_T")).equals("256");
         expect(answer("_CM")).equals("");
 
-        expect(additional(DnsRecordType.AAAA)).equals("abcd::80");
-        expect(additional(DnsRecordType.A)).equals("10.10.10.128");
-        expect(additional(DnsRecordType.SRV)?.port).equals(operationalPort);
+        expect(record(DnsRecordType.AAAA)).equals("abcd::80");
+        expect(record(DnsRecordType.A)).equals("10.10.10.128");
+        expect(record(DnsRecordType.SRV)?.port).equals(operationalPort);
 
         const expirationReceived = new Promise<Bytes>(resolve =>
             scannerChannel.onData((_netInterface, _peerAddress, _peerPort, data) => resolve(data)),

--- a/packages/protocol/src/advertisement/mdns/MdnsAdvertisement.ts
+++ b/packages/protocol/src/advertisement/mdns/MdnsAdvertisement.ts
@@ -17,6 +17,7 @@ import {
     Duration,
     Logger,
     NetworkInterfaceDetails,
+    ServerAddress,
     SrvRecord,
     Time,
     Timestamp,
@@ -163,14 +164,17 @@ export abstract class MdnsAdvertisement<T extends ServiceDescription = ServiceDe
             ),
         ];
 
-        for (const addr of addrs.ipV6) {
-            records.push(AAAARecord(hostname, addr));
+        const ips = [...addrs.ipV6];
+        if (this.advertiser.server.supportsIpv4) {
+            ips.push(...addrs.ipV4);
         }
 
-        if (this.advertiser.server.supportsIpv4) {
-            for (const addr of addrs.ipV4) {
-                records.push(ARecord(hostname, addr));
-            }
+        // Emit address records in SelectionPreference order so peers that truncate or pick naively favor the most
+        // reachable addresses
+        ips.sort((a, b) => ServerAddress.selectionPreferenceOfIp(a) - ServerAddress.selectionPreferenceOfIp(b));
+
+        for (const ip of ips) {
+            records.push(ip.includes(":") ? AAAARecord(hostname, ip) : ARecord(hostname, ip));
         }
 
         return records;

--- a/packages/protocol/src/mdns/MdnsServer.ts
+++ b/packages/protocol/src/mdns/MdnsServer.ts
@@ -192,14 +192,11 @@ export class MdnsServer {
     }
 
     async #announceRecordsForInterface(netInterface: string, records: DnsRecord<any>[]) {
-        const answers = records.filter(({ recordType }) => recordType === DnsRecordType.PTR);
-        const additionalRecords = records.filter(({ recordType }) => recordType !== DnsRecordType.PTR);
-
+        // RFC 6762 §8.3: announcements carry all records in the answer section
         await this.#socket.send(
             {
                 messageType: DnsMessageType.Response,
-                answers,
-                additionalRecords,
+                answers: records,
             },
             netInterface,
         );

--- a/packages/protocol/test/mdns/MdnsServerTest.ts
+++ b/packages/protocol/test/mdns/MdnsServerTest.ts
@@ -873,7 +873,7 @@ describe("MdnsServer", () => {
     });
 
     describe("Server splits response into multiple packets when answer gets too big", () => {
-        it("include as many answers as possible and potentially leave additionalRecords out", async () => {
+        it("include as many answers as possible and spill remaining additionalRecords into a follow-up packet", async () => {
             const responses = new Array<{ message?: DnsMessage; netInterface?: string; uniCastTarget?: string }>();
             onResponse = async (message: Bytes, netInterface?: string, uniCastTarget?: string) => {
                 responses.push({ message: DnsCodec.decode(message), netInterface, uniCastTarget });
@@ -916,7 +916,9 @@ describe("MdnsServer", () => {
                 INTERFACE_NAME,
             );
 
-            await MockTime.yield3();
+            while (responses.length !== 2) {
+                await MockTime.yield();
+            }
 
             expect(responses).deep.equal([
                 {
@@ -925,6 +927,18 @@ describe("MdnsServer", () => {
                         messageType: DnsMessageType.Response,
                         answers: recordsAnswers,
                         additionalRecords: recordsAdditional.slice(0, 5),
+                        authorities: [],
+                        queries: [],
+                    },
+                    netInterface: INTERFACE_NAME,
+                    uniCastTarget: undefined,
+                },
+                {
+                    message: {
+                        transactionId: 0,
+                        messageType: DnsMessageType.Response,
+                        answers: [],
+                        additionalRecords: recordsAdditional.slice(5),
                         authorities: [],
                         queries: [],
                     },

--- a/packages/protocol/test/mdns/MdnsServerTest.ts
+++ b/packages/protocol/test/mdns/MdnsServerTest.ts
@@ -916,7 +916,8 @@ describe("MdnsServer", () => {
                 INTERFACE_NAME,
             );
 
-            while (responses.length !== 2) {
+            // Bounded so a regression fails at the assertion instead of starving the macrotask queue
+            for (let i = 0; responses.length !== 2 && i < 100; i++) {
                 await MockTime.yield();
             }
 
@@ -991,7 +992,8 @@ describe("MdnsServer", () => {
                 INTERFACE_NAME,
             );
 
-            while (responses.length !== 2) {
+            // Bounded so a regression fails at the assertion instead of starving the macrotask queue
+            for (let i = 0; responses.length !== 2 && i < 100; i++) {
                 await MockTime.yield();
             }
 

--- a/packages/protocol/test/mdns/MdnsTest.ts
+++ b/packages/protocol/test/mdns/MdnsTest.ts
@@ -8,12 +8,14 @@ import { Fabric } from "#fabric/Fabric.js";
 import { Advertisement, CommissioningMode, MdnsAdvertiser, MdnsServer, ServiceDescription } from "#index.js";
 import {
     Bytes,
+    createPromise,
     DnsCodec,
     DnsMessage,
     DnsRecordType,
     Duration,
     Instant,
     InternalError,
+    MAX_MDNS_MESSAGE_SIZE,
     MdnsSocket,
     Millis,
     MockCrypto,
@@ -317,9 +319,6 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             ttl: Seconds(120),
                             value: "0000000000000018-0000000000000001._matter._tcp.local",
                         },
-                    ],
-                    authorities: [],
-                    additionalRecords: [
                         {
                             flushCache: false,
                             name: "0000000000000018-0000000000000001._matter._tcp.local",
@@ -338,6 +337,8 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                         },
                         ...IPDnsRecords,
                     ],
+                    authorities: [],
+                    additionalRecords: [],
                 });
 
                 const expiration = waitForMessage();
@@ -385,9 +386,6 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             ttl: Instant,
                             value: "0000000000000018-0000000000000001._matter._tcp.local",
                         },
-                    ],
-                    authorities: [],
-                    additionalRecords: [
                         {
                             flushCache: false,
                             name: "0000000000000018-0000000000000001._matter._tcp.local",
@@ -406,6 +404,8 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                         },
                         ...IPDnsRecords.map(record => ({ ...record, ttl: Instant })),
                     ],
+                    authorities: [],
+                    additionalRecords: [],
                 });
             });
 
@@ -415,7 +415,8 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                 advertise(COMMISSIONABLE_SERVICE);
 
                 expectMessage(await announcement, {
-                    additionalRecords: [
+                    additionalRecords: [],
+                    answers: [
                         {
                             flushCache: false,
                             name: "8080808080808080._matterc._udp.local",
@@ -433,8 +434,6 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             value: ["VP=1+32768", "DT=1", "DN=Test Device", "D=1234", "CM=1", "PH=33"],
                         },
                         ...IPDnsRecords,
-                    ],
-                    answers: [
                         {
                             flushCache: false,
                             name: "_services._dns-sd._udp.local",
@@ -555,7 +554,8 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                 );
 
                 expectMessage(await announcement, {
-                    additionalRecords: [
+                    additionalRecords: [],
+                    answers: [
                         {
                             flushCache: false,
                             name: "8080808080808080._matterd._udp.local",
@@ -573,8 +573,6 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             value: ["VP=1+32768", "DT=1", "DN=Test Commissioner"],
                         },
                         ...IPDnsRecords,
-                    ],
-                    answers: [
                         {
                             flushCache: false,
                             name: "_services._dns-sd._udp.local",
@@ -680,9 +678,6 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             ttl: Seconds(120),
                             value: "0000000000000018-0000000000000001._matter._tcp.local",
                         },
-                    ],
-                    authorities: [],
-                    additionalRecords: [
                         {
                             flushCache: false,
                             name: "0000000000000018-0000000000000001._matter._tcp.local",
@@ -702,10 +697,13 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                         },
                         ...IPDnsRecords,
                     ],
+                    authorities: [],
+                    additionalRecords: [],
                 });
 
                 expectMessage(message2, {
-                    additionalRecords: [
+                    additionalRecords: [],
+                    answers: [
                         {
                             flushCache: false,
                             name: "8080808080808080._matterc._udp.local",
@@ -723,8 +721,6 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             value: ["VP=1+32768", "DT=1", "DN=Test Device", "D=1234", "CM=1", "PH=33"],
                         },
                         ...IPDnsRecords,
-                    ],
-                    answers: [
                         {
                             flushCache: false,
                             name: "_services._dns-sd._udp.local",
@@ -829,7 +825,8 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                 });
 
                 expectMessage(message3, {
-                    additionalRecords: [
+                    additionalRecords: [],
+                    answers: [
                         {
                             flushCache: false,
                             name: "8080808080808080._matterd._udp.local",
@@ -847,8 +844,6 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             value: ["VP=1+32768", "DT=1", "DN=Test Commissioner"],
                         },
                         ...IPDnsRecords,
-                    ],
-                    answers: [
                         {
                             flushCache: false,
                             name: "_services._dns-sd._udp.local",
@@ -903,6 +898,89 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
     });
 });
 
+describe("MDNS announcement overflow", () => {
+    const crypto = MockCrypto();
+    before(MockTime.enable);
+
+    it("splits oversized announcements into multiple packets with all records in the answer section", async () => {
+        // Enough AAAA records to push the announcement past MAX_MDNS_MESSAGE_SIZE
+        const GLOBAL_IPv6 = Array.from({ length: 16 }, (_, i) => `fd54:23a1:c6de:1::${i + 1}`);
+
+        const simulator = new NetworkSimulator();
+        const serverNetwork = new MockNetwork(simulator, SERVER_MAC, [...GLOBAL_IPv6, SERVER_IPv4, SERVER_IPv6]);
+        const clientNetwork = new MockNetwork(simulator, CLIENT_MAC, [CLIENT_IPv4, CLIENT_IPv6]);
+
+        const serverSocket = await MdnsSocket.create(serverNetwork, { netInterface: "fake0" });
+        const server = new MdnsServer(serverSocket);
+        const advertiser = new MdnsAdvertiser(crypto, server, { port: PORT });
+
+        const listener = new MockUdpSocket(clientNetwork, {
+            listeningPort: 5353,
+            listeningAddress: CLIENT_IPv4,
+            type: "udp4",
+        });
+        listener.addMembership("224.0.0.251");
+
+        const messages = new Array<DnsMessage>();
+        const packetSizes = new Array<number>();
+        const { promise: received, resolver } = createPromise<void>();
+        const dataListener = listener.onData((_intf, _peer, _port, data) => {
+            const message = DnsCodec.decode(data);
+            if (message === undefined) {
+                throw new InternalError("DNS message decode failure");
+            }
+            messages.push(message);
+            packetSizes.push(data.byteLength);
+
+            const answers = messages.flatMap(m => m.answers);
+            if (
+                answers.some(({ recordType }) => recordType === DnsRecordType.A) &&
+                answers.filter(({ recordType }) => recordType === DnsRecordType.AAAA).length === GLOBAL_IPv6.length + 1
+            ) {
+                resolver();
+            }
+        });
+
+        try {
+            advertiser.advertise({ ...COMMISSIONABLE_SERVICE, port: PORT }, "startup");
+            await MockTime.resolve(received);
+
+            // The full record set exceeds one packet
+            expect(messages.length).greaterThan(1);
+
+            // Everything is delivered in the answer section (RFC 6762 §8.3)
+            for (const message of messages) {
+                expect(message.additionalRecords).deep.equals([]);
+                expect(message.answers.length).greaterThan(0);
+            }
+
+            const answers = messages.flatMap(m => m.answers);
+
+            // No packet exceeds the size limit
+            for (const size of packetSizes) {
+                expect(size).lessThanOrEqual(MAX_MDNS_MESSAGE_SIZE);
+            }
+
+            // The A record and all AAAA records made it through
+            const aRecords = answers.filter(({ recordType }) => recordType === DnsRecordType.A);
+            expect(aRecords.length).equals(1);
+            expect(aRecords[0].value).equals(SERVER_IPv4);
+
+            const aaaaValues = answers
+                .filter(({ recordType }) => recordType === DnsRecordType.AAAA)
+                .map(({ value }) => value);
+            expect(aaaaValues.sort()).deep.equals([...GLOBAL_IPv6, SERVER_IPv6].sort());
+        } finally {
+            await dataListener.close();
+            await MockTime.advance(1000);
+            await MockTime.resolve(advertiser.close());
+            await server.close();
+            await serverSocket.close();
+            await listener.close();
+        }
+    });
+});
+
 function expectMessage(actual: DnsMessage | undefined, expected: DnsMessage) {
     for (const message of [actual, expected]) {
         if (!message) {
@@ -915,7 +993,7 @@ function expectMessage(actual: DnsMessage | undefined, expected: DnsMessage) {
             (a, b) => a.name.localeCompare(b.name) || sortKey(a.value).localeCompare(sortKey(b.value)),
         );
 
-        message.additionalRecords.forEach(r => {
+        [...message.answers, ...message.additionalRecords].forEach(r => {
             if (r.recordType === DnsRecordType.TXT && Array.isArray(r.value)) {
                 // Fixtures may declare value as string[]; normalize to Bytes[] then sort by hex (lossless on binary).
                 r.value = (r.value as (Uint8Array | string)[])

--- a/packages/protocol/test/mdns/MdnsTest.ts
+++ b/packages/protocol/test/mdns/MdnsTest.ts
@@ -904,10 +904,10 @@ describe("MDNS announcement overflow", () => {
 
     it("splits oversized announcements into multiple packets with all records in the answer section", async () => {
         // Enough AAAA records to push the announcement past MAX_MDNS_MESSAGE_SIZE
-        const GLOBAL_IPv6 = Array.from({ length: 16 }, (_, i) => `fd54:23a1:c6de:1::${i + 1}`);
+        const ULA_IPv6 = Array.from({ length: 16 }, (_, i) => `fd54:23a1:c6de:1::${i + 1}`);
 
         const simulator = new NetworkSimulator();
-        const serverNetwork = new MockNetwork(simulator, SERVER_MAC, [...GLOBAL_IPv6, SERVER_IPv4, SERVER_IPv6]);
+        const serverNetwork = new MockNetwork(simulator, SERVER_MAC, [...ULA_IPv6, SERVER_IPv4, SERVER_IPv6]);
         const clientNetwork = new MockNetwork(simulator, CLIENT_MAC, [CLIENT_IPv4, CLIENT_IPv6]);
 
         const serverSocket = await MdnsSocket.create(serverNetwork, { netInterface: "fake0" });
@@ -935,7 +935,7 @@ describe("MDNS announcement overflow", () => {
             const answers = messages.flatMap(m => m.answers);
             if (
                 answers.some(({ recordType }) => recordType === DnsRecordType.A) &&
-                answers.filter(({ recordType }) => recordType === DnsRecordType.AAAA).length === GLOBAL_IPv6.length + 1
+                answers.filter(({ recordType }) => recordType === DnsRecordType.AAAA).length === ULA_IPv6.length + 1
             ) {
                 resolver();
             }
@@ -961,15 +961,11 @@ describe("MDNS announcement overflow", () => {
                 expect(size).lessThanOrEqual(MAX_MDNS_MESSAGE_SIZE);
             }
 
-            // The A record and all AAAA records made it through
-            const aRecords = answers.filter(({ recordType }) => recordType === DnsRecordType.A);
-            expect(aRecords.length).equals(1);
-            expect(aRecords[0].value).equals(SERVER_IPv4);
-
-            const aaaaValues = answers
-                .filter(({ recordType }) => recordType === DnsRecordType.AAAA)
+            // All address records made it through, in SelectionPreference order: link-local, ULA, IPv4
+            const addressValues = answers
+                .filter(({ recordType }) => recordType === DnsRecordType.AAAA || recordType === DnsRecordType.A)
                 .map(({ value }) => value);
-            expect(aaaaValues.sort()).deep.equals([...GLOBAL_IPv6, SERVER_IPv6].sort());
+            expect(addressValues).deep.equals([SERVER_IPv6, ...ULA_IPv6, SERVER_IPv4]);
         } finally {
             await dataListener.close();
             await MockTime.advance(1000);


### PR DESCRIPTION
## Problem

When a network interface has enough IPv6 addresses (e.g. privacy extensions on Windows yield 3+ AAAA records), mDNS announcements exceeded the 1232-byte message limit and the A record — placed last in the additional section — was silently dropped. Devices were discoverable but unreachable over IPv4. See #3836 for the full root-cause analysis.

## Changes

Two structural fixes, both aligned with the CHIP SDK's Minimal mDNS responder (which never drops records — it splits into continuation packets, `ResponseSender::AddResponse`):

1. **Announcements put all records in the answer section** (`MdnsServer.#announceRecordsForInterface`), per RFC 6762 §8.3 — CHIP does the same (`ResponseSender.cpp`: announce broadcasts skip the additional-section assignment, citing §8.3). The existing answer chunking in `MdnsSocket.send` then splits oversized announcements across multiple packets, so every record is always delivered. No TC flag on response chunks (RFC 6762 §18.5: TC must be zero in multicast responses) — already handled.

2. **Query responses spill overflowing additional records into follow-up packets** (`MdnsSocket.send`) instead of silently truncating. RFC 6762 §6 would allow omitting them, but Matter peers rely on the A/AAAA records carried in the additional section, and not every querier re-queries explicitly.

Plus an address-preference alignment:

3. **Link-local now ranks highest when selecting peer addresses** (`ServerAddress.SelectionPreference`): link-local → ULA → global → IPv4. Link-local is the most reliable endpoint on the local link (immune to prefix rotation, DHCP changes, ISP renumbering); the CHIP SDK's `IPAddressSorter` also scores it highest. ULA stays above global since Matter ULAs are typically Thread mesh addresses routed via the border router. The fc00::/8 half of RFC 4193 ULA space is now classified correctly. mDNS A/AAAA records are also emitted in this order so peers that truncate or pick naively favor the most reachable addresses.

## Tests

- New: announcement with 17 AAAA + 1 A → splits into multiple packets, every packet ≤1232 bytes, all records in the answer section, A record delivered in preference order (`MdnsTest`)
- New: socket-level additional-record spill — all records delivered across packets (`MdnsSocketTest`)
- New: selection-preference ordering lock + fc00::/8 classification (`ServerAddressTest`)
- Updated: `MdnsServerTest` overflow test now asserts the spill packet (the old single-packet expectation only kept passing through a `yield3()` race that snapshotted responses before the second packet arrived; now waits bounded and deterministically)
- Updated announce-structure expectations in `MdnsTest`/`ServerNodeTest` for the answer-section move

Receiver side is unaffected: `DnssdNames` merges answer + additional sections, and CHIP devices already announce all-in-answers.

Fixes #3836

🤖 Generated with [Claude Code](https://claude.com/claude-code)