### PR TITLE
refactor(node): make GroupKeyManagement keySetRemove synchronous

### DIFF
--- a/packages/node/src/behaviors/group-key-management/GroupKeyManagementServer.ts
+++ b/packages/node/src/behaviors/group-key-management/GroupKeyManagementServer.ts
@@ -402,7 +402,7 @@ export class GroupKeyManagementServer extends GroupKeyManagementBehavior {
         };
     }
 
-    override async keySetRemove({ groupKeySetId }: GroupKeyManagement.KeySetRemoveRequest) {
+    override keySetRemove({ groupKeySetId }: GroupKeyManagement.KeySetRemoveRequest) {
         if (groupKeySetId === 0) {
             throw new StatusResponseError(`GroupKeySet ${groupKeySetId} cannot be removed`, Status.InvalidCommand);
         }
@@ -412,7 +412,7 @@ export class GroupKeyManagementServer extends GroupKeyManagementBehavior {
         const fabric = this.context.session.associatedFabric;
         const fabricIndex = fabric.fabricIndex;
 
-        // Replace or add the group key set to the internal persisted state
+        // Remove the group key set from the internal persisted state
         const existingIndex = this.state.groupKeySets.findIndex(
             ({ groupKeySetId: entryId, fabricIndex: entryIndex }) =>
                 entryIndex === fabricIndex && entryId === groupKeySetId,
@@ -429,7 +429,7 @@ export class GroupKeyManagementServer extends GroupKeyManagementBehavior {
         );
 
         // Sync to Fabric group manager to remove too
-        await fabric.groups.removeGroupKeySet(groupKeySetId);
+        fabric.groups.removeGroupKeySet(groupKeySetId);
     }
 
     override keySetReadAllIndices(): GroupKeyManagement.KeySetReadAllIndicesResponse {


### PR DESCRIPTION
Follow-up to #3870. Now that `FabricGroups.removeGroupKeySet` is synchronous (the group data counter is no longer tied to key-set lifecycle), `GroupKeyManagementServer.keySetRemove` no longer needs to be `async` — it had only one `await`, on `removeGroupKeySet`. The command handler returns `MaybePromise`, so a synchronous override is valid.

Also corrects a stale `// Replace or add the group key set...` comment (copied from `keySetWrite`) to describe removal.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)