### PR TITLE
fix(protocol): self-heal corrupt DCL cert cache and surface attestation errors as findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Group-send epoch-key selection no longer fails when a future-dated epoch key is installed during key rotation
     - Fix: Group data message counters are now a single node-global counter (per Matter spec) instead of per operational key; former per-key counters are properly migrated to prevent nonce reuse
     - Fix: Ensure that the default `regulatoryCountryCode` ("XX") is applied when commissioning a Wi-Fi/Thread device without an explicit value
+    - Fix: A corrupted PAA in the local DCL certificate cache is now re-fetched from DCL once before failing, recovering from broken storage
+    - Fix: Unexpected errors during device attestation validation (e.g. an unrecoverably corrupt trust-store certificate) are now surfaced as an attestation finding for the `onAttestationFailure` policy to judge, instead of aborting commissioning outside the findings mechanism
 
 - @matter/node
     - Enhancement: Added `network.ownNetworkProfileId` to set the local network's MRP additive margin, and exposed `additionalMrpDelay` and `probeAddress` in network profile config

--- a/packages/node/test/node/ClientAttestationTest.ts
+++ b/packages/node/test/node/ClientAttestationTest.ts
@@ -4,7 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, Crypto, DerCodec, DerType, MockCrypto, MockFetch, ObjectId, Pem, Seconds } from "@matter/general";
+import {
+    Bytes,
+    Crypto,
+    DerCodec,
+    DerType,
+    MockCrypto,
+    MockFetch,
+    ObjectId,
+    Pem,
+    Seconds,
+    StorageService,
+} from "@matter/general";
 import {
     AttestationFinding,
     CertificationDeclaration,
@@ -160,6 +171,16 @@ interface AttestationTestOptions {
 
     /** Called after site + DCL setup but before commissioning. Use to add revocation mocks. */
     setupBeforeCommission?: (context: { fetchMock: MockFetch }) => void | Promise<void>;
+
+    /**
+     * After the DCL trust store is populated, overwrite the cached PAA at this SKID with unparseable
+     * bytes. With re-fetch available this exercises the storage self-heal; combined with
+     * {@link blockCachedPaaRefetch} it exercises the unexpected-error → finding path.
+     */
+    corruptCachedPaaSkid?: Bytes | string;
+
+    /** Block the DCL root-certificate re-fetch so a corrupted cache cannot self-heal. */
+    blockCachedPaaRefetch?: boolean;
 }
 
 /**
@@ -198,6 +219,21 @@ async function runAttestationTest(options: AttestationTestOptions) {
             }
             // Inject the Matter test CD signer so CD signature verification works for test CDs
             await dclService.addCertificate(CertificationDeclaration.testSignerCertificate(), "CDSigner");
+
+            if (options.corruptCachedPaaSkid !== undefined) {
+                const normalizedSkid =
+                    typeof options.corruptCachedPaaSkid === "string"
+                        ? options.corruptCachedPaaSkid.replace(/:/g, "").toUpperCase()
+                        : Bytes.toHex(options.corruptCachedPaaSkid).toUpperCase();
+                const storage = await controller.env.get(StorageService).open("certificates");
+                await storage.createContext("root").set(normalizedSkid, Bytes.fromHex("3003010203"));
+                if (options.blockCachedPaaRefetch) {
+                    // Empty root list wins on reverse-order match, so the corrupt cache cannot self-heal.
+                    fetchMock.addResponse("/dcl/pki/root-certificates", {
+                        approvedRootCertificates: { schemaVersion: 0, certs: [] },
+                    });
+                }
+            }
         }
 
         const controllerCrypto = controller.env.get(Crypto) as MockCrypto;
@@ -358,6 +394,45 @@ describe("device attestation during commissioning", () => {
                 dclPaaCert: TestCert_PAA_NoVID_Cert,
                 onAttestationFailure: false,
                 expectRejection: /finding\(s\) and was rejected by policy/,
+            }));
+    });
+
+    describe("corrupt cached PAA", () => {
+        it("self-heals a corrupt cached PAA by re-fetching from DCL", () =>
+            runAttestationTest({
+                dclPaaCert: TestCert_PAA_NoVID_Cert,
+                corruptCachedPaaSkid: TestCert_PAA_NoVID_SKID,
+                onAttestationFailure: () => true,
+                assertFindings: findings => {
+                    // Recovered, so the normal chain runs — no unexpected ValidationError.
+                    expect(findings.map(f => f.type)).to.not.include(DeviceAttestationCheck.ValidationError);
+                },
+                assertResult: device => {
+                    expect(device.state.commissioning.commissioned).equals(true);
+                },
+            }));
+
+        it("surfaces an unrecoverable corrupt cached PAA as a judgeable finding", () =>
+            runAttestationTest({
+                dclPaaCert: TestCert_PAA_NoVID_Cert,
+                corruptCachedPaaSkid: TestCert_PAA_NoVID_SKID,
+                blockCachedPaaRefetch: true,
+                onAttestationFailure: () => true,
+                assertFindings: findings => {
+                    expect(findings.map(f => f.type)).to.include(DeviceAttestationCheck.ValidationError);
+                },
+                assertResult: device => {
+                    expect(device.state.commissioning.commissioned).equals(true);
+                },
+            }));
+
+        it("rejects an unrecoverable corrupt cached PAA when policy rejects, surfacing the cause", () =>
+            runAttestationTest({
+                dclPaaCert: TestCert_PAA_NoVID_Cert,
+                corruptCachedPaaSkid: TestCert_PAA_NoVID_SKID,
+                blockCachedPaaRefetch: true,
+                onAttestationFailure: false,
+                expectRejection: /Invalid certificate structure/,
             }));
     });
 

--- a/packages/protocol/src/certificate/DeviceAttestationValidator.ts
+++ b/packages/protocol/src/certificate/DeviceAttestationValidator.ts
@@ -32,6 +32,9 @@ export enum DeviceAttestationCheck {
     PaaTrustStoreTimeMismatch = "PaaTrustStoreTimeMismatch",
     DclServiceUnavailable = "DclServiceUnavailable",
     TrustedAsTestCertificate = "TrustedAsTestCertificate",
+
+    /** An unexpected error during validation (e.g. an unrecoverably corrupt trust-store certificate). */
+    ValidationError = "ValidationError",
 }
 
 /** A single finding from the attestation validation process. */

