### PR TITLE
refactor(protocol): backport node-global group data message counter to 0.16.x (#3870)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/protocol
     - Enhancement: Implemented Matter message privacy (header obfuscation) for group messages; receiving is always supported, sending is opt-in per session and off by default. Unicast messages carrying the privacy flag are dropped like in CHIP SDK (Backported from 0.17.2)
     - Fix: Group-send epoch-key selection no longer fails when a future-dated epoch key is installed during key rotation (Backported from 0.17.2)
+    - Fix: Group data message counters are now a single node-global counter (per Matter spec) instead of per operational key; former per-key counters are properly migrated to prevent nonce reuse (Backported from 0.17.2)
 
 ## 0.16.11 (2026-04-10)
 

--- a/packages/protocol/src/fabric/FabricManager.ts
+++ b/packages/protocol/src/fabric/FabricManager.ts
@@ -272,6 +272,32 @@ export class FabricManager {
         return this.fabrics.map(translator);
     }
 
+    /**
+     * @deprecated Migration-only. Returns the maximum legacy per-operational-key group data counter across all fabrics,
+     * so the node-global group data counter can be seeded above every previously used value. Remove once the migration
+     * window has passed.
+     */
+    async legacyGroupDataCounterMax(): Promise<number | undefined> {
+        let max: number | undefined;
+        for (const fabric of this.fabrics) {
+            const fabricMax = await fabric.groups.messaging.legacyGroupDataCounterMax();
+            if (fabricMax !== undefined && (max === undefined || fabricMax > max)) {
+                max = fabricMax;
+            }
+        }
+        return max;
+    }
+
+    /**
+     * @deprecated Migration-only. Clears the legacy per-operational-key group data counters from all fabrics after the
+     * node-global counter has been seeded from them. Remove once the migration window has passed.
+     */
+    async clearLegacyGroupDataCounters(): Promise<void> {
+        for (const fabric of this.fabrics) {
+            await fabric.groups.messaging.clearLegacyGroupDataCounters();
+        }
+    }
+
     async findFabricFromDestinationId(destinationId: Bytes, initiatorRandom: Bytes) {
         this.#construction.assert();
 

--- a/packages/protocol/src/groups/FabricGroups.ts
+++ b/packages/protocol/src/groups/FabricGroups.ts
@@ -28,7 +28,7 @@ export class FabricGroups {
     constructor(fabric: Fabric, storage?: StorageContext) {
         this.#fabric = fabric;
         this.#groups = new Groups(fabric, this.#keySets);
-        this.#messagingState = new MessagingState(fabric.crypto, storage);
+        this.#messagingState = new MessagingState();
 
         // KeySet with ID 0 is always the Fabric IPK, so we initialize from there because this is not stored
         // in Key Management Cluster
@@ -113,14 +113,11 @@ export class FabricGroups {
      * Overwriting the existing one if it exists.
      */
     async setFromGroupKeySet(groupKeySet: GroupKeySet) {
-        const { groupKeySetId, epochKey0, epochKey1, epochKey2 } = groupKeySet;
+        const { epochKey0, epochKey1, epochKey2 } = groupKeySet;
 
         if (epochKey0 === null) {
             throw new MatterFlowError("EpochKey0 must be set"); // checked before, but to make typing happy
         }
-
-        // Clean up the counters and data from old keys, will be initialized again on next use
-        await this.#cleanUpCounters(groupKeySetId);
 
         // Lets pre-calculate the operational keys
         const globalId = Bytes.fromHex(hex.fixed(this.#fabric.globalId, 16));
@@ -164,25 +161,11 @@ export class FabricGroups {
         });
     }
 
-    /** Removes a group key set by its id and cleans up the counters and data. */
-    async removeGroupKeySet(groupKeySetId: number) {
+    /** Removes a group key set by its id. */
+    removeGroupKeySet(groupKeySetId: number) {
         if (groupKeySetId === 0) {
             throw new InternalError("Cannot remove the group key set 0.");
         }
-        await this.#cleanUpCounters(groupKeySetId, true);
         return this.#keySets.delete("groupKeySetId", groupKeySetId);
-    }
-
-    /** Cleans up the counters and data for a group key set by its id. */
-    async #cleanUpCounters(groupKeySetId: number, forDelete = false) {
-        if (this.#keySets.forId(groupKeySetId) === undefined) {
-            return;
-        }
-
-        // Clean up counters for the group key set
-        const operationalKeys = this.#keySets.allKeysForId(groupKeySetId);
-        for (const { key } of operationalKeys) {
-            await this.#messagingState.removeCounter(key, forDelete);
-        }
     }
 }

--- a/packages/protocol/src/groups/MessagingState.ts
+++ b/packages/protocol/src/groups/MessagingState.ts
@@ -3,28 +3,23 @@
  * Copyright 2022-2026 Matter.js Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { Bytes, Crypto, ImplementationError, InternalError, StorageContext } from "#general";
-import { PersistedMessageCounter } from "#protocol/MessageCounter.js";
+import { Bytes, InternalError, Logger, StorageContext } from "#general";
+import { MAX_COUNTER_VALUE_32BIT } from "#protocol/MessageCounter.js";
 import { MessageReceptionStateEncryptedWithRollover } from "#protocol/MessageReceptionState.js";
 import { NodeId } from "#types";
 
-export class MessagingState {
-    /**
-     * Message counter for sending data messages to a group per Operational key. No need to scope to a source node
-     * because we are the sending node
-     * TODO: For management: Make sure to start rotating the key early enough that a former counter-value is not used
-     *  again for the same key.
-     */
-    readonly #groupDataCounters = new Map<string, PersistedMessageCounter>();
+const logger = Logger.get("MessagingState");
 
+/** Legacy per-operational-key group data counter storage key: 32 hex chars (16-byte key hash) + "-data". */
+const LEGACY_GROUP_DATA_COUNTER_KEY = /^[0-9a-f]{32}-data$/;
+
+export class MessagingState {
     /** Message reception state for data messages per Operational key and source node. */
     readonly #messageDataReceptionState = new Map<string, Map<NodeId, MessageReceptionStateEncryptedWithRollover>>();
 
-    #crypto: Crypto;
     #storage?: StorageContext;
 
-    constructor(crypto: Crypto, storage?: StorageContext) {
-        this.#crypto = crypto;
+    constructor(storage?: StorageContext) {
         if (storage !== undefined) {
             this.#storage = storage;
         }
@@ -38,27 +33,43 @@ export class MessagingState {
     }
 
     /**
-     * Return the message counter for sending messages to a group with the given operational key.
+     * @deprecated Migration-only. Reads the maximum value across the legacy per-operational-key group data counters so
+     * the node-global group data counter can be seeded above every previously used value. Remove once the migration
+     * window has passed.
      */
-    counterFor(operationalKey: Bytes) {
+    async legacyGroupDataCounterMax(): Promise<number | undefined> {
         if (!this.#storage) {
-            throw new ImplementationError("Group session cannot be created without storage context.");
+            return undefined;
         }
-        const operationalKeyHex = Bytes.toHex(operationalKey);
-        let counter = this.#groupDataCounters.get(operationalKeyHex);
-        if (counter === undefined) {
-            counter = new PersistedMessageCounter(this.#crypto, this.#storage, `${operationalKeyHex}-data`);
-            this.#groupDataCounters.set(operationalKeyHex, counter);
+        let max: number | undefined;
+        for (const storageKey of await this.#storage.keys()) {
+            if (!LEGACY_GROUP_DATA_COUNTER_KEY.test(storageKey)) {
+                continue;
+            }
+            const value = await this.#storage.get<number>(storageKey);
+            if (typeof value !== "number" || value < 0 || value > MAX_COUNTER_VALUE_32BIT) {
+                logger.warn(`Ignoring invalid legacy group data counter at ${storageKey}: ${value}`);
+                continue;
+            }
+            if (max === undefined || value > max) {
+                max = value;
+            }
         }
-        return counter;
+        return max;
     }
 
-    async removeCounter(key: Bytes, forDelete = false) {
-        const operationalKeyHex = Bytes.toHex(key);
-        this.#groupDataCounters.delete(operationalKeyHex);
-        if (forDelete) {
-            // If we are deleting the group key set, also delete the persisted counter values
-            await this.#storage?.delete(`${operationalKeyHex}-data`);
+    /**
+     * @deprecated Migration-only. Deletes the legacy per-operational-key group data counters after the node-global
+     * counter has been seeded from them. Remove once the migration window has passed.
+     */
+    async clearLegacyGroupDataCounters(): Promise<void> {
+        if (!this.#storage) {
+            return;
+        }
+        for (const storageKey of await this.#storage.keys()) {
+            if (LEGACY_GROUP_DATA_COUNTER_KEY.test(storageKey)) {
+                await this.#storage.delete(storageKey);
+            }
         }
     }
 

--- a/packages/protocol/src/protocol/MessageCounter.ts
+++ b/packages/protocol/src/protocol/MessageCounter.ts
@@ -10,7 +10,7 @@ import { Construction, Crypto, InternalError, StorageContext, asyncNew } from "#
 export const MAX_COUNTER_VALUE_32BIT = 0xfffffffe;
 
 /** Default number of messages before a rollover callback is called. */
-const ROLLOVER_INFO_DIFFERENCE = 1000;
+const ROLLOVER_INFO_DIFFERENCE = 100_000;
 
 export enum MessageCounterTypes {
     /**
@@ -78,9 +78,29 @@ export class MessageCounter {
     }
 }
 
+/** Options for {@link PersistedMessageCounter}. */
+export interface PersistedMessageCounterOptions {
+    aboutToRolloverCallback?: () => Promise<void>;
+    rolloverInfoDifference?: number;
+
+    /**
+     * When set, persist the counter a block of this size ahead instead of on every increment: the stored value is kept
+     * `reserve` above the in-RAM counter and only re-written when the counter crosses it. An unclean restart then
+     * resumes at the reserved mark — above any value already issued — so the counter never rolls back (Matter spec
+     * §4.6.1.3 for the group data counter; matches CHIP `GROUP_MSG_COUNTER_MIN_INCREMENT`). Up to `reserve` values are
+     * skipped per unclean restart.
+     */
+    reserve?: number;
+
+    /** Initial counter value to use when no value is persisted yet, instead of a random start. */
+    seed?: number;
+}
+
 /** Enhanced Message counter that can be persisted and will be initialized from the persisted value (if existing). */
 export class PersistedMessageCounter extends MessageCounter {
     #construction: Construction<PersistedMessageCounter>;
+    readonly #reserve?: number;
+    #reserved = Infinity;
 
     get construction() {
         return this.#construction;
@@ -90,33 +110,30 @@ export class PersistedMessageCounter extends MessageCounter {
         crypto: Crypto,
         storageContext: StorageContext,
         storageKey: string,
-        aboutToRolloverCallback?: () => Promise<void>,
-        rolloverInfoDifference = ROLLOVER_INFO_DIFFERENCE,
+        options: PersistedMessageCounterOptions = {},
     ) {
-        return asyncNew(
-            PersistedMessageCounter,
-            crypto,
-            storageContext,
-            storageKey,
-            aboutToRolloverCallback,
-            rolloverInfoDifference,
-        );
+        return asyncNew(PersistedMessageCounter, crypto, storageContext, storageKey, options);
     }
 
     constructor(
         crypto: Crypto,
         private readonly storageContext: StorageContext,
         private readonly storageKey: string,
-        aboutToRolloverCallback?: () => Promise<void>,
-        rolloverInfoDifference = ROLLOVER_INFO_DIFFERENCE,
+        options: PersistedMessageCounterOptions = {},
     ) {
+        const { aboutToRolloverCallback, rolloverInfoDifference = ROLLOVER_INFO_DIFFERENCE, reserve, seed } = options;
+        if (reserve !== undefined && (!Number.isInteger(reserve) || reserve <= 0)) {
+            throw new InternalError(`Invalid message counter reserve: ${reserve}`);
+        }
         super(crypto, aboutToRolloverCallback, rolloverInfoDifference);
+        this.#reserve = reserve;
         this.#construction = Construction(this, async () => {
             if (await storageContext.has(storageKey)) {
-                this.messageCounter = await storageContext.get<number>(storageKey);
-                if (this.messageCounter < 0 || this.messageCounter > MAX_COUNTER_VALUE_32BIT) {
-                    throw new InternalError(`Invalid message counter value: ${this.messageCounter}`);
+                const stored = await storageContext.get<number>(storageKey);
+                if (typeof stored !== "number" || stored < 0 || stored > MAX_COUNTER_VALUE_32BIT) {
+                    throw new InternalError(`Invalid message counter value: ${stored}`);
                 }
+                this.messageCounter = stored;
                 // Make sure to call the callback if we are close to a rollover also for edge cases on initialization
                 if (
                     this.onRollover !== undefined &&
@@ -124,13 +141,32 @@ export class PersistedMessageCounter extends MessageCounter {
                 ) {
                     await this.onRollover();
                 }
+            } else if (seed !== undefined) {
+                if (typeof seed !== "number" || seed < 0 || seed > MAX_COUNTER_VALUE_32BIT) {
+                    throw new InternalError(`Invalid message counter seed: ${seed}`);
+                }
+                this.messageCounter = seed;
+            }
+            if (reserve !== undefined) {
+                await this.#reserveAhead();
             }
         });
     }
 
+    async #reserveAhead() {
+        this.#reserved = Math.min(this.messageCounter + this.#reserve!, MAX_COUNTER_VALUE_32BIT);
+        await this.storageContext.set(this.storageKey, this.#reserved);
+    }
+
     override async getIncrementedCounter() {
         const counter = await super.getIncrementedCounter();
-        await this.storageContext.set(this.storageKey, counter);
+        if (this.#reserve === undefined) {
+            await this.storageContext.set(this.storageKey, counter);
+        } else if (counter >= this.#reserved || counter < this.#reserved - this.#reserve) {
+            // Re-reserve at the block boundary, and also after a rollover to 0 (counter drops below the reserved
+            // window) so the wrapped-around low values are persisted ahead and never re-issued after a restart.
+            await this.#reserveAhead();
+        }
         return counter;
     }
 }

--- a/packages/protocol/src/session/GroupSession.ts
+++ b/packages/protocol/src/session/GroupSession.ts
@@ -26,6 +26,7 @@ import {
 } from "#general";
 import { PairRetransmissionLimitReachedError } from "#peer/ControllerDiscovery.js";
 import { PeerAddress } from "#peer/PeerAddress.js";
+import type { MessageCounter } from "#protocol/MessageCounter.js";
 import { FabricIndex, GroupId, NodeId } from "#types";
 import { SecureSession } from "./SecureSession.js";
 import { Session } from "./Session.js";
@@ -46,11 +47,20 @@ export class GroupSession extends SecureSession {
     readonly keySetId: number;
 
     constructor(config: GroupSession.Config) {
-        const { manager, fabric, operationalGroupKey, operationalPrivacyKey, id, peerNodeId, keySetId } = config;
+        const {
+            manager,
+            fabric,
+            operationalGroupKey,
+            operationalPrivacyKey,
+            id,
+            peerNodeId,
+            keySetId,
+            messageCounter,
+        } = config;
         super({
             ...config,
             setActiveTimestamp: false, // We always set the active timestamp for Secure sessions TODO Check
-            messageCounter: fabric.groups.messaging.counterFor(operationalGroupKey),
+            messageCounter,
         });
         this.#id = id;
         this.#fabric = fabric;
@@ -76,8 +86,9 @@ export class GroupSession extends SecureSession {
         keySetId: number;
         groupNodeId: NodeId;
         operationalGroupKey: Bytes;
+        messageCounter: MessageCounter;
     }) {
-        const { manager, transports, id, fabric, keySetId, groupNodeId, operationalGroupKey } = options;
+        const { manager, transports, id, fabric, keySetId, groupNodeId, operationalGroupKey, messageCounter } = options;
 
         const groupId = GroupId.fromNodeId(groupNodeId);
         const multicastAddress = fabric.groups.multicastAddressFor(groupId);
@@ -103,6 +114,7 @@ export class GroupSession extends SecureSession {
             peerNodeId: groupNodeId,
             operationalGroupKey,
             operationalPrivacyKey: Bytes.of(await MessagePrivacy.deriveKey(fabric.crypto, operationalGroupKey)),
+            messageCounter,
         });
     }
 
@@ -345,6 +357,7 @@ export namespace GroupSession {
         peerNodeId: NodeId; //The Target Group Node Id
         operationalGroupKey: Bytes; // The Operational Group Key that was used to encrypt the incoming group message.
         operationalPrivacyKey?: Bytes;
+        messageCounter: MessageCounter;
     }
 
     export function assert(session?: Session, errorText?: string): asserts session is GroupSession {

--- a/packages/protocol/src/session/SessionManager.ts
+++ b/packages/protocol/src/session/SessionManager.ts
@@ -38,7 +38,7 @@ import { GroupSession } from "#session/GroupSession.js";
 import { CaseAuthenticatedTag, FabricId, FabricIndex, GroupId, NodeId } from "#types";
 import { UnexpectedDataError } from "@matter/general";
 import type { ExposedFabricInformation, Fabric } from "../fabric/Fabric.js";
-import { MessageCounter } from "../protocol/MessageCounter.js";
+import { MessageCounter, PersistedMessageCounter } from "../protocol/MessageCounter.js";
 import { NodeSession } from "./NodeSession.js";
 import { SecureSession } from "./SecureSession.js";
 import type { Session } from "./Session.js";
@@ -118,6 +118,15 @@ export interface SessionManagerContext {
 
 const ID_SPACE_UPPER_BOUND = 0xffff;
 
+/** Storage key for the node-global Group Encrypted Data Message Counter in the session storage context. */
+const GROUP_DATA_COUNTER_KEY = "groupDataCounter";
+
+/**
+ * Reserve block size for the persisted group data counter; matches CHIP `GROUP_MSG_COUNTER_MIN_INCREMENT`. The counter
+ * is persisted this far ahead so an unclean restart never rolls it back (Matter spec §4.6.1.3).
+ */
+const GROUP_DATA_COUNTER_RESERVE = 1000;
+
 /**
  * Manages Matter sessions associated with peer connections.
  */
@@ -129,6 +138,7 @@ export class SessionManager {
     #nextSessionId: number;
     #resumptionRecords = new PeerAddressMap<InternalResumptionRecord>();
     readonly #globalUnencryptedMessageCounter;
+    #groupDataMessageCounter!: PersistedMessageCounter;
     #sessionParameters: SessionParameters;
     readonly #construction: Construction<SessionManager>;
     readonly #observers = new ObserverGroup();
@@ -188,6 +198,12 @@ export class SessionManager {
 
     get crypto() {
         return this.#context.fabrics.crypto;
+    }
+
+    /** The single node-global Group Encrypted Data Message Counter shared by all group sessions (spec §4.6.1.3). */
+    get groupDataMessageCounter() {
+        this.#construction.assert();
+        return this.#groupDataMessageCounter;
     }
 
     /**
@@ -480,6 +496,7 @@ export class SessionManager {
      * Returns the session for the current group epoch key.  The source is this node and the peer is the group.
      */
     async groupSessionForAddress(address: PeerAddress, transports: ConnectionlessTransportSet) {
+        this.#construction.assert();
         const groupId = GroupId.fromNodeId(address.nodeId);
         GroupId.assertGroupId(groupId);
 
@@ -504,6 +521,7 @@ export class SessionManager {
             keySetId,
             operationalGroupKey: key,
             groupNodeId: address.nodeId,
+            messageCounter: this.#groupDataMessageCounter,
         });
     }
 
@@ -516,6 +534,7 @@ export class SessionManager {
      * result in an error.
      */
     groupSessionFromPacket(packet: DecodedPacket, aad: Bytes) {
+        this.#construction.assert();
         const { message, key, privacyKey, sessionId, sourceNodeId, keySetId, fabric } = GroupSession.decode(
             this.#context.fabrics,
             packet,
@@ -538,6 +557,7 @@ export class SessionManager {
                 operationalGroupKey: key,
                 operationalPrivacyKey: privacyKey,
                 peerNodeId: sourceNodeId,
+                messageCounter: this.#groupDataMessageCounter,
             });
         }
 
@@ -652,6 +672,8 @@ export class SessionManager {
     async #initialize() {
         await this.#context.fabrics.construction;
 
+        this.#groupDataMessageCounter = await this.#createGroupDataMessageCounter();
+
         const storedResumptionRecords = await this.#context.storage.get<ResumptionStorageRecord[]>(
             "resumptionRecords",
             [],
@@ -698,6 +720,39 @@ export class SessionManager {
         );
     }
 
+    /**
+     * Build the node-global group data message counter. On the first run after upgrading from the legacy per-key
+     * model, seed it above every value any per-key counter could already have used so it never rolls back below a
+     * value already sent with a surviving key (spec §4.6.1.3); then clear the legacy entries.
+     */
+    async #createGroupDataMessageCounter() {
+        const storage = this.#context.storage;
+
+        const migrating = !(await storage.has(GROUP_DATA_COUNTER_KEY));
+        const seed = migrating ? await this.#context.fabrics.legacyGroupDataCounterMax() : undefined;
+
+        const counter = await PersistedMessageCounter.create(this.crypto, storage, GROUP_DATA_COUNTER_KEY, {
+            reserve: GROUP_DATA_COUNTER_RESERVE,
+            seed,
+            // Presence of the callback lets the counter roll over to 0 (matching CHIP) rather than throwing. The node
+            // cannot rotate group epoch keys itself (the Administrator does, §4.17.3.3); for now we only warn near
+            // exhaustion (spec §4.6.4).
+            // TODO Expose this "group epoch keys must be rotated" signal to external logic instead of only logging, so
+            //  the controller key-management layer can act on it.
+            aboutToRolloverCallback: async () => {
+                logger.warn(
+                    "Group data message counter is approaching rollover; group epoch keys should be rotated to avoid message counter reuse.",
+                );
+            },
+        });
+
+        if (migrating) {
+            await this.#context.fabrics.clearLegacyGroupDataCounters();
+        }
+
+        return counter;
+    }
+
     getActiveSessionInformation(): ActiveSessionInformation[] {
         this.#construction.assert();
         return [...this.#sessions]
@@ -734,6 +789,7 @@ export class SessionManager {
         await this.closeAllSessions();
         await this.#context.storage.clear();
         this.#resumptionRecords.clear();
+        this.#groupDataMessageCounter = await this.#createGroupDataMessageCounter();
     }
 
     async closeAllSessions() {

--- a/packages/protocol/test/groups/MessagingStateTest.ts
+++ b/packages/protocol/test/groups/MessagingStateTest.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InternalError, StorageBackendMemory, StorageManager, type StorageContext } from "#general";
+import { MessagingState } from "#groups/MessagingState.js";
+import { NodeId } from "#types";
+
+const storage = {} as StorageContext;
+const key = new Uint8Array([1, 2, 3]);
+
+describe("MessagingState", () => {
+    describe("storage", () => {
+        it("allows setting storage once when constructed without it", () => {
+            const state = new MessagingState();
+            expect(() => (state.storage = storage)).not.throws();
+        });
+
+        it("rejects setting storage a second time", () => {
+            const state = new MessagingState(storage);
+            expect(() => (state.storage = storage)).throws(InternalError, "only be set once");
+        });
+    });
+
+    describe("receptionStateFor", () => {
+        it("returns a stable instance per (source node, key)", () => {
+            const state = new MessagingState();
+
+            const first = state.receptionStateFor(NodeId(1n), key);
+
+            expect(state.receptionStateFor(NodeId(1n), key)).equal(first);
+            expect(state.receptionStateFor(NodeId(2n), key)).not.equal(first);
+        });
+    });
+
+    describe("legacy group data counter migration", () => {
+        async function realStorage() {
+            const backend = new StorageBackendMemory();
+            const manager = new StorageManager(backend);
+            await manager.initialize();
+            return manager.createContext("fabric-1");
+        }
+
+        it("returns the max across legacy *-data entries, ignoring others", async () => {
+            const ctx = await realStorage();
+            await ctx.set(`${"a".repeat(32)}-data`, 100);
+            await ctx.set(`${"b".repeat(32)}-data`, 4242);
+            await ctx.set("resumptionRecords", 7);
+            const state = new MessagingState(ctx);
+
+            expect(await state.legacyGroupDataCounterMax()).equal(4242);
+        });
+
+        it("returns undefined when there are no legacy entries", async () => {
+            const ctx = await realStorage();
+            const state = new MessagingState(ctx);
+
+            expect(await state.legacyGroupDataCounterMax()).undefined;
+        });
+
+        it("clears only the legacy *-data entries", async () => {
+            const ctx = await realStorage();
+            const dataKey = `${"c".repeat(32)}-data`;
+            await ctx.set(dataKey, 5);
+            await ctx.set("keep", 1);
+            const state = new MessagingState(ctx);
+
+            await state.clearLegacyGroupDataCounters();
+
+            expect(await ctx.has(dataKey)).equal(false);
+            expect(await ctx.has("keep")).equal(true);
+        });
+    });
+});

--- a/packages/protocol/test/protocol/MessageCounterTest.ts
+++ b/packages/protocol/test/protocol/MessageCounterTest.ts
@@ -89,12 +89,9 @@ describe("MessageCounter", () => {
 
         it("Message counter rolls over if allowed", async () => {
             await testStorageContext.set("counter", MAX_COUNTER_VALUE_32BIT);
-            const messageCounter = await PersistedMessageCounter.create(
-                crypto,
-                testStorageContext,
-                "counter",
-                async () => {},
-            );
+            const messageCounter = await PersistedMessageCounter.create(crypto, testStorageContext, "counter", {
+                aboutToRolloverCallback: async () => {},
+            });
             expect(await messageCounter.getIncrementedCounter()).equals(0);
         });
 
@@ -102,15 +99,12 @@ describe("MessageCounter", () => {
             const initCounter = MAX_COUNTER_VALUE_32BIT - 101;
             await testStorageContext.set("counter", initCounter);
             let callbackCalled = false;
-            const messageCounter = await PersistedMessageCounter.create(
-                crypto,
-                testStorageContext,
-                "counter",
-                async () => {
+            const messageCounter = await PersistedMessageCounter.create(crypto, testStorageContext, "counter", {
+                aboutToRolloverCallback: async () => {
                     callbackCalled = true;
                 },
-                100,
-            );
+                rolloverInfoDifference: 100,
+            });
             expect(callbackCalled).to.be.false;
             expect(await messageCounter.getIncrementedCounter()).equals(initCounter + 1);
             expect(callbackCalled).to.be.true;
@@ -123,19 +117,84 @@ describe("MessageCounter", () => {
             const initCounter = MAX_COUNTER_VALUE_32BIT - 100;
             await testStorageContext.set("counter", initCounter);
             let callbackCalled = false;
-            const messageCounter = await PersistedMessageCounter.create(
-                crypto,
-                testStorageContext,
-                "counter",
-                async () => {
+            const messageCounter = await PersistedMessageCounter.create(crypto, testStorageContext, "counter", {
+                aboutToRolloverCallback: async () => {
                     callbackCalled = true;
                 },
-                100,
-            );
+                rolloverInfoDifference: 100,
+            });
             expect(callbackCalled).to.be.true;
             callbackCalled = false;
             expect(await messageCounter.getIncrementedCounter()).equals(initCounter + 1);
             expect(callbackCalled).to.be.false;
+        });
+
+        it("reserves a block ahead and does not write storage within the block", async () => {
+            const messageCounter = await PersistedMessageCounter.create(crypto, testStorageContext, "counter", {
+                reserve: 1000,
+            });
+            const start = (0x12345678 >>> 4) + 1;
+            expect(await testStorageContext.get<number>("counter")).equal(start + 1000);
+            await messageCounter.getIncrementedCounter();
+            await messageCounter.getIncrementedCounter();
+            expect(await testStorageContext.get<number>("counter")).equal(start + 1000);
+        });
+
+        it("never rolls back across a restart when reserving", async () => {
+            const first = await PersistedMessageCounter.create(crypto, testStorageContext, "counter", {
+                reserve: 1000,
+            });
+            const used = await first.getIncrementedCounter();
+            const second = await PersistedMessageCounter.create(crypto, testStorageContext, "counter", {
+                reserve: 1000,
+            });
+            expect(await second.getIncrementedCounter()).greaterThan(used);
+        });
+
+        it("seeds the initial value when nothing is persisted", async () => {
+            const messageCounter = await PersistedMessageCounter.create(crypto, testStorageContext, "counter", {
+                seed: 5_000_000,
+            });
+            expect(await messageCounter.getIncrementedCounter()).equal(5_000_001);
+        });
+
+        it("ignores the seed when a value is already persisted", async () => {
+            await testStorageContext.set("counter", 9_000_000);
+            const messageCounter = await PersistedMessageCounter.create(crypto, testStorageContext, "counter", {
+                seed: 1,
+            });
+            expect(await messageCounter.getIncrementedCounter()).equal(9_000_001);
+        });
+
+        it("rejects an invalid reserve", async () => {
+            await expect(
+                PersistedMessageCounter.create(crypto, testStorageContext, "counter", { reserve: 0 }),
+            ).rejectedWith("Invalid message counter reserve");
+        });
+
+        it("re-reserves after a rollover so wrapped values are not re-issued", async () => {
+            await testStorageContext.set("counter", MAX_COUNTER_VALUE_32BIT);
+            const counter = await PersistedMessageCounter.create(crypto, testStorageContext, "counter", {
+                reserve: 1000,
+                aboutToRolloverCallback: async () => {},
+            });
+            expect(await counter.getIncrementedCounter()).equal(0); // rolls over
+            // Wrapped low values are persisted ahead immediately, not left at the stale near-MAX reserve.
+            expect(await testStorageContext.get<number>("counter")).equal(1000);
+
+            const used = await counter.getIncrementedCounter();
+            const restart = await PersistedMessageCounter.create(crypto, testStorageContext, "counter", {
+                reserve: 1000,
+                aboutToRolloverCallback: async () => {},
+            });
+            expect(await restart.getIncrementedCounter()).greaterThan(used);
+        });
+
+        it("rejects a non-numeric persisted value", async () => {
+            await testStorageContext.set("counter", "not-a-number");
+            await expect(PersistedMessageCounter.create(crypto, testStorageContext, "counter")).rejectedWith(
+                "Invalid message counter value",
+            );
         });
     });
 });

--- a/packages/protocol/test/session/SecureSessionTest.ts
+++ b/packages/protocol/test/session/SecureSessionTest.ts
@@ -8,6 +8,7 @@ import { Message, MessageCodec, SessionType } from "#codec/MessageCodec.js";
 import { Fabric } from "#fabric/Fabric.js";
 import { FabricManager } from "#fabric/FabricManager.js";
 import { b$, Bytes, Key, PrivateKey, StandardCrypto, StorageBackendMemory, StorageContext } from "#general";
+import { MessageCounter } from "#protocol/MessageCounter.js";
 import { GroupSession } from "#session/GroupSession.js";
 import { NodeSession } from "#session/NodeSession.js";
 import { FabricId, FabricIndex, GlobalFabricId, NodeId, VendorId } from "#types";
@@ -139,6 +140,7 @@ describe("SecureSession", () => {
                 operationalGroupKey: current.key,
                 operationalPrivacyKey: current.privacyKey,
                 peerNodeId: NodeId(0xffffffffffff0000n | BigInt(groupId)),
+                messageCounter: new MessageCounter(fabric.crypto),
             });
 
             const message: Message = {

--- a/packages/protocol/test/session/SessionManagerTest.ts
+++ b/packages/protocol/test/session/SessionManagerTest.ts
@@ -4,13 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Fabric } from "#fabric/Fabric.js";
 import { FabricManager } from "#fabric/FabricManager.js";
-import { StandardCrypto, StorageBackendMemory, StorageContext } from "#general";
+import { b$, Bytes, Key, PrivateKey, StandardCrypto, StorageBackendMemory, StorageContext } from "#general";
 import { SessionParameters } from "#index.js";
 import { SessionManager } from "#session/SessionManager.js";
-import { NodeId } from "#types";
+import { FabricId, FabricIndex, GlobalFabricId, NodeId, VendorId } from "#types";
 
 const DUMMY_BYTEARRAY = new Uint8Array();
+
+const TEST_ROOT_PUBLIC_KEY = Bytes.fromHex(
+    "044a9f42b1ca4840d37292bbc7f6a7e11e22200c976fc900dbc98a7a383a641cb8254a2e56d4e295a847943b4e3897c4a773e930277b4d9fbede8a052686bfacfa",
+);
+const TEST_IDENTITY_PROTECTION_KEY = Bytes.fromHex("9bc61cd9c62a2df6d64dfcaa9dc472d4");
+const SEC1_KEY = Bytes.fromHex(
+    "30770201010420aef3484116e9481ec57be0472df41bf499064e5024ad869eca5e889802d48075a00a06082a8648ce3d030107a144034200043c398922452b55caf389c25bd1bca4656952ccb90e8869249ad8474653014cbf95d687965e036b521c51037e6b8cedefca1eb44046694fa08882eed6519decba",
+);
 
 describe("SessionManager", () => {
     describe("getNextAvailableSessionId", () => {
@@ -117,6 +126,104 @@ describe("SessionManager", () => {
             }
             expect(await sessionManager.getNextAvailableSessionId()).to.equal(first);
             expect(firstClosed).to.be.true;
+        });
+    });
+
+    describe("group data message counter", () => {
+        function groupFabric(crypto: StandardCrypto, fabricStorage: StorageContext) {
+            const fabric = new Fabric(crypto, {
+                fabricIndex: FabricIndex(1),
+                fabricId: FabricId(BigInt("0x456789ABCDEF1234")),
+                nodeId: NodeId(1),
+                rootNodeId: NodeId(1),
+                globalId: GlobalFabricId(0),
+                keyPair: Key({ sec1: SEC1_KEY }) as PrivateKey,
+                rootPublicKey: TEST_ROOT_PUBLIC_KEY,
+                rootVendorId: VendorId(0),
+                rootCert: new Uint8Array(),
+                identityProtectionKey: new Uint8Array(),
+                operationalIdentityProtectionKey: TEST_IDENTITY_PROTECTION_KEY,
+                intermediateCACert: new Uint8Array(),
+                operationalCert: new Uint8Array(),
+                label: "",
+            });
+            fabric.storage = fabricStorage;
+            return fabric;
+        }
+
+        it("exposes one node-global counter shared across group sessions", async () => {
+            const storage = new StorageBackendMemory();
+            storage.initialize();
+            const sessionManager = new SessionManager({
+                parameters: {} as SessionParameters,
+                fabrics: new FabricManager(new StandardCrypto()),
+                storage: new StorageContext(storage, ["sessions"]),
+            });
+            await sessionManager.construction.ready;
+
+            const first = await sessionManager.groupDataMessageCounter.getIncrementedCounter();
+            const second = await sessionManager.groupDataMessageCounter.getIncrementedCounter();
+            expect(second).equal(first + 1);
+        });
+
+        it("seeds the global counter above legacy per-key counters and clears them (Q-02 migration)", async () => {
+            const crypto = new StandardCrypto();
+            const storage = new StorageBackendMemory();
+            storage.initialize();
+
+            const fabricManager = new FabricManager(crypto);
+            await fabricManager.construction.ready;
+            const fabricStorage = new StorageContext(storage, ["fabric"]);
+            const fabric = groupFabric(crypto, fabricStorage);
+            fabricManager.addFabric(fabric);
+
+            // Simulate a legacy per-operational-key data counter persisted by the old model.
+            const legacyKey = `${"a".repeat(32)}-data`;
+            await fabricStorage.set(legacyKey, 4242);
+
+            const sessionManager = new SessionManager({
+                parameters: {} as SessionParameters,
+                fabrics: fabricManager,
+                storage: new StorageContext(storage, ["sessions"]),
+            });
+            await sessionManager.construction.ready;
+
+            expect(await sessionManager.groupDataMessageCounter.getIncrementedCounter()).greaterThan(4242);
+            expect(await fabricStorage.has(legacyKey)).equal(false);
+        });
+
+        it("does not roll the counter back when a group key set is removed (Q-02)", async () => {
+            const crypto = new StandardCrypto();
+            const storage = new StorageBackendMemory();
+            storage.initialize();
+
+            const fabricManager = new FabricManager(crypto);
+            await fabricManager.construction.ready;
+            const fabric = groupFabric(crypto, new StorageContext(storage, ["fabric"]));
+            fabricManager.addFabric(fabric);
+            await fabric.groups.setFromGroupKeySet({
+                groupKeySetId: 1,
+                groupKeySecurityPolicy: 0,
+                epochKey0: b$`000102030405060708090a0b0c0d0e0f`,
+                epochStartTime0: 1,
+                epochKey1: null,
+                epochStartTime1: null,
+                epochKey2: null,
+                epochStartTime2: null,
+                groupKeyMulticastPolicy: 0,
+            });
+
+            const sessionManager = new SessionManager({
+                parameters: {} as SessionParameters,
+                fabrics: fabricManager,
+                storage: new StorageContext(storage, ["sessions"]),
+            });
+            await sessionManager.construction.ready;
+
+            const before = await sessionManager.groupDataMessageCounter.getIncrementedCounter();
+            fabric.groups.removeGroupKeySet(1);
+            const after = await sessionManager.groupDataMessageCounter.getIncrementedCounter();
+            expect(after).greaterThan(before);
         });
     });
 });


### PR DESCRIPTION
Backport of #3870 to the 0.16.x line, **stacked on #3856** (message-privacy backport) since they touch the same group/session files. Base this PR's merge on #3856; merge #3856 first, then this, then 0.16.x.

## What

Replaces per-operational-key group **data** message counters with one node-global, block-reserve-persisted counter (Matter spec §4.6.1.3 / CHIP), decoupled from key-set lifecycle. On first start after upgrade, the global counter is seeded above the max legacy per-key counter across all fabrics and the legacy `<keyHex>-data` entries are cleared — preventing AES-CCM nonce reuse on a key that survives the upgrade. Rolls over like CHIP with a near-exhaustion warning.

See #3870 for the full rationale.

## Adaptation to 0.16.x

- Import conventions `#general` / `#types` / `#protocol` (not `@matter/*`).
- `StorageBackendMemory` in tests (not `MemoryStorageDriver`).
- `MAX_COUNTER_VALUE_32BIT` stays `0xfffffffe` (0.16.x value); all logic uses the constant.
- Composed with #3856's privacy changes (`operationalPrivacyKey`, `ConnectionlessTransportSet`, 0.16.x `clear()`).
- Added `MessagingStateTest` (absent on 0.16.x).

## Tests

Protocol ESM 578/578 + CJS 578/578, node `GroupKeyManagement` green; full monorepo build green; lint + format clean. (Web test target launch is an environment issue on this branch, unrelated to the change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)