### PR TITLE
fix(node): resolve self-bindings to runtime-added cluster servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/general
     - Fix: An empty mDNS TXT record is now encoded as a single zero byte as required by RFC 6763 §6.1
 
+- @matter/node
+    - Fix: Self-bindings now detect cluster servers added to an endpoint at runtime via `behaviors.require`, and no longer treat a client cluster as satisfying the server check
+
 - @matter/protocol
     - Enhancement: SII/SAI/SAT keys are now omitted from advertised DNS-SD TXT records when at their default values, matching CHIP SDK behavior
     - Fix: Corrected the Session Active Threshold limit to 65535 milliseconds (was wrongly checked against 65535 seconds)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: An empty mDNS TXT record is now encoded as a single zero byte as required by RFC 6763 §6.1
 
 - @matter/node
-    - Fix: Self-bindings now detect cluster servers added to an endpoint at runtime via `behaviors.require`, and no longer treat a client cluster as satisfying the server check
+    - Fix: Ensure that Self-bindings also detect cluster servers added to an endpoint at runtime via `behaviors.require` and ignore client clusters on the endpoint
 
 - @matter/protocol
     - Enhancement: SII/SAI/SAT keys are now omitted from advertised DNS-SD TXT records when at their default values, matching CHIP SDK behavior

--- a/packages/node/src/behaviors/binding/BindingManager.ts
+++ b/packages/node/src/behaviors/binding/BindingManager.ts
@@ -5,6 +5,7 @@
  */
 
 import { ClusterBehavior } from "#behavior/cluster/ClusterBehavior.js";
+import { isClientBehavior } from "#behavior/cluster/cluster-behavior-utils.js";
 import { Endpoint } from "#endpoint/Endpoint.js";
 import { ClientGroup } from "#node/ClientGroup.js";
 import { ClientNode } from "#node/ClientNode.js";
@@ -314,11 +315,9 @@ export class BindingManager {
     }
 
     #endpointHasClusterServer(endpoint: Endpoint, clusterId: number): boolean {
-        const behaviors = endpoint.type.behaviors;
-        if (behaviors === undefined) {
-            return false;
-        }
-        return Object.values(behaviors).some(b => ClusterBehavior.is(b) && b.cluster.id === clusterId);
+        return Object.values(endpoint.behaviors.supported).some(
+            b => ClusterBehavior.is(b) && !isClientBehavior(b) && b.cluster.id === clusterId,
+        );
     }
 
     #selectClientClusters(sourceEp: Endpoint, filterCluster: number | undefined): ClusterBehavior.Type[] | undefined {

--- a/packages/node/test/behaviors/binding/BindingManagerTest.ts
+++ b/packages/node/test/behaviors/binding/BindingManagerTest.ts
@@ -486,6 +486,64 @@ describe("BindingManager", () => {
         await node.close();
     });
 
+    it("kind=server accepts a cluster server added to the endpoint at runtime via behaviors.require", async () => {
+        const node = await MockServerNode.createOnline(undefined, { device: OnOffLightSwitchDevice });
+        const fabric = await node.addFabric();
+        const manager = node.env.get(BindingManager);
+        const server = makeFakeBindingServer();
+        const sourceEp = node.parts.get(1)!;
+
+        // OnOffServer is not part of OnOffLightSwitchDevice's type — install it dynamically. This lands in
+        // endpoint.behaviors.supported but never in endpoint.type.behaviors, so the resolver must consult the former.
+        sourceEp.behaviors.require(OnOffServer);
+
+        const entry = new Binding.Target({
+            node: fabric.nodeId,
+            endpoint: sourceEp.number,
+            cluster: ClusterId(OnOffServer.cluster.id),
+            group: undefined,
+            fabricIndex: fabric.fabricIndex,
+        });
+
+        manager.register(server, sourceEp, entry);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const emitted = fakeEmitted(server) as Array<BindingResolution>;
+        expect(emitted).has.length(1);
+        expect(emitted[0].kind).equals("server");
+        expect((emitted[0] as BindingResolution & { kind: "server" }).endpoint).equals(sourceEp);
+
+        await node.close();
+    });
+
+    it("kind=server rejects when the endpoint only has the cluster as a client, not a server", async () => {
+        const node = await MockServerNode.createOnline(undefined, { device: OnOffLightSwitchDevice });
+        const fabric = await node.addFabric();
+        const manager = node.env.get(BindingManager);
+        const server = makeFakeBindingServer();
+        const sourceEp = node.parts.get(1)!;
+
+        // A client behavior shares the cluster id of its server counterpart, but a self-binding target must serve the
+        // cluster. behaviors.supported holds both client and server behaviors, so the server check must exclude clients.
+        sourceEp.behaviors.require(OnOffClient);
+
+        const entry = new Binding.Target({
+            node: fabric.nodeId,
+            endpoint: sourceEp.number,
+            cluster: ClusterId(OnOffServer.cluster.id),
+            group: undefined,
+            fabricIndex: fabric.fabricIndex,
+        });
+
+        manager.register(server, sourceEp, entry);
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(fakeEmitted(server)).deep.equals([]);
+
+        await node.close();
+    });
+
     it("kind=group rejects when source endpoint is not a group member", async () => {
         const node = await MockServerNode.createOnline(undefined, { device: OnOffLightSwitchDevice });
         const fabric = await node.addFabric();


### PR DESCRIPTION
## Problem

`BindingManager.#endpointHasClusterServer` read `endpoint.type.behaviors` to decide whether a self-binding target serves a cluster. But cluster servers added at runtime via `endpoint.behaviors.require(...)` land in `endpoint.behaviors.supported`, never in `type.behaviors` (`Behaviors` clones off the shared `type.behaviors` reference on first inject). So self-bindings to runtime-installed cluster servers were wrongly rejected.

## Fix

- Read `endpoint.behaviors.supported` instead of `endpoint.type.behaviors`.
- Exclude client cluster behaviors via `isClientBehavior` — `behaviors.supported` also holds client `ClusterBehavior`s (installed for bindings), and a client shares its server counterpart's `cluster.id`, so a pure id match would false-positive on a client-only endpoint.
- Dropped the dead `=== undefined` guard (`supported` is always an object).

The mirror `#selectClientClusters` was reviewed and is correct as-is: client cluster declarations are static metadata living only in `type.clientClusters`, never runtime-injected into a source endpoint's `supported`.

## Tests

Two regression tests (both verified red→green):
- `kind=server` accepts a cluster server added at runtime via `behaviors.require`.
- `kind=server` rejects when the endpoint only has the cluster as a client, not a server.

Full `@matter/node` suite green (ESM/CJS/Web), lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)