### PR TITLE
WIP: feat(node): ICD LIT operating mode & operational advertising

### DIFF
--- a/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
+++ b/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
@@ -22,11 +22,13 @@ import { FabricIndex, NodeId, Status, StatusResponseError } from "@matter/types"
 import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { IcdManagementBehavior } from "./IcdManagementBehavior.js";
 
-// Both CIP and LITS are in the base so `this.state.operatingMode` and `this.events.operatingMode$Changed` typecheck
-// without casts throughout the shared logic. The exported IcdManagementServer resets to CIP-only via `.with(CIP)`.
+// CIP, LITS, and DSLS are all in the base so `this.state.operatingMode`, `this.events.operatingMode$Changed`, and
+// `this.features.dynamicSitLitSupport` typecheck throughout the shared logic. The exported IcdManagementServer
+// resets to CIP-only via `.with(CIP)`.
 const IcdManagementLogicBase = IcdManagementBehavior.with(
     IcdManagement.Feature.CheckInProtocolSupport,
     IcdManagement.Feature.LongIdleTimeSupport,
+    IcdManagement.Feature.DynamicSitLitSupport,
 );
 
 /**
@@ -59,6 +61,12 @@ const STAY_ACTIVE_PROMISE_FLOOR = Seconds(30);
  * When enabled via `IcdManagementServer.with(IcdManagement.Feature.LongIdleTimeSupport)`, the mandatory
  * `operatingMode` attribute has no spec-defined default and must be configured by the application (initialization
  * throws otherwise). Configure it to {@link IcdManagement.OperatingMode.Sit} unless the device starts in LIT.
+ *
+ * ### Dynamic SIT/LIT (DSLS)
+ *
+ * When also enabled via `IcdManagement.Feature.DynamicSitLitSupport`, the application may call
+ * {@link setOperatingMode} at runtime to switch between SIT and LIT even when registrations exist — for example
+ * when a mains-powered device switches to battery.
  *
  * @see {@link MatterSpecification.v151.Core} § 9.16
  */
