### PR TITLE
WIP: feat(node): ICD device cluster (IcdManagementServer)

### DIFF
--- a/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
+++ b/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
@@ -4,11 +4,32 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*** THIS FILE WILL BE REGENERATED IF YOU DO NOT REMOVE THIS MESSAGE ***/
-
+import { ImplementationError } from "@matter/general";
+import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { IcdManagementBehavior } from "./IcdManagementBehavior.js";
 
+const Base = IcdManagementBehavior.with(IcdManagement.Feature.CheckInProtocolSupport);
+
 /**
- * This is the default server implementation of {@link IcdManagementBehavior}.
+ * Default device-side ICD Management behavior. Enables the Check-In Protocol Support (CIP) feature and validates
+ * spec constraints on the timing attributes at startup.
+ *
+ * @see {@link MatterSpecification.v151.Core} § 9.16
  */
-export class IcdManagementServer extends IcdManagementBehavior {}
+export class IcdManagementServer extends Base {
+    override initialize() {
+        // IdleModeDuration is in seconds; ActiveModeDuration is in milliseconds — unit conversion required.
+        // @see {@link MatterSpecification.v151.Core} § 9.16.6.1
+        if (this.state.idleModeDuration * 1000 < this.state.activeModeDuration) {
+            throw new ImplementationError(
+                `idleModeDuration (${this.state.idleModeDuration}s) * 1000 must be >= activeModeDuration (${this.state.activeModeDuration}ms)`,
+            );
+        }
+        // @see {@link MatterSpecification.v151.Core} § 9.16.6.10
+        if (this.state.maximumCheckInBackoff < this.state.idleModeDuration) {
+            throw new ImplementationError(
+                `maximumCheckInBackoff (${this.state.maximumCheckInBackoff}s) must be >= idleModeDuration (${this.state.idleModeDuration}s)`,
+            );
+        }
+    }
+}

--- a/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
+++ b/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
@@ -5,60 +5,71 @@
  */
 
 import { NodeLifecycle } from "#node/NodeLifecycle.js";
-import { Bytes, ImplementationError } from "@matter/general";
+import { Bytes, Duration, ImplementationError, Millis, Seconds } from "@matter/general";
 import { AccessLevel, DataModelPath, fabricIdx, field, listOf, nodeId, nonvolatile, octstr } from "@matter/model";
 import { AccessControl, assertRemoteActor, Fabric, FabricManager, hasRemoteActor, IcdCounter } from "@matter/protocol";
 import { FabricIndex, NodeId, Status, StatusResponseError } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { IcdManagementBehavior } from "./IcdManagementBehavior.js";
 
-const Base = IcdManagementBehavior.with(IcdManagement.Feature.CheckInProtocolSupport);
+const IcdManagementLogicBase = IcdManagementBehavior.with(IcdManagement.Feature.CheckInProtocolSupport);
 
 /**
- * Default device-side ICD Management behavior. Enables the Check-In Protocol Support (CIP) feature and validates
- * spec constraints on the timing attributes at startup.
+ * Default device-side ICD Management server implementation. Enables the Check-In Protocol Support (CIP) feature and
+ * validates spec constraints on the timing attributes at startup. Use {@link IcdManagementServer.with} to specialize
+ * for additional features, or extend this class to override its behavior.
+ *
+ * ## Extension points
+ *
+ * Override {@link stayActive} to react to StayActiveRequest: extend the device's active period for the requested time
+ * and return the duration actually promised. The default implementation only honors the spec minimum and does not
+ * track active time, so a device that wants to genuinely stay awake should override it.
  *
  * @see {@link MatterSpecification.v151.Core} § 9.16
  */
