### PR TITLE
WIP: feat(node): ICD idle/active mode (external-driven) & UAT

### DIFF
--- a/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
+++ b/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
@@ -24,13 +24,14 @@ import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { IcdManagementBehavior } from "./IcdManagementBehavior.js";
 import { IcdModeState } from "./IcdMode.js";
 
-// CIP, LITS, and DSLS are all in the base so `this.state.operatingMode`, `this.events.operatingMode$Changed`, and
-// `this.features.dynamicSitLitSupport` typecheck throughout the shared logic. The exported IcdManagementServer
-// resets to CIP-only via `.with(CIP)`.
+// CIP, LITS, DSLS, and UAT are all in the base so `this.state.operatingMode`, `this.events.operatingMode$Changed`,
+// `this.features.dynamicSitLitSupport`, and `this.features.userActiveModeTrigger` typecheck throughout the shared
+// logic. The exported IcdManagementServer resets to CIP-only via `.with(CIP)`.
 const IcdManagementLogicBase = IcdManagementBehavior.with(
     IcdManagement.Feature.CheckInProtocolSupport,
     IcdManagement.Feature.LongIdleTimeSupport,
     IcdManagement.Feature.DynamicSitLitSupport,
+    IcdManagement.Feature.UserActiveModeTrigger,
 );
 
 /**
@@ -46,6 +47,23 @@ const MIN_LIT_ACTIVE_MODE_THRESHOLD = Seconds(5);
  * @see {@link MatterSpecification.v151.Core} § 9.16.7.5.1.1
  */
 const STAY_ACTIVE_PROMISE_FLOOR = Seconds(30);