@@ -108,10 +116,14 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
             this.reactTo(counter.changed, this.#persistCounter);
             this.reactTo(fabrics.events.deleted, this.#onFabricDeleted);
 
-            this.#refreshIcdAdvertisementCache();
-
             if (this.features.longIdleTimeSupport) {
                 this.reactTo(this.events.operatingMode$Changed, this.#onOperatingModeChanged);
+                // Reconcile the persisted operatingMode with the effective mode: a DSLS force is runtime-only and gone
+                // after a restart, so the attribute must fall back to the registration-driven mode (and refresh the
+                // advertisement cache to match).
+                this.#updateOperatingMode();
+            } else {
+                this.#refreshIcdAdvertisementCache();
             }
         }
 
@@ -152,14 +164,20 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
 
     /**
      * Effective ICD operating mode: LIT when LITS is enabled and at least one client is registered, otherwise SIT.
+     * DSLS devices may override with a forced mode set via {@link setOperatingMode}.
      *
      * @see {@link MatterSpecification.v151.Core} § 9.15.1.5–9.15.1.6
      */
     get #effectiveMode(): IcdManagement.OperatingMode {
-        if (this.features.longIdleTimeSupport && this.state.registeredClients.length > 0) {
-            return IcdManagement.OperatingMode.Lit;
+        if (!this.features.longIdleTimeSupport) {
+            return IcdManagement.OperatingMode.Sit;
         }
-        return IcdManagement.OperatingMode.Sit;
+        if (this.features.dynamicSitLitSupport && this.internal.forcedOperatingMode !== undefined) {
+            return this.internal.forcedOperatingMode;
+        }
+        return this.state.registeredClients.length > 0
+            ? IcdManagement.OperatingMode.Lit
+            : IcdManagement.OperatingMode.Sit;
     }
 
     /**
@@ -312,6 +330,35 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
     }
 
     /**
+     * Set the ICD operating mode at runtime.
+     *
+     * Requires the Long Idle Time feature. Without Dynamic SIT/LIT Support the mode is registration-driven and the
+     * requested mode must match the current registration state; with DSLS the mode may be forced either way (e.g. a
+     * mains-powered device dropping to battery).
+     *
+     * @see {@link MatterSpecification.v151.Core} § 9.15.1.6.4
+     */
+    setOperatingMode(mode: IcdManagement.OperatingMode) {
+        if (!this.features.longIdleTimeSupport) {
+            throw new ImplementationError("setOperatingMode requires the LongIdleTimeSupport feature");
+        }
+        if (!this.features.dynamicSitLitSupport) {
+            const registrationDriven =
+                this.state.registeredClients.length > 0
+                    ? IcdManagement.OperatingMode.Lit
+                    : IcdManagement.OperatingMode.Sit;
+            if (mode !== registrationDriven) {
+                throw new ImplementationError(
+                    "Without DynamicSitLitSupport the operating mode follows registration state and cannot be forced",
+                );
+            }
+        } else {
+            this.internal.forcedOperatingMode = mode;
+        }
+        this.#updateOperatingMode();
+    }
+
+    /**
      * @see {@link MatterSpecification.v151.Core} § 9.16.7.3
      */
     override async unregisterClient(request: IcdManagement.UnregisterClientRequest): Promise<void> {
@@ -406,6 +453,8 @@ export namespace IcdManagementBaseServer {
         icdKeys: Map<string, IcdKeyEntry> = new Map();
         /** Cached advertisement data read by the DeviceAdvertiser provider outside a behavior transaction. */
         currentIcdAdvertisement?: IcdAdvertisement;
+        /** Runtime-only; not persisted, so a restart reverts to the registration-driven mode. {@link IcdManagementBaseServer.setOperatingMode} */
+        forcedOperatingMode?: IcdManagement.OperatingMode;
     }
 
     export declare const ExtensionInterface: {

--- a/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
+++ b/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
@@ -15,6 +15,20 @@ import { IcdManagementBehavior } from "./IcdManagementBehavior.js";
 const IcdManagementLogicBase = IcdManagementBehavior.with(IcdManagement.Feature.CheckInProtocolSupport);
 
 /**
+ * Minimum ActiveModeThreshold a LIT ICD must use.
+ *
+ * @see {@link MatterSpecification.v151.Core} § 9.15.1.6.2
+ */
+const MIN_LIT_ACTIVE_MODE_THRESHOLD = Seconds(5);
+
+/**
+ * The promised StayActiveRequest duration is at least `min(this, requested)` — i.e. this caps the guaranteed minimum.
+ *
+ * @see {@link MatterSpecification.v151.Core} § 9.16.7.5.1.1
+ */
+const STAY_ACTIVE_PROMISE_FLOOR = Seconds(30);
+
+/**
  * Default device-side ICD Management server implementation. Enables the Check-In Protocol Support (CIP) feature and
  * validates spec constraints on the timing attributes at startup. Use {@link IcdManagementServer.with} to specialize
  * for additional features, or extend this class to override its behavior.
@@ -24,6 +38,12 @@ const IcdManagementLogicBase = IcdManagementBehavior.with(IcdManagement.Feature.
  * Override {@link stayActive} to react to StayActiveRequest: extend the device's active period for the requested time
  * and return the duration actually promised. The default implementation only honors the spec minimum and does not
  * track active time, so a device that wants to genuinely stay awake should override it.
+ *
+ * ## Long Idle Time (LITS)
+ *
+ * When enabled via `IcdManagementServer.with(IcdManagement.Feature.LongIdleTimeSupport)`, the mandatory
+ * `operatingMode` attribute has no spec-defined default and must be configured by the application (initialization
+ * throws otherwise). Configure it to {@link IcdManagement.OperatingMode.Sit} unless the device starts in LIT.
  *
  * @see {@link MatterSpecification.v151.Core} § 9.16
  */
@@ -46,6 +66,13 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
         if (maximumCheckInBackoff < idleModeDuration) {
             throw new ImplementationError(
                 `maximumCheckInBackoff (${Duration.format(maximumCheckInBackoff)}) must be >= idleModeDuration (${Duration.format(idleModeDuration)})`,
+            );
+        }
+
+        // @see {@link MatterSpecification.v151.Core} § 9.15.1.6.2
+        if (this.features.longIdleTimeSupport && this.state.activeModeThreshold < MIN_LIT_ACTIVE_MODE_THRESHOLD) {
+            throw new ImplementationError(
+                `LIT ICD requires activeModeThreshold (${Duration.format(Millis(this.state.activeModeThreshold))}) >= ${Duration.format(MIN_LIT_ACTIVE_MODE_THRESHOLD)}`,
             );
         }
 
@@ -190,7 +217,7 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
      * @see {@link MatterSpecification.v151.Core} § 9.16.7.5.1.1
      */
     protected stayActive(requestedDuration: Duration): Duration {
-        return Duration.min(Seconds(30), requestedDuration);
+        return Duration.min(STAY_ACTIVE_PROMISE_FLOOR, requestedDuration);
     }
 
     /**

--- a/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
+++ b/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
@@ -7,12 +7,27 @@
 import { NodeLifecycle } from "#node/NodeLifecycle.js";
 import { Bytes, Duration, ImplementationError, Millis, Seconds } from "@matter/general";
 import { AccessLevel, DataModelPath, fabricIdx, field, listOf, nodeId, nonvolatile, octstr } from "@matter/model";
-import { AccessControl, assertRemoteActor, Fabric, FabricManager, hasRemoteActor, IcdCounter } from "@matter/protocol";
+import {
+    AccessControl,
+    assertRemoteActor,
+    DeviceAdvertiser,
+    Fabric,
+    FabricManager,
+    hasRemoteActor,
+    IcdAdvertisement,
+    IcdCounter,
+    SessionManager,
+} from "@matter/protocol";
 import { FabricIndex, NodeId, Status, StatusResponseError } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { IcdManagementBehavior } from "./IcdManagementBehavior.js";
 
-const IcdManagementLogicBase = IcdManagementBehavior.with(IcdManagement.Feature.CheckInProtocolSupport);
+// Both CIP and LITS are in the base so `this.state.operatingMode` and `this.events.operatingMode$Changed` typecheck
+// without casts throughout the shared logic. The exported IcdManagementServer resets to CIP-only via `.with(CIP)`.
+const IcdManagementLogicBase = IcdManagementBehavior.with(
+    IcdManagement.Feature.CheckInProtocolSupport,
+    IcdManagement.Feature.LongIdleTimeSupport,
+);
 
 /**
  * Minimum ActiveModeThreshold a LIT ICD must use.
@@ -92,7 +107,16 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
             this.state.icdCounter = counter.value;
             this.reactTo(counter.changed, this.#persistCounter);
             this.reactTo(fabrics.events.deleted, this.#onFabricDeleted);
+
+            this.#refreshIcdAdvertisementCache();
+
+            if (this.features.longIdleTimeSupport) {
+                this.reactTo(this.events.operatingMode$Changed, this.#onOperatingModeChanged);
+            }
         }
+
+        // DeviceAdvertiser is closed and recreated on each stop/start cycle; register the provider every time.
+        this.env.get(DeviceAdvertiser).setIcdAdvertisementProvider(() => this.internal.currentIcdAdvertisement);
 
         // Rebuild the operational view on every online: fabric.icd is runtime-only and starts empty after a full
         // restart. Drop keys for fabrics that no longer exist so a stale key can never be replayed.
@@ -126,6 +150,69 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
         }
     }
 
+    /**
+     * Effective ICD operating mode: LIT when LITS is enabled and at least one client is registered, otherwise SIT.
+     *
+     * @see {@link MatterSpecification.v151.Core} § 9.15.1.5–9.15.1.6
+     */
+    get #effectiveMode(): IcdManagement.OperatingMode {
+        if (this.features.longIdleTimeSupport && this.state.registeredClients.length > 0) {
+            return IcdManagement.OperatingMode.Lit;
+        }
+        return IcdManagement.OperatingMode.Sit;
+    }
+
+    /**
+     * Rebuild and cache the ICD advertisement in {@link IcdManagementBaseServer.Internal.currentIcdAdvertisement}.
+     *
+     * The cached value is read by the DeviceAdvertiser provider outside the behavior's transaction context, so we push
+     * rather than letting the provider pull from state.
+     *
+     * @see {@link MatterSpecification.v151.Core} § 9.15.1.6
+     */
+    #refreshIcdAdvertisementCache() {
+        const mode = this.#effectiveMode;
+        const { idleInterval, activeInterval } = this.env.get(SessionManager).sessionParameters;
+        const advertisement: IcdAdvertisement = {
+            icd: mode,
+            activeInterval,
+            activeThreshold: Millis(this.state.activeModeThreshold),
+        };
+        // @see {@link MatterSpecification.v151.Core} § 9.15.1.6.2 — LIT SHOULD NOT advertise SII
+        if (mode === IcdManagement.OperatingMode.Sit) {
+            advertisement.idleInterval = idleInterval;
+        }
+        this.internal.currentIcdAdvertisement = advertisement;
+    }
+
+    /**
+     * Update the `operatingMode` attribute to the effective mode (LITS only, no-op otherwise).
+     *
+     * Must be called inside a reactor or command context so the state write is transactional.
+     */
+    #updateOperatingMode() {
+        if (!this.features.longIdleTimeSupport) {
+            return;
+        }
+        const effective = this.#effectiveMode;
+        if (this.state.operatingMode !== effective) {
+            this.state.operatingMode = effective;
+        }
+        this.#refreshIcdAdvertisementCache();
+    }
+
+    /**
+     * Re-advertise all fabrics when the operating mode transitions between SIT and LIT.
+     *
+     * @see {@link MatterSpecification.v151.Core} § 9.15.1.6
+     */
+    async #onOperatingModeChanged() {
+        const advertiser = this.env.get(DeviceAdvertiser);
+        for (const fabric of this.env.get(FabricManager).fabrics) {
+            await advertiser.refreshOperationalAdvertisement(fabric);
+        }
+    }
+
     async #onFabricDeleted(fabric: Fabric) {
         const fabricIndex = fabric.fabricIndex;
 