-export class IcdManagementServer extends Base {
-    declare internal: IcdManagementServer.Internal;
-    declare readonly state: IcdManagementServer.State;
+export class IcdManagementBaseServer extends IcdManagementLogicBase {
+    declare internal: IcdManagementBaseServer.Internal;
+    declare readonly state: IcdManagementBaseServer.State;
 
     override initialize() {
-        // IdleModeDuration is in seconds; ActiveModeDuration is in milliseconds — unit conversion required.
+        const idleModeDuration = Seconds(this.state.idleModeDuration);
+        const activeModeDuration = Millis(this.state.activeModeDuration);
+        const maximumCheckInBackoff = Seconds(this.state.maximumCheckInBackoff);
+
         // @see {@link MatterSpecification.v151.Core} § 9.16.6.1
-        if (this.state.idleModeDuration * 1000 < this.state.activeModeDuration) {
+        if (idleModeDuration < activeModeDuration) {
             throw new ImplementationError(
-                `idleModeDuration (${this.state.idleModeDuration}s) * 1000 must be >= activeModeDuration (${this.state.activeModeDuration}ms)`,
+                `idleModeDuration (${Duration.format(idleModeDuration)}) must be >= activeModeDuration (${Duration.format(activeModeDuration)})`,
             );
         }
         // @see {@link MatterSpecification.v151.Core} § 9.16.6.10
-        if (this.state.maximumCheckInBackoff < this.state.idleModeDuration) {
+        if (maximumCheckInBackoff < idleModeDuration) {
             throw new ImplementationError(
-                `maximumCheckInBackoff (${this.state.maximumCheckInBackoff}s) must be >= idleModeDuration (${this.state.idleModeDuration}s)`,
+                `maximumCheckInBackoff (${Duration.format(maximumCheckInBackoff)}) must be >= idleModeDuration (${Duration.format(idleModeDuration)})`,
             );
         }
 
         this.reactTo((this.endpoint.lifecycle as NodeLifecycle).online, this.#online);
     }
 
-    async #online() {
-        const prev = this.internal.icdCounter;
-        if (prev !== undefined) {
-            // Node restarted — drop the old counter's reactor so it doesn't accumulate dead backings.
-            await this.stopReacting({ observable: prev.changed });
-        }
-        const counter = new IcdCounter(this.state.icdCounter);
-        this.internal.icdCounter = counter;
-        // Persist the boot-bump immediately; later increments go through the reactor so state writes stay transactional.
-        // @see {@link MatterSpecification.v151.Core} § 4.6.3
-        this.state.icdCounter = counter.value;
-        this.reactTo(counter.changed, this.#persistCounter);
-
-        // Rebuild the key map, dropping keys for fabrics removed while the node was down (the fabric-removal
-        // reactor cannot fire across a restart, so prune here as GroupKeyManagementServer does).
+    #online() {
         const fabrics = this.env.get(FabricManager);
-        const keyMap = new Map<string, IcdManagementServer.IcdKeyEntry>();
+
+        // One-time setup. online may re-fire across stop/start on the same instance; the counter and its persistence
+        // reactor must be created once (and are torn down with the behavior on dispose).
+        if (this.internal.icdCounter === undefined) {
+            const counter = new IcdCounter(this.state.icdCounter);
+            this.internal.icdCounter = counter;
+            // Persist the boot-bump now; later increments persist via the reactor so writes stay transactional.
+            // @see {@link MatterSpecification.v151.Core} § 4.6.3
+            this.state.icdCounter = counter.value;
+            this.reactTo(counter.changed, this.#persistCounter);
+            this.reactTo(fabrics.events.deleted, this.#onFabricDeleted);
+        }
+
+        // Rebuild the operational view on every online: fabric.icd is runtime-only and starts empty after a full
+        // restart. Drop keys for fabrics that no longer exist so a stale key can never be replayed.
+        const keyMap = new Map<string, IcdManagementBaseServer.IcdKeyEntry>();
         let prunedKeys = false;
         for (const entry of this.state.icdKeys) {
             if (fabrics.maybeFor(entry.fabricIndex) === undefined) {
@@ -72,15 +83,11 @@ export class IcdManagementServer extends Base {
             this.#persistKeys();
         }
 
-        // Replay persisted registrations into fabric.icd so the operational check-in path has up-to-date keys.
         // @see {@link MatterSpecification.v151.Core} § 9.16.6.4
         for (const client of this.state.registeredClients) {
             const key = keyMap.get(this.#keyFor(client.fabricIndex, client.checkInNodeId))?.key;
-            if (key === undefined) {
-                continue;
-            }
             const fabric = fabrics.maybeFor(client.fabricIndex);
-            if (fabric === undefined) {
+            if (key === undefined || fabric === undefined) {
                 continue;
             }
             fabric.icd.setRegistration({
@@ -90,8 +97,6 @@ export class IcdManagementServer extends Base {
                 clientType: client.clientType,
             });
         }
-
-        this.reactTo(fabrics.events.deleted, this.#onFabricDeleted);
     }
 
     async #onFabricDeleted(fabric: Fabric) {
@@ -125,34 +130,17 @@ export class IcdManagementServer extends Base {
         const fabricIndex = fabric.fabricIndex;
 
         const clients = this.state.registeredClients;
-        let existingIndex = -1;
-        let fabricCount = 0;
-        for (let i = 0; i < clients.length; i++) {
-            const c = clients[i];
-            if (c.fabricIndex !== fabricIndex) {
-                continue;
-            }
-            fabricCount++;
-            if (c.checkInNodeId === request.checkInNodeId) {
-                existingIndex = i;
-            }
-        }
+        const fabricClients = clients.filter(c => c.fabricIndex === fabricIndex);
+        const existing = fabricClients.find(c => c.checkInNodeId === request.checkInNodeId);
 
-        if (existingIndex === -1) {
+        if (existing === undefined) {
             // @see {@link MatterSpecification.v151.Core} § 9.16.7.1 step 1
-            if (fabricCount >= this.state.clientsSupportedPerFabric) {
+            if (fabricClients.length >= this.state.clientsSupportedPerFabric) {
                 throw new StatusResponseError("ICD client slots exhausted for fabric", Status.ResourceExhausted);
             }
-        } else if (!this.#isAdministrator()) {
+        } else {
             // @see {@link MatterSpecification.v151.Core} § 9.16.7.1 steps 2-3
-            const stored = this.internal.icdKeys.get(this.#keyFor(fabricIndex, request.checkInNodeId));
-            if (
-                request.verificationKey === undefined ||
-                stored === undefined ||
-                !Bytes.areEqual(request.verificationKey, stored.key)
-            ) {
-                throw new StatusResponseError("VerificationKey mismatch", Status.Failure);
-            }
+            this.#assertMayModify(fabricIndex, request.checkInNodeId, request.verificationKey);
         }
 
         const entry: IcdManagement.MonitoringRegistration = {
@@ -162,10 +150,10 @@ export class IcdManagementServer extends Base {
             fabricIndex,
         };
 
-        if (existingIndex === -1) {
+        if (existing === undefined) {
             clients.push(entry);
         } else {
-            clients[existingIndex] = entry;
+            clients[clients.indexOf(existing)] = entry;
         }
 
         this.internal.icdKeys.set(this.#keyFor(fabricIndex, request.checkInNodeId), {
@@ -189,20 +177,20 @@ export class IcdManagementServer extends Base {
      * @see {@link MatterSpecification.v151.Core} § 9.16.7.4
      */
     override stayActiveRequest(request: IcdManagement.StayActiveRequest): IcdManagement.StayActiveResponse {
-        return { promisedActiveDuration: this.stayActive(request.stayActiveDuration) };
+        return { promisedActiveDuration: this.stayActive(Millis(request.stayActiveDuration)) };
     }
 
     /**
-     * Extension point: return the promised active duration (ms) for a StayActiveRequest.
+     * Extension point: return the duration for which the device promises to stay active.
      *
-     * The default honors the spec floor only (promised >= min(30000, requested)); with no active-mode machine yet it
-     * neither tracks nor extends real active time. Phase 2b overrides this to fold in remaining active time and
-     * actually extend active mode; apps may override for custom power policy.
+     * The default honors the spec floor only (the promise is at least the smaller of 30s and the request); with no
+     * active-mode machine yet it neither tracks nor extends real active time. Phase 2b overrides this to fold in
+     * remaining active time and actually extend active mode; apps may override for custom power policy.
      *
      * @see {@link MatterSpecification.v151.Core} § 9.16.7.5.1.1
      */
-    protected stayActive(requestedDurationMs: number): number {
-        return Math.min(30000, requestedDurationMs);
+    protected stayActive(requestedDuration: Duration): Duration {
+        return Duration.min(Seconds(30), requestedDuration);
     }
 
     /**
@@ -220,17 +208,8 @@ export class IcdManagementServer extends Base {
             throw new StatusResponseError("No such ICD client registration", Status.NotFound);
         }
 
-        if (!this.#isAdministrator()) {
-            // @see {@link MatterSpecification.v151.Core} § 9.16.7.3 step 2
-            const stored = this.internal.icdKeys.get(this.#keyFor(fabricIndex, request.checkInNodeId));
-            if (
-                request.verificationKey === undefined ||
-                stored === undefined ||
-                !Bytes.areEqual(request.verificationKey, stored.key)
-            ) {
-                throw new StatusResponseError("VerificationKey mismatch", Status.Failure);
-            }
-        }
+        // @see {@link MatterSpecification.v151.Core} § 9.16.7.3 step 2
+        this.#assertMayModify(fabricIndex, request.checkInNodeId, request.verificationKey);
 
         this.state.registeredClients = this.state.registeredClients.filter(
             c => !(c.fabricIndex === fabricIndex && c.checkInNodeId === request.checkInNodeId),
@@ -260,6 +239,20 @@ export class IcdManagementServer extends Base {
         return context.authorityAt(AccessLevel.Administer, location) === AccessControl.Authority.Granted;
     }
 
+    /**
+     * Enforces the verificationKey rule shared by register-update and unregister: an Administrator may modify any
+     * entry, while a Manage-privileged caller must supply a verificationKey matching the stored ICDToken.
+     */
+    #assertMayModify(fabricIndex: FabricIndex, checkInNodeId: NodeId, verificationKey?: Bytes) {
+        if (this.#isAdministrator()) {
+            return;
+        }
+        const stored = this.internal.icdKeys.get(this.#keyFor(fabricIndex, checkInNodeId));
+        if (verificationKey === undefined || stored === undefined || !Bytes.areEqual(verificationKey, stored.key)) {
+            throw new StatusResponseError("VerificationKey mismatch", Status.Failure);
+        }
+    }
+
     #keyFor(fabricIndex: FabricIndex, checkInNodeId: NodeId): string {
         return `${fabricIndex}:${checkInNodeId}`;
     }
@@ -269,7 +262,7 @@ export class IcdManagementServer extends Base {
     }
 }
 
-export namespace IcdManagementServer {
+export namespace IcdManagementBaseServer {
     /** Persisted key entry. */
     export class IcdKeyEntry {
         @field(fabricIdx)
@@ -282,7 +275,7 @@ export namespace IcdManagementServer {
         key!: Bytes;
     }
 
-    export class State extends Base.State {
+    export class State extends IcdManagementLogicBase.State {
         /** Persisted ICDToken keys, mirroring the per-registration key not stored in the RegisteredClients attribute. */
         @field(listOf(IcdKeyEntry), nonvolatile)
         icdKeys: IcdKeyEntry[] = [];
@@ -292,4 +285,13 @@ export namespace IcdManagementServer {
         icdCounter?: IcdCounter;
         icdKeys: Map<string, IcdKeyEntry> = new Map();
     }
+
+    export declare const ExtensionInterface: {
+        stayActive(requestedDuration: Duration): Duration;
+    };
 }
+
+/**
+ * The default {@link IcdManagementBehavior} server implementation, with the Check-In Protocol Support feature.
+ */
+export class IcdManagementServer extends IcdManagementBaseServer {}

--- a/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
+++ b/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
@@ -98,7 +98,7 @@ export class IcdManagementServer extends Base {
         const fabricIndex = fabric.fabricIndex;
 
         // registeredClients is fabric-scoped and auto-pruned by the framework during the deleting phase; we only
-        // need to clean the non-scoped internal key store here.
+        // need to clean the non-scoped internal key store here. The reactor supplies a transaction for the state write.
         for (const key of [...this.internal.icdKeys.keys()]) {
             if (key.startsWith(`${fabricIndex}:`)) {
                 this.internal.icdKeys.delete(key);

--- a/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
+++ b/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
@@ -186,6 +186,26 @@ export class IcdManagementServer extends Base {
     }
 
     /**
+     * @see {@link MatterSpecification.v151.Core} § 9.16.7.4
+     */
+    override stayActiveRequest(request: IcdManagement.StayActiveRequest): IcdManagement.StayActiveResponse {
+        return { promisedActiveDuration: this.stayActive(request.stayActiveDuration) };
+    }
+
+    /**
+     * Extension point: return the promised active duration (ms) for a StayActiveRequest.
+     *
+     * The default honors the spec floor only (promised >= min(30000, requested)); with no active-mode machine yet it
+     * neither tracks nor extends real active time. Phase 2b overrides this to fold in remaining active time and
+     * actually extend active mode; apps may override for custom power policy.
+     *
+     * @see {@link MatterSpecification.v151.Core} § 9.16.7.5.1.1
+     */
+    protected stayActive(requestedDurationMs: number): number {
+        return Math.min(30000, requestedDurationMs);
+    }
+
+    /**
      * @see {@link MatterSpecification.v151.Core} § 9.16.7.3
      */
     override async unregisterClient(request: IcdManagement.UnregisterClientRequest): Promise<void> {

--- a/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
+++ b/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
@@ -138,10 +138,46 @@ export class IcdManagementServer extends Base {
     }
 
     /**
+     * @see {@link MatterSpecification.v151.Core} § 9.16.7.3
+     */
+    override async unregisterClient(request: IcdManagement.UnregisterClientRequest): Promise<void> {
+        assertRemoteActor(this.context);
+        const fabric = this.context.session.associatedFabric;
+        const fabricIndex = fabric.fabricIndex;
+
+        const existing = this.state.registeredClients.find(
+            c => c.fabricIndex === fabricIndex && c.checkInNodeId === request.checkInNodeId,
+        );
+        if (existing === undefined) {
+            throw new StatusResponseError("No such ICD client registration", Status.NotFound);
+        }
+
+        if (!this.#isAdministrator()) {
+            // @see {@link MatterSpecification.v151.Core} § 9.16.7.3 step 2
+            const stored = this.internal.icdKeys.get(this.#keyFor(fabricIndex, request.checkInNodeId));
+            if (
+                request.verificationKey === undefined ||
+                stored === undefined ||
+                !Bytes.areEqual(request.verificationKey, stored.key)
+            ) {
+                throw new StatusResponseError("VerificationKey mismatch", Status.Failure);
+            }
+        }
+
+        this.state.registeredClients = this.state.registeredClients.filter(
+            c => !(c.fabricIndex === fabricIndex && c.checkInNodeId === request.checkInNodeId),
+        );
+        this.internal.icdKeys.delete(this.#keyFor(fabricIndex, request.checkInNodeId));
+        this.#persistKeys();
+        fabric.icd.deleteRegistration(request.checkInNodeId);
+    }
+
+    /**
      * Returns true when the invoking session has Administer privilege on this cluster.
      *
-     * Spec requires Administer to skip verificationKey on update/remove; Manage must provide it.
+     * Administer skips the verificationKey check on register update and unregister; Manage must provide it.
      * @see {@link MatterSpecification.v151.Core} § 9.16.7.1 step 2
+     * @see {@link MatterSpecification.v151.Core} § 9.16.7.3 step 2
      */
     #isAdministrator(): boolean {
         const context = this.context;
@@ -156,12 +192,10 @@ export class IcdManagementServer extends Base {
         return context.authorityAt(AccessLevel.Administer, location) === AccessControl.Authority.Granted;
     }
 
-    /** Stable map key for the runtime icdKeys map. */
     #keyFor(fabricIndex: FabricIndex, checkInNodeId: NodeId): string {
         return `${fabricIndex}:${checkInNodeId}`;
     }
 
-    /** Write the runtime icdKeys map back to the persisted @nonvolatile state array. */
     #persistKeys() {
         this.state.icdKeys = [...this.internal.icdKeys.values()];
     }

--- a/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
+++ b/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
@@ -7,7 +7,7 @@
 import { NodeLifecycle } from "#node/NodeLifecycle.js";
 import { Bytes, ImplementationError } from "@matter/general";
 import { AccessLevel, DataModelPath, fabricIdx, field, listOf, nodeId, nonvolatile, octstr } from "@matter/model";
-import { AccessControl, assertRemoteActor, hasRemoteActor, IcdCounter } from "@matter/protocol";
+import { AccessControl, assertRemoteActor, Fabric, FabricManager, hasRemoteActor, IcdCounter } from "@matter/protocol";
 import { FabricIndex, NodeId, Status, StatusResponseError } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { IcdManagementBehavior } from "./IcdManagementBehavior.js";
@@ -55,11 +55,59 @@ export class IcdManagementServer extends Base {
         this.state.icdCounter = counter.value;
         this.reactTo(counter.changed, this.#persistCounter);
 
+        // Rebuild the key map, dropping keys for fabrics removed while the node was down (the fabric-removal
+        // reactor cannot fire across a restart, so prune here as GroupKeyManagementServer does).
+        const fabrics = this.env.get(FabricManager);
         const keyMap = new Map<string, IcdManagementServer.IcdKeyEntry>();
+        let prunedKeys = false;
         for (const entry of this.state.icdKeys) {
+            if (fabrics.maybeFor(entry.fabricIndex) === undefined) {
+                prunedKeys = true;
+                continue;
+            }
             keyMap.set(this.#keyFor(entry.fabricIndex, entry.checkInNodeId), entry);
         }
         this.internal.icdKeys = keyMap;
+        if (prunedKeys) {
+            this.#persistKeys();
+        }
+
+        // Replay persisted registrations into fabric.icd so the operational check-in path has up-to-date keys.
+        // @see {@link MatterSpecification.v151.Core} § 9.16.6.4
+        for (const client of this.state.registeredClients) {
+            const key = keyMap.get(this.#keyFor(client.fabricIndex, client.checkInNodeId))?.key;
+            if (key === undefined) {
+                continue;
+            }
+            const fabric = fabrics.maybeFor(client.fabricIndex);
+            if (fabric === undefined) {
+                continue;
+            }
+            fabric.icd.setRegistration({
+                checkInNodeId: client.checkInNodeId,
+                monitoredSubject: client.monitoredSubject,
+                key,
+                clientType: client.clientType,
+            });
+        }
+
+        this.reactTo(fabrics.events.deleted, this.#onFabricDeleted);
+    }
+
+    async #onFabricDeleted(fabric: Fabric) {
+        const fabricIndex = fabric.fabricIndex;
+
+        // registeredClients is fabric-scoped and auto-pruned by the framework during the deleting phase; we only
+        // need to clean the non-scoped internal key store here.
+        for (const key of [...this.internal.icdKeys.keys()]) {
+            if (key.startsWith(`${fabricIndex}:`)) {
+                this.internal.icdKeys.delete(key);
+            }
+        }
+        this.#persistKeys();
+
+        // The fabric object still exists at this point; clear its operational registrations.
+        fabric.icd.clearRegistrations();
     }
 
     #persistCounter(value: number) {

--- a/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
+++ b/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
@@ -5,8 +5,10 @@
  */
 
 import { NodeLifecycle } from "#node/NodeLifecycle.js";
-import { ImplementationError } from "@matter/general";
-import { IcdCounter } from "@matter/protocol";
+import { Bytes, ImplementationError } from "@matter/general";
+import { AccessLevel, DataModelPath, fabricIdx, field, listOf, nodeId, nonvolatile, octstr } from "@matter/model";
+import { AccessControl, assertRemoteActor, hasRemoteActor, IcdCounter } from "@matter/protocol";
+import { FabricIndex, NodeId, Status, StatusResponseError } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { IcdManagementBehavior } from "./IcdManagementBehavior.js";
 
@@ -20,6 +22,7 @@ const Base = IcdManagementBehavior.with(IcdManagement.Feature.CheckInProtocolSup
  */
 export class IcdManagementServer extends Base {
     declare internal: IcdManagementServer.Internal;
+    declare readonly state: IcdManagementServer.State;
 
     override initialize() {
         // IdleModeDuration is in seconds; ActiveModeDuration is in milliseconds — unit conversion required.
@@ -51,15 +54,140 @@ export class IcdManagementServer extends Base {
         // @see {@link MatterSpecification.v151.Core} § 4.6.3
         this.state.icdCounter = counter.value;
         this.reactTo(counter.changed, this.#persistCounter);
+
+        const keyMap = new Map<string, IcdManagementServer.IcdKeyEntry>();
+        for (const entry of this.state.icdKeys) {
+            keyMap.set(this.#keyFor(entry.fabricIndex, entry.checkInNodeId), entry);
+        }
+        this.internal.icdKeys = keyMap;
     }
 
     #persistCounter(value: number) {
         this.state.icdCounter = value;
     }
+
+    /**
+     * @see {@link MatterSpecification.v151.Core} § 9.16.7.1
+     */
+    override async registerClient(
+        request: IcdManagement.RegisterClientRequest,
+    ): Promise<IcdManagement.RegisterClientResponse> {
+        assertRemoteActor(this.context);
+        const fabric = this.context.session.associatedFabric;
+        const fabricIndex = fabric.fabricIndex;
+
+        const clients = this.state.registeredClients;
+        let existingIndex = -1;
+        let fabricCount = 0;
+        for (let i = 0; i < clients.length; i++) {
+            const c = clients[i];
+            if (c.fabricIndex !== fabricIndex) {
+                continue;
+            }
+            fabricCount++;
+            if (c.checkInNodeId === request.checkInNodeId) {
+                existingIndex = i;
+            }
+        }
+
+        if (existingIndex === -1) {
+            // @see {@link MatterSpecification.v151.Core} § 9.16.7.1 step 1
+            if (fabricCount >= this.state.clientsSupportedPerFabric) {
+                throw new StatusResponseError("ICD client slots exhausted for fabric", Status.ResourceExhausted);
+            }
+        } else if (!this.#isAdministrator()) {
+            // @see {@link MatterSpecification.v151.Core} § 9.16.7.1 steps 2-3
+            const stored = this.internal.icdKeys.get(this.#keyFor(fabricIndex, request.checkInNodeId));
+            if (
+                request.verificationKey === undefined ||
+                stored === undefined ||
+                !Bytes.areEqual(request.verificationKey, stored.key)
+            ) {
+                throw new StatusResponseError("VerificationKey mismatch", Status.Failure);
+            }
+        }
+
+        const entry: IcdManagement.MonitoringRegistration = {
+            checkInNodeId: request.checkInNodeId,
+            monitoredSubject: request.monitoredSubject,
+            clientType: request.clientType,
+            fabricIndex,
+        };
+
+        if (existingIndex === -1) {
+            clients.push(entry);
+        } else {
+            clients[existingIndex] = entry;
+        }
+
+        this.internal.icdKeys.set(this.#keyFor(fabricIndex, request.checkInNodeId), {
+            fabricIndex,
+            checkInNodeId: request.checkInNodeId,
+            key: request.key,
+        });
+        this.#persistKeys();
+
+        fabric.icd.setRegistration({
+            checkInNodeId: request.checkInNodeId,
+            monitoredSubject: request.monitoredSubject,
+            key: request.key,
+            clientType: request.clientType,
+        });
+
+        return { icdCounter: this.internal.icdCounter!.value };
+    }
+
+    /**
+     * Returns true when the invoking session has Administer privilege on this cluster.
+     *
+     * Spec requires Administer to skip verificationKey on update/remove; Manage must provide it.
+     * @see {@link MatterSpecification.v151.Core} § 9.16.7.1 step 2
+     */
+    #isAdministrator(): boolean {
+        const context = this.context;
+        if (!hasRemoteActor(context)) {
+            return false;
+        }
+        const location: AccessControl.Location = {
+            path: DataModelPath.none,
+            endpoint: this.endpoint.number,
+            cluster: this.cluster.id,
+        };
+        return context.authorityAt(AccessLevel.Administer, location) === AccessControl.Authority.Granted;
+    }
+
+    /** Stable map key for the runtime icdKeys map. */
+    #keyFor(fabricIndex: FabricIndex, checkInNodeId: NodeId): string {
+        return `${fabricIndex}:${checkInNodeId}`;
+    }
+
+    /** Write the runtime icdKeys map back to the persisted @nonvolatile state array. */
+    #persistKeys() {
+        this.state.icdKeys = [...this.internal.icdKeys.values()];
+    }
 }
 
 export namespace IcdManagementServer {
+    /** Persisted key entry. */
+    export class IcdKeyEntry {
+        @field(fabricIdx)
+        fabricIndex!: FabricIndex;
+
+        @field(nodeId)
+        checkInNodeId!: NodeId;
+
+        @field(octstr)
+        key!: Bytes;
+    }
+
+    export class State extends Base.State {
+        /** Persisted ICDToken keys, mirroring the per-registration key not stored in the RegisteredClients attribute. */
+        @field(listOf(IcdKeyEntry), nonvolatile)
+        icdKeys: IcdKeyEntry[] = [];
+    }
+
     export class Internal {
         icdCounter?: IcdCounter;
+        icdKeys: Map<string, IcdKeyEntry> = new Map();
     }
 }

--- a/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
+++ b/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { NodeLifecycle } from "#node/NodeLifecycle.js";
 import { ImplementationError } from "@matter/general";
+import { IcdCounter } from "@matter/protocol";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { IcdManagementBehavior } from "./IcdManagementBehavior.js";
 
@@ -17,6 +19,8 @@ const Base = IcdManagementBehavior.with(IcdManagement.Feature.CheckInProtocolSup
  * @see {@link MatterSpecification.v151.Core} § 9.16
  */
 export class IcdManagementServer extends Base {
+    declare internal: IcdManagementServer.Internal;
+
     override initialize() {
         // IdleModeDuration is in seconds; ActiveModeDuration is in milliseconds — unit conversion required.
         // @see {@link MatterSpecification.v151.Core} § 9.16.6.1
@@ -31,5 +35,31 @@ export class IcdManagementServer extends Base {
                 `maximumCheckInBackoff (${this.state.maximumCheckInBackoff}s) must be >= idleModeDuration (${this.state.idleModeDuration}s)`,
             );
         }
+
+        this.reactTo((this.endpoint.lifecycle as NodeLifecycle).online, this.#online);
+    }
+
+    async #online() {
+        const prev = this.internal.icdCounter;
+        if (prev !== undefined) {
+            // Node restarted — drop the old counter's reactor so it doesn't accumulate dead backings.
+            await this.stopReacting({ observable: prev.changed });
+        }
+        const counter = new IcdCounter(this.state.icdCounter);
+        this.internal.icdCounter = counter;
+        // Persist the boot-bump immediately; later increments go through the reactor so state writes stay transactional.
+        // @see {@link MatterSpecification.v151.Core} § 4.6.3
+        this.state.icdCounter = counter.value;
+        this.reactTo(counter.changed, this.#persistCounter);
+    }
+
+    #persistCounter(value: number) {
+        this.state.icdCounter = value;
+    }
+}
+
+export namespace IcdManagementServer {
+    export class Internal {
+        icdCounter?: IcdCounter;
     }
 }

--- a/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
@@ -267,6 +267,35 @@ describe("IcdManagementServer", () => {
         });
     });
 
+    describe("StayActiveRequest", () => {
+        it("promises at least the spec floor", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const cmds = controller.peers.get("peer1")!.commandsOf(IcdManagementClient);
+
+            const r1 = await cmds.stayActiveRequest({ stayActiveDuration: 5000 });
+            expect(r1.promisedActiveDuration).greaterThanOrEqual(5000);
+
+            const r2 = await cmds.stayActiveRequest({ stayActiveDuration: 60000 });
+            expect(r2.promisedActiveDuration).greaterThanOrEqual(30000);
+        });
+
+        it("small request promises at least min(30000, requested)", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const r = await controller.peers.get("peer1")!.commandsOf(IcdManagementClient).stayActiveRequest({
+                stayActiveDuration: 20,
+            });
+            expect(r.promisedActiveDuration).greaterThanOrEqual(20);
+        });
+    });
+
     describe("fabric lifecycle", () => {
         const key = Bytes.fromHex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf");
 

--- a/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
@@ -80,4 +80,40 @@ describe("IcdManagementServer", () => {
             ).rejectedWith("Behaviors have errors");
         });
     });
+
+    describe("ICD counter", () => {
+        // MockSite has no restart primitive, so boot-bump and increment linkage is tested against a live device node.
+
+        it("applies boot bump to icdCounter attribute on node online", async () => {
+            await using site = new MockSite();
+            const { device } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            // Fresh node seeds from the default 0; the constructor boot bump advances it past 0.
+            expect(device.stateOf(IcdManagementServer).icdCounter).greaterThan(0);
+        });
+
+        it("persists icdCounter attribute when the internal counter is incremented", async () => {
+            await using site = new MockSite();
+            const { device } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const before = device.stateOf(IcdManagementServer).icdCounter;
+
+            // Increment via device.act so the call runs inside the node's actor context.  The reactTo subscriber
+            // (#persistCounter) fires in an independent LocalActorContext; we wait for all pending microtasks and
+            // macrotasks to drain before reading the attribute back.
+            await device.act(agent => {
+                const { icdCounter } = agent.get(IcdManagementServer).internal;
+                if (icdCounter === undefined) throw new Error("icdCounter not initialized");
+                icdCounter.increment();
+            });
+            await MockTime.resolve(Promise.resolve());
+
+            const after = device.stateOf(IcdManagementServer).icdCounter;
+            expect(after).equals(before + 1);
+        });
+    });
 });

--- a/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
@@ -8,9 +8,11 @@ import { IcdManagementClient, IcdManagementServer } from "#behaviors/icd-managem
 import { OperationalCredentialsClient } from "#behaviors/operational-credentials";
 import { ServerNode } from "#node/index.js";
 import { Bytes } from "@matter/general";
+import { AccessLevel } from "@matter/model";
 import { FabricManager } from "@matter/protocol";
-import { NodeId } from "@matter/types";
+import { FabricIndex, NodeId } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
+import { MockExchange } from "../../node/mock-exchange.js";
 import { MockServerNode } from "../../node/mock-server-node.js";
 import { MockSite } from "../../node/mock-site.js";
 
@@ -293,6 +295,137 @@ describe("IcdManagementServer", () => {
                 stayActiveDuration: 20,
             });
             expect(r.promisedActiveDuration).greaterThanOrEqual(20);
+        });
+    });
+
+    describe("Manage-privilege verificationKey", () => {
+        // MockExchange with a non-zero fabricIndex (FabricIndex(1)) satisfies the framework's fabric-scoped data
+        // constraint. The MockExchange constructor overrides accessLevelsFor on its internal fake Fabric to return
+        // exactly [View, <accessLevel>], so #isAdministrator() sees only the specified privilege.
+
+        const fabricIndex = FabricIndex(1);
+        const checkInNodeId = NodeId(0x0101n);
+        const initialKey = Bytes.fromHex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf");
+        const replacementKey = Bytes.fromHex("a0a1a2a3a4a5a6a7a8a9aaabacadaeaf");
+        const wrongKey = Bytes.fromHex("f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff");
+
+        function adminExchange() {
+            return new MockExchange({ fabricIndex, nodeId: NodeId(1) }, { accessLevel: AccessLevel.Administer });
+        }
+
+        function manageExchange() {
+            return new MockExchange({ fabricIndex, nodeId: NodeId(2) }, { accessLevel: AccessLevel.Manage });
+        }
+
+        async function withRegisteredNode() {
+            const node = await MockServerNode.createOnline(MockServerNode.RootEndpoint.with(IcdManagementServer));
+
+            await node.online({ exchange: adminExchange(), command: true }, agent =>
+                agent.get(IcdManagementServer).registerClient({
+                    checkInNodeId,
+                    monitoredSubject: checkInNodeId,
+                    key: initialKey,
+                    clientType: IcdManagement.ClientType.Permanent,
+                }),
+            );
+
+            return node;
+        }
+
+        it("registerClient update as Manage with correct verificationKey succeeds and updates the entry", async () => {
+            await using node = await withRegisteredNode();
+
+            await node.online({ exchange: manageExchange(), command: true }, agent =>
+                agent.get(IcdManagementServer).registerClient({
+                    checkInNodeId,
+                    monitoredSubject: checkInNodeId,
+                    key: replacementKey,
+                    verificationKey: initialKey,
+                    clientType: IcdManagement.ClientType.Ephemeral,
+                }),
+            );
+
+            const state = node.stateOf(IcdManagementServer);
+            expect(state.registeredClients).length(1);
+            expect(state.registeredClients[0].clientType).equals(IcdManagement.ClientType.Ephemeral);
+
+            // The stored ICDToken must rotate to the new key, else a later verificationKey check would use the old one.
+            await node.online({ exchange: adminExchange(), command: true }, agent => {
+                const stored = [...agent.get(IcdManagementServer).internal.icdKeys.values()].find(
+                    e => e.checkInNodeId === checkInNodeId,
+                );
+                expect(stored).not.undefined;
+                expect(Bytes.areEqual(stored!.key, replacementKey)).true;
+            });
+        });
+
+        it("registerClient update as Manage with wrong verificationKey rejects with Failure", async () => {
+            await using node = await withRegisteredNode();
+
+            await expect(
+                node.online({ exchange: manageExchange(), command: true }, agent =>
+                    agent.get(IcdManagementServer).registerClient({
+                        checkInNodeId,
+                        monitoredSubject: checkInNodeId,
+                        key: replacementKey,
+                        verificationKey: wrongKey,
+                        clientType: IcdManagement.ClientType.Ephemeral,
+                    }),
+                ),
+            ).rejectedWith(/verificationkey mismatch/i);
+        });
+
+        it("registerClient update as Manage with missing verificationKey rejects with Failure", async () => {
+            await using node = await withRegisteredNode();
+
+            await expect(
+                node.online({ exchange: manageExchange(), command: true }, agent =>
+                    agent.get(IcdManagementServer).registerClient({
+                        checkInNodeId,
+                        monitoredSubject: checkInNodeId,
+                        key: replacementKey,
+                        clientType: IcdManagement.ClientType.Ephemeral,
+                    }),
+                ),
+            ).rejectedWith(/verificationkey mismatch/i);
+        });
+
+        it("unregisterClient as Manage with correct verificationKey succeeds and removes the entry", async () => {
+            await using node = await withRegisteredNode();
+
+            await node.online({ exchange: manageExchange(), command: true }, agent =>
+                agent.get(IcdManagementServer).unregisterClient({
+                    checkInNodeId,
+                    verificationKey: initialKey,
+                }),
+            );
+
+            expect(node.stateOf(IcdManagementServer).registeredClients).deep.equals([]);
+        });
+
+        it("unregisterClient as Manage with wrong verificationKey rejects with Failure", async () => {
+            await using node = await withRegisteredNode();
+
+            await expect(
+                node.online({ exchange: manageExchange(), command: true }, agent =>
+                    agent.get(IcdManagementServer).unregisterClient({
+                        checkInNodeId,
+                        verificationKey: wrongKey,
+                    }),
+                ),
+            ).rejectedWith(/verificationkey mismatch/i);
+        });
+
+        it("unregisterClient as Manage with missing verificationKey rejects with Failure", async () => {
+            await using node = await withRegisteredNode();
+
+            await expect(
+                node.online({ exchange: manageExchange(), command: true }, agent =>
+                    agent.get(IcdManagementServer).unregisterClient({
+                        checkInNodeId,
+                    }),
+                ),
+            ).rejectedWith(/verificationkey mismatch/i);
         });
     });
 

--- a/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
@@ -222,4 +222,47 @@ describe("IcdManagementServer", () => {
             expect(Bytes.areEqual(registrations[0].key, secondKey)).true;
         });
     });
+
+    describe("UnregisterClient command", () => {
+        it("unregisters a client", async () => {
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            const cmds = peer1.commandsOf(IcdManagementClient);
+            const checkInNodeId = peer1.peerAddress!.nodeId;
+
+            await cmds.registerClient({
+                checkInNodeId,
+                monitoredSubject: checkInNodeId,
+                key: Bytes.fromHex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"),
+                clientType: IcdManagement.ClientType.Permanent,
+            });
+
+            await cmds.unregisterClient({ checkInNodeId });
+
+            expect(device.stateOf(IcdManagementServer).registeredClients).deep.equals([]);
+            expect(device.env.get(FabricManager).fabrics[0].icd.registrations).deep.equals([]);
+            // The persisted ICDToken must also be dropped, else a later Manage re-registration would wrongly reject.
+            await device.act(agent => {
+                expect(agent.get(IcdManagementServer).internal.icdKeys.size).equals(0);
+            });
+        });
+
+        it("returns NOT_FOUND for unknown client", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            const cmds = peer1.commandsOf(IcdManagementClient);
+
+            await expect(
+                cmds.unregisterClient({ checkInNodeId: NodeId(peer1.peerAddress!.nodeId + 99n) }),
+            ).rejectedWith(/not found/i);
+        });
+    });
 });

--- a/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
@@ -5,6 +5,7 @@
  */
 
 import { IcdManagementClient, IcdManagementServer } from "#behaviors/icd-management";
+import { OperationalCredentialsClient } from "#behaviors/operational-credentials";
 import { ServerNode } from "#node/index.js";
 import { Bytes } from "@matter/general";
 import { FabricManager } from "@matter/protocol";
@@ -263,6 +264,86 @@ describe("IcdManagementServer", () => {
             await expect(
                 cmds.unregisterClient({ checkInNodeId: NodeId(peer1.peerAddress!.nodeId + 99n) }),
             ).rejectedWith(/not found/i);
+        });
+    });
+
+    describe("fabric lifecycle", () => {
+        const key = Bytes.fromHex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf");
+
+        it("restores registrations into fabric.icd after node stop and restart", async () => {
+            // MockSite has no restart primitive, so we use stop/start directly on the device node to
+            // re-trigger #online() and verify that the rebuild path repopulates fabric.icd from persisted state.
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            const checkInNodeId = peer1.peerAddress!.nodeId;
+
+            await peer1.commandsOf(IcdManagementClient).registerClient({
+                checkInNodeId,
+                monitoredSubject: checkInNodeId,
+                key,
+                clientType: IcdManagement.ClientType.Permanent,
+            });
+
+            // Confirm fabric.icd has the registration from the command handler.
+            const fabric = device.env.get(FabricManager).fabrics[0];
+            expect(fabric.icd.registrations).length(1);
+
+            // Simulate state loss by clearing fabric.icd, as would happen if the node were fully restarted
+            // without reinitializing from persisted storage.
+            fabric.icd.clearRegistrations();
+            expect(fabric.icd.registrations).length(0);
+
+            // Stop then restart the device node — #online() fires again and replays persisted state.
+            await MockTime.resolve(device.stop());
+            await MockTime.resolve(device.start());
+
+            const fabricAfter = device.env.get(FabricManager).fabrics[0];
+            const registrations = fabricAfter.icd.registrations;
+            expect(registrations).length(1);
+            expect(registrations[0].checkInNodeId).equals(checkInNodeId);
+            expect(Bytes.areEqual(registrations[0].key, key)).true;
+        });
+
+        it("drops icdKeys when the fabric is removed", async () => {
+            // Tests the #onFabricDeleted handler: after fabric removal the internal key store must be empty.
+            // The registeredClients attribute is fabric-scoped and auto-pruned by the framework during the
+            // deleting phase (FabricScopedDataHandler), so we only verify the icdKeys cleanup here.
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            const checkInNodeId = peer1.peerAddress!.nodeId;
+
+            await peer1.commandsOf(IcdManagementClient).registerClient({
+                checkInNodeId,
+                monitoredSubject: checkInNodeId,
+                key,
+                clientType: IcdManagement.ClientType.Permanent,
+            });
+
+            // Confirm the key is present before removal.
+            await device.act(agent => {
+                expect(agent.get(IcdManagementServer).internal.icdKeys.size).equals(1);
+            });
+
+            // Trigger fabric removal via the controller — this fires the full fabric deletion sequence,
+            // including the deleting event (which auto-prunes registeredClients) and deleted event
+            // (which triggers our #onFabricDeleted handler to clean icdKeys).
+            const fabricIndex = device.env.get(FabricManager).fabrics[0].fabricIndex;
+            await MockTime.resolve(peer1.commandsOf(OperationalCredentialsClient).removeFabric({ fabricIndex }), {
+                macrotasks: true,
+            });
+
+            // icdKeys must be empty after deletion.
+            await device.act(agent => {
+                expect(agent.get(IcdManagementServer).internal.icdKeys.size).equals(0);
+            });
         });
     });
 });

--- a/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IcdManagementServer } from "#behaviors/icd-management";
+import { ServerNode } from "#node/index.js";
+import { MockServerNode } from "../../node/mock-server-node.js";
+import { MockSite } from "../../node/mock-site.js";
+
+const RootWithIcd = ServerNode.RootEndpoint.with(IcdManagementServer);
+
+describe("IcdManagementServer", () => {
+    before(() => {
+        MockTime.init();
+    });
+
+    describe("attribute defaults and CIP feature", () => {
+        it("installs with CIP and exposes correct attribute values when configured", async () => {
+            await using site = new MockSite();
+            const { device } = await site.addCommissionedPair({
+                device: {
+                    type: RootWithIcd,
+                    icdManagement: {
+                        idleModeDuration: 3600,
+                        activeModeDuration: 1000,
+                        activeModeThreshold: 500,
+                        clientsSupportedPerFabric: 2,
+                        maximumCheckInBackoff: 3600,
+                    },
+                },
+            });
+
+            const state = device.stateOf(IcdManagementServer);
+            expect(state.idleModeDuration).equals(3600);
+            expect(state.activeModeDuration).equals(1000);
+            expect(state.activeModeThreshold).equals(500);
+            expect(state.clientsSupportedPerFabric).equals(2);
+            expect(state.maximumCheckInBackoff).equals(3600);
+            expect(state.registeredClients).deep.equals([]);
+            expect(state.icdCounter).greaterThanOrEqual(0);
+        });
+
+        it("accepts spec default attribute values without config override", async () => {
+            await using site = new MockSite();
+            const { device } = await site.addCommissionedPair({
+                device: {
+                    type: RootWithIcd,
+                },
+            });
+
+            const state = device.stateOf(IcdManagementServer);
+            // Spec defaults: idleModeDuration=1s, activeModeDuration=300ms — constraint satisfied (1000ms >= 300ms).
+            expect(state.idleModeDuration).equals(1);
+            expect(state.activeModeDuration).equals(300);
+            expect(state.maximumCheckInBackoff).equals(1);
+        });
+    });
+
+    describe("constraint validation", () => {
+        // Both tests verify that an ImplementationError thrown from initialize() surfaces as an initialization
+        // failure. The distinct invalid configurations ensure each constraint code path is independently exercised.
+
+        it("rejects when idleModeDuration * 1000 < activeModeDuration", async () => {
+            // idleModeDuration=1s → 1000ms, activeModeDuration=5000ms: 1000 < 5000 → invalid
+            await expect(
+                MockServerNode.create(RootWithIcd, {
+                    icdManagement: { idleModeDuration: 1, activeModeDuration: 5000 },
+                }),
+            ).rejectedWith("Behaviors have errors");
+        });
+
+        it("rejects when maximumCheckInBackoff < idleModeDuration", async () => {
+            // idleModeDuration=3600s, maximumCheckInBackoff=1800s: 1800 < 3600 → invalid
+            await expect(
+                MockServerNode.create(RootWithIcd, {
+                    icdManagement: { idleModeDuration: 3600, activeModeDuration: 300, maximumCheckInBackoff: 1800 },
+                }),
+            ).rejectedWith("Behaviors have errors");
+        });
+    });
+});

--- a/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
@@ -507,5 +507,20 @@ describe("IcdManagementServer", () => {
                 expect(agent.get(IcdManagementServer).internal.icdKeys.size).equals(0);
             });
         });
+
+        it("prunes persisted keys for fabrics that no longer exist on online", async () => {
+            // A key persisted for a fabric that is gone must be dropped on online so a stale ICDToken is never
+            // replayed (defense in depth — normal removal cleans up via #onFabricDeleted while online).
+            await using node = await MockServerNode.createOnline(
+                MockServerNode.RootEndpoint.with(IcdManagementServer),
+                {
+                    icdManagement: {
+                        icdKeys: [{ fabricIndex: FabricIndex(7), checkInNodeId: NodeId(0x1234n), key }],
+                    },
+                },
+            );
+
+            expect(node.stateOf(IcdManagementServer).icdKeys).deep.equals([]);
+        });
     });
 });

--- a/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
@@ -4,8 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IcdManagementServer } from "#behaviors/icd-management";
+import { IcdManagementClient, IcdManagementServer } from "#behaviors/icd-management";
 import { ServerNode } from "#node/index.js";
+import { Bytes } from "@matter/general";
+import { FabricManager } from "@matter/protocol";
+import { NodeId } from "@matter/types";
+import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { MockServerNode } from "../../node/mock-server-node.js";
 import { MockSite } from "../../node/mock-site.js";
 
@@ -45,9 +49,7 @@ describe("IcdManagementServer", () => {
         it("accepts spec default attribute values without config override", async () => {
             await using site = new MockSite();
             const { device } = await site.addCommissionedPair({
-                device: {
-                    type: RootWithIcd,
-                },
+                device: { type: RootWithIcd },
             });
 
             const state = device.stateOf(IcdManagementServer);
@@ -114,6 +116,110 @@ describe("IcdManagementServer", () => {
 
             const after = device.stateOf(IcdManagementServer).icdCounter;
             expect(after).equals(before + 1);
+        });
+    });
+
+    describe("RegisterClient command", () => {
+        it("registers a client and returns the ICD counter", async () => {
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            expect(peer1).not.undefined;
+
+            const key = Bytes.fromHex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf");
+            const response = await peer1.commandsOf(IcdManagementClient).registerClient({
+                checkInNodeId: peer1.peerAddress!.nodeId,
+                monitoredSubject: peer1.peerAddress!.nodeId,
+                key,
+                clientType: IcdManagement.ClientType.Permanent,
+            });
+
+            // Response must carry the current ICD counter value.
+            expect(response.icdCounter).greaterThanOrEqual(0);
+
+            // Device-side: the attribute has one entry (no key field — struct doesn't have one).
+            const registeredClients = device.stateOf(IcdManagementServer).registeredClients;
+            expect(registeredClients).length(1);
+            const entry = registeredClients[0];
+            expect(entry.checkInNodeId).equals(peer1.peerAddress!.nodeId);
+            expect(entry.clientType).equals(IcdManagement.ClientType.Permanent);
+
+            // Device-side: fabric.icd has the entry WITH the key (the attribute struct carries no usable key).
+            const fabric = device.env.get(FabricManager).fabrics[0];
+            const registrations = fabric.icd.registrations;
+            expect(registrations).length(1);
+            expect(Bytes.areEqual(registrations[0].key, key)).true;
+        });
+
+        it("rejects a second checkInNodeId when fabric slots are exhausted", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair({
+                device: {
+                    type: RootWithIcd,
+                    icdManagement: { clientsSupportedPerFabric: 1 },
+                },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            const cmds = peer1.commandsOf(IcdManagementClient);
+
+            await cmds.registerClient({
+                checkInNodeId: peer1.peerAddress!.nodeId,
+                monitoredSubject: peer1.peerAddress!.nodeId,
+                key: Bytes.fromHex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"),
+                clientType: IcdManagement.ClientType.Permanent,
+            });
+
+            // A different checkInNodeId exceeds the per-fabric slot limit.
+            await expect(
+                cmds.registerClient({
+                    checkInNodeId: NodeId(peer1.peerAddress!.nodeId + 1n),
+                    monitoredSubject: peer1.peerAddress!.nodeId,
+                    key: Bytes.fromHex("e0e1e2e3e4e5e6e7e8e9eaebecedeeef"),
+                    clientType: IcdManagement.ClientType.Permanent,
+                }),
+            ).rejectedWith(/resource exhausted/i);
+        });
+
+        it("updates an existing entry as Administrator without requiring verificationKey", async () => {
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            const cmds = peer1.commandsOf(IcdManagementClient);
+
+            const firstKey = Bytes.fromHex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf");
+            await cmds.registerClient({
+                checkInNodeId: peer1.peerAddress!.nodeId,
+                monitoredSubject: peer1.peerAddress!.nodeId,
+                key: firstKey,
+                clientType: IcdManagement.ClientType.Permanent,
+            });
+
+            // Update with a new key and clientType, no verificationKey required (Administrator).
+            const secondKey = Bytes.fromHex("a0a1a2a3a4a5a6a7a8a9aaabacadaeaf");
+            await cmds.registerClient({
+                checkInNodeId: peer1.peerAddress!.nodeId,
+                monitoredSubject: peer1.peerAddress!.nodeId,
+                key: secondKey,
+                clientType: IcdManagement.ClientType.Ephemeral,
+            });
+
+            // Still only one entry in the registered clients list.
+            const registeredClients = device.stateOf(IcdManagementServer).registeredClients;
+            expect(registeredClients).length(1);
+            expect(registeredClients[0].clientType).equals(IcdManagement.ClientType.Ephemeral);
+
+            // fabric.icd carries the updated key.
+            const fabric = device.env.get(FabricManager).fabrics[0];
+            const registrations = fabric.icd.registrations;
+            expect(registrations).length(1);
+            expect(Bytes.areEqual(registrations[0].key, secondKey)).true;
         });
     });
 });


### PR DESCRIPTION
**WIP — Phase 2a of ICD support.** Stacked on `feat/icd-protocol` (umbrella PR #3848); merges into that branch, not main.

Device-side `IcdManagementServer` cluster behavior (CIP feature) built on the phase-1 protocol layer.

## What's here
- **CIP feature** + init constraint validation (`idleModeDuration ≥ activeModeDuration`, `maximumCheckInBackoff ≥ idleModeDuration`).
- **RegisterClient / UnregisterClient** per spec § 9.16.7: per-fabric slot limit (RESOURCE_EXHAUSTED), create-vs-update verificationKey asymmetry (Administer skips; Manage must match → FAILURE), NOT_FOUND. Registration metadata lives in the `RegisteredClients` attribute; the 128-bit ICDTokens persist in internal `@nonvolatile` state (the struct has no key field) and mirror into `fabric.icd`.
- **ICDCounter** seeded from the phase-1 `IcdCounter` (boot-bump) and persisted transactionally on each change.
- **fabric.icd** operational view rebuilt at node online (with orphan-key prune) and cleaned on fabric removal.
- **StayActiveRequest** returns the spec floor via a `protected stayActive()` extension point (the mode machine in 2b overrides it).
- Caller privilege determined via `context.authorityAt(Administer, …)`.

## Not here (later phases)
- **2b:** LITS/UAT/DSLS, idle/active mode state machine, SII/SAI/SAT + ICD advertising, SIT↔LIT transitions, app power hooks.
- **2c:** check-in transmission (device-side peer resolution + unsecured send + scheduling/backoff).

## Verification
Clean build (all packages typecheck); `packages/node` 1193 tests ×3 envs and `packages/protocol` 1133 ×3 green; format + lint clean. Command paths covered via commissioned device↔controller pairs; the Manage-privilege verificationKey branch covered with a Manage-only caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)