### PR TITLE
fix(node): robust self-fabric decommission + distinguish delivered-vs-unacked peer timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A TCP-enabled server now reports TCP support in its session parameters (not only in mDNS), so peers learn it during PASE/CASE
     - Fix: Claim the peer node ID only once a candidate wins PASE, to avoid spurious "peer address already in use" conflicts across parallel commissioning attempts
     - Fix: Refreshing a discovered node's metadata while it is being commissioned no longer crashes the process with a synchronous transaction conflict
+    - Fix: Ensure that decommissioning removes a node locally even when the device drops the RemoveFabric response after closing the session, and no longer stalls shutdown
+    - Fix: Ensure that probing a node during teardown reports it unreachable instead of throwing
 
 - @matter/protocol
     - Enhancement: Implemented Matter message privacy (header obfuscation) for group messages; receiving is always supported, sending is opt-in per session and off by default. Unicast messages carrying the privacy flag are dropped like in CHIP SDK
@@ -32,6 +34,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: Subscription maxIntervalCeiling now lengthens by up to +max(10%, 10s) one-sided jitter for all device types (previously only Thread-active devices)
     - Enhancement: Prefer TCP for operational connections when the peer advertises TCP-server support via its session parameters or mDNS; a negotiated TCP session is declined only on an explicit no-TCP report
     - Enhancement: Lengthened the BTP handshake-response timeout (5s → 15s) and central idle timeout (30s → 60s) to match CHIP
+    - Enhancement: Added `PeerMessageMissingError` (subtype of `PeerUnresponsiveError`) thrown when an expected message does not arrive on an active exchange, distinguishing it from a request that was never acknowledged
     - Fix: Ignore announced TCP support for peers reporting Matter spec version < 1.5.0
     - Fix: Corrected the Session Active Threshold limit to 65535 milliseconds (was wrongly checked against 65535 seconds)
     - Fix: Invalid or out-of-range SII/SAI/SAT values in discovered DNS-SD TXT records are now ignored so MRP defaults apply, as required by the Matter spec

--- a/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
+++ b/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
@@ -7,6 +7,7 @@
 import { Behavior } from "#behavior/Behavior.js";
 import { Events as BaseEvents } from "#behavior/Events.js";
 import { SoftwareUpdateManager } from "#behavior/system/software-update/SoftwareUpdateManager.js";
+import { BasicInformationClient } from "#behaviors/basic-information";
 import { OperationalCredentialsClient } from "#behaviors/operational-credentials";
 import { OtaSoftwareUpdateProviderServer } from "#behaviors/ota-software-update-provider";
 import type { ClientNode } from "#node/ClientNode.js";
@@ -14,6 +15,7 @@ import { IdentityConflictError, IdentityService } from "#node/server/IdentitySer
 import type { ServerNode } from "#node/ServerNode.js";
 import {
     ClassExtends,
+    causedBy,
     Diagnostic,
     Duration,
     ImplementationError,
@@ -56,12 +58,15 @@ import {
     Fabric,
     FabricAuthority,
     FabricManager,
+    FabricRemovedError,
     LocatedNodeCommissioningOptions,
     OperationalAddress,
     Peer,
     PeerAddress,
+    PeerInitiatedCloseError,
     PeerLeftError,
     PeerSet,
+    PeerUnresponsiveError,
     PeerTimingParameters,
     PeerAddress as ProtocolPeerAddress,
     SessionParameters as ProtocolSessionParameters,
@@ -328,36 +333,78 @@ export class CommissioningClient extends Behavior {
         const opcreds = this.agent.get(OperationalCredentialsClient);
 
         const fabricIndex = opcreds.state.currentFabricIndex;
-        logger.debug(`Removing node ${formerAddress} by removing fabric ${fabricIndex} on the node`);
 
-        const result = await opcreds.removeFabric({ fabricIndex });
+        // Removing the fabric we communicate over destroys the session the NocResponse must travel on, so the response
+        // is frequently lost.  Treat the command as confirmed if it was delivered (transient peer error) or if a
+        // matching leave event arrives.  Arm the listener before sending so a fast leave cannot be missed.
+        let leaveSeen = false;
+        const leaveEvents = this.endpoint.eventsOf(BasicInformationClient).leave;
+        const onLeave = ({ fabricIndex: leftFabricIndex }: { fabricIndex: FabricIndex }) => {
+            if (leftFabricIndex === fabricIndex) {
+                leaveSeen = true;
+            }
+        };
+        leaveEvents?.on(onLeave);
 
-        if (result.statusCode !== OperationalCredentials.NodeOperationalCertStatus.Ok) {
-            throw new MatterError(
-                `Removing node ${formerAddress} failed with status ${result.statusCode} "${result.debugText}".`,
-            );
-        }
-
-        // Must run before commit unbinds Peer via peerAddress$Changed.
-        const node = this.endpoint as ClientNode;
         try {
-            await node.env.maybeGet(Peer)?.disconnect(new PeerLeftError());
-        } catch (error) {
-            logger.warn(`Error force-closing sessions for ${formerAddress} after decommission:`, error);
+            logger.debug(`Removing node ${formerAddress} by removing fabric ${fabricIndex} on the node`);
+
+            // A non-Ok status is an explicit refusal and must never be overridden by a leave event, so raise it after
+            // the rescue block rather than inside the try.
+            let nonOkFailure: MatterError | undefined;
+            try {
+                const result = await opcreds.removeFabric({ fabricIndex });
+                if (result.statusCode !== OperationalCredentials.NodeOperationalCertStatus.Ok) {
+                    nonOkFailure = new MatterError(
+                        `Removing node ${formerAddress} failed with status ${result.statusCode} "${result.debugText}".`,
+                    );
+                }
+            } catch (error) {
+                if (
+                    leaveSeen ||
+                    causedBy(
+                        error,
+                        PeerUnresponsiveError,
+                        PeerLeftError,
+                        FabricRemovedError,
+                        PeerInitiatedCloseError,
+                    )
+                ) {
+                    logger.info(
+                        `Node ${formerAddress} removal confirmed without response`,
+                        `(${leaveSeen ? "leave event" : "session closed"})`,
+                    );
+                } else {
+                    throw error;
+                }
+            }
+            if (nonOkFailure !== undefined) {
+                throw nonOkFailure;
+            }
+
+            // Removal confirmed.  Must run before commit unbinds Peer via peerAddress$Changed.
+            const node = this.endpoint as ClientNode;
+            try {
+                await node.env.maybeGet(Peer)?.disconnect(new PeerLeftError());
+            } catch (error) {
+                logger.warn(`Error force-closing sessions for ${formerAddress} after decommission:`, error);
+            }
+
+            this.state.peerAddress = undefined;
+            this.state.commissionedAt = undefined;
+            this.state.fabricIndexOnPeer = undefined;
+
+            await this.context.transaction.commit();
+
+            logger.info(
+                "Decommissioned",
+                Diagnostic.strong(this.endpoint.id),
+                "formerly",
+                Diagnostic.strong(formerAddress),
+            );
+        } finally {
+            leaveEvents?.off(onLeave);
         }
-
-        this.state.peerAddress = undefined;
-        this.state.commissionedAt = undefined;
-        this.state.fabricIndexOnPeer = undefined;
-
-        await this.context.transaction.commit();
-
-        logger.info(
-            "Decommissioned",
-            Diagnostic.strong(this.endpoint.id),
-            "formerly",
-            Diagnostic.strong(formerAddress),
-        );
     }
 
     /**

--- a/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
+++ b/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
@@ -340,7 +340,9 @@ export class CommissioningClient extends Behavior {
         let leaveSeen = false;
         const leaveEvents = this.endpoint.eventsOf(BasicInformationClient).leave;
         const onLeave = ({ fabricIndex: leftFabricIndex }: { fabricIndex: FabricIndex }) => {
-            if (leftFabricIndex === fabricIndex) {
+            // Ignore leaves replayed during subscription establishment; they may be stale events from a prior
+            // commissioning with the same identifier, matching the guard in Peers#onLeave.
+            if (leftFabricIndex === fabricIndex && this.agent.get(NetworkClient).subscriptionActive) {
                 leaveSeen = true;
             }
         };

--- a/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
+++ b/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
@@ -65,8 +65,8 @@ import {
     PeerAddress,
     PeerInitiatedCloseError,
     PeerLeftError,
+    PeerResponseMissingError,
     PeerSet,
-    PeerUnresponsiveError,
     PeerTimingParameters,
     PeerAddress as ProtocolPeerAddress,
     SessionParameters as ProtocolSessionParameters,
@@ -349,8 +349,7 @@ export class CommissioningClient extends Behavior {
         try {
             logger.debug(`Removing node ${formerAddress} by removing fabric ${fabricIndex} on the node`);
 
-            // A non-Ok status is an explicit refusal and must never be overridden by a leave event, so raise it after
-            // the rescue block rather than inside the try.
+            // A non-Ok status is an explicit refusal and must never be overridden by a leave event.
             let nonOkFailure: MatterError | undefined;
             try {
                 const result = await opcreds.removeFabric({ fabricIndex });
@@ -364,7 +363,7 @@ export class CommissioningClient extends Behavior {
                     leaveSeen ||
                     causedBy(
                         error,
-                        PeerUnresponsiveError,
+                        PeerResponseMissingError,
                         PeerLeftError,
                         FabricRemovedError,
                         PeerInitiatedCloseError,

--- a/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
+++ b/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
@@ -14,8 +14,8 @@ import type { ClientNode } from "#node/ClientNode.js";
 import { IdentityConflictError, IdentityService } from "#node/server/IdentityService.js";
 import type { ServerNode } from "#node/ServerNode.js";
 import {
-    ClassExtends,
     causedBy,
+    ClassExtends,
     Diagnostic,
     Duration,
     ImplementationError,
@@ -361,13 +361,7 @@ export class CommissioningClient extends Behavior {
             } catch (error) {
                 if (
                     leaveSeen ||
-                    causedBy(
-                        error,
-                        PeerMessageMissingError,
-                        PeerLeftError,
-                        FabricRemovedError,
-                        PeerInitiatedCloseError,
-                    )
+                    causedBy(error, PeerMessageMissingError, PeerLeftError, FabricRemovedError, PeerInitiatedCloseError)
                 ) {
                     logger.info(
                         `Node ${formerAddress} removal confirmed without response`,

--- a/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
+++ b/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
@@ -65,7 +65,7 @@ import {
     PeerAddress,
     PeerInitiatedCloseError,
     PeerLeftError,
-    PeerResponseMissingError,
+    PeerMessageMissingError,
     PeerSet,
     PeerTimingParameters,
     PeerAddress as ProtocolPeerAddress,
@@ -363,7 +363,7 @@ export class CommissioningClient extends Behavior {
                     leaveSeen ||
                     causedBy(
                         error,
-                        PeerResponseMissingError,
+                        PeerMessageMissingError,
                         PeerLeftError,
                         FabricRemovedError,
                         PeerInitiatedCloseError,

--- a/packages/node/src/node/client/ClientNodeInteraction.ts
+++ b/packages/node/src/node/client/ClientNodeInteraction.ts
@@ -163,6 +163,14 @@ export class ClientNodeInteraction implements Interactable<ActionContext> {
     }
 
     async probe(options?: ClientProbeOptions): Promise<boolean> {
+        // A monitor probe can race node teardown (decommission/destroy); report unreachable rather than throwing.
+        if (
+            this.#node.construction.status !== Lifecycle.Status.Active ||
+            !this.#node.owner?.lifecycle.isOnline ||
+            this.#node.state.commissioning.peerAddress === undefined
+        ) {
+            return false;
+        }
         return this.#interaction.probe(options);
     }
 

--- a/packages/node/test/node/DecommissionTest.ts
+++ b/packages/node/test/node/DecommissionTest.ts
@@ -6,7 +6,7 @@
 
 import { OperationalCredentialsClient } from "#behaviors/operational-credentials";
 import { Seconds } from "@matter/general";
-import { PeerSet, PeerUnresponsiveError } from "@matter/protocol";
+import { PeerResponseMissingError, PeerSet, PeerUnresponsiveError } from "@matter/protocol";
 import { FabricIndex } from "@matter/types";
 import { MockSite } from "./mock-site.js";
 
@@ -36,7 +36,7 @@ describe("Decommission", () => {
 
     it("removes the node when removeFabric is delivered but the response is lost", async () => {
         await using site = new MockSite();
-        const { controller, device } = await site.addCommissionedPair();
+        const { controller } = await site.addCommissionedPair();
 
         const peer1 = controller.peers.get("peer1")!;
         const peerAddress = peer1.peerAddress!;
@@ -46,7 +46,7 @@ describe("Decommission", () => {
         const restore = await patchRemoveFabric(peer1, async function () {
             stubCalled = true;
             // Device tore down the session keyed to our fabric before delivering NocResponse.
-            throw new PeerUnresponsiveError(Seconds(11));
+            throw new PeerResponseMissingError(Seconds(11));
         });
 
         try {
@@ -58,6 +58,27 @@ describe("Decommission", () => {
         expect(stubCalled).is.true;
         expect(controller.peers.size).equals(0);
         expect(controller.env.get(PeerSet).has(peerAddress)).is.false;
-        void device;
+    });
+
+    it("keeps the node when removeFabric is never acknowledged", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+
+        const peer1 = controller.peers.get("peer1")!;
+        const peerAddress = peer1.peerAddress!;
+
+        const restore = await patchRemoveFabric(peer1, async function () {
+            // Outbound MRP ack never arrived: the device may never have received the command.
+            throw new PeerUnresponsiveError(Seconds(11));
+        });
+
+        try {
+            await expect(MockTime.resolve(peer1.decommission())).rejectedWith(PeerUnresponsiveError);
+        } finally {
+            restore();
+        }
+
+        expect(controller.peers.size).equals(1);
+        expect(controller.env.get(PeerSet).has(peerAddress)).is.true;
     });
 });

--- a/packages/node/test/node/DecommissionTest.ts
+++ b/packages/node/test/node/DecommissionTest.ts
@@ -6,7 +6,7 @@
 
 import { OperationalCredentialsClient } from "#behaviors/operational-credentials";
 import { Seconds } from "@matter/general";
-import { PeerResponseMissingError, PeerSet, PeerUnresponsiveError } from "@matter/protocol";
+import { PeerMessageMissingError, PeerSet, PeerUnresponsiveError } from "@matter/protocol";
 import { FabricIndex } from "@matter/types";
 import { MockSite } from "./mock-site.js";
 
@@ -46,7 +46,7 @@ describe("Decommission", () => {
         const restore = await patchRemoveFabric(peer1, async function () {
             stubCalled = true;
             // Device tore down the session keyed to our fabric before delivering NocResponse.
-            throw new PeerResponseMissingError(Seconds(11));
+            throw new PeerMessageMissingError(Seconds(11));
         });
 
         try {

--- a/packages/node/test/node/DecommissionTest.ts
+++ b/packages/node/test/node/DecommissionTest.ts
@@ -6,11 +6,11 @@
 
 import { BasicInformationClient } from "#behaviors/basic-information";
 import { OperationalCredentialsClient } from "#behaviors/operational-credentials";
+import { ClientNodeInteraction } from "#node/client/ClientNodeInteraction.js";
 import { Seconds } from "@matter/general";
 import { PeerMessageMissingError, PeerSet, PeerUnresponsiveError } from "@matter/protocol";
 import { FabricIndex } from "@matter/types";
 import { OperationalCredentials } from "@matter/types/clusters/operational-credentials";
-import { ClientNodeInteraction } from "#node/client/ClientNodeInteraction.js";
 import { MockSite } from "./mock-site.js";
 
 /**

--- a/packages/node/test/node/DecommissionTest.ts
+++ b/packages/node/test/node/DecommissionTest.ts
@@ -12,6 +12,7 @@ import { PeerMessageMissingError, PeerSet, PeerUnresponsiveError } from "@matter
 import { FabricIndex } from "@matter/types";
 import { OperationalCredentials } from "@matter/types/clusters/operational-credentials";
 import { MockSite } from "./mock-site.js";
+import { subscribedPeer } from "./node-helpers.js";
 
 /**
  * Replace the exact `removeFabric` the decommission path invokes, on the runtime prototype of the peer's
@@ -89,7 +90,7 @@ describe("Decommission", () => {
         await using site = new MockSite();
         const { controller } = await site.addCommissionedPair();
 
-        const peer1 = controller.peers.get("peer1")!;
+        const peer1 = await subscribedPeer(controller, "peer1");
         const peerAddress = peer1.peerAddress!;
         const fabricIndex = peer1.stateOf(OperationalCredentialsClient).currentFabricIndex;
 
@@ -113,7 +114,7 @@ describe("Decommission", () => {
         await using site = new MockSite();
         const { controller } = await site.addCommissionedPair();
 
-        const peer1 = controller.peers.get("peer1")!;
+        const peer1 = await subscribedPeer(controller, "peer1");
         const peerAddress = peer1.peerAddress!;
         const fabricIndex = peer1.stateOf(OperationalCredentialsClient).currentFabricIndex;
         const otherFabricIndex = FabricIndex(fabricIndex + 1);
@@ -137,7 +138,7 @@ describe("Decommission", () => {
         await using site = new MockSite();
         const { controller } = await site.addCommissionedPair();
 
-        const peer1 = controller.peers.get("peer1")!;
+        const peer1 = await subscribedPeer(controller, "peer1");
         const fabricIndex = peer1.stateOf(OperationalCredentialsClient).currentFabricIndex;
 
         const restore = await patchRemoveFabric(peer1, async function () {

--- a/packages/node/test/node/DecommissionTest.ts
+++ b/packages/node/test/node/DecommissionTest.ts
@@ -4,10 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { BasicInformationClient } from "#behaviors/basic-information";
 import { OperationalCredentialsClient } from "#behaviors/operational-credentials";
 import { Seconds } from "@matter/general";
 import { PeerMessageMissingError, PeerSet, PeerUnresponsiveError } from "@matter/protocol";
 import { FabricIndex } from "@matter/types";
+import { OperationalCredentials } from "@matter/types/clusters/operational-credentials";
 import { MockSite } from "./mock-site.js";
 
 /**
@@ -80,5 +82,78 @@ describe("Decommission", () => {
 
         expect(controller.peers.size).equals(1);
         expect(controller.env.get(PeerSet).has(peerAddress)).is.true;
+    });
+
+    it("removes the node when a matching leave event arrives even if removeFabric rejects", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+
+        const peer1 = controller.peers.get("peer1")!;
+        const peerAddress = peer1.peerAddress!;
+        const fabricIndex = peer1.stateOf(OperationalCredentialsClient).currentFabricIndex;
+
+        const restore = await patchRemoveFabric(peer1, async function () {
+            // Device emits leave as a side effect of removal, then never acks our request.
+            this.endpoint.eventsOf(BasicInformationClient).leave.emit({ fabricIndex }, this.context);
+            throw new PeerUnresponsiveError(Seconds(11));
+        });
+
+        try {
+            await MockTime.resolve(peer1.decommission());
+        } finally {
+            restore();
+        }
+
+        expect(controller.peers.size).equals(0);
+        expect(controller.env.get(PeerSet).has(peerAddress)).is.false;
+    });
+
+    it("does not treat a leave for a different fabric as confirmation", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+
+        const peer1 = controller.peers.get("peer1")!;
+        const peerAddress = peer1.peerAddress!;
+        const fabricIndex = peer1.stateOf(OperationalCredentialsClient).currentFabricIndex;
+        const otherFabricIndex = FabricIndex(fabricIndex + 1);
+
+        const restore = await patchRemoveFabric(peer1, async function () {
+            this.endpoint.eventsOf(BasicInformationClient).leave.emit({ fabricIndex: otherFabricIndex }, this.context);
+            throw new PeerUnresponsiveError(Seconds(11));
+        });
+
+        try {
+            await expect(MockTime.resolve(peer1.decommission())).rejectedWith(PeerUnresponsiveError);
+        } finally {
+            restore();
+        }
+
+        expect(controller.peers.size).equals(1);
+        expect(controller.env.get(PeerSet).has(peerAddress)).is.true;
+    });
+
+    it("keeps the node and throws when removeFabric returns a non-Ok status, even if a leave arrives", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+
+        const peer1 = controller.peers.get("peer1")!;
+        const fabricIndex = peer1.stateOf(OperationalCredentialsClient).currentFabricIndex;
+
+        const restore = await patchRemoveFabric(peer1, async function () {
+            // A stale/racing leave for our own fabric must NOT rescue an explicit refusal.
+            this.endpoint.eventsOf(BasicInformationClient).leave.emit({ fabricIndex }, this.context);
+            return {
+                statusCode: OperationalCredentials.NodeOperationalCertStatus.InvalidFabricIndex,
+                debugText: "no such fabric",
+            };
+        });
+
+        try {
+            await expect(MockTime.resolve(peer1.decommission())).rejectedWith(/failed with status/);
+        } finally {
+            restore();
+        }
+
+        expect(controller.peers.size).equals(1);
     });
 });

--- a/packages/node/test/node/DecommissionTest.ts
+++ b/packages/node/test/node/DecommissionTest.ts
@@ -10,6 +10,7 @@ import { Seconds } from "@matter/general";
 import { PeerMessageMissingError, PeerSet, PeerUnresponsiveError } from "@matter/protocol";
 import { FabricIndex } from "@matter/types";
 import { OperationalCredentials } from "@matter/types/clusters/operational-credentials";
+import { ClientNodeInteraction } from "#node/client/ClientNodeInteraction.js";
 import { MockSite } from "./mock-site.js";
 
 /**
@@ -155,5 +156,26 @@ describe("Decommission", () => {
         }
 
         expect(controller.peers.size).equals(1);
+    });
+
+    it("probe resolves false on a destroyed node instead of throwing", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+
+        const peer1 = controller.peers.get("peer1")!;
+        const interaction = peer1.interaction as ClientNodeInteraction;
+
+        const restore = await patchRemoveFabric(peer1, async function () {
+            throw new PeerMessageMissingError(Seconds(11));
+        });
+        try {
+            await MockTime.resolve(peer1.decommission());
+        } finally {
+            restore();
+        }
+
+        // Node is now destroyed; a late monitor probe must not throw.
+        const reachable = await MockTime.resolve(interaction.probe());
+        expect(reachable).is.false;
     });
 });

--- a/packages/node/test/node/DecommissionTest.ts
+++ b/packages/node/test/node/DecommissionTest.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { OperationalCredentialsClient } from "#behaviors/operational-credentials";
+import { Seconds } from "@matter/general";
+import { PeerSet, PeerUnresponsiveError } from "@matter/protocol";
+import { FabricIndex } from "@matter/types";
+import { MockSite } from "./mock-site.js";
+
+/**
+ * Replace the exact `removeFabric` the decommission path invokes, on the runtime prototype of the peer's
+ * OperationalCredentialsClient facade.  Robust to per-endpoint behavior specialization.  Returns a restore fn.
+ *
+ * `impl` runs with `this` bound to the behavior facade (has `.endpoint` and `.context`), so it can emit a client-side
+ * leave event before resolving/rejecting to mimic the device's teardown.
+ */
+async function patchRemoveFabric(
+    peer: any,
+    impl: (this: any, request: { fabricIndex: FabricIndex }) => Promise<unknown>,
+) {
+    const proto = await peer.act((agent: any) => Object.getPrototypeOf(agent.get(OperationalCredentialsClient)));
+    const original = proto.removeFabric;
+    proto.removeFabric = impl;
+    return () => {
+        proto.removeFabric = original;
+    };
+}
+
+describe("Decommission", () => {
+    before(() => {
+        MockTime.init();
+    });
+
+    it("removes the node when removeFabric is delivered but the response is lost", async () => {
+        await using site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair();
+
+        const peer1 = controller.peers.get("peer1")!;
+        const peerAddress = peer1.peerAddress!;
+        expect(controller.peers.size).equals(1);
+
+        let stubCalled = false;
+        const restore = await patchRemoveFabric(peer1, async function () {
+            stubCalled = true;
+            // Device tore down the session keyed to our fabric before delivering NocResponse.
+            throw new PeerUnresponsiveError(Seconds(11));
+        });
+
+        try {
+            await MockTime.resolve(peer1.decommission());
+        } finally {
+            restore();
+        }
+
+        expect(stubCalled).is.true;
+        expect(controller.peers.size).equals(0);
+        expect(controller.env.get(PeerSet).has(peerAddress)).is.false;
+        void device;
+    });
+});

--- a/packages/protocol/src/peer/PeerCommunicationError.ts
+++ b/packages/protocol/src/peer/PeerCommunicationError.ts
@@ -46,6 +46,15 @@ export class PeerUnresponsiveError extends TransientPeerCommunicationError {
 }
 
 /**
+ * Thrown when the peer acknowledged our request but did not send the expected response before the timeout.
+ *
+ * Subtype of {@link PeerUnresponsiveError}: the exchange was active and our message was delivered (acked); only the
+ * response is missing.  Distinguished from the bare {@link PeerUnresponsiveError} raised when our outbound message was
+ * never acked (the peer may never have received it).
+ */
+export class PeerResponseMissingError extends PeerUnresponsiveError {}
+
+/**
  * Thrown when a session is closed due to peer shutdown.
  */
 export class PeerShutdownError extends TransientPeerCommunicationError {

--- a/packages/protocol/src/peer/PeerCommunicationError.ts
+++ b/packages/protocol/src/peer/PeerCommunicationError.ts
@@ -46,13 +46,15 @@ export class PeerUnresponsiveError extends TransientPeerCommunicationError {
 }
 
 /**
- * Thrown when the peer acknowledged our request but did not send the expected response before the timeout.
+ * Thrown when an expected message did not arrive on an active exchange before the timeout.
  *
- * Subtype of {@link PeerUnresponsiveError}: the exchange was active and our message was delivered (acked); only the
- * response is missing.  Distinguished from the bare {@link PeerUnresponsiveError} raised when our outbound message was
- * never acked (the peer may never have received it).
+ * Subtype of {@link PeerUnresponsiveError}, distinguished from the bare error which is raised when our own outbound
+ * message was never acknowledged (the peer may never have received it).  This subtype means the exchange was live but
+ * the awaited message — a command response or a subscription/server report — never came.  It does not by itself imply
+ * our request was delivered; a caller that reads strictly after a successful (acked) send may additionally infer
+ * delivery from that ordering.
  */
-export class PeerResponseMissingError extends PeerUnresponsiveError {}
+export class PeerMessageMissingError extends PeerUnresponsiveError {}
 
 /**
  * Thrown when a session is closed due to peer shutdown.

--- a/packages/protocol/src/protocol/MessageExchange.ts
+++ b/packages/protocol/src/protocol/MessageExchange.ts
@@ -7,7 +7,7 @@
 import { Message, PacketHeader, SessionType } from "#codec/MessageCodec.js";
 import { Mark } from "#common/Mark.js";
 import { NetworkProfile } from "#peer/NetworkProfile.js";
-import { PeerUnresponsiveError, TransientPeerCommunicationError } from "#peer/PeerCommunicationError.js";
+import { PeerResponseMissingError, PeerUnresponsiveError, TransientPeerCommunicationError } from "#peer/PeerCommunicationError.js";
 import { GroupSession } from "#session/GroupSession.js";
 import type { NodeSession } from "#session/NodeSession.js";
 import { Session } from "#session/Session.js";
@@ -696,7 +696,7 @@ export class MessageExchange {
             abort: options?.abort,
 
             timeoutHandler: () => {
-                throw new PeerUnresponsiveError(timeout!);
+                throw new PeerResponseMissingError(timeout!);
             },
         });
 

--- a/packages/protocol/src/protocol/MessageExchange.ts
+++ b/packages/protocol/src/protocol/MessageExchange.ts
@@ -7,7 +7,7 @@
 import { Message, PacketHeader, SessionType } from "#codec/MessageCodec.js";
 import { Mark } from "#common/Mark.js";
 import { NetworkProfile } from "#peer/NetworkProfile.js";
-import { PeerResponseMissingError, PeerUnresponsiveError, TransientPeerCommunicationError } from "#peer/PeerCommunicationError.js";
+import { PeerMessageMissingError, PeerUnresponsiveError, TransientPeerCommunicationError } from "#peer/PeerCommunicationError.js";
 import { GroupSession } from "#session/GroupSession.js";
 import type { NodeSession } from "#session/NodeSession.js";
 import { Session } from "#session/Session.js";
@@ -696,7 +696,7 @@ export class MessageExchange {
             abort: options?.abort,
 
             timeoutHandler: () => {
-                throw new PeerResponseMissingError(timeout!);
+                throw new PeerMessageMissingError(timeout!);
             },
         });
 

--- a/packages/protocol/src/protocol/MessageExchange.ts
+++ b/packages/protocol/src/protocol/MessageExchange.ts
@@ -7,7 +7,11 @@
 import { Message, PacketHeader, SessionType } from "#codec/MessageCodec.js";
 import { Mark } from "#common/Mark.js";
 import { NetworkProfile } from "#peer/NetworkProfile.js";
-import { PeerMessageMissingError, PeerUnresponsiveError, TransientPeerCommunicationError } from "#peer/PeerCommunicationError.js";
+import {
+    PeerMessageMissingError,
+    PeerUnresponsiveError,
+    TransientPeerCommunicationError,
+} from "#peer/PeerCommunicationError.js";
 import { GroupSession } from "#session/GroupSession.js";
 import type { NodeSession } from "#session/NodeSession.js";
 import { Session } from "#session/Session.js";


### PR DESCRIPTION
## Summary

Decommissioning a node over an operational session intermittently left the controller broken: the node stayed commissioned locally, shutdown hung ~2 minutes, and a noisy `Multiplex` "destroyed node" error was logged.

**Root cause:** `removeFabric` on our own fabric destroys the CASE session the `NocResponse` must travel on, so the response is lost. `CommissioningClient.decommission()` then rejected and skipped all local cleanup (`Peer.disconnect`, clearing `peerAddress`/`commissionedAt`/`fabricIndexOnPeer`, commit) — even though removal had succeeded on the device. The skipped `disconnect` also left the subscription's `StatusResponse` MRP-retransmitting to a dead session (~2m14s), which shutdown then waited on.

## Changes

- **`decommission()` rework** — confirmed removal when `removeFabric` resolves `Ok`, **or** rejects with a delivered-cause (`PeerMessageMissingError` / `PeerLeftError` / `FabricRemovedError` / `PeerInitiatedCloseError`), **or** a matching-`fabricIndex` `leave` event arrived. Hard failure (keep node, throw) on non-Ok status (never overridden by a leave) or a non-delivery reject without a leave. The now-reached `Peer.disconnect(PeerLeftError)` aborts the orphaned exchange — eliminating the shutdown hang.
- **`PeerMessageMissingError extends PeerUnresponsiveError`** — the response-read timeout (`MessageExchange` `#nextMessage`) now throws this subtype; the outbound-never-acked site keeps the bare `PeerUnresponsiveError`. This distinguishes "delivered, response lost" from "never reached the device", so we don't remove a node that was merely unreachable. Subtype is backward compatible — every existing `causedBy(..., PeerUnresponsiveError)` consumer still matches (audited: `InteractionMessenger`, `CaseServer`, `ControllerCommissioningFlow`, the `nextMessage` peer-loss wrapper, `PeerAddressMonitor`; no exact-class checks anywhere).
- **`ClientNodeInteraction.probe()`** — resolves `false` instead of throwing when the node is torn down (not Active / owner offline / uncommissioned), fixing a `PeerAddressMonitor` probe that races teardown.

## Test Plan

- [x] New `DecommissionTest.ts` — 6 cases: delivered→removed, never-acked→kept, leave-confirmed→removed, fabric-mismatch leave→kept, non-Ok status→kept, destroyed-node probe→`false`.
- [x] `npm run build -- --clean` (type-check + transpile)
- [x] `npm run format-verify`, `npm run lint`
- [x] Full `npm test` (all packages green; protocol 1162/1162, node 1192/1192)

🤖 Generated with [Claude Code](https://claude.com/claude-code)