### PR TITLE
fix(protocol): honor peer activity per MRP retransmission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Corrected the Session Active Threshold limit to 65535 milliseconds (was wrongly checked against 65535 seconds)
     - Fix: Invalid or out-of-range SII/SAI/SAT values in discovered DNS-SD TXT records are now ignored so MRP defaults apply, as required by the Matter spec
     - Fix: Added size checks for Message Extensions and Secured Extensions length fields on message decode
+    - Fix: MRP retransmissions now use the idle interval when the peer left its active window mid-exchange, matching CHIP SDK behavior
 
 ## 0.17.1 (2026-06-03)
 

--- a/packages/protocol/src/protocol/MRP.ts
+++ b/packages/protocol/src/protocol/MRP.ts
@@ -128,9 +128,10 @@ export namespace MRP {
     ) {
         const { activeInterval, idleInterval } = sessionParameters;
 
-        // For the first message of a new exchange ... SHALL be set according to the idle state of the peer node.
-        // For all subsequent messages of the exchange, ... SHOULD be set according to the active state of the peer node
-        const peerActive = transmissionNumber > 0 && (!calculateMaximum || isPeerActive);
+        // The first message of an exchange SHALL use the idle interval; subsequent ones SHOULD use the active
+        // interval "unless the sender has other means to determine whether the device is active or idle" —
+        // isPeerActive is that means, so honor it per retransmission like CHIP does (ICD correctness)
+        const peerActive = transmissionNumber > 0 && isPeerActive;
         let baseInterval = peerActive ? activeInterval : idleInterval;
         if (!calculateMaximum) {
             baseInterval += ADDITIONAL_MRP_DELAY;
@@ -152,7 +153,6 @@ export namespace MRP {
 function maxResponseTimeOf(sessionParameters: SessionParameters, isPeerActive: boolean) {
     let finalWaitTime = 0;
 
-    // and then add the time the other side needs for a full resubmission cycle under the assumption we are active
     for (let i = 0; i < MRP.MAX_TRANSMISSIONS; i++) {
         if (isPeerActive && finalWaitTime > sessionParameters.activeThreshold) {
             // If we considered the device active initially but the wait time goes beyond the active threshold,

--- a/packages/protocol/test/protocol/MRPTest.ts
+++ b/packages/protocol/test/protocol/MRPTest.ts
@@ -6,9 +6,106 @@
 
 import { MRP } from "#protocol/MRP.js";
 import { SessionParameters } from "#session/SessionParameters.js";
-import { ChannelType, Seconds } from "@matter/general";
+import { ChannelType, Millis, Seconds } from "@matter/general";
 
 describe("MRP", () => {
+    describe("retransmissionIntervalOf", () => {
+        // Distinct intervals so idle- and active-based results cannot overlap, even with jitter
+        const sessionParameters = SessionParameters({
+            idleInterval: Seconds(10),
+            activeInterval: Millis(500),
+        });
+
+        function runtimeRangeFor(baseInterval: number, transmissionNumber: number) {
+            const deterministic =
+                (baseInterval + MRP.ADDITIONAL_MRP_DELAY) *
+                MRP.BACKOFF_MARGIN *
+                Math.pow(MRP.BACKOFF_BASE, Math.max(0, transmissionNumber - MRP.BACKOFF_THRESHOLD));
+            return { min: Math.floor(deterministic), max: Math.floor(deterministic * (1 + MRP.BACKOFF_JITTER)) };
+        }
+
+        function expectWithin(value: number, { min, max }: { min: number; max: number }) {
+            expect(value).to.be.at.least(min);
+            expect(value).to.be.at.most(max);
+        }
+
+        it("uses the idle interval for the first transmission even when the peer is active", () => {
+            const interval = MRP.retransmissionIntervalOf({
+                transmissionNumber: 0,
+                sessionParameters,
+                isPeerActive: true,
+            });
+
+            expectWithin(interval, runtimeRangeFor(Seconds(10), 0));
+        });
+
+        it("uses the active interval for retransmissions while the peer is active", () => {
+            const interval = MRP.retransmissionIntervalOf({
+                transmissionNumber: 1,
+                sessionParameters,
+                isPeerActive: true,
+            });
+
+            expectWithin(interval, runtimeRangeFor(Millis(500), 1));
+        });
+
+        it("uses the idle interval for retransmissions when the peer is no longer active", () => {
+            const interval = MRP.retransmissionIntervalOf({
+                transmissionNumber: 1,
+                sessionParameters,
+                isPeerActive: false,
+            });
+
+            expectWithin(interval, runtimeRangeFor(Seconds(10), 1));
+        });
+    });
+
+    describe("maxRetransmissionIntervalOf", () => {
+        const sessionParameters = SessionParameters({
+            idleInterval: Seconds(10),
+            activeInterval: Millis(500),
+        });
+
+        function maximumFor(baseInterval: number, transmissionNumber: number) {
+            return Math.floor(
+                baseInterval *
+                    MRP.BACKOFF_MARGIN *
+                    Math.pow(MRP.BACKOFF_BASE, Math.max(0, transmissionNumber - MRP.BACKOFF_THRESHOLD)) *
+                    (1 + MRP.BACKOFF_JITTER),
+            );
+        }
+
+        it("uses the idle interval for the first transmission even when the peer is active", () => {
+            const interval = MRP.maxRetransmissionIntervalOf({
+                transmissionNumber: 0,
+                sessionParameters,
+                isPeerActive: true,
+            });
+
+            expect(interval).to.equal(maximumFor(Seconds(10), 0));
+        });
+
+        it("uses the idle interval for retransmissions when the peer is not active", () => {
+            const interval = MRP.maxRetransmissionIntervalOf({
+                transmissionNumber: 1,
+                sessionParameters,
+                isPeerActive: false,
+            });
+
+            expect(interval).to.equal(maximumFor(Seconds(10), 1));
+        });
+
+        it("uses the active interval for retransmissions when the peer is active", () => {
+            const interval = MRP.maxRetransmissionIntervalOf({
+                transmissionNumber: 1,
+                sessionParameters,
+                isPeerActive: true,
+            });
+
+            expect(interval).to.equal(maximumFor(Millis(500), 1));
+        });
+    });
+
     describe("maxPeerResponseTimeOf", () => {
         const localSessionParameters = SessionParameters();
 


### PR DESCRIPTION
## Summary

MRP runtime retransmissions (n>0) hard-coded the active interval — `isPeerActive` was ignored via the `!calculateMaximum ||` shortcut in `MRP.retransmissionIntervalOf()`. A peer dropping out of its active window mid-exchange kept getting active-spaced (aggressive) retries.

Now peer activity is re-checked per retransmission, matching CHIP (`ReliableMessageMgr` → `GetMRPBaseTimeout()` = `IsPeerActive() ? active : idle` on every retry, documented there as deliberate for ICD correctness).

Spec §4.12.2.1: subsequent messages SHOULD use the active interval "unless the sender has other means to determine whether the device is active or idle" — `Session.isPeerActive` is that means, computed live from the last-received-message timestamp at each retry.

## Unchanged

- `calculateMaximum` path (worst-case bound): already gated on `isPeerActive`; boolean-identical before/after.
- First transmission (n=0): stays idle-interval per spec SHALL. (CHIP diverges here; spec reconciliation tracked separately.)

## Tests

New `MRPTest.ts` coverage pinning: n=0 always idle, n>0 active-peer → active interval, n>0 idle-peer → idle interval (the bug), plus `maxRetransmissionIntervalOf` equivalents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)