### PR TITLE
fix(nodejs-shell): apply stored network credentials only when non-empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/node
     - Enhancement: Added `network.ownNetworkProfileId` to set the local network's MRP additive margin, and exposed `additionalMrpDelay` and `probeAddress` in network profile config
 
+- @matter/nodejs-shell
+    - Fix: Stored Wi-Fi/Thread credentials are only applied during commissioning when their values are non-empty, so an empty operational dataset no longer fails commissioning of IP-only devices
+    - Fix: `config wifi/thread set` now rejects empty credential values
+
 ## 0.17.1 (2026-06-03)
 
 - @matter/\*

--- a/packages/nodejs-shell/src/shell/cmd_commission.ts
+++ b/packages/nodejs-shell/src/shell/cmd_commission.ts
@@ -161,22 +161,19 @@ export default function commands(theNode: MatterNode) {
 
                                     await theNode.certificateService();
 
-                                    if (theNode.Store.has("WiFiSsid") && theNode.Store.has("WiFiPassword")) {
-                                        options.commissioning.wifiNetwork = {
-                                            wifiSsid: await theNode.Store.get<string>("WiFiSsid", ""),
-                                            wifiCredentials: await theNode.Store.get<string>("WiFiPassword", ""),
-                                        };
+                                    const wifiSsid = await theNode.Store.get<string>("WiFiSsid", "");
+                                    const wifiCredentials = await theNode.Store.get<string>("WiFiPassword", "");
+                                    if (wifiSsid.length > 0 && wifiCredentials.length > 0) {
+                                        options.commissioning.wifiNetwork = { wifiSsid, wifiCredentials };
                                     }
-                                    if (
-                                        theNode.Store.has("ThreadName") &&
-                                        theNode.Store.has("ThreadOperationalDataset")
-                                    ) {
+                                    const threadOperationalDataset = await theNode.Store.get<string>(
+                                        "ThreadOperationalDataset",
+                                        "",
+                                    );
+                                    if (threadOperationalDataset.length > 0) {
                                         options.commissioning.threadNetwork = {
                                             networkName: await theNode.Store.get<string>("ThreadName", ""),
-                                            operationalDataset: await theNode.Store.get<string>(
-                                                "ThreadOperationalDataset",
-                                                "",
-                                            ),
+                                            operationalDataset: threadOperationalDataset,
                                         };
                                     }
 

--- a/packages/nodejs-shell/src/shell/cmd_config.ts
+++ b/packages/nodejs-shell/src/shell/cmd_config.ts
@@ -546,7 +546,7 @@ async function doThreadCredentials(
             break;
         case "set":
             if (!threadName || !threadOperationalDataset) {
-                console.log(`Cannot change Thread network credentials: New values not provided`);
+                console.log(`Cannot change Thread network credentials: values must be non-empty`);
                 return;
             }
             await theNode.Store.set("ThreadName", threadName);

--- a/packages/nodejs-shell/src/shell/cmd_config.ts
+++ b/packages/nodejs-shell/src/shell/cmd_config.ts
@@ -503,7 +503,7 @@ async function doWifiCredentials(
             );
             break;
         case "set":
-            if (wifiSsid === undefined || wifiPassword === undefined) {
+            if (!wifiSsid || !wifiPassword) {
                 console.log(`Cannot change Wi-Fi credentials: New values not provided`);
                 return;
             }
@@ -545,7 +545,7 @@ async function doThreadCredentials(
             );
             break;
         case "set":
-            if (threadName === undefined || threadOperationalDataset === undefined) {
+            if (!threadName || !threadOperationalDataset) {
                 console.log(`Cannot change Thread network credentials: New values not provided`);
                 return;
             }

--- a/packages/nodejs-shell/src/shell/cmd_config.ts
+++ b/packages/nodejs-shell/src/shell/cmd_config.ts
@@ -504,7 +504,7 @@ async function doWifiCredentials(
             break;
         case "set":
             if (!wifiSsid || !wifiPassword) {
-                console.log(`Cannot change Wi-Fi credentials: New values not provided`);
+                console.log(`Cannot change Wi-Fi credentials: values must be non-empty`);
                 return;
             }
             await theNode.Store.set("WiFiSsid", wifiSsid);


### PR DESCRIPTION
## Problem

Commissioning an IP-only device via the shell failed with:

```
[commissioning] Thread operational dataset must not be empty
  at ControllerCommissioner.#validateCommissioningOptions
```

even though no Thread credentials were intended.

## Cause

`cmd_commission.ts` injected `wifiNetwork`/`threadNetwork` into the commissioning options whenever the corresponding Store **keys** existed, gated on `Store.has()`. `has()` is value-blind — it returns `true` for an empty-string value. A stored but empty `ThreadOperationalDataset` therefore produced `threadNetwork = { networkName, operationalDataset: "" }`, which `ControllerCommissioner.#validateCommissioningOptions` rejects.

The printed options JSON looked clean because it is logged *before* the credential injection step.

## Fix

- `cmd_commission.ts`: gate Wi-Fi/Thread injection on non-empty credential **values**, not key presence.
- `cmd_config.ts`: `config wifi/thread set` now rejects empty credential values (previously only `undefined` was rejected).

Note: existing stores with an empty `ThreadOperationalDataset` should run `config thread delete` to clear the stale key.

## Test

`npm run build`, `npm run format-verify`, `npm run lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)