### PR TITLE
feat(protocol): backport message privacy to 0.16.x (#3854)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ The main work (all changes without a GitHub username in brackets in the below li
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+
+- @matter/general
+    - Fix: AES-CCM encryption now honors the `byteOffset` of subarray inputs for plaintext and AAD (Backported from 0.17.2)
+
+- @matter/protocol
+    - Enhancement: Implemented Matter message privacy (header obfuscation) for group messages; receiving is always supported, sending is opt-in per session and off by default. Unicast messages carrying the privacy flag are dropped like in CHIP SDK (Backported from 0.17.2)
+
 ## 0.16.11 (2026-04-10)
 
 - @project-chip/matter.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/protocol
     - Enhancement: Implemented Matter message privacy (header obfuscation) for group messages; receiving is always supported, sending is opt-in per session and off by default. Unicast messages carrying the privacy flag are dropped like in CHIP SDK (Backported from 0.17.2)
+    - Fix: Group-send epoch-key selection no longer fails when a future-dated epoch key is installed during key rotation (Backported from 0.17.2)
 
 ## 0.16.11 (2026-04-10)
 

--- a/packages/general/src/crypto/aes/Ccm.ts
+++ b/packages/general/src/crypto/aes/Ccm.ts
@@ -73,7 +73,7 @@ export function Ccm(key: Bytes) {
             }
 
             // Create view for loading plaintext words in platform byte order
-            const ptView = new DataView(input.pt.buffer);
+            const ptView = new DataView(input.pt.buffer, input.pt.byteOffset, input.pt.byteLength);
 
             // Allocate ciphertext output buffer
             const ct = new Uint8Array(ptLength + CRYPTO_AEAD_MIC_LENGTH_BYTES);
@@ -175,7 +175,7 @@ export function Ccm(key: Bytes) {
 
             // Add remainder of adata
             if (adataLength > 14) {
-                const adataView = new DataView(input.adata!.buffer);
+                const adataView = new DataView(input.adata!.buffer, input.adata!.byteOffset, input.adata!.byteLength);
                 for (let i = 14; i < adataLength; i += 16) {
                     WordArray.bytesToBlock(adataView, tempBlock1.words, i);
                     add();

--- a/packages/general/test/crypto/aes/CcmTest.ts
+++ b/packages/general/test/crypto/aes/CcmTest.ts
@@ -177,4 +177,22 @@ describe("Ccm", () => {
             });
         });
     }
+
+    describe("byte offset handling", () => {
+        // NIST tcId 10 has 16-byte adata (>14 bytes), exercising the multi-block adata path that also builds a DataView.
+        const v = vectors.find(entry => entry.name === "NIST tcId 10")!;
+
+        it("encrypts plaintext and adata supplied at a non-zero byteOffset", () => {
+            const ccm = Ccm(Bytes.fromHex(v.key));
+
+            const ptView = Bytes.of(Bytes.concat(Bytes.fromHex("aabbcc"), Bytes.fromHex(v.pt))).subarray(3);
+            const aadView = Bytes.of(Bytes.concat(Bytes.fromHex("ddeeff"), Bytes.fromHex(v.adata))).subarray(3);
+
+            const result = Bytes.toHex(
+                ccm.encrypt({ nonce: Bytes.of(Bytes.fromHex(v.nonce)), adata: aadView, pt: ptView }),
+            );
+
+            expect(result).equals(v.ct + v.tag);
+        });
+    });
 });

