### PR TITLE
fix(node): claim peer node ID only after PASE winner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: OnOff timed-off handling now honors the `0xFFFF` "hold indefinitely" value for OnTime/OffWaitTime
     - Fix: Peers commissioned with a custom id via `commission({ id })` are now restored correctly from storage on restart
     - Fix: A TCP-enabled server now reports TCP support in its session parameters (not only in mDNS), so peers learn it during PASE/CASE
+    - Fix: Claim the peer node ID only once a candidate wins PASE, to avoid spurious "peer address already in use" conflicts across parallel commissioning attempts
+    - Fix: Refreshing a discovered node's metadata while it is being commissioned no longer crashes the process with a synchronous transaction conflict
 
 - @matter/protocol
     - Enhancement: Implemented Matter message privacy (header obfuscation) for group messages; receiving is always supported, sending is opt-in per session and off by default. Unicast messages carrying the privacy flag are dropped like in CHIP SDK

--- a/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
+++ b/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
@@ -10,7 +10,7 @@ import { SoftwareUpdateManager } from "#behavior/system/software-update/Software
 import { OperationalCredentialsClient } from "#behaviors/operational-credentials";
 import { OtaSoftwareUpdateProviderServer } from "#behaviors/ota-software-update-provider";
 import type { ClientNode } from "#node/ClientNode.js";
