### PR TITLE
fix(protocol): select operational TCP via session params or mDNS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: SII/SAI/SAT keys are now omitted from advertised DNS-SD TXT records when at their default values, matching CHIP SDK behavior
     - Enhancement: MRP retransmission additive delay is now a tunable per-`NetworkProfile.additionalMrpDelay` instead of a fixed constant
     - Enhancement: Subscription maxIntervalCeiling now lengthens by up to +max(10%, 10s) one-sided jitter for all device types (previously only Thread-active devices)
-    - Enhancement: Validate the CASE session parameters when establishing a TCP connection and fail the session if they do not match the expectations
+    - Enhancement: Prefer TCP for operational connections when the peer advertises TCP-server support via its session parameters or mDNS; a negotiated TCP session is declined only on an explicit no-TCP report
     - Enhancement: Lengthened the BTP handshake-response timeout (5s → 15s) and central idle timeout (30s → 60s) to match CHIP
     - Fix: Ignore announced TCP support for peers reporting Matter spec version < 1.5.0
     - Fix: Corrected the Session Active Threshold limit to 65535 milliseconds (was wrongly checked against 65535 seconds)

--- a/packages/node/test/node/ClientNodeTcpTest.ts
+++ b/packages/node/test/node/ClientNodeTcpTest.ts
@@ -277,6 +277,31 @@ describe("ClientNodeTcp", () => {
 
             expect(peer.resolveTransports(undefined, ChannelType.TCP)).undefined;
         });
+
+        it("attempts TCP when session parameters omit TCP support but mDNS advertises a TCP server", async () => {
+            await using site = new MockSite();
+            const { controller } = await commissionPair(site, { tcp: true }, { tcp: true });
+
+            const peer = protocolPeer(controller);
+            // Some 1.5+ peers omit SUPPORTED_TRANSPORTS (tag 8) yet serve TCP; mDNS T must then decide.
+            peer.descriptor.sessionParameters = { ...peer.sessionParameters, supportedTransports: {} };
+            expect(peer.sessionParameters.supportedTransports?.tcpServer).undefined;
+            expect(peer.descriptor.discoveryData?.T?.tcpServer).true;
+
+            expect(peer.resolveTransports(undefined, ChannelType.TCP)).deep.equals([ChannelType.TCP, ChannelType.UDP]);
+        });
+
+        it("falls back to UDP when session parameters omit TCP support and mDNS does not advertise a TCP server", async () => {
+            await using site = new MockSite();
+            const { controller } = await commissionPair(site, { tcp: true }, /* deviceNetwork: */ undefined);
+
+            const peer = protocolPeer(controller);
+            peer.descriptor.sessionParameters = { ...peer.sessionParameters, supportedTransports: {} };
+            expect(peer.sessionParameters.supportedTransports?.tcpServer).undefined;
+            expect(peer.descriptor.discoveryData?.T?.tcpServer).not.true;
+
+            expect(peer.resolveTransports(undefined, ChannelType.TCP)).undefined;
+        });
     });
 
     describe("tcp-unsupported flag", () => {

--- a/packages/nodejs-shell/src/shell/cmd_nodes.ts
+++ b/packages/nodejs-shell/src/shell/cmd_nodes.ts
@@ -5,7 +5,7 @@
  */
 
 import { capitalize, ChannelType, decamelize, Diagnostic, ServerAddress } from "@matter/general";
-import { ClientNode, NetworkClient, SoftwareUpdateManager } from "@matter/node";
+import { ClientNode, CommissioningClient, NetworkClient, SoftwareUpdateManager } from "@matter/node";
 import { PeerAddress, PeerSet } from "@matter/protocol";
 import { FabricIndex, NodeId, VendorId } from "@matter/types";
 import { CommissioningControllerNodeOptions, NodeStateInformation } from "@project-chip/matter.js/device";
@@ -51,6 +51,41 @@ export function createDiagnosticCallbacks(): Partial<CommissioningControllerNode
             }
         },
     };
+}
+
+/** Parse a `udp://host:port` / `tcp://host:port` URL (IPv6 host in brackets) into a {@link ServerAddress}. */
+function parseFallbackAddress(input: string): ServerAddress {
+    const match = /^(udp|tcp):\/\/(.+)$/i.exec(input);
+    if (!match) {
+        throw new Error(`Invalid address "${input}". Expected udp://<host>:<port> or tcp://<host>:<port>`);
+    }
+    const type = match[1].toLowerCase() === "tcp" ? "tcp" : "udp";
+    const rest = match[2];
+
+    let ip: string;
+    let portStr: string;
+    if (rest.startsWith("[")) {
+        const end = rest.indexOf("]");
+        if (end === -1 || rest[end + 1] !== ":") {
+            throw new Error(`Invalid IPv6 address "${input}". Expected ${type}://[<ipv6>]:<port>`);
+        }
+        ip = rest.slice(1, end);
+        portStr = rest.slice(end + 2);
+    } else {
+        const idx = rest.lastIndexOf(":");
+        if (idx === -1) {
+            throw new Error(`Missing port in "${input}". Expected ${type}://<host>:<port>`);
+        }
+        ip = rest.slice(0, idx);
+        portStr = rest.slice(idx + 1);
+    }
+
+    const port = Number(portStr);
+    if (!ip.length || !Number.isInteger(port) || port < 1 || port > 65535) {
+        throw new Error(`Invalid host/port in "${input}". Expected ${type}://<host>:<port> with port 1-65535`);
+    }
+
+    return { ip, port, type };
 }
 
 export default function commands(theNode: MatterNode) {
@@ -332,8 +367,9 @@ export default function commands(theNode: MatterNode) {
                                 demandOption: true,
                             })
                             .positional("preference", {
-                                describe: "tcp preference: on/off (on = prefer TCP, off = prefer UDP)",
-                                choices: ["on", "off"],
+                                describe:
+                                    "tcp preference: on (prefer TCP) / off (prefer UDP) / clear (inherit controller default)",
+                                choices: ["on", "off", "clear"],
                                 demandOption: true,
                                 type: "string",
                             });
@@ -348,7 +384,7 @@ export default function commands(theNode: MatterNode) {
                         const nodeId = NodeId(BigInt(nodeIdStr));
                         const node = await theNode.commissioningController.getNode(nodeId);
 
-                        const pref = preference === "on" ? "tcp" : "udp";
+                        const pref = preference === "on" ? "tcp" : preference === "off" ? "udp" : undefined;
                         await node.node.setStateOf(NetworkClient, { transportPreference: pref });
 
                         // Also update the protocol-level peer preference
@@ -360,8 +396,89 @@ export default function commands(theNode: MatterNode) {
                         }
 
                         console.log(
-                            `Transport preference for node ${nodeIdStr} set to ${pref.toUpperCase()}. Reconnect to the  node to take effect.`,
+                            `Transport preference for node ${nodeIdStr} set to ${pref?.toUpperCase() ?? "CLEARED (inherit controller default)"}. Reconnect to the node to take effect.`,
                         );
+                    },
+                )
+                .command(
+                    "fallback",
+                    "Get or set the fallback (commissioning) addresses used to reach a node",
+                    yargs =>
+                        yargs
+                            .command(
+                                "get <node-id>",
+                                "Print the fallback addresses currently stored for a node",
+                                yargs => {
+                                    return yargs.positional("node-id", {
+                                        describe: "node id",
+                                        type: "string",
+                                        demandOption: true,
+                                    });
+                                },
+                                async argv => {
+                                    const { nodeId: nodeIdStr } = argv;
+                                    await theNode.start();
+                                    if (theNode.commissioningController === undefined) {
+                                        throw new Error("CommissioningController not initialized");
+                                    }
+
+                                    const nodeId = NodeId(BigInt(nodeIdStr));
+                                    const node = await theNode.commissioningController.getNode(nodeId);
+                                    const addresses = node.node.state.commissioning.addresses;
+
+                                    if (!addresses?.length) {
+                                        console.log(`Node ${nodeIdStr} has no fallback addresses stored`);
+                                        return;
+                                    }
+
+                                    console.log(`Fallback addresses for node ${nodeIdStr}:`);
+                                    for (const address of addresses) {
+                                        console.log(`  ${ServerAddress.urlFor(address)}`);
+                                    }
+                                },
+                            )
+                            .command(
+                                "set <node-id> <address>",
+                                "Set or drop the fallback address for a node (udp://host:port, tcp://host:port, or 'drop')",
+                                yargs => {
+                                    return yargs
+                                        .positional("node-id", {
+                                            describe: "node id",
+                                            type: "string",
+                                            demandOption: true,
+                                        })
+                                        .positional("address", {
+                                            describe: "udp://<host>:<port>, tcp://<host>:<port>, or 'drop' to remove",
+                                            type: "string",
+                                            demandOption: true,
+                                        });
+                                },
+                                async argv => {
+                                    const { nodeId: nodeIdStr, address: addressStr } = argv;
+                                    await theNode.start();
+                                    if (theNode.commissioningController === undefined) {
+                                        throw new Error("CommissioningController not initialized");
+                                    }
+
+                                    const nodeId = NodeId(BigInt(nodeIdStr));
+                                    const node = await theNode.commissioningController.getNode(nodeId);
+
+                                    if (addressStr === "drop") {
+                                        await node.node.setStateOf(CommissioningClient, { addresses: undefined });
+                                        console.log(`Fallback address for node ${nodeIdStr} dropped`);
+                                        return;
+                                    }
+
+                                    const address = parseFallbackAddress(addressStr);
+                                    await node.node.setStateOf(CommissioningClient, { addresses: [address] });
+                                    console.log(
+                                        `Fallback address for node ${nodeIdStr} set to ${ServerAddress.urlFor(address)}`,
+                                    );
+                                },
+                            )
+                            .demandCommand(1, "Please specify 'get' or 'set'"),
+                    async (argv: any) => {
+                        argv.unhandled = true;
                     },
                 )
                 .command(

--- a/packages/protocol/src/peer/Peer.ts
+++ b/packages/protocol/src/peer/Peer.ts
@@ -294,31 +294,61 @@ export class Peer {
     /**
      * Resolve the ordered list of transports to attempt for this peer.
      *
-     * - `requiredTransport` is a hard constraint: only that transport.
-     * - Else effective soft preference is `preferredTransport ?? transportPreference`. When TCP, the peer's session
-     *   parameters confirm TCP server support (pre-1.5 peers and peers proven not to support TCP report no TCP via
-     *   {@link SessionParameters}/{@link markTcpUnsupported}; unknown support is treated as none), and the peer
-     *   advertises TCP server support, returns `[TCP, UDP]`.
-     * - Else `undefined` (default UDP, no constraint).
+     * `requiredTransport` is a hard constraint.  Otherwise, with an effective TCP preference
+     * (`preferredTransport ?? transportPreference`), the `SUPPORTED_TRANSPORTS.tcpServer` session parameter (tag 8)
+     * decides when present, falling back to the mDNS TXT `T` advertisement only when absent.  Pre-1.5 peers resolve
+     * to UDP.  `undefined` means default UDP.
      */
     resolveTransports(requiredTransport?: ChannelType, preferredTransport?: ChannelType): IpChannelType[] | undefined {
+        return this.#transportDecision(requiredTransport, preferredTransport).transports;
+    }
+
+    #transportDecision(
+        requiredTransport?: ChannelType,
+        preferredTransport?: ChannelType,
+    ): { transports: IpChannelType[] | undefined; reason: string; diag: Record<string, unknown> } {
+        const tcp: IpChannelType[] = [ChannelType.TCP, ChannelType.UDP];
         if (requiredTransport === ChannelType.TCP || requiredTransport === ChannelType.UDP) {
-            return [requiredTransport];
+            return { transports: [requiredTransport], reason: "transport explicitly required", diag: {} };
         }
         const effectivePreference = preferredTransport ?? this.transportPreference;
         if (effectivePreference !== ChannelType.TCP) {
-            return undefined;
+            return { transports: undefined, reason: "no TCP preference active", diag: {} };
         }
-        if (!this.sessionParameters.supportedTransports?.tcpServer) {
-            return undefined;
+
+        // mDNS T is a fallback for an absent tag 8 only — some 1.5+ peers omit the field yet serve TCP.  Pre-1.5 peers
+        // arrive as an explicit `false` (SessionParameters clears their TCP), so the 1.5.0 gate needs no code here.
+        // Live TXT first: the descriptor cache lags a tick when TXT and addresses share one mDNS response.
+        const params = this.sessionParameters;
+        const specVersion = Diagnostic.hex(params.specificationVersion);
+        const tcpServerParam = params.supportedTransports.tcpServer;
+        if (tcpServerParam === true) {
+            return {
+                transports: tcp,
+                reason: "session parameter confirms TCP server",
+                diag: { paramTcpServer: true, specVersion },
+            };
         }
-        // Live-read from service TXT params; the descriptor cache lags by one observer tick when
-        // operational TXT and addresses arrive in the same mDNS response. Trade-off: if `tcpServer`
-        // is later withdrawn, the heap ordering of already-enqueued addresses becomes stale —
-        // acceptable since TCP-server-capability withdrawal mid-connect is not a real-world flow.
-        const liveT = DiscoveryData(this.#service.parameters).T;
-        const T = liveT ?? this.#descriptor.discoveryData?.T;
-        return T?.tcpServer ? [ChannelType.TCP, ChannelType.UDP] : undefined;
+        if (tcpServerParam === false) {
+            return {
+                transports: undefined,
+                reason: "session parameter denies TCP server",
+                diag: { paramTcpServer: false, specVersion },
+            };
+        }
+        const tcpServerMdns =
+            (DiscoveryData(this.#service.parameters).T ?? this.#descriptor.discoveryData?.T)?.tcpServer === true;
+        return tcpServerMdns
+            ? {
+                  transports: tcp,
+                  reason: "TCP server advertised via mDNS (session parameter absent)",
+                  diag: { paramTcpServer: "absent", mdnsTcpServer: true, specVersion },
+              }
+            : {
+                  transports: undefined,
+                  reason: "no TCP server (session parameter absent, no mDNS advertisement)",
+                  diag: { paramTcpServer: "absent", mdnsTcpServer: false, specVersion },
+              };
     }
 
     /**
@@ -330,7 +360,22 @@ export class Peer {
         }
 
         while (true) {
-            const transports = this.resolveTransports(options?.requiredTransport, options?.preferredTransport);
+            const { transports } = this.#transportDecision(options?.requiredTransport, options?.preferredTransport);
+            /* Debug aid (one line per connect — noisy); uncomment to trace transport selection:
+            {
+                const { reason, diag } = this.#transportDecision(options?.requiredTransport, options?.preferredTransport);
+                logger.debug(
+                    "Transport resolution",
+                    Diagnostic.dict({
+                        peer: this.address.toString(),
+                        result: transports === undefined ? "UDP (no constraint)" : transports.join("+"),
+                        reason,
+                        peerPreference: this.transportPreference ?? "none",
+                        ...diag,
+                    }),
+                );
+            }
+            */
             let session: NodeSession | undefined;
             if (transports === undefined) {
                 session = this.newestSession();
@@ -341,6 +386,16 @@ export class Peer {
                 }
             }
             if (session) {
+                /* Debug aid; uncomment to trace existing-session reuse:
+                logger.debug(
+                    "Reusing existing session",
+                    Diagnostic.dict({
+                        peer: this.address.toString(),
+                        sessionTransport: session.channel.transportChannel.type,
+                        wantedTransports: transports === undefined ? "UDP (no constraint)" : transports.join("+"),
+                    }),
+                );
+                */
                 return session;
             }
 

--- a/packages/protocol/src/peer/PeerConnection.ts
+++ b/packages/protocol/src/peer/PeerConnection.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Message } from "#codec/MessageCodec.js";
+import { DiscoveryData } from "#common/Scanner.js";
 import type { ExchangeManager } from "#protocol/ExchangeManager.js";
 import { ChannelStatusResponseError } from "#securechannel/SecureChannelMessenger.js";
 import { CaseClient } from "#session/case/CaseClient.js";
@@ -519,12 +520,22 @@ export async function PeerConnection(
                     initialRetransmissionTime: isFallback ? timing.maxDelayBetweenInitialContactRetries : undefined,
                     validateSessionParameters: isTcp
                         ? params => {
-                              if (!params.supportedTransports?.tcpServer) {
-                                  peer.markTcpUnsupported();
-                                  throw new TcpUnsupportedError(
-                                      `Peer negotiated a TCP session but reports no TCP server support`,
-                                  );
+                              // Mirror resolveTransports so connect and validation agree: absent tag 8 never denies, and
+                              // a `false` (which on resume can be a stale resumption-record value, not the device's
+                              // current advertisement) is overridden while mDNS still advertises a TCP server.
+                              if (params.supportedTransports.tcpServer !== false) {
+                                  return;
                               }
+                              const advertisedByMdns =
+                                  (DiscoveryData(peer.service.parameters).T ?? peer.descriptor.discoveryData?.T)
+                                      ?.tcpServer === true;
+                              if (advertisedByMdns) {
+                                  return;
+                              }
+                              peer.markTcpUnsupported();
+                              throw new TcpUnsupportedError(
+                                  `Peer negotiated a TCP session but reports no TCP server support`,
+                              );
                           }
                         : undefined,
                 });

--- a/packages/protocol/src/session/case/CaseClient.ts
+++ b/packages/protocol/src/session/case/CaseClient.ts
@@ -165,13 +165,15 @@ export class CaseClient {
                 sessionParameters: resumptionSessionParams,
                 caseAuthenticatedTags,
             } = resumptionRecord;
-            const { responderSessionId: peerSessionId, resumptionId, resumeMic } = sigma2Resume;
+            const { responderSessionId: peerSessionId, resumptionId, resumeMic, responderSessionParams } = sigma2Resume;
 
-            // We use the Fallbacks for the session parameters overridden by our stored ones from the resumption record.
-            // Normalize via the factory so validation sees the same decoded/spec-gated parameters the session adopts.
+            // Sigma2Resume's freshly-sent parameters are more current than the resumption record, so they take
+            // precedence.  Normalize via the factory so validation sees the same decoded/spec-gated parameters the
+            // session adopts.
             const sessionParameters = SessionParameters({
                 ...exchange.session.parameters,
                 ...(resumptionSessionParams ?? {}),
+                ...(responderSessionParams ?? {}),
             });
 
             validateSessionParameters?.(sessionParameters);


### PR DESCRIPTION
## Summary
Fixes operational TCP transport selection so 1.5+ peers that support TCP but omit the `SUPPORTED_TRANSPORTS` session parameter (tag 8) — yet advertise it via mDNS — are reached over TCP instead of silently falling back to UDP.

### Transport decision (`Peer.resolveTransports`)
Precedence when a TCP preference is active:
1. `requiredTransport` — hard constraint
2. session parameter `SUPPORTED_TRANSPORTS.tcpServer` — authoritative when present (`true` → TCP, `false` → UDP)
3. mDNS TXT `T.tcpServer` — used only when tag 8 is **absent**
4. pre-1.5 / unknown-spec peers → UDP (implicit: `SessionParameters` already clears their TCP support)

### CASE validator sync (`PeerConnection`)
The TCP session validator now mirrors the same rule: an **absent** tag 8 never denies, and a `false` (which on resume can be a stale resumption-record value rather than the device's current advertisement) is overridden while mDNS still advertises a TCP server. A working TCP session is no longer torn down spuriously.

### CASE resume (`CaseClient`)
Resume now adopts the freshly-sent `Sigma2Resume.responderSessionParams` in addition to the stored resumption record, so the device's current parameters take precedence.

### nodejs-shell
- `nodes fallback get/set <node-id> <udp://…|tcp://…|drop>` — inspect/override a peer's commissioning (fallback) addresses
- `nodes tcp <node-id> clear` — reset the per-node transport preference so the controller default wins (was only `on`/`off`)

## Test plan
- New unit tests in `ClientNodeTcpTest`: tag 8 absent + mDNS advertises → TCP; tag 8 absent + no mDNS → UDP
- `npm test -p packages/protocol` → 1159/1159
- `npm test -p packages/node` → 1186/1186
- Verified live against a real device (Google-cast-style) that omits tag 8 but advertises TCP via mDNS: connects and subscribes over TCP across tcp/udp fallback × tcp/udp preference combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)