### PR TITLE
WIP: feat(node): ICD Check-In transmission, suppression & back-off

### DIFF
--- a/packages/node/src/behaviors/icd-management/IcdCheckInBackOff.ts
+++ b/packages/node/src/behaviors/icd-management/IcdCheckInBackOff.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Duration, Seconds } from "@matter/general";
+
+/**
+ * Per-client ICD Check-In back-off. Consulted once per idle→active wake for each Permanent registration. Keyed by
+ * `${fabricIndex}:${checkInNodeId}`.
+ *
+ * @see {@link MatterSpecification.v151.Core} § 9.15.1, § 9.16.6.10
+ */
+export interface IcdCheckInBackOff {
+    /** True when a Check-In is due for this client this wake. Advances the per-wake countdown — call exactly once per wake. */
+    shouldSend(key: string): boolean;
+    /** Record that a Check-In was attempted this wake (advances the schedule). */
+    recordSent(key: string): void;
+    /** The client interacted (became covered by an active subscription) — reset to immediate. */
+    recordAnswered(key: string): void;
+    /** User Active Mode Trigger — reset all clients to immediate (spec-mandatory). */
+    resetAll(): void;
+    /** Drop a client's state (registration removed). */
+    forget(key: string): void;
+}
+
+interface BackOffState {
+    sendCount: number;
+    cyclesUntilNextSend: number;
+}
+
+/**
+ * Default back-off: send on wake, then skip a doubling number of idle cycles (1,2,4,…) capped so the interval never
+ * exceeds `maximumCheckInBackoff`. When `maximumCheckInBackoff === idleModeDuration` the cap is one cycle, i.e. no
+ * back-off (a Check-In every wake).
+ */
+export class DoublingCheckInBackOff implements IcdCheckInBackOff {
+    readonly #maxCycles: number;
+    readonly #clients = new Map<string, BackOffState>();
+
+    constructor(idleModeDuration: Duration, maximumCheckInBackoff: Duration) {
+        const idleSeconds = Seconds.of(idleModeDuration);
+        this.#maxCycles =
+            idleSeconds > 0 ? Math.max(1, Math.floor(Seconds.of(maximumCheckInBackoff) / idleSeconds)) : 1;
+    }
+
+    #stateFor(key: string): BackOffState {
+        let state = this.#clients.get(key);
+        if (state === undefined) {
+            state = { sendCount: 0, cyclesUntilNextSend: 0 };
+            this.#clients.set(key, state);
+        }
+        return state;
+    }
+
+    shouldSend(key: string): boolean {
+        const state = this.#stateFor(key);
+        if (state.cyclesUntilNextSend <= 0) {
+            return true;
+        }
+        state.cyclesUntilNextSend--;
+        return false;
+    }
+
+    recordSent(key: string): void {
+        const state = this.#stateFor(key);
+        state.sendCount++;
+        state.cyclesUntilNextSend = Math.min(2 ** (state.sendCount - 1), this.#maxCycles) - 1;
+    }
+
+    recordAnswered(key: string): void {
+        // Dropping the state resets to immediate: a fresh entry sends on the next wake.
+        this.#clients.delete(key);
+    }
+
+    resetAll(): void {
+        this.#clients.clear();
+    }
+
+    forget(key: string): void {
+        this.#clients.delete(key);
+    }
+}