-import { IdentityService } from "#node/server/IdentityService.js";
+import { IdentityConflictError, IdentityService } from "#node/server/IdentityService.js";
 import type { ServerNode } from "#node/ServerNode.js";
 import {
     ClassExtends,
@@ -203,6 +203,19 @@ export class CommissioningClient extends Behavior {
             throw new ImplementationError(`Cannot commission ${node} because the node has not been located`);
         }
 
+        const identity = this.env.get(IdentityService);
+
+        // Reservation is deferred to the post-PASE gate below, so fast-fail an explicit node ID that is already
+        // taken (a commissioned peer or the controller's own identity) here instead of only after discovery+PASE.
+        if (
+            opts.nodeId !== undefined &&
+            identity.peerAddressInUse({ fabricIndex: fabric.fabricIndex, nodeId: opts.nodeId })
+        ) {
+            throw new IdentityConflictError(
+                `Cannot assign NodeId ${opts.nodeId} on fabric ${fabric.fabricIndex}: the peer address is already in use`,
+            );
+        }
+
         const commissioner = node.env.get(ControllerCommissioner);
 
         // Claim the node ID only once a candidate wins PASE.  Parallel candidates share one supplied node ID, so
@@ -263,7 +276,7 @@ export class CommissioningClient extends Behavior {
             await this.#update(this.env.get(PeerSet).for(address));
         } catch (e) {
             if (allocatedAddress !== undefined) {
-                this.env.get(IdentityService).releasePeerAddress(allocatedAddress);
+                identity.releasePeerAddress(allocatedAddress);
             }
             throw e;
         }

--- a/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
+++ b/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
@@ -205,18 +205,28 @@ export class CommissioningClient extends Behavior {
 
         const commissioner = node.env.get(ControllerCommissioner);
 
-        const address = await controller.allocatePeerAddress(fabric.fabricIndex, opts.nodeId);
+        // Claim the node ID only once a candidate wins PASE.  Parallel candidates share one supplied node ID, so
+        // reserving before PASE would fail every loser with an identity conflict; only the winner reserves here.
+        const raceGate = options.continueCommissioningAfterPase;
+        let allocatedAddress: PeerAddress | undefined;
+        const claimNodeIdAfterPase = async () => {
+            if (raceGate !== undefined && !raceGate()) {
+                return undefined;
+            }
+            allocatedAddress = await controller.allocatePeerAddress(fabric.fabricIndex, opts.nodeId);
+            return allocatedAddress.nodeId;
+        };
 
         const commissioningOptions: LocatedNodeCommissioningOptions = {
             addresses: addresses.map(ServerAddress),
             fabric,
-            nodeId: address.nodeId,
+            nodeId: opts.nodeId,
             passcode,
             discoveryData: this.descriptor,
             commissioningFlowImpl: options.commissioningFlowImpl,
             onAttestationFailure: options.onAttestationFailure,
             abort: options.abort,
-            continueCommissioningAfterPase: options.continueCommissioningAfterPase,
+            claimNodeIdAfterPase,
             wifiNetwork: options.wifiNetwork,
             threadNetwork: options.threadNetwork,
             regulatoryLocation: options.regulatoryLocation,
@@ -244,7 +254,7 @@ export class CommissioningClient extends Behavior {
         }
 
         try {
-            const { fabricIndexOnPeer } = await commissioner.commission(commissioningOptions);
+            const { address, fabricIndexOnPeer } = await commissioner.commission(commissioningOptions);
             this.state.peerAddress = address;
             this.state.commissionedAt = Time.nowMs;
             this.state.fabricIndexOnPeer = fabricIndexOnPeer;
@@ -252,7 +262,9 @@ export class CommissioningClient extends Behavior {
             // Apply changes from the peer
             await this.#update(this.env.get(PeerSet).for(address));
         } catch (e) {
-            this.env.get(IdentityService).releasePeerAddress(address);
+            if (allocatedAddress !== undefined) {
+                this.env.get(IdentityService).releasePeerAddress(allocatedAddress);
+            }
             throw e;
         }
 

--- a/packages/node/src/behavior/system/controller/discovery/Discovery.ts
+++ b/packages/node/src/behavior/system/controller/discovery/Discovery.ts
@@ -214,24 +214,21 @@ export abstract class Discovery<T = unknown> extends CancelablePromise<T> {
                             // expired-node cull observe stale `discoveredAt` and delete the node mid-commission,
                             // which collapses the BehaviorBacking and surfaces as "Datasource not yet initialized".
                             //
-                            // The descriptor refresh is tracked in `promises` for discovery-level error reporting, but
-                            // the onDiscovered chain is fire-and-forget with errors swallowed — same pattern as the
-                            // new-node branch below.  Pushing the chained promise into `promises` is unsafe because
-                            // DiscoveryAggregateError.allSettled snapshots the array and would not await callback-side
-                            // additions.
-                            const updatePromise = node.act(agent => {
-                                agent.commissioning.descriptor = descriptor;
-                            });
+                            // Fire-and-forget with errors swallowed, same as the new-node branch below.
                             const reusedNode = node;
-                            if (MaybePromise.is(updatePromise)) {
-                                promises.push(updatePromise);
-                                updatePromise.then(
-                                    () => this.onDiscovered(reusedNode),
-                                    () => {},
-                                );
-                            } else {
-                                this.onDiscovered(reusedNode);
-                            }
+                            MaybePromise.then(
+                                node.act(async agent => {
+                                    // Open the transaction asynchronously so a concurrent commission on this node
+                                    // serializes us; a plain synchronous write throws SynchronousTransactionConflictError
+                                    // mid-commission and that rejection crashes the process.
+                                    const { transaction } = agent.context;
+                                    await transaction.addResources(agent.commissioning);
+                                    await transaction.begin();
+                                    agent.commissioning.descriptor = descriptor;
+                                }),
+                                () => this.onDiscovered(reusedNode),
+                                () => {},
+                            );
                         } else {
                             // This node is new to us — defer onDiscovered until construction completes
                             // so that node.state.commissioning is committed and readable by listeners.

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -375,6 +375,51 @@ describe("ClientNode", () => {
         expect(controller.peers.size).at.least(1);
     });
 
+    it("commissions same-discriminator devices with an explicit node ID without a peer-address conflict", async () => {
+        await using site = new MockSite();
+        const controller = await site.addController();
+        const wrongPasscodeDevice = await site.addDevice({
+            commissioning: {
+                discriminator: 1234,
+                passcode: 20202021,
+            },
+        });
+        const matchingPasscodeDevice = await site.addDevice({
+            commissioning: {
+                discriminator: 1234,
+                passcode: 22223333,
+            },
+        });
+
+        const controllerCrypto = controller.env.get(Crypto) as MockCrypto;
+        const wrongDeviceCrypto = wrongPasscodeDevice.env.get(Crypto) as MockCrypto;
+        const matchingDeviceCrypto = matchingPasscodeDevice.env.get(Crypto) as MockCrypto;
+        controllerCrypto.entropic = wrongDeviceCrypto.entropic = matchingDeviceCrypto.entropic = true;
+
+        await controller.start();
+
+        // A caller-supplied node ID is shared by every parallel candidate.  Allocation must happen only after a
+        // candidate wins PASE, otherwise the losing candidate reserves the ID first and the winner fails with an
+        // identity conflict before it can commission.
+        const explicitNodeId = NodeId(88n);
+        const commissioned = await MockTime.resolve(
+            controller.peers.commission({
+                passcode: 22223333,
+                discriminator: 1234,
+                nodeId: explicitNodeId,
+                timeout: Seconds(90),
+            }),
+            { macrotasks: true },
+        );
+
+        controllerCrypto.entropic = wrongDeviceCrypto.entropic = matchingDeviceCrypto.entropic = false;
+
+        expect(commissioned).not.undefined;
+        expect(wrongPasscodeDevice.state.commissioning.commissioned).equals(false);
+        expect(matchingPasscodeDevice.state.commissioning.commissioned).equals(true);
+        expect(commissioned.state.commissioning.peerAddress?.nodeId).equals(explicitNodeId);
+    });
+
     it("commissions via known-address flow even when first address has invalid credentials", async () => {
         await using site = new MockSite();
         const controller = await site.addController();

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -420,6 +420,37 @@ describe("ClientNode", () => {
         expect(commissioned.state.commissioning.peerAddress?.nodeId).equals(explicitNodeId);
     });
 
+    it("rejects commissioning with an explicit node ID that is already in use before establishing PASE", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+        const device = await site.addDevice({
+            commissioning: {
+                discriminator: 999,
+                passcode: 22223333,
+            },
+        });
+
+        // The node ID already assigned to the commissioned peer is reserved and must be refused.
+        const usedNodeId = controller.peers.get("peer1")!.peerAddress!.nodeId;
+
+        const discovered = await MockTime.resolve(
+            controller.peers.discover({ longDiscriminator: 999, timeout: Seconds(30) }),
+            { macrotasks: true },
+        );
+        const candidate = discovered[0];
+        expect(candidate).not.undefined;
+
+        // Use a wrong passcode: the conflict must be reported before PASE, so we expect "already in use"
+        // rather than a PASE failure that would result if the check ran only at post-PASE allocation.
+        await MockTime.resolve(
+            expect(candidate.commission({ passcode: 11112222, discriminator: 999, nodeId: usedNodeId })).rejectedWith(
+                /already in use/i,
+            ),
+        );
+
+        expect(device.state.commissioning.commissioned).equals(false);
+    });
+
     it("commissions via known-address flow even when first address has invalid credentials", async () => {
         await using site = new MockSite();
         const controller = await site.addController();

--- a/packages/protocol/src/peer/ControllerCommissioner.ts
+++ b/packages/protocol/src/peer/ControllerCommissioner.ts
@@ -238,9 +238,21 @@ export class ControllerCommissioner {
         });
 
         // Claim the operational identity only after PASE; undefined means another candidate already won the race.
+        // We own the ephemeral session until #commissionConnectedNode takes over and force-closes it, so on any
+        // early exit here (lost race, or a claim error such as a node ID conflict) close it ourselves.
         let assignedNodeId = nodeId;
         if (claimNodeIdAfterPase !== undefined) {
-            assignedNodeId = await claimNodeIdAfterPase();
+            try {
+                assignedNodeId = await claimNodeIdAfterPase();
+            } catch (error) {
+                // Close the ephemeral session but let the original claim error surface, not a close failure.
+                await session
+                    .initiateForceClose({ cause: new CommissioningError("Claiming the node ID failed after PASE") })
+                    .catch(closeError =>
+                        logger.info("Error closing PASE session after failed node ID claim:", closeError),
+                    );
+                throw error;
+            }
             if (assignedNodeId === undefined) {
                 await session.initiateForceClose({
                     cause: new CommissioningError("PASE established but other device connected faster"),

--- a/packages/protocol/src/peer/ControllerCommissioner.ts
+++ b/packages/protocol/src/peer/ControllerCommissioner.ts
@@ -117,16 +117,17 @@ export interface LocatedNodeCommissioningOptions extends CommissioningOptions {
     /**
      * Called immediately after PASE is established, before the main commissioning flow begins.
      *
-     * Return `true` to proceed with commissioning (this candidate won the race).
-     * Return `false` to abort — the PASE session is closed and commissioning is skipped.
+     * Returns the {@link NodeId} to assign this device, reserved at win-time so the operational identity is
+     * claimed only once a candidate has won the PASE race.  Returns `undefined` to abort — the PASE session is
+     * closed and commissioning is skipped.
      *
-     * This is the hook used by {@link CommissioningDiscovery} for multi-candidate parallel flows:
-     * the first candidate to establish PASE returns `true` and signals the others (via {@link abort})
-     * to stop.  Any candidate that establishes PASE after another has already won returns `false` here
-     * and cleans up.  In the single-device located-node path this callback is unnecessary and need not
-     * be provided.
+     * This is the hook used by {@link CommissioningDiscovery} for multi-candidate parallel flows: the first
+     * candidate to establish PASE claims and returns its node ID (and signals the others via {@link abort} to
+     * stop).  Any candidate that establishes PASE after another has already won returns `undefined` here and
+     * cleans up.  In the single-device located-node path this callback is unnecessary; provide {@link nodeId}
+     * (or leave it undefined for an automatically assigned ID) instead.
      */
-    continueCommissioningAfterPase?: () => boolean;
+    claimNodeIdAfterPase?: () => MaybePromise<NodeId | undefined>;
 }
 
 /**
@@ -217,7 +218,7 @@ export class ControllerCommissioner {
             fabric,
             nodeId,
             abort,
-            continueCommissioningAfterPase,
+            claimNodeIdAfterPase,
             timeout = Seconds(30),
         } = options;
 
@@ -236,17 +237,21 @@ export class ControllerCommissioner {
             abort,
         });
 
-        // Check with the caller whether to proceed.  In parallel commissioning this callback atomically
-        // determines the winner: the first call returns true (and fires the abort signal to stop others);
-        // any subsequent call from a later PASE returns false and we clean up this session.
-        if (continueCommissioningAfterPase !== undefined && !continueCommissioningAfterPase()) {
-            await session.initiateForceClose({
-                cause: new CommissioningError("PASE established but other device connected faster"),
-            });
-            throw new CommissioningError("Commissioning cancelled: another device was already successfully connected");
+        // Claim the operational identity only after PASE; undefined means another candidate already won the race.
+        let assignedNodeId = nodeId;
+        if (claimNodeIdAfterPase !== undefined) {
+            assignedNodeId = await claimNodeIdAfterPase();
+            if (assignedNodeId === undefined) {
+                await session.initiateForceClose({
+                    cause: new CommissioningError("PASE established but other device connected faster"),
+                });
+                throw new CommissioningError(
+                    "Commissioning cancelled: another device was already successfully connected",
+                );
+            }
         }
 
-        return await this.#commissionConnectedNode(session, options, discoveryData);
+        return await this.#commissionConnectedNode(session, { ...options, nodeId: assignedNodeId }, discoveryData);
     }
 
     /**


### PR DESCRIPTION
## Problem

Reports of `[identity-conflict] Cannot assign NodeId N on fabric 1: the peer address is already in use` during **parallel PASE commissioning**, sometimes failing the whole commission even when the correct device was discoverable.

Two distinct defects:

### 1. Peer-address allocation before PASE
`CommissioningClient.commission()` allocated the peer address (NodeId) **before** PASE. In parallel commissioning every discovered candidate runs `commission()` concurrently with the same caller-supplied `nodeId`, so:
- the first candidate reserves the id; **all other candidates fail with an identity conflict before they even attempt PASE**;
- if the one candidate that reserved the id then fails PASE (e.g. it's not the device matching the passcode), the entire commission fails — viable candidates were knocked out pre-PASE.

The `identity-conflict` warnings are the losers; the only throw site is the caller-supplied-`nodeId` path, so this is reachable whenever a controller passes an explicit node ID (e.g. matter-server / ws-controller).

### 2. Process crash on descriptor refresh
`Discovery` refreshed a re-discovered node's descriptor with a **synchronous** state write. When that node was concurrently locked by its own in-flight commission transaction, the synchronous lock acquisition threw `SynchronousTransactionConflictError` — unhandled → **FATAL process crash**.

## Fix

1. **Defer allocation to the post-PASE win gate.** Only the candidate that wins the PASE race reserves an address; losers never allocate, so a supplied node ID no longer conflicts across parallel attempts. The protocol-layer gate is renamed `continueCommissioningAfterPase` → **`claimNodeIdAfterPase`** and now returns the claimed `NodeId` (or `undefined` to abort) instead of a boolean. The discovery-layer boolean race-gate keeps its name.
2. **Async transaction for the descriptor refresh** — it now `addResources` + `begin` asynchronously so it serializes on the node lock instead of throwing synchronously.

## Coverage

- New regression test (`ClientNodeTest`): same-discriminator parallel devices + explicit node ID → correct device commissioned, gets the exact id, no conflict. **Verified to fail on the pre-fix code.**
- The legacy `CommissioningController` / `MatterController.commission` path routes entirely through this flow (both the single-node and parallel-discovery branches), so it benefits from the fix.

## Verification
`npm run build -- --clean`, `@matter/node` 1177/1177, `@matter/protocol` 1148/1148, format-verify, lint — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)