+
+/**
+ * UserActiveModeTriggerHint bits that require a non-empty UserActiveModeTriggerInstruction. The `*LightsBlink` bits also
+ * depend on the instruction but may leave it empty, so they are excluded.
+ *
+ * @see {@link MatterSpecification.v151.Core} § 9.16.6.7
+ */
+const INSTRUCTION_REQUIRED_TRIGGER_HINTS = [
+    "customInstruction",
+    "actuateSensorSeconds",
+    "actuateSensorTimes",
+    "resetButtonSeconds",
+    "resetButtonTimes",
+    "setupButtonSeconds",
+    "setupButtonTimes",
+    "appDefinedButton",
+] as const;
 
 /**
  * Default device-side ICD Management server implementation. Enables the Check-In Protocol Support (CIP) feature and
@@ -107,6 +125,19 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
             throw new ImplementationError(
                 `LIT ICD requires activeModeThreshold (${Duration.format(Millis(this.state.activeModeThreshold))}) >= ${Duration.format(MIN_LIT_ACTIVE_MODE_THRESHOLD)}`,
             );
+        }
+
+        // @see {@link MatterSpecification.v151.Core} § 9.16.6.7–9.16.6.8 — these trigger hints require a non-empty
+        // instruction string telling the user how to trigger active mode. The generated conformance is "desc" (prose
+        // table), so this coupling is not enforced by the framework and must be checked here.
+        if (this.features.userActiveModeTrigger && !this.state.userActiveModeTriggerInstruction) {
+            const hint = this.state.userActiveModeTriggerHint;
+            const missing = INSTRUCTION_REQUIRED_TRIGGER_HINTS.find(bit => hint[bit]);
+            if (missing !== undefined) {
+                throw new ImplementationError(
+                    `userActiveModeTriggerHint.${missing} requires a non-empty userActiveModeTriggerInstruction`,
+                );
+            }
         }
 
         this.reactTo((this.endpoint.lifecycle as NodeLifecycle).online, this.#online);
@@ -385,6 +416,16 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
     }
 
     /**
+     * Simulate the device-physical User Active Mode Trigger (button press, power cycle, etc.): wakes the device into
+     * Active mode. UAT exposes no Matter command — this is a device-side action.
+     *
+     * @see {@link MatterSpecification.v151.Core} § 9.16.6.7
+     */
+    triggerUserActiveMode() {
+        this.requestActiveMode();
+    }
+
+    /**
      * Put the device into Idle mode (e.g. when the application/test decides to "sleep"). Forces idle unconditionally.
      * No-op before the node is online.
      *
@@ -539,6 +580,7 @@ export namespace IcdManagementBaseServer {
         stayActive(requestedDuration: Duration): Duration;
         requestActiveMode(): void;
         enterIdleMode(): void;
+        triggerUserActiveMode(): void;
     };
 }
 

--- a/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
+++ b/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
@@ -54,9 +54,8 @@ const STAY_ACTIVE_PROMISE_FLOOR = Seconds(30);
  *
  * ## Extension points
  *
- * Override {@link stayActive} to react to StayActiveRequest: extend the device's active period for the requested time
- * and return the duration actually promised. The default implementation only honors the spec minimum and does not
- * track active time, so a device that wants to genuinely stay awake should override it.
+ * Override {@link stayActive} to customize the StayActiveRequest response: return the duration actually promised.
+ * The default drives the mode machine and honors the spec floor (`min(30s, requested)`); override for a custom policy.
  *
  * ## Long Idle Time (LITS)
  *
@@ -361,16 +360,38 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
     }
 
     /**
-     * Extension point: return the duration for which the device promises to stay active.
-     *
-     * The default honors the spec floor only (the promise is at least the smaller of 30s and the request); with no
-     * active-mode machine yet it neither tracks nor extends real active time. Phase 2b overrides this to fold in
-     * remaining active time and actually extend active mode; apps may override for custom power policy.
+     * Extend the device's active window by the requested duration and return the duration actually promised: the real
+     * remaining active duration, never less than the spec floor of `min(30s, requested)`. Override for a custom policy.
      *
      * @see {@link MatterSpecification.v151.Core} § 9.16.7.5.1.1
      */
     protected stayActive(requestedDuration: Duration): Duration {
-        return Duration.min(STAY_ACTIVE_PROMISE_FLOOR, requestedDuration);
+        const floor = Duration.min(STAY_ACTIVE_PROMISE_FLOOR, requestedDuration);
+        const modeState = this.internal.modeState;
+        if (modeState === undefined) {
+            return floor;
+        }
+        return Duration.max(modeState.requestActive(requestedDuration), floor);
+    }
+
+    /**
+     * Wake the device into Active mode for a full active window (the idle→active transition; on a CIP device this is
+     * where Phase 2c sends Check-Ins). No-op before the node is online.
+     *
+     * @see {@link MatterSpecification.v151.Core} § 9.15.1
+     */
+    requestActiveMode() {
+        this.internal.modeState?.requestActive(Millis(this.state.activeModeDuration));
+    }
+
+    /**
+     * Put the device into Idle mode (e.g. when the application/test decides to "sleep"). Forces idle unconditionally.
+     * No-op before the node is online.
+     *
+     * @see {@link MatterSpecification.v151.Core} § 9.15.1
+     */
+    enterIdleMode() {
+        this.internal.modeState?.enterIdle();
     }
 
     /**
@@ -516,6 +537,8 @@ export namespace IcdManagementBaseServer {
 
     export declare const ExtensionInterface: {
         stayActive(requestedDuration: Duration): Duration;
+        requestActiveMode(): void;
+        enterIdleMode(): void;
     };
 }
 

--- a/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
+++ b/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
@@ -79,8 +79,8 @@ const INSTRUCTION_REQUIRED_TRIGGER_HINTS = [
  * idle→active wake; it stays active until told to sleep.
  *
  * Events (subscribe via `events.<name>`):
- * - `activeModeEntered` — entered active mode (initial power-up or an idle→active wake). On a CIP device this is where
- *   Phase 2c will send Check-Ins. Hook hardware power-up here.
+ * - `activeModeEntered` — entered active mode (initial power-up or an idle→active wake). On a CIP device this is the
+ *   idle→active transition at which Check-Ins are sent (§ 9.15.1). Hook hardware power-up here.
  * - `idleModeEntered` — entered idle mode. Hook hardware power-down here.
  * - `mayEnterIdleMode` — the active window (≥ `activeModeDuration`, extended by network activity and StayActive) has
  *   elapsed while quiet: the application may now put the device to sleep. Advisory only — no transition happens.
@@ -97,7 +97,7 @@ const INSTRUCTION_REQUIRED_TRIGGER_HINTS = [
  *
  * **For tests / a cert harness:** drive transitions deterministically — call {@link enterIdleMode} to go quiet, then
  * {@link requestActiveMode}/{@link triggerUserActiveMode} (or send any request to the device) to force the idle→active
- * transition that triggers Check-In sending (Phase 2c). Advance a mock time source to elapse the active window.
+ * transition that triggers Check-In sending. Advance a mock time source to elapse the active window.
  *
  * ## Extension points
  *
@@ -203,7 +203,7 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
             }
 
             // Idle/active mode machine, externally driven. Created once; (re)started below on every online, paused on
-            // goingOffline. The idle→active transition is the Check-In send point (Phase 2c hooks activeModeEntered).
+            // goingOffline. The idle→active transition is the Check-In send point.
             // @see {@link MatterSpecification.v151.Core} § 9.15.1
             this.internal.modeState = new IcdModeState({
                 activeModeDuration: Millis(this.state.activeModeDuration),
@@ -443,7 +443,7 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
 
     /**
      * Wake the device into Active mode for a full active window (the idle→active transition; on a CIP device this is
-     * where Phase 2c sends Check-Ins). No-op before the node is online.
+     * where a CIP ICD sends Check-Ins). No-op before the node is online.
      *
      * @see {@link MatterSpecification.v151.Core} § 9.15.1
      */