@@ -140,6 +227,8 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
 
         // The fabric object still exists at this point; clear its operational registrations.
         fabric.icd.clearRegistrations();
+
+        this.#updateOperatingMode();
     }
 
     #persistCounter(value: number) {
@@ -197,6 +286,8 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
             clientType: request.clientType,
         });
 
+        this.#updateOperatingMode();
+
         return { icdCounter: this.internal.icdCounter!.value };
     }
 
@@ -244,6 +335,8 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
         this.internal.icdKeys.delete(this.#keyFor(fabricIndex, request.checkInNodeId));
         this.#persistKeys();
         fabric.icd.deleteRegistration(request.checkInNodeId);
+
+        this.#updateOperatingMode();
     }
 
     /**
@@ -311,6 +404,8 @@ export namespace IcdManagementBaseServer {
     export class Internal {
         icdCounter?: IcdCounter;
         icdKeys: Map<string, IcdKeyEntry> = new Map();
+        /** Cached advertisement data read by the DeviceAdvertiser provider outside a behavior transaction. */
+        currentIcdAdvertisement?: IcdAdvertisement;
     }
 
     export declare const ExtensionInterface: {
@@ -320,5 +415,9 @@ export namespace IcdManagementBaseServer {
 
 /**
  * The default {@link IcdManagementBehavior} server implementation, with the Check-In Protocol Support feature.
+ *
+ * The active feature set is reset to CIP-only here even though the logic base includes LITS. This matches the
+ * OnOff/SmokeCoAlarm pattern: the base composes all features for type safety, the exported class narrows to the
+ * deployed set. To also enable LITS use `IcdManagementServer.with(IcdManagement.Feature.LongIdleTimeSupport)`.
  */
-export class IcdManagementServer extends IcdManagementBaseServer {}
+export class IcdManagementServer extends IcdManagementBaseServer.with(IcdManagement.Feature.CheckInProtocolSupport) {}

--- a/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
+++ b/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
@@ -58,9 +58,12 @@ const STAY_ACTIVE_PROMISE_FLOOR = Seconds(30);
  *
  * ## Long Idle Time (LITS)
  *
- * When enabled via `IcdManagementServer.with(IcdManagement.Feature.LongIdleTimeSupport)`, the mandatory
- * `operatingMode` attribute has no spec-defined default and must be configured by the application (initialization
- * throws otherwise). Configure it to {@link IcdManagement.OperatingMode.Sit} unless the device starts in LIT.
+ * Enable LITS with `IcdManagementServer.with(IcdManagement.Feature.CheckInProtocolSupport,
+ * IcdManagement.Feature.LongIdleTimeSupport)` — CIP is mandatory under LITS and `.with` replaces (does not augment)
+ * the feature set, so both must be listed. The mandatory `operatingMode` attribute has no spec-defined default and
+ * must be configured by the application (initialization throws otherwise); set it to
+ * {@link IcdManagement.OperatingMode.Sit} unless the device starts in LIT. DSLS devices may additionally call
+ * {@link setOperatingMode} to switch SIT↔LIT at runtime.
  *
  * ### Dynamic SIT/LIT (DSLS)
  *
@@ -92,6 +95,11 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
             );
         }
 
