### PR TITLE
fix(protocol): prevent duplicate BTP ack racing a stand-alone ack with a data send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: BTP now reserves the remote receive window's last slot for an acknowledgement and sends a stand-alone ack proactively once its own receive window runs low
     - Fix: BTP now resumes a stalled send queue when an incoming acknowledgement reopens the window
     - Fix: BTP now closes the session if reassembly exceeds the declared message length
+    - Fix: BTP commits the acknowledged sequence number before awaiting the write so a stand-alone ack and a concurrent data send no longer acknowledge the same sequence twice (a duplicate ack is rejected by spec-compliant peers)
     - Fix: A corrupted PAA in the local DCL certificate cache is now re-fetched from DCL once before failing, recovering from broken storage
     - Fix: Unexpected errors during device attestation validation (e.g. an unrecoverably corrupt trust-store certificate) are now surfaced as an attestation finding for the `onAttestationFailure` policy to judge, instead of aborting commissioning outside the findings mechanism
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: BTP now resumes a stalled send queue when an incoming acknowledgement reopens the window
     - Fix: BTP now closes the session if reassembly exceeds the declared message length
     - Fix: BTP commits the acknowledged sequence number before awaiting the write so a stand-alone ack and a concurrent data send no longer acknowledge the same sequence twice (a duplicate ack is rejected by spec-compliant peers)
+    - Fix: BTP no longer issues a stand-alone ack into a full remote receive window or concurrently with an in-flight fragment write
     - Fix: A corrupted PAA in the local DCL certificate cache is now re-fetched from DCL once before failing, recovering from broken storage
     - Fix: Unexpected errors during device attestation validation (e.g. an unrecoverably corrupt trust-store certificate) are now surfaced as an attestation finding for the `onAttestationFailure` policy to judge, instead of aborting commissioning outside the findings mechanism
 

--- a/packages/protocol/src/ble/BleConsts.ts
+++ b/packages/protocol/src/ble/BleConsts.ts
@@ -33,10 +33,7 @@ export namespace MatterBle {
     export const MAXIMUM_BTP_MTU = 244; // Maximum size of BTP segment
     export const MAXIMUM_ATT_MTU = MAXIMUM_BTP_MTU + 3; // 247: BTP segment plus the 3-byte GATT header (§4.19.3.1.4)
 
-    /**
-     * Derive the BTP segment size from a negotiated GATT ATT_MTU. Per §4.19.3.1.4 the value carried in the BTP
-     * handshake is the ATT_MTU minus the 3-byte GATT header; clamp the result to the supported BTP range.
-     */
+    /** §4.19.3.1.4: BTP segment size is the ATT_MTU minus the 3-byte GATT header, clamped to the supported range. */
     export function btpSegmentSizeFromAttMtu(attMtu: number): number {
         const segmentSize = attMtu - 3;
         if (segmentSize < MINIMUM_ATT_MTU) return MINIMUM_ATT_MTU;
@@ -46,16 +43,10 @@ export namespace MatterBle {
 
     export const BTP_MAXIMUM_WINDOW_SIZE = 255; // Server maximum window size
 
-    /**
-     * §4.19.4.7: a peer must not consume the remote receive window's last open slot with a data-only packet; that
-     * slot is reserved for an acknowledgement so a full window on both sides cannot deadlock.
-     */
+    /** §4.19.4.7: reserve the remote window's last slot for an ack so a full window on both sides can't deadlock. */
     export const BTP_WINDOW_NO_ACK_SEND_THRESHOLD = 1;
 
-    /**
-     * §4.19.4.8: once the local receive window shrinks to this many free slots or fewer, send any pending
-     * acknowledgement immediately as a stand-alone packet rather than waiting for the send-ack timer.
-     */
+    /** §4.19.4.8: at this many free local-window slots or fewer, send any pending ack immediately. */
     export const BTP_IMMEDIATE_ACK_WINDOW_THRESHOLD = 2;
 
     /**

--- a/packages/protocol/src/ble/BtpSessionHandler.ts
+++ b/packages/protocol/src/ble/BtpSessionHandler.ts
@@ -112,6 +112,9 @@ export class BtpSessionHandler {
 
         await writeBleCallback(handshakeResponse);
 
+        // Start awaiting the ack for the just-sent handshake response only now that it is on the wire.
+        btpSession.ackReceiveTimer.start();
+
         return btpSession;
     }
 
@@ -163,10 +166,9 @@ export class BtpSessionHandler {
             throw new BtpProtocolError(`Unsupported BTP version ${btpVersion}`);
         }
         if (role === "peripheral") {
-            // No sequenced packet has been received yet (the handshake request is unsequenced), so there is
-            // nothing to acknowledge until the first fragment arrives.
+            // The handshake request is unsequenced, so nothing is pending to acknowledge yet.
             this.prevAckedSequenceNumber = this.prevIncomingSequenceNumber;
-            this.ackReceiveTimer.start();
+            // ackReceiveTimer is started once the handshake response has actually been written (see factory).
         } else {
             this.sendAckTimer.start();
             this.prevIncomingSequenceNumber = 0;
@@ -304,11 +306,9 @@ export class BtpSessionHandler {
                 await this.handleMatterMessagePayload(payloadToProcess);
             }
 
-            // A received ack may have reopened the remote window, so flush any queued fragments that were
-            // previously held back; the ack pending for this packet piggybacks on them.
+            // A received ack may have reopened the remote window; flush held-back fragments (they piggyback the ack).
             await this.processSendQueue();
-
-            // Otherwise, if nothing is queued to piggyback on and our receive window has run low, ack proactively.
+            // If nothing was queued to piggyback on, ack proactively when our receive window is low.
             await this.sendImmediateAckIfWindowLow();
         } catch (error) {
             logger.warn(`Error while handling incoming BTP data:`, error);
@@ -411,9 +411,8 @@ export class BtpSessionHandler {
             const packet = BtpCodec.encodeBtpPacket(btpPacket);
             logger.debug(`Sending BTP packet raw: ${Bytes.toHex(packet)}`);
 
-            // Commit the acknowledgement before awaiting the write so a concurrent send (e.g. a stand-alone ack
-            // or a reply triggered by an incoming message) cannot observe the stale value and ack the same
-            // sequence number twice — a duplicate ack is rejected by spec-compliant peers.
+            // Commit the ack before the await so a concurrent send can't observe the stale value and ack the same
+            // sequence twice (spec-compliant peers reject a duplicate ack).
             const previousAckedSequenceNumber = this.prevAckedSequenceNumber;
             if (ackNumberToSend !== undefined) {
                 this.prevAckedSequenceNumber = ackNumberToSend;
@@ -422,9 +421,8 @@ export class BtpSessionHandler {
             try {
                 await this.writeBleCallback(packet);
             } catch (error) {
-                // Roll back the bookkeeping the failed write left half-applied (ack commit, queue, send flag) so it
-                // runs for every error, then absorb an expected disconnect and re-raise anything unexpected.
-                // The queue is cleared to avoid malformed state from partially-consumed DataReaders.
+                // Roll back before re-raising so every error type (not just an absorbed disconnect) leaves clean
+                // state; the queue is cleared to drop partially-consumed DataReaders.
                 this.prevAckedSequenceNumber = previousAckedSequenceNumber;
                 this.queuedOutgoingMatterMessages.length = 0;
                 this.sendInProgress = false;
@@ -481,11 +479,7 @@ export class BtpSessionHandler {
         await this.sendStandaloneAck();
     }
 
-    /**
-     * §4.19.4.8: send a pending acknowledgement immediately, ahead of the send-ack timer, once our receive window
-     * has shrunk to the immediate-ack threshold. Skipped when an outgoing message is queued, since that fragment
-     * will piggyback the acknowledgement.
-     */
+    /** §4.19.4.8: ack proactively once our receive window runs low; skipped if queued data will piggyback it. */
     private async sendImmediateAckIfWindowLow() {
         if (this.queuedOutgoingMatterMessages.length > 0 || this.sendInProgress) return;
         if (this.localWindowFreeSlots() > MatterBle.BTP_IMMEDIATE_ACK_WINDOW_THRESHOLD) return;
@@ -494,8 +488,12 @@ export class BtpSessionHandler {
 
     /** Send a stand-alone acknowledgement packet if one is pending. */
     private async sendStandaloneAck() {
+        // A data send already in flight will piggyback the pending ack; don't issue a racing concurrent write.
+        if (this.sendInProgress) return;
         const ackNumberToSend = this.prevIncomingSequenceNumber;
         if (ackNumberToSend === this.prevAckedSequenceNumber) return;
+        // §4.19.4.7: an ack still consumes a remote-window slot, so never send into a full window.
+        if (!this.canSend(true)) return;
         logger.debug(`Sending BTP ACK for sequence number ${ackNumberToSend}`);
         const btpPacket = {
             header: {
@@ -513,15 +511,14 @@ export class BtpSessionHandler {
         };
         const packet = BtpCodec.encodeBtpPacket(btpPacket);
 
-        // Commit the acknowledgement before awaiting the write so an interleaved data send cannot observe the
-        // stale value and ack the same sequence number again — a duplicate ack is rejected by spec-compliant peers.
+        // Commit the ack before the await so an interleaved data send can't re-ack the same sequence
+        // (spec-compliant peers reject a duplicate ack).
         const previousAckedSequenceNumber = this.prevAckedSequenceNumber;
         this.prevAckedSequenceNumber = ackNumberToSend;
         try {
             await this.writeBleCallback(packet);
         } catch (error) {
-            // Roll back the ack commit before absorbing an expected disconnect and re-raising anything unexpected,
-            // so a failed write never leaves the acknowledgement marked as sent.
+            // Roll back before re-raising so a failed write never leaves the ack marked as sent.
             this.prevAckedSequenceNumber = previousAckedSequenceNumber;
             BleDisconnectedError.accept(error);
             logger.debug("BTP ACK send failed because BLE is disconnected", Diagnostic.errorMessage(error));
@@ -555,38 +552,24 @@ export class BtpSessionHandler {
         return this.sequenceNumber;
     }
 
-    /**
-     * Wrap-safe forward distance between two sequence numbers (modulo 256). The -1 "nothing yet" sentinels map
-     * to 255, so callers must keep those sentinels distinct from a real sequence number 255 (true today because
-     * sequence numbers start at 0 and a session never has 256 outstanding packets).
-     */
+    /** Wrap-safe forward distance between two sequence numbers (modulo 256); the -1 sentinels read as 255. */
     private modularDistance(from: number, to: number): number {
         return (((to - from) % 256) + 256) % 256;
     }
 
-    /**
-     * Free slots remaining in the remote peer's receive window: the negotiated window size minus the number of
-     * sent-but-unacknowledged packets. Gates our sending (§4.19.4.7). Mirrors CHIP's mRemoteReceiveWindowSize.
-     */
+    /** Free slots in the remote peer's receive window; gates our sending (§4.19.4.7). */
     private remoteWindowFreeSlots(): number {
         return this.clientWindowSize - this.modularDistance(this.prevIncomingAckNumber, this.sequenceNumber);
     }
 
-    /**
-     * Free slots remaining in our own receive window: the negotiated window size minus the number of
-     * received-but-unacknowledged packets. Drives proactive acknowledgement (§4.19.4.8). Mirrors CHIP's
-     * mLocalReceiveWindowSize.
-     */
+    /** Free slots in our own receive window; drives proactive acknowledgement (§4.19.4.8). */
     private localWindowFreeSlots(): number {
         return (
             this.clientWindowSize - this.modularDistance(this.prevAckedSequenceNumber, this.prevIncomingSequenceNumber)
         );
     }
 
-    /**
-     * Whether a packet may be sent now without violating the remote receive window rules. A packet carrying an
-     * acknowledgement may use the last open slot; a data-only packet must leave it free (§4.19.4.7).
-     */
+    /** §4.19.4.7: a data-only packet must leave the last window slot free; an ack-bearing packet may use it. */
     private canSend(carriesAck: boolean): boolean {
         const free = this.remoteWindowFreeSlots();
         if (free <= 0) return false;

--- a/packages/protocol/src/ble/BtpSessionHandler.ts
+++ b/packages/protocol/src/ble/BtpSessionHandler.ts
@@ -427,7 +427,10 @@ export class BtpSessionHandler {
                 this.queuedOutgoingMatterMessages.length = 0;
                 this.sendInProgress = false;
                 BleDisconnectedError.accept(error);
-                logger.debug("BTP packet send failed because BLE is disconnected", Diagnostic.errorMessage(error));
+                logger.debug(
+                    `BTP packet (seq ${btpPacket.payload.sequenceNumber}) send failed because BLE is disconnected`,
+                    Diagnostic.errorMessage(error),
+                );
                 return;
             }
 
@@ -448,6 +451,11 @@ export class BtpSessionHandler {
             }
         }
         this.sendInProgress = false;
+
+        // A pending ack that could not be piggybacked (e.g. an incoming packet arrived mid-send) would otherwise
+        // be stranded until the send-ack timer, since the timer is one-shot and may have already fired while a
+        // send held the lock; flush it now that the send completed.
+        await this.sendStandaloneAck();
     }
 
     /**
@@ -488,46 +496,59 @@ export class BtpSessionHandler {
 
     /** Send a stand-alone acknowledgement packet if one is pending. */
     private async sendStandaloneAck() {
-        // A data send already in flight will piggyback the pending ack; don't issue a racing concurrent write.
+        // Mutually exclusive with processSendQueue (both directions): if a send is in progress it will piggyback
+        // the pending ack, and two concurrent writes could otherwise reach the wire out of order.
         if (this.sendInProgress) return;
         const ackNumberToSend = this.prevIncomingSequenceNumber;
         if (ackNumberToSend === this.prevAckedSequenceNumber) return;
         // §4.19.4.7: an ack still consumes a remote-window slot, so never send into a full window.
         if (!this.canSend(true)) return;
-        logger.debug(`Sending BTP ACK for sequence number ${ackNumberToSend}`);
-        const btpPacket = {
-            header: {
-                isHandshakeRequest: false,
-                hasManagementOpcode: false,
-                hasAckNumber: true,
-                isBeginningSegment: false,
-                isContinuingSegment: false,
-                isEndingSegment: false,
-            },
-            payload: {
-                ackNumber: ackNumberToSend,
-                sequenceNumber: this.getNextSequenceNumber(),
-            },
-        };
-        const packet = BtpCodec.encodeBtpPacket(btpPacket);
 
-        // Commit the ack before the await so an interleaved data send can't re-ack the same sequence
-        // (spec-compliant peers reject a duplicate ack).
-        const previousAckedSequenceNumber = this.prevAckedSequenceNumber;
-        this.prevAckedSequenceNumber = ackNumberToSend;
+        this.sendInProgress = true;
         try {
-            await this.writeBleCallback(packet);
-        } catch (error) {
-            // Roll back before re-raising so a failed write never leaves the ack marked as sent.
-            this.prevAckedSequenceNumber = previousAckedSequenceNumber;
-            BleDisconnectedError.accept(error);
-            logger.debug("BTP ACK send failed because BLE is disconnected", Diagnostic.errorMessage(error));
-            return;
+            logger.debug(`Sending BTP ACK for sequence number ${ackNumberToSend}`);
+            const btpPacket = {
+                header: {
+                    isHandshakeRequest: false,
+                    hasManagementOpcode: false,
+                    hasAckNumber: true,
+                    isBeginningSegment: false,
+                    isContinuingSegment: false,
+                    isEndingSegment: false,
+                },
+                payload: {
+                    ackNumber: ackNumberToSend,
+                    sequenceNumber: this.getNextSequenceNumber(),
+                },
+            };
+            const packet = BtpCodec.encodeBtpPacket(btpPacket);
+
+            // Commit the ack before the await so an interleaved send can't re-ack the same sequence
+            // (spec-compliant peers reject a duplicate ack).
+            const previousAckedSequenceNumber = this.prevAckedSequenceNumber;
+            this.prevAckedSequenceNumber = ackNumberToSend;
+            try {
+                await this.writeBleCallback(packet);
+            } catch (error) {
+                // Roll back before re-raising so a failed write never leaves the ack marked as sent.
+                this.prevAckedSequenceNumber = previousAckedSequenceNumber;
+                BleDisconnectedError.accept(error);
+                logger.debug(
+                    `BTP ACK (seq ${btpPacket.payload.sequenceNumber}, ack ${ackNumberToSend}) send failed because BLE is disconnected`,
+                    Diagnostic.errorMessage(error),
+                );
+                return;
+            }
+            this.sendAckTimer.stop();
+            if (!this.ackReceiveTimer.isRunning) {
+                this.ackReceiveTimer.start(); // starts the timer
+            }
+        } finally {
+            this.sendInProgress = false;
         }
-        this.sendAckTimer.stop();
-        if (!this.ackReceiveTimer.isRunning) {
-            this.ackReceiveTimer.start(); // starts the timer
-        }
+
+        // Flush any Matter message that was queued while the ack held the send lock.
+        await this.processSendQueue();
     }
 
     /**

--- a/packages/protocol/src/ble/BtpSessionHandler.ts
+++ b/packages/protocol/src/ble/BtpSessionHandler.ts
@@ -422,14 +422,14 @@ export class BtpSessionHandler {
             try {
                 await this.writeBleCallback(packet);
             } catch (error) {
-                // Only silently absorb BleDisconnectedError (expected during peripheral disconnect).
-                // Clear the queue to avoid malformed state from partially-consumed DataReaders.
-                // Any other error is unexpected and is rethrown so the session can handle it.
-                BleDisconnectedError.accept(error);
-                logger.debug("BTP packet send failed because BLE is disconnected", Diagnostic.errorMessage(error));
+                // Roll back the bookkeeping the failed write left half-applied (ack commit, queue, send flag) so it
+                // runs for every error, then absorb an expected disconnect and re-raise anything unexpected.
+                // The queue is cleared to avoid malformed state from partially-consumed DataReaders.
                 this.prevAckedSequenceNumber = previousAckedSequenceNumber;
                 this.queuedOutgoingMatterMessages.length = 0;
                 this.sendInProgress = false;
+                BleDisconnectedError.accept(error);
+                logger.debug("BTP packet send failed because BLE is disconnected", Diagnostic.errorMessage(error));
                 return;
             }
 
@@ -520,11 +520,11 @@ export class BtpSessionHandler {
         try {
             await this.writeBleCallback(packet);
         } catch (error) {
-            // Only silently absorb BleDisconnectedError (expected during peripheral disconnect).
-            // Any other error is unexpected and is rethrown so the session can handle it.
+            // Roll back the ack commit before absorbing an expected disconnect and re-raising anything unexpected,
+            // so a failed write never leaves the acknowledgement marked as sent.
+            this.prevAckedSequenceNumber = previousAckedSequenceNumber;
             BleDisconnectedError.accept(error);
             logger.debug("BTP ACK send failed because BLE is disconnected", Diagnostic.errorMessage(error));
-            this.prevAckedSequenceNumber = previousAckedSequenceNumber;
             return;
         }
         this.sendAckTimer.stop();

--- a/packages/protocol/src/ble/BtpSessionHandler.ts
+++ b/packages/protocol/src/ble/BtpSessionHandler.ts
@@ -396,10 +396,11 @@ export class BtpSessionHandler {
 
             const segmentPayload = currentProcessedMessage.readByteArray(this.fragmentSize - btpHeaderLength);
 
+            const ackNumberToSend = hasAckNumber ? this.prevIncomingSequenceNumber : undefined;
             const btpPacket = {
                 header: packetHeader,
                 payload: {
-                    ackNumber: hasAckNumber ? this.prevIncomingSequenceNumber : undefined,
+                    ackNumber: ackNumberToSend,
                     sequenceNumber: this.getNextSequenceNumber(),
                     messageLength: packetHeader.isBeginningSegment ? remainingMessageLength : undefined, // remainingMessageLength if the fill length on beginning packet
                     segmentPayload,
@@ -410,6 +411,14 @@ export class BtpSessionHandler {
             const packet = BtpCodec.encodeBtpPacket(btpPacket);
             logger.debug(`Sending BTP packet raw: ${Bytes.toHex(packet)}`);
 
+            // Commit the acknowledgement before awaiting the write so a concurrent send (e.g. a stand-alone ack
+            // or a reply triggered by an incoming message) cannot observe the stale value and ack the same
+            // sequence number twice — a duplicate ack is rejected by spec-compliant peers.
+            const previousAckedSequenceNumber = this.prevAckedSequenceNumber;
+            if (ackNumberToSend !== undefined) {
+                this.prevAckedSequenceNumber = ackNumberToSend;
+            }
+
             try {
                 await this.writeBleCallback(packet);
             } catch (error) {
@@ -418,13 +427,10 @@ export class BtpSessionHandler {
                 // Any other error is unexpected and is rethrown so the session can handle it.
                 BleDisconnectedError.accept(error);
                 logger.debug("BTP packet send failed because BLE is disconnected", Diagnostic.errorMessage(error));
+                this.prevAckedSequenceNumber = previousAckedSequenceNumber;
                 this.queuedOutgoingMatterMessages.length = 0;
                 this.sendInProgress = false;
                 return;
-            }
-            // Update ACK bookkeeping only after the packet was sent successfully
-            if (hasAckNumber) {
-                this.prevAckedSequenceNumber = this.prevIncomingSequenceNumber;
             }
 
             if (!this.ackReceiveTimer.isRunning) {
@@ -488,8 +494,9 @@ export class BtpSessionHandler {
 
     /** Send a stand-alone acknowledgement packet if one is pending. */
     private async sendStandaloneAck() {
-        if (this.prevIncomingSequenceNumber === this.prevAckedSequenceNumber) return;
-        logger.debug(`Sending BTP ACK for sequence number ${this.prevIncomingSequenceNumber}`);
+        const ackNumberToSend = this.prevIncomingSequenceNumber;
+        if (ackNumberToSend === this.prevAckedSequenceNumber) return;
+        logger.debug(`Sending BTP ACK for sequence number ${ackNumberToSend}`);
         const btpPacket = {
             header: {
                 isHandshakeRequest: false,
@@ -500,11 +507,17 @@ export class BtpSessionHandler {
                 isEndingSegment: false,
             },
             payload: {
-                ackNumber: this.prevIncomingSequenceNumber,
+                ackNumber: ackNumberToSend,
                 sequenceNumber: this.getNextSequenceNumber(),
             },
         };
         const packet = BtpCodec.encodeBtpPacket(btpPacket);
+
+        // Commit the acknowledgement before awaiting the write so an interleaved data send cannot observe the
+        // stale value and ack the same sequence number again — a duplicate ack is rejected by spec-compliant peers.
+        const previousAckedSequenceNumber = this.prevAckedSequenceNumber;
+        this.prevAckedSequenceNumber = ackNumberToSend;
+        this.sendAckTimer.stop();
         try {
             await this.writeBleCallback(packet);
         } catch (error) {
@@ -512,10 +525,9 @@ export class BtpSessionHandler {
             // Any other error is unexpected and is rethrown so the session can handle it.
             BleDisconnectedError.accept(error);
             logger.debug("BTP ACK send failed because BLE is disconnected", Diagnostic.errorMessage(error));
+            this.prevAckedSequenceNumber = previousAckedSequenceNumber;
             return;
         }
-        this.sendAckTimer.stop();
-        this.prevAckedSequenceNumber = this.prevIncomingSequenceNumber;
         if (!this.ackReceiveTimer.isRunning) {
             this.ackReceiveTimer.start(); // starts the timer
         }

--- a/packages/protocol/src/ble/BtpSessionHandler.ts
+++ b/packages/protocol/src/ble/BtpSessionHandler.ts
@@ -517,7 +517,6 @@ export class BtpSessionHandler {
         // stale value and ack the same sequence number again — a duplicate ack is rejected by spec-compliant peers.
         const previousAckedSequenceNumber = this.prevAckedSequenceNumber;
         this.prevAckedSequenceNumber = ackNumberToSend;
-        this.sendAckTimer.stop();
         try {
             await this.writeBleCallback(packet);
         } catch (error) {
@@ -528,6 +527,7 @@ export class BtpSessionHandler {
             this.prevAckedSequenceNumber = previousAckedSequenceNumber;
             return;
         }
+        this.sendAckTimer.stop();
         if (!this.ackReceiveTimer.isRunning) {
             this.ackReceiveTimer.start(); // starts the timer
         }

--- a/packages/protocol/src/codec/BtpCodec.ts
+++ b/packages/protocol/src/codec/BtpCodec.ts
@@ -266,9 +266,8 @@ export class BtpCodec {
             throw new BtpProtocolError("Please use the specific methods to encode a Handshake packet");
         }
 
+        // The handshake and management-opcode bits are rejected above, so only the segment/ack bits remain.
         const header =
-            // (isHandshakeRequest ? BtpHeaderBits.HandshakeBit : 0) | ... but always false here
-            // (hasManagementOpcode ? BtpHeaderBits.ManagementMsg : 0) | ... but alw<ys false here
             (hasAckNumber ? BtpHeaderBits.AckMsg : 0) |
             (isEndingSegment ? BtpHeaderBits.EndSegment : 0) |
             (isContinuingSegment ? BtpHeaderBits.ContinuingSegment : 0) |

--- a/packages/protocol/test/ble/BtpSessionHandlerTest.ts
+++ b/packages/protocol/test/ble/BtpSessionHandlerTest.ts
@@ -848,6 +848,42 @@ describe("BtpSessionHandler", () => {
             await peripheral.close();
         });
 
+        // A non-disconnect write error must re-raise but still roll back send state, so the session is not
+        // left wedged (sendInProgress stuck, queue half-applied).
+        it("re-raises a non-disconnect write error and resets send state", async () => {
+            let failNextWrite = true;
+            const writes = new Array<Bytes>();
+            const central = await BtpSessionHandler.createAsCentral(
+                Bytes.fromHex("656c04f40005"), // window size 5
+                async data => {
+                    if (failNextWrite) {
+                        failNextWrite = false;
+                        throw new Error("boom");
+                    }
+                    writes.push(data);
+                },
+                async () => {},
+                async () => {
+                    throw new Error("Should not be called");
+                },
+            );
+
+            let raised: unknown;
+            try {
+                await central.sendMatterMessage(Bytes.fromHex("0102"));
+            } catch (error) {
+                raised = error;
+            }
+            expect(raised).instanceOf(Error);
+            expect((raised as Error).message).equal("boom");
+
+            // sendInProgress was reset, so a subsequent send proceeds and succeeds.
+            await central.sendMatterMessage(Bytes.fromHex("0304"));
+            expect(writes.length).equal(1);
+
+            await central.close();
+        });
+
         // Regression: a stand-alone ack whose write is still in flight must not let a concurrent data send
         // re-acknowledge the same sequence number (a duplicate ack is rejected by spec-compliant peers).
         it("does not duplicate an acknowledgement when a data send interleaves a pending stand-alone ack", async () => {

--- a/packages/protocol/test/ble/BtpSessionHandlerTest.ts
+++ b/packages/protocol/test/ble/BtpSessionHandlerTest.ts
@@ -943,17 +943,21 @@ describe("BtpSessionHandler", () => {
             expect(writes.length).equal(1); // the stand-alone ack (still in flight)
             expect(BtpCodec.decodeBtpPacket(writes[0]).payload.ackNumber).equal(3);
 
-            // While the ack write is pending, send a data message: it must not re-ack sequence number 3.
+            // While the ack write is in flight, a data message is queued (not sent concurrently) since the ack
+            // holds the send lock.
             const sending = peripheral.sendMatterMessage(Bytes.fromHex("0a0b0c"));
             await Promise.resolve();
+            expect(writes.length).equal(1);
 
-            const dataPacket = BtpCodec.decodeBtpPacket(writes[writes.length - 1]);
-            expect(dataPacket.payload.segmentPayload.byteLength).greaterThan(0); // it is the data packet
-            expect(dataPacket.header.hasAckNumber).equal(false);
-
+            // Once the ack write completes, the queued data is flushed — and must not re-ack sequence number 3.
             releaseStandaloneWrite?.();
             await incoming;
             await sending;
+
+            expect(writes.length).equal(2);
+            const dataPacket = BtpCodec.decodeBtpPacket(writes[1]);
+            expect(dataPacket.payload.segmentPayload.byteLength).greaterThan(0); // it is the data packet
+            expect(dataPacket.header.hasAckNumber).equal(false);
 
             await peripheral.close();
         });
@@ -1010,8 +1014,15 @@ describe("BtpSessionHandler", () => {
             await MockTime.advance(MatterBle.BTP_SEND_ACK_TIMEOUT);
             expect(writes.length).equal(1);
 
+            // Once the data write completes, the stranded ack must be flushed (not lost to the one-shot timer).
             releaseDataWrite?.();
             await sending;
+
+            expect(writes.length).equal(2);
+            const flushedAck = BtpCodec.decodeBtpPacket(writes[1]);
+            expect(flushedAck.header.hasAckNumber).equal(true);
+            expect(flushedAck.payload.ackNumber).equal(0);
+            expect(flushedAck.payload.segmentPayload.byteLength).equal(0);
 
             await peripheral.close();
         });

--- a/packages/protocol/test/ble/BtpSessionHandlerTest.ts
+++ b/packages/protocol/test/ble/BtpSessionHandlerTest.ts
@@ -848,6 +848,80 @@ describe("BtpSessionHandler", () => {
             await peripheral.close();
         });
 
+        // Regression: a stand-alone ack whose write is still in flight must not let a concurrent data send
+        // re-acknowledge the same sequence number (a duplicate ack is rejected by spec-compliant peers).
+        it("does not duplicate an acknowledgement when a data send interleaves a pending stand-alone ack", async () => {
+            const writes = new Array<Bytes>();
+            let hangStandalone = false;
+            let releaseStandaloneWrite: (() => void) | undefined;
+
+            let onWrite = (_: Bytes): Promise<void> => Promise.resolve();
+            const peripheral = await BtpSessionHandler.createFromHandshakeRequest(
+                20,
+                Bytes.fromHex("656c04000000b90006"), // window size 6
+                async data => onWrite(data),
+                async () => {},
+                async () => {
+                    throw new Error("Should not be called");
+                },
+            );
+            onWrite = data => {
+                const decoded = BtpCodec.decodeBtpPacket(data);
+                writes.push(data);
+                // A stand-alone ack carries no segment payload; hold its write open to force the interleave.
+                if (hangStandalone && decoded.payload.segmentPayload.byteLength === 0) {
+                    return new Promise<void>(resolve => {
+                        releaseStandaloneWrite = resolve;
+                    });
+                }
+                return Promise.resolve();
+            };
+
+            const continuing = (sequenceNumber: number) =>
+                BtpCodec.encodeBtpPacket({
+                    header: {
+                        isHandshakeRequest: false,
+                        hasManagementOpcode: false,
+                        hasAckNumber: false,
+                        isEndingSegment: false,
+                        isContinuingSegment: sequenceNumber !== 0,
+                        isBeginningSegment: sequenceNumber === 0,
+                    },
+                    payload: {
+                        sequenceNumber,
+                        messageLength: sequenceNumber === 0 ? 100 : undefined,
+                        segmentPayload: Bytes.fromHex("0102"),
+                    },
+                });
+
+            // Drop the local receive window to the immediate-ack threshold without completing a message.
+            await peripheral.handleIncomingBleData(continuing(0));
+            await peripheral.handleIncomingBleData(continuing(1));
+            await peripheral.handleIncomingBleData(continuing(2));
+            expect(writes.length).equal(0);
+
+            // The fourth packet triggers a stand-alone ack whose write we hold open.
+            hangStandalone = true;
+            const incoming = peripheral.handleIncomingBleData(continuing(3));
+            await Promise.resolve();
+            expect(writes.length).equal(1); // the stand-alone ack (still in flight)
+            expect(BtpCodec.decodeBtpPacket(writes[0]).payload.ackNumber).equal(3);
+
+            // While the ack write is pending, send a data message: it must not re-ack sequence number 3.
+            const sending = peripheral.sendMatterMessage(Bytes.fromHex("0a0b0c"));
+            await Promise.resolve();
+
+            const dataPacket = BtpCodec.decodeBtpPacket(writes[writes.length - 1]);
+            expect(dataPacket.payload.segmentPayload.byteLength).greaterThan(0); // it is the data packet
+            expect(dataPacket.header.hasAckNumber).equal(false);
+
+            releaseStandaloneWrite?.();
+            await incoming;
+            await sending;
+
+            await peripheral.close();
+        });
+
         // §4.19.4.6 + the window guard: outstanding packets that span the 255 -> 0 wrap must be counted by
         // modular distance, so the window neither over-sends nor stalls across the boundary.
         it("transfers many messages correctly while sequence numbers wrap", async () => {

--- a/packages/protocol/test/ble/BtpSessionHandlerTest.ts
+++ b/packages/protocol/test/ble/BtpSessionHandlerTest.ts
@@ -958,6 +958,64 @@ describe("BtpSessionHandler", () => {
             await peripheral.close();
         });
 
+        // §4.19.4.7 + concurrency: while a data write is in flight, neither an incoming packet nor the send-ack
+        // timer may issue a concurrent stand-alone ack write (the in-flight fragment will carry the ack).
+        it("does not send a stand-alone ack while a data write is in flight", async () => {
+            const writes = new Array<Bytes>();
+            let hangData = false;
+            let releaseDataWrite: (() => void) | undefined;
+
+            let onWrite = (_: Bytes): Promise<void> => Promise.resolve();
+            const peripheral = await BtpSessionHandler.createFromHandshakeRequest(
+                20,
+                Bytes.fromHex("656c04000000b90006"), // window size 6
+                async data => onWrite(data),
+                async () => {},
+                async () => {}, // accept incoming Matter messages without responding
+            );
+            onWrite = data => {
+                const decoded = BtpCodec.decodeBtpPacket(data);
+                writes.push(data);
+                if (hangData && decoded.payload.segmentPayload.byteLength > 0) {
+                    return new Promise<void>(resolve => {
+                        releaseDataWrite = resolve;
+                    });
+                }
+                return Promise.resolve();
+            };
+
+            // Start a data send with no pending ack yet; its write hangs, holding sendInProgress.
+            hangData = true;
+            const sending = peripheral.sendMatterMessage(Bytes.fromHex("0a0b0c"));
+            await Promise.resolve();
+            expect(writes.length).equal(1);
+            expect(BtpCodec.decodeBtpPacket(writes[0]).header.hasAckNumber).equal(false);
+
+            // An incoming data packet now creates a pending ack, but must not write while the data send is in flight.
+            const incoming = BtpCodec.encodeBtpPacket({
+                header: {
+                    isHandshakeRequest: false,
+                    hasManagementOpcode: false,
+                    hasAckNumber: false,
+                    isEndingSegment: true,
+                    isContinuingSegment: false,
+                    isBeginningSegment: true,
+                },
+                payload: { sequenceNumber: 0, messageLength: 2, segmentPayload: Bytes.fromHex("0102") },
+            });
+            await peripheral.handleIncomingBleData(incoming);
+            expect(writes.length).equal(1);
+
+            // The send-ack timer firing mid-write must also not produce a concurrent ack.
+            await MockTime.advance(MatterBle.BTP_SEND_ACK_TIMEOUT);
+            expect(writes.length).equal(1);
+
+            releaseDataWrite?.();
+            await sending;
+
+            await peripheral.close();
+        });
+
         // §4.19.4.6 + the window guard: outstanding packets that span the 255 -> 0 wrap must be counted by
         // modular distance, so the window neither over-sends nor stalls across the boundary.
         it("transfers many messages correctly while sequence numbers wrap", async () => {


### PR DESCRIPTION
Follow-up to #3886 (BTP flow-control fixes). The proactive stand-alone ack added there could race a concurrent data send and acknowledge the same sequence number twice, which broke real-device commissioning.

## Root cause

`prevAckedSequenceNumber` was committed only **after** `await writeBleCallback`. When the local receive window dropped to the immediate-ack threshold (§4.19.4.8), the session sent a stand-alone ack; while that write was in flight, the reply generated for the just-received message was built on a separate async chain, still observed the stale `prevAckedSequenceNumber`, and acknowledged the same sequence number again.

A spec-compliant peer (CHIP `IsValidAck`) rejects an ack it is no longer expecting and closes the session. In practice this first triggered at the certificate-chain response — the first multi-fragment device→controller message, where three fragments arrive with no reply between them and the local receive window reaches the threshold.

Observed on a live commission:
```
17.178  Sending BTP ACK for sequence number 13      (stand-alone, wire seq 10)
17.180  certChainRequest  seq 11  ackNumber 13       (duplicate ack of 13)
17.537  Disconnected from peripheral
```

## Fix

Commit the acknowledged sequence number **before** awaiting the write, in both send paths (`processSendQueue` piggyback and `sendStandaloneAck`), and roll it back on write failure. A concurrent send then observes the committed value and never re-acknowledges an already-acknowledged sequence. This mirrors CHIP, which clears its pending-ack state synchronously.

## Tests

New regression test holds a stand-alone ack's write open, issues a data send while it is in flight, and asserts the data packet does not re-acknowledge the same sequence — fails without the fix, passes with it. Verified end-to-end with a live BLE commission. Full protocol suite green (28 BTP tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)