### PR TITLE
fix(protocol): evict least-recently-active exchange instead of oldest-created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: MRP retransmissions now use the idle interval when the peer left its active window mid-exchange, matching CHIP SDK behavior
     - Fix: TcpChannel now closes the connection on a zero-length stream frame instead of silently skipping it, preventing a peer from holding a connection slot open indefinitely
     - Fix: A forward message-counter jump of exactly the window size no longer retains stale replay-bitmap bits, which could wrongly reject a later legitimate message as duplicate
+    - Fix: When the per-session concurrent-exchange limit is exceeded, the least-recently-active exchange is now closed instead of the oldest-created one
 
 ## 0.17.1 (2026-06-03)
 

--- a/packages/protocol/src/protocol/ExchangeManager.ts
+++ b/packages/protocol/src/protocol/ExchangeManager.ts
@@ -429,8 +429,9 @@ export class ExchangeManager implements Transport.Provider {
         exchange.closed.on(() => this.deleteExchange(exchangeIndex));
         this.#exchanges.set(exchangeIndex, exchange);
 
-        // A node SHOULD limit itself to a maximum of 5 concurrent exchanges over a unicast session. This is
-        // to prevent a node from exhausting the message counter window of the peer node.
+        // The spec recommends a maximum of 5 concurrent exchanges over a unicast session to avoid exhausting the
+        // peer's message counter window; we allow MAXIMUM_CONCURRENT_OUTGOING_EXCHANGES_PER_SESSION as a practical
+        // upper bound and evict the least-recently-active exchange once exceeded.
         // TODO Make sure Group sessions are handled differently
         this.#cleanupSessionExchanges(exchange.session.id);
     }
@@ -446,14 +447,15 @@ export class ExchangeManager implements Transport.Provider {
         if (sessionExchanges.length <= MAXIMUM_CONCURRENT_OUTGOING_EXCHANGES_PER_SESSION) {
             return;
         }
-        // let's use the first entry in the Map as the oldest exchange and close it
         // TODO: Adjust this logic into a Exchange creation queue instead of hard closing
-        const exchangeToClose = sessionExchanges[0];
+        const exchangeToClose = sessionExchanges.reduce((oldest, exchange) =>
+            exchange.lastActive < oldest.lastActive ? exchange : oldest,
+        );
         logger.info(
             exchangeToClose.via,
-            `Closing oldest exchange for session because of too many concurrent outgoing exchanges. Ensure to not send that many parallel messages to one peer.`,
+            `Closing least-recently-active exchange for session because of too many concurrent outgoing exchanges. Ensure to not send that many parallel messages to one peer.`,
         );
-        logger.debug(exchangeToClose.via, "Closing oldest exchange");
+        logger.debug(exchangeToClose.via, "Closing least-recently-active exchange");
         this.#workers.add(exchangeToClose.close());
     }
 

--- a/packages/protocol/src/protocol/ExchangeManager.ts
+++ b/packages/protocol/src/protocol/ExchangeManager.ts
@@ -448,12 +448,12 @@ export class ExchangeManager implements Transport.Provider {
             return;
         }
         // TODO: Adjust this logic into a Exchange creation queue instead of hard closing
