### PR TITLE
fix(examples): start peer before toggle/decommission in OnOffController

### DIFF
--- a/examples/control-onoff/src/OnOffController.ts
+++ b/examples/control-onoff/src/OnOffController.ts
@@ -45,6 +45,11 @@ switch (command) {
             if (node === undefined) {
                 die("Cannot toggle because there is no commissioned device");
             }
+
+            // A peer must be online before we can interact with it.  Either start the controller ServerNode (its
+            // `online` event starts all peers automatically) or start each peer individually as we do here.
+            await node.start();
+
             const endpoint = node.parts.get(endpointNo);
             if (endpoint === undefined) {
                 die(`Cannot toggle because endpoint ${endpointNo} does not exist`);
@@ -64,8 +69,10 @@ switch (command) {
                 die("Cannot decommission because there is no commissioned device");
             }
 
-            // Decommission
-            await node.delete();
+            // decommission() talks to the device to remove our fabric, so the peer must be online first (same as
+            // toggle).  Use delete() instead if the device is unreachable, but that leaves it factory-reset-pending.
+            await node.start();
+            await node.decommission();
         }
         break;
 


### PR DESCRIPTION
## Problem

The `OnOffController` example never brings its peers online, so `toggle` and `decommission` had no operational session and failed.

ClientNodes become online either when the controller `ServerNode` starts (its `online` event auto-starts all peers, `Peers.#nodeOnline`) or when each peer is started individually. The example does neither.

## Fix

- **toggle**: `await node.start()` before accessing the endpoint and invoking the command (also ensures the structure is populated before `parts.get`).
- **decommission**: switch from local-only `node.delete()` to `node.decommission()`, which removes our fabric from the device. This requires an online peer too, so `node.start()` first. `delete()` remains the documented fallback for unreachable devices.

A comment documents both options (start the ServerNode vs. start each peer).

## Verification

- `npm run build -p examples/control-onoff` — clean
- `npm run format-verify` — clean
- `npm run lint` — clean
- Behavior confirmed: toggle works once the peer is started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)