### PR TITLE
fix(protocol): clear stale replay-bitmap bits on counter jump of exactly the window size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Added size checks for Message Extensions and Secured Extensions length fields on message decode
     - Fix: MRP retransmissions now use the idle interval when the peer left its active window mid-exchange, matching CHIP SDK behavior
     - Fix: TcpChannel now closes the connection on a zero-length stream frame instead of silently skipping it, preventing a peer from holding a connection slot open indefinitely
+    - Fix: A forward message-counter jump of exactly the window size no longer retains stale replay-bitmap bits, which could wrongly reject a later legitimate message as duplicate
 
 ## 0.17.1 (2026-06-03)
 

--- a/packages/protocol/src/protocol/MessageReceptionState.ts
+++ b/packages/protocol/src/protocol/MessageReceptionState.ts
@@ -62,18 +62,16 @@ export class MessageReceptionStateEncryptedWithoutRollover extends MessageRecept
     private calculateMessageCounterBitmap(messageCounterBitmap: number, diff: number) {
         if (diff < 0) {
             // negative value means the new message counter is smaller than the current maximum
-            if (diff < -MSG_COUNTER_WINDOW_SIZE) {
-                throw new InternalError(`Message counter difference too large: ${diff}`);
-            }
-            // set the corresponding bit
             const bit = 1 << (-diff - 1);
             messageCounterBitmap |= bit;
         } else if (diff > 0) {
             // positive value means new message counter is larger than the current maximum
             if (diff <= MSG_COUNTER_WINDOW_SIZE) {
-                // shift the bitmap and set the bit for the previous maximum
-                const bit = 1 << (diff - 1);
-                messageCounterBitmap = ((messageCounterBitmap << diff) >>> 0) | bit;
+                // shift the bitmap and set the bit for the previous maximum.
+                // `x << 32` is a no-op in JS (shift count is taken mod 32), so a jump of exactly the
+                // window size must clear all prior bits explicitly, leaving only the old-max bit.
+                const shifted = diff < MSG_COUNTER_WINDOW_SIZE ? (messageCounterBitmap << diff) >>> 0 : 0;
+                messageCounterBitmap = shifted | (1 << (diff - 1));
             } else {
                 // diff is larger than the window size, so no previous message counter is known
                 messageCounterBitmap = 0;
@@ -91,16 +89,13 @@ export class MessageReceptionStateEncryptedWithoutRollover extends MessageRecept
 
         this.messageCounterBitmap = this.calculateMessageCounterBitmap(this.messageCounterBitmap, diff);
 
-        if (diff > 0 || diff < -MSG_COUNTER_WINDOW_SIZE) {
+        if (diff > 0) {
             this.maximumMessageCounter = messageCounter;
         }
     }
 
     /** Check if the message counter is known in the bitmap. */
     private isCounterKnownInBitmap(diff: number) {
-        if (diff < -MSG_COUNTER_WINDOW_SIZE || diff >= 0) {
-            throw new InternalError(`Invalid Message counter difference for check: ${diff}`);
-        }
         const bit = 1 << (-diff - 1);
         return (this.messageCounterBitmap & bit) !== 0;
     }

--- a/packages/protocol/test/protocol/MessageReceptionStateTest.ts
+++ b/packages/protocol/test/protocol/MessageReceptionStateTest.ts
@@ -294,6 +294,25 @@ describe("MessageReceptionState", () => {
                 const state = new MessageReceptionStateEncryptedWithoutRollover();
                 expect(() => state.updateMessageCounter(0xffffffff)).not.throw();
             });
+
+            it("rejects out-of-range counter values", () => {
+                const state = new MessageReceptionStateEncryptedWithoutRollover();
+                expect(() => state.updateMessageCounter(-1)).throws("Invalid message counter value");
+                expect(() => state.updateMessageCounter(0x100000000)).throws("Invalid message counter value");
+            });
+
+            it("forward jump of exactly the window size clears stale bitmap bits", () => {
+                const state = new MessageReceptionStateEncryptedWithoutRollover();
+                const prototype = MessageReceptionStateEncryptedWithoutRollover.prototype;
+                state.updateMessageCounter(1);
+                state.updateMessageCounter(100);
+                // Seed a low in-window bit (counter 94 = max - 6).
+                assertMessageWindowUpdate(prototype, state, 94, 0b100000, false, -6);
+                // Jump forward by exactly the window size: only the old max bit (offset 32 -> bit 31) survives.
+                assertMessageWindowUpdate(prototype, state, 132, 0b10000000000000000000000000000000, false, 32);
+                // Counter 126 (= new max - 6) was never received; its stale bit must have been cleared.
+                assertMessageWindowUpdate(prototype, state, 126, 0b10000000000000000000000000100000, false, -6);
+            });
         });
     });
 
@@ -532,6 +551,16 @@ describe("MessageReceptionState", () => {
                     MAX_COUNTER_VALUE_32BIT - highBase + (highBase - MAX_COUNTER_INCREASE_2POW31 - 1) + 1,
                 );
             });
+
+            it("forward jump of exactly the window size clears stale bitmap bits", () => {
+                const state = new MessageReceptionStateEncryptedWithRollover();
+                const prototype = MessageReceptionStateEncryptedWithRollover.prototype;
+                state.updateMessageCounter(1);
+                state.updateMessageCounter(100);
+                assertMessageWindowUpdate(prototype, state, 94, 0b100000, false, -6);
+                assertMessageWindowUpdate(prototype, state, 132, 0b10000000000000000000000000000000, false, 32);
+                assertMessageWindowUpdate(prototype, state, 126, 0b10000000000000000000000000100000, false, -6);
+            });
         });
     });
     describe("MessageReceptionStateUnencryptedWithRollover", () => {
@@ -747,6 +776,16 @@ describe("MessageReceptionState", () => {
 
                 // Counting continues forward past the rollover.
                 assertMessageWindowDifference(prototype, state, 1, false, 1);
+            });
+
+            it("forward jump of exactly the window size clears stale bitmap bits", () => {
+                const state = new MessageReceptionStateUnencryptedWithRollover();
+                const prototype = MessageReceptionStateUnencryptedWithRollover.prototype;
+                state.updateMessageCounter(1);
+                state.updateMessageCounter(100);
+                assertMessageWindowUpdate(prototype, state, 94, 0b100000, false, -6);
+                assertMessageWindowUpdate(prototype, state, 132, 0b10000000000000000000000000000000, false, 32);
+                assertMessageWindowUpdate(prototype, state, 126, 0b10000000000000000000000000100000, false, -6);
             });
         });
     });


### PR DESCRIPTION
## Problem

A forward message-counter jump of **exactly** the replay window size (`MSG_COUNTER_WINDOW_SIZE = 32`) hit a JavaScript shift-by-32 no-op: `messageCounterBitmap << 32` is a no-op because the shift count is taken mod 32 (`<< 32` ≡ `<< 0`). So `calculateMessageCounterBitmap` **retained the previous window's bits** instead of shifting them out.

A retained stale bit maps to a counter now *inside* the new window that was never actually received. When that counter legitimately arrives, `isCounterKnownInBitmap` finds the bit set and `updateMessageCounter` throws `DuplicateMessageError` → a **legitimate message is wrongly rejected**.

Worked example: `max = 100`, bit 5 set (counter 94 seen). Counter `132` arrives → `diff = +32`, new `max = 132`. Correct bitmap = only the old-max bit (counter 100 → bit 31). The no-op shift instead yields `oldBitmap | (1<<31)`, so bit 5 survives — the code now believes counter `126` was received. When counter `126` legitimately arrives, it is dropped as a duplicate.

Reachability: a single forward jump of exactly the window size (31 consecutive counters lost, then the 32nd arrives). Rare on a healthy link, plausible under heavy loss. `diff` in `(32, 2^31-1]` already resets the bitmap; `diff` in `[1, 31]` shifts correctly. Only `diff === 32` was wrong.

## Fix

Guard the shift explicitly so a jump of exactly the window size clears all prior bits, while still marking the old-max bit:

```ts
const shifted = diff < MSG_COUNTER_WINDOW_SIZE ? (messageCounterBitmap << diff) >>> 0 : 0;
messageCounterBitmap = shifted | (1 << (diff - 1));
```

## Tests

- Forward-jump-of-exactly-32 regression test across all three subclasses (`EncryptedWithoutRollover`, `EncryptedWithRollover`, `UnencryptedWithRollover`).
- Out-of-range counter (`<0` / `>0xFFFFFFFF`) rejection test.

## Cleanup

Removed three guards proven unreachable via `updateMessageCounter`'s existing diff checks (it throws `DuplicateMessageError` for `diff < -32`, throws on `counter === max`, and inits when undefined, so the private methods only ever see `diff > 0` or `diff ∈ [-32, -1]`):

- `diff < -32` `InternalError` throw in `calculateMessageCounterBitmap`
- the `|| diff < -32` clause in `updateMessageCounterAndBitmap`'s max-update condition
- the `diff < -32 || diff >= 0` `InternalError` throw in `isCounterKnownInBitmap`

## Verification

Full `@matter/protocol` suite (1097 tests), format-verify, and lint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)