-        const exchangeToClose = sessionExchanges.reduce((oldest, exchange) =>
-            exchange.lastActive < oldest.lastActive ? exchange : oldest,
+        const exchangeToClose = sessionExchanges.reduce((leastRecentlyActive, exchange) =>
+            exchange.lastActive < leastRecentlyActive.lastActive ? exchange : leastRecentlyActive,
         );
         logger.info(
             exchangeToClose.via,
-            `Closing least-recently-active exchange for session because of too many concurrent outgoing exchanges. Ensure to not send that many parallel messages to one peer.`,
+            `Closing least-recently-active exchange for session because of too many concurrent exchanges. Ensure to not send that many parallel messages to one peer.`,
         );
         logger.debug(exchangeToClose.via, "Closing least-recently-active exchange");
         this.#workers.add(exchangeToClose.close());

--- a/packages/protocol/src/protocol/MessageExchange.ts
+++ b/packages/protocol/src/protocol/MessageExchange.ts
@@ -229,6 +229,7 @@ export class MessageExchange {
     #messageSendCounter = 0;
     #messageReceivedCounter = 0;
     #retransmissionTimer?: Timer;
+    #lastActive = Time.nowMs;
 
     constructor(config: MessageExchange.Config) {
         const {
@@ -304,6 +305,16 @@ export class MessageExchange {
         return this.#closed.value || (this.#isInitiator && this.#closing.value);
     }
 
+    /** Timestamp of the last send or receive on this exchange, used to evict the least-recently-active exchange. */
+    get lastActive() {
+        return this.#lastActive;
+    }
+
+    #notifyActivity(messageReceived: boolean) {
+        this.#lastActive = Time.nowMs;
+        this.session.notifyActivity(messageReceived);
+    }
+
     /**
      * Emit when the exchange is closing, but not yet closed. We only wait for acks and retries to happen, but the
      * actual interaction logic is already done.
@@ -373,7 +384,7 @@ export class MessageExchange {
             );
         }
 
-        this.session.notifyActivity(true);
+        this.#notifyActivity(true);
         this.#onReceive?.(message, duplicate);
 
         if (duplicate) {
@@ -506,7 +517,7 @@ export class MessageExchange {
 
         this.#used = true;
         this.#messageSendCounter++;
-        this.session.notifyActivity(false);
+        this.#notifyActivity(false);
 
         let ackedMessageId = standaloneAckMessageId;
         if (ackedMessageId === undefined && this.session.usesMrp) {
@@ -748,7 +759,7 @@ export class MessageExchange {
         }
 
         this.#messageSendCounter++;
-        this.session.notifyActivity(false);
+        this.#notifyActivity(false);
 
         this.context.retry(this.#retransmissionCounter);
         const resubmissionBackoffTime = this.#mrpResubmissionBackOffTime;

--- a/packages/protocol/test/protocol/MessageExchangeTest.ts
+++ b/packages/protocol/test/protocol/MessageExchangeTest.ts
@@ -117,6 +117,32 @@ describe("MessageExchange", () => {
         });
     });
 
+    describe("activity tracking", () => {
+        before(() => MockTime.enable());
+
+        it("updates lastActive on receive", async () => {
+            const { exchange } = createExchange(new ProtocolMocks.NodeSession());
+            const before = exchange.lastActive;
+
+            await MockTime.advance(1000);
+            await exchange.onMessageReceived(fakeInboundMessage());
+
+            expect(exchange.lastActive).to.equal(before + 1000);
+        });
+
+        it("updates lastActive on send", async () => {
+            const session = new ProtocolMocks.NodeSession();
+            (session.channel as any).send = async (): Promise<void> => {};
+            const { exchange } = createExchange(session);
+            const before = exchange.lastActive;
+
+            await MockTime.advance(2000);
+            await exchange.send(0, Bytes.empty, { requiresAck: false, disableMrpLogic: true });
+
+            expect(exchange.lastActive).to.equal(before + 2000);
+        });
+    });
+
     describe("cross-protocol StatusReport", () => {
         it("accepts SecureChannel StatusReport on a non-SecureChannel exchange and delivers it to the consumer", async () => {
             // Reproduces the case where a peer sends a spec-compliant StatusReport (protocolId=0, type=0x40)


### PR DESCRIPTION
## Summary

When a session exceeds `MAXIMUM_CONCURRENT_OUTGOING_EXCHANGES_PER_SESSION`, `ExchangeManager.#cleanupSessionExchanges` previously closed `sessionExchanges[0]` — the **oldest created** exchange in Map order, regardless of how recently it was used. A long-lived but still-active exchange created first could be killed in favor of a freshly-created idle one.

Root cause: a `MessageExchange` had no own activity timestamp — it only forwarded `session.notifyActivity()`, which updates the *session*, not the exchange. Nothing to sort by.

## Changes

- `MessageExchange` now tracks a per-exchange `lastActive` timestamp, stamped via a `#notifyActivity()` wrapper at the three sites that forward to `session.notifyActivity()` (one receive, two send/retransmit).
- `#cleanupSessionExchanges` now evicts the **least-recently-active** exchange (`reduce` over min `lastActive`) instead of the oldest-created one. Log text updated to match.
- Clarified the stale comment that said "5 concurrent exchanges" (spec value) while the constant is 30 (practical limit).

Strictly better than the previous FIFO-by-creation eviction. A back-pressure creation queue (replacing the hard limit entirely) remains a separate, larger follow-up.

## Test

New `MessageExchangeTest.ts` "activity tracking" tests verify `lastActive` updates on receive and on send (MockTime-driven). Full protocol suite passes (1101/1101), format and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)