+        // CIP is mandatory under LITS; `.with(LongIdleTimeSupport)` alone silently drops it, so fail loudly.
+        if (this.features.longIdleTimeSupport && !this.features.checkInProtocolSupport) {
+            throw new ImplementationError("LongIdleTimeSupport requires the CheckInProtocolSupport feature");
+        }
+
         // @see {@link MatterSpecification.v151.Core} § 9.15.1.6.2
         if (this.features.longIdleTimeSupport && this.state.activeModeThreshold < MIN_LIT_ACTIVE_MODE_THRESHOLD) {
             throw new ImplementationError(
@@ -118,9 +126,8 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
 
             if (this.features.longIdleTimeSupport) {
                 this.reactTo(this.events.operatingMode$Changed, this.#onOperatingModeChanged);
-                // Reconcile the persisted operatingMode with the effective mode: a DSLS force is runtime-only and gone
-                // after a restart, so the attribute must fall back to the registration-driven mode (and refresh the
-                // advertisement cache to match).
+                // A DSLS force is runtime-only, so after a restart reconcile operatingMode to the registration-driven
+                // mode and prime the advertisement cache.
                 this.#updateOperatingMode();
             } else {
                 this.#refreshIcdAdvertisementCache();
@@ -467,6 +474,7 @@ export namespace IcdManagementBaseServer {
  *
  * The active feature set is reset to CIP-only here even though the logic base includes LITS. This matches the
  * OnOff/SmokeCoAlarm pattern: the base composes all features for type safety, the exported class narrows to the
- * deployed set. To also enable LITS use `IcdManagementServer.with(IcdManagement.Feature.LongIdleTimeSupport)`.
+ * deployed set. To also enable LITS use
+ * `IcdManagementServer.with(IcdManagement.Feature.CheckInProtocolSupport, IcdManagement.Feature.LongIdleTimeSupport)`.
  */
 export class IcdManagementServer extends IcdManagementBaseServer.with(IcdManagement.Feature.CheckInProtocolSupport) {}

--- a/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
@@ -7,9 +7,9 @@
 import { IcdManagementClient, IcdManagementServer } from "#behaviors/icd-management";
 import { OperationalCredentialsClient } from "#behaviors/operational-credentials";
 import { ServerNode } from "#node/index.js";
-import { Bytes } from "@matter/general";
+import { Bytes, Millis } from "@matter/general";
 import { AccessLevel } from "@matter/model";
-import { FabricManager } from "@matter/protocol";
+import { Advertiser, DeviceAdvertiser, FabricManager, ServiceDescription } from "@matter/protocol";
 import { FabricIndex, NodeId } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { MockExchange } from "../../node/mock-exchange.js";
@@ -597,6 +597,185 @@ describe("IcdManagementServer", () => {
             );
 
             expect(node.stateOf(IcdManagementServer).icdKeys).deep.equals([]);
+        });
+    });
+
+    describe("ICD advertisement", () => {
+        // CIP + LITS variant used throughout these tests.
+        const litServer = IcdManagementServer.with(
+            IcdManagement.Feature.CheckInProtocolSupport,
+            IcdManagement.Feature.LongIdleTimeSupport,
+        );
+        const RootWithLit = ServerNode.RootEndpoint.with(litServer);
+
+        const LIT_CONFIG = {
+            operatingMode: IcdManagement.OperatingMode.Sit,
+            activeModeThreshold: 5000,
+            idleModeDuration: 3600,
+            activeModeDuration: 1000,
+            maximumCheckInBackoff: 3600,
+        } as const;
+
+        /**
+         * Minimal mock advertiser that records ServiceDescriptions passed to advertise().
+         * Extends Advertiser so it can be added to DeviceAdvertiser.
+         */
+        class RecordingAdvertiser extends Advertiser {
+            readonly calls: Array<{ description: ServiceDescription; event: Advertiser.BroadcastEvent }> = [];
+
+            protected getAdvertisement(_description: ServiceDescription) {
+                return undefined;
+            }
+
+            override advertise(description: ServiceDescription, event: Advertiser.BroadcastEvent) {
+                this.calls.push({ description, event });
+                return undefined;
+            }
+        }
+
+        it("LITS device with no registrations starts in SIT mode", async () => {
+            await using site = new MockSite();
+            const { device } = await site.addCommissionedPair({
+                device: { type: RootWithLit, icdManagement: LIT_CONFIG },
+            });
+
+            expect(device.stateOf(litServer).operatingMode).equals(IcdManagement.OperatingMode.Sit);
+        });
+
+        it("LITS device provider yields SIT advertisement with idleInterval when no registrations", async () => {
+            await using site = new MockSite();
+            const { device } = await site.addCommissionedPair({
+                device: { type: RootWithLit, icdManagement: LIT_CONFIG },
+            });
+
+            // Add a recording advertiser and trigger a re-advertisement to observe the ServiceDescription.
+            const recorder = new RecordingAdvertiser();
+            const deviceAdvertiser = device.env.get(DeviceAdvertiser);
+            deviceAdvertiser.addAdvertiser(recorder);
+            const fabric = device.env.get(FabricManager).fabrics[0];
+            await deviceAdvertiser.refreshOperationalAdvertisement(fabric);
+
+            const opAds = recorder.calls.filter(c => c.description.kind === "operational");
+            expect(opAds.length).greaterThan(0);
+            const desc = opAds[0].description as ServiceDescription.Operational;
+            expect(desc.icd).equals(IcdManagement.OperatingMode.Sit);
+            expect(desc.idleInterval).not.undefined;
+            expect(desc.activeInterval).not.undefined;
+            expect(desc.activeThreshold).equals(Millis(LIT_CONFIG.activeModeThreshold));
+        });
+
+        it("operatingMode transitions to LIT after registerClient and provider omits idleInterval", async () => {
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: { type: RootWithLit, icdManagement: LIT_CONFIG },
+            });
+
+            // Spy on refreshOperationalAdvertisement to confirm it is called after registration.
+            const deviceAdvertiser = device.env.get(DeviceAdvertiser);
+            let refreshCount = 0;
+            const origRefresh = deviceAdvertiser.refreshOperationalAdvertisement.bind(deviceAdvertiser);
+            deviceAdvertiser.refreshOperationalAdvertisement = async fabric => {
+                refreshCount++;
+                return origRefresh(fabric);
+            };
+
+            const peer1 = controller.peers.get("peer1")!;
+            const checkInNodeId = peer1.peerAddress!.nodeId;
+            await peer1.commandsOf(IcdManagementClient).registerClient({
+                checkInNodeId,
+                monitoredSubject: checkInNodeId,
+                key: Bytes.fromHex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"),
+                clientType: IcdManagement.ClientType.Permanent,
+            });
+            await MockTime.resolve(Promise.resolve());
+
+            expect(device.stateOf(litServer).operatingMode).equals(IcdManagement.OperatingMode.Lit);
+            expect(refreshCount).greaterThan(0);
+
+            // Verify the provider now yields LIT with no idleInterval.
+            const recorder = new RecordingAdvertiser();
+            deviceAdvertiser.addAdvertiser(recorder);
+            const fabric = device.env.get(FabricManager).fabrics[0];
+            await deviceAdvertiser.refreshOperationalAdvertisement(fabric);
+            const opAds = recorder.calls.filter(c => c.description.kind === "operational");
+            expect(opAds.length).greaterThan(0);
+            const desc = opAds[0].description as ServiceDescription.Operational;
+            expect(desc.icd).equals(IcdManagement.OperatingMode.Lit);
+            expect(desc.idleInterval).to.be.undefined;
+            expect(desc.activeThreshold).equals(Millis(LIT_CONFIG.activeModeThreshold));
+        });
+
+        it("operatingMode falls back to SIT after unregisterClient removes the last registration", async () => {
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: { type: RootWithLit, icdManagement: LIT_CONFIG },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            const checkInNodeId = peer1.peerAddress!.nodeId;
+            const cmds = peer1.commandsOf(IcdManagementClient);
+
+            await cmds.registerClient({
+                checkInNodeId,
+                monitoredSubject: checkInNodeId,
+                key: Bytes.fromHex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"),
+                clientType: IcdManagement.ClientType.Permanent,
+            });
+            await MockTime.resolve(Promise.resolve());
+            expect(device.stateOf(litServer).operatingMode).equals(IcdManagement.OperatingMode.Lit);
+
+            const deviceAdvertiser = device.env.get(DeviceAdvertiser);
+            let refreshAfterUnregister = 0;
+            const origRefresh = deviceAdvertiser.refreshOperationalAdvertisement.bind(deviceAdvertiser);
+            deviceAdvertiser.refreshOperationalAdvertisement = async fabric => {
+                refreshAfterUnregister++;
+                return origRefresh(fabric);
+            };
+
+            await cmds.unregisterClient({ checkInNodeId });
+            await MockTime.resolve(Promise.resolve());
+
+            expect(device.stateOf(litServer).operatingMode).equals(IcdManagement.OperatingMode.Sit);
+            expect(refreshAfterUnregister).greaterThan(0);
+        });
+
+        it("non-LITS default IcdManagementServer provider yields SIT and mode never changes with registrations", async () => {
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const recorder = new RecordingAdvertiser();
+            const deviceAdvertiser = device.env.get(DeviceAdvertiser);
+            deviceAdvertiser.addAdvertiser(recorder);
+            const fabric = device.env.get(FabricManager).fabrics[0];
+            await deviceAdvertiser.refreshOperationalAdvertisement(fabric);
+
+            const opAdsBefore = recorder.calls.filter(c => c.description.kind === "operational");
+            expect(opAdsBefore.length).greaterThan(0);
+            const descBefore = opAdsBefore[0].description as ServiceDescription.Operational;
+            // CIP-only server is always SIT and must include SII.
+            expect(descBefore.icd).equals(IcdManagement.OperatingMode.Sit);
+            expect(descBefore.idleInterval).not.undefined;
+
+            recorder.calls.length = 0;
+
+            const peer1 = controller.peers.get("peer1")!;
+            const checkInNodeId = peer1.peerAddress!.nodeId;
+            await peer1.commandsOf(IcdManagementClient).registerClient({
+                checkInNodeId,
+                monitoredSubject: checkInNodeId,
+                key: Bytes.fromHex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"),
+                clientType: IcdManagement.ClientType.Permanent,
+            });
+            await MockTime.resolve(Promise.resolve());
+
+            // Still SIT after registration — non-LITS server never flips to LIT.
+            await deviceAdvertiser.refreshOperationalAdvertisement(fabric);
+            const opAdsAfter = recorder.calls.filter(c => c.description.kind === "operational");
+            expect(opAdsAfter.length).greaterThan(0);
+            const descAfter = opAdsAfter[0].description as ServiceDescription.Operational;
+            expect(descAfter.icd).equals(IcdManagement.OperatingMode.Sit);
         });
     });
 });

