### PR TITLE
fix(chip): skip duplicate matter-controller-wheels in python install

### DIFF
--- a/.github/workflows/build-test.chip.yml
+++ b/.github/workflows/build-test.chip.yml
@@ -77,11 +77,12 @@ jobs:
         id: check-rebuild
         run: echo "build-needed=true" >> $GITHUB_OUTPUT
 
-      # Run the additional matter.js WebSocket controller variant only on scheduled/manual runs to keep PR cycles fast
+      # Run the additional matter.js WebSocket controller variant on scheduled/manual runs and whenever CHIP image
+      # files change; otherwise stick to chiptool only to keep PR cycles fast
       - name: Determine controllers to test
         id: controllers
         run: |
-          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ steps.changes.outputs.src }}" = "true" ]; then
             echo 'controllers=["chiptool","matterjs"]' >> $GITHUB_OUTPUT
           else
             echo 'controllers=["chiptool"]' >> $GITHUB_OUTPUT

--- a/support/chip/support/install-chip-python
+++ b/support/chip/support/install-chip-python
@@ -81,8 +81,11 @@ pip install --break-system-packages -r scripts/tests/requirements.txt
 pip install --break-system-packages nest_asyncio
 
 # Install CHIP wheels globally
+# matter-controller-wheels is a collection target re-bundling matter-clusters/matter-core/matter-repl, which the
+# individual *._build_wheel targets already emit; installing both copies makes pip's resolver fail on duplicates
 find out -name \*.whl \
     | grep -v matter_yamltests-0.0.1 \
+    | grep -v matter-controller-wheels \
     | xargs pip install --break-system-packages --upgrade
 
 # Nuke build artifacts


### PR DESCRIPTION
## Problem

The CHIP image build has failed since ~2026-05-30. `install-chip-python` ends with:

```
ERROR: Cannot install matter-clusters 1.0.0 (.../matter-clusters._build_wheel/...) and
matter-clusters 1.0.0 (.../matter-controller-wheels/...) because these package versions
have conflicting dependencies.
ERROR: ResolutionImpossible
```

## Root cause

CHIP commit `507b1088c7` (#72214, *Repackage Controller Python package*) added a new `pw_python_wheels("matter-controller-wheels")` collection target that re-bundles `matter-clusters` / `matter-core` / `matter-repl` — the same wheels the individual `*._build_wheel` targets already emit.

`support/chip/support/install-chip-python` installs **every** wheel under `out/` via `find ... | xargs pip install`, so pip receives two copies of each controller package from different paths and the resolver aborts.

## Fix

Exclude the `matter-controller-wheels` collection dir from the install glob, restoring the prior single-copy install set. Verified against the actual failing wheel list: the three duplicate entries drop out, leaving exactly one wheel per package.

This PR touches `support/chip/**`, so CI rebuilds the image and exercises the fix end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)