### PR TITLE
fix(node): restore client nodes commissioned with a custom id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/node
     - Fix: Ensure that Self-bindings also detect cluster servers added to an endpoint at runtime via `behaviors.require` and ignore client clusters on the endpoint
     - Fix: OnOff timed-off handling now honors the `0xFFFF` "hold indefinitely" value for OnTime/OffWaitTime
-    - Fix: Peers commissioned with a custom id via `commission({ id })` are now restored from storage on restart
+    - Fix: Peers commissioned with a custom id via `commission({ id })` are now restored correctly from storage on restart
 
 - @matter/protocol
     - Enhancement: Implemented Matter message privacy (header obfuscation) for group messages; receiving is always supported, sending is opt-in per session and off by default. Unicast messages carrying the privacy flag are dropped like in CHIP SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/node
     - Fix: Ensure that Self-bindings also detect cluster servers added to an endpoint at runtime via `behaviors.require` and ignore client clusters on the endpoint
     - Fix: OnOff timed-off handling now honors the `0xFFFF` "hold indefinitely" value for OnTime/OffWaitTime
+    - Fix: Peers commissioned with a custom id via `commission({ id })` are now restored from storage on restart
 
 - @matter/protocol
     - Enhancement: Implemented Matter message privacy (header obfuscation) for group messages; receiving is always supported, sending is opt-in per session and off by default. Unicast messages carrying the privacy flag are dropped like in CHIP SDK

--- a/packages/node/src/behavior/system/controller/discovery/Discovery.ts
+++ b/packages/node/src/behavior/system/controller/discovery/Discovery.ts
@@ -305,7 +305,7 @@ export namespace Discovery {
          * The local ID to assign the node if newly discovered.  This is the stable identifier used for the node's "id"
          * property.
          *
-         * By default matter.js assigns an ID of the form "nodeN".
+         * By default matter.js assigns an ID of the form "peerN".
          */
         id?: string;
     };

--- a/packages/node/src/storage/client/ClientNodeStores.ts
+++ b/packages/node/src/storage/client/ClientNodeStores.ts
@@ -45,13 +45,10 @@ export class ClientNodeStores {
         const contexts = await this.#storage.contexts();
 
         for (const id of contexts) {
-            if (!id.startsWith(CLIENT_ID_PREFIX)) {
-                continue;
-            }
-
-            const num = Number.parseInt(id.slice(CLIENT_ID_PREFIX.length));
-            if (Number.isFinite(num)) {
-                if (this.#nextAutomaticId <= num) {
+            // Keep the auto-allocation counter ahead of any persisted "peerN" id; custom ids are restored too.
+            if (id.startsWith(CLIENT_ID_PREFIX)) {
+                const num = Number.parseInt(id.slice(CLIENT_ID_PREFIX.length));
+                if (Number.isFinite(num) && this.#nextAutomaticId <= num) {
                     this.#nextAutomaticId = num + 1;
                 }
             }

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -240,6 +240,38 @@ describe("ClientNode", () => {
         expect(controller.peers.size).equals(1);
     });
 
+    it("commissions with an explicit id and restores the peer under that id after restart", async () => {
+        await using site = new MockSite();
+        const controller = await site.addController();
+        const device = await site.addDevice();
+
+        const controllerCrypto = controller.env.get(Crypto) as MockCrypto;
+        const deviceCrypto = device.env.get(Crypto) as MockCrypto;
+        controllerCrypto.entropic = deviceCrypto.entropic = true;
+
+        await controller.start();
+        const { passcode, discriminator } = device.state.commissioning;
+        await MockTime.resolve(
+            controller.peers.commission({ id: "device", passcode, discriminator, timeout: Seconds(90) }),
+            { macrotasks: true },
+        );
+
+        controllerCrypto.entropic = deviceCrypto.entropic = false;
+
+        expect(device.state.commissioning.commissioned).equals(true);
+        expect(controller.peers.size).equals(1);
+        expect([...controller.peers].map(n => n.id)).deep.equals(["device"]);
+        expect(controller.peers.get("device")).not.undefined;
+
+        // *** RESTART controller (models the two-process commission-then-toggle flow) ***
+        await site.close();
+        const controllerB = await site.addNode(undefined, { id: "controller1", index: 1 });
+
+        expect(controllerB.peers.size).equals(1);
+        expect([...controllerB.peers].map(n => n.id)).deep.equals(["device"]);
+        expect(controllerB.peers.get("device")).not.undefined;
+    });
+
     it("rejects node-level commissioning without known addresses", async () => {
         await using site = new MockSite();
         const { controller, device } = await site.addUncommissionedPair();


### PR DESCRIPTION
## Problem

Peers commissioned with an explicit id — `controller.peers.commission({ id: "device", ... })` — work in-memory but **vanish after a restart**. A fresh process loading the same storage finds no peer, so `controller.peers.get("device")` returns `undefined`.

Root cause is in `ClientNodeStores[Construction.construct]()`: it restored only persisted sub-contexts whose id started with the `"peer"` auto-allocation prefix:

```js
for (const id of contexts) {
    if (!id.startsWith(CLIENT_ID_PREFIX)) {   // "peer"
        continue;                              // <-- custom ids dropped here
    }
    ...
    this.#createNodeStore(id, true);
}
```

Auto-allocated ids (`peer1`, `peer2`, …) reload fine; a custom id like `"device"` is persisted on commission but skipped on reload.

## Fix

The `"nodes"` storage context is owned **exclusively** by `ClientNodeStores` — every persisted sub-context there is a client node store (group stores use a separate in-memory driver and are never persisted here). So restore **every** persisted sub-context, and keep the `"peer"`-prefix check only to advance the auto-allocation counter.

## Test

Added a regression test that commissions with an explicit id, restarts the controller (modelling the two-process commission-then-use flow), and asserts the peer is restored under that id. Fails before the fix, passes after. Full `@matter/node` suite green.

## Also

- Corrected the `Discovery.InstanceOptions.id` jsdoc: default ids are `"peerN"`, not `"nodeN"`.

Related to #3843 (this is the library-side cause behind the example failure; the example fixes are in #3847).

🤖 Generated with [Claude Code](https://claude.com/claude-code)