--- a/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
@@ -429,6 +429,82 @@ describe("IcdManagementServer", () => {
         });
     });
 
+    describe("LongIdleTime feature", () => {
+        // CIP is mandatory when LITS is enabled (spec conformance "LITS, O" on CIP); both must be passed to .with().
+        const litServer = IcdManagementServer.with(
+            IcdManagement.Feature.CheckInProtocolSupport,
+            IcdManagement.Feature.LongIdleTimeSupport,
+        );
+        const RootWithLit = ServerNode.RootEndpoint.with(litServer);
+
+        it("exposes the configured operatingMode", async () => {
+            // operatingMode is mandatory under LITS with no spec default — the app must configure it.
+            await using site = new MockSite();
+            const { device } = await site.addCommissionedPair({
+                device: {
+                    type: RootWithLit,
+                    icdManagement: {
+                        operatingMode: IcdManagement.OperatingMode.Sit,
+                        activeModeThreshold: 5000,
+                        idleModeDuration: 3600,
+                        activeModeDuration: 1000,
+                        maximumCheckInBackoff: 3600,
+                    },
+                },
+            });
+
+            expect(device.stateOf(litServer).operatingMode).equals(IcdManagement.OperatingMode.Sit);
+        });
+
+        it("rejects a LIT device that omits the mandatory operatingMode", async () => {
+            await expect(
+                MockServerNode.create(RootWithLit, {
+                    icdManagement: { activeModeThreshold: 5000 },
+                }),
+            ).rejectedWith("Behaviors have errors");
+        });
+
+        it("rejects a LIT device with activeModeThreshold < 5000 ms", async () => {
+            // operatingMode supplied so the LIT activeModeThreshold floor is the only violated constraint.
+            await expect(
+                MockServerNode.create(RootWithLit, {
+                    icdManagement: { operatingMode: IcdManagement.OperatingMode.Sit, activeModeThreshold: 1000 },
+                }),
+            ).rejectedWith("Behaviors have errors");
+        });
+
+        it("accepts a LIT device with activeModeThreshold exactly 5000 ms", async () => {
+            await using site = new MockSite();
+            const { device } = await site.addCommissionedPair({
+                device: {
+                    type: RootWithLit,
+                    icdManagement: {
+                        operatingMode: IcdManagement.OperatingMode.Sit,
+                        activeModeThreshold: 5000,
+                        idleModeDuration: 3600,
+                        activeModeDuration: 1000,
+                        maximumCheckInBackoff: 3600,
+                    },
+                },
+            });
+
+            expect(device.stateOf(litServer).activeModeThreshold).equals(5000);
+        });
+
+        it("does not apply the LIT activeModeThreshold constraint to a plain (non-LITS) server", async () => {
+            // The 5s floor is a LIT-only constraint; non-LITS devices may use any activeModeThreshold.
+            await using site = new MockSite();
+            const { device } = await site.addCommissionedPair({
+                device: {
+                    type: RootWithIcd,
+                    icdManagement: { activeModeThreshold: 1000 },
+                },
+            });
+
+            expect(device.stateOf(IcdManagementServer).activeModeThreshold).equals(1000);
+        });
+    });
+
     describe("fabric lifecycle", () => {
         const key = Bytes.fromHex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf");
 

--- a/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
@@ -907,6 +907,14 @@ describe("IcdManagementServer", () => {
             expect(device.stateOf(litServer).operatingMode).equals(IcdManagement.OperatingMode.Sit);
         });
 
+        it("rejects a LITS-only server (CIP dropped by single-feature .with)", async () => {
+            // `.with(LongIdleTimeSupport)` replaces the feature set, dropping the baked-in CIP; init must fail loudly.
+            const litOnly = IcdManagementServer.with(IcdManagement.Feature.LongIdleTimeSupport);
+            await expect(
+                MockServerNode.create(ServerNode.RootEndpoint.with(litOnly), { icdManagement: DSLS_CONFIG }),
+            ).rejectedWith("Behaviors have errors");
+        });
+
         it("CIP-only IcdManagementServer setOperatingMode throws for missing LITS feature", async () => {
             await using site = new MockSite();
             const { device } = await site.addCommissionedPair({

--- a/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
@@ -18,6 +18,23 @@ import { MockSite } from "../../node/mock-site.js";
 
 const RootWithIcd = ServerNode.RootEndpoint.with(IcdManagementServer);
 
+/**
+ * Minimal mock advertiser that records ServiceDescriptions passed to advertise().
+ * Extends Advertiser so it can be added to DeviceAdvertiser.
+ */
+class RecordingAdvertiser extends Advertiser {
+    readonly calls: Array<{ description: ServiceDescription; event: Advertiser.BroadcastEvent }> = [];
+
+    protected getAdvertisement(_description: ServiceDescription) {
+        return undefined;
+    }
+
+    override advertise(description: ServiceDescription, event: Advertiser.BroadcastEvent) {
+        this.calls.push({ description, event });
+        return undefined;
+    }
+}
+
 describe("IcdManagementServer", () => {
     before(() => {
         MockTime.init();
@@ -616,23 +633,6 @@ describe("IcdManagementServer", () => {
             maximumCheckInBackoff: 3600,
         } as const;
 
-        /**
-         * Minimal mock advertiser that records ServiceDescriptions passed to advertise().
-         * Extends Advertiser so it can be added to DeviceAdvertiser.
-         */
-        class RecordingAdvertiser extends Advertiser {
-            readonly calls: Array<{ description: ServiceDescription; event: Advertiser.BroadcastEvent }> = [];
-
-            protected getAdvertisement(_description: ServiceDescription) {
-                return undefined;
-            }
-
-            override advertise(description: ServiceDescription, event: Advertiser.BroadcastEvent) {
-                this.calls.push({ description, event });
-                return undefined;
-            }
-        }
-
         it("LITS device with no registrations starts in SIT mode", async () => {
             await using site = new MockSite();
             const { device } = await site.addCommissionedPair({
@@ -776,6 +776,151 @@ describe("IcdManagementServer", () => {
             expect(opAdsAfter.length).greaterThan(0);
             const descAfter = opAdsAfter[0].description as ServiceDescription.Operational;
             expect(descAfter.icd).equals(IcdManagement.OperatingMode.Sit);
+        });
+    });
+
+    describe("DynamicSitLitSupport (DSLS) setOperatingMode", () => {
+        const dslsServer = IcdManagementServer.with(
+            IcdManagement.Feature.CheckInProtocolSupport,
+            IcdManagement.Feature.LongIdleTimeSupport,
+            IcdManagement.Feature.DynamicSitLitSupport,
+        );
+        const RootWithDsls = ServerNode.RootEndpoint.with(dslsServer);
+
+        const DSLS_CONFIG = {
+            operatingMode: IcdManagement.OperatingMode.Sit,
+            activeModeThreshold: 5000,
+            idleModeDuration: 3600,
+            activeModeDuration: 1000,
+            maximumCheckInBackoff: 3600,
+        } as const;
+
+        it("setOperatingMode(Lit) with no registrations forces LIT and refreshes advertisement", async () => {
+            await using site = new MockSite();
+            const { device } = await site.addCommissionedPair({
+                device: { type: RootWithDsls, icdManagement: DSLS_CONFIG },
+            });
+
+            const deviceAdvertiser = device.env.get(DeviceAdvertiser);
+            let refreshCount = 0;
+            const origRefresh = deviceAdvertiser.refreshOperationalAdvertisement.bind(deviceAdvertiser);
+            deviceAdvertiser.refreshOperationalAdvertisement = async fabric => {
+                refreshCount++;
+                return origRefresh(fabric);
+            };
+
+            await device.act(agent => agent.get(dslsServer).setOperatingMode(IcdManagement.OperatingMode.Lit));
+            await MockTime.resolve(Promise.resolve());
+
+            expect(device.stateOf(dslsServer).operatingMode).equals(IcdManagement.OperatingMode.Lit);
+            expect(refreshCount).greaterThan(0);
+
+            // Provider should yield LIT with no idleInterval.
+            const recorder = new RecordingAdvertiser();
+            deviceAdvertiser.addAdvertiser(recorder);
+            const fabric = device.env.get(FabricManager).fabrics[0];
+            await deviceAdvertiser.refreshOperationalAdvertisement(fabric);
+            const opAds = recorder.calls.filter(c => c.description.kind === "operational");
+            expect(opAds.length).greaterThan(0);
+            const desc = opAds[0].description as ServiceDescription.Operational;
+            expect(desc.icd).equals(IcdManagement.OperatingMode.Lit);
+            expect(desc.idleInterval).to.be.undefined;
+            expect(desc.activeThreshold).equals(Millis(DSLS_CONFIG.activeModeThreshold));
+        });
+
+        it("setOperatingMode(Sit) after forced LIT switches back to SIT and refreshes advertisement", async () => {
+            await using site = new MockSite();
+            const { device } = await site.addCommissionedPair({
+                device: { type: RootWithDsls, icdManagement: DSLS_CONFIG },
+            });
+
+            // Force to LIT first.
+            await device.act(agent => agent.get(dslsServer).setOperatingMode(IcdManagement.OperatingMode.Lit));
+            await MockTime.resolve(Promise.resolve());
+            expect(device.stateOf(dslsServer).operatingMode).equals(IcdManagement.OperatingMode.Lit);
+
+            const deviceAdvertiser = device.env.get(DeviceAdvertiser);
+            let refreshCount = 0;
+            const origRefresh = deviceAdvertiser.refreshOperationalAdvertisement.bind(deviceAdvertiser);
+            deviceAdvertiser.refreshOperationalAdvertisement = async fabric => {
+                refreshCount++;
+                return origRefresh(fabric);
+            };
+
+            // Switch back to SIT.
+            await device.act(agent => agent.get(dslsServer).setOperatingMode(IcdManagement.OperatingMode.Sit));
+            await MockTime.resolve(Promise.resolve());
+
+            expect(device.stateOf(dslsServer).operatingMode).equals(IcdManagement.OperatingMode.Sit);
+            expect(refreshCount).greaterThan(0);
+
+            // Provider should yield SIT with idleInterval present.
+            const recorder = new RecordingAdvertiser();
+            deviceAdvertiser.addAdvertiser(recorder);
+            const fabric = device.env.get(FabricManager).fabrics[0];
+            await deviceAdvertiser.refreshOperationalAdvertisement(fabric);
+            const opAds = recorder.calls.filter(c => c.description.kind === "operational");
+            expect(opAds.length).greaterThan(0);
+            const desc = opAds[0].description as ServiceDescription.Operational;
+            expect(desc.icd).equals(IcdManagement.OperatingMode.Sit);
+            expect(desc.idleInterval).not.undefined;
+        });
+
+        it("non-DSLS LITS device setOperatingMode(Lit) with no registrations throws", async () => {
+            const litServer = IcdManagementServer.with(
+                IcdManagement.Feature.CheckInProtocolSupport,
+                IcdManagement.Feature.LongIdleTimeSupport,
+            );
+            await using site = new MockSite();
+            const { device } = await site.addCommissionedPair({
+                device: {
+                    type: ServerNode.RootEndpoint.with(litServer),
+                    icdManagement: DSLS_CONFIG,
+                },
+            });
+
+            // device.act() throws synchronously when the actor throws; wrap in a thenable so rejectedWith can catch it.
+            await expect(
+                Promise.resolve().then(() =>
+                    device.act(agent => agent.get(litServer).setOperatingMode(IcdManagement.OperatingMode.Lit)),
+                ),
+            ).rejectedWith(/DynamicSitLitSupport.*operating mode follows/i);
+        });
+
+        it("non-DSLS LITS device setOperatingMode matching registration state succeeds", async () => {
+            const litServer = IcdManagementServer.with(
+                IcdManagement.Feature.CheckInProtocolSupport,
+                IcdManagement.Feature.LongIdleTimeSupport,
+            );
+            await using site = new MockSite();
+            const { device } = await site.addCommissionedPair({
+                device: {
+                    type: ServerNode.RootEndpoint.with(litServer),
+                    icdManagement: DSLS_CONFIG,
+                },
+            });
+
+            // No registrations → registration-driven mode is SIT; requesting SIT is allowed without DSLS.
+            await device.act(agent => agent.get(litServer).setOperatingMode(IcdManagement.OperatingMode.Sit));
+            await MockTime.resolve(Promise.resolve());
+
+            expect(device.stateOf(litServer).operatingMode).equals(IcdManagement.OperatingMode.Sit);
+        });
+
+        it("CIP-only IcdManagementServer setOperatingMode throws for missing LITS feature", async () => {
+            await using site = new MockSite();
+            const { device } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            // device.act() throws synchronously when the actor throws; wrap in a thenable so rejectedWith can catch it.
+            await expect(
+                Promise.resolve().then(() =>
+                    device.act(agent =>
+                        agent.get(IcdManagementServer).setOperatingMode(IcdManagement.OperatingMode.Lit),
+                    ),
+                ),
+            ).rejectedWith(/requires the LongIdleTimeSupport feature/i);
         });
     });
 });

--- a/packages/protocol/src/protocol/DeviceAdvertiser.ts
+++ b/packages/protocol/src/protocol/DeviceAdvertiser.ts
@@ -12,9 +12,34 @@ import { Fabric } from "#fabric/Fabric.js";
 import { FabricManager } from "#fabric/FabricManager.js";
 import { SecureSession } from "#session/SecureSession.js";
 import { SessionManager } from "#session/SessionManager.js";
-import { Environment, Environmental, Logger, MatterAggregateError, ObserverGroup } from "@matter/general";
+import { Duration, Environment, Environmental, Logger, MatterAggregateError, ObserverGroup } from "@matter/general";
+import type { IcdManagement } from "@matter/types/clusters/icd-management";
 
 const logger = Logger.get("DeviceAdvertiser");
+
+/**
+ * ICD operating mode and session intervals supplied to operational DNS-SD advertisement.
+ *
+ * @see {@link MatterSpecification.v151.Core} § 9.15.1.5–9.15.1.6
+ */
+export interface IcdAdvertisement {
+    icd: IcdManagement.OperatingMode;
+    /**
+     * Omitted for LIT mode — a LIT ICD SHOULD NOT advertise SII.
+     *
+     * @see {@link MatterSpecification.v151.Core} § 9.15.1.6.2
+     */
+    idleInterval?: Duration;
+    activeInterval: Duration;
+    activeThreshold: Duration;
+}
+
+/**
+ * Returns the {@link IcdAdvertisement} to use for a fabric, or `undefined` when the fabric is not ICD-managed.
+ *
+ * @see {@link MatterSpecification.v151.Core} § 9.15.1.6
+ */
+export type IcdAdvertisementProvider = (fabric: Fabric) => IcdAdvertisement | undefined;
 
 /**
  * Interfaces the {@link DeviceAdvertiser} with other components.
@@ -36,6 +61,7 @@ export class DeviceAdvertiser {
     #isOperational = false;
     #isClosing = false;
     #commissioningService?: ServiceDescription;
+    #icdAdvertisementProvider?: IcdAdvertisementProvider;
 
     constructor(context: DeviceAdvertiserContext) {
         this.#context = context;
@@ -156,6 +182,41 @@ export class DeviceAdvertiser {
     /** Set the transport support bitmap for operational advertisements. */
     set supportedTransports(value: SupportedTransportsBitmap | undefined) {
         this.#context.supportedTransports = value;
+    }
+
+    /**
+     * Register a per-fabric ICD advertisement provider.
+     *
+     * The provider is called each time an operational advertisement is built for a fabric.  Pass `undefined` to remove
+     * a previously registered provider; non-ICD nodes need not register one.
+     *
+     * @see {@link MatterSpecification.v151.Core} § 9.15.1.6
+     */
+    setIcdAdvertisementProvider(provider: IcdAdvertisementProvider | undefined) {
+        this.#icdAdvertisementProvider = provider;
+    }
+
+    /**
+     * Close the current operational advertisement for a fabric and rebuild it.
+     *
+     * Call this whenever the ICD operating mode or intervals change so that DNS-SD reflects the new state.
+     *
+     * @see {@link MatterSpecification.v151.Core} § 9.15.1.6
+     */
+    async refreshOperationalAdvertisement(fabric: Fabric) {
+        if (!this.#isOperational || this.#isClosing) {
+            return;
+        }
+
+        const ads = this.#advertisements(
+            ad => ad.isOperational() && ad.description.fabric.fabricIndex === fabric.fabricIndex,
+        );
+
+        for (const ad of ads) {
+            await ad.close();
+        }
+
+        this.#advertiseFabric(fabric, "retransmit");
     }
 
     toString() {
@@ -295,6 +356,8 @@ export class DeviceAdvertiser {
             return;
         }
 
+        const icd = this.#icdAdvertisementProvider?.(fabric);
+
         for (const advertiser of this.#advertisers) {
             if (event === "startup") {
                 // For startup events where we have active subscriptions somewhere on the fabric, we just convert
@@ -305,7 +368,7 @@ export class DeviceAdvertiser {
             }
 
             advertiser.advertise(
-                ServiceDescription.Operational({ fabric, tcp: this.#context.supportedTransports }),
+                ServiceDescription.Operational({ fabric, tcp: this.#context.supportedTransports, ...icd }),
                 event,
             );
         }

--- a/packages/protocol/src/protocol/DeviceAdvertiser.ts
+++ b/packages/protocol/src/protocol/DeviceAdvertiser.ts
@@ -216,7 +216,9 @@ export class DeviceAdvertiser {
             await ad.close();
         }
 
-        this.#advertiseFabric(fabric, "retransmit");
+        // "startup" runs the full announcement burst so a record-content change is observed reliably; a single
+        // "retransmit" packet could be lost. Matches the fabric-replaced rebuild path.
+        this.#advertiseFabric(fabric, "startup");
     }
 
     toString() {

--- a/packages/protocol/test/advertisement/ServiceDescriptionTest.ts
+++ b/packages/protocol/test/advertisement/ServiceDescriptionTest.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ServiceDescription } from "#advertisement/ServiceDescription.js";
+import { Seconds } from "@matter/general";
+import { IcdManagement } from "@matter/types/clusters/icd-management";
+
+describe("ServiceDescription", () => {
+    it("carries ICD operating mode and session intervals on operational descriptions", () => {
+        const fabric = {} as never; // the operational factory only needs a fabric reference
+        const desc = ServiceDescription.Operational({
+            fabric,
+            icd: IcdManagement.OperatingMode.Lit,
+            idleInterval: Seconds(30),
+            activeInterval: Seconds(3),
+            activeThreshold: Seconds(5),
+        });
+        expect(desc.kind).equals("operational");
+        expect(desc.icd).equals(IcdManagement.OperatingMode.Lit);
+        expect(desc.idleInterval).equals(Seconds(30));
+        expect(desc.activeInterval).equals(Seconds(3));
+        expect(desc.activeThreshold).equals(Seconds(5));
+    });
+
+    it("keeps icd: Sit (value 0) defined, not dropped as falsy", () => {
+        const fabric = {} as never;
+        const desc = ServiceDescription.Operational({ fabric, icd: IcdManagement.OperatingMode.Sit });
+        expect(desc.icd).equals(IcdManagement.OperatingMode.Sit);
+        expect(desc.icd).not.undefined;
+    });
+});

--- a/packages/protocol/test/protocol/DeviceAdvertiserTest.ts
+++ b/packages/protocol/test/protocol/DeviceAdvertiserTest.ts
@@ -7,9 +7,10 @@
 import { Advertiser } from "#advertisement/Advertiser.js";
 import { CommissioningMode } from "#advertisement/CommissioningMode.js";
 import { ServiceDescription } from "#advertisement/ServiceDescription.js";
-import { DeviceAdvertiser, DeviceAdvertiserContext } from "#protocol/DeviceAdvertiser.js";
-import { Observable } from "@matter/general";
+import { DeviceAdvertiser, DeviceAdvertiserContext, IcdAdvertisement } from "#protocol/DeviceAdvertiser.js";
+import { Observable, Seconds } from "@matter/general";
 import { FabricIndex, NodeId, VendorId } from "@matter/types";
+import { IcdManagement } from "@matter/types/clusters/icd-management";
 
 /**
  * Minimal mock advertiser that records calls to advertise().
@@ -198,6 +199,122 @@ describe("DeviceAdvertiser", () => {
 
             const desc = opAds[0].description as ServiceDescription.Operational;
             expect(desc.tcp).deep.equal({ tcpClient: false, tcpServer: true });
+        });
+    });
+
+    describe("ICD advertisement provider", () => {
+        function createFabric() {
+            return {
+                fabricIndex: FabricIndex(1),
+                globalId: 1n,
+                nodeId: NodeId(1n),
+            } as any;
+        }
+
+        it("includes ICD operating mode and intervals in operational advertisement when a provider is registered", () => {
+            const { fabrics, sessions } = createMockContext();
+            const advertiser = new MockAdvertiser();
+            const deviceAdvertiser = new DeviceAdvertiser({ fabrics, sessions });
+            deviceAdvertiser.addAdvertiser(advertiser);
+
+            const icdData: IcdAdvertisement = {
+                icd: IcdManagement.OperatingMode.Lit,
+                // idleInterval intentionally omitted — LIT SHOULD NOT advertise SII
+                activeInterval: Seconds(3),
+                activeThreshold: Seconds(5),
+            };
+            deviceAdvertiser.setIcdAdvertisementProvider(() => icdData);
+            deviceAdvertiser.enterOperationalMode();
+
+            const fabric = createFabric();
+            (fabrics as any)[Symbol.iterator] = () => [fabric].values();
+            (fabrics.events.added as Observable<[any]>).emit(fabric);
+
+            const opAds = advertiser.advertiseCalls.filter(c => c.description.kind === "operational");
+            expect(opAds.length).greaterThan(0);
+
+            const desc = opAds[0].description as ServiceDescription.Operational;
+            expect(desc.icd).equals(IcdManagement.OperatingMode.Lit);
+            expect(desc.activeInterval).equals(Seconds(3));
+            expect(desc.activeThreshold).equals(Seconds(5));
+            expect(desc.idleInterval).to.be.undefined;
+        });
+
+        it("does not include ICD fields when no provider is registered", () => {
+            const { fabrics, sessions } = createMockContext();
+            const advertiser = new MockAdvertiser();
+            const deviceAdvertiser = new DeviceAdvertiser({ fabrics, sessions });
+            deviceAdvertiser.addAdvertiser(advertiser);
+            deviceAdvertiser.enterOperationalMode();
+
+            const fabric = createFabric();
+            (fabrics as any)[Symbol.iterator] = () => [fabric].values();
+            (fabrics.events.added as Observable<[any]>).emit(fabric);
+
+            const opAds = advertiser.advertiseCalls.filter(c => c.description.kind === "operational");
+            expect(opAds.length).greaterThan(0);
+
+            const desc = opAds[0].description as ServiceDescription.Operational;
+            expect(desc.icd).to.be.undefined;
+        });
+
+        it("refreshOperationalAdvertisement re-advertises the fabric when in operational mode", async () => {
+            const { fabrics, sessions } = createMockContext();
+            const advertiser = new MockAdvertiser();
+            const deviceAdvertiser = new DeviceAdvertiser({ fabrics, sessions });
+            deviceAdvertiser.addAdvertiser(advertiser);
+            deviceAdvertiser.enterOperationalMode();
+
+            const fabric = createFabric();
+            (fabrics as any)[Symbol.iterator] = () => [fabric].values();
+            (fabrics.events.added as Observable<[any]>).emit(fabric);
+
+            const countBefore = advertiser.advertiseCalls.filter(c => c.description.kind === "operational").length;
+
+            await deviceAdvertiser.refreshOperationalAdvertisement(fabric);
+
+            const countAfter = advertiser.advertiseCalls.filter(c => c.description.kind === "operational").length;
+            expect(countAfter).greaterThan(countBefore);
+        });
+
+        it("refreshOperationalAdvertisement does nothing when not in operational mode", async () => {
+            const { fabrics, sessions } = createMockContext();
+            const advertiser = new MockAdvertiser();
+            const deviceAdvertiser = new DeviceAdvertiser({ fabrics, sessions });
+            deviceAdvertiser.addAdvertiser(advertiser);
+
+            const fabric = createFabric();
+            await deviceAdvertiser.refreshOperationalAdvertisement(fabric);
+
+            expect(advertiser.advertiseCalls.filter(c => c.description.kind === "operational").length).equals(0);
+        });
+
+        it("clearing the provider reverts to no ICD fields on next advertisement", () => {
+            const { fabrics, sessions } = createMockContext();
+            const advertiser = new MockAdvertiser();
+            const deviceAdvertiser = new DeviceAdvertiser({ fabrics, sessions });
+            deviceAdvertiser.addAdvertiser(advertiser);
+
+            deviceAdvertiser.setIcdAdvertisementProvider(() => ({
+                icd: IcdManagement.OperatingMode.Sit,
+                idleInterval: Seconds(30),
+                activeInterval: Seconds(1),
+                activeThreshold: Seconds(4),
+            }));
+            // Clear the provider
+            deviceAdvertiser.setIcdAdvertisementProvider(undefined);
+
+            deviceAdvertiser.enterOperationalMode();
+
+            const fabric = createFabric();
+            (fabrics as any)[Symbol.iterator] = () => [fabric].values();
+            (fabrics.events.added as Observable<[any]>).emit(fabric);
+
+            const opAds = advertiser.advertiseCalls.filter(c => c.description.kind === "operational");
+            expect(opAds.length).greaterThan(0);
+
+            const desc = opAds[0].description as ServiceDescription.Operational;
+            expect(desc.icd).to.be.undefined;
         });
     });
 });


### PR DESCRIPTION
**WIP — Phase 2b-1 of ICD support.** Stacked on `feat/icd-protocol` (umbrella PR #3848); merges into that branch, not main.

Device-side LIT operating mode and ICD operational DNS-SD advertising, building on the phase-2a `IcdManagementServer`.

## What's here
- **DeviceAdvertiser seam** (`packages/protocol`): nodes supply per-operation ICD advertisement data (operating mode + session intervals) via `setIcdAdvertisementProvider`; `refreshOperationalAdvertisement(fabric)` re-announces (full burst) on change. No regression for non-ICD nodes (provider absent → unchanged).
- **LITS feature** on `IcdManagementServer`: `operatingMode` attribute, LIT `activeModeThreshold ≥ 5 s` constraint, and a guard that LongIdleTimeSupport implies CheckInProtocolSupport. The LogicBase composes CIP+LITS for type-safe shared logic; the default `IcdManagementServer` resets to CIP-only.
- **Effective operating mode** (node-global): LIT iff LITS enabled and ≥1 client registered, else SIT. Maintains the `operatingMode` attribute and drives the advertisement — `ICD=0/1` TXT key, `SAT` = ActiveModeThreshold, `SAI`/`SII` from session params, `SII` omitted in LIT — refreshing on SIT↔LIT transitions.
- **DSLS** `setOperatingMode()`: runtime SIT↔LIT forcing (non-DSLS follows registration state; force is runtime-only and reverts on restart).

LITS requires the app to configure `operatingMode` (no spec default — init throws otherwise), documented on the class.

## Not here (later phases)
- **2b-2:** idle/active mode state machine + timers, NodeActivity-driven active extension, `activeModeEntered`/`idleModeEntered` + `requestActiveMode()`, StayActiveRequest folding in remaining active time, UAT attributes + `triggerUserActiveMode()`.
- **2c:** check-in transmission + subscription-subject/`subject_matches` for check-in suppression.

## Verification
Clean build (all packages typecheck); `packages/node` 1210/1201 ×3 envs and `packages/protocol` 1140 ×3 green; format + lint clean. Tests cover the advertiser seam, SIT↔LIT transitions, non-LITS no-flip, DSLS force both ways, non-DSLS rejection, and the LITS⇒CIP / operatingMode-required guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)