--- a/packages/protocol/src/codec/MessageCodec.ts
+++ b/packages/protocol/src/codec/MessageCodec.ts
@@ -7,6 +7,7 @@
 import { Mark } from "#common/Mark.js";
 import {
     Bytes,
+    CRYPTO_AEAD_MIC_LENGTH_BYTES,
     DataReader,
     DataWriter,
     Diagnostic,
@@ -50,10 +51,14 @@ export interface Packet {
     header: PacketHeader;
     messageExtension?: Bytes;
     applicationPayload: Bytes;
+    /** Optional pre-serialized (and possibly privacy-obfuscated) header bytes; used instead of re-encoding `header`. */
+    headerBytes?: Bytes;
 }
 
 export interface DecodedPacket extends Packet {
     header: DecodedPacketHeader;
+    /** For privacy-enhanced packets: the still-obfuscated header region (message counter + node/group IDs). */
+    privacyHeader?: Bytes;
 }
 
 export interface Message {
@@ -154,20 +159,142 @@ function mapProtocolAndMessageType(protocolId: number, messageType: number): { t
 export class MessageCodec {
     static decodePacket(data: Bytes): DecodedPacket {
         const reader = new DataReader(data, Endian.Little);
-        const header = this.decodePacketHeader(reader);
+
+        const flags = reader.readUInt8();
+        const version = (flags & PacketHeaderFlag.VersionMask) >> 4;
+        const hasDestNodeId = (flags & PacketHeaderFlag.HasDestNodeId) !== 0;
+        const hasDestGroupId = (flags & PacketHeaderFlag.HasDestGroupId) !== 0;
+        const hasSourceNodeId = (flags & PacketHeaderFlag.HasSourceNodeId) !== 0;
+
+        if (hasDestNodeId && hasDestGroupId)
+            throw new UnexpectedDataError(
+                "The header cannot contain destination group and node at the same time. Reserved for future use. Discard message.",
+            );
+        if (version !== HEADER_VERSION) throw new NotImplementedError(`Unsupported header version ${version}.`);
+
+        const sessionId = reader.readUInt16();
+        const securityFlags = reader.readUInt8();
+
+        const sessionType = securityFlags & SecurityFlag.SessionTypeMask;
+        if (sessionType !== SessionType.Group && sessionType !== SessionType.Unicast) {
+            throw new UnexpectedDataError(`Unsupported session type ${sessionType}.`);
+        }
+        if (sessionType === SessionType.Unicast && hasDestGroupId) {
+            throw new UnexpectedDataError(`Unicast session cannot have destination group id.`);
+        }
+        if (sessionType === SessionType.Group) {
+            if (!hasDestGroupId && !hasDestNodeId) {
+                throw new UnexpectedDataError(`Group session must have destination group id or destination node id.`);
+            }
+            if (!hasSourceNodeId) {
+                throw new UnexpectedDataError(`Group session must have source node id.`);
+            }
+        }
+
+        const hasPrivacyEnhancements = (securityFlags & SecurityFlag.HasPrivacyEnhancements) !== 0;
+        const isControlMessage = (securityFlags & SecurityFlag.IsControlMessage) !== 0;
+        if (isControlMessage) {
+            throw new NotImplementedError(`Control Messages not supported.`);
+        }
+        const hasMessageExtensions = (securityFlags & SecurityFlag.HasMessageExtension) !== 0;
+
+        if (hasPrivacyEnhancements) {
+            if (hasMessageExtensions) {
+                throw new NotImplementedError(`Privacy enhancements with message extensions not supported.`);
+            }
+            const privacyHeaderLength = 4 + (hasSourceNodeId ? 8 : 0) + (hasDestNodeId ? 8 : hasDestGroupId ? 2 : 0);
+            if (reader.remainingBytesCount < privacyHeaderLength) {
+                throw new UnexpectedDataError(
+                    `Privacy header length ${privacyHeaderLength} exceeds remaining message size ${reader.remainingBytesCount}.`,
+                );
+            }
+            const privacyHeader = reader.readByteArray(privacyHeaderLength);
+            // Reject early: the privacy nonce is derived from the MIC, so a packet without a full MIC must not proceed.
+            if (reader.remainingBytesCount < CRYPTO_AEAD_MIC_LENGTH_BYTES) {
+                throw new UnexpectedDataError(
+                    `Privacy-enhanced message too short to contain a MIC: ${reader.remainingBytesCount} bytes remaining.`,
+                );
+            }
+            return {
+                header: {
+                    securityFlags,
+                    sessionId,
+                    sessionType,
+                    hasPrivacyEnhancements: true,
+                    isControlMessage: false,
+                    hasMessageExtensions: false,
+                    messageId: 0,
+                    sourceNodeId: undefined,
+                    destNodeId: undefined,
+                    destGroupId: undefined,
+                },
+                privacyHeader,
+                applicationPayload: reader.remainingBytes,
+            };
+        }
+
+        const messageId = reader.readUInt32();
+        const sourceNodeId = hasSourceNodeId ? NodeId(reader.readUInt64()) : undefined;
+        const destNodeId = hasDestNodeId ? NodeId(reader.readUInt64()) : undefined;
+        const destGroupId = hasDestGroupId ? GroupId(reader.readUInt16()) : undefined;
+
+        const header: DecodedPacketHeader = {
+            securityFlags,
+            sessionId,
+            sourceNodeId,
+            messageId,
+            destGroupId,
+            destNodeId,
+            sessionType,
+            hasPrivacyEnhancements: false,
+            isControlMessage: false,
+            hasMessageExtensions,
+        };
 
         let messageExtension: Bytes | undefined = undefined;
-        if (header.hasMessageExtensions) {
+        if (hasMessageExtensions) {
             const extensionLength = reader.readUInt16();
             messageExtension = reader.readByteArray(extensionLength);
         }
 
-        const applicationPayload = reader.remainingBytes;
         return {
             header,
             messageExtension,
-            applicationPayload,
+            applicationPayload: reader.remainingBytes,
         };
+    }
+
+    /**
+     * Decode the message counter and node/group IDs from a deobfuscated privacy header region. Presence of each field
+     * is determined from the (cleartext) message flags byte.
+     */
+    static decodeObfuscatedHeaderFields(
+        messageFlags: number,
+        region: Bytes,
+    ): Pick<DecodedPacketHeader, "messageId" | "sourceNodeId" | "destNodeId" | "destGroupId"> {
+        const hasDestNodeId = (messageFlags & PacketHeaderFlag.HasDestNodeId) !== 0;
+        const hasDestGroupId = (messageFlags & PacketHeaderFlag.HasDestGroupId) !== 0;
+        const hasSourceNodeId = (messageFlags & PacketHeaderFlag.HasSourceNodeId) !== 0;
+
+        if (hasDestNodeId && hasDestGroupId)
+            throw new UnexpectedDataError(
+                "The header cannot contain destination group and node at the same time. Reserved for future use. Discard message.",
+            );
+
+        const expectedLength = 4 + (hasSourceNodeId ? 8 : 0) + (hasDestNodeId ? 8 : hasDestGroupId ? 2 : 0);
+        if (region.byteLength < expectedLength) {
+            throw new UnexpectedDataError(
+                `Privacy header region length ${region.byteLength} is shorter than expected ${expectedLength}.`,
+            );
+        }
+
+        const reader = new DataReader(region, Endian.Little);
+        const messageId = reader.readUInt32();
+        const sourceNodeId = hasSourceNodeId ? NodeId(reader.readUInt64()) : undefined;
+        const destNodeId = hasDestNodeId ? NodeId(reader.readUInt64()) : undefined;
+        const destGroupId = hasDestGroupId ? GroupId(reader.readUInt16()) : undefined;
+
+        return { messageId, sourceNodeId, destNodeId, destGroupId };
     }
 
     static decodePayload({ header, applicationPayload }: DecodedPacket): DecodedMessage {
@@ -204,73 +331,11 @@ export class MessageCodec {
         };
     }
 
-    static encodePacket({ header, applicationPayload, messageExtension }: Packet): Bytes {
+    static encodePacket({ header, applicationPayload, messageExtension, headerBytes }: Packet): Bytes {
         if (messageExtension !== undefined || header.hasMessageExtensions) {
             throw new NotImplementedError(`Message extensions not supported when encoding a packet.`);
         }
-        return Bytes.concat(this.encodePacketHeader(header), applicationPayload);
-    }
-
-    private static decodePacketHeader(reader: DataReader<Endian.Little>): DecodedPacketHeader {
-        // Read and parse message flags
-        const flags = reader.readUInt8();
-        const version = (flags & PacketHeaderFlag.VersionMask) >> 4;
-        const hasDestNodeId = (flags & PacketHeaderFlag.HasDestNodeId) !== 0;
-        const hasDestGroupId = (flags & PacketHeaderFlag.HasDestGroupId) !== 0;
-        const hasSourceNodeId = (flags & PacketHeaderFlag.HasSourceNodeId) !== 0;
-
-        if (hasDestNodeId && hasDestGroupId)
-            throw new UnexpectedDataError(
-                "The header cannot contain destination group and node at the same time. Reserved for future use. Discard message.",
-            );
-        if (version !== HEADER_VERSION) throw new NotImplementedError(`Unsupported header version ${version}.`);
-
-        const sessionId = reader.readUInt16();
-        const securityFlags = reader.readUInt8();
-        const messageId = reader.readUInt32();
-        const sourceNodeId = hasSourceNodeId ? NodeId(reader.readUInt64()) : undefined;
-        const destNodeId = hasDestNodeId ? NodeId(reader.readUInt64()) : undefined;
-        const destGroupId = hasDestGroupId ? GroupId(reader.readUInt16()) : undefined;
-
-        const sessionType = securityFlags & SecurityFlag.SessionTypeMask;
-
-        if (sessionType !== SessionType.Group && sessionType !== SessionType.Unicast) {
-            throw new UnexpectedDataError(`Unsupported session type ${sessionType}.`);
-        }
-        if (sessionType === SessionType.Unicast && hasDestGroupId) {
-            throw new UnexpectedDataError(`Unicast session cannot have destination group id.`);
-        }
-        if (sessionType === SessionType.Group) {
-            if (!hasDestGroupId && !hasDestNodeId) {
-                throw new UnexpectedDataError(`Group session must have destination group id or destination node id.`);
-            }
-            if (!hasSourceNodeId) {
-                throw new UnexpectedDataError(`Group session must have source node id.`);
-            }
-        }
-        const hasPrivacyEnhancements = (securityFlags & SecurityFlag.HasPrivacyEnhancements) !== 0;
-        if (hasPrivacyEnhancements) {
-            throw new NotImplementedError(`Privacy enhancements not supported.`);
-        }
-        const isControlMessage = (securityFlags & SecurityFlag.IsControlMessage) !== 0;
-        if (isControlMessage) {
-            // And also currently not needed because MCP is not relevant
-            throw new NotImplementedError(`Control Messages not supported.`);
-        }
-        const hasMessageExtensions = (securityFlags & SecurityFlag.HasMessageExtension) !== 0;
-
-        return {
-            securityFlags,
-            sessionId,
-            sourceNodeId,
-            messageId,
-            destGroupId,
-            destNodeId,
-            sessionType,
-            hasPrivacyEnhancements,
-            isControlMessage,
-            hasMessageExtensions,
-        };
+        return Bytes.concat(headerBytes ?? this.encodePacketHeader(header), applicationPayload);
     }
 
     private static decodePayloadHeader(reader: DataReader<Endian.Little>): PayloadHeader {
@@ -305,6 +370,7 @@ export class MessageCodec {
         destNodeId,
         sourceNodeId,
         sessionType,
+        hasPrivacyEnhancements,
     }: PacketHeader) {
         if (
             sessionType === SessionType.Group &&
@@ -318,7 +384,7 @@ export class MessageCodec {
             (destGroupId !== undefined ? PacketHeaderFlag.HasDestGroupId : 0) |
             (destNodeId !== undefined ? PacketHeaderFlag.HasDestNodeId : 0) |
             (sourceNodeId !== undefined ? PacketHeaderFlag.HasSourceNodeId : 0);
-        const securityFlags = sessionType;
+        const securityFlags = sessionType | (hasPrivacyEnhancements ? SecurityFlag.HasPrivacyEnhancements : 0);
 
         writer.writeUInt8(flags);
         writer.writeUInt16(sessionId);

--- a/packages/protocol/src/codec/MessageCodec.ts
+++ b/packages/protocol/src/codec/MessageCodec.ts
@@ -75,6 +75,7 @@ export namespace Message {
 
     export function diagnosticsOf(context: { via: string }, message: Message, logContext?: ExchangeLogContext) {
         const {
+            packetHeader: { hasPrivacyEnhancements },
             payloadHeader: { messageType, protocolId, ackedMessageId, requiresAck },
             payload,
         } = message;
@@ -95,6 +96,7 @@ export namespace Message {
                 msgFlags: Diagnostic.asFlags({
                     reqAck: requiresAck,
                     dup: duplicate,
+                    privacy: hasPrivacyEnhancements,
                 }),
                 size: payload.byteLength ? payload.byteLength : undefined,
                 payload: payload.byteLength ? payload : undefined,

--- a/packages/protocol/src/codec/MessagePrivacy.ts
+++ b/packages/protocol/src/codec/MessagePrivacy.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    Bytes,
+    Crypto,
+    CRYPTO_AEAD_MIC_LENGTH_BYTES,
+    CRYPTO_SYMMETRIC_KEY_LENGTH,
+    CryptoInputError,
+    MaybePromise,
+} from "#general";
+
+/** HKDF info string for deriving a privacy key from an encryption key (Matter spec §4.8.2). */
+const PRIVACY_KEY_INFO = Bytes.fromString("PrivacyKey");
+
+const NONCE_MIC_OFFSET = CRYPTO_AEAD_MIC_LENGTH_BYTES - 11;
+const NONCE_MIC_LENGTH = 11;
+
+/**
+ * Matter message privacy (spec §4.8): obfuscation of the packet header for privacy-enhanced messages.
+ */
+export namespace MessagePrivacy {
+    /** Derive a privacy key from an encryption key: HKDF(key, salt=[], info="PrivacyKey", 16). */
+    export function deriveKey(crypto: Crypto, encryptionKey: Bytes): MaybePromise<Bytes> {
+        return crypto.createHkdfKey(encryptionKey, new Uint8Array(0), PRIVACY_KEY_INFO, CRYPTO_SYMMETRIC_KEY_LENGTH);
+    }
+
+    /** Build the 13-byte privacy nonce: sessionId (2 bytes, big-endian) then the last 11 bytes of the message MIC. */
+    export function buildNonce(sessionId: number, mic: Bytes): Bytes {
+        const micBytes = Bytes.of(mic);
+        if (micBytes.length !== CRYPTO_AEAD_MIC_LENGTH_BYTES) {
+            throw new CryptoInputError(`Privacy nonce requires a ${CRYPTO_AEAD_MIC_LENGTH_BYTES}-byte MIC`);
+        }
+        return Bytes.concat(
+            Uint8Array.of((sessionId >> 8) & 0xff, sessionId & 0xff),
+            micBytes.slice(NONCE_MIC_OFFSET, NONCE_MIC_OFFSET + NONCE_MIC_LENGTH),
+        );
+    }
+
+    /**
+     * Obfuscate or deobfuscate a header region using AES-CTR (as AES-CCM with empty AAD, ciphertext-only).
+     * CTR keystream XOR is symmetric, so the same call serves both directions.
+     */
+    export function obfuscate(crypto: Crypto, privacyKey: Bytes, data: Bytes, nonce: Bytes): Bytes {
+        const dataBytes = Bytes.of(data);
+        return Bytes.of(crypto.encrypt(privacyKey, dataBytes, nonce)).slice(0, dataBytes.length);
+    }
+}

--- a/packages/protocol/src/codec/index.ts
+++ b/packages/protocol/src/codec/index.ts
@@ -7,3 +7,4 @@
 export { Base64, DerCodec, DnsCodec, type DerNode } from "#general";
 export * from "./BtpCodec.js";
 export * from "./MessageCodec.js";
+export * from "./MessagePrivacy.js";

--- a/packages/protocol/src/groups/FabricGroups.ts
+++ b/packages/protocol/src/groups/FabricGroups.ts
@@ -3,6 +3,7 @@
  * Copyright 2022-2026 Matter.js Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+import { MessagePrivacy } from "#codec/MessagePrivacy.js";
 import type { Fabric } from "#fabric/Fabric.js";
 import { BasicMap, Bytes, hex, InternalError, MatterFlowError, StorageContext } from "#general";
 import { GroupKeySet, KeySets, OperationalKeySet } from "#groups/KeySets.js";
@@ -132,16 +133,30 @@ export class FabricGroups {
             epochKey2 !== null
                 ? await this.#fabric.crypto.createHkdfKey(epochKey2, globalId, GROUP_SECURITY_INFO)
                 : null;
+        const operationalPrivacyKey0 = Bytes.of(
+            await MessagePrivacy.deriveKey(this.#fabric.crypto, operationalEpochKey0),
+        );
+        const operationalPrivacyKey1 =
+            operationalEpochKey1 !== null
+                ? Bytes.of(await MessagePrivacy.deriveKey(this.#fabric.crypto, operationalEpochKey1))
+                : null;
+        const operationalPrivacyKey2 =
+            operationalEpochKey2 !== null
+                ? Bytes.of(await MessagePrivacy.deriveKey(this.#fabric.crypto, operationalEpochKey2))
+                : null;
         this.#keySets.add({
             ...groupKeySet,
             operationalEpochKey0,
+            operationalPrivacyKey0,
             groupSessionId0: await this.#keySets.sessionIdFromKey(this.#fabric.crypto, operationalEpochKey0),
             operationalEpochKey1,
+            operationalPrivacyKey1,
             groupSessionId1:
                 operationalEpochKey1 !== null
                     ? await this.#keySets.sessionIdFromKey(this.#fabric.crypto, operationalEpochKey1)
                     : null,
             operationalEpochKey2,
+            operationalPrivacyKey2,
             groupSessionId2:
                 operationalEpochKey2 !== null
                     ? await this.#keySets.sessionIdFromKey(this.#fabric.crypto, operationalEpochKey2)

--- a/packages/protocol/src/groups/KeySets.ts
+++ b/packages/protocol/src/groups/KeySets.ts
@@ -11,7 +11,7 @@ export const GROUP_KEY_INFO = Bytes.fromString("GroupKeyHash");
 
 export class KeySets<T extends OperationalKeySet> extends BasicSet<T> {
     /** Operational enhanced structure for fast access based on the group session id. */
-    readonly #sessions = new Map<number, { keySetId: number; key: Bytes }[]>();
+    readonly #sessions = new Map<number, { keySetId: number; key: Bytes; privacyKey?: Bytes }[]>();
 
     get sessions() {
         return this.#sessions;
@@ -44,15 +44,18 @@ export class KeySets<T extends OperationalKeySet> extends BasicSet<T> {
         if (groupKeySet === undefined) {
             throw new MatterFlowError(`GroupKeySet for groupKeySet ${keySetId} not found.`);
         }
-        const operationalKeys = Array<{ key: Bytes; sessionId?: number; startTime: Timestamp }>();
+        const operationalKeys = Array<{ key: Bytes; privacyKey?: Bytes; sessionId?: number; startTime: Timestamp }>();
         const {
             operationalEpochKey0,
+            operationalPrivacyKey0,
             groupSessionId0,
             epochStartTime0,
             operationalEpochKey1,
+            operationalPrivacyKey1,
             groupSessionId1,
             epochStartTime1,
             operationalEpochKey2,
+            operationalPrivacyKey2,
             groupSessionId2,
             epochStartTime2,
         } = groupKeySet;
@@ -62,12 +65,14 @@ export class KeySets<T extends OperationalKeySet> extends BasicSet<T> {
         }
         operationalKeys.push({
             key: operationalEpochKey0,
+            privacyKey: operationalPrivacyKey0,
             sessionId: groupSessionId0 !== null ? groupSessionId0 : undefined,
             startTime: Timestamp.fromMicroseconds(epochStartTime0),
         });
         if (operationalEpochKey1 !== null && groupSessionId1 !== null && epochStartTime1 !== null) {
             operationalKeys.push({
                 key: operationalEpochKey1,
+                privacyKey: operationalPrivacyKey1 ?? undefined,
                 sessionId: groupSessionId1,
                 startTime: Timestamp.fromMicroseconds(epochStartTime1),
             });
@@ -75,6 +80,7 @@ export class KeySets<T extends OperationalKeySet> extends BasicSet<T> {
         if (operationalEpochKey2 !== null && groupSessionId2 !== null && epochStartTime2 !== null) {
             operationalKeys.push({
                 key: operationalEpochKey2,
+                privacyKey: operationalPrivacyKey2 ?? undefined,
                 sessionId: groupSessionId2,
                 startTime: Timestamp.fromMicroseconds(epochStartTime2),
             });
@@ -172,17 +178,29 @@ export class KeySets<T extends OperationalKeySet> extends BasicSet<T> {
             }
             if (keySet.groupSessionId0 !== null) {
                 const list = this.#sessions.get(keySet.groupSessionId0) ?? [];
-                list.push({ key: keySet.operationalEpochKey0, keySetId: id });
+                list.push({
+                    key: keySet.operationalEpochKey0,
+                    privacyKey: keySet.operationalPrivacyKey0,
+                    keySetId: id,
+                });
                 this.#sessions.set(keySet.groupSessionId0, list);
             }
             if (keySet.groupSessionId1 !== null && keySet.operationalEpochKey1 !== null) {
                 const list = this.#sessions.get(keySet.groupSessionId1) ?? [];
-                list.push({ key: keySet.operationalEpochKey1, keySetId: id });
+                list.push({
+                    key: keySet.operationalEpochKey1,
+                    privacyKey: keySet.operationalPrivacyKey1 ?? undefined,
+                    keySetId: id,
+                });
                 this.#sessions.set(keySet.groupSessionId1, list);
             }
             if (keySet.groupSessionId2 !== null && keySet.operationalEpochKey2 !== null) {
                 const list = this.#sessions.get(keySet.groupSessionId2) ?? [];
-                list.push({ key: keySet.operationalEpochKey2, keySetId: id });
+                list.push({
+                    key: keySet.operationalEpochKey2,
+                    privacyKey: keySet.operationalPrivacyKey2 ?? undefined,
+                    keySetId: id,
+                });
                 this.#sessions.set(keySet.groupSessionId2, list);
             }
         }
@@ -194,9 +212,12 @@ export type GroupKeySet = GroupKeyManagement.GroupKeySet;
 /** Enhanced structure of GroupKeySet to include operational data for easier operational processing. */
 export type OperationalKeySet = GroupKeySet & {
     operationalEpochKey0: Bytes;
+    operationalPrivacyKey0?: Bytes;
     groupSessionId0: number | null;
     operationalEpochKey1: Bytes | null;
+    operationalPrivacyKey1?: Bytes | null;
     groupSessionId1: number | null;
     operationalEpochKey2: Bytes | null;
+    operationalPrivacyKey2?: Bytes | null;
     groupSessionId2: number | null;
 };

--- a/packages/protocol/src/groups/KeySets.ts
+++ b/packages/protocol/src/groups/KeySets.ts
@@ -117,7 +117,7 @@ export class KeySets<T extends OperationalKeySet> extends BasicSet<T> {
                     `No operational keys found for groupKeySet ${keySetId} that are not in the future.`,
                 );
             }
-            return relevantKeys[operationalKeys.length - 1];
+            return relevantKeys[relevantKeys.length - 1];
         }
     }
 

--- a/packages/protocol/src/protocol/ExchangeManager.ts
+++ b/packages/protocol/src/protocol/ExchangeManager.ts
@@ -170,7 +170,12 @@ export class ExchangeManager {
         const bytes = Bytes.of(messageBytes);
         const aad = bytes.slice(0, bytes.length - packet.applicationPayload.byteLength); // Header+Extensions
 
-        const messageId = packet.header.messageId;
+        // Privacy enhancements are only defined for group messages; a unicast message with the privacy flag is invalid
+        // and dropped, matching the CHIP SDK.
+        if (packet.header.hasPrivacyEnhancements && packet.header.sessionType !== SessionType.Group) {
+            logger.info("Dropping unicast message with privacy flag set");
+            return;
+        }
 
         let isDuplicate: boolean;
         let session: Session | undefined;
@@ -207,7 +212,7 @@ export class ExchangeManager {
             message = session.decode(packet, aad);
 
             try {
-                session.updateMessageCounter(messageId);
+                session.updateMessageCounter(message.packetHeader.messageId);
                 isDuplicate = false;
             } catch (e) {
                 DuplicateMessageError.accept(e);
@@ -215,15 +220,17 @@ export class ExchangeManager {
             }
         } else if (packet.header.sessionType === SessionType.Group) {
             if (this.#isClosing) return;
-            if (packet.header.sourceNodeId === undefined) {
-                throw new UnexpectedDataError("Group session message must include a source NodeId");
-            }
 
             let key: Bytes;
             ({ session, message, key } = this.#sessions.groupSessionFromPacket(packet, aad));
 
+            const sourceNodeId = message.packetHeader.sourceNodeId;
+            if (sourceNodeId === undefined) {
+                throw new UnexpectedDataError("Group session message must include a source NodeId");
+            }
+
             try {
-                session.updateMessageCounter(messageId, packet.header.sourceNodeId, key);
+                session.updateMessageCounter(message.packetHeader.messageId, sourceNodeId, key);
                 isDuplicate = false;
             } catch (e) {
                 DuplicateMessageError.accept(e);
@@ -232,6 +239,8 @@ export class ExchangeManager {
         } else {
             throw new MatterFlowError(`Unsupported session type: ${packet.header.sessionType}`);
         }
+
+        const messageId = message.packetHeader.messageId;
 
         const exchangeIndex = message.payloadHeader.isInitiatorMessage
             ? message.payloadHeader.exchangeId

--- a/packages/protocol/src/protocol/MessageExchange.ts
+++ b/packages/protocol/src/protocol/MessageExchange.ts
@@ -405,7 +405,7 @@ export class MessageExchange {
                 messageId: await this.session.getIncrementedMessageCounter(),
                 destNodeId: this.#peerNodeId,
                 sourceNodeId: this.#nodeId,
-                hasPrivacyEnhancements: false,
+                hasPrivacyEnhancements: false, // Privacy is only defined for group messages
                 isControlMessage: false,
                 hasMessageExtensions: false,
             };
@@ -424,7 +424,7 @@ export class MessageExchange {
                 messageId: await session.getIncrementedMessageCounter(),
                 destGroupId,
                 sourceNodeId: this.#nodeId, // We are the source node, so use our NodeId
-                hasPrivacyEnhancements: false,
+                hasPrivacyEnhancements: this.session.usePrivacy,
                 isControlMessage: false,
                 hasMessageExtensions: false,
             };

--- a/packages/protocol/src/session/GroupSession.ts
+++ b/packages/protocol/src/session/GroupSession.ts
@@ -5,6 +5,7 @@
  */
 import { Subject } from "#action/server/Subject.js";
 import { DecodedMessage, DecodedPacket, Message, MessageCodec, Packet, SessionType } from "#codec/MessageCodec.js";
+import { MessagePrivacy } from "#codec/MessagePrivacy.js";
 import { Mark } from "#common/Mark.js";
 import type { Fabric } from "#fabric/Fabric.js";
 import type { FabricManager } from "#fabric/FabricManager.js";
@@ -12,6 +13,7 @@ import {
     Bytes,
     ChannelType,
     ConnectionlessTransportSet,
+    CRYPTO_AEAD_MIC_LENGTH_BYTES,
     CryptoDecryptError,
     Diagnostic,
     hex,
@@ -37,13 +39,14 @@ export class GroupSession extends SecureSession {
     readonly #fabric: Fabric;
     readonly #peerNodeId: NodeId;
     readonly #operationalGroupKey: Bytes;
+    readonly #operationalPrivacyKey?: Bytes;
     readonly supportsMRP = false;
     readonly closingAfterExchangeFinished = false; // Group sessions do not close after exchange finished, they are long-lived
 
     readonly keySetId: number;
 
     constructor(config: GroupSession.Config) {
-        const { manager, fabric, operationalGroupKey, id, peerNodeId, keySetId } = config;
+        const { manager, fabric, operationalGroupKey, operationalPrivacyKey, id, peerNodeId, keySetId } = config;
         super({
             ...config,
             setActiveTimestamp: false, // We always set the active timestamp for Secure sessions TODO Check
@@ -54,6 +57,7 @@ export class GroupSession extends SecureSession {
         this.#peerNodeId = peerNodeId;
         this.keySetId = keySetId;
         this.#operationalGroupKey = operationalGroupKey;
+        this.#operationalPrivacyKey = operationalPrivacyKey;
 
         manager?.registerGroupSession(this);
         fabric.addSession(this);
@@ -98,12 +102,26 @@ export class GroupSession extends SecureSession {
             keySetId,
             peerNodeId: groupNodeId,
             operationalGroupKey,
+            operationalPrivacyKey: Bytes.of(await MessagePrivacy.deriveKey(fabric.crypto, operationalGroupKey)),
         });
     }
 
     override get type() {
         return SessionType.Group;
     }
+
+    /*
+     * TODO: enable once clarified with CHIP SDK developers.
+     *
+     * The Matter spec requires group multicasts to be sent with privacy enabled — Core Specification, Secure Channel,
+     * "Sending a group message": the Security Flags "SHALL have only the P Flag set". The CHIP SDK does not set the
+     * privacy flag when sending group messages, so we keep it off to match the dominant implementation until the
+     * spec/SDK divergence is resolved. Enabling it passes the full CHIP controller test suite (interop verified).
+     *
+     * override get usePrivacy() {
+     *     return true;
+     * }
+     */
 
     get fabric(): Fabric {
         return this.#fabric;
@@ -173,16 +191,31 @@ export class GroupSession extends SecureSession {
         const headerBytes = MessageCodec.encodePacketHeader(message.packetHeader);
         const securityFlags = headerBytes[3];
         const nonce = Session.generateNonce(securityFlags, header.messageId, this.#fabric.nodeId);
+        const ciphertext = this.#fabric.crypto.encrypt(
+            this.#operationalGroupKey,
+            applicationPayload,
+            nonce,
+            headerBytes,
+        );
 
-        return {
-            header,
-            applicationPayload: this.#fabric.crypto.encrypt(
-                this.#operationalGroupKey,
-                applicationPayload,
-                nonce,
-                headerBytes,
-            ),
-        };
+        if (!message.packetHeader.hasPrivacyEnhancements) {
+            return { header, applicationPayload: ciphertext };
+        }
+
+        if (this.#operationalPrivacyKey === undefined) {
+            throw new InternalError("Privacy key not available for this group session.");
+        }
+        const mic = Bytes.of(ciphertext).slice(-CRYPTO_AEAD_MIC_LENGTH_BYTES);
+        const privacyNonce = MessagePrivacy.buildNonce(header.sessionId, mic);
+        const region = Bytes.of(headerBytes).slice(4);
+        const obfuscated = MessagePrivacy.obfuscate(
+            this.#fabric.crypto,
+            this.#operationalPrivacyKey,
+            region,
+            privacyNonce,
+        );
+        const obfuscatedHeader = Bytes.concat(Bytes.of(headerBytes).slice(0, 4), obfuscated);
+        return { header, applicationPayload: ciphertext, headerBytes: obfuscatedHeader };
     }
 
     decode(): DecodedMessage {
@@ -191,11 +224,12 @@ export class GroupSession extends SecureSession {
 
     static decode(
         fabrics: FabricManager,
-        { header, applicationPayload, messageExtension }: DecodedPacket,
+        { header, applicationPayload, messageExtension, privacyHeader }: DecodedPacket,
         aad: Bytes,
     ): {
         message: DecodedMessage;
         key: Bytes;
+        privacyKey?: Bytes;
         sessionId: number;
         sourceNodeId: NodeId;
         keySetId: number;
@@ -206,14 +240,9 @@ export class GroupSession extends SecureSession {
                 `Message extensions are not supported. Ignoring ${messageExtension ? Bytes.toHex(messageExtension) : undefined}`,
             );
         }
-        const sourceNodeId = header.sourceNodeId;
-        if (sourceNodeId === undefined) {
-            // Already checked on decoding, but validate twice
-            throw new UnexpectedDataError("Source Node ID is required for GroupSession decode.");
-        }
-        const nonce = Session.generateNonce(header.securityFlags, header.messageId, sourceNodeId);
+
         const sessionId = header.sessionId;
-        const keys = new Array<{ key: Bytes; keySetId: number; fabric: Fabric }>();
+        const keys = new Array<{ key: Bytes; privacyKey?: Bytes; keySetId: number; fabric: Fabric }>();
         for (const fabric of fabrics) {
             const sessions = fabric.groups.sessions.get(sessionId);
             if (sessions?.length) {
@@ -225,24 +254,71 @@ export class GroupSession extends SecureSession {
         if (keys.length === 0) {
             throw new MatterFlowError("No key candidate found for group session decryption.");
         }
+
+        const messageFlags = Bytes.of(aad)[0];
+        const mic = Bytes.of(applicationPayload).slice(-CRYPTO_AEAD_MIC_LENGTH_BYTES);
+
         let message: DecodedMessage | undefined;
         let key: Bytes | undefined;
+        let privacyKey: Bytes | undefined;
         let fabric: Fabric | undefined;
         let keySetId: number | undefined;
+        let sourceNodeId: NodeId | undefined;
         let found = false;
-        for ({ key, keySetId, fabric } of keys) {
+        for (const candidate of keys) {
             try {
+                let packetHeader = header;
+                let decryptAad = aad;
+                if (header.hasPrivacyEnhancements) {
+                    if (privacyHeader === undefined || candidate.privacyKey === undefined) {
+                        logger.debug(`No privacy key for group session candidate ${candidate.keySetId}, skipping`);
+                        continue;
+                    }
+                    const privacyNonce = MessagePrivacy.buildNonce(sessionId, mic);
+                    const deobfuscated = MessagePrivacy.obfuscate(
+                        candidate.fabric.crypto,
+                        candidate.privacyKey,
+                        privacyHeader,
+                        privacyNonce,
+                    );
+                    packetHeader = {
+                        ...header,
+                        ...MessageCodec.decodeObfuscatedHeaderFields(messageFlags, deobfuscated),
+                    };
+                    decryptAad = Bytes.concat(Bytes.of(aad).slice(0, 4), deobfuscated);
+                }
+
+                if (packetHeader.sourceNodeId === undefined) {
+                    throw new UnexpectedDataError("Source Node ID is required for GroupSession decode.");
+                }
+                const nonce = Session.generateNonce(
+                    packetHeader.securityFlags,
+                    packetHeader.messageId,
+                    packetHeader.sourceNodeId,
+                );
                 message = MessageCodec.decodePayload({
-                    header,
-                    applicationPayload: fabric.crypto.decrypt(key, applicationPayload, nonce, aad),
+                    header: packetHeader,
+                    applicationPayload: candidate.fabric.crypto.decrypt(
+                        candidate.key,
+                        applicationPayload,
+                        nonce,
+                        decryptAad,
+                    ),
                 });
+                key = candidate.key;
+                privacyKey = candidate.privacyKey;
+                keySetId = candidate.keySetId;
+                fabric = candidate.fabric;
+                sourceNodeId = packetHeader.sourceNodeId;
                 found = true;
-                break; // Exit loop on first successful decryption
+                break;
             } catch (error) {
+                // A wrong key (including a wrong privacy key, whose garbage header yields a different nonce) fails AEAD
+                // decryption; skip to the next candidate. Genuine parse errors on an authenticated payload propagate.
                 CryptoDecryptError.accept(error);
             }
         }
-        if (!found || !message || !key || !keySetId || !fabric) {
+        if (!found || !message || !key || keySetId === undefined || !fabric || sourceNodeId === undefined) {
             throw new MatterFlowError("Failed to decode group message with any key candidate.");
         }
 
@@ -252,7 +328,7 @@ export class GroupSession extends SecureSession {
             );
         }
 
-        return { message, key, sessionId, sourceNodeId, keySetId, fabric };
+        return { message, key, privacyKey, sessionId, sourceNodeId, keySetId, fabric };
     }
 
     override async close() {
@@ -268,6 +344,7 @@ export namespace GroupSession {
         keySetId: number; // The Group Key Set ID that was used to encrypt the incoming group message.
         peerNodeId: NodeId; //The Target Group Node Id
         operationalGroupKey: Bytes; // The Operational Group Key that was used to encrypt the incoming group message.
+        operationalPrivacyKey?: Bytes;
     }
 
     export function assert(session?: Session, errorText?: string): asserts session is GroupSession {

--- a/packages/protocol/src/session/Session.ts
+++ b/packages/protocol/src/session/Session.ts
@@ -309,6 +309,11 @@ export abstract class Session {
         return this.#channel !== undefined && !!this.#channel?.supportsLargeMessages;
     }
 
+    /** Whether outgoing messages set the privacy ("P") flag and obfuscate the header. Gates encode only; off by default. */
+    get usePrivacy(): boolean {
+        return false;
+    }
+
     get hasActiveExchanges() {
         return !!this.#exchanges.size;
     }

--- a/packages/protocol/src/session/SessionManager.ts
+++ b/packages/protocol/src/session/SessionManager.ts
@@ -516,17 +516,17 @@ export class SessionManager {
      * result in an error.
      */
     groupSessionFromPacket(packet: DecodedPacket, aad: Bytes) {
-        const groupId = packet.header.destGroupId;
-        if (groupId === undefined) {
-            throw new UnexpectedDataError("Group ID is required for GroupSession fromPacket.");
-        }
-        GroupId.assertGroupId(GroupId(groupId));
-
-        const { message, key, sessionId, sourceNodeId, keySetId, fabric } = GroupSession.decode(
+        const { message, key, privacyKey, sessionId, sourceNodeId, keySetId, fabric } = GroupSession.decode(
             this.#context.fabrics,
             packet,
             aad,
         );
+
+        const groupId = message.packetHeader.destGroupId;
+        if (groupId === undefined) {
+            throw new UnexpectedDataError("Group ID is required for GroupSession fromPacket.");
+        }
+        GroupId.assertGroupId(GroupId(groupId));
 
         let session = this.#groupSessions.get(sourceNodeId)?.get("id", sessionId);
         if (session === undefined) {
@@ -536,6 +536,7 @@ export class SessionManager {
                 fabric,
                 keySetId,
                 operationalGroupKey: key,
+                operationalPrivacyKey: privacyKey,
                 peerNodeId: sourceNodeId,
             });
         }

--- a/packages/protocol/test/codec/MessageCodecTest.ts
+++ b/packages/protocol/test/codec/MessageCodecTest.ts
@@ -122,6 +122,80 @@ describe("MessageCodec", () => {
 
             expect(result).deep.equal(DECODED_WITH_SECURED_EXTENSION);
         });
+
+        it("decodes the cleartext prefix of a privacy-enhanced group packet (CHIP vector)", () => {
+            // "private group message" vector from CHIP TestSessionManagerDispatch.cpp
+            const wire = Bytes.fromHex(
+                "067ddb81d926afce24c8a0981bdd44f4e7302b2f915a66c9596290ebe4408217b3c0c921a2fca4e1",
+            );
+            const packet = MessageCodec.decodePacket(wire);
+
+            expect(packet.header.hasPrivacyEnhancements).equals(true);
+            expect(packet.header.sessionId).equals(0xdb7d);
+            expect(packet.header.securityFlags).equals(0x81);
+            expect(packet.header.sessionType).equals(1); // group
+            // Obfuscated fields are not yet decoded:
+            expect(packet.header.messageId).equals(0);
+            expect(packet.header.sourceNodeId).equals(undefined);
+            expect(packet.header.destGroupId).equals(undefined);
+            // The obfuscated region is exposed for the session to deobfuscate (4 + 8 + 2 = 14 bytes):
+            expect(Bytes.toHex(packet.privacyHeader!)).equals("d926afce24c8a0981bdd44f4e730");
+            // Application payload = ciphertext + MIC (6 + 16 = 22 bytes):
+            expect(packet.applicationPayload.byteLength).equals(22);
+        });
+
+        it("rejects a privacy-enhanced packet truncated below the MIC length", () => {
+            // Same CHIP vector but truncated to an 18-byte header + only 8 payload bytes (< 16-byte MIC).
+            const wire = Bytes.fromHex("067ddb81d926afce24c8a0981bdd44f4e7302b2f915a66c95962");
+            expect(() => MessageCodec.decodePacket(wire)).throws(/too short to contain a MIC/);
+        });
+
+        it("decodes obfuscated header fields once deobfuscated", () => {
+            const messageFlags = 0x06; // version 0, source node id + dest group id present
+            const region = Bytes.fromHex("7956341201000000000000000200");
+            const fields = MessageCodec.decodeObfuscatedHeaderFields(messageFlags, region);
+            expect(fields.messageId).equals(0x12345679);
+            expect(fields.sourceNodeId).equals(NodeId(1n));
+            expect(fields.destNodeId).equals(undefined);
+            expect(fields.destGroupId).equals(2);
+        });
+    });
+
+    describe("encode privacy", () => {
+        it("sets the privacy bit in the encoded packet header", () => {
+            const headerBytes = MessageCodec.encodePacketHeader({
+                sessionId: 0xdb7d,
+                sessionType: 1, // group
+                messageId: 0x12345679,
+                destGroupId: 2,
+                sourceNodeId: NodeId(1n),
+                hasPrivacyEnhancements: true,
+                isControlMessage: false,
+                hasMessageExtensions: false,
+            });
+            // security flags byte (index 3) = group (0x01) | privacy (0x80) = 0x81
+            expect(Bytes.of(headerBytes)[3]).equals(0x81);
+        });
+
+        it("encodePacket uses pre-serialized headerBytes when present", () => {
+            const headerBytes = Bytes.fromHex("067ddb81d926afce24c8a0981bdd44f4e730");
+            const applicationPayload = Bytes.fromHex("2b2f915a66c9596290ebe44082177b3c0c921a2fca4e10");
+            const result = MessageCodec.encodePacket({
+                header: {
+                    sessionId: 0xdb7d,
+                    sessionType: 1,
+                    messageId: 0x12345679,
+                    destGroupId: 2,
+                    sourceNodeId: NodeId(1n),
+                    hasPrivacyEnhancements: true,
+                    isControlMessage: false,
+                    hasMessageExtensions: false,
+                },
+                headerBytes,
+                applicationPayload,
+            });
+            expect(Bytes.toHex(result)).equals(Bytes.toHex(Bytes.concat(headerBytes, applicationPayload)));
+        });
     });
 
     describe("encode", () => {

--- a/packages/protocol/test/codec/MessagePrivacyTest.ts
+++ b/packages/protocol/test/codec/MessagePrivacyTest.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MessagePrivacy } from "#codec/MessagePrivacy.js";
+import { Bytes, StandardCrypto } from "#general";
+
+describe("MessagePrivacy", () => {
+    const crypto = new StandardCrypto();
+
+    describe("buildNonce", () => {
+        it("matches the CHIP test vector", () => {
+            const mic = Bytes.fromHex("c5a0063ad5d2518191400dd68c5c163b");
+            const nonce = MessagePrivacy.buildNonce(0x002a, mic);
+            expect(Bytes.toHex(nonce)).equals("002ad2518191400dd68c5c163b");
+        });
+
+        it("rejects a MIC that is not 16 bytes", () => {
+            expect(() => MessagePrivacy.buildNonce(0x002a, Bytes.fromHex("c5a0063ad5d2518191400d"))).throws(
+                /requires a 16-byte MIC/,
+            );
+        });
+    });
+
+    describe("deriveKey", () => {
+        it("matches the CHIP group test vector", async () => {
+            const operationalKey = Bytes.fromHex("ca92d7a0942d1a511a0e26ad074f4c2f");
+            const privacyKey = await MessagePrivacy.deriveKey(crypto, operationalKey);
+            expect(Bytes.toHex(privacyKey)).equals("bfe9da016a765365f2dd97a9f939e425");
+        });
+    });
+
+    describe("obfuscate", () => {
+        const privacyKey = Bytes.fromHex("bfe9da016a765365f2dd97a9f939e425");
+        const privacyNonce = Bytes.fromHex("db7d408217b3c0c921a2fca4e1");
+        const cleartextRegion = Bytes.fromHex("7956341201000000000000000200");
+        const obfuscatedRegion = Bytes.fromHex("d926afce24c8a0981bdd44f4e730");
+
+        it("obfuscates the header region", () => {
+            const result = MessagePrivacy.obfuscate(crypto, privacyKey, cleartextRegion, privacyNonce);
+            expect(Bytes.toHex(result)).equals(Bytes.toHex(obfuscatedRegion));
+        });
+
+        it("is symmetric (deobfuscates)", () => {
+            const result = MessagePrivacy.obfuscate(crypto, privacyKey, obfuscatedRegion, privacyNonce);
+            expect(Bytes.toHex(result)).equals(Bytes.toHex(cleartextRegion));
+        });
+    });
+});

--- a/packages/protocol/test/session/SecureSessionTest.ts
+++ b/packages/protocol/test/session/SecureSessionTest.ts
@@ -5,9 +5,20 @@
  */
 
 import { Message, MessageCodec, SessionType } from "#codec/MessageCodec.js";
-import { b$, Bytes, StandardCrypto } from "#general";
+import { Fabric } from "#fabric/Fabric.js";
+import { FabricManager } from "#fabric/FabricManager.js";
+import { b$, Bytes, Key, PrivateKey, StandardCrypto, StorageBackendMemory, StorageContext } from "#general";
+import { GroupSession } from "#session/GroupSession.js";
 import { NodeSession } from "#session/NodeSession.js";
-import { NodeId } from "#types";
+import { FabricId, FabricIndex, GlobalFabricId, NodeId, VendorId } from "#types";
+
+const TEST_ROOT_PUBLIC_KEY = Bytes.fromHex(
+    "044a9f42b1ca4840d37292bbc7f6a7e11e22200c976fc900dbc98a7a383a641cb8254a2e56d4e295a847943b4e3897c4a773e930277b4d9fbede8a052686bfacfa",
+);
+const TEST_IDENTITY_PROTECTION_KEY = Bytes.fromHex("9bc61cd9c62a2df6d64dfcaa9dc472d4");
+const SEC1_KEY = Bytes.fromHex(
+    "30770201010420aef3484116e9481ec57be0472df41bf499064e5024ad869eca5e889802d48075a00a06082a8648ce3d030107a144034200043c398922452b55caf389c25bd1bca4656952ccb90e8869249ad8474653014cbf95d687965e036b521c51037e6b8cedefca1eb44046694fa08882eed6519decba",
+);
 
 const ENCRYPT_KEY = b$`66951379d0a6d151cf5472cccf13f360`;
 const DECRYPT_KEY = b$`bacb178b2588443d5d5b1e4559e7accc`;
@@ -71,6 +82,101 @@ describe("SecureSession", () => {
             const result = secureSession().encode(MESSAGE);
 
             expect(Bytes.toHex(result.applicationPayload)).to.deep.equal(Bytes.toHex(ENCRYPTED_BYTES));
+        });
+    });
+
+    describe("group privacy", () => {
+        async function groupFabric() {
+            const crypto = new StandardCrypto();
+            const fabric = new Fabric(crypto, {
+                fabricIndex: FabricIndex(1),
+                fabricId: FabricId(BigInt("0x456789ABCDEF1234")),
+                nodeId: NodeId(1),
+                rootNodeId: NodeId(1),
+                globalId: GlobalFabricId(0),
+                keyPair: Key({ sec1: SEC1_KEY }) as PrivateKey,
+                rootPublicKey: TEST_ROOT_PUBLIC_KEY,
+                rootVendorId: VendorId(0),
+                rootCert: new Uint8Array(),
+                identityProtectionKey: new Uint8Array(),
+                operationalIdentityProtectionKey: TEST_IDENTITY_PROTECTION_KEY,
+                intermediateCACert: new Uint8Array(),
+                operationalCert: new Uint8Array(),
+                label: "",
+            });
+
+            const storage = new StorageBackendMemory();
+            storage.initialize();
+            fabric.storage = new StorageContext(storage, ["fabric"]);
+
+            const fabricManager = new FabricManager(crypto);
+            await fabricManager.construction.ready;
+            fabricManager.addFabric(fabric);
+
+            await fabric.groups.setFromGroupKeySet({
+                groupKeySetId: 1,
+                groupKeySecurityPolicy: 0,
+                epochKey0: b$`000102030405060708090a0b0c0d0e0f`,
+                epochStartTime0: 1,
+                epochKey1: null,
+                epochStartTime1: null,
+                epochKey2: null,
+                epochStartTime2: null,
+                groupKeyMulticastPolicy: 0,
+            });
+
+            return { fabric, fabricManager };
+        }
+
+        it("round-trips a group message with privacy enabled", async () => {
+            const { fabric, fabricManager } = await groupFabric();
+            const current = fabric.groups.keySets.currentKeyForId(1);
+            const groupId = 2;
+            const session = new GroupSession({
+                id: current.sessionId!,
+                fabric,
+                keySetId: 1,
+                operationalGroupKey: current.key,
+                operationalPrivacyKey: current.privacyKey,
+                peerNodeId: NodeId(0xffffffffffff0000n | BigInt(groupId)),
+            });
+
+            const message: Message = {
+                packetHeader: {
+                    sessionId: current.sessionId!,
+                    sessionType: SessionType.Group,
+                    messageId: 0x12345679,
+                    destGroupId: groupId,
+                    sourceNodeId: fabric.nodeId,
+                    hasPrivacyEnhancements: true,
+                    isControlMessage: false,
+                    hasMessageExtensions: false,
+                },
+                payloadHeader: {
+                    isInitiatorMessage: true,
+                    requiresAck: false,
+                    messageType: 0x05,
+                    exchangeId: 0x1234,
+                    protocolId: 0x0001,
+                    ackedMessageId: undefined,
+                    hasSecuredExtension: false,
+                },
+                payload: b$`00112233`,
+            };
+
+            const packet = session.encode(message);
+            const wire = MessageCodec.encodePacket(packet);
+
+            expect(Bytes.of(wire)[3] & 0x80).equals(0x80);
+
+            const decodedPacket = MessageCodec.decodePacket(wire);
+            const aad = Bytes.of(wire).slice(0, wire.byteLength - decodedPacket.applicationPayload.byteLength);
+            const result = GroupSession.decode(fabricManager, decodedPacket, aad);
+
+            expect(Bytes.toHex(result.message.payload)).equals("00112233");
+            expect(result.sourceNodeId).equals(fabric.nodeId);
+            expect(result.message.packetHeader.destGroupId).equals(groupId);
+            expect(result.message.packetHeader.messageId).equals(0x12345679);
         });
     });
 });


### PR DESCRIPTION
## Summary

Backport of **#3854** (Matter message privacy) to the `0.16.x` release line.

Group-only message header privacy (spec §4.8 "P" flag): receive always supported, send opt-in via `Session.usePrivacy` and **off by default** (CHIP-aligned), unicast P=1 messages dropped. Reuses AES-CCM for obfuscation (no new primitive). Also includes the independent AES-CCM `byteOffset` fix.

See #3854 for the full design rationale, CHIP-interop proof, and review history.

## Backport notes
- 0.16.x's privacy-relevant code regions were identical to main's pre-feature version, so the feature applied cleanly. Adaptations: import-path style (`#general`), `StorageBackendMemory` (0.16.x), test anchor positions.
- No crypto-layer changes needed — all primitives have identical signatures on 0.16.x.
- `NodeSession` untouched (no unicast privacy). `usePrivacy` group override stays commented-out with its TODO/spec-ref.
- **CI:** enabled `0.16.x` on `build-test.chip.yml` and `chip-tool-tests.yml` (were main-only) so the release line gets full CHIP coverage; `build-test.js.yml` and the controller tests already covered `0.16.x`.

## Testing
- ESM (Node) gates green in the backport worktree: `@matter/general` 518/518, `@matter/protocol` 562/562 (incl. MessagePrivacy, MessageCodec, SecureSession group-privacy round-trip). Build, format, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
