### PR TITLE
fix(protocol): correct group-send current-epoch-key selection off-by-list-length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A forward message-counter jump of exactly the window size no longer retains stale replay-bitmap bits, which could wrongly reject a later legitimate message as duplicate
     - Fix: When the per-session concurrent-exchange limit is exceeded, the least-recently-active exchange is now closed instead of the oldest-created one
     - Fix: A Sigma1 carrying only one of `resumptionId`/`initiatorResumeMic` is now rejected with INVALID_PARAMETER instead of being treated as a fresh handshake
+    - Fix: Group-send epoch-key selection no longer fails when a future-dated epoch key is installed during key rotation
 
 - @matter/node
     - Enhancement: Added `network.ownNetworkProfileId` to set the local network's MRP additive margin, and exposed `additionalMrpDelay` and `probeAddress` in network profile config

--- a/packages/protocol/src/groups/KeySets.ts
+++ b/packages/protocol/src/groups/KeySets.ts
@@ -126,7 +126,7 @@ export class KeySets<T extends OperationalKeySet> extends BasicSet<T> {
                     `No operational keys found for groupKeySet ${keySetId} that are not in the future.`,
                 );
             }
-            return relevantKeys[operationalKeys.length - 1];
+            return relevantKeys[relevantKeys.length - 1];
         }
     }
 

--- a/packages/protocol/test/groups/KeySetsTest.ts
+++ b/packages/protocol/test/groups/KeySetsTest.ts
@@ -5,7 +5,29 @@
  */
 
 import { KeySets, type OperationalKeySet } from "#groups/KeySets.js";
-import { MatterFlowError } from "@matter/general";
+import { ImplementationError, MatterFlowError, Time } from "@matter/general";
+
+const HOUR_US = 60 * 60 * 1000 * 1000;
+
+/** Build a 3-slot key set whose slots carry distinct session ids 100/101/102 and the given epoch start times (µs). */
+function threeKeySet(
+    groupKeySetId: number,
+    startTimes0Us: number,
+    startTimes1Us: number,
+    startTimes2Us: number,
+): OperationalKeySet {
+    return keySet(groupKeySetId, {
+        operationalEpochKey0: Uint8Array.of(0),
+        groupSessionId0: 100,
+        epochStartTime0: startTimes0Us,
+        operationalEpochKey1: Uint8Array.of(1),
+        groupSessionId1: 101,
+        epochStartTime1: startTimes1Us,
+        operationalEpochKey2: Uint8Array.of(2),
+        groupSessionId2: 102,
+        epochStartTime2: startTimes2Us,
+    } as Partial<OperationalKeySet>);
+}
 
 function keySet(groupKeySetId: number, overrides: Partial<OperationalKeySet> = {}): OperationalKeySet {
     return {
@@ -67,6 +89,38 @@ describe("KeySets", () => {
             sets.add(keySet(0));
 
             expect(sets.currentKeyForId(0).sessionId).equal(100);
+        });
+
+        it("returns the newest non-future key when a future-dated key is installed", () => {
+            const nowUs = Time.nowUs * 1000;
+            const sets = new KeySets<OperationalKeySet>();
+            sets.add(threeKeySet(5, nowUs - 2 * HOUR_US, nowUs - HOUR_US, nowUs + HOUR_US));
+
+            expect(sets.currentKeyForId(5).sessionId).equal(101);
+        });
+
+        it("returns the newest key when all keys are in the past", () => {
+            const nowUs = Time.nowUs * 1000;
+            const sets = new KeySets<OperationalKeySet>();
+            sets.add(threeKeySet(5, nowUs - 3 * HOUR_US, nowUs - 2 * HOUR_US, nowUs - HOUR_US));
+
+            expect(sets.currentKeyForId(5).sessionId).equal(102);
+        });
+
+        it("throws when every key is in the future", () => {
+            const nowUs = Time.nowUs * 1000;
+            const sets = new KeySets<OperationalKeySet>();
+            sets.add(threeKeySet(5, nowUs + HOUR_US, nowUs + 2 * HOUR_US, nowUs + 3 * HOUR_US));
+
+            expect(() => sets.currentKeyForId(5)).throws(ImplementationError, "not in the future");
+        });
+
+        it("returns the second-newest key for the IPK key set (§4.14.2.6)", () => {
+            const nowUs = Time.nowUs * 1000;
+            const sets = new KeySets<OperationalKeySet>();
+            sets.add(threeKeySet(0, nowUs - 3 * HOUR_US, nowUs - 2 * HOUR_US, nowUs - HOUR_US));
+
+            expect(sets.currentKeyForId(0).sessionId).equal(101);
         });
     });
 });

--- a/packages/protocol/test/groups/KeySetsTest.ts
+++ b/packages/protocol/test/groups/KeySetsTest.ts
@@ -17,13 +17,13 @@ function threeKeySet(
     startTimes2Us: number,
 ): OperationalKeySet {
     return keySet(groupKeySetId, {
-        operationalEpochKey0: Uint8Array.of(0),
+        operationalEpochKey0: Uint8Array.from({ length: 16 }, () => 0),
         groupSessionId0: 100,
         epochStartTime0: startTimes0Us,
-        operationalEpochKey1: Uint8Array.of(1),
+        operationalEpochKey1: Uint8Array.from({ length: 16 }, () => 1),
         groupSessionId1: 101,
         epochStartTime1: startTimes1Us,
-        operationalEpochKey2: Uint8Array.of(2),
+        operationalEpochKey2: Uint8Array.from({ length: 16 }, () => 2),
         groupSessionId2: 102,
         epochStartTime2: startTimes2Us,
     } as Partial<OperationalKeySet>);


### PR DESCRIPTION
## Problem

`KeySets.currentKeyForId` non-IPK branch indexed the filtered `relevantKeys` array with `operationalKeys.length - 1` — the **unfiltered** list length.

When a 3-key set is in a normal rotation window (spec §4.17.3.3 installs a new epoch key with a *future* start time), `relevantKeys` is shorter than `operationalKeys`, so the index reads past the end → `undefined`. The caller guard (`SessionManager.groupSessionForAddress`) then throws `UnexpectedDataError` and the group multicast send fails for the entire key-propagation interval.

The old code was correct only by coincidence when all keys are current (`relevantKeys.length === operationalKeys.length`), which is why existing single-key tests didn't catch it.

## Fix

`return relevantKeys[relevantKeys.length - 1]` — the newest non-future key. Per spec §4.17.3.1 the sender uses "the epoch key with the latest start time that is not in the future"; `relevantKeys` is oldest→newest (KeySetWrite enforces strictly increasing start times), so the last element is correct.

## Tests

Adds 4 regression tests for the non-IPK multi-key branch (previously untested):
- 3-key set with a future-dated slot → picks newest non-future (the regression guard; fails on old code)
- 3-key set all past → picks newest
- 3-key set all future → throws
- IPK 3-key set → second-newest (§4.14.2.6)

Source: Matter 1.6.0 spec↔impl verification, finding Q-01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)