@@ -604,7 +604,7 @@ export namespace IcdManagementBaseServer {
     }
 
     export class Events extends IcdManagementLogicBase.Events {
-        /** Idle→Active transition (also fires on initial power-up); hook hardware power-up / Check-In send (Phase 2c). */
+        /** Idle→Active transition (also fires on initial power-up); hook hardware power-up / Check-In send. */
         activeModeEntered = Observable();
         /** Active→Idle transition; hook hardware power-down. */
         idleModeEntered = Observable();

--- a/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
+++ b/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
@@ -70,6 +70,35 @@ const INSTRUCTION_REQUIRED_TRIGGER_HINTS = [
  * validates spec constraints on the timing attributes at startup. Use {@link IcdManagementServer.with} to specialize
  * for additional features, or extend this class to override its behavior.
  *
+ * ## Idle/active mode
+ *
+ * The server tracks the ICD idle/active mode (distinct from the SIT/LIT {@link IcdManagement.OperatingMode}). matter.js
+ * nodes never truly sleep and stay reachable, so the mode is **fully externally driven** — the device never sleeps or
+ * wakes on its own. It is meant for spec/cert completeness, for verifying a controller against a real ICD peer, and as
+ * power hooks for a node that proxies real sleepy hardware. The device enters active mode at startup and on every
+ * idle→active wake; it stays active until told to sleep.
+ *
+ * Events (subscribe via `events.<name>`):
+ * - `activeModeEntered` — entered active mode (initial power-up or an idle→active wake). On a CIP device this is where
+ *   Phase 2c will send Check-Ins. Hook hardware power-up here.
+ * - `idleModeEntered` — entered idle mode. Hook hardware power-down here.
+ * - `mayEnterIdleMode` — the active window (≥ `activeModeDuration`, extended by network activity and StayActive) has
+ *   elapsed while quiet: the application may now put the device to sleep. Advisory only — no transition happens.
+ *
+ * Runtime methods:
+ * - {@link requestActiveMode} — wake into active mode for a full active window.
+ * - {@link enterIdleMode} — force idle now (unconditional); pairs with `mayEnterIdleMode`.
+ * - {@link triggerUserActiveMode} — simulate the device-physical User Active Mode Trigger (UAT feature; wakes the
+ *   device). UAT exposes no Matter command.
+ * - {@link setOperatingMode} — switch SIT↔LIT at runtime (DSLS feature; orthogonal to idle/active mode).
+ *
+ * Inbound network activity also extends/wakes active mode automatically. Idle/active transitions only happen via these
+ * methods, a StayActiveRequest, or inbound activity — never on an internal timer.
+ *
+ * **For tests / a cert harness:** drive transitions deterministically — call {@link enterIdleMode} to go quiet, then
+ * {@link requestActiveMode}/{@link triggerUserActiveMode} (or send any request to the device) to force the idle→active
+ * transition that triggers Check-In sending (Phase 2c). Advance a mock time source to elapse the active window.
+ *
  * ## Extension points
  *
  * Override {@link stayActive} to customize the StayActiveRequest response: return the duration actually promised.
@@ -89,6 +118,13 @@ const INSTRUCTION_REQUIRED_TRIGGER_HINTS = [
  * When also enabled via `IcdManagement.Feature.DynamicSitLitSupport`, the application may call
  * {@link setOperatingMode} at runtime to switch between SIT and LIT even when registrations exist — for example
  * when a mains-powered device switches to battery.
+ *
+ * ## User Active Mode Trigger (UAT)
+ *
+ * Enable with `IcdManagement.Feature.UserActiveModeTrigger`. The application configures `userActiveModeTriggerHint`
+ * (which physical action wakes the device) and, when the hint requires it, `userActiveModeTriggerInstruction`
+ * (initialization throws if a hint bit that depends on the instruction is set without one). UAT defines no Matter
+ * command — call {@link triggerUserActiveMode} to simulate the physical trigger.
  *
  * @see {@link MatterSpecification.v151.Core} § 9.16
  */

--- a/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
+++ b/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { NodeActivity } from "#behavior/context/NodeActivity.js";
 import { NodeLifecycle } from "#node/NodeLifecycle.js";
-import { Bytes, Duration, ImplementationError, Millis, Seconds } from "@matter/general";
+import { Bytes, Duration, ImplementationError, Millis, Observable, Seconds } from "@matter/general";
 import { AccessLevel, DataModelPath, fabricIdx, field, listOf, nodeId, nonvolatile, octstr } from "@matter/model";
 import {
     AccessControl,
@@ -21,6 +22,7 @@ import {
 import { FabricIndex, NodeId, Status, StatusResponseError } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { IcdManagementBehavior } from "./IcdManagementBehavior.js";
+import { IcdModeState } from "./IcdMode.js";
 
 // CIP, LITS, and DSLS are all in the base so `this.state.operatingMode`, `this.events.operatingMode$Changed`, and
 // `this.features.dynamicSitLitSupport` typecheck throughout the shared logic. The exported IcdManagementServer
@@ -76,6 +78,7 @@ const STAY_ACTIVE_PROMISE_FLOOR = Seconds(30);
 export class IcdManagementBaseServer extends IcdManagementLogicBase {
     declare internal: IcdManagementBaseServer.Internal;
     declare readonly state: IcdManagementBaseServer.State;
+    declare readonly events: IcdManagementBaseServer.Events;
 
     override initialize() {
         const idleModeDuration = Seconds(this.state.idleModeDuration);
@@ -132,6 +135,25 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
             } else {
                 this.#refreshIcdAdvertisementCache();
             }
+
+            // Idle/active mode machine, externally driven. Created once; (re)started below on every online, paused on
+            // goingOffline. The idle→active transition is the Check-In send point (Phase 2c hooks activeModeEntered).
+            // @see {@link MatterSpecification.v151.Core} § 9.15.1
+            this.internal.modeState = new IcdModeState({
+                activeModeDuration: Millis(this.state.activeModeDuration),
+                activeModeThreshold: Millis(this.state.activeModeThreshold),
+                onActiveEntered: () => this.events.activeModeEntered.emit(),
+                onIdleEntered: () => this.events.idleModeEntered.emit(),
+                onMayEnterIdle: () => this.events.mayEnterIdleMode.emit(),
+            });
+            this.reactTo((this.endpoint.lifecycle as NodeLifecycle).goingOffline, this.#onGoingOffline);
+
+            // Must use .on() directly: reactTo wraps each invocation in a NodeActivity whose close re-emits inactive,
+            // causing infinite recursion.
+            const inactive = this.env.get(NodeActivity).inactive;
+            const observer = () => this.internal.modeState?.noteActivity();
+            inactive.on(observer);
+            this.internal.inactiveObserver = { inactive, observer };
         }
 
         // DeviceAdvertiser is closed and recreated on each stop/start cycle; register the provider every time.
@@ -167,6 +189,21 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
                 clientType: client.clientType,
             });
         }
+
+        this.internal.modeState?.start();
+    }
+
+    #onGoingOffline() {
+        this.internal.modeState?.stop();
+    }
+
+    override async [Symbol.asyncDispose]() {
+        const { inactive, observer } = this.internal.inactiveObserver ?? {};
+        if (inactive && observer) {
+            inactive.off(observer);
+        }
+        this.internal.modeState?.[Symbol.dispose]();
+        await super[Symbol.asyncDispose]?.();
     }
 
     /**
@@ -462,6 +499,19 @@ export namespace IcdManagementBaseServer {
         currentIcdAdvertisement?: IcdAdvertisement;
         /** Runtime-only; not persisted, so a restart reverts to the registration-driven mode. {@link IcdManagementBaseServer.setOperatingMode} */
         forcedOperatingMode?: IcdManagement.OperatingMode;
+        /** Idle/active mode machine; created once on first online, (re)started on each subsequent online. */
+        modeState?: IcdModeState;
+        /** Direct NodeActivity.inactive subscription, stored for cleanup (reactTo would recurse). */
+        inactiveObserver?: { inactive: NodeActivity["inactive"]; observer: () => void };
+    }
+
+    export class Events extends IcdManagementLogicBase.Events {
+        /** Idle→Active transition (also fires on initial power-up); hook hardware power-up / Check-In send (Phase 2c). */
+        activeModeEntered = Observable();
+        /** Active→Idle transition; hook hardware power-down. */
+        idleModeEntered = Observable();
+        /** Active window elapsed and quiet: the app may now put the device to sleep via enterIdleMode. */
+        mayEnterIdleMode = Observable();
     }
 
     export declare const ExtensionInterface: {

--- a/packages/node/src/behaviors/icd-management/IcdMode.ts
+++ b/packages/node/src/behaviors/icd-management/IcdMode.ts
@@ -16,7 +16,7 @@ export interface IcdModeStateOptions {
     activeModeDuration: Duration;
     /** Active-window extension granted per network activity. @see {@link MatterSpecification.v151.Core} § 9.16.6.3 */
     activeModeThreshold: Duration;
-    /** Entered Active mode — initial power-up or an idle→active wake. The Check-In send point (Phase 2c). */
+    /** Entered Active mode — initial power-up or an idle→active wake. The Check-In send point. */
     onActiveEntered: () => void;
     /** Active→Idle transition (device went idle). */
     onIdleEntered: () => void;

--- a/packages/node/src/behaviors/icd-management/IcdMode.ts
+++ b/packages/node/src/behaviors/icd-management/IcdMode.ts
@@ -1,0 +1,151 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Duration, Millis, Time, Timer, Timespan, Timestamp } from "@matter/general";
+
+export enum IcdMode {
+    Idle = "idle",
+    Active = "active",
+}
+
+export interface IcdModeStateOptions {
+    /** Minimum active-window length after entering Active mode. @see {@link MatterSpecification.v151.Core} § 9.16.6.2 */
+    activeModeDuration: Duration;
+    /** Active-window extension granted per network activity. @see {@link MatterSpecification.v151.Core} § 9.16.6.3 */
+    activeModeThreshold: Duration;
+    /** Entered Active mode — initial power-up or an idle→active wake. The Check-In send point (Phase 2c). */
+    onActiveEntered: () => void;
+    /** Active→Idle transition (device went idle). */
+    onIdleEntered: () => void;
+    /** Active window elapsed with no further activity: the device may now be put to sleep. */
+    onMayEnterIdle: () => void;
+}
+
+/**
+ * Device-side ICD idle/active mode, fully externally driven.
+ *
+ * matter.js nodes never truly sleep and stay reachable; this models the logical mode for spec/cert completeness,
+ * controller verification, and app power hooks. It never cycles on its own: the single one-shot active-window timer
+ * only signals `onMayEnterIdle`; all transitions are driven by {@link start}/{@link stop}, {@link enterIdle},
+ * {@link requestActive}, and {@link noteActivity}. Distinct from the ICD SIT/LIT OperatingMode.
+ *
+ * @see {@link MatterSpecification.v151.Core} § 9.15.1, § 9.16
+ */
+export class IcdModeState {
+    readonly #activeModeDuration: Duration;
+    readonly #activeModeThreshold: Duration;
+    readonly #onActiveEntered: () => void;
+    readonly #onIdleEntered: () => void;
+    readonly #onMayEnterIdle: () => void;
+
+    #mode = IcdMode.Idle;
+    #running = false;
+    #activeUntil = Timestamp(0);
+    #activeTimer?: Timer;
+
+    constructor(options: IcdModeStateOptions) {
+        this.#activeModeDuration = options.activeModeDuration;
+        this.#activeModeThreshold = options.activeModeThreshold;
+        this.#onActiveEntered = options.onActiveEntered;
+        this.#onIdleEntered = options.onIdleEntered;
+        this.#onMayEnterIdle = options.onMayEnterIdle;
+    }
+
+    get mode() {
+        return this.#mode;
+    }
+
+    get isActive() {
+        return this.#mode === IcdMode.Active;
+    }
+
+    /** Node online: enter Active mode and begin tracking. Idempotent. */
+    start() {
+        if (this.#running) {
+            return;
+        }
+        this.#running = true;
+        this.#enterActive(this.#activeModeDuration);
+    }
+
+    /** Node going offline: pause; stop the active-window timer without emitting transitions. Idempotent. */
+    stop() {
+        this.#running = false;
+        this.#activeTimer?.stop();
+        this.#mode = IcdMode.Idle;
+    }
+
+    /** Record network activity: extend the active window if Active, or wake to Active if Idle (idle→active). */
+    noteActivity() {
+        if (!this.#running) {
+            return;
+        }
+        if (this.#mode === IcdMode.Idle) {
+            this.#enterActive(this.#activeModeThreshold);
+        } else {
+            this.#scheduleActiveFor(this.#activeModeThreshold);
+        }
+    }
+
+    /**
+     * Force Active mode for at least `duration`, waking if Idle. Returns the total remaining Active-window duration the
+     * device is now committed to.
+     */
+    requestActive(duration: Duration): Duration {
+        if (!this.#running) {
+            return Millis(0);
+        }
+        if (this.#mode === IcdMode.Idle) {
+            this.#enterActive(duration);
+        } else {
+            this.#scheduleActiveFor(duration);
+        }
+        return this.#remainingActive();
+    }
+
+    /** Force Idle mode now (unconditional — harness/app control). No-op when not running or already Idle. */
+    enterIdle() {
+        if (!this.#running || this.#mode === IcdMode.Idle) {
+            return;
+        }
+        this.#activeTimer?.stop();
+        this.#mode = IcdMode.Idle;
+        this.#onIdleEntered();
+    }
+
+    [Symbol.dispose]() {
+        this.stop();
+    }
+
+    #remainingActive(): Duration {
+        return Duration.max(Millis(0), Timespan(Time.nowMs, this.#activeUntil).duration);
+    }
+
+    #enterActive(forAtLeast: Duration) {
+        this.#mode = IcdMode.Active;
+        this.#activeUntil = Timestamp(0); // reset so the next schedule sets the floor from now
+        this.#scheduleActiveFor(Duration.max(this.#activeModeDuration, forAtLeast));
+        this.#onActiveEntered();
+    }
+
+    /** Extend the active deadline to at least now + `fromNow`, never shortening it; rearm the one-shot window timer. */
+    #scheduleActiveFor(fromNow: Duration) {
+        const candidate = Timestamp(Time.nowMs + fromNow);
+        if (candidate <= this.#activeUntil) {
+            return;
+        }
+        this.#activeUntil = candidate;
+        this.#activeTimer?.stop();
+        this.#activeTimer = Time.getTimer("icd-active-window", this.#remainingActive(), () =>
+            this.#onWindowExpired(),
+        ).start();
+    }
+
+    #onWindowExpired() {
+        this.#activeTimer?.stop();
+        this.#onMayEnterIdle();
+    }
+}