--- a/packages/node/src/behaviors/icd-management/IcdCheckInSuppression.ts
+++ b/packages/node/src/behaviors/icd-management/IcdCheckInSuppression.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SessionManager, Subject, subjectMatches } from "@matter/protocol";
+import { FabricIndex, NodeId, SubjectId } from "@matter/types";
+
+/** A subscription's subject as exposed by NodeSession.subjectFor(). */
+export interface SubscriptionSubject {
+    id: NodeId;
+    catSubjects?: NodeId[];
+}
+
+/**
+ * True when any subscription subject matches `monitoredSubject` (node id or CAT version compare). When covered, the ICD
+ * suppresses the Check-In for that registration.
+ *
+ * @see {@link MatterSpecification.v151.Core} § 9.16.5.3.2
+ */
+export function isMonitoredSubjectCovered(monitoredSubject: SubjectId, subjects: SubscriptionSubject[]): boolean {
+    for (const subject of subjects) {
+        if (subjectMatches(monitoredSubject, subject.id)) {
+            return true;
+        }
+        for (const cat of subject.catSubjects ?? []) {
+            if (subjectMatches(monitoredSubject, cat)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+/** Collect the subjects of all active subscriptions on a fabric. */
+export function activeSubscriptionSubjects(sessions: SessionManager, fabricIndex: FabricIndex): SubscriptionSubject[] {
+    const subjects = new Array<SubscriptionSubject>();
+    for (const session of sessions.sessionsForFabricIndex(fabricIndex)) {
+        // A closing session's subscriptions drain asynchronously; don't let it suppress a Check-In the client needs.
+        if (session.isClosing || session.subscriptions.size === 0) {
+            continue;
+        }
+        const subject = session.subjectFor();
+        if (!Subject.isNode(subject)) {
+            continue;
+        }
+        subjects.push({ id: subject.id, catSubjects: subject.catSubjects });
+    }
+    return subjects;
+}

--- a/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
+++ b/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
@@ -6,21 +6,37 @@
 
 import { NodeActivity } from "#behavior/context/NodeActivity.js";
 import { NodeLifecycle } from "#node/NodeLifecycle.js";
-import { Bytes, Duration, ImplementationError, Millis, Observable, Seconds } from "@matter/general";
+import {
+    Bytes,
+    ChannelType,
+    Crypto,
+    Duration,
+    ImplementationError,
+    isIPv6,
+    Millis,
+    Observable,
+    Seconds,
+} from "@matter/general";
 import { AccessLevel, DataModelPath, fabricIdx, field, listOf, nodeId, nonvolatile, octstr } from "@matter/model";
 import {
     AccessControl,
     assertRemoteActor,
     DeviceAdvertiser,
+    ExchangeManager,
     Fabric,
     FabricManager,
     hasRemoteActor,
     IcdAdvertisement,
+    IcdCheckInSender,
     IcdCounter,
+    PeerAddress,
+    PeerSet,
     SessionManager,
 } from "@matter/protocol";
-import { FabricIndex, NodeId, Status, StatusResponseError } from "@matter/types";
+import { FabricIndex, NodeId, SECURE_CHANNEL_PROTOCOL_ID, Status, StatusResponseError } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
+import { DoublingCheckInBackOff, IcdCheckInBackOff } from "./IcdCheckInBackOff.js";
+import { activeSubscriptionSubjects, isMonitoredSubjectCovered } from "./IcdCheckInSuppression.js";
 import { IcdManagementBehavior } from "./IcdManagementBehavior.js";
 import { IcdModeState } from "./IcdMode.js";
 
@@ -214,6 +230,13 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
             });
             this.reactTo((this.endpoint.lifecycle as NodeLifecycle).goingOffline, this.#onGoingOffline);
 
+            this.internal.checkInBackOff = new DoublingCheckInBackOff(
+                Seconds(this.state.idleModeDuration),
+                Seconds(this.state.maximumCheckInBackoff),
+            );
+            this.internal.checkInSender ??= this.createCheckInSender();
+            this.reactTo(this.events.activeModeEntered, this.#sendCheckIns);
+
             // Must use .on() directly: reactTo wraps each invocation in a NodeActivity whose close re-emits inactive,
             // causing infinite recursion.
             const inactive = this.env.get(NodeActivity).inactive;
@@ -261,6 +284,103 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
 
     #onGoingOffline() {
         this.internal.modeState?.stop();
+    }
+
+    /**
+     * Builds the Check-In sender. Override in tests to record sends. Resolution uses the peer's cached operational
+     * address (tagged from its last session, refreshed by mDNS); the send opens a one-shot unsecured Secure Channel
+     * session and transmits unreliably.
+     *
+     * @see {@link MatterSpecification.v151.Core} § 9.15.1
+     */
+    protected createCheckInSender(): IcdCheckInSender {
+        const peers = this.env.get(PeerSet);
+        const sessions = this.env.get(SessionManager);
+        const exchanges = this.env.get(ExchangeManager);
+        return new IcdCheckInSender({
+            crypto: this.env.get(Crypto),
+            resolveAddress: async ({ fabricIndex, peerNodeId }) => {
+                const peer = peers.addKnownPeer({ address: PeerAddress({ fabricIndex, nodeId: peerNodeId }) });
+                return peer.descriptor.operationalAddress;
+            },
+            sendUnsecured: async (address, messageType, payload) => {
+                const channelType = address.type === "tcp" ? ChannelType.TCP : ChannelType.UDP;
+                const lookupAddress =
+                    channelType === ChannelType.UDP ? (isIPv6(address.ip) ? "::" : "0.0.0.0") : undefined;
+                const iface = exchanges.interfaceFor(channelType, lookupAddress);
+                if (iface === undefined) {
+                    return false;
+                }
+                const channel = await iface.openChannel(address, {});
+                let owned = false;
+                try {
+                    await using session = sessions.createUnsecuredSession({ channel, isInitiator: true });
+                    owned = true;
+                    await using exchange = exchanges.initiateExchangeForSession(session, SECURE_CHANNEL_PROTOCOL_ID);
+                    await exchange.send(messageType, payload, {
+                        requiresAck: false,
+                        disableMrpLogic: true,
+                        suppressPeerLoss: true,
+                    });
+                    return true;
+                } finally {
+                    if (!owned) {
+                        await channel.close();
+                    }
+                }
+            },
+        });
+    }
+
+    /**
+     * Send a Check-In to every Permanent registration not currently covered by an active matching subscription, gated
+     * by the per-client back-off. Runs on each idle→active wake. The ICD counter advances once per real send.
+     *
+     * @see {@link MatterSpecification.v151.Core} § 9.15.1, § 9.16.5.3.2
+     */
+    async #sendCheckIns() {
+        const sender = this.internal.checkInSender;
+        const backOff = this.internal.checkInBackOff;
+        const counter = this.internal.icdCounter;
+        // Guard against overlapping passes: the pass awaits per-client sends while mutating back-off state, so a wake
+        // that re-fires mid-pass must not start a second concurrent pass over the same state.
+        if (sender === undefined || backOff === undefined || counter === undefined || this.internal.sendingCheckIns) {
+            return;
+        }
+        this.internal.sendingCheckIns = true;
+        try {
+            const sessions = this.env.get(SessionManager);
+            const activeModeThreshold = this.state.activeModeThreshold;
+            for (const fabric of this.env.get(FabricManager).fabrics) {
+                const subjects = activeSubscriptionSubjects(sessions, fabric.fabricIndex);
+                for (const reg of fabric.icd.registrations) {
+                    if (reg.clientType !== IcdManagement.ClientType.Permanent) {
+                        continue;
+                    }
+                    const key = this.#keyFor(fabric.fabricIndex, reg.checkInNodeId);
+                    if (isMonitoredSubjectCovered(reg.monitoredSubject, subjects)) {
+                        backOff.recordAnswered(key);
+                        continue;
+                    }
+                    if (!backOff.shouldSend(key)) {
+                        continue;
+                    }
+                    backOff.recordSent(key);
+                    const ok = await sender.send({
+                        fabricIndex: fabric.fabricIndex,
+                        peerNodeId: reg.checkInNodeId,
+                        key: reg.key,
+                        counter: counter.value,
+                        activeModeThreshold,
+                    });
+                    if (ok) {
+                        counter.increment();
+                    }
+                }
+            }
+        } finally {
+            this.internal.sendingCheckIns = false;
+        }
     }
 
     override async [Symbol.asyncDispose]() {
@@ -349,6 +469,7 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
         for (const key of [...this.internal.icdKeys.keys()]) {
             if (key.startsWith(`${fabricIndex}:`)) {
                 this.internal.icdKeys.delete(key);
+                this.internal.checkInBackOff?.forget(key);
             }
         }
         this.#persistKeys();
@@ -458,6 +579,7 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
      * @see {@link MatterSpecification.v151.Core} § 9.16.6.7
      */
     triggerUserActiveMode() {
+        this.internal.checkInBackOff?.resetAll();
         this.requestActiveMode();
     }
 
@@ -521,9 +643,11 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
         this.state.registeredClients = this.state.registeredClients.filter(
             c => !(c.fabricIndex === fabricIndex && c.checkInNodeId === request.checkInNodeId),
         );
-        this.internal.icdKeys.delete(this.#keyFor(fabricIndex, request.checkInNodeId));
+        const key = this.#keyFor(fabricIndex, request.checkInNodeId);
+        this.internal.icdKeys.delete(key);
         this.#persistKeys();
         fabric.icd.deleteRegistration(request.checkInNodeId);
+        this.internal.checkInBackOff?.forget(key);
 
         this.#updateOperatingMode();
     }
@@ -601,6 +725,12 @@ export namespace IcdManagementBaseServer {
         modeState?: IcdModeState;
         /** Direct NodeActivity.inactive subscription, stored for cleanup (reactTo would recurse). */
         inactiveObserver?: { inactive: NodeActivity["inactive"]; observer: () => void };
+        /** Per-client Check-In back-off; runtime-only, created on first online. */
+        checkInBackOff?: IcdCheckInBackOff;
+        /** Check-In sender; built via createCheckInSender(), overridable in tests. */
+        checkInSender?: IcdCheckInSender;
+        /** True while a Check-In send pass is in flight, to prevent overlapping passes on rapid re-wakes. */
+        sendingCheckIns?: boolean;
     }
 
     export class Events extends IcdManagementLogicBase.Events {

--- a/packages/node/test/behaviors/icd-management/IcdCheckInBackOffTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdCheckInBackOffTest.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Seconds } from "@matter/general";
+import { DoublingCheckInBackOff } from "../../../src/behaviors/icd-management/IcdCheckInBackOff.js";
+
+/** Advance `cycles` idle→active wakes; return the cycle indices at which a send was due. */
+function sendCycles(backoff: DoublingCheckInBackOff, key: string, cycles: number): number[] {
+    const out = new Array<number>();
+    for (let c = 0; c < cycles; c++) {
+        if (backoff.shouldSend(key)) {
+            out.push(c);
+            backoff.recordSent(key);
+        }
+    }
+    return out;
+}
+
+describe("DoublingCheckInBackOff", () => {
+    it("doubles the gap, capped at maximumCheckInBackoff", () => {
+        const backoff = new DoublingCheckInBackOff(Seconds(60), Seconds(960)); // maxCycles = 16
+        expect(sendCycles(backoff, "a", 64)).deep.equals([0, 1, 3, 7, 15, 31, 47, 63]);
+    });
+
+    it("never backs off when maximumCheckInBackoff equals idleModeDuration", () => {
+        const backoff = new DoublingCheckInBackOff(Seconds(60), Seconds(60)); // maxCycles = 1
+        expect(sendCycles(backoff, "a", 5)).deep.equals([0, 1, 2, 3, 4]);
+    });
+
+    it("recordAnswered resets to immediate", () => {
+        const backoff = new DoublingCheckInBackOff(Seconds(60), Seconds(960));
+        backoff.shouldSend("a");
+        backoff.recordSent("a"); // missed=1
+        backoff.shouldSend("a");
+        backoff.recordSent("a"); // missed=2 -> waiting 2 cycles
+        backoff.recordAnswered("a");
+        expect(backoff.shouldSend("a")).equals(true);
+    });
+
+    it("resetAll resets every client", () => {
+        const backoff = new DoublingCheckInBackOff(Seconds(60), Seconds(960));
+        for (const k of ["a", "b"]) {
+            backoff.shouldSend(k);
+            backoff.recordSent(k);
+            backoff.shouldSend(k);
+            backoff.recordSent(k);
+        }
+        backoff.resetAll();
+        expect(backoff.shouldSend("a")).equals(true);
+        expect(backoff.shouldSend("b")).equals(true);
+    });
+
+    it("forget drops a client's state", () => {
+        const backoff = new DoublingCheckInBackOff(Seconds(60), Seconds(960));
+        backoff.shouldSend("a");
+        backoff.recordSent("a");
+        backoff.forget("a");
+        expect(backoff.shouldSend("a")).equals(true);
+    });
+});

--- a/packages/node/test/behaviors/icd-management/IcdCheckInSuppressionTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdCheckInSuppressionTest.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CaseAuthenticatedTag, NodeId, SubjectId } from "@matter/types";
+import { isMonitoredSubjectCovered } from "../../../src/behaviors/icd-management/IcdCheckInSuppression.js";
+
+describe("isMonitoredSubjectCovered", () => {
+    it("is covered when a subscription subject node id matches", () => {
+        const subjects = [{ id: NodeId(0x1234n), catSubjects: [] }];
+        expect(isMonitoredSubjectCovered(SubjectId(0x1234n), subjects)).equals(true);
+    });
+
+    it("is covered when a subscription CAT matches the monitored CAT", () => {
+        const monitored = NodeId.fromCaseAuthenticatedTag(CaseAuthenticatedTag(0xabcd0001));
+        const subjects = [
+            { id: NodeId(0x9n), catSubjects: [NodeId.fromCaseAuthenticatedTag(CaseAuthenticatedTag(0xabcd0002))] },
+        ];
+        expect(isMonitoredSubjectCovered(monitored, subjects)).equals(true);
+    });
+
+    it("is not covered when nothing matches", () => {
+        const subjects = [{ id: NodeId(0x9n), catSubjects: [] }];
+        expect(isMonitoredSubjectCovered(SubjectId(0x1234n), subjects)).equals(false);
+    });
+
+    it("is not covered with no subscriptions", () => {
+        expect(isMonitoredSubjectCovered(SubjectId(0x1234n), [])).equals(false);
+    });
+});

--- a/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
@@ -8,17 +8,61 @@ import { NodeActivity } from "#behavior/context/NodeActivity.js";
 import { IcdManagementClient, IcdManagementServer } from "#behaviors/icd-management";
 import { OperationalCredentialsClient } from "#behaviors/operational-credentials";
 import { ServerNode } from "#node/index.js";
-import { Bytes, Millis } from "@matter/general";
+import { Bytes, Crypto, Millis } from "@matter/general";
 import { AccessLevel } from "@matter/model";
-import { Advertiser, DeviceAdvertiser, FabricManager, ServiceDescription } from "@matter/protocol";
+import {
+    Advertiser,
+    DeviceAdvertiser,
+    FabricManager,
+    type IcdCheckInRequest,
+    IcdCheckInSender,
+    ServiceDescription,
+    SessionManager,
+} from "@matter/protocol";
 import { FabricIndex, NodeId } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
+import { activeSubscriptionSubjects } from "../../../src/behaviors/icd-management/IcdCheckInSuppression.js";
 import { MockExchange } from "../../node/mock-exchange.js";
 import { MockServerNode } from "../../node/mock-server-node.js";
 import { MockSite } from "../../node/mock-site.js";
+import { subscribedPeer } from "../../node/node-helpers.js";
 
 const RootWithIcd = ServerNode.RootEndpoint.with(IcdManagementServer);
 const RootWithIcdOnline = MockServerNode.RootEndpoint.with(IcdManagementServer);
+
+/**
+ * Builds an IcdManagementServer subclass whose Check-In sender records each send() and reports success without
+ * dialing. The real IcdCheckInSender.send() encode path runs (dummy address + sendUnsecured → true).
+ */
+function recordingIcdServer() {
+    const sent = new Array<{ fabricIndex: number; peerNodeId: bigint; counter: number }>();
+
+    class RecordingSender extends IcdCheckInSender {
+        override async send(request: IcdCheckInRequest): Promise<boolean> {
+            const ok = await super.send(request);
+            if (ok) {
+                sent.push({
+                    fabricIndex: request.fabricIndex,
+                    peerNodeId: request.peerNodeId,
+                    counter: request.counter,
+                });
+            }
+            return ok;
+        }
+    }
+
+    class RecordingIcdServer extends IcdManagementServer {
+        protected createCheckInSender() {
+            return new RecordingSender({
+                crypto: this.env.get(Crypto),
+                resolveAddress: async () => ({ type: "udp", ip: "::1", port: 5540 }),
+                sendUnsecured: async () => true,
+            });
+        }
+    }
+
+    return { sent, RecordingIcdServer };
+}
 
 /**
  * Minimal mock advertiser that records ServiceDescriptions passed to advertise().
@@ -1090,6 +1134,177 @@ describe("IcdManagementServer", () => {
             expect(res.promisedActiveDuration).equals(45000);
             expect(events).deep.equals([]); // no spurious activeModeEntered on an already-active device
             await device.close();
+        });
+    });
+
+    describe("Check-In sending", () => {
+        // idleModeDuration (s) >= activeModeDuration (ms); maximumCheckInBackoff (s) >= idleModeDuration. With
+        // maximumCheckInBackoff == idleModeDuration the back-off cap is one cycle: a send on every wake.
+        const checkInConfig = {
+            idleModeDuration: 4,
+            maximumCheckInBackoff: 4,
+            activeModeDuration: 2000,
+            activeModeThreshold: 1000,
+        } as const;
+
+        const key = Bytes.fromHex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf");
+
+        /** Force one idle→active wake and let the activeModeEntered reactor's send pass run to completion. */
+        async function wake(device: ServerNode) {
+            await device.act(agent => agent.get(IcdManagementServer).enterIdleMode());
+            await device.act(agent => agent.get(IcdManagementServer).requestActiveMode());
+            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+        }
+
+        async function commissionedRecordingPair() {
+            const { sent, RecordingIcdServer } = recordingIcdServer();
+            const site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: {
+                    type: ServerNode.RootEndpoint.with(RecordingIcdServer),
+                    icdManagement: checkInConfig,
+                },
+            });
+            return { site, sent, controller, device };
+        }
+
+        it("sends one Check-In per wake for a Permanent client with no covering subscription", async () => {
+            const { site, sent, controller, device } = await commissionedRecordingPair();
+            await using _site = site;
+
+            const peer1 = controller.peers.get("peer1")!;
+            const checkInNodeId = peer1.peerAddress!.nodeId;
+            await peer1.commandsOf(IcdManagementClient).registerClient({
+                checkInNodeId,
+                monitoredSubject: checkInNodeId,
+                key,
+                clientType: IcdManagement.ClientType.Permanent,
+            });
+
+            const counterBefore = device.stateOf(IcdManagementServer).icdCounter;
+            sent.length = 0;
+
+            await wake(device);
+
+            expect(sent).length(1);
+            expect(sent[0].peerNodeId).equals(checkInNodeId);
+            expect(device.stateOf(IcdManagementServer).icdCounter).equals(counterBefore + 1);
+        });
+
+        it("suppresses the Check-In for a client covered by an active matching subscription", async () => {
+            const { site, sent, controller, device } = await commissionedRecordingPair();
+            await using _site = site;
+
+            const peer1 = await subscribedPeer(controller, "peer1");
+            const checkInNodeId = peer1.peerAddress!.nodeId;
+
+            // The covering subscription's subject is the controller's operational node id on the device's fabric.
+            const monitoredSubject = await device.act(agent => {
+                const fabricIndex = agent.env.get(FabricManager).fabrics[0].fabricIndex;
+                const subjects = activeSubscriptionSubjects(agent.env.get(SessionManager), fabricIndex);
+                return subjects[0]?.id;
+            });
+            expect(monitoredSubject).not.undefined;
+
+            await peer1.commandsOf(IcdManagementClient).registerClient({
+                checkInNodeId,
+                monitoredSubject: monitoredSubject!,
+                key,
+                clientType: IcdManagement.ClientType.Permanent,
+            });
+
+            sent.length = 0;
+            await wake(device);
+
+            expect(sent).length(0);
+        });
+
+        it("never sends to an Ephemeral client", async () => {
+            const { site, sent, controller, device } = await commissionedRecordingPair();
+            await using _site = site;
+
+            const peer1 = controller.peers.get("peer1")!;
+            const checkInNodeId = peer1.peerAddress!.nodeId;
+            await peer1.commandsOf(IcdManagementClient).registerClient({
+                checkInNodeId,
+                monitoredSubject: checkInNodeId,
+                key,
+                clientType: IcdManagement.ClientType.Ephemeral,
+            });
+
+            sent.length = 0;
+            await wake(device);
+
+            expect(sent).length(0);
+        });
+
+        it("follows the back-off schedule across no-response wakes", async () => {
+            // maximumCheckInBackoff (16s) is 4x idleModeDuration (4s) → cap 4 cycles. Doubling gaps 1,2,4 (capped):
+            // sends at wakes 0, 1, 3, 7, then every 4th (11, 15, ...).
+            const { sent, RecordingIcdServer } = recordingIcdServer();
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: {
+                    type: ServerNode.RootEndpoint.with(RecordingIcdServer),
+                    icdManagement: { ...checkInConfig, maximumCheckInBackoff: 16 },
+                },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            const checkInNodeId = peer1.peerAddress!.nodeId;
+            await peer1.commandsOf(IcdManagementClient).registerClient({
+                checkInNodeId,
+                monitoredSubject: checkInNodeId,
+                key,
+                clientType: IcdManagement.ClientType.Permanent,
+            });
+
+            sent.length = 0;
+            const sentAtWake = new Array<number>();
+            for (let w = 0; w < 12; w++) {
+                const before = sent.length;
+                await wake(device);
+                if (sent.length > before) {
+                    sentAtWake.push(w);
+                }
+            }
+
+            expect(sentAtWake).deep.equals([0, 1, 3, 7, 11]);
+        });
+
+        it("triggerUserActiveMode resets the back-off so the next wake sends again", async () => {
+            const { sent, RecordingIcdServer } = recordingIcdServer();
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: {
+                    type: ServerNode.RootEndpoint.with(RecordingIcdServer),
+                    icdManagement: { ...checkInConfig, maximumCheckInBackoff: 16 },
+                },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            const checkInNodeId = peer1.peerAddress!.nodeId;
+            await peer1.commandsOf(IcdManagementClient).registerClient({
+                checkInNodeId,
+                monitoredSubject: checkInNodeId,
+                key,
+                clientType: IcdManagement.ClientType.Permanent,
+            });
+
+            sent.length = 0;
+            // Wake 0 sends; wake 1 sends; wake 2 is suppressed by back-off (gap of 2 cycles).
+            await wake(device);
+            await wake(device);
+            const beforeSuppressed = sent.length;
+            await wake(device);
+            expect(sent.length).equals(beforeSuppressed); // wake 2 suppressed
+
+            // UAT resets the back-off; the wake it triggers sends immediately.
+            await device.act(agent => agent.get(IcdManagementServer).enterIdleMode());
+            await device.act(agent => agent.get(IcdManagementServer).triggerUserActiveMode());
+            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+
+            expect(sent.length).equals(beforeSuppressed + 1);
         });
     });
 });

--- a/packages/protocol/src/icd/IcdCheckInSender.ts
+++ b/packages/protocol/src/icd/IcdCheckInSender.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Bytes, Crypto, Logger } from "@matter/general";
+import { FabricIndex, NodeId, SecureMessageType } from "@matter/types";
+import { CheckInMessage } from "./CheckInMessage.js";
+
+const logger = Logger.get("IcdCheckInSender");
+
+/** A resolved operational address to dial, or undefined when the peer cannot be located. */
+export interface IcdCheckInAddress {
+    type: "udp" | "tcp";
+    ip: string;
+    port: number;
+}
+
+export interface IcdCheckInSenderContext {
+    crypto: Crypto;
+    /** Resolve a registered client's operational address (cached address preferred; best-effort). */
+    resolveAddress(input: { fabricIndex: FabricIndex; peerNodeId: NodeId }): Promise<IcdCheckInAddress | undefined>;
+    /** Send `payload` as an unsecured Secure Channel message of `messageType` to `address`. Returns false on failure. */
+    sendUnsecured(address: IcdCheckInAddress, messageType: number, payload: Bytes): Promise<boolean>;
+}
+
+export interface IcdCheckInRequest {
+    fabricIndex: FabricIndex;
+    peerNodeId: NodeId;
+    key: Bytes;
+    counter: number;
+    /** Active-mode threshold in milliseconds (uint16 on the wire). */
+    activeModeThreshold: number;
+}
+
+/**
+ * Builds and sends device-side ICD Check-In messages (Secure Channel opcode 0x50) unsecured to a registered client.
+ * Best-effort: returns false (never throws) when the peer is unresolvable or the send fails.
+ *
+ * @see {@link MatterSpecification.v151.Core} § 9.15.1
+ */
+export class IcdCheckInSender {
+    readonly #context: IcdCheckInSenderContext;
+
+    constructor(context: IcdCheckInSenderContext) {
+        this.#context = context;
+    }
+
+    async send(request: IcdCheckInRequest): Promise<boolean> {
+        const { fabricIndex, peerNodeId, key, counter, activeModeThreshold } = request;
+        try {
+            const address = await this.#context.resolveAddress({ fabricIndex, peerNodeId });
+            if (address === undefined) {
+                return false;
+            }
+            const payload = await CheckInMessage.encodeIcd(this.#context.crypto, key, counter, activeModeThreshold);
+            return await this.#context.sendUnsecured(address, SecureMessageType.IcdCheckInMessage, payload);
+        } catch (error) {
+            logger.debug(`Check-In to ${peerNodeId} on fabric ${fabricIndex} failed`, error);
+            return false;
+        }
+    }
+}

--- a/packages/protocol/src/icd/index.ts
+++ b/packages/protocol/src/icd/index.ts
@@ -6,4 +6,5 @@
 
 export * from "./CheckInMessage.js";
 export * from "./FabricIcd.js";
+export * from "./IcdCheckInSender.js";
 export * from "./IcdCounter.js";

--- a/packages/protocol/src/interaction/FabricAccessControl.ts
+++ b/packages/protocol/src/interaction/FabricAccessControl.ts
@@ -8,7 +8,6 @@ import type { Fabric } from "#fabric/Fabric.js";
 import { Diagnostic, InternalError, Logger, MatterFlowError } from "@matter/general";
 import { AccessLevel } from "@matter/model";
 import {
-    CaseAuthenticatedTag,
     ClusterId,
     DeviceTypeId,
     EndpointNumber,
@@ -20,6 +19,7 @@ import {
 } from "@matter/types";
 import { AccessControl } from "@matter/types/clusters/access-control";
 import { AccessControl as AccessControlContext } from "../action/server/AccessControl.js";
+import { subjectMatches } from "./subjectMatches.js";
 
 const logger = Logger.get("FabricAccessControl");
 
@@ -137,27 +137,6 @@ export class FabricAccessControl {
     }
 
     /**
-     * Subjects must match exactly, or both are CAT with matching CAT ID and acceptable CAT version
-     */
-    #subjectMatches(aclSubject: SubjectId, isdSubject: SubjectId): boolean {
-        if (BigInt(aclSubject) === BigInt(isdSubject)) {
-            return true;
-        }
-        const aclNode = NodeId(aclSubject);
-        const isdNode = NodeId(isdSubject);
-        if (!NodeId.isCaseAuthenticatedTag(aclNode) || !NodeId.isCaseAuthenticatedTag(isdNode)) {
-            return false;
-        }
-        const aclSubjectCat = NodeId.extractAsCaseAuthenticatedTag(aclNode);
-        const isdSubjectCat = NodeId.extractAsCaseAuthenticatedTag(isdNode);
-        return (
-            CaseAuthenticatedTag.getIdentifyValue(aclSubjectCat) ===
-                CaseAuthenticatedTag.getIdentifyValue(isdSubjectCat) &&
-            CaseAuthenticatedTag.getVersion(isdSubjectCat) >= CaseAuthenticatedTag.getVersion(aclSubjectCat)
-        );
-    }
-
-    /**
      * Add the new privilege to the granted privileges set and also add any privileges subsumed by the new privilege.
      */
     #addGrantedPrivilege(grantedPrivileges: Set<AccessLevel>, privilege: AccessLevel): void {
@@ -239,7 +218,7 @@ export class FabricAccessControl {
                 let matchedSubject = false;
                 subjectLoop: for (const aclSubject of aclEntry.subjects) {
                     for (const isdSubject of subjectDesc.subjects) {
-                        if (this.#subjectMatches(aclSubject, isdSubject)) {
+                        if (subjectMatches(aclSubject, isdSubject)) {
                             matchedSubject = true;
                             break subjectLoop;
                         }

--- a/packages/protocol/src/interaction/index.ts
+++ b/packages/protocol/src/interaction/index.ts
@@ -10,4 +10,5 @@ export * from "./DecodedDataReport.js";
 export * from "./EventDataDecoder.js";
 export * from "./FabricAccessControl.js";
 export * from "./InteractionMessenger.js";
+export * from "./subjectMatches.js";
 export * from "./Subscription.js";

--- a/packages/protocol/src/interaction/subjectMatches.ts
+++ b/packages/protocol/src/interaction/subjectMatches.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CaseAuthenticatedTag, NodeId, SubjectId } from "@matter/types";
+
+/**
+ * The Access-Control subject-matching function: true when `candidate` satisfies `target`. Exact match, else both must
+ * be CASE Authenticated Tags with the same identifier and `candidate` version >= `target` version.
+ *
+ * Shared by the Access Control privilege-granting algorithm and ICD Check-In suppression (the MonitoredSubject of a
+ * registration is matched against active subscription subjects with this same function).
+ *
+ * @see {@link MatterSpecification.v151.Core} § 9.10
+ */
+export function subjectMatches(target: SubjectId, candidate: SubjectId): boolean {
+    if (BigInt(target) === BigInt(candidate)) {
+        return true;
+    }
+    if (!NodeId.isCaseAuthenticatedTag(target) || !NodeId.isCaseAuthenticatedTag(candidate)) {
+        return false;
+    }
+    const targetCat = NodeId.extractAsCaseAuthenticatedTag(target);
+    const candidateCat = NodeId.extractAsCaseAuthenticatedTag(candidate);
+    return (
+        CaseAuthenticatedTag.getIdentifyValue(targetCat) === CaseAuthenticatedTag.getIdentifyValue(candidateCat) &&
+        CaseAuthenticatedTag.getVersion(candidateCat) >= CaseAuthenticatedTag.getVersion(targetCat)
+    );
+}

--- a/packages/protocol/test/icd/IcdCheckInSenderTest.ts
+++ b/packages/protocol/test/icd/IcdCheckInSenderTest.ts
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CheckInMessage } from "#icd/CheckInMessage.js";
+import { IcdCheckInSender } from "#icd/IcdCheckInSender.js";
+import { Bytes, StandardCrypto } from "@matter/general";
+import { FabricIndex, NodeId, SecureMessageType } from "@matter/types";
+
+const crypto = new StandardCrypto();
+const KEY = Bytes.fromHex("5a6b7c8d9e0f00112233445566778899");
+
+describe("IcdCheckInSender", () => {
+    it("sends a decodable 0x50 to the resolved address", async () => {
+        const sent = new Array<{ messageType: number; payload: Bytes }>();
+        const sender = new IcdCheckInSender({
+            crypto,
+            resolveAddress: async () => ({ type: "udp", ip: "fe80::1", port: 5540 }),
+            sendUnsecured: async (_address, messageType, payload) => {
+                sent.push({ messageType, payload });
+                return true;
+            },
+        });
+
+        const ok = await sender.send({
+            fabricIndex: FabricIndex(1),
+            peerNodeId: NodeId(0x1122334455667788n),
+            key: KEY,
+            counter: 42,
+            activeModeThreshold: 4000,
+        });
+
+        expect(ok).equals(true);
+        expect(sent.length).equals(1);
+        expect(sent[0].messageType).equals(SecureMessageType.IcdCheckInMessage);
+        const decoded = await CheckInMessage.decodeIcd(crypto, KEY, sent[0].payload);
+        expect(decoded.counter).equals(42);
+        expect(decoded.activeModeThreshold).equals(4000);
+    });
+
+    it("returns false and sends nothing when the address is unresolvable", async () => {
+        let sends = 0;
+        const sender = new IcdCheckInSender({
+            crypto,
+            resolveAddress: async () => undefined,
+            sendUnsecured: async () => {
+                sends++;
+                return true;
+            },
+        });
+        const ok = await sender.send({
+            fabricIndex: FabricIndex(1),
+            peerNodeId: NodeId(0x1n),
+            key: KEY,
+            counter: 1,
+            activeModeThreshold: 4000,
+        });
+        expect(ok).equals(false);
+        expect(sends).equals(0);
+    });
+
+    it("returns false when the send fails", async () => {
+        const sender = new IcdCheckInSender({
+            crypto,
+            resolveAddress: async () => ({ type: "udp", ip: "fe80::1", port: 5540 }),
+            sendUnsecured: async () => false,
+        });
+        const ok = await sender.send({
+            fabricIndex: FabricIndex(1),
+            peerNodeId: NodeId(0x1n),
+            key: KEY,
+            counter: 1,
+            activeModeThreshold: 4000,
+        });
+        expect(ok).equals(false);
+    });
+
+    it("returns false (best-effort) when a collaborator throws", async () => {
+        const sender = new IcdCheckInSender({
+            crypto,
+            resolveAddress: async () => ({ type: "udp", ip: "fe80::1", port: 5540 }),
+            sendUnsecured: async () => {
+                throw new Error("transport blew up");
+            },
+        });
+        const ok = await sender.send({
+            fabricIndex: FabricIndex(1),
+            peerNodeId: NodeId(0x1n),
+            key: KEY,
+            counter: 1,
+            activeModeThreshold: 4000,
+        });
+        expect(ok).equals(false);
+    });
+});


### PR DESCRIPTION
Phase 2c of ICD support (stacked on `feat/icd-protocol`, after 2b-2 #3861). Device-side Check-In **transmission**.

## Summary
On each idle→active wake (§ 9.15.1), the device sends an unsecured Secure Channel Check-In (opcode `0x50`) to each registered **Permanent** client that has **no active subscription matching its MonitoredSubject**:

- **`subjectMatches`** (protocol) — extracted from `FabricAccessControl.#subjectMatches` into a public helper (CAT-aware: exact match, else same CAT id + candidate version ≥ target). The ACL now delegates to it; ICD Check-In suppression reuses it (the spec defines suppression in terms of this exact function, § 9.16.5.3.2).
- **`IcdCheckInSender`** (protocol) — encodes via `CheckInMessage.encodeIcd` and sends `SecureMessageType.IcdCheckInMessage` unsecured/unreliable; best-effort (never throws). Address resolution + dial are injected seams.
- **`DoublingCheckInBackOff`** (node) — per-client doubling back-off (1,2,4,… idle cycles) capped at `MaximumCheckInBackoff`; `max == idle` ⇒ no back-off (§ 9.16.6.10). Resets when a client becomes covered and on User Active Mode Trigger (the 2b-2 reset hook).
- **Suppression helper** (node) — enumerates active subscription subjects per fabric (skipping closing sessions) and matches against `monitoredSubject`.
- **Orchestration** in `IcdManagementServer` — hooks `activeModeEntered`: Permanent-only, suppress (→ reset back-off), back-off gate, send, increment the ICD counter once per real send (persisted). Re-entrancy-guarded. Production dial reuses the unsecured-session path (`interfaceFor`→`openChannel`→`createUnsecuredSession`→`initiateExchangeForSession`), leak-free.

## Test Plan
- [x] `npm run build -- --clean`
- [x] `npm test -- -p packages/protocol` — 1155/1155
- [x] `npm test -- -p packages/node` — 1247/1247 (ESM/CJS), 1238/1238 (Web)
- [x] `npm run format-verify`, `npm run lint`
- Unit: `subjectMatches` via consumers; `IcdCheckInSender` (encode round-trip, unresolvable, throw → false); back-off curve incl. cap & no-backoff; suppression node-id/CAT. Integration: send-on-wake + counter increment, suppression, Ephemeral-skip, back-off schedule, UAT reset.

## Follow-up (later phases)
Controller-side `IcdClient`/RX behavior; LIT-aware SustainedSubscription/interaction hold + auto key-refresh; chip-testing TC_ICDM + live chip-tool interop (real on-wire send verification); persisting back-off across restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)