--- a/packages/protocol/src/dcl/DclCertificateService.ts
+++ b/packages/protocol/src/dcl/DclCertificateService.ts
@@ -173,19 +173,7 @@ export class DclCertificateService {
      */
     async getCertificateAsPem(subjectKeyId: Bytes | string, options?: DclCertificateService.GetCertificateOptions) {
         this.construction.assert();
-
-        const normalizedId = this.#normalizeSubjectKeyId(subjectKeyId);
-        const metadata = this.#certificateIndex.get(normalizedId);
-        if (!metadata || !this.#isRelevant(metadata, options)) {
-            throw new MatterDclError(`Certificate not found`, Diagnostic.dict({ skid: normalizedId }));
-        }
-
-        const derBytes = await this.#storage!.get<Bytes>(normalizedId);
-        if (!derBytes || derBytes.byteLength === 0) {
-            throw new MatterDclError(`Certificate data not found in storage`, Diagnostic.dict({ skid: normalizedId }));
-        }
-
-        return Pem.encode(derBytes);
+        return Pem.encode(await this.#getCertificateDer(subjectKeyId, options));
     }
 
     /**

--- a/packages/protocol/src/dcl/DclCertificateService.ts
+++ b/packages/protocol/src/dcl/DclCertificateService.ts
@@ -190,11 +190,133 @@ export class DclCertificateService {
 
     /**
      * Get certificate as DER bytes.
+     *
+     * Self-heals a corrupted local cache: if the stored certificate no longer parses (e.g. a
+     * truncated or mangled storage entry), make one best-effort re-fetch from DCL so a broken cache
+     * entry cannot permanently break attestation for an otherwise-valid trust anchor. If recovery
+     * fails the original bytes are returned unchanged, leaving the caller's normal validation to
+     * surface the parse failure rather than masking it with a different error here.
+     *
      * @throws {MatterDclError} if certificate not found or filtered by trust policy
      */
     async getCertificateAsDer(subjectKeyId: Bytes | string, options?: DclCertificateService.GetCertificateOptions) {
         this.construction.assert();
-        return this.#getCertificateDer(subjectKeyId, options);
+
+        const der = await this.#getCertificateDer(subjectKeyId, options);
+        const normalizedId = this.#normalizeSubjectKeyId(subjectKeyId);
+        const metadata = this.#certificateIndex.get(normalizedId);
+
+        const parseError = this.#certificateParseError(der, metadata?.kind);
+        if (parseError === undefined) {
+            return der;
+        }
+
+        logger.notice(
+            `Cached certificate failed to parse; attempting one re-fetch from DCL to recover`,
+            Diagnostic.dict({ skid: normalizedId }),
+            Diagnostic.errorMessage(parseError),
+        );
+        const refetched = await this.#tryRefetchRootCertificate(normalizedId, metadata?.isProduction ?? true, options);
+        if (refetched !== undefined) {
+            const refetchParseError = this.#certificateParseError(refetched, metadata?.kind);
+            if (refetchParseError === undefined) {
+                return refetched;
+            }
+            logger.warn(
+                `Re-fetched certificate also failed to parse`,
+                Diagnostic.dict({ skid: normalizedId }),
+                Diagnostic.errorMessage(refetchParseError),
+            );
+        }
+
+        return der;
+    }
+
+    /** Parse error of a DER certificate, or undefined if it parses, using the extension set for its kind. */
+    #certificateParseError(der: Bytes, kind?: DclCertificateService.CertificateKind): Error | undefined {
+        try {
+            Certificate.parseAsn1Certificate(
+                der,
+                (kind ?? "PAA") === "PAA" ? Certificate.REQUIRED_PAA_EXTENSIONS : Certificate.REQUIRED_EXTENSIONS,
+            );
+            return undefined;
+        } catch (error) {
+            return asError(error);
+        }
+    }
+
+    /**
+     * Best-effort force re-fetch of a single root certificate from DCL, overwriting the cached copy
+     * to recover from a corrupted local storage entry. Never throws: returns the freshly stored DER,
+     * or undefined if the certificate could not be re-fetched (not a root cert, absent from DCL, or
+     * any fetch error).
+     */
+    async #tryRefetchRootCertificate(
+        normalizedId: string,
+        isProduction: boolean,
+        options?: DclCertificateService.GetCertificateOptions,
+    ): Promise<Bytes | undefined> {
+        if (this.#fetchPromise !== undefined) {
+            await this.#fetchPromise;
+        }
+
+        try {
+            if (!(await this.#fetchAndStoreRootCertificateBySkid(normalizedId, isProduction, true, this.#options))) {
+                return undefined;
+            }
+        } catch (error) {
+            logger.warn(
+                `Re-fetch of certificate ${normalizedId} from DCL failed`,
+                Diagnostic.errorMessage(asError(error)),
+            );
+            return undefined;
+        }
+
+        const metadata = this.#certificateIndex.get(normalizedId);
+        if (metadata === undefined || !this.#isRelevant(metadata, options)) {
+            return undefined;
+        }
+
+        const der = await this.#storage!.get<Bytes>(normalizedId);
+        return der && der.byteLength > 0 ? Bytes.of(der) : undefined;
+    }
+
+    /**
+     * Fetch a single root certificate from DCL by SubjectKeyIdentifier and store it. Returns true if
+     * a matching root certificate was found and stored, false if DCL has no such root certificate.
+     * Throws on DCL/network errors; callers decide how to handle them.
+     */
+    async #fetchAndStoreRootCertificateBySkid(
+        normalizedId: string,
+        isProduction: boolean,
+        force: boolean,
+        options?: DclClient.Options,
+    ): Promise<boolean> {
+        const config = isProduction
+            ? (this.#options.dclConfig ?? DclConfig.production)
+            : (this.#options.testDclConfig ?? DclConfig.test);
+        const dclClient = new DclClient(config);
+        const certRefs = await dclClient.fetchRootCertificateList(options);
+
+        const skidWithColons = normalizedId
+            .match(/.{1,2}/g)
+            ?.join(":")
+            .toUpperCase();
+        const certRef = certRefs.find(ref => ref.subjectKeyId === skidWithColons);
+        if (!certRef) {
+            return false;
+        }
+
+        await this.#fetchAndStoreCertificate(
+            this.#storage!,
+            dclClient,
+            certRef,
+            isProduction,
+            force,
+            options ?? this.#options,
+        );
+        await this.#saveIndex();
+        return true;
     }
 
     /** Internal DER retrieval without construction assert (safe during init). */
@@ -286,19 +408,7 @@ export class DclCertificateService {
 
         try {
             const isProduction = options?.isProduction ?? true;
-            const config = isProduction
-                ? (this.#options.dclConfig ?? DclConfig.production)
-                : (this.#options.testDclConfig ?? DclConfig.test);
-            const dclClient = new DclClient(config);
-            const certRefs = await dclClient.fetchRootCertificateList(options);
-
-            const subjectKeyIdWithColons = normalizedId
-                .match(/.{1,2}/g)
-                ?.join(":")
-                .toUpperCase();
-            const certRef = certRefs.find(ref => ref.subjectKeyId === subjectKeyIdWithColons);
-
-            if (!certRef) {
+            if (!(await this.#fetchAndStoreRootCertificateBySkid(normalizedId, isProduction, false, options))) {
                 logger.debug(
                     `Certificate not found in DCL`,
                     Diagnostic.dict({ skid: normalizedId, prod: isProduction }),
@@ -306,18 +416,8 @@ export class DclCertificateService {
                 return;
             }
 
-            await this.#fetchAndStoreCertificate(
-                this.#storage!,
-                dclClient,
-                certRef,
-                isProduction,
-                false,
-                options ?? this.#options,
-            );
-
             const fetched = this.#certificateIndex.get(normalizedId);
             if (fetched) {
-                await this.#saveIndex();
                 logger.info(
                     `Fetched and stored certificate from DCL`,
                     Diagnostic.dict({ skid: normalizedId, prod: isProduction }),

--- a/packages/protocol/src/peer/ControllerCommissioningFlow.ts
+++ b/packages/protocol/src/peer/ControllerCommissioningFlow.ts
@@ -16,6 +16,7 @@ import { PeerUnresponsiveError } from "#peer/PeerCommunicationError.js";
 import {
     asError,
     Bytes,
+    CanceledError,
     causedBy,
     ChannelType,
     Diagnostic,
@@ -57,6 +58,7 @@ import { TimeSynchronization } from "@matter/types/clusters/time-synchronization
 import { CertificateAuthority } from "../certificate/CertificateAuthority.js";
 import {
     AttestationFinding,
+    DeviceAttestationCheck,
     DeviceAttestationError,
     DeviceAttestationValidator,
 } from "../certificate/DeviceAttestationValidator.js";
@@ -1199,9 +1201,22 @@ export class ControllerCommissioningFlow {
             );
             findings = result.findings;
         } catch (error) {
-            DeviceAttestationError.accept(error);
-            findings = [{ level: "error", type: error.failure, message: error.message }];
-            baseError = error;
+            // A cancellation (e.g. shutdown/close while the DCL service is consulted) must propagate
+            // cleanly rather than be downgraded to an attestation finding.
+            if (causedBy(error, CanceledError)) {
+                throw error;
+            }
+            baseError = asError(error);
+            if (error instanceof DeviceAttestationError) {
+                findings = [{ level: "error", type: error.failure, message: error.message }];
+            } else {
+                // Unexpected validation error (e.g. an unrecoverably corrupt trust-store certificate).
+                // Surface it as an error finding so the onFailure policy can still judge it, instead of
+                // hard-aborting commissioning outside the findings mechanism.
+                findings = [
+                    { level: "error", type: DeviceAttestationCheck.ValidationError, message: baseError.message },
+                ];
+            }
         }
 
         if (findings.length > 0) {

--- a/packages/protocol/test/dcl/DclCertificateServiceTest.ts
+++ b/packages/protocol/test/dcl/DclCertificateServiceTest.ts
@@ -5,6 +5,7 @@
  */
 
 import { TestCert_PAA_FFF1_Cert, TestCert_PAA_NoVID_Cert } from "#certificate/ChipPAAuthorities.js";
+import { Paa } from "#certificate/kinds/AttestationCertificates.js";
 import { CertificationDeclaration } from "#certificate/kinds/CertificationDeclaration.js";
 import { DclCertificateService } from "#dcl/DclCertificateService.js";
 import {
@@ -497,6 +498,50 @@ describe("DclCertificateService", () => {
             await service.construction;
 
             await expect(service.getCertificateAsPem("NONEXISTENT")).to.be.rejected;
+
+            await service.close();
+        });
+
+        const NOVID_SKID = "785CE705B86B8F4E6FC793AA60CB43EA696882D5";
+
+        async function corruptStoredCertificate(skid: string) {
+            const storage = await environment.get(StorageService).open("certificates");
+            await storage.createContext("root").set(skid, Bytes.fromHex("3003010203"));
+        }
+
+        it("force re-fetches a corrupted cached certificate and returns valid DER", async () => {
+            const service = new DclCertificateService(environment);
+            await service.construction;
+
+            const good = await service.getCertificateAsDer(NOVID_SKID);
+            expect(() => Paa.fromAsn1(good)).to.not.throw();
+
+            await corruptStoredCertificate(NOVID_SKID);
+
+            const healed = await service.getCertificateAsDer(NOVID_SKID);
+            expect(Bytes.areEqual(healed, good)).to.be.true;
+            expect(() => Paa.fromAsn1(healed)).to.not.throw();
+
+            await service.close();
+        });
+
+        it("returns the original bytes when a corrupted cache cannot be re-fetched", async () => {
+            const service = new DclCertificateService(environment);
+            await service.construction;
+            await service.getCertificateAsDer(NOVID_SKID);
+
+            const corrupt = Bytes.fromHex("3003010203");
+            await corruptStoredCertificate(NOVID_SKID);
+            // Empty root list wins on reverse-order match, so the re-fetch finds no replacement.
+            fetchMock.addResponse("/dcl/pki/root-certificates", {
+                approvedRootCertificates: { schemaVersion: 0, certs: [] },
+            });
+
+            // Recovery fails, so the original (corrupt) bytes are returned unchanged for the caller's
+            // normal validation to surface the parse failure rather than masking it here.
+            const result = await service.getCertificateAsDer(NOVID_SKID);
+            expect(Bytes.areEqual(result, corrupt)).to.be.true;
+            expect(() => Paa.fromAsn1(result)).to.throw();
 
             await service.close();
         });


### PR DESCRIPTION
## Problem

A commissioning failure was reported with `Commission failed: Could not decode DER signature` → `Missing number in DER object`, thrown from `Paa.fromAsn1` during device attestation. Investigation of the captured log showed **all certificates are valid**:

- Device DAC and PAI parse correctly and the full chain verifies cryptographically (PAA→PAI→DAC + attestation signature, all VALID).
- The PAA fetched live from DCL is byte-identical to the CHIP mirror and parses fine.

The failure originated from a **corrupted PAA in the controller's local DCL certificate cache** (`getCertificateAsDer` returned bytes whose signature no longer DER-decoded). Two problems compounded:

1. A broken cache entry permanently blocked attestation for an otherwise-valid trust anchor, with no recovery.
2. The raw `SignatureEncodingError` (not a `DeviceAttestationError`) was rethrown by `DeviceAttestationError.accept(...)`, bypassing the `onAttestationFailure` judgement and hard-aborting commissioning outside the findings mechanism.

## Changes

- **`DclCertificateService.getCertificateAsDer`** validates the cached certificate parses; on failure it makes **one best-effort re-fetch from DCL** (`#tryRefetchRootCertificate`, never throws) to self-heal broken storage. If recovery fails the original bytes are returned unchanged so the caller's normal validation surfaces the parse failure rather than masking it. Parse failures are logged with `Diagnostic.errorMessage` (no stack), including the case where the re-fetched cert is also broken. The DCL fetch-by-SKID logic is now a shared helper used by both `getOrFetchCertificate` and the re-fetch path.
- **`ControllerCommissioningFlow`** now converts unexpected (non-`DeviceAttestationError`) validation errors into a `ValidationError` attestation finding so the `onAttestationFailure` policy can judge them. Genuine cancellations (`CanceledError`, incl. wrapped) still propagate cleanly.
- New `DeviceAttestationCheck.ValidationError`.
- **Cleanup (separate commit):** `getCertificateAsPem` now routes through the shared `#getCertificateDer` helper, removing duplicated lookup/storage/throw code (only the final `Pem.encode` vs raw-bytes transform differs). Closes a pre-existing greg-review duplication finding.

## Tests

- 2 unit tests for the cache self-heal (recover via re-fetch; return original bytes when unrecoverable).
- 3 commissioning-integration tests (self-heal success; unrecoverable → judgeable finding that policy can accept; policy reject surfaces the underlying cause).
- Full suites green: `@matter/protocol` 1143/1143, `@matter/node` 1180/1180 (ESM/CJS/Web); format + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)