--- a/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
@@ -799,7 +799,7 @@ describe("IcdManagementServer", () => {
         };
 
         it("triggerUserActiveMode wakes an idle device", async () => {
-            const events: string[] = [];
+            const events = new Array<string>();
             const device = await MockServerNode.createOnline(MockServerNode.RootEndpoint.with(uatServer), uatConfig);
             device.eventsOf(IcdManagementServer).activeModeEntered.on(() => void events.push("active"));
             await device.act(agent => agent.get(IcdManagementServer).enterIdleMode());
@@ -1006,7 +1006,7 @@ describe("IcdManagementServer", () => {
         };
 
         it("starts in active mode and emits activeModeEntered on online", async () => {
-            const events: string[] = [];
+            const events = new Array<string>();
             const device = await MockServerNode.create(RootWithIcd, idleActiveConfig);
             device.eventsOf(IcdManagementServer).activeModeEntered.on(() => void events.push("active"));
             device.eventsOf(IcdManagementServer).idleModeEntered.on(() => void events.push("idle"));
@@ -1017,7 +1017,7 @@ describe("IcdManagementServer", () => {
         });
 
         it("signals mayEnterIdleMode after the active window without transitioning", async () => {
-            const events: string[] = [];
+            const events = new Array<string>();
             const device = await MockServerNode.createOnline(RootWithIcdOnline, idleActiveConfig);
             device.eventsOf(IcdManagementServer).idleModeEntered.on(() => void events.push("idle"));
             device.eventsOf(IcdManagementServer).mayEnterIdleMode.on(() => void events.push("may"));
@@ -1027,7 +1027,7 @@ describe("IcdManagementServer", () => {
         });
 
         it("inbound node activity extends the active window", async () => {
-            const events: string[] = [];
+            const events = new Array<string>();
             const device = await MockServerNode.createOnline(RootWithIcdOnline, idleActiveConfig);
             device.eventsOf(IcdManagementServer).mayEnterIdleMode.on(() => void events.push("may"));
             await MockTime.advance(1500);
@@ -1040,7 +1040,7 @@ describe("IcdManagementServer", () => {
         });
 
         it("requestActiveMode wakes an idle device", async () => {
-            const events: string[] = [];
+            const events = new Array<string>();
             const device = await MockServerNode.createOnline(RootWithIcdOnline, idleActiveConfig);
             device.eventsOf(IcdManagementServer).activeModeEntered.on(() => void events.push("active"));
             await device.act(agent => agent.get(IcdManagementServer).enterIdleMode());
@@ -1050,7 +1050,7 @@ describe("IcdManagementServer", () => {
         });
 
         it("enterIdleMode forces idle unconditionally", async () => {
-            const events: string[] = [];
+            const events = new Array<string>();
             const device = await MockServerNode.createOnline(RootWithIcdOnline, idleActiveConfig);
             device.eventsOf(IcdManagementServer).idleModeEntered.on(() => void events.push("idle"));
             await device.act(agent => agent.get(IcdManagementServer).enterIdleMode()); // before window elapses
@@ -1080,7 +1080,7 @@ describe("IcdManagementServer", () => {
         });
 
         it("stayActive extends an already-active window without re-emitting activeModeEntered", async () => {
-            const events: string[] = [];
+            const events = new Array<string>();
             const device = await MockServerNode.createOnline(RootWithIcdOnline, idleActiveConfig);
             device.eventsOf(IcdManagementServer).activeModeEntered.on(() => void events.push("active"));
             // Device is already Active; stayActiveRequest must extend the window without firing activeModeEntered again.

--- a/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
@@ -781,6 +781,66 @@ describe("IcdManagementServer", () => {
         });
     });
 
+    describe("UserActiveModeTrigger (UAT)", () => {
+        const uatServer = IcdManagementServer.with(
+            IcdManagement.Feature.CheckInProtocolSupport,
+            IcdManagement.Feature.UserActiveModeTrigger,
+        );
+
+        const uatConfig = {
+            icdManagement: {
+                idleModeDuration: 4,
+                maximumCheckInBackoff: 4,
+                activeModeDuration: 2000,
+                activeModeThreshold: 1000,
+                userActiveModeTriggerHint: { customInstruction: true },
+                userActiveModeTriggerInstruction: "Press and hold the button for 5s",
+            },
+        };
+
+        it("triggerUserActiveMode wakes an idle device", async () => {
+            const events: string[] = [];
+            const device = await MockServerNode.createOnline(MockServerNode.RootEndpoint.with(uatServer), uatConfig);
+            device.eventsOf(IcdManagementServer).activeModeEntered.on(() => void events.push("active"));
+            await device.act(agent => agent.get(IcdManagementServer).enterIdleMode());
+            await device.act(agent => agent.get(IcdManagementServer).triggerUserActiveMode());
+            expect(events).deep.equals(["active"]);
+            await device.close();
+        });
+
+        it("rejects a CustomInstruction hint without an instruction string", async () => {
+            await expect(
+                MockServerNode.create(ServerNode.RootEndpoint.with(uatServer), {
+                    icdManagement: {
+                        userActiveModeTriggerHint: { customInstruction: true },
+                        userActiveModeTriggerInstruction: "",
+                    },
+                }),
+            ).rejectedWith("Behaviors have errors");
+        });
+
+        it("rejects any instruction-dependent hint without an instruction string", async () => {
+            await expect(
+                MockServerNode.create(ServerNode.RootEndpoint.with(uatServer), {
+                    icdManagement: {
+                        userActiveModeTriggerHint: { resetButtonSeconds: true },
+                        userActiveModeTriggerInstruction: "",
+                    },
+                }),
+            ).rejectedWith("Behaviors have errors");
+        });
+
+        it("accepts a hint that does not depend on the instruction with an empty instruction", async () => {
+            const device = await MockServerNode.create(ServerNode.RootEndpoint.with(uatServer), {
+                icdManagement: {
+                    userActiveModeTriggerHint: { powerCycle: true },
+                    userActiveModeTriggerInstruction: "",
+                },
+            });
+            await device.close();
+        });
+    });
+
     describe("DynamicSitLitSupport (DSLS) setOperatingMode", () => {
         const dslsServer = IcdManagementServer.with(
             IcdManagement.Feature.CheckInProtocolSupport,

--- a/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { NodeActivity } from "#behavior/context/NodeActivity.js";
 import { IcdManagementClient, IcdManagementServer } from "#behaviors/icd-management";
 import { OperationalCredentialsClient } from "#behaviors/operational-credentials";
 import { ServerNode } from "#node/index.js";
@@ -17,6 +18,7 @@ import { MockServerNode } from "../../node/mock-server-node.js";
 import { MockSite } from "../../node/mock-site.js";
 
 const RootWithIcd = ServerNode.RootEndpoint.with(IcdManagementServer);
+const RootWithIcdOnline = MockServerNode.RootEndpoint.with(IcdManagementServer);
 
 /**
  * Minimal mock advertiser that records ServiceDescriptions passed to advertise().
@@ -929,6 +931,52 @@ describe("IcdManagementServer", () => {
                     ),
                 ),
             ).rejectedWith(/requires the LongIdleTimeSupport feature/i);
+        });
+    });
+
+    describe("idle/active mode", () => {
+        // idleModeDuration (seconds) must be >= activeModeDuration (ms) and maximumCheckInBackoff >= idleModeDuration.
+        const idleActiveConfig = {
+            icdManagement: {
+                idleModeDuration: 4,
+                maximumCheckInBackoff: 4,
+                activeModeDuration: 2000,
+                activeModeThreshold: 1000,
+            },
+        };
+
+        it("starts in active mode and emits activeModeEntered on online", async () => {
+            const events: string[] = [];
+            const device = await MockServerNode.create(RootWithIcd, idleActiveConfig);
+            device.eventsOf(IcdManagementServer).activeModeEntered.on(() => void events.push("active"));
+            device.eventsOf(IcdManagementServer).idleModeEntered.on(() => void events.push("idle"));
+            device.eventsOf(IcdManagementServer).mayEnterIdleMode.on(() => void events.push("may"));
+            await MockTime.resolve(device.start());
+            expect(events).deep.equals(["active"]);
+            await device.close();
+        });
+
+        it("signals mayEnterIdleMode after the active window without transitioning", async () => {
+            const events: string[] = [];
+            const device = await MockServerNode.createOnline(RootWithIcdOnline, idleActiveConfig);
+            device.eventsOf(IcdManagementServer).idleModeEntered.on(() => void events.push("idle"));
+            device.eventsOf(IcdManagementServer).mayEnterIdleMode.on(() => void events.push("may"));
+            await MockTime.advance(2000);
+            expect(events).deep.equals(["may"]);
+            await device.close();
+        });
+
+        it("inbound node activity extends the active window", async () => {
+            const events: string[] = [];
+            const device = await MockServerNode.createOnline(RootWithIcdOnline, idleActiveConfig);
+            device.eventsOf(IcdManagementServer).mayEnterIdleMode.on(() => void events.push("may"));
+            await MockTime.advance(1500);
+            device.env.get(NodeActivity).begin("test").close(); // both inactive emissions call noteActivity; window extends to t+1000=2500ms
+            await MockTime.advance(900); // t=2400: not yet
+            expect(events).deep.equals([]);
+            await MockTime.advance(200); // t=2600: window elapsed
+            expect(events).deep.equals(["may"]);
+            await device.close();
         });
     });
 });

--- a/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
@@ -978,5 +978,58 @@ describe("IcdManagementServer", () => {
             expect(events).deep.equals(["may"]);
             await device.close();
         });
+
+        it("requestActiveMode wakes an idle device", async () => {
+            const events: string[] = [];
+            const device = await MockServerNode.createOnline(RootWithIcdOnline, idleActiveConfig);
+            device.eventsOf(IcdManagementServer).activeModeEntered.on(() => void events.push("active"));
+            await device.act(agent => agent.get(IcdManagementServer).enterIdleMode());
+            await device.act(agent => agent.get(IcdManagementServer).requestActiveMode());
+            expect(events).deep.equals(["active"]); // one wake after the idle
+            await device.close();
+        });
+
+        it("enterIdleMode forces idle unconditionally", async () => {
+            const events: string[] = [];
+            const device = await MockServerNode.createOnline(RootWithIcdOnline, idleActiveConfig);
+            device.eventsOf(IcdManagementServer).idleModeEntered.on(() => void events.push("idle"));
+            await device.act(agent => agent.get(IcdManagementServer).enterIdleMode()); // before window elapses
+            expect(events).deep.equals(["idle"]);
+            await device.close();
+        });
+
+        it("stayActive extends the active window and promises the real remaining duration", async () => {
+            const device = await MockServerNode.createOnline(RootWithIcdOnline, idleActiveConfig);
+            await device.act(agent => agent.get(IcdManagementServer).enterIdleMode());
+            const res = await device.act(agent =>
+                agent.get(IcdManagementServer).stayActiveRequest({ stayActiveDuration: 45000 }),
+            );
+            expect(res.promisedActiveDuration).equals(45000);
+            await device.close();
+        });
+
+        it("stayActive honors the 30s floor for a short request", async () => {
+            const device = await MockServerNode.createOnline(RootWithIcdOnline, idleActiveConfig);
+            await device.act(agent => agent.get(IcdManagementServer).enterIdleMode());
+            const res = await device.act(agent =>
+                agent.get(IcdManagementServer).stayActiveRequest({ stayActiveDuration: 10 }),
+            );
+            // 10ms request while idle: window floor = activeModeDuration 2s; promise = max(2000, min(30000,10)) = 2000.
+            expect(res.promisedActiveDuration).equals(2000);
+            await device.close();
+        });
+
+        it("stayActive extends an already-active window without re-emitting activeModeEntered", async () => {
+            const events: string[] = [];
+            const device = await MockServerNode.createOnline(RootWithIcdOnline, idleActiveConfig);
+            device.eventsOf(IcdManagementServer).activeModeEntered.on(() => void events.push("active"));
+            // Device is already Active; stayActiveRequest must extend the window without firing activeModeEntered again.
+            const res = await device.act(agent =>
+                agent.get(IcdManagementServer).stayActiveRequest({ stayActiveDuration: 45000 }),
+            );
+            expect(res.promisedActiveDuration).equals(45000);
+            expect(events).deep.equals([]); // no spurious activeModeEntered on an already-active device
+            await device.close();
+        });
     });
 });

--- a/packages/node/test/behaviors/icd-management/IcdModeTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdModeTest.ts
@@ -8,7 +8,7 @@ import { Seconds } from "@matter/general";
 import { IcdMode, IcdModeState } from "../../../src/behaviors/icd-management/IcdMode.js";
 
 function makeState() {
-    const events: string[] = [];
+    const events = new Array<string>();
     const state = new IcdModeState({
         activeModeDuration: Seconds(2),
         activeModeThreshold: Seconds(1),

--- a/packages/node/test/behaviors/icd-management/IcdModeTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdModeTest.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Seconds } from "@matter/general";
+import { IcdMode, IcdModeState } from "../../../src/behaviors/icd-management/IcdMode.js";
+
+function makeState() {
+    const events: string[] = [];
+    const state = new IcdModeState({
+        activeModeDuration: Seconds(2),
+        activeModeThreshold: Seconds(1),
+        onActiveEntered: () => events.push("active"),
+        onIdleEntered: () => events.push("idle"),
+        onMayEnterIdle: () => events.push("may-idle"),
+    });
+    return { state, events };
+}
+
+describe("IcdModeState", () => {
+    beforeEach(() => MockTime.reset());
+
+    it("enters active mode on start", () => {
+        const { state, events } = makeState();
+        state.start();
+        expect(state.mode).equals(IcdMode.Active);
+        expect(events).deep.equals(["active"]);
+    });
+
+    it("signals may-enter-idle after the active window but stays active (no auto-transition)", async () => {
+        const { state, events } = makeState();
+        state.start();
+        await MockTime.advance(2000); // activeModeDuration
+        expect(events).deep.equals(["active", "may-idle"]);
+        expect(state.mode).equals(IcdMode.Active); // still active until told to sleep
+        await MockTime.advance(60000);
+        expect(events).deep.equals(["active", "may-idle"]); // nothing auto-cycles
+    });
+
+    it("enters idle only when told, unconditionally", () => {
+        const { state, events } = makeState();
+        state.start();
+        state.enterIdle(); // forced, even before the window elapsed
+        expect(state.mode).equals(IcdMode.Idle);
+        expect(events).deep.equals(["active", "idle"]);
+    });
+
+    it("comes back to active on requestActive while idle", () => {
+        const { state, events } = makeState();
+        state.start();
+        state.enterIdle();
+        const promised = state.requestActive(Seconds(5));
+        expect(state.mode).equals(IcdMode.Active);
+        expect(promised).equals(Seconds(5)); // 5s > activeModeDuration floor
+        expect(events).deep.equals(["active", "idle", "active"]);
+    });
+
+    it("comes back to active on activity while idle", () => {
+        const { state, events } = makeState();
+        state.start();
+        state.enterIdle();
+        state.noteActivity();
+        expect(state.mode).equals(IcdMode.Active);
+        expect(events).deep.equals(["active", "idle", "active"]);
+    });
+
+    it("activity extends the active window, deferring may-enter-idle, never shortening", async () => {
+        const { state, events } = makeState();
+        state.start();
+        await MockTime.advance(1500); // 0.5s before the 2s window
+        state.noteActivity(); // window -> 1.5s + 1s threshold = 2.5s
+        await MockTime.advance(900); // t=2.4s: not yet
+        expect(events).deep.equals(["active"]);
+        await MockTime.advance(200); // t=2.6s: window elapsed
+        expect(events).deep.equals(["active", "may-idle"]);
+        expect(state.mode).equals(IcdMode.Active);
+    });
+
+    it("requestActive never shortens an existing longer window", () => {
+        const { state } = makeState();
+        state.start();
+        const long = state.requestActive(Seconds(8));
+        const short = state.requestActive(Seconds(1));
+        expect(short).equals(long);
+    });
+
+    it("stop halts the machine; enterIdle/noteActivity become no-ops", async () => {
+        const { state, events } = makeState();
+        state.start();
+        state.stop();
+        expect(state.mode).equals(IcdMode.Idle);
+        state.noteActivity();
+        state.enterIdle();
+        await MockTime.advance(60000);
+        expect(events).deep.equals(["active"]);
+    });
+
+    it("enterIdle is a no-op when already idle", () => {
+        const { state, events } = makeState();
+        state.start();
+        state.enterIdle();
+        state.enterIdle();
+        expect(events).deep.equals(["active", "idle"]);
+    });
+});


### PR DESCRIPTION
Phase 2b-2 of ICD support (stacked on `feat/icd-protocol`, after 2b-1 #3853).

## Summary
- **External-driven idle/active mode** (`IcdModeState`): a single one-shot active-window timer; the device never sleeps or wakes on its own. Transitions are driven by node lifecycle, app/test calls, `StayActiveRequest`, or inbound network activity. matter.js never truly sleeps — device-side ICD exists for spec/cert completeness, controller verification, and the chip-test harness.
- **Behavior events**: `activeModeEntered` (idle→active wake; the Phase 2c Check-In send point; also fires at power-up), `idleModeEntered`, `mayEnterIdleMode` (active window elapsed & quiet — app may sleep).
- **Runtime methods**: `requestActiveMode()`, `enterIdleMode()` (force idle), `triggerUserActiveMode()`.
- **StayActiveRequest** now genuinely extends the active window and returns the real remaining duration, floored at `min(30s, requested)` (§ 9.16.7.5.1.1).
- **User Active Mode Trigger (UAT)** feature: `userActiveModeTriggerHint`/`userActiveModeTriggerInstruction` config validation (instruction required for instruction-dependent hint bits, § 9.16.6.7); device-physical `triggerUserActiveMode()` (UAT defines no Matter command).
- Class JSDoc documents the model for both real sleepy-hardware proxies and test/cert harnesses.

Idle/active mode is independent of the SIT/LIT `OperatingMode` (2b-1).

## Test Plan
- [x] `npm run build -- --clean`
- [x] `npm test -- -p packages/node` — 1233/1233 (ESM/CJS), 1224/1224 (Web)
- [x] `npm run format-verify`
- [x] `npm run lint`

## Follow-up (Phase 2c)
Check-In transmission on `activeModeEntered` (suppression + back-off); the `triggerUserActiveMode` back-off reset hook lands there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)