### PR TITLE
feat(node): ICD Phase 3a — controller IcdClient

### DIFF
--- a/packages/node/src/behavior/system/icd/IcdClient.ts
+++ b/packages/node/src/behavior/system/icd/IcdClient.ts
@@ -110,6 +110,7 @@ export class IcdClient extends Behavior {
         this.state.lastOffset = undefined;
         this.state.monitoredSubject = undefined;
         this.state.clientType = undefined;
+        this.state.lastCheckInReceivedAt = undefined;
         this.events.unregistered.emit();
     }
 
@@ -330,6 +331,7 @@ export class IcdClient extends Behavior {
      */
     override async [Symbol.asyncDispose]() {
         await this.internal.keyRefresh;
+        await super[Symbol.asyncDispose]?.();
     }
 }
 

--- a/packages/node/src/behavior/system/icd/IcdClient.ts
+++ b/packages/node/src/behavior/system/icd/IcdClient.ts
@@ -6,10 +6,9 @@
 
 import { Behavior } from "#behavior/Behavior.js";
 import { Events as BaseEvents } from "#behavior/Events.js";
-import { IcdMultiAdminError } from "#behavior/system/icd/IcdMultiAdminError.js";
 import { Bytes, Observable, Timestamp } from "@matter/general";
-import { bool, field, listOf, nonvolatile, octstr, subjectId, systimeMs, uint32, uint8, vendorId } from "@matter/model";
-import { SubjectId, VendorId } from "@matter/types";
+import { bool, field, nonvolatile, octstr, subjectId, systimeMs, uint32, uint8 } from "@matter/model";
+import { SubjectId } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
 
 /**
@@ -79,12 +78,6 @@ export namespace IcdClient {
          */
         @field(systimeMs)
         lastCheckInReceivedAt?: Timestamp;
-
-        /**
-         * Admin VendorIds excluded from the multi-admin safety check at registration.
-         */
-        @field(listOf(vendorId), nonvolatile)
-        ignoredFabricVendors: VendorId[] = [...IcdMultiAdminError.TRUSTED_ECOSYSTEM_VENDORS];
     }
 
     export class Events extends BaseEvents {

--- a/packages/node/src/behavior/system/icd/IcdClient.ts
+++ b/packages/node/src/behavior/system/icd/IcdClient.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Behavior } from "#behavior/Behavior.js";
+import { Events as BaseEvents } from "#behavior/Events.js";
+import { IcdMultiAdminError } from "#behavior/system/icd/IcdMultiAdminError.js";
+import { Bytes, Observable, Timestamp } from "@matter/general";
+import { bool, field, listOf, nonvolatile, octstr, subjectId, systimeMs, uint32, uint8, vendorId } from "@matter/model";
+import { SubjectId, VendorId } from "@matter/types";
+import { IcdManagement } from "@matter/types/clusters/icd-management";
+
+/**
+ * Controller-side client for ICD (Intermittently Connected Device) Check-In support.
+ *
+ * Auto-installed on a {@link ClientNode} whose peer exposes the IcdManagement cluster; installation alone does not
+ * register this controller as a Check-In client — registration is an explicit application action. Receiving Check-Ins
+ * emits events and updates informational state only; this behavior does not resubscribe or track peer wakefulness.
+ *
+ * @see {@link MatterSpecification.v151.Core} § 9.15.1, § 9.16
+ */
+export class IcdClient extends Behavior {
+    declare internal: IcdClient.Internal;
+    declare readonly state: IcdClient.State;
+    declare readonly events: IcdClient.Events;
+
+    static override readonly early = true;
+    static override readonly id = "icd";
+
+    get isRegistered() {
+        return this.state.registered;
+    }
+}
+
+export namespace IcdClient {
+    export class Internal {}
+
+    export class State {
+        /**
+         * Shared secret installed on the peer at registration, used to verify Check-In message ICD counters.
+         */
+        @field(octstr, nonvolatile)
+        key?: Bytes;
+
+        /**
+         * ICD counter value the peer reported at registration; Check-In counters are validated relative to this.
+         */
+        @field(uint32, nonvolatile)
+        counterStart?: number;
+
+        /**
+         * Offset of the most recently observed Check-In counter from {@link counterStart}.
+         */
+        @field(uint32, nonvolatile)
+        lastOffset?: number;
+
+        /**
+         * Subject the peer monitors on our behalf (the node ID notified on Check-In).
+         */
+        @field(subjectId, nonvolatile)
+        monitoredSubject?: SubjectId;
+
+        /**
+         * Client type registered with the peer (permanent or ephemeral).
+         */
+        @field(uint8, nonvolatile)
+        clientType?: IcdManagement.ClientType;
+
+        /**
+         * Whether this controller is currently registered as a Check-In client on the peer.
+         */
+        @field(bool, nonvolatile)
+        registered: boolean = false;
+
+        /**
+         * Time of the most recently received Check-In from the peer.
+         */
+        @field(systimeMs)
+        lastCheckInReceivedAt?: Timestamp;
+
+        /**
+         * Admin VendorIds excluded from the multi-admin safety check at registration.
+         */
+        @field(listOf(vendorId), nonvolatile)
+        ignoredFabricVendors: VendorId[] = [...IcdMultiAdminError.TRUSTED_ECOSYSTEM_VENDORS];
+    }
+
+    export class Events extends BaseEvents {
+        registered = Observable();
+        unregistered = Observable();
+        checkedIn = Observable<[checkIn: { counter: number; activeModeThreshold: number }]>();
+        keyRefreshed = Observable();
+    }
+}

--- a/packages/node/src/behavior/system/icd/IcdClient.ts
+++ b/packages/node/src/behavior/system/icd/IcdClient.ts
@@ -6,10 +6,16 @@
 
 import { Behavior } from "#behavior/Behavior.js";
 import { Events as BaseEvents } from "#behavior/Events.js";
-import { Bytes, Observable, Timestamp } from "@matter/general";
+import { CommissioningClient } from "#behavior/system/commissioning/CommissioningClient.js";
+import { IcdManagementClient } from "#behaviors/icd-management";
+import { OperationalCredentialsClient } from "#behaviors/operational-credentials";
+import { Node } from "#node/Node.js";
+import { Bytes, Crypto, ImplementationError, Observable, Timestamp } from "@matter/general";
 import { bool, field, nonvolatile, octstr, subjectId, systimeMs, uint32, uint8 } from "@matter/model";
-import { SubjectId } from "@matter/types";
+import { FabricManager, type FabricIcd } from "@matter/protocol";
+import { NodeId, SubjectId, VendorId } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
+import { IcdMultiAdminError } from "./IcdMultiAdminError.js";
 
 /**
  * Controller-side client for ICD (Intermittently Connected Device) Check-In support.
@@ -31,10 +37,112 @@ export class IcdClient extends Behavior {
     get isRegistered() {
         return this.state.registered;
     }
+
+    /**
+     * Register this controller as a Check-In client on the peer.
+     *
+     * Installs a shared {@link IcdManagement.RegisterClientRequest.key} on the peer so it can send us encrypted
+     * Check-In messages, records the rolling-counter baseline in {@link State}, and arms the controller-side Check-In
+     * receive path on the fabric.
+     *
+     * @throws {ImplementationError} if the peer is not online (registration reads from and writes to the peer), or its
+     *   IcdManagement cluster lacks the Check-In Protocol feature.
+     * @throws {IcdMultiAdminError} if the peer has more than one administrator from other vendors and
+     *   `allowMultiAdmin` is not set — see {@link IcdMultiAdminError.assertSingleAdmin}.
+     */
+    async register(options?: {
+        monitoredSubject?: SubjectId;
+        clientType?: IcdManagement.ClientType;
+        allowMultiAdmin?: boolean;
+        ignoredVendors?: VendorId[];
+    }) {
+        if (!(this.endpoint instanceof Node) || !this.endpoint.lifecycle.isOnline) {
+            throw new ImplementationError("ICD registration requires the peer node to be online.");
+        }
+
+        if (!this.endpoint.maybeFeaturesOf(IcdManagementClient)?.checkInProtocolSupport) {
+            throw new ImplementationError(
+                "ICD registration refused: peer does not support the Check-In Protocol (CIP).",
+            );
+        }
+
+        const { fabric, ownNodeId, peerNodeId } = this.#fabricContext();
+
+        const {
+            monitoredSubject = SubjectId(ownNodeId),
+            clientType = IcdManagement.ClientType.Permanent,
+            allowMultiAdmin = false,
+            ignoredVendors = IcdMultiAdminError.TRUSTED_ECOSYSTEM_VENDORS,
+        } = options ?? {};
+
+        const fabrics = await this.#readPeerFabrics();
+        IcdMultiAdminError.assertSingleAdmin(
+            fabrics.map(f => f.vendorId),
+            ignoredVendors,
+            allowMultiAdmin,
+        );
+
+        const key = this.env.get(Crypto).randomBytes(16);
+
+        const { icdCounter } = await this.#peerIcd().registerClient({
+            checkInNodeId: ownNodeId,
+            monitoredSubject,
+            key,
+            clientType,
+        });
+
+        this.state.key = key;
+        this.state.counterStart = icdCounter;
+        this.state.lastOffset = 0;
+        this.state.monitoredSubject = monitoredSubject;
+        this.state.clientType = clientType;
+        this.state.registered = true;
+
+        this.#feedFabricIcd(fabric, peerNodeId);
+        this.events.registered.emit();
+    }
+
+    #fabricContext() {
+        const peerAddress = this.endpoint.stateOf(CommissioningClient).peerAddress;
+        if (peerAddress === undefined) {
+            throw new ImplementationError("ICD registration requires a commissioned peer.");
+        }
+        const { fabricIndex, nodeId: peerNodeId } = peerAddress;
+        const fabric = this.env.get(FabricManager).for(fabricIndex);
+        const ownNodeId = fabric.nodeId;
+        return { fabric, ownNodeId, peerNodeId };
+    }
+
+    async #readPeerFabrics() {
+        const { fabrics } = await this.endpoint.getStateOf(OperationalCredentialsClient, ["fabrics"], {
+            fabricFilter: false,
+        });
+        return fabrics ?? [];
+    }
+
+    #peerIcd() {
+        return this.agent.get(IcdManagementClient);
+    }
+
+    #feedFabricIcd(fabric: ReturnType<FabricManager["for"]>, peerNodeId: NodeId) {
+        const { key, counterStart, lastOffset } = this.state;
+        if (key === undefined || counterStart === undefined || lastOffset === undefined) {
+            throw new ImplementationError("ICD peer cannot be fed to the fabric before registration state is set.");
+        }
+        if (this.internal.checkInHandler === undefined) {
+            this.internal.checkInHandler = this.callback(this.#onCheckIn, { offline: true, lock: true });
+        }
+        fabric.icd.addPeer({ peerNodeId, key, counterStart, lastOffset }, this.internal.checkInHandler);
+    }
+
+    #onCheckIn(_checkIn: FabricIcd.ReceivedCheckIn) {}
 }
 
 export namespace IcdClient {
-    export class Internal {}
+    export class Internal {
+        /** Retained across re-registrations so the protocol RX path stays armed without creating a second closure. */
+        checkInHandler?: FabricIcd.CheckInHandler;
+    }
 
     export class State {
         /**

--- a/packages/node/src/behavior/system/icd/IcdClient.ts
+++ b/packages/node/src/behavior/system/icd/IcdClient.ts
@@ -10,12 +10,14 @@ import { CommissioningClient } from "#behavior/system/commissioning/Commissionin
 import { IcdManagementClient } from "#behaviors/icd-management";
 import { OperationalCredentialsClient } from "#behaviors/operational-credentials";
 import { Node } from "#node/Node.js";
-import { Bytes, Crypto, ImplementationError, Observable, Timestamp } from "@matter/general";
+import { Bytes, Crypto, ImplementationError, Logger, Observable, Time, Timestamp } from "@matter/general";
 import { bool, field, nonvolatile, octstr, subjectId, systimeMs, uint32, uint8 } from "@matter/model";
 import { FabricManager, type FabricIcd } from "@matter/protocol";
 import { NodeId, SubjectId, VendorId } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { IcdMultiAdminError } from "./IcdMultiAdminError.js";
+
+const logger = Logger.get("IcdClient");
 
 /**
  * Controller-side client for ICD (Intermittently Connected Device) Check-In support.
@@ -135,13 +137,83 @@ export class IcdClient extends Behavior {
         fabric.icd.addPeer({ peerNodeId, key, counterStart, lastOffset }, this.internal.checkInHandler);
     }
 
-    #onCheckIn(_checkIn: FabricIcd.ReceivedCheckIn) {}
+    #onCheckIn(checkIn: FabricIcd.ReceivedCheckIn) {
+        const { offset, counter, activeModeThreshold, refreshNeeded } = checkIn;
+
+        // fabric.icd advanced its own runtime offset before invoking us; persist it so a restart cannot restore a stale
+        // lastOffset and reopen the replay window.
+        this.state.lastOffset = offset;
+        this.state.lastCheckInReceivedAt = Time.nowMs;
+        this.events.checkedIn.emit({ counter, activeModeThreshold });
+
+        // A tracked in-flight refresh (presence also guards against a second overlapping re-key) keeps the promise
+        // awaitable at teardown instead of orphaned.
+        if (refreshNeeded && this.internal.keyRefresh === undefined) {
+            this.internal.keyRefresh = this.#startKeyRefresh();
+        }
+    }
+
+    async #startKeyRefresh(): Promise<void> {
+        try {
+            // Defer one microtask so the Check-In RX transaction settles before we open the refresh transaction; the
+            // refresh does peer I/O and writes state, so it must run in its own transaction rather than escaping the
+            // RX one.
+            await Promise.resolve();
+            await this.endpoint.act("icd-key-refresh", agent => agent.get(IcdClient).#refreshKey());
+        } catch (error) {
+            logger.warn("ICD key refresh failed", error);
+        } finally {
+            this.internal.keyRefresh = undefined;
+        }
+    }
+
+    /**
+     * Re-key the registration in place before the rolling counter offset reaches 2³¹.
+     *
+     * @see {@link MatterSpecification.v151.Core} § 4.22.3.4.1
+     */
+    async #refreshKey() {
+        const { fabric, ownNodeId, peerNodeId } = this.#fabricContext();
+        const { monitoredSubject, clientType } = this.state;
+        if (monitoredSubject === undefined || clientType === undefined) {
+            throw new ImplementationError("ICD key refresh requires an existing registration.");
+        }
+
+        const verificationKey = this.state.key;
+        const key = this.env.get(Crypto).randomBytes(16);
+        const { icdCounter } = await this.#peerIcd().registerClient({
+            checkInNodeId: ownNodeId,
+            monitoredSubject,
+            key,
+            clientType,
+            verificationKey,
+        });
+
+        this.state.key = key;
+        this.state.counterStart = icdCounter;
+        this.state.lastOffset = 0;
+
+        fabric.icd.deletePeer(peerNodeId);
+        this.#feedFabricIcd(fabric, peerNodeId);
+        this.events.keyRefreshed.emit();
+    }
+
+    /**
+     * Wait for an in-flight key refresh to finish on teardown — aborting between the peer re-key and our state write
+     * would leave the controller and peer with mismatched keys.
+     */
+    override async [Symbol.asyncDispose]() {
+        await this.internal.keyRefresh;
+    }
 }
 
 export namespace IcdClient {
     export class Internal {
         /** Retained across re-registrations so the protocol RX path stays armed without creating a second closure. */
         checkInHandler?: FabricIcd.CheckInHandler;
+
+        /** In-flight key refresh; tracked so a second refreshNeeded Check-In can't overlap it and teardown can await it. */
+        keyRefresh?: Promise<void>;
     }
 
     export class State {

--- a/packages/node/src/behavior/system/icd/IcdClient.ts
+++ b/packages/node/src/behavior/system/icd/IcdClient.ts
@@ -10,9 +10,19 @@ import { CommissioningClient } from "#behavior/system/commissioning/Commissionin
 import { IcdManagementClient } from "#behaviors/icd-management";
 import { OperationalCredentialsClient } from "#behaviors/operational-credentials";
 import { Node } from "#node/Node.js";
-import { Bytes, Crypto, ImplementationError, Logger, Observable, Time, Timestamp } from "@matter/general";
+import {
+    Bytes,
+    Crypto,
+    Duration,
+    ImplementationError,
+    Logger,
+    Millis,
+    Observable,
+    Time,
+    Timestamp,
+} from "@matter/general";
 import { bool, field, nonvolatile, octstr, subjectId, systimeMs, uint32, uint8 } from "@matter/model";
-import { FabricManager, type FabricIcd } from "@matter/protocol";
+import { FabricManager, PeerAddress, type FabricIcd } from "@matter/protocol";
 import { NodeId, SubjectId, VendorId } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { IcdMultiAdminError } from "./IcdMultiAdminError.js";
@@ -40,6 +50,78 @@ export class IcdClient extends Behavior {
         return this.state.registered;
     }
 
+    /** Whether the peer supports the Long Idle Time feature; undefined feature map (unknown) reads as false. */
+    get peerSupportsLit() {
+        return this.endpoint.maybeFeaturesOf(IcdManagementClient)?.longIdleTimeSupport === true;
+    }
+
+    /** A LIT peer publishes Check-Ins rather than staying subscribable, so callers must await one before contacting it. */
+    get peerRequiresCheckIn() {
+        return this.peerSupportsLit;
+    }
+
+    /**
+     * Wire lifecycle reactors. Runs `early` so they are registered before the owner first comes online.
+     */
+    override initialize() {
+        if (this.endpoint instanceof Node) {
+            this.reactTo(this.endpoint.lifecycle.decommissioned, this.#onDecommissioned);
+        }
+
+        // Restore keys off the OWNER (controller) being online, not the peer: only then is the controller fabric
+        // loaded. The peer's own online state is irrelevant — an ICD peer is offline precisely when it sends Check-Ins.
+        const owner = this.endpoint.owner;
+        if (owner instanceof Node) {
+            this.reactTo(owner.lifecycle.online, this.#restoreReceivePath);
+            if (owner.lifecycle.isOnline) {
+                this.#restoreReceivePath();
+            }
+        }
+    }
+
+    /**
+     * Re-arm the Check-In receive path from persisted registration state. The {@link FabricIcd} peer entry is
+     * runtime-only, so it is rebuilt on every controller online (restart or reconnect).
+     */
+    #restoreReceivePath() {
+        if (!this.state.registered || this.state.key === undefined) {
+            return;
+        }
+        const { fabric, peerNodeId } = this.#fabricContext();
+        this.#feedFabricIcd(fabric, peerNodeId);
+    }
+
+    /**
+     * Decommission already removed our fabric from the peer (peerAddress is cleared), so no peer
+     * {@link IcdManagement.unregisterClient} is possible or needed — only local cleanup.
+     */
+    #onDecommissioned() {
+        if (this.state.registered) {
+            this.#clearRegistration();
+        }
+    }
+
+    /** Drop the FabricIcd peer entry, clear all registration state, and emit `unregistered`. */
+    #clearRegistration() {
+        this.#dropFedPeer();
+        this.state.registered = false;
+        this.state.key = undefined;
+        this.state.counterStart = undefined;
+        this.state.lastOffset = undefined;
+        this.state.monitoredSubject = undefined;
+        this.state.clientType = undefined;
+        this.events.unregistered.emit();
+    }
+
+    #dropFedPeer() {
+        const fedPeer = this.internal.fedPeer;
+        if (fedPeer === undefined) {
+            return;
+        }
+        this.env.get(FabricManager).maybeFor(fedPeer.fabricIndex)?.icd.deletePeer(fedPeer.nodeId);
+        this.internal.fedPeer = undefined;
+    }
+
     /**
      * Register this controller as a Check-In client on the peer.
      *
@@ -58,6 +140,12 @@ export class IcdClient extends Behavior {
         allowMultiAdmin?: boolean;
         ignoredVendors?: VendorId[];
     }) {
+        if (this.state.registered) {
+            throw new ImplementationError(
+                "ICD client is already registered; unregister first or let key refresh re-key in place.",
+            );
+        }
+
         if (!(this.endpoint instanceof Node) || !this.endpoint.lifecycle.isOnline) {
             throw new ImplementationError("ICD registration requires the peer node to be online.");
         }
@@ -104,6 +192,43 @@ export class IcdClient extends Behavior {
         this.events.registered.emit();
     }
 
+    /**
+     * Remove this controller's Check-In registration from the peer and tear down the local receive path.
+     *
+     * Best-effort on the peer: local state is cleared even if the peer {@link IcdManagement.unregisterClient} fails (it
+     * may be unreachable). A no-op when not registered.
+     */
+    async unregister(): Promise<void> {
+        if (!this.state.registered) {
+            return;
+        }
+
+        // Clear registered up front so a late refreshNeeded Check-In cannot start a new re-key that races this
+        // teardown; then settle any already in-flight re-key before we tear down the peer entry.
+        this.state.registered = false;
+        await this.internal.keyRefresh;
+
+        const { ownNodeId } = this.#fabricContext();
+
+        try {
+            await this.#peerIcd().unregisterClient({ checkInNodeId: ownNodeId, verificationKey: this.state.key });
+        } finally {
+            this.#clearRegistration();
+        }
+    }
+
+    /**
+     * Ask the peer to remain in Active mode for at least `duration` and return the duration it actually promised.
+     *
+     * @see {@link MatterSpecification.v151.Core} § 9.16.7.4
+     */
+    async stayActive(duration: Duration): Promise<Duration> {
+        const { promisedActiveDuration } = await this.#peerIcd().stayActiveRequest({
+            stayActiveDuration: Millis.of(duration),
+        });
+        return Millis(promisedActiveDuration);
+    }
+
     #fabricContext() {
         const peerAddress = this.endpoint.stateOf(CommissioningClient).peerAddress;
         if (peerAddress === undefined) {
@@ -135,6 +260,7 @@ export class IcdClient extends Behavior {
             this.internal.checkInHandler = this.callback(this.#onCheckIn, { offline: true, lock: true });
         }
         fabric.icd.addPeer({ peerNodeId, key, counterStart, lastOffset }, this.internal.checkInHandler);
+        this.internal.fedPeer = PeerAddress({ fabricIndex: fabric.fabricIndex, nodeId: peerNodeId });
     }
 
     #onCheckIn(checkIn: FabricIcd.ReceivedCheckIn) {
@@ -148,7 +274,7 @@ export class IcdClient extends Behavior {
 
         // A tracked in-flight refresh (presence also guards against a second overlapping re-key) keeps the promise
         // awaitable at teardown instead of orphaned.
-        if (refreshNeeded && this.internal.keyRefresh === undefined) {
+        if (refreshNeeded && this.state.registered && this.internal.keyRefresh === undefined) {
             this.internal.keyRefresh = this.#startKeyRefresh();
         }
     }
@@ -214,6 +340,9 @@ export namespace IcdClient {
 
         /** In-flight key refresh; tracked so a second refreshNeeded Check-In can't overlap it and teardown can await it. */
         keyRefresh?: Promise<void>;
+
+        /** Address of the peer fed to {@link FabricIcd}; lets decommission drop it after peerAddress is already gone. */
+        fedPeer?: PeerAddress;
     }
 
     export class State {

--- a/packages/node/src/behavior/system/icd/IcdMultiAdminError.ts
+++ b/packages/node/src/behavior/system/icd/IcdMultiAdminError.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ImplementationError } from "@matter/general";
+import { VendorId } from "@matter/types";
+
+/**
+ * Thrown by {@link IcdMultiAdminError.assertSingleAdmin} when a Check-In registration is refused because the peer has
+ * more than one administrator fabric. Distinct subtype so callers can detect the multi-admin case specifically
+ * (`catch (e) { if (e instanceof IcdMultiAdminError) ... }`) and surface the `register({ allowMultiAdmin: true })`
+ * opt-in. Extends {@link ImplementationError} so existing misuse-handling stays correct.
+ */
+export class IcdMultiAdminError extends ImplementationError {
+    /**
+     * Distinct VendorIds of the peer's other administrator fabrics that triggered the refusal — present these to the
+     * user when asking whether to register anyway.
+     */
+    readonly adminVendorIds: readonly VendorId[];
+
+    constructor(message: string, adminVendorIds: readonly VendorId[]) {
+        super(message);
+        this.adminVendorIds = adminVendorIds;
+    }
+}
+
+export namespace IcdMultiAdminError {
+    /**
+     * Default allowlist of admin VendorIds whose fabrics are not counted as co-admins by the ICD registration safety
+     * check — ecosystem vendors known to coexist safely with a Check-In client (their management/ecosystem fabrics
+     * don't represent an independent administrator whose reachability we'd degrade). Pre-filled with Apple (whose Home
+     * adds a separate management fabric); apps extend it with other known-cooperative ecosystems (e.g. Samsung).
+     */
+    export const TRUSTED_ECOSYSTEM_VENDORS: readonly VendorId[] = [VendorId(0x1349) /* Apple */];
+
+    /**
+     * Throws unless the peer has at most one administrator besides the ignored ecosystem vendors. Registering a
+     * Check-In client influences device behavior shared across fabrics (a LIT peer driven to long idle can degrade
+     * other admins' reachability), so a multi-admin device requires an explicit opt-in.
+     *
+     * @param vendorIds one VendorId per administrator fabric on the peer (duplicates allowed — each fabric is a
+     *   distinct administrator).
+     * @param ignoredVendors VendorIds not counted as co-admins (e.g. {@link TRUSTED_ECOSYSTEM_VENDORS}).
+     * @param allowMultiAdmin when true the check is skipped entirely (explicit opt-in).
+     * @throws {IcdMultiAdminError} if more than one non-ignored administrator fabric is present and `allowMultiAdmin`
+     *   is false; its {@link IcdMultiAdminError.adminVendorIds} lists the distinct offending vendors.
+     * @see {@link MatterSpecification.v151.Core} § 9.15.1
+     */
+    export function assertSingleAdmin(
+        vendorIds: readonly VendorId[],
+        ignoredVendors: readonly VendorId[],
+        allowMultiAdmin: boolean,
+    ): void {
+        if (allowMultiAdmin) {
+            return;
+        }
+        const ignored = new Set(ignoredVendors);
+        const counted = vendorIds.filter(v => !ignored.has(v));
+        if (counted.length > 1) {
+            throw new IcdMultiAdminError(
+                `ICD registration refused: peer has ${counted.length} administrator fabrics from other vendors. ` +
+                    `Pass register({ allowMultiAdmin: true }) or add their VendorIds to register({ ignoredVendors }).`,
+                [...new Set(counted)],
+            );
+        }
+    }
+}

--- a/packages/node/src/behavior/system/icd/index.ts
+++ b/packages/node/src/behavior/system/icd/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from "./IcdClient.js";
+export * from "./IcdMultiAdminError.js";

--- a/packages/node/src/behavior/system/index.ts
+++ b/packages/node/src/behavior/system/index.ts
@@ -9,6 +9,7 @@ export * from "./controller/index.js";
 export * from "./dcl/index.js";
 export * from "./events/index.js";
 export * from "./http/index.js";
+export * from "./icd/index.js";
 export * from "./index/index.js";
 export * from "./mqtt/index.js";
 export * from "./network/index.js";

--- a/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
+++ b/packages/node/src/behaviors/icd-management/IcdManagementServer.ts
@@ -334,7 +334,10 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
 
     /**
      * Send a Check-In to every Permanent registration not currently covered by an active matching subscription, gated
-     * by the per-client back-off. Runs on each idle→active wake. The ICD counter advances once per real send.
+     * by the per-client back-off. Runs on each idle→active wake. The ICD counter advances once per send pass.
+     *
+     * The transmitted counter is the post-increment value: clients track the registration counter as offset 0 and
+     * reject offsets <= the last seen, so the first Check-In must carry an offset >= 1.
      *
      * @see {@link MatterSpecification.v151.Core} § 9.15.1, § 9.16.5.3.2
      */
@@ -351,6 +354,9 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
         try {
             const sessions = this.env.get(SessionManager);
             const activeModeThreshold = this.state.activeModeThreshold;
+            // One counter value shared by every Check-In in this pass across all fabrics (ICDCounter is device-global);
+            // advanced once when the first send is due so the available range is not depleted per client.
+            let sendCounter: number | undefined;
             for (const fabric of this.env.get(FabricManager).fabrics) {
                 const subjects = activeSubscriptionSubjects(sessions, fabric.fabricIndex);
                 for (const reg of fabric.icd.registrations) {
@@ -366,16 +372,16 @@ export class IcdManagementBaseServer extends IcdManagementLogicBase {
                         continue;
                     }
                     backOff.recordSent(key);
-                    const ok = await sender.send({
+                    if (sendCounter === undefined) {
+                        sendCounter = counter.increment();
+                    }
+                    await sender.send({
                         fabricIndex: fabric.fabricIndex,
                         peerNodeId: reg.checkInNodeId,
                         key: reg.key,
-                        counter: counter.value,
+                        counter: sendCounter,
                         activeModeThreshold,
                     });
-                    if (ok) {
-                        counter.increment();
-                    }
                 }
             }
         } finally {

--- a/packages/node/src/node/client/Peers.ts
+++ b/packages/node/src/node/client/Peers.ts
@@ -13,8 +13,10 @@ import { ContinuousDiscovery } from "#behavior/system/controller/discovery/Conti
 import { Discovery } from "#behavior/system/controller/discovery/Discovery.js";
 import { InstanceDiscovery } from "#behavior/system/controller/discovery/InstanceDiscovery.js";
 import { PaseDiscovery } from "#behavior/system/controller/discovery/PaseDiscovery.js";
+import { IcdClient } from "#behavior/system/icd/IcdClient.js";
 import { NetworkClient } from "#behavior/system/network/NetworkClient.js";
 import { BasicInformationClient } from "#behaviors/basic-information";
+import { IcdManagementClient } from "#behaviors/icd-management";
 import { OperationalCredentialsClient } from "#behaviors/operational-credentials";
 import { Endpoint } from "#endpoint/Endpoint.js";
 import { EndpointContainer } from "#endpoint/properties/EndpointContainer.js";
@@ -85,6 +87,7 @@ export class Peers extends EndpointContainer<ClientNode> {
         this.deleted.on(this.#manageExpiration.bind(this));
 
         this.clusterInstalled(BasicInformationClient).on(this.#instrumentBasicInformation.bind(this));
+        this.clusterInstalled(IcdManagementClient).on(this.#installIcdClient.bind(this));
 
         const lifecycle = owner.lifecycle;
         lifecycle.online.on(this.#nodeOnline.bind(this));
@@ -478,6 +481,14 @@ export class Peers extends EndpointContainer<ClientNode> {
         node.eventsOf(type).leave?.on(({ fabricIndex }) => this.#onLeave(node, fabricIndex));
         node.eventsOf(type).shutDown?.on(() => this.#onShutdown(node));
         node.eventsOf(type).startUp?.on(() => this.#onStartUp(node));
+    }
+
+    #installIcdClient(node: Endpoint) {
+        if (!(node instanceof ClientNode) || node.behaviors.has(IcdClient)) {
+            return;
+        }
+
+        node.behaviors.inject(IcdClient);
     }
 
     #onLeave(node: ClientNode, fabricIndex: FabricIndex) {

--- a/packages/node/test/behavior/system/icd/IcdClientTest.ts
+++ b/packages/node/test/behavior/system/icd/IcdClientTest.ts
@@ -4,9 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { CommissioningClient } from "#behavior/system/commissioning/CommissioningClient.js";
 import { IcdClient } from "#behavior/system/icd/IcdClient.js";
+import { IcdMultiAdminError } from "#behavior/system/icd/IcdMultiAdminError.js";
 import { IcdManagementServer } from "#behaviors/icd-management";
 import { ServerNode } from "#node/index.js";
+import { FabricManager, TestFabric } from "@matter/protocol";
+import { FabricId, VendorId } from "@matter/types";
 import { MockSite } from "../../../node/mock-site.js";
 
 const RootWithIcd = ServerNode.RootEndpoint.with(IcdManagementServer);
@@ -49,5 +53,87 @@ describe("IcdClient", () => {
         const peer1 = controller.peers.get("peer1")!;
         const isRegistered = await peer1.act(agent => agent.get(IcdClient).isRegistered);
         expect(isRegistered).false;
+    });
+
+    describe("register", () => {
+        it("registers the controller on the peer and records the counter baseline", async () => {
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            await peer1.act(agent => agent.get(IcdClient).register());
+
+            const state = peer1.stateOf(IcdClient);
+            expect(state.registered).true;
+            expect(state.counterStart).not.undefined;
+            expect(state.lastOffset).equals(0);
+            expect(state.key).not.undefined;
+
+            // Device side proves the real registerClient round-trip landed.
+            const registeredClients = device.stateOf(IcdManagementServer).registeredClients;
+            expect(registeredClients).length(1);
+
+            const fabricIndex = peer1.stateOf(CommissioningClient).peerAddress!.fabricIndex;
+            const fabric = controller.env.get(FabricManager).for(fabricIndex);
+
+            // The controller registers under its own operational node id on the fabric.
+            expect(registeredClients[0].checkInNodeId).equals(fabric.nodeId);
+
+            // The controller-side fabric feed carries the peer (the Check-In RX path is armed).
+            expect(fabric.icd.hasPeers).true;
+        });
+
+        it("rejects a multi-admin peer and succeeds when allowMultiAdmin is set", async () => {
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            // Add a real second administrator fabric to the device under a different (non-ignored) vendor. The
+            // controller reads it back via the fabricFilter:false OperationalCredentials read.
+            const fabrics = device.env.get(FabricManager);
+            const authority = await TestFabric.Authority({ fabrics });
+            await authority.createFabric({
+                adminFabricLabel: "second-admin",
+                adminVendorId: VendorId(0xfff2),
+                adminFabricId: FabricId(2),
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+
+            let caught: unknown;
+            try {
+                await peer1.act(agent => agent.get(IcdClient).register());
+            } catch (e) {
+                caught = e;
+            }
+            expect(caught).instanceof(IcdMultiAdminError);
+            expect((caught as IcdMultiAdminError).adminVendorIds.map(Number)).contains(0xfff2);
+            expect(peer1.stateOf(IcdClient).registered).false;
+
+            // Explicit opt-in registers despite the co-admin.
+            await peer1.act(agent => agent.get(IcdClient).register({ allowMultiAdmin: true }));
+            expect(peer1.stateOf(IcdClient).registered).true;
+        });
+
+        it("registers against a CIP-capable peer (the only ICD shape this harness can build)", async () => {
+            // The CIP gate refuses registration when maybeFeaturesOf(IcdManagementClient).checkInProtocolSupport is
+            // not true. A pure non-CIP ICD device cannot be constructed here: IcdManagementServer bakes CIP in and a
+            // server with CIP dropped fails init (see IcdManagementServerTest "rejects a LITS-only server"). So the
+            // negative path has no buildable fixture; this test pins the positive side — a CIP peer passes the gate.
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            expect(peer1.maybeStateOf(IcdClient)).not.undefined;
+
+            await peer1.act(agent => agent.get(IcdClient).register());
+            expect(peer1.stateOf(IcdClient).registered).true;
+            expect(device.stateOf(IcdManagementServer).registeredClients).length(1);
+        });
     });
 });

--- a/packages/node/test/behavior/system/icd/IcdClientTest.ts
+++ b/packages/node/test/behavior/system/icd/IcdClientTest.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IcdClient } from "#behavior/system/icd/IcdClient.js";
+import { IcdManagementServer } from "#behaviors/icd-management";
+import { ServerNode } from "#node/index.js";
+import { MockSite } from "../../../node/mock-site.js";
+
+const RootWithIcd = ServerNode.RootEndpoint.with(IcdManagementServer);
+
+describe("IcdClient", () => {
+    before(() => {
+        MockTime.init();
+    });
+
+    it("auto-installs on a ClientNode when the peer exposes IcdManagement", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair({
+            device: { type: RootWithIcd },
+        });
+
+        const peer1 = controller.peers.get("peer1")!;
+        expect(peer1).not.undefined;
+
+        expect(peer1.behaviors.has(IcdClient)).true;
+    });
+
+    it("defaults to unregistered with no Check-In timestamp", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair({
+            device: { type: RootWithIcd },
+        });
+
+        const peer1 = controller.peers.get("peer1")!;
+        const state = peer1.stateOf(IcdClient);
+        expect(state.registered).false;
+        expect(state.lastCheckInReceivedAt).undefined;
+    });
+
+    it("exposes isRegistered reflecting state.registered", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair({
+            device: { type: RootWithIcd },
+        });
+
+        const peer1 = controller.peers.get("peer1")!;
+        const isRegistered = await peer1.act(agent => agent.get(IcdClient).isRegistered);
+        expect(isRegistered).false;
+    });
+});

--- a/packages/node/test/behavior/system/icd/IcdClientTest.ts
+++ b/packages/node/test/behavior/system/icd/IcdClientTest.ts
@@ -9,11 +9,27 @@ import { IcdClient } from "#behavior/system/icd/IcdClient.js";
 import { IcdMultiAdminError } from "#behavior/system/icd/IcdMultiAdminError.js";
 import { IcdManagementServer } from "#behaviors/icd-management";
 import { ServerNode } from "#node/index.js";
+import { ImplementationError, Seconds } from "@matter/general";
 import { FabricManager, TestFabric } from "@matter/protocol";
 import { FabricId, NodeId, SubjectId, VendorId } from "@matter/types";
+import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { MockSite } from "../../../node/mock-site.js";
 
 const RootWithIcd = ServerNode.RootEndpoint.with(IcdManagementServer);
+
+const LitIcdServer = IcdManagementServer.with(
+    IcdManagement.Feature.CheckInProtocolSupport,
+    IcdManagement.Feature.LongIdleTimeSupport,
+);
+const RootWithLitIcd = ServerNode.RootEndpoint.with(LitIcdServer);
+
+const LIT_CONFIG = {
+    operatingMode: IcdManagement.OperatingMode.Sit,
+    activeModeThreshold: 5000,
+    idleModeDuration: 3600,
+    activeModeDuration: 1000,
+    maximumCheckInBackoff: 3600,
+};
 
 /** Force one device idle→active wake and let the Check-In send pass run to completion. */
 async function wakeDevice(device: ServerNode) {
@@ -142,6 +158,25 @@ describe("IcdClient", () => {
             expect(peer1.stateOf(IcdClient).registered).true;
             expect(device.stateOf(IcdManagementServer).registeredClients).length(1);
         });
+
+        it("throws when already registered", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            await peer1.act(agent => agent.get(IcdClient).register());
+
+            let caught: unknown;
+            try {
+                await peer1.act(agent => agent.get(IcdClient).register());
+            } catch (e) {
+                caught = e;
+            }
+            expect(caught).instanceof(ImplementationError);
+            expect(peer1.stateOf(IcdClient).registered).true;
+        });
     });
 
     describe("check-in receipt", () => {
@@ -227,6 +262,144 @@ describe("IcdClient", () => {
             // A Check-In validating against the NEW key lands past the reset baseline.
             expect(again.counter).greaterThan(peer1.stateOf(IcdClient).counterStart!);
             expect(peer1.stateOf(IcdClient).lastOffset).greaterThan(0);
+        });
+    });
+
+    describe("unregister", () => {
+        it("removes the peer registration, clears state, drops the fabric feed, and emits unregistered", async () => {
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            await peer1.act(agent => agent.get(IcdClient).register());
+            expect(device.stateOf(IcdManagementServer).registeredClients).length(1);
+
+            const fabricIndex = peer1.stateOf(CommissioningClient).peerAddress!.fabricIndex;
+            const fabric = controller.env.get(FabricManager).for(fabricIndex);
+            expect(fabric.icd.hasPeers).true;
+
+            const unregistered = new Promise<void>(resolve =>
+                peer1.eventsOf(IcdClient).unregistered.once(() => resolve()),
+            );
+
+            await peer1.act(agent => agent.get(IcdClient).unregister());
+            await MockTime.resolve(unregistered, { macrotasks: true });
+
+            const state = peer1.stateOf(IcdClient);
+            expect(state.registered).false;
+            expect(state.key).undefined;
+            expect(state.counterStart).undefined;
+            expect(state.lastOffset).undefined;
+
+            expect(device.stateOf(IcdManagementServer).registeredClients).length(0);
+            expect(fabric.icd.hasPeers).false;
+        });
+
+        it("is a no-op when not registered", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            await peer1.act(agent => agent.get(IcdClient).unregister());
+            expect(peer1.stateOf(IcdClient).registered).false;
+        });
+    });
+
+    describe("stayActive", () => {
+        it("requests a stay-active window and returns the promised duration", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            const promised = await peer1.act(agent => agent.get(IcdClient).stayActive(Seconds(60)));
+
+            expect(promised).greaterThan(0);
+        });
+    });
+
+    describe("feature getters", () => {
+        it("reports peerSupportsLit false for a CIP-only peer", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            expect(peer1.stateOf(IcdClient)).not.undefined;
+            const supportsLit = await peer1.act(agent => agent.get(IcdClient).peerSupportsLit);
+            const requiresCheckIn = await peer1.act(agent => agent.get(IcdClient).peerRequiresCheckIn);
+            expect(supportsLit).false;
+            expect(requiresCheckIn).false;
+        });
+
+        it("reports peerSupportsLit true for a LIT peer", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair({
+                device: { type: RootWithLitIcd, icdManagement: LIT_CONFIG },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            const supportsLit = await peer1.act(agent => agent.get(IcdClient).peerSupportsLit);
+            const requiresCheckIn = await peer1.act(agent => agent.get(IcdClient).peerRequiresCheckIn);
+            expect(supportsLit).true;
+            expect(requiresCheckIn).true;
+        });
+    });
+
+    describe("init restore", () => {
+        it("re-arms the Check-In receive path after a controller restart", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            await peer1.act(agent => agent.get(IcdClient).register());
+
+            const controllerId = controller.id;
+            await site.close();
+
+            const controllerB = await site.addNode(undefined, { id: controllerId, index: 1 });
+            const peer1b = controllerB.peers.get("peer1")!;
+            expect(peer1b).not.undefined;
+            expect(peer1b.stateOf(IcdClient).registered).true;
+
+            const fabricIndex = peer1b.stateOf(CommissioningClient).peerAddress!.fabricIndex;
+            const fabric = controllerB.env.get(FabricManager).for(fabricIndex);
+            // initialize() re-fed the restored peer so a Check-In arriving after restart still validates.
+            expect(fabric.icd.hasPeers).true;
+        });
+    });
+
+    describe("decommission cleanup", () => {
+        it("unregisters locally when the node is decommissioned", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            await peer1.act(agent => agent.get(IcdClient).register());
+
+            const fabricIndex = peer1.stateOf(CommissioningClient).peerAddress!.fabricIndex;
+            const fabric = controller.env.get(FabricManager).for(fabricIndex);
+            expect(fabric.icd.hasPeers).true;
+
+            const unregistered = new Promise<void>(resolve =>
+                peer1.eventsOf(IcdClient).unregistered.once(() => resolve()),
+            );
+
+            await peer1.act(agent => agent.get(CommissioningClient).decommission());
+            await MockTime.resolve(unregistered, { macrotasks: true });
+
+            expect(peer1.stateOf(IcdClient).registered).false;
+            expect(fabric.icd.hasPeers).false;
         });
     });
 });

--- a/packages/node/test/behavior/system/icd/IcdClientTest.ts
+++ b/packages/node/test/behavior/system/icd/IcdClientTest.ts
@@ -10,10 +10,17 @@ import { IcdMultiAdminError } from "#behavior/system/icd/IcdMultiAdminError.js";
 import { IcdManagementServer } from "#behaviors/icd-management";
 import { ServerNode } from "#node/index.js";
 import { FabricManager, TestFabric } from "@matter/protocol";
-import { FabricId, VendorId } from "@matter/types";
+import { FabricId, NodeId, SubjectId, VendorId } from "@matter/types";
 import { MockSite } from "../../../node/mock-site.js";
 
 const RootWithIcd = ServerNode.RootEndpoint.with(IcdManagementServer);
+
+/** Force one device idle→active wake and let the Check-In send pass run to completion. */
+async function wakeDevice(device: ServerNode) {
+    await device.act(agent => agent.get(IcdManagementServer).enterIdleMode());
+    await device.act(agent => agent.get(IcdManagementServer).requestActiveMode());
+    await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+}
 
 describe("IcdClient", () => {
     before(() => {
@@ -134,6 +141,92 @@ describe("IcdClient", () => {
             await peer1.act(agent => agent.get(IcdClient).register());
             expect(peer1.stateOf(IcdClient).registered).true;
             expect(device.stateOf(IcdManagementServer).registeredClients).length(1);
+        });
+    });
+
+    describe("check-in receipt", () => {
+        it("receives a real device Check-In, emits checkedIn, and advances counter state", async () => {
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            // addCommissionedPair leaves an active subscription whose subject is the controller's own node id. Register a
+            // monitored subject that subscription does not cover so the device's suppression check does not fire and a
+            // real Check-In is transmitted to us.
+            await peer1.act(agent => agent.get(IcdClient).register({ monitoredSubject: SubjectId(NodeId(0xabcdn)) }));
+
+            const activeModeThreshold = device.stateOf(IcdManagementServer).activeModeThreshold;
+            const counterBefore = device.stateOf(IcdManagementServer).icdCounter;
+
+            const checkedIn = new Promise<{ counter: number; activeModeThreshold: number }>(resolve =>
+                peer1.eventsOf(IcdClient).checkedIn.once(resolve),
+            );
+
+            // No subscription exists, so the device's monitored subject is uncovered and a Check-In is transmitted.
+            await wakeDevice(device);
+            const received = await MockTime.resolve(checkedIn, { macrotasks: true });
+
+            expect(received.activeModeThreshold).equals(activeModeThreshold);
+            // The device transmits the post-increment counter, so the first Check-In lands one past the registration
+            // baseline (offset 1) rather than at the baseline (offset 0, which would be rejected as a replay).
+            expect(received.counter).equals(counterBefore + 1);
+
+            const state = peer1.stateOf(IcdClient);
+            expect(state.lastCheckInReceivedAt).not.undefined;
+            expect(state.lastOffset).equals(received.counter - state.counterStart!);
+            expect(state.lastOffset).greaterThan(0);
+        });
+    });
+
+    describe("key refresh", () => {
+        it("refreshes the key when a Check-In counter crosses the refresh threshold", async () => {
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            await peer1.act(agent => agent.get(IcdClient).register({ monitoredSubject: SubjectId(NodeId(0xabcdn)) }));
+
+            const originalCounterStart = peer1.stateOf(IcdClient).counterStart!;
+
+            // Pull the running peer's rolling baseline back by 2^31 so the next real device Check-In (counter near the
+            // original baseline) lands at offset >= KEY_REFRESH_OFFSET and reports refreshNeeded — the state a real
+            // deployment reaches organically after 2^31 check-ins. The real RX path then drives #onCheckIn → #refreshKey.
+            const fabricIndex = peer1.stateOf(CommissioningClient).peerAddress!.fabricIndex;
+            const fabric = controller.env.get(FabricManager).for(fabricIndex);
+            const peerNodeId = peer1.stateOf(CommissioningClient).peerAddress!.nodeId;
+            const peerEntry = fabric.icd.peerFor(peerNodeId)!;
+            peerEntry.counterStart = (originalCounterStart - 0x80000000) >>> 0;
+
+            const refreshed = new Promise<void>(resolve =>
+                peer1.eventsOf(IcdClient).keyRefreshed.once(() => resolve()),
+            );
+
+            await wakeDevice(device);
+            await MockTime.resolve(refreshed, { macrotasks: true });
+            // keyRefreshed emits inside the refresh transaction; let it commit before reading state.
+            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+
+            const state = peer1.stateOf(IcdClient);
+            // counterStart advancing proves the re-key registerClient round-trip ran (MockCrypto.randomBytes is
+            // deterministic, so the key bytes themselves cannot be asserted to differ).
+            expect(state.lastOffset).equals(0);
+            expect(state.counterStart).not.equals(originalCounterStart);
+
+            // The device accepted the re-key in place: still exactly one registration for this controller.
+            expect(device.stateOf(IcdManagementServer).registeredClients).length(1);
+
+            const checkedInAgain = new Promise<{ counter: number }>(resolve =>
+                peer1.eventsOf(IcdClient).checkedIn.once(resolve),
+            );
+            await wakeDevice(device);
+            const again = await MockTime.resolve(checkedInAgain, { macrotasks: true });
+            // A Check-In validating against the NEW key lands past the reset baseline.
+            expect(again.counter).greaterThan(peer1.stateOf(IcdClient).counterStart!);
+            expect(peer1.stateOf(IcdClient).lastOffset).greaterThan(0);
         });
     });
 });

--- a/packages/node/test/behavior/system/icd/IcdMultiAdminErrorTest.ts
+++ b/packages/node/test/behavior/system/icd/IcdMultiAdminErrorTest.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IcdMultiAdminError } from "#behavior/system/icd/IcdMultiAdminError.js";
+import { ImplementationError } from "@matter/general";
+import { VendorId } from "@matter/types";
+
+const { assertSingleAdmin, TRUSTED_ECOSYSTEM_VENDORS } = IcdMultiAdminError;
+
+const v = (id: number) => VendorId(id);
+
+describe("IcdMultiAdminError.assertSingleAdmin", () => {
+    it("passes with a single fabric", () => {
+        assertSingleAdmin([v(0xfff1)], TRUSTED_ECOSYSTEM_VENDORS, false);
+    });
+
+    it("throws IcdMultiAdminError with two admin fabrics from different vendors", () => {
+        expect(() => assertSingleAdmin([v(0xfff1), v(0xfff2)], TRUSTED_ECOSYSTEM_VENDORS, false)).throws(
+            IcdMultiAdminError,
+        );
+    });
+
+    it("the thrown error is also an ImplementationError", () => {
+        let caught: unknown;
+        try {
+            assertSingleAdmin([v(0xfff1), v(0xfff2)], TRUSTED_ECOSYSTEM_VENDORS, false);
+        } catch (error) {
+            caught = error;
+        }
+        expect(caught).instanceOf(IcdMultiAdminError);
+        expect(caught).instanceOf(ImplementationError);
+    });
+
+    it("exposes the offending vendor ids on the error", () => {
+        let caught: IcdMultiAdminError | undefined;
+        try {
+            assertSingleAdmin([v(0xfff1), v(0xfff2)], TRUSTED_ECOSYSTEM_VENDORS, false);
+        } catch (error) {
+            caught = error as IcdMultiAdminError;
+        }
+        expect(caught?.adminVendorIds.map(Number)).deep.equals([0xfff1, 0xfff2]);
+    });
+
+    it("deduplicates vendor ids on the error", () => {
+        let caught: IcdMultiAdminError | undefined;
+        try {
+            assertSingleAdmin([v(0xfff1), v(0xfff1)], TRUSTED_ECOSYSTEM_VENDORS, false);
+        } catch (error) {
+            caught = error as IcdMultiAdminError;
+        }
+        expect(caught?.adminVendorIds.map(Number)).deep.equals([0xfff1]);
+    });
+
+    it("ignores a trusted ecosystem vendor", () => {
+        assertSingleAdmin([v(0xfff1), v(0x1349)], TRUSTED_ECOSYSTEM_VENDORS, false);
+    });
+
+    it("allowMultiAdmin overrides the throw", () => {
+        assertSingleAdmin([v(0xfff1), v(0xfff2)], TRUSTED_ECOSYSTEM_VENDORS, true);
+    });
+
+    it("defaults include Apple 0x1349", () => {
+        expect(TRUSTED_ECOSYSTEM_VENDORS.map(Number)).contains(0x1349);
+    });
+});

--- a/packages/protocol/src/icd/FabricIcd.ts
+++ b/packages/protocol/src/icd/FabricIcd.ts
@@ -91,6 +91,7 @@ export class FabricIcd {
                 handler({
                     peerNodeId: peer.peerNodeId,
                     counter: decoded.counter,
+                    offset: validation.offset,
                     activeModeThreshold: decoded.activeModeThreshold,
                     refreshNeeded: validation.refreshNeeded,
                 });
@@ -129,6 +130,8 @@ export namespace FabricIcd {
     export interface ReceivedCheckIn {
         peerNodeId: NodeId;
         counter: number;
+        /** Unsigned offset of {@link counter} from the peer's registration baseline; the persisted rolling position. */
+        offset: number;
         activeModeThreshold: number;
         refreshNeeded: boolean;
     }

--- a/packages/protocol/test/icd/FabricIcdTest.ts
+++ b/packages/protocol/test/icd/FabricIcdTest.ts
@@ -69,7 +69,7 @@ describe("FabricIcd", () => {
 
             expect(result).true;
             expect(received).deep.equal([
-                { peerNodeId: NodeId(11), counter: 12, activeModeThreshold: 5000, refreshNeeded: false },
+                { peerNodeId: NodeId(11), counter: 12, offset: 2, activeModeThreshold: 5000, refreshNeeded: false },
             ]);
         });
 

--- a/packages/protocol/test/securechannel/SecureChannelProtocolTest.ts
+++ b/packages/protocol/test/securechannel/SecureChannelProtocolTest.ts
@@ -71,7 +71,7 @@ describe("SecureChannelProtocol — ICD Check-In routing", () => {
         await protocol.onNewExchange(exchange, message);
 
         expect(received).deep.equal([
-            { peerNodeId: NodeId(11), counter: 12, activeModeThreshold: 5000, refreshNeeded: false },
+            { peerNodeId: NodeId(11), counter: 12, offset: 2, activeModeThreshold: 5000, refreshNeeded: false },
         ]);
         expect(sendCalled).false;
         expect(exchange.closed.value).true;


### PR DESCRIPTION
Phase 3a of ICD support: a per-ClientNode controller `IcdClient` that registers the controller as a Check-In client of a peer, receives/validates Check-Ins (reusing the Phase-1 0x50 RX path), auto-rotates the ICDToken, and exposes informational status — gated by a multi-admin safety check. **Subscription/wakefulness wiring is out of scope (Phase 3b).** Base: `feat/icd-protocol` (umbrella PR #3848).

## What's here
- **`IcdClient`** (`packages/node/src/behavior/system/icd/IcdClient.ts`): `early` ClientNode system behavior (`id="icd"`), auto-installed when a peer exposes IcdManagement (via `Peers.clusterInstalled(IcdManagementClient)` → `behaviors.inject`). Installation ≠ registration.
- **`register({ monitoredSubject?, clientType?, allowMultiAdmin?, ignoredVendors? })`** — gates on the peer being online + supporting CIP, runs the multi-admin guard, installs a random key via `registerClient`, records the counter baseline, and arms the Check-In receive path. Throws if already registered.
- **Multi-admin guard** (`IcdMultiAdminError.ts`): `register()` does a `fabricFilter:false` read of `OperationalCredentials.Fabrics`; if more than one administrator fabric remains after dropping `TRUSTED_ECOSYSTEM_VENDORS` (default Apple `0x1349`, app-extensible per call), it throws `IcdMultiAdminError` — a detectable `ImplementationError` subtype carrying the distinct offending `adminVendorIds` so an app can prompt the user before retrying with `allowMultiAdmin: true`.
- **Check-in handling**: persists the validated rolling offset (replay floor that survives restart), emits `checkedIn`, and silently re-keys in place at offset ≥ 2³¹. The refresh runs in its own transaction off the RX path, is tracked so it's awaitable (and guards against an overlapping re-key), and `asyncDispose` awaits it so teardown can't desync keys.
- **`unregister()`** (best-effort peer call + always local cleanup), **`stayActive(duration)`**, getters `peerSupportsLit`/`peerRequiresCheckIn`.
- **Restore** on the *owner* (controller) coming online — the controller fabric that owns `FabricManager` is only guaranteed loaded then; the peer's own connectivity is irrelevant (an ICD peer is offline exactly when it sends Check-Ins). **Decommission** cleanup is local-only (peerAddress already cleared).
- **Device-side 2c fix** (`IcdManagementServer.#sendCheckIns`): the device sent the pre-increment counter on the first Check-In (offset 0 → controller rejects as replay). Now increments once per wake pass before the first send, shared across all clients/fabrics (ICDCounter is device-global). Exposed by the first end-to-end device→controller Check-In test.
- `FabricIcd.ReceivedCheckIn` gains `offset` (the validated rolling offset the controller persists).

## Validation
- `npm run build -- --clean`, `npm test -p packages/node` (1262/1262), `npm test -p packages/protocol` (1155/1155), `npm run format-verify`, `npm run lint` — all green.
- Tests drive the real commissioned-pair round-trip: register + device-side registration, multi-admin rejection (real two-fabric device, asserts `adminVendorIds`) + override, real device→controller Check-In, forced key-refresh (back-dated baseline), unregister, stayActive, LIT feature getters, restart-restore, decommission.

## Follow-ups (Phase 3b / noted)
- No test for the unregister-while-refresh-in-flight path (logic verified by reading; race guard in place).
- Device ICDCounter "increment once per pass vs per message" is a spec-ambiguity judgement (per-batch chosen); flagged for possible revisit.
- Wakefulness tracker, resubscribe-on-check-in, SustainedSubscription park-until-wake → Phase 3b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)