### PR TITLE
fix(examples): correct argv parsing and isolate storage in OnOffController

### DIFF
--- a/examples/control-onoff/src/OnOffController.ts
+++ b/examples/control-onoff/src/OnOffController.ts
@@ -14,9 +14,9 @@ import { ServerNode } from "@matter/main";
 import { OnOffClient } from "@matter/main/behaviors/on-off";
 
 // Create the controller
-const controller = await ServerNode.create();
+const controller = await ServerNode.create({ id: "controller" });
 
-const [, , command, ...args] = process.argv.slice(2);
+const [command, ...args] = process.argv.slice(2);
 
 switch (command) {
     case "commission":
@@ -70,9 +70,7 @@ switch (command) {
         break;
 
     default:
-        die(
-            `Unsupported command ${process.argv[1] ?? "(none)"}.  Supported commands: commission, toggle, decommission`,
-        );
+        die(`Unsupported command ${command ?? "(none)"}.  Supported commands: commission, toggle, decommission`);
 }
 
 /**


### PR DESCRIPTION
## Problem

The `control-onoff` controller example never dispatched commands correctly.

Line 19 dropped **two extra arguments**:

```js
const [, , command, ...args] = process.argv.slice(2);
```

`process.argv.slice(2)` already removes `node` + the script path; the
`[, , command, ...]` destructure then skips the first two *real* args. So
`node OnOffController.ts toggle 1` resolves `command` to `undefined` and falls
through to `default` → `"Unsupported command"`. Verified across plain `node`,
`tsx`, and `node --import tsx` — all give the same broken parse.

Secondarily, the controller called `ServerNode.create()` with no id. The
fallback id is `node${counter}` where the counter is in-memory and resets to
`0` each process, so the controller shares `~/.matter/node0` with the device
examples (e.g. the on/off light), which can clobber its peer storage.

## Fix

- Parse with `const [command, ...args] = process.argv.slice(2);`
- Report the actual `command` in the unsupported-command message (was printing `process.argv[1]`, the script path)
- Give the controller an explicit id (`ServerNode.create({ id: "controller" })`) so its storage is isolated from device examples

## Migration note

The explicit id moves controller storage from `~/.matter/node0` to
`~/.matter/controller`. Anyone who already commissioned with the old example
will need to re-commission once.

Related to #3843

🤖 Generated with [Claude Code](https://claude.com/claude-code)