### PR TITLE
feat(icd): Phase 3b — LIT-aware interaction (hold/park until awake)

### DIFF
--- a/packages/node/src/behavior/system/icd/IcdClient.ts
+++ b/packages/node/src/behavior/system/icd/IcdClient.ts
@@ -11,6 +11,7 @@ import { IcdManagementClient } from "#behaviors/icd-management";
 import { OperationalCredentialsClient } from "#behaviors/operational-credentials";
 import { Node } from "#node/Node.js";
 import {
+    AsyncObservableValue,
     Bytes,
     Crypto,
     Duration,
@@ -18,6 +19,8 @@ import {
     Logger,
     Millis,
     Observable,
+    Observer,
+    Seconds,
     Time,
     Timestamp,
 } from "@matter/general";
@@ -60,6 +63,14 @@ export class IcdClient extends Behavior {
         return this.peerSupportsLit;
     }
 
+    /** Whether the peer is currently operating in LIT mode (LIT-capable AND OperatingMode === Lit; a DSLS flip changes this at runtime). */
+    get #peerIsLongIdleTimeOperating() {
+        return (
+            this.peerSupportsLit &&
+            this.endpoint.maybeStateOf(IcdManagementClient)?.operatingMode === IcdManagement.OperatingMode.Lit
+        );
+    }
+
     /**
      * Wire lifecycle reactors. Runs `early` so they are registered before the owner first comes online.
      */
@@ -77,6 +88,31 @@ export class IcdClient extends Behavior {
                 this.#restoreReceivePath();
             }
         }
+
+        // A DSLS peer can flip SIT⇄LIT at runtime; track it so a fed peer's requiresAwait stays correct. operatingMode
+        // (and thus operatingMode$Changed) only exists on LIT-capable peers.
+        if (this.endpoint.behaviors.has(IcdManagementClient)) {
+            this.maybeReactTo(
+                this.endpoint.eventsOf(IcdManagementClient).operatingMode$Changed,
+                this.#onOperatingModeChanged,
+            );
+        }
+    }
+
+    #onOperatingModeChanged() {
+        const wakefulness = this.#fedWakefulness();
+        if (wakefulness !== undefined) {
+            wakefulness.requiresAwait = this.#peerIsLongIdleTimeOperating;
+        }
+    }
+
+    /** The {@link IcdPeerWakefulness} for the currently fed peer, or undefined when no peer is fed. */
+    #fedWakefulness() {
+        const fedPeer = this.internal.fedPeer;
+        if (fedPeer === undefined) {
+            return undefined;
+        }
+        return this.env.get(FabricManager).maybeFor(fedPeer.fabricIndex)?.icd.wakefulnessFor(fedPeer.nodeId);
     }
 
     /**
@@ -88,7 +124,8 @@ export class IcdClient extends Behavior {
             return;
         }
         const { fabric, peerNodeId } = this.#fabricContext();
-        this.#feedFabricIcd(fabric, peerNodeId);
+        // Peer reachability is unknown after a controller restart, so do not seed the availability window.
+        this.#feedFabricIcd(fabric, peerNodeId, false);
     }
 
     /**
@@ -111,6 +148,7 @@ export class IcdClient extends Behavior {
         this.state.monitoredSubject = undefined;
         this.state.clientType = undefined;
         this.state.lastCheckInReceivedAt = undefined;
+        this.state.available = false;
         this.events.unregistered.emit();
     }
 
@@ -119,8 +157,18 @@ export class IcdClient extends Behavior {
         if (fedPeer === undefined) {
             return;
         }
+        this.#unsubscribeAvailable();
         this.env.get(FabricManager).maybeFor(fedPeer.fabricIndex)?.icd.deletePeer(fedPeer.nodeId);
         this.internal.fedPeer = undefined;
+    }
+
+    #unsubscribeAvailable() {
+        const { availableSource, availableListener } = this.internal;
+        if (availableSource !== undefined && availableListener !== undefined) {
+            availableSource.off(availableListener);
+        }
+        this.internal.availableSource = undefined;
+        this.internal.availableListener = undefined;
     }
 
     /**
@@ -189,7 +237,8 @@ export class IcdClient extends Behavior {
         this.state.clientType = clientType;
         this.state.registered = true;
 
-        this.#feedFabricIcd(fabric, peerNodeId);
+        // The peer just answered registration I/O, so it is reachable: seed the availability window.
+        this.#feedFabricIcd(fabric, peerNodeId, true);
         this.events.registered.emit();
     }
 
@@ -227,7 +276,9 @@ export class IcdClient extends Behavior {
         const { promisedActiveDuration } = await this.#peerIcd().stayActiveRequest({
             stayActiveDuration: Millis.of(duration),
         });
-        return Millis(promisedActiveDuration);
+        const promised = Millis(promisedActiveDuration);
+        this.#fedWakefulness()?.noteStayActive(promised);
+        return promised;
     }
 
     #fabricContext() {
@@ -252,7 +303,7 @@ export class IcdClient extends Behavior {
         return this.agent.get(IcdManagementClient);
     }
 
-    #feedFabricIcd(fabric: ReturnType<FabricManager["for"]>, peerNodeId: NodeId) {
+    #feedFabricIcd(fabric: ReturnType<FabricManager["for"]>, peerNodeId: NodeId, seed: boolean) {
         const { key, counterStart, lastOffset } = this.state;
         if (key === undefined || counterStart === undefined || lastOffset === undefined) {
             throw new ImplementationError("ICD peer cannot be fed to the fabric before registration state is set.");
@@ -262,6 +313,35 @@ export class IcdClient extends Behavior {
         }
         fabric.icd.addPeer({ peerNodeId, key, counterStart, lastOffset }, this.internal.checkInHandler);
         this.internal.fedPeer = PeerAddress({ fabricIndex: fabric.fabricIndex, nodeId: peerNodeId });
+
+        const wakefulness = fabric.icd.wakefulnessFor(peerNodeId);
+        if (wakefulness === undefined) {
+            return;
+        }
+
+        const icdState = this.endpoint.maybeStateOf(IcdManagementClient);
+        wakefulness.setTimings({
+            activeModeThreshold:
+                icdState?.activeModeThreshold === undefined ? undefined : Millis(icdState.activeModeThreshold),
+            idleModeDuration: icdState?.idleModeDuration === undefined ? undefined : Seconds(icdState.idleModeDuration),
+        });
+        wakefulness.requiresAwait = this.#peerIsLongIdleTimeOperating;
+
+        if (seed) {
+            wakefulness.noteSignal();
+        }
+
+        // addPeer recreates the wakefulness each feed (e.g. key refresh), so re-establish the availability mirror.
+        this.#unsubscribeAvailable();
+        const listener = this.callback(this.#onAvailableChanged, { offline: true, lock: true });
+        wakefulness.available.on(listener);
+        this.internal.availableSource = wakefulness.available;
+        this.internal.availableListener = listener;
+        this.state.available = wakefulness.available.value === true;
+    }
+
+    #onAvailableChanged(available: boolean) {
+        this.state.available = available;
     }
 
     #onCheckIn(checkIn: FabricIcd.ReceivedCheckIn) {
@@ -321,7 +401,8 @@ export class IcdClient extends Behavior {
         this.state.lastOffset = 0;
 
         fabric.icd.deletePeer(peerNodeId);
-        this.#feedFabricIcd(fabric, peerNodeId);
+        // The refresh is driven by a Check-In we just decrypted, so the peer is reachable: seed the window.
+        this.#feedFabricIcd(fabric, peerNodeId, true);
         this.events.keyRefreshed.emit();
     }
 
@@ -345,6 +426,12 @@ export namespace IcdClient {
 
         /** Address of the peer fed to {@link FabricIcd}; lets decommission drop it after peerAddress is already gone. */
         fedPeer?: PeerAddress;
+
+        /** The fed peer's wakefulness `available` observable we currently mirror; recreated on every feed. */
+        availableSource?: AsyncObservableValue<[boolean]>;
+
+        /** Listener mirroring {@link availableSource} into {@link State.available}; removed on drop and before re-feed. */
+        availableListener?: Observer<[boolean]>;
     }
 
     export class State {
@@ -389,6 +476,12 @@ export namespace IcdClient {
          */
         @field(systimeMs)
         lastCheckInReceivedAt?: Timestamp;
+
+        /**
+         * Whether the peer is reachable (within its expected Check-In window). Non-LIT peers are always available.
+         */
+        @field(bool)
+        available: boolean = false;
     }
 
     export class Events extends BaseEvents {
@@ -396,5 +489,6 @@ export namespace IcdClient {
         unregistered = Observable();
         checkedIn = Observable<[checkIn: { counter: number; activeModeThreshold: number }]>();
         keyRefreshed = Observable();
+        available$Changed = new Observable<[value: boolean, oldValue: boolean]>();
     }
 }

--- a/packages/node/src/behavior/system/icd/IcdClient.ts
+++ b/packages/node/src/behavior/system/icd/IcdClient.ts
@@ -400,9 +400,9 @@ export class IcdClient extends Behavior {
         this.state.counterStart = icdCounter;
         this.state.lastOffset = 0;
 
-        fabric.icd.deletePeer(peerNodeId);
-        // The refresh is driven by a Check-In we just decrypted, so the peer is reachable: seed the window.
-        this.#feedFabricIcd(fabric, peerNodeId, true);
+        // Re-key in place rather than delete+re-add: the wakefulness (and any subscription parked on it) must survive
+        // the refresh. The triggering Check-In already re-armed the windows.
+        fabric.icd.updatePeer(peerNodeId, { key, counterStart: icdCounter, lastOffset: 0 });
         this.events.keyRefreshed.emit();
     }
 

--- a/packages/node/src/behavior/system/icd/IcdPeerAsleepError.ts
+++ b/packages/node/src/behavior/system/icd/IcdPeerAsleepError.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Duration, MatterError } from "@matter/general";
+import type { PeerAddress } from "@matter/protocol";
+
+/**
+ * Thrown by a one-shot interaction (read/write/invoke) with a LIT (Long Idle Time) ICD peer when the peer does not wake
+ * within the await window. A LIT peer is asleep most of the time and only reachable inside the active window following a
+ * Check-In, so matter.js holds the operation until the peer wakes; this error surfaces the timeout. Distinct subtype so
+ * callers can detect the asleep case specifically (`catch (e) { if (e instanceof IcdPeerAsleepError) ... }`).
+ */
+export class IcdPeerAsleepError extends MatterError {
+    readonly address: PeerAddress;
+
+    constructor(address: PeerAddress, timeout: Duration) {
+        super(`LIT ICD peer ${address} did not wake within ${Duration.format(timeout)}`);
+        this.address = address;
+    }
+}

--- a/packages/node/src/behavior/system/icd/index.ts
+++ b/packages/node/src/behavior/system/icd/index.ts
@@ -6,3 +6,4 @@
 
 export * from "./IcdClient.js";
 export * from "./IcdMultiAdminError.js";
+export * from "./IcdPeerAsleepError.js";

--- a/packages/node/src/node/NodePhysicalProperties.ts
+++ b/packages/node/src/node/NodePhysicalProperties.ts
@@ -31,6 +31,7 @@ export function NodePhysicalProperties(node: Node) {
         isMainsPowered: false,
         isBatteryPowered: false,
         isIntermittentlyConnected: rootEndpointServerList.includes(IcdManagement.id as ClusterId),
+        isLongIdleTimeOperating: false,
         isThreadSleepyEndDevice: false,
     };
 

--- a/packages/node/src/node/NodePhysicalProperties.ts
+++ b/packages/node/src/node/NodePhysicalProperties.ts
@@ -5,15 +5,15 @@
  */
 
 import { DescriptorClient } from "#behaviors/descriptor";
+import { IcdManagementClient } from "#behaviors/icd-management";
 import { NetworkCommissioningClient } from "#behaviors/network-commissioning";
 import { PowerSourceClient } from "#behaviors/power-source";
 import { ThreadNetworkDiagnosticsClient } from "#behaviors/thread-network-diagnostics";
 import { Endpoint } from "#endpoint/Endpoint.js";
 import { AggregatorEndpoint } from "#endpoints/aggregator";
 import { Node } from "#node/Node.js";
-import { IcdManagement } from "@matter/model";
 import { PhysicalDeviceProperties } from "@matter/protocol";
-import { ClusterId } from "@matter/types";
+import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { PowerSource } from "@matter/types/clusters/power-source";
 import { ThreadNetworkDiagnostics } from "@matter/types/clusters/thread-network-diagnostics";
 
@@ -23,6 +23,9 @@ import { ThreadNetworkDiagnostics } from "@matter/types/clusters/thread-network-
 export function NodePhysicalProperties(node: Node) {
     const rootEndpointServerList = [...(node.maybeStateOf(DescriptorClient)?.serverList ?? [])];
 
+    const supportsLit = node.maybeFeaturesOf(IcdManagementClient)?.longIdleTimeSupport === true;
+    const operatingMode = node.maybeStateOf(IcdManagementClient)?.operatingMode;
+
     const properties: PhysicalDeviceProperties = {
         supportsThread: false,
         supportsWifi: false,
@@ -30,8 +33,8 @@ export function NodePhysicalProperties(node: Node) {
         rootEndpointServerList,
         isMainsPowered: false,
         isBatteryPowered: false,
-        isIntermittentlyConnected: rootEndpointServerList.includes(IcdManagement.id as ClusterId),
-        isLongIdleTimeOperating: false,
+        isIntermittentlyConnected: rootEndpointServerList.includes(IcdManagement.id),
+        isLongIdleTimeOperating: supportsLit && operatingMode === IcdManagement.OperatingMode.Lit,
         isThreadSleepyEndDevice: false,
     };
 

--- a/packages/node/src/node/client/ClientNodeInteraction.ts
+++ b/packages/node/src/node/client/ClientNodeInteraction.ts
@@ -21,6 +21,7 @@ import {
     ClientSubscriptions,
     ClientWrite,
     DecodedInvokeResult,
+    FabricManager,
     Interactable,
     OperationalAddressChangedError,
     PeerSet,
@@ -121,6 +122,10 @@ export class ClientNodeInteraction implements Interactable<ActionContext> {
 
             closed: request.closed?.bind(request),
         };
+
+        if (intermediateRequest.sustain && ClientNodePhysicalProperties(this.#node).isLongIdleTimeOperating) {
+            intermediateRequest.icdWakefulness = this.#icdWakefulness();
+        }
 
         return this.#interaction.subscribe(intermediateRequest, context);
     }
@@ -223,6 +228,18 @@ export class ClientNodeInteraction implements Interactable<ActionContext> {
 
     get #structure() {
         return (this.#node.env.get(EndpointInitializer) as ClientEndpointInitializer).structure;
+    }
+
+    /**
+     * Wakefulness of a LIT peer, or undefined when the peer is uncommissioned or has no registered ICD entry yet.  An
+     * undefined result routes the subscription to the non-LIT path rather than throwing.
+     */
+    #icdWakefulness() {
+        const address = this.#node.state.commissioning.peerAddress;
+        if (address === undefined) {
+            return undefined;
+        }
+        return this.#node.env.get(FabricManager).maybeFor(address.fabricIndex)?.icd.wakefulnessFor(address.nodeId);
     }
 
     /**

--- a/packages/node/src/node/client/ClientNodeInteraction.ts
+++ b/packages/node/src/node/client/ClientNodeInteraction.ts
@@ -5,10 +5,22 @@
  */
 
 import type { ActionContext } from "#behavior/context/ActionContext.js";
+import { IcdPeerAsleepError } from "#behavior/system/icd/IcdPeerAsleepError.js";
 import { NetworkClient } from "#behavior/system/network/NetworkClient.js";
+import { IcdManagementClient } from "#behaviors/icd-management";
 import { EndpointInitializer } from "#endpoint/properties/EndpointInitializer.js";
 import type { ClientNode } from "#node/ClientNode.js";
-import { ImplementationError, Lifecycle, Logger, MatterAggregateError, ObserverGroup } from "@matter/general";
+import {
+    Abort,
+    Duration,
+    ImplementationError,
+    Lifecycle,
+    Logger,
+    MatterAggregateError,
+    Millis,
+    ObserverGroup,
+    Seconds,
+} from "@matter/general";
 import {
     ClientBdxRequest,
     ClientBdxResponse,
@@ -21,9 +33,12 @@ import {
     ClientSubscriptions,
     ClientWrite,
     DecodedInvokeResult,
+    type FabricIcd,
     FabricManager,
+    IcdPeerWakefulness,
     Interactable,
     OperationalAddressChangedError,
+    PeerAddress,
     PeerSet,
     PhysicalDeviceProperties,
     ReadResult,
@@ -31,7 +46,7 @@ import {
     Val,
     WriteResult,
 } from "@matter/protocol";
-import { EndpointNumber } from "@matter/types";
+import { EndpointNumber, NodeId } from "@matter/types";
 import { ClientEndpointInitializer } from "./ClientEndpointInitializer.js";
 import { ClientNodePhysicalProperties } from "./ClientNodePhysicalProperties.js";
 
@@ -45,13 +60,18 @@ export class ClientNodeInteraction implements Interactable<ActionContext> {
     #observers = new ObserverGroup();
     #interactable?: ClientInteraction;
     #interactableClosed?: Promise<unknown>;
+    #icd?: FabricIcd;
+    #icdPeerNodeId?: NodeId;
 
     constructor(node: ClientNode) {
         this.#node = node;
 
-        this.#observers.on(this.#node.events.commissioning.peerAddress$Changed, () =>
-            this.#closeInteraction(new OperationalAddressChangedError()),
-        );
+        this.#observers.on(this.#node.events.commissioning.peerAddress$Changed, () => {
+            // The cached fabric.icd is keyed to the prior peer address; a new commissioning invalidates it.
+            this.#icd = undefined;
+            this.#icdPeerNodeId = undefined;
+            this.#closeInteraction(new OperationalAddressChangedError());
+        });
         this.#observers.on(this.#node.owner?.lifecycle.goingOffline, () => this.#closeInteraction(new ShutdownError()));
     }
 
@@ -67,6 +87,12 @@ export class ClientNodeInteraction implements Interactable<ActionContext> {
      * request to skip version injection and always receive a full response from the server.
      */
     async *read(request: ClientRead, context?: ActionContext): ReadResult {
+        // Hold for a LIT peer to wake before the first yield* so we never transmit into a sleeping radio.
+        const hold = this.#holdUntilAwake(request.icdAwaitTimeout);
+        if (hold !== undefined) {
+            await hold;
+        }
+
         if (
             !request.includeKnownVersions &&
             (request.isFabricFiltered ?? true) === this.#structure.subscribedFabricFiltered
@@ -123,8 +149,11 @@ export class ClientNodeInteraction implements Interactable<ActionContext> {
             closed: request.closed?.bind(request),
         };
 
-        if (intermediateRequest.sustain && ClientNodePhysicalProperties(this.#node).isLongIdleTimeOperating) {
-            intermediateRequest.icdWakefulness = this.#icdWakefulness();
+        if (intermediateRequest.sustain) {
+            const wakefulness = this.#icdWakefulness();
+            if (wakefulness?.requiresAwait) {
+                intermediateRequest.icdWakefulness = wakefulness;
+            }
         }
 
         return this.#interaction.subscribe(intermediateRequest, context);
@@ -135,6 +164,10 @@ export class ClientNodeInteraction implements Interactable<ActionContext> {
      * The returned attribute write status information is returned.
      */
     async write<T extends ClientWrite>(request: T, context?: ActionContext): WriteResult<T> {
+        const hold = this.#holdUntilAwake(request.icdAwaitTimeout);
+        if (hold !== undefined) {
+            await hold;
+        }
         return this.#interaction.write(request, context);
     }
 
@@ -151,6 +184,12 @@ export class ClientNodeInteraction implements Interactable<ActionContext> {
         // For commands, by default ignore the queue because the user is responsible for managing that themselves
         if (request.network === undefined) {
             request.network = "unlimited";
+        }
+
+        // Hold for a LIT peer to wake before the first yield* so we never transmit into a sleeping radio.
+        const hold = this.#holdUntilAwake(request.icdAwaitTimeout);
+        if (hold !== undefined) {
+            await hold;
         }
 
         yield* this.#interaction.invoke(request, context);
@@ -231,15 +270,76 @@ export class ClientNodeInteraction implements Interactable<ActionContext> {
     }
 
     /**
-     * Wakefulness of a LIT peer, or undefined when the peer is uncommissioned or has no registered ICD entry yet.  An
-     * undefined result routes the subscription to the non-LIT path rather than throwing.
+     * Hold a one-shot operation until an idle LIT peer wakes, bounded by a timeout.
+     *
+     * Returns `undefined` for the common passthrough cases (non-LIT peer, unregistered peer, or an already-awake LIT
+     * peer) so callers add no latency and no microtask boundary on the hot path — important for same-tick invoke
+     * batching.  Returns a promise only when the operation must actually park; it resolves when a Check-In re-arms the
+     * awake window and rejects with {@link IcdPeerAsleepError} if the timeout elapses first.
      */
-    #icdWakefulness() {
+    #holdUntilAwake(timeout?: Duration): Promise<void> | undefined {
+        // requiresAwait is the live LIT classification (kept current through DSLS flips by IcdClient), so it gates the
+        // hold without rebuilding physical properties on every interaction.
+        const wakefulness = this.#icdWakefulness();
+        if (wakefulness === undefined || !wakefulness.requiresAwait || wakefulness.awake.value === true) {
+            return undefined;
+        }
+
         const address = this.#node.state.commissioning.peerAddress;
         if (address === undefined) {
             return undefined;
         }
-        return this.#node.env.get(FabricManager).maybeFor(address.fabricIndex)?.icd.wakefulnessFor(address.nodeId);
+
+        // Default wait spans the peer's idle window plus the same reachability margin used for availability.
+        const idle = this.#node.maybeStateOf(IcdManagementClient)?.idleModeDuration;
+        const effectiveTimeout =
+            timeout ??
+            Millis(
+                (idle === undefined ? IcdPeerWakefulness.DEFAULT_IDLE : Seconds(idle)) +
+                    IcdPeerWakefulness.AVAILABILITY_MARGIN,
+            );
+
+        return this.#awaitWake(wakefulness, address, effectiveTimeout);
+    }
+
+    async #awaitWake(wakefulness: IcdPeerWakefulness, address: PeerAddress, timeout: Duration) {
+        using abort = Abort.subtask(undefined, timeout);
+        await abort.race(wakefulness.awake);
+
+        if (abort.aborted) {
+            throw new IcdPeerAsleepError(address, timeout);
+        }
+    }
+
+    /**
+     * Wakefulness of a LIT peer, or undefined when the peer is uncommissioned or has no registered ICD entry yet.  An
+     * undefined result routes the subscription to the non-LIT path rather than throwing.
+     */
+    #icdWakefulness() {
+        const icd = this.#peerIcd();
+        return icd?.icd.wakefulnessFor(icd.nodeId);
+    }
+
+    /**
+     * The peer's {@link FabricIcd} and node ID, resolved once and cached: the fabric backing a commissioned peer is
+     * stable for the peer's lifetime, so the per-interaction lookup is unnecessary.  Cleared on `peerAddress$Changed`.
+     * A not-yet-loaded fabric is not cached, so it is retried on the next access.
+     */
+    #peerIcd(): { icd: FabricIcd; nodeId: NodeId } | undefined {
+        if (this.#icd !== undefined && this.#icdPeerNodeId !== undefined) {
+            return { icd: this.#icd, nodeId: this.#icdPeerNodeId };
+        }
+        const address = this.#node.state.commissioning.peerAddress;
+        if (address === undefined) {
+            return undefined;
+        }
+        const icd = this.#node.env.get(FabricManager).maybeFor(address.fabricIndex)?.icd;
+        if (icd === undefined) {
+            return undefined;
+        }
+        this.#icd = icd;
+        this.#icdPeerNodeId = address.nodeId;
+        return { icd, nodeId: address.nodeId };
     }
 
     /**

--- a/packages/node/src/node/client/ClientNodePhysicalProperties.ts
+++ b/packages/node/src/node/client/ClientNodePhysicalProperties.ts
@@ -54,6 +54,10 @@ export function ClientNodePhysicalProperties(node: ClientNode) {
             return props().isIntermittentlyConnected;
         },
 
+        get isLongIdleTimeOperating() {
+            return props().isLongIdleTimeOperating;
+        },
+
         get isThreadSleepyEndDevice() {
             return props().isThreadSleepyEndDevice;
         },

--- a/packages/node/test/behavior/system/icd/IcdClientTest.ts
+++ b/packages/node/test/behavior/system/icd/IcdClientTest.ts
@@ -7,13 +7,15 @@
 import { CommissioningClient } from "#behavior/system/commissioning/CommissioningClient.js";
 import { IcdClient } from "#behavior/system/icd/IcdClient.js";
 import { IcdMultiAdminError } from "#behavior/system/icd/IcdMultiAdminError.js";
-import { IcdManagementServer } from "#behaviors/icd-management";
+import { IcdManagementClient, IcdManagementServer } from "#behaviors/icd-management";
+import { ClientNode } from "#node/ClientNode.js";
 import { ServerNode } from "#node/index.js";
-import { ImplementationError, Seconds } from "@matter/general";
+import { Crypto, ImplementationError, MockCrypto, Seconds } from "@matter/general";
 import { FabricManager, TestFabric } from "@matter/protocol";
 import { FabricId, NodeId, SubjectId, VendorId } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { MockSite } from "../../../node/mock-site.js";
+import { subscribedPeer } from "../../../node/node-helpers.js";
 
 const RootWithIcd = ServerNode.RootEndpoint.with(IcdManagementServer);
 
@@ -22,6 +24,13 @@ const LitIcdServer = IcdManagementServer.with(
     IcdManagement.Feature.LongIdleTimeSupport,
 );
 const RootWithLitIcd = ServerNode.RootEndpoint.with(LitIcdServer);
+
+const DslsIcdServer = IcdManagementServer.with(
+    IcdManagement.Feature.CheckInProtocolSupport,
+    IcdManagement.Feature.LongIdleTimeSupport,
+    IcdManagement.Feature.DynamicSitLitSupport,
+);
+const RootWithDslsIcd = ServerNode.RootEndpoint.with(DslsIcdServer);
 
 const LIT_CONFIG = {
     operatingMode: IcdManagement.OperatingMode.Sit,
@@ -36,6 +45,40 @@ async function wakeDevice(device: ServerNode) {
     await device.act(agent => agent.get(IcdManagementServer).enterIdleMode());
     await device.act(agent => agent.get(IcdManagementServer).requestActiveMode());
     await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+}
+
+async function commission(controller: ServerNode, device: ServerNode) {
+    const controllerCrypto = controller.env.get(Crypto) as MockCrypto;
+    const deviceCrypto = device.env.get(Crypto) as MockCrypto;
+    controllerCrypto.entropic = deviceCrypto.entropic = true;
+
+    if (!controller.lifecycle.isOnline) {
+        await controller.start();
+    }
+
+    const { passcode, discriminator } = device.state.commissioning;
+    await MockTime.resolve(controller.peers.commission({ passcode, discriminator, timeout: Seconds(90) }), {
+        macrotasks: true,
+    });
+
+    controllerCrypto.entropic = deviceCrypto.entropic = false;
+}
+
+/** Commission a DSLS device that is operating in LIT mode before the controller subscribes. */
+async function litOperatingPair(site: MockSite) {
+    const { controller, device } = await site.addUncommissionedPair({
+        device: { type: RootWithDslsIcd, icdManagement: LIT_CONFIG },
+    });
+    await device.act(agent => agent.get(DslsIcdServer).setOperatingMode(IcdManagement.OperatingMode.Lit));
+    await commission(controller, device);
+    const peer1 = await subscribedPeer(controller, "peer1");
+    return { controller, device, peer1 };
+}
+
+function wakefulnessOf(controller: ServerNode, peer: ClientNode) {
+    const peerAddress = peer.stateOf(CommissioningClient).peerAddress!;
+    const fabric = controller.env.get(FabricManager).for(peerAddress.fabricIndex);
+    return fabric.icd.wakefulnessFor(peerAddress.nodeId);
 }
 
 describe("IcdClient", () => {
@@ -374,6 +417,96 @@ describe("IcdClient", () => {
             const fabric = controllerB.env.get(FabricManager).for(fabricIndex);
             // initialize() re-fed the restored peer so a Check-In arriving after restart still validates.
             expect(fabric.icd.hasPeers).true;
+        });
+    });
+
+    describe("availability", () => {
+        it("seeds available true on register and expires it after the idle window with no check-in", async () => {
+            await using site = new MockSite();
+            const { controller, peer1 } = await litOperatingPair(site);
+
+            await peer1.act(agent => agent.get(IcdClient).register({ monitoredSubject: SubjectId(NodeId(0xabcdn)) }));
+            expect(peer1.stateOf(IcdClient).available).true;
+
+            const changed = new Promise<void>(resolve =>
+                peer1.eventsOf(IcdClient).available$Changed.once(() => resolve()),
+            );
+
+            // idleModeDuration (3600s) + AVAILABILITY_MARGIN (5s) + slack.
+            await MockTime.advance(Seconds(3700));
+            await MockTime.resolve(changed, { macrotasks: true });
+
+            expect(peer1.stateOf(IcdClient).available).false;
+            expect(wakefulnessOf(controller, peer1)!.available.value).false;
+        });
+
+        it("restores available true on a check-in after expiry", async () => {
+            await using site = new MockSite();
+            const { controller, device, peer1 } = await litOperatingPair(site);
+
+            await peer1.act(agent => agent.get(IcdClient).register({ monitoredSubject: SubjectId(NodeId(0xabcdn)) }));
+
+            await MockTime.advance(Seconds(3700));
+            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+            expect(peer1.stateOf(IcdClient).available).false;
+
+            await wakeDevice(device);
+            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+
+            expect(peer1.stateOf(IcdClient).available).true;
+            expect(wakefulnessOf(controller, peer1)!.available.value).true;
+        });
+
+        it("keeps a SIT/non-LIT registered peer available at all times", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair({
+                device: { type: RootWithIcd },
+            });
+
+            const peer1 = controller.peers.get("peer1")!;
+            await peer1.act(agent => agent.get(IcdClient).register());
+
+            expect(peer1.stateOf(IcdClient).available).true;
+            expect(wakefulnessOf(controller, peer1)!.requiresAwait).false;
+
+            await MockTime.advance(Seconds(3700));
+            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+            expect(peer1.stateOf(IcdClient).available).true;
+        });
+
+        it("extends the awake window when stayActive promises a longer duration", async () => {
+            await using site = new MockSite();
+            const { controller, peer1 } = await litOperatingPair(site);
+
+            await peer1.act(agent => agent.get(IcdClient).register({ monitoredSubject: SubjectId(NodeId(0xabcdn)) }));
+
+            const wakefulness = wakefulnessOf(controller, peer1)!;
+            const promised = await peer1.act(agent => agent.get(IcdClient).stayActive(Seconds(120)));
+            expect(promised).greaterThan(0);
+
+            // activeModeThreshold is 5s, so absent the StayActive extension awake would already have lapsed by now.
+            await MockTime.advance(Seconds(30));
+            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+            expect(wakefulness.awake.value).true;
+        });
+
+        it("flips requiresAwait when a registered DSLS peer switches SIT→LIT at runtime", async () => {
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: { type: RootWithDslsIcd, icdManagement: LIT_CONFIG },
+            });
+            const peer1 = await subscribedPeer(controller, "peer1");
+
+            await peer1.act(agent => agent.get(IcdClient).register({ monitoredSubject: SubjectId(NodeId(0xabcdn)) }));
+            expect(wakefulnessOf(controller, peer1)!.requiresAwait).false;
+
+            const modeChanged = new Promise<void>(resolve =>
+                peer1.eventsOf(IcdManagementClient).operatingMode$Changed.once(() => resolve()),
+            );
+            await device.act(agent => agent.get(DslsIcdServer).setOperatingMode(IcdManagement.OperatingMode.Lit));
+            await MockTime.resolve(modeChanged, { macrotasks: true });
+
+            expect(wakefulnessOf(controller, peer1)!.requiresAwait).true;
         });
     });
 

--- a/packages/node/test/behavior/system/icd/IcdClientTest.ts
+++ b/packages/node/test/behavior/system/icd/IcdClientTest.ts
@@ -11,7 +11,14 @@ import { IcdManagementClient, IcdManagementServer } from "#behaviors/icd-managem
 import { ClientNode } from "#node/ClientNode.js";
 import { ServerNode } from "#node/index.js";
 import { Crypto, ImplementationError, MockCrypto, Seconds } from "@matter/general";
-import { FabricManager, TestFabric } from "@matter/protocol";
+import {
+    ClientSubscribe,
+    FabricManager,
+    IcdSustainedSubscription,
+    Subscribe,
+    SustainedSubscription,
+    TestFabric,
+} from "@matter/protocol";
 import { FabricId, NodeId, SubjectId, VendorId } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { MockSite } from "../../../node/mock-site.js";
@@ -533,6 +540,37 @@ describe("IcdClient", () => {
 
             expect(peer1.stateOf(IcdClient).registered).false;
             expect(fabric.icd.hasPeers).false;
+        });
+    });
+
+    describe("sustained subscription routing", () => {
+        const sustainRequest: ClientSubscribe = { ...Subscribe({ attributes: [{}] }), sustain: true };
+
+        it("routes a registered LIT peer to an IcdSustainedSubscription", async () => {
+            await using site = new MockSite();
+            const { controller, peer1 } = await litOperatingPair(site);
+
+            await peer1.act(agent => agent.get(IcdClient).register());
+            expect(wakefulnessOf(controller, peer1)).not.undefined;
+
+            const subscription = await peer1.interaction.subscribe(sustainRequest);
+            IcdSustainedSubscription.assert(subscription);
+            subscription.close();
+            await MockTime.resolve(subscription.done!, { macrotasks: true });
+        });
+
+        it("routes a non-ICD peer to a SustainedSubscription", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair();
+            const peer1 = await subscribedPeer(controller, "peer1");
+
+            const subscription = await MockTime.resolve(peer1.interaction.subscribe(sustainRequest), {
+                macrotasks: true,
+            });
+            SustainedSubscription.assert(subscription);
+            expect(subscription instanceof IcdSustainedSubscription).false;
+            subscription.close();
+            await MockTime.resolve(subscription.done!, { macrotasks: true });
         });
     });
 });

--- a/packages/node/test/behavior/system/icd/IcdClientTest.ts
+++ b/packages/node/test/behavior/system/icd/IcdClientTest.ts
@@ -286,6 +286,9 @@ describe("IcdClient", () => {
             const peerEntry = fabric.icd.peerFor(peerNodeId)!;
             peerEntry.counterStart = (originalCounterStart - 0x80000000) >>> 0;
 
+            // The wakefulness must survive a re-key in place: a parked subscription holds this instance.
+            const wakefulnessBefore = fabric.icd.wakefulnessFor(peerNodeId);
+
             const refreshed = new Promise<void>(resolve =>
                 peer1.eventsOf(IcdClient).keyRefreshed.once(() => resolve()),
             );
@@ -303,6 +306,9 @@ describe("IcdClient", () => {
 
             // The device accepted the re-key in place: still exactly one registration for this controller.
             expect(device.stateOf(IcdManagementServer).registeredClients).length(1);
+
+            // Re-key preserved the wakefulness instance (not delete+recreate), so a parked subscription stays valid.
+            expect(fabric.icd.wakefulnessFor(peerNodeId)).equals(wakefulnessBefore);
 
             const checkedInAgain = new Promise<{ counter: number }>(resolve =>
                 peer1.eventsOf(IcdClient).checkedIn.once(resolve),

--- a/packages/node/test/node/client/ClientNodeInteractionIcdTest.ts
+++ b/packages/node/test/node/client/ClientNodeInteractionIcdTest.ts
@@ -1,0 +1,188 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CommissioningClient } from "#behavior/system/commissioning/CommissioningClient.js";
+import { IcdClient } from "#behavior/system/icd/IcdClient.js";
+import { IcdPeerAsleepError } from "#behavior/system/icd/IcdPeerAsleepError.js";
+import { IcdManagementServer } from "#behaviors/icd-management";
+import { ClientNode } from "#node/ClientNode.js";
+import { ServerNode } from "#node/index.js";
+import { Crypto, MockCrypto, Seconds } from "@matter/general";
+import { FabricManager, Read } from "@matter/protocol";
+import { EndpointNumber, NodeId, SubjectId } from "@matter/types";
+import { Descriptor } from "@matter/types/clusters/descriptor";
+import { IcdManagement } from "@matter/types/clusters/icd-management";
+import { MockSite } from "../mock-site.js";
+import { subscribedPeer } from "../node-helpers.js";
+
+const DslsIcdServer = IcdManagementServer.with(
+    IcdManagement.Feature.CheckInProtocolSupport,
+    IcdManagement.Feature.LongIdleTimeSupport,
+    IcdManagement.Feature.DynamicSitLitSupport,
+);
+const RootWithDslsIcd = ServerNode.RootEndpoint.with(DslsIcdServer);
+
+const SitIcdServer = IcdManagementServer.with(IcdManagement.Feature.CheckInProtocolSupport);
+const RootWithSitIcd = ServerNode.RootEndpoint.with(SitIcdServer);
+
+const LIT_CONFIG = {
+    operatingMode: IcdManagement.OperatingMode.Sit,
+    activeModeThreshold: 5000,
+    idleModeDuration: 3600,
+    activeModeDuration: 1000,
+    maximumCheckInBackoff: 3600,
+};
+
+const MONITORED = SubjectId(NodeId(0xabcdn));
+
+const descriptorRead = Read(
+    Read.Attribute({ endpoint: EndpointNumber(0), cluster: Descriptor, attributes: "serverList" }),
+);
+
+/** Force one device idle→active wake and let the Check-In send pass run to completion. */
+async function wakeDevice(device: ServerNode) {
+    await device.act(agent => agent.get(IcdManagementServer).enterIdleMode());
+    await device.act(agent => agent.get(IcdManagementServer).requestActiveMode());
+    await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+}
+
+async function commission(controller: ServerNode, device: ServerNode) {
+    const controllerCrypto = controller.env.get(Crypto) as MockCrypto;
+    const deviceCrypto = device.env.get(Crypto) as MockCrypto;
+    controllerCrypto.entropic = deviceCrypto.entropic = true;
+
+    if (!controller.lifecycle.isOnline) {
+        await controller.start();
+    }
+
+    const { passcode, discriminator } = device.state.commissioning;
+    await MockTime.resolve(controller.peers.commission({ passcode, discriminator, timeout: Seconds(90) }), {
+        macrotasks: true,
+    });
+
+    controllerCrypto.entropic = deviceCrypto.entropic = false;
+}
+
+/** Commission a DSLS device that is operating in LIT mode and register the controller as a Check-In client. */
+async function registeredLitPair(site: MockSite) {
+    const { controller, device } = await site.addUncommissionedPair({
+        device: { type: RootWithDslsIcd, icdManagement: LIT_CONFIG },
+    });
+    await device.act(agent => agent.get(DslsIcdServer).setOperatingMode(IcdManagement.OperatingMode.Lit));
+    await commission(controller, device);
+    const peer1 = await subscribedPeer(controller, "peer1");
+    await peer1.act(agent => agent.get(IcdClient).register({ monitoredSubject: MONITORED }));
+    // register seeds a signal (awake for activeModeThreshold = 5s); let that window lapse so the peer is idle.
+    await MockTime.advance(Seconds(6));
+    await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+    return { controller, device, peer1 };
+}
+
+function wakefulnessOf(controller: ServerNode, peer: ClientNode) {
+    const peerAddress = peer.stateOf(CommissioningClient).peerAddress!;
+    const fabric = controller.env.get(FabricManager).for(peerAddress.fabricIndex);
+    return fabric.icd.wakefulnessFor(peerAddress.nodeId);
+}
+
+async function drainRead(peer: ClientNode) {
+    for await (const chunk of peer.interaction.read(descriptorRead)) {
+        for await (const _report of chunk);
+    }
+}
+
+describe("ClientNodeInteraction ICD hold", () => {
+    before(() => {
+        MockTime.init();
+    });
+
+    it("holds a read for an idle LIT peer and completes it once a check-in wakes the peer", async () => {
+        await using site = new MockSite();
+        const { controller, device, peer1 } = await registeredLitPair(site);
+
+        expect(wakefulnessOf(controller, peer1)!.awake.value).false;
+
+        let settled = false;
+        const read = drainRead(peer1).then(
+            () => (settled = true),
+            e => {
+                settled = true;
+                throw e;
+            },
+        );
+
+        // Let the gate park; the read must not transmit while the peer is asleep.
+        await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+        expect(settled).false;
+
+        await wakeDevice(device);
+        await MockTime.resolve(read, { macrotasks: true });
+        expect(settled).true;
+    });
+
+    it("rejects with IcdPeerAsleepError when no check-in arrives within the default window", async () => {
+        await using site = new MockSite();
+        const { controller, peer1 } = await registeredLitPair(site);
+
+        expect(wakefulnessOf(controller, peer1)!.awake.value).false;
+
+        let caught: unknown;
+        const read = drainRead(peer1).catch(e => (caught = e));
+
+        // idleModeDuration (3600s) + AVAILABILITY_MARGIN (5s) + slack.
+        await MockTime.advance(Seconds(3700));
+        await MockTime.resolve(read, { macrotasks: true });
+
+        expect(caught).instanceof(IcdPeerAsleepError);
+    });
+
+    it("passes a read through immediately when the LIT peer is awake", async () => {
+        await using site = new MockSite();
+        const { controller, device, peer1 } = await registeredLitPair(site);
+
+        const checkedIn = new Promise<void>(resolve => peer1.eventsOf(IcdClient).checkedIn.once(() => resolve()));
+        await wakeDevice(device);
+        await MockTime.resolve(checkedIn, { macrotasks: true });
+        expect(wakefulnessOf(controller, peer1)!.awake.value).true;
+
+        // No MockTime advance: an awake peer must not park.
+        await MockTime.resolve(drainRead(peer1), { macrotasks: true });
+    });
+
+    it("passes a read through immediately for a non-LIT peer", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair({
+            device: { type: RootWithSitIcd },
+        });
+        const peer1 = await subscribedPeer(controller, "peer1");
+        await peer1.act(agent => agent.get(IcdClient).register());
+
+        expect(wakefulnessOf(controller, peer1)!.requiresAwait).false;
+
+        await MockTime.resolve(drainRead(peer1), { macrotasks: true });
+    });
+
+    it("honors a per-call timeout override that expires before the default window", async () => {
+        await using site = new MockSite();
+        const { controller, peer1 } = await registeredLitPair(site);
+
+        expect(wakefulnessOf(controller, peer1)!.awake.value).false;
+
+        const overrideRead = { ...descriptorRead, icdAwaitTimeout: Seconds(10) };
+
+        let caught: unknown;
+        const read = (async () => {
+            for await (const chunk of peer1.interaction.read(overrideRead)) {
+                for await (const _report of chunk);
+            }
+        })().catch(e => (caught = e));
+
+        // Past the 10s override but well short of the 3605s default.
+        await MockTime.advance(Seconds(15));
+        await MockTime.resolve(read, { macrotasks: true });
+
+        expect(caught).instanceof(IcdPeerAsleepError);
+    });
+});

--- a/packages/node/test/node/client/ClientNodePhysicalPropertiesIcdTest.ts
+++ b/packages/node/test/node/client/ClientNodePhysicalPropertiesIcdTest.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IcdManagementServer } from "#behaviors/icd-management";
+import { ClientNodePhysicalProperties } from "#node/client/ClientNodePhysicalProperties.js";
+import { ServerNode } from "#node/index.js";
+import { Crypto, MockCrypto, Seconds } from "@matter/general";
+import { IcdManagement } from "@matter/types/clusters/icd-management";
+import { MockSite } from "../mock-site.js";
+import { subscribedPeer } from "../node-helpers.js";
+
+async function commission(controller: ServerNode, device: ServerNode) {
+    const controllerCrypto = controller.env.get(Crypto) as MockCrypto;
+    const deviceCrypto = device.env.get(Crypto) as MockCrypto;
+    controllerCrypto.entropic = deviceCrypto.entropic = true;
+
+    if (!controller.lifecycle.isOnline) {
+        await controller.start();
+    }
+
+    const { passcode, discriminator } = device.state.commissioning;
+    await MockTime.resolve(controller.peers.commission({ passcode, discriminator, timeout: Seconds(90) }), {
+        macrotasks: true,
+    });
+
+    controllerCrypto.entropic = deviceCrypto.entropic = false;
+}
+
+const RootWithCipIcd = ServerNode.RootEndpoint.with(IcdManagementServer);
+
+const LitIcdServer = IcdManagementServer.with(
+    IcdManagement.Feature.CheckInProtocolSupport,
+    IcdManagement.Feature.LongIdleTimeSupport,
+    IcdManagement.Feature.DynamicSitLitSupport,
+);
+const RootWithLitIcd = ServerNode.RootEndpoint.with(LitIcdServer);
+
+const LIT_CONFIG = {
+    operatingMode: IcdManagement.OperatingMode.Sit,
+    activeModeThreshold: 5000,
+    idleModeDuration: 3600,
+    activeModeDuration: 1000,
+    maximumCheckInBackoff: 3600,
+};
+
+describe("ClientNodePhysicalProperties ICD operating mode", () => {
+    before(() => {
+        MockTime.init();
+    });
+
+    it("reports isLongIdleTimeOperating true for a peer operating in LIT mode", async () => {
+        await using site = new MockSite();
+        const { controller, device } = await site.addUncommissionedPair({
+            device: { type: RootWithLitIcd, icdManagement: LIT_CONFIG },
+        });
+
+        // Put the peer in LIT mode before the controller subscribes so the first structure read sees it.
+        await device.act(agent => agent.get(LitIcdServer).setOperatingMode(IcdManagement.OperatingMode.Lit));
+
+        await commission(controller, device);
+        const peer1 = await subscribedPeer(controller, "peer1");
+
+        const properties = ClientNodePhysicalProperties(peer1);
+        expect(properties.isIntermittentlyConnected).true;
+        expect(properties.isLongIdleTimeOperating).true;
+    });
+
+    it("reports isLongIdleTimeOperating false for a LIT-capable peer still operating in SIT mode", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair({
+            device: { type: RootWithLitIcd, icdManagement: LIT_CONFIG },
+        });
+        const peer1 = await subscribedPeer(controller, "peer1");
+
+        const properties = ClientNodePhysicalProperties(peer1);
+        expect(properties.isIntermittentlyConnected).true;
+        expect(properties.isLongIdleTimeOperating).false;
+    });
+
+    it("reports isLongIdleTimeOperating false for a CIP-only (SIT) ICD peer", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair({
+            device: { type: RootWithCipIcd },
+        });
+        const peer1 = await subscribedPeer(controller, "peer1");
+
+        const properties = ClientNodePhysicalProperties(peer1);
+        expect(properties.isIntermittentlyConnected).true;
+        expect(properties.isLongIdleTimeOperating).false;
+    });
+
+    it("reports isLongIdleTimeOperating false for a non-ICD peer", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+        const peer1 = await subscribedPeer(controller, "peer1");
+
+        const properties = ClientNodePhysicalProperties(peer1);
+        expect(properties.isIntermittentlyConnected).false;
+        expect(properties.isLongIdleTimeOperating).false;
+    });
+});

--- a/packages/protocol/src/action/client/ClientInteraction.ts
+++ b/packages/protocol/src/action/client/ClientInteraction.ts
@@ -57,6 +57,7 @@ import { ClientSubscribe } from "./subscription/ClientSubscribe.js";
 import { ClientSubscription } from "./subscription/ClientSubscription.js";
 import { ClientSubscriptions } from "./subscription/ClientSubscriptions.js";
 import { PeerSubscription } from "./subscription/PeerSubscription.js";
+import { subscriptionFor } from "./subscription/subscriptionFor.js";
 import { SustainedSubscription } from "./subscription/SustainedSubscription.js";
 
 const logger = Logger.get("ClientInteraction");
@@ -942,22 +943,29 @@ export class ClientInteraction<
             // Update interactionSession BEFORE constructing SustainedSubscription so closures see the correct value
             interactionSession = { ...interactionSession, connectionTimeout: Forever } as SessionT;
 
-            subscription = new SustainedSubscription({
-                lifetime: this.subscriptions,
-                subscribe,
-                peer,
-                closed: () => this.subscriptions.delete(subscription),
-                request,
-                abort: session?.abort,
-                retries: this.#sustainRetries,
-                read,
-                // TCP has 1:1 session-connection binding plus OS keep-alive — the session is
-                // evicted when the connection drops, so no liveness probe is needed.
-                probe: abort =>
-                    this.#exchangeProvider.channelType === ChannelType.TCP
-                        ? Promise.resolve(true)
-                        : this.probe({ abort }),
-            });
+            const wakefulness = request.icdWakefulness;
+            subscription = subscriptionFor(
+                { isLongIdleTimeOperating: wakefulness !== undefined },
+                {
+                    sustained: {
+                        lifetime: this.subscriptions,
+                        subscribe,
+                        peer,
+                        closed: () => this.subscriptions.delete(subscription),
+                        request,
+                        abort: session?.abort,
+                        retries: this.#sustainRetries,
+                        read,
+                        // TCP has 1:1 session-connection binding plus OS keep-alive — the session is
+                        // evicted when the connection drops, so no liveness probe is needed.
+                        probe: abort =>
+                            this.#exchangeProvider.channelType === ChannelType.TCP
+                                ? Promise.resolve(true)
+                                : this.probe({ abort }),
+                    },
+                    wakefulness,
+                },
+            );
         } else {
             subscription = await subscribe(request);
         }

--- a/packages/protocol/src/action/client/ClientRequest.ts
+++ b/packages/protocol/src/action/client/ClientRequest.ts
@@ -5,7 +5,7 @@
  */
 
 import type { NetworkProfile } from "#peer/NetworkProfile.js";
-import type { ServerAddressUdp } from "@matter/general";
+import type { Duration, ServerAddressUdp } from "@matter/general";
 
 /**
  * Represents a client request with customizable transmission behavior.
@@ -30,4 +30,13 @@ export interface ClientRequest {
      * without affecting other exchanges on the session.
      */
     addressOverride?: ServerAddressUdp;
+
+    /**
+     * Override the wait applied to a one-shot interaction with an idle LIT (Long Idle Time) ICD peer.
+     *
+     * A LIT peer is asleep most of the time, so matter.js holds the operation until the peer wakes (a Check-In re-arms
+     * the awake window) before transmitting. The default wait is the peer's idle window plus margin; set this to bound
+     * it per-call. On expiry the operation rejects with `IcdPeerAsleepError`. Ignored for non-LIT peers.
+     */
+    icdAwaitTimeout?: Duration;
 }

--- a/packages/protocol/src/action/client/subscription/ClientSubscribe.ts
+++ b/packages/protocol/src/action/client/subscription/ClientSubscribe.ts
@@ -1,4 +1,5 @@
 import { Subscribe } from "#action/request/Subscribe.js";
+import type { IcdPeerWakefulness } from "#icd/IcdPeerWakefulness.js";
 import { ClientRequest } from "../ClientRequest.js";
 
 export interface PlainClientSubscribe extends Subscribe, ClientRequest {
@@ -29,6 +30,13 @@ export interface SustainedClientSubscribe extends Subscribe, ClientRequest {
      * This is mainly used to update the Dataversion filters in the request for sustained subscriptions.
      */
     refreshRequest?: (request: SustainedClientSubscribe) => SustainedClientSubscribe;
+
+    /**
+     * Wakefulness signals for a LIT (Long Idle Time) ICD peer.  When present, the sustained subscription parks on the
+     * peer's wake signal instead of running a timed retry/probe.  Attached by the node layer, which knows both that the
+     * peer is operating in Long Idle Time mode and the peer's {@link IcdPeerWakefulness}.
+     */
+    icdWakefulness?: IcdPeerWakefulness;
 }
 
 export type ClientSubscribe = PlainClientSubscribe | SustainedClientSubscribe;

--- a/packages/protocol/src/action/client/subscription/IcdSustainedSubscription.ts
+++ b/packages/protocol/src/action/client/subscription/IcdSustainedSubscription.ts
@@ -1,0 +1,237 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { SustainedClientSubscribe } from "#action/client/subscription/ClientSubscribe.js";
+import { Read } from "#action/request/Read.js";
+import { Subscribe } from "#action/request/Subscribe.js";
+import { ReadResult } from "#action/response/ReadResult.js";
+import type { ActiveSubscription } from "#action/response/SubscribeResult.js";
+import type { IcdPeerWakefulness } from "#icd/IcdPeerWakefulness.js";
+import type { ExchangeLogContext } from "#protocol/MessageExchange.js";
+import {
+    AbortedError,
+    asError,
+    AsyncObservableValue,
+    causedBy,
+    Diagnostic,
+    Hours,
+    ImplementationError,
+    Logger,
+    Observer,
+} from "@matter/general";
+import { SubscribeResponse } from "@matter/types";
+import { ClientSubscription } from "./ClientSubscription.js";
+import { PeerSubscription } from "./PeerSubscription.js";
+
+const logger = Logger.get("ClientSubscription");
+
+/**
+ * A sustained {@link ActiveSubscription} for a LIT (Long Idle Time) ICD peer.
+ *
+ * A LIT peer is asleep most of the time, so we must not blind-send or run a timed retry against it.  Instead we park on
+ * the peer's wake signal (driven by Check-In messages) and (re)subscribe only when the peer becomes awake.  Liveness is
+ * the Check-In itself, so there is no proactive probe.
+ *
+ * Reachability ({@link active}/{@link inactive}) mirrors {@link IcdPeerWakefulness#available}, not the presence of an
+ * underlying subscription: a parked-but-expected peer is still reachable; only a missed Check-In window means offline.
+ */
+export class IcdSustainedSubscription extends ClientSubscription {
+    #request: SustainedClientSubscribe;
+    #subscription?: ActiveSubscription;
+    #subscribe: (request: Subscribe, abort: AbortSignal) => Promise<PeerSubscription>;
+    #read?: (request: Read, abort: AbortSignal, logContext?: ExchangeLogContext) => ReadResult;
+    #wakefulness: IcdPeerWakefulness;
+    #active = AsyncObservableValue(false);
+    #inactive = AsyncObservableValue(true);
+
+    constructor(config: IcdSustainedSubscription.Configuration) {
+        super(config);
+
+        const { request, read, subscribe, wakefulness } = config;
+
+        this.#request = request;
+        this.#subscribe = subscribe;
+        this.#read = read;
+        this.#wakefulness = wakefulness;
+        this.done = this.#run();
+    }
+
+    /**
+     * Emits when the active state changes.
+     */
+    get active() {
+        return this.#active;
+    }
+
+    /**
+     * Emits when inactive state changes.
+     */
+    get inactive() {
+        return this.#inactive;
+    }
+
+    async #run() {
+        // Reachability follows the peer's availability window, not the subscription: a parked LIT peer awaiting its
+        // next Check-In is still reachable.
+        const onAvailable: Observer<[boolean]> = available => {
+            this.#active.emit(available);
+            this.#inactive.emit(!available);
+        };
+        this.#active.value = this.#wakefulness.available.value;
+        this.#inactive.value = !this.#wakefulness.available.value;
+        this.#wakefulness.available.on(onAvailable);
+
+        const updated = this.#request.updated?.bind(this.#request);
+        let { bootstrapWithRead, refreshRequest } = this.#request;
+        let needToRefreshRequest = false;
+
+        // After a failed send we must wait for a fresh Check-In rather than retry within the current awake window,
+        // which would hammer a peer that has likely already gone back to sleep.
+        let awaitFreshSignal = false;
+
+        try {
+            while (!this.abort.aborted) {
+                if (awaitFreshSignal) {
+                    await this.#nextWake();
+                    awaitFreshSignal = false;
+                } else if (!this.#wakefulness.awake.value) {
+                    // Park until the peer is awake; a Check-In re-arms the awake window.
+                    await this.abort.race(this.#wakefulness.awake);
+                }
+                if (this.abort.aborted) {
+                    break;
+                }
+
+                const request: SustainedClientSubscribe = { ...this.#request, updated };
+                if (this.#request.updated) {
+                    request.updated = this.#request.updated.bind(request);
+                }
+                const closed = new Promise<void>(resolve => {
+                    request.closed = () => {
+                        this.#subscription = undefined;
+                        this.subscriptionId = ClientSubscription.NO_SUBSCRIPTION;
+                        resolve();
+                    };
+                });
+
+                try {
+                    if (needToRefreshRequest && refreshRequest !== undefined) {
+                        Object.assign(request, refreshRequest(request));
+                    }
+                    needToRefreshRequest = true;
+
+                    if (bootstrapWithRead && this.#read !== undefined) {
+                        const response = this.#read(request, this.abort, Diagnostic.asFlags({ bootstrap: true }));
+                        if (request.updated) {
+                            await request.updated(response);
+                        } else {
+                            for await (const _chunk of response);
+                        }
+                        if (this.abort.aborted) {
+                            break;
+                        }
+                        bootstrapWithRead = false;
+                        if (refreshRequest !== undefined) {
+                            Object.assign(request, refreshRequest(request));
+                        }
+                    }
+
+                    this.#subscription = await this.#subscribe(request, this.abort);
+                    this.subscriptionId = this.#subscription.subscriptionId;
+                } catch (e) {
+                    if (this.abort.aborted) {
+                        break;
+                    }
+                    if (!causedBy(e, AbortedError)) {
+                        logger.info(
+                            `Failed to establish subscription to LIT peer ${this.peer}, parking until next check-in:`,
+                            Diagnostic.errorMessage(asError(e)),
+                        );
+                    }
+                    awaitFreshSignal = true;
+                    continue;
+                }
+
+                await this.abort.race(closed);
+            }
+        } finally {
+            this.#wakefulness.available.off(onAvailable);
+
+            const subscription = this.#subscription;
+            this.#subscription = undefined;
+            if (subscription !== undefined) {
+                this.subscriptionId = ClientSubscription.NO_SUBSCRIPTION;
+                await subscription.close();
+            }
+        }
+    }
+
+    /**
+     * Resolve on the next awake transition to true, regardless of the current value.  Unlike awaiting the observable
+     * directly (which resolves immediately when already truthy), this waits for a genuinely fresh Check-In.
+     */
+    #nextWake() {
+        return new Promise<void>(resolve => {
+            const observer: Observer<[boolean]> = awake => {
+                if (awake) {
+                    cleanup();
+                    resolve();
+                }
+            };
+            const onAbort = () => {
+                cleanup();
+                resolve();
+            };
+            const cleanup = () => {
+                this.#wakefulness.awake.off(observer);
+                this.abort.removeEventListener("abort", onAbort);
+            };
+            this.#wakefulness.awake.on(observer);
+            this.abort.addEventListener("abort", onAbort);
+        });
+    }
+
+    get interactionModelRevision() {
+        return this.#subscription?.interactionModelRevision;
+    }
+
+    get maxInterval() {
+        return this.#subscription?.maxInterval ?? Hours.one;
+    }
+}
+
+export namespace IcdSustainedSubscription {
+    /**
+     * Configuration for {@link IcdSustainedSubscription}.
+     */
+    export interface Configuration extends Omit<ClientSubscription.Configuration, "request"> {
+        request: SustainedClientSubscribe;
+
+        /**
+         * Function to establish the underlying subscription.
+         */
+        subscribe: (request: Subscribe, abort: AbortSignal) => Promise<PeerSubscription>;
+
+        /**
+         * Performs the optional bootstrap read.
+         */
+        read?: (request: Read, abort: AbortSignal) => ReadResult;
+
+        /**
+         * Wakefulness signals for the LIT peer.  The wake signal replaces the retry schedule and liveness probe used by
+         * non-ICD sustained subscriptions.
+         */
+        wakefulness: IcdPeerWakefulness;
+    }
+
+    export function assert(subscription: SubscribeResponse): asserts subscription is IcdSustainedSubscription {
+        if (!(subscription instanceof IcdSustainedSubscription)) {
+            throw new ImplementationError(
+                `Non-ICD-sustained subscription provided where ICD-sustained subscription required`,
+            );
+        }
+    }
+}

--- a/packages/protocol/src/action/client/subscription/IcdSustainedSubscription.ts
+++ b/packages/protocol/src/action/client/subscription/IcdSustainedSubscription.ts
@@ -21,6 +21,8 @@ import {
     ImplementationError,
     Logger,
     Observer,
+    Seconds,
+    Time,
 } from "@matter/general";
 import { SubscribeResponse } from "@matter/types";
 import { ClientSubscription } from "./ClientSubscription.js";
@@ -39,6 +41,9 @@ const logger = Logger.get("ClientSubscription");
  * underlying subscription: a parked-but-expected peer is still reachable; only a missed Check-In window means offline.
  */
 export class IcdSustainedSubscription extends ClientSubscription {
+    /** Bounded retry interval used only on the degraded path where a once-LIT peer no longer requires await. */
+    static readonly SIT_RETRY_INTERVAL = Seconds(15);
+
     #request: SustainedClientSubscribe;
     #subscription?: ActiveSubscription;
     #subscribe: (request: Subscribe, abort: AbortSignal) => Promise<PeerSubscription>;
@@ -107,7 +112,13 @@ export class IcdSustainedSubscription extends ClientSubscription {
 
                 const request: SustainedClientSubscribe = { ...this.#request, updated };
                 if (this.#request.updated) {
-                    request.updated = this.#request.updated.bind(request);
+                    const bound = this.#request.updated.bind(request);
+                    // A report (or bootstrap-read response) is inbound peer activity, so refresh the wake/availability
+                    // windows: an actively-reporting peer must read as awake for concurrent interactions.
+                    request.updated = result => {
+                        this.#wakefulness.noteSignal();
+                        return bound(result);
+                    };
                 }
                 const closed = new Promise<void>(resolve => {
                     request.closed = () => {
@@ -170,11 +181,24 @@ export class IcdSustainedSubscription extends ClientSubscription {
     }
 
     /**
-     * Resolve on the next awake transition to true, regardless of the current value.  Unlike awaiting the observable
-     * directly (which resolves immediately when already truthy), this waits for a genuinely fresh Check-In.
+     * Resume the run loop after a failed send. For a LIT peer this resolves on the next awake transition to true (a
+     * genuinely fresh Check-In), avoiding a retry within the current window against a peer that has likely gone back to
+     * sleep. A peer no longer requiring await (e.g. a runtime DSLS LIT→SIT flip) has no Check-In to park for, so it
+     * resumes after a bounded delay instead of stranding on an awake edge that will never re-emit; such a peer ideally
+     * re-selects a plain SustainedSubscription (tracked as a follow-up).
      */
-    #nextWake() {
-        return new Promise<void>(resolve => {
+    async #nextWake(): Promise<void> {
+        if (!this.#wakefulness.requiresAwait) {
+            const retry = Time.sleep("icd sit retry", IcdSustainedSubscription.SIT_RETRY_INTERVAL);
+            try {
+                await this.abort.race(retry);
+            } finally {
+                retry.cancel();
+            }
+            return;
+        }
+
+        await new Promise<void>(resolve => {
             const observer: Observer<[boolean]> = awake => {
                 if (awake) {
                     cleanup();

--- a/packages/protocol/src/action/client/subscription/index.ts
+++ b/packages/protocol/src/action/client/subscription/index.ts
@@ -8,5 +8,7 @@ export * from "./ClientSubscribe.js";
 export * from "./ClientSubscription.js";
 export * from "./ClientSubscriptionHandler.js";
 export * from "./ClientSubscriptions.js";
+export * from "./IcdSustainedSubscription.js";
 export * from "./PeerSubscription.js";
+export * from "./subscriptionFor.js";
 export * from "./SustainedSubscription.js";

--- a/packages/protocol/src/action/client/subscription/subscriptionFor.ts
+++ b/packages/protocol/src/action/client/subscription/subscriptionFor.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IcdPeerWakefulness } from "#icd/IcdPeerWakefulness.js";
+import type { PhysicalDeviceProperties } from "#peer/PhysicalDeviceProperties.js";
+import { ClientSubscription } from "./ClientSubscription.js";
+import { IcdSustainedSubscription } from "./IcdSustainedSubscription.js";
+import { SustainedSubscription } from "./SustainedSubscription.js";
+
+/**
+ * Select and construct the sustained {@link ClientSubscription} appropriate for a peer.
+ *
+ * A LIT (Long Idle Time) ICD peer with known wakefulness parks on its wake signal via {@link IcdSustainedSubscription}.
+ * Every other peer uses {@link SustainedSubscription}, retaining the timed retry schedule and liveness probe.
+ */
+export function subscriptionFor(
+    properties: Pick<PhysicalDeviceProperties, "isLongIdleTimeOperating">,
+    config: { sustained: SustainedSubscription.Configuration; wakefulness?: IcdPeerWakefulness },
+): ClientSubscription {
+    const { sustained, wakefulness } = config;
+
+    if (properties.isLongIdleTimeOperating && wakefulness !== undefined) {
+        const { request, peer, closed, lifetime, abort, subscribe, read } = sustained;
+        return new IcdSustainedSubscription({ request, peer, closed, lifetime, abort, subscribe, read, wakefulness });
+    }
+
+    return new SustainedSubscription(sustained);
+}

--- a/packages/protocol/src/icd/FabricIcd.ts
+++ b/packages/protocol/src/icd/FabricIcd.ts
@@ -9,6 +9,7 @@ import { Bytes, Logger } from "@matter/general";
 import { type SubjectId, NodeId } from "@matter/types";
 import type { IcdManagement } from "@matter/types/clusters/icd-management";
 import { CheckInMessage } from "./CheckInMessage.js";
+import { IcdPeerWakefulness } from "./IcdPeerWakefulness.js";
 
 const logger = Logger.get("FabricIcd");
 
@@ -23,7 +24,10 @@ const logger = Logger.get("FabricIcd");
 export class FabricIcd {
     readonly #crypto: Crypto;
     readonly #registrations = new Map<NodeId, FabricIcd.Registration>();
-    readonly #peers = new Map<NodeId, { peer: FabricIcd.Peer; handler: FabricIcd.CheckInHandler }>();
+    readonly #peers = new Map<
+        NodeId,
+        { peer: FabricIcd.Peer; handler: FabricIcd.CheckInHandler; wakefulness: IcdPeerWakefulness }
+    >();
 
     constructor(crypto: Crypto) {
         this.#crypto = crypto;
@@ -48,14 +52,20 @@ export class FabricIcd {
     }
 
     addPeer(peer: FabricIcd.Peer, handler: FabricIcd.CheckInHandler): void {
-        this.#peers.set(peer.peerNodeId, { peer, handler });
+        this.#peers.get(peer.peerNodeId)?.wakefulness.close();
+        this.#peers.set(peer.peerNodeId, { peer, handler, wakefulness: new IcdPeerWakefulness() });
     }
 
     peerFor(peerNodeId: NodeId): FabricIcd.Peer | undefined {
         return this.#peers.get(peerNodeId)?.peer;
     }
 
+    wakefulnessFor(peerNodeId: NodeId): IcdPeerWakefulness | undefined {
+        return this.#peers.get(peerNodeId)?.wakefulness;
+    }
+
     deletePeer(peerNodeId: NodeId): void {
+        this.#peers.get(peerNodeId)?.wakefulness.close();
         this.#peers.delete(peerNodeId);
     }
 
@@ -71,7 +81,7 @@ export class FabricIcd {
      * @see {@link MatterSpecification.v151.Core} § 4.22.4.2
      */
     async processCheckIn(payload: Bytes): Promise<boolean> {
-        for (const { peer, handler } of this.#peers.values()) {
+        for (const { peer, handler, wakefulness } of this.#peers.values()) {
             let decoded: CheckInMessage.DecodedIcdCheckIn;
             try {
                 decoded = await CheckInMessage.decodeIcd(this.#crypto, peer.key, payload);
@@ -87,6 +97,7 @@ export class FabricIcd {
 
             // Advance before the handler: a received counter value is consumed exactly once regardless of handler outcome.
             peer.lastOffset = validation.offset;
+            wakefulness.noteSignal();
             try {
                 handler({
                     peerNodeId: peer.peerNodeId,

--- a/packages/protocol/src/icd/FabricIcd.ts
+++ b/packages/protocol/src/icd/FabricIcd.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Crypto } from "@matter/general";
-import { Bytes, Logger } from "@matter/general";
+import { Bytes, ImplementationError, Logger } from "@matter/general";
 import { type SubjectId, NodeId } from "@matter/types";
 import type { IcdManagement } from "@matter/types/clusters/icd-management";
 import { CheckInMessage } from "./CheckInMessage.js";
@@ -54,6 +54,21 @@ export class FabricIcd {
     addPeer(peer: FabricIcd.Peer, handler: FabricIcd.CheckInHandler): void {
         this.#peers.get(peer.peerNodeId)?.wakefulness.close();
         this.#peers.set(peer.peerNodeId, { peer, handler, wakefulness: new IcdPeerWakefulness() });
+    }
+
+    /**
+     * Re-key a registered peer in place (key refresh), preserving its {@link IcdPeerWakefulness} and handler. Recreating
+     * the entry would orphan consumers that hold the wakefulness (e.g. a parked IcdSustainedSubscription), so the
+     * rolling-counter baseline is updated without disturbing the wakefulness windows.
+     */
+    updatePeer(peerNodeId: NodeId, peer: Pick<FabricIcd.Peer, "key" | "counterStart" | "lastOffset">): void {
+        const entry = this.#peers.get(peerNodeId);
+        if (entry === undefined) {
+            throw new ImplementationError(`Cannot update unregistered ICD peer ${peerNodeId}.`);
+        }
+        entry.peer.key = peer.key;
+        entry.peer.counterStart = peer.counterStart;
+        entry.peer.lastOffset = peer.lastOffset;
     }
 
     peerFor(peerNodeId: NodeId): FabricIcd.Peer | undefined {

--- a/packages/protocol/src/icd/IcdPeerWakefulness.ts
+++ b/packages/protocol/src/icd/IcdPeerWakefulness.ts
@@ -61,8 +61,10 @@ export class IcdPeerWakefulness {
             this.#setAvailable(false);
         } else {
             this.#cancelTimers();
-            this.#setAwake(true);
-            this.#setAvailable(true);
+            // Force-emit (not the change-guarded setter): a consumer parked on the awake/available edge must resume
+            // when the peer becomes always-awake, even if the value was already true.
+            this.#awake.emit(true);
+            this.#available.emit(true);
         }
     }
 

--- a/packages/protocol/src/icd/IcdPeerWakefulness.ts
+++ b/packages/protocol/src/icd/IcdPeerWakefulness.ts
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AsyncObservableValue, Duration, Millis, Seconds, Time, Timer, Timespan, Timestamp } from "@matter/general";
+
+/**
+ * Per-peer wakefulness for a LIT (Long Idle Time) ICD peer.
+ *
+ * Tracks two sliding-window boolean signals so a controller knows when it may send and whether a peer is still
+ * reachable:
+ *
+ *   - {@link awake} — send-now. Window length is `activeModeThreshold`. Any inbound signal re-arms it; a StayActive
+ *     promise extends it; expiry clears it.
+ *   - {@link available} — not-offline. Longer window of `idleModeDuration + AVAILABILITY_MARGIN`. Expiry means an
+ *     expected Check-In was missed, i.e. the peer is offline.
+ *
+ * Invariant: `awake` implies `available` — a signal refreshes both. A non-LIT peer (`requiresAwait === false`) is
+ * always awake and available with no timers.
+ */
+export class IcdPeerWakefulness {
+    static readonly AVAILABILITY_MARGIN = Seconds(5);
+    static readonly DEFAULT_SAT = Seconds(5);
+    static readonly DEFAULT_IDLE = Seconds(30);
+
+    readonly #awake = AsyncObservableValue(true);
+    readonly #available = AsyncObservableValue(true);
+
+    #requiresAwait = false;
+    #activeModeThreshold = IcdPeerWakefulness.DEFAULT_SAT;
+    #idleModeDuration = IcdPeerWakefulness.DEFAULT_IDLE;
+
+    #awakeUntil = Timestamp(0);
+    #availableUntil = Timestamp(0);
+    #awakeTimer?: Timer;
+    #availableTimer?: Timer;
+
+    /** Emits when send-now state changes. `.value` reads the current boolean. */
+    get awake() {
+        return this.#awake;
+    }
+
+    /** Emits when reachability state changes. `.value` reads the current boolean. */
+    get available() {
+        return this.#available;
+    }
+
+    get requiresAwait() {
+        return this.#requiresAwait;
+    }
+
+    set requiresAwait(value: boolean) {
+        if (value === this.#requiresAwait) {
+            return;
+        }
+        this.#requiresAwait = value;
+        if (value) {
+            this.#setAwake(false);
+            this.#setAvailable(false);
+        } else {
+            this.#cancelTimers();
+            this.#setAwake(true);
+            this.#setAvailable(true);
+        }
+    }
+
+    setTimings(timings: { activeModeThreshold?: Duration; idleModeDuration?: Duration }) {
+        if (timings.activeModeThreshold !== undefined) {
+            this.#activeModeThreshold = timings.activeModeThreshold;
+        }
+        if (timings.idleModeDuration !== undefined) {
+            this.#idleModeDuration = timings.idleModeDuration;
+        }
+    }
+
+    /** Record an inbound signal: re-arm both windows and mark awake + available. */
+    noteSignal() {
+        if (!this.#requiresAwait) {
+            return;
+        }
+        this.#armAwake(this.#activeModeThreshold);
+        this.#armAvailable(Millis(this.#idleModeDuration + IcdPeerWakefulness.AVAILABILITY_MARGIN));
+        this.#setAwake(true);
+        this.#setAvailable(true);
+    }
+
+    /** Extend the awake window to honor a StayActive promise without ever truncating a longer existing window. */
+    noteStayActive(promised: Duration) {
+        if (!this.#requiresAwait) {
+            return;
+        }
+        // A peer promised awake until T is, by definition, available until T (awake ⇒ available).
+        this.#armAwake(promised);
+        this.#armAvailable(promised);
+        this.#setAwake(true);
+        this.#setAvailable(true);
+    }
+
+    close() {
+        this.#cancelTimers();
+    }
+
+    [Symbol.dispose]() {
+        this.close();
+    }
+
+    // Extend rather than truncate: keep the later of the pending expiry and now + duration.
+    #armAwake(duration: Duration) {
+        const candidate = Timestamp(Time.nowMs + duration);
+        if (candidate <= this.#awakeUntil && this.#awakeTimer !== undefined) {
+            return;
+        }
+        this.#awakeUntil = candidate;
+        const remaining = Timespan(Time.nowMs, this.#awakeUntil).duration;
+        this.#awakeTimer?.stop();
+        this.#awakeTimer = Time.getTimer("icd-peer-awake", remaining, () => {
+            this.#awakeTimer?.stop();
+            this.#awakeTimer = undefined;
+            this.#setAwake(false);
+        }).start();
+    }
+
+    #armAvailable(duration: Duration) {
+        const candidate = Timestamp(Time.nowMs + duration);
+        if (candidate <= this.#availableUntil && this.#availableTimer !== undefined) {
+            return;
+        }
+        this.#availableUntil = candidate;
+        const remaining = Timespan(Time.nowMs, this.#availableUntil).duration;
+        this.#availableTimer?.stop();
+        this.#availableTimer = Time.getTimer("icd-peer-available", remaining, () => {
+            this.#availableTimer?.stop();
+            this.#availableTimer = undefined;
+            this.#setAvailable(false);
+        }).start();
+    }
+
+    #cancelTimers() {
+        this.#awakeTimer?.stop();
+        this.#awakeTimer = undefined;
+        this.#availableTimer?.stop();
+        this.#availableTimer = undefined;
+        this.#awakeUntil = Timestamp(0);
+        this.#availableUntil = Timestamp(0);
+    }
+
+    #setAwake(value: boolean) {
+        if (this.#awake.value !== value) {
+            this.#awake.emit(value);
+        }
+    }
+
+    #setAvailable(value: boolean) {
+        if (this.#available.value !== value) {
+            this.#available.emit(value);
+        }
+    }
+}

--- a/packages/protocol/src/icd/index.ts
+++ b/packages/protocol/src/icd/index.ts
@@ -8,3 +8,4 @@ export * from "./CheckInMessage.js";
 export * from "./FabricIcd.js";
 export * from "./IcdCheckInSender.js";
 export * from "./IcdCounter.js";
+export * from "./IcdPeerWakefulness.js";

--- a/packages/protocol/src/peer/PhysicalDeviceProperties.ts
+++ b/packages/protocol/src/peer/PhysicalDeviceProperties.ts
@@ -24,6 +24,10 @@ export interface PhysicalDeviceProperties {
     isMainsPowered: boolean;
     isBatteryPowered: boolean;
     isIntermittentlyConnected: boolean;
+
+    /** Peer is operating in Long Idle Time mode — controller must await a notification (Check-In or subscription report) before sending. */
+    isLongIdleTimeOperating: boolean;
+
     isThreadSleepyEndDevice: boolean;
     threadActive?: boolean;
     threadPan?: bigint;

--- a/packages/protocol/src/protocol/MessageExchange.ts
+++ b/packages/protocol/src/protocol/MessageExchange.ts
@@ -716,6 +716,9 @@ export class MessageExchange {
     }
 
     #retransmitMessage(message: Message, expectedProcessingTime?: Duration) {
+        // TODO(ICD phase 3b-4 follow-up): for an ICD peer, MRP 4.12 requires starting Operational Discovery in parallel
+        // with the first retry and adopting the freshly discovered address/MRP parameters. #addressOverride is fixed at
+        // construction, so this is not yet done. See the pending test in MessageExchangeTest.
         this.#retransmissionCounter++;
         this.#totalRetransmissionCounter++;
         if (

--- a/packages/protocol/test/action/client/subscription/IcdSustainedSubscriptionTest.ts
+++ b/packages/protocol/test/action/client/subscription/IcdSustainedSubscriptionTest.ts
@@ -169,6 +169,64 @@ describe("IcdSustainedSubscription", () => {
         await MockTime.resolve(subscription.done, { macrotasks: true });
     });
 
+    it("retries a flipped SIT peer after a bounded delay instead of stranding on a wake edge", async () => {
+        const wakefulness = litWakefulness();
+
+        let subscribeCount = 0;
+        const subscription = build(wakefulness, {
+            subscribe: async () => {
+                subscribeCount++;
+                if (subscribeCount === 1) {
+                    throw new Error("transient failure");
+                }
+                return fakePeerSub();
+            },
+        });
+
+        // A runtime DSLS LIT->SIT flip forces always-awake and releases the parked loop, which then subscribes (and
+        // fails). A SIT peer sends no Check-In, so the post-failure resume must come from the bounded fallback.
+        wakefulness.requiresAwait = false;
+        await flush();
+        expect(subscribeCount).equal(1);
+
+        await MockTime.advance(IcdSustainedSubscription.SIT_RETRY_INTERVAL);
+        await flush();
+        expect(subscribeCount).equal(2);
+        expect(subscription.active.value).equal(true);
+
+        subscription.close();
+        await MockTime.resolve(subscription.done, { macrotasks: true });
+    });
+
+    it("refreshes the awake window on each subscription report", async () => {
+        const wakefulness = litWakefulness();
+
+        let capturedUpdated: SustainedClientSubscribe["updated"];
+        const subscription = build(wakefulness, {
+            request: { sustain: true, updated: async () => {} } as unknown as SustainedClientSubscribe,
+            subscribe: async (request: Subscribe) => {
+                capturedUpdated = (request as SustainedClientSubscribe).updated;
+                return fakePeerSub();
+            },
+        });
+
+        wakefulness.noteSignal(); // awake for activeModeThreshold (5s)
+        await flush();
+        expect(subscription.active.value).equal(true);
+
+        // Near the end of the 5s window, a report arrives and must re-arm the awake window.
+        await MockTime.advance(4_000);
+        await capturedUpdated?.(undefined as never);
+        await flush();
+
+        // Past the original 5s window but within the refreshed one -> still awake.
+        await MockTime.advance(2_000);
+        expect(wakefulness.awake.value).equal(true);
+
+        subscription.close();
+        await MockTime.resolve(subscription.done, { macrotasks: true });
+    });
+
     it("close() resolves done cleanly while parked", async () => {
         const wakefulness = litWakefulness();
         const subscription = build(wakefulness);

--- a/packages/protocol/test/action/client/subscription/IcdSustainedSubscriptionTest.ts
+++ b/packages/protocol/test/action/client/subscription/IcdSustainedSubscriptionTest.ts
@@ -1,0 +1,203 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { SustainedClientSubscribe } from "#action/client/subscription/ClientSubscribe.js";
+import { ClientSubscription } from "#action/client/subscription/ClientSubscription.js";
+import { IcdSustainedSubscription } from "#action/client/subscription/IcdSustainedSubscription.js";
+import { PeerSubscription } from "#action/client/subscription/PeerSubscription.js";
+import { Subscribe } from "#action/request/Subscribe.js";
+import { IcdPeerWakefulness } from "#icd/IcdPeerWakefulness.js";
+import { PeerAddress } from "#peer/PeerAddress.js";
+import { Lifetime, Seconds } from "@matter/general";
+import { FabricIndex, NodeId } from "@matter/types";
+
+function fakePeerSub(onClose?: () => void): PeerSubscription {
+    return {
+        subscriptionId: 1,
+        maxInterval: 60,
+        interactionModelRevision: 12,
+        close: async () => {
+            onClose?.();
+        },
+    } as unknown as PeerSubscription;
+}
+
+function litWakefulness() {
+    const wakefulness = new IcdPeerWakefulness();
+    wakefulness.setTimings({ activeModeThreshold: Seconds(5), idleModeDuration: Seconds(30) });
+    wakefulness.requiresAwait = true; // start asleep + unavailable
+    return wakefulness;
+}
+
+/**
+ * The parked run loop resumes on a macrotask hop (Abort.race), so the harness must drain macrotasks, not just
+ * microtasks, before asserting the loop reacted to a signal.
+ */
+async function flush() {
+    for (let i = 0; i < 5; i++) {
+        await MockTime.yield();
+        await MockTime.advance(0);
+    }
+}
+
+function build(wakefulness: IcdPeerWakefulness, overrides: Partial<IcdSustainedSubscription.Configuration> = {}) {
+    const lifetime = Lifetime("test icd sustained subscription");
+    const peer = PeerAddress({ fabricIndex: FabricIndex(1), nodeId: NodeId(BigInt(1)) });
+
+    const subscription = new IcdSustainedSubscription({
+        request: { sustain: true } as SustainedClientSubscribe,
+        peer,
+        closed: () => {},
+        lifetime,
+        wakefulness,
+        subscribe: async () => fakePeerSub(),
+        read: () => {
+            throw new Error("read should not be invoked when bootstrapWithRead is unset");
+        },
+        ...overrides,
+    });
+
+    return subscription;
+}
+
+describe("IcdSustainedSubscription", () => {
+    beforeEach(() => {
+        MockTime.reset();
+    });
+
+    it("parks while asleep and subscribes only after a wake signal", async () => {
+        const wakefulness = litWakefulness();
+
+        let subscribeCount = 0;
+        const subscription = build(wakefulness, {
+            subscribe: async () => {
+                subscribeCount++;
+                return fakePeerSub();
+            },
+        });
+
+        // While asleep nothing should subscribe even as time advances.
+        await flush();
+        await MockTime.advance(20_000);
+        await flush();
+
+        expect(subscribeCount).equal(0);
+        expect(subscription.active.value).equal(false);
+        expect(subscription.inactive.value).equal(true);
+
+        // Wake signal -> subscribe.
+        wakefulness.noteSignal();
+        await flush();
+
+        expect(subscribeCount).equal(1);
+        expect(subscription.active.value).equal(true);
+        expect(subscription.inactive.value).equal(false);
+
+        subscription.close();
+        await MockTime.resolve(subscription.done, { macrotasks: true });
+    });
+
+    it("stays active while parked after a subscription loss until availability lapses", async () => {
+        const wakefulness = litWakefulness();
+
+        let lastRequest: SustainedClientSubscribe | undefined;
+        const subscription = build(wakefulness, {
+            subscribe: async (request: Subscribe) => {
+                lastRequest = request as SustainedClientSubscribe;
+                return fakePeerSub();
+            },
+        });
+
+        wakefulness.noteSignal();
+        await flush();
+        expect(subscription.active.value).equal(true);
+
+        // Simulate underlying subscription closing (peer went idle); the subscription wires `closed` on the request.
+        lastRequest?.closed?.();
+        await flush();
+
+        // Within the availability window the peer is still expected -> remain active even though parked.
+        await MockTime.advance(20_000);
+        await flush();
+        expect(subscription.active.value).equal(true);
+        expect(subscription.inactive.value).equal(false);
+
+        // Availability window (idle 30s + 5s margin) lapses -> inactive.
+        await MockTime.advance(20_000);
+        await flush();
+        expect(wakefulness.available.value).equal(false);
+        expect(subscription.active.value).equal(false);
+        expect(subscription.inactive.value).equal(true);
+
+        subscription.close();
+        await MockTime.resolve(subscription.done, { macrotasks: true });
+    });
+
+    it("parks on subscribe failure instead of running a timed retry", async () => {
+        const wakefulness = litWakefulness();
+
+        let subscribeCount = 0;
+        const subscription = build(wakefulness, {
+            subscribe: async () => {
+                subscribeCount++;
+                if (subscribeCount === 1) {
+                    throw new Error("transient send failure to now-asleep peer");
+                }
+                return fakePeerSub();
+            },
+        });
+
+        wakefulness.noteSignal();
+        await flush();
+        expect(subscribeCount).equal(1);
+
+        // No timed retry: advancing well past the 15s SustainedSubscription schedule must not resubscribe.
+        await MockTime.advance(60_000);
+        await flush();
+        expect(subscribeCount).equal(1);
+
+        // Next wake signal triggers the retry.
+        wakefulness.noteSignal();
+        await flush();
+        expect(subscribeCount).equal(2);
+        expect(subscription.active.value).equal(true);
+
+        subscription.close();
+        await MockTime.resolve(subscription.done, { macrotasks: true });
+    });
+
+    it("close() resolves done cleanly while parked", async () => {
+        const wakefulness = litWakefulness();
+        const subscription = build(wakefulness);
+
+        await flush();
+        subscription.close();
+
+        const result = await MockTime.resolve(
+            subscription.done!.then(() => "ok" as const),
+            { macrotasks: true },
+        );
+        expect(result).equal("ok");
+    });
+
+    it("closes the active peer subscription on abort", async () => {
+        const wakefulness = litWakefulness();
+
+        let peerSubClosed = 0;
+        const subscription = build(wakefulness, {
+            subscribe: async () => fakePeerSub(() => peerSubClosed++),
+        });
+
+        wakefulness.noteSignal();
+        await flush();
+
+        subscription.close();
+        await MockTime.resolve(subscription.done, { macrotasks: true });
+
+        expect(peerSubClosed).equal(1);
+        expect(subscription.subscriptionId).equal(ClientSubscription.NO_SUBSCRIPTION);
+    });
+});

--- a/packages/protocol/test/action/client/subscription/subscriptionForTest.ts
+++ b/packages/protocol/test/action/client/subscription/subscriptionForTest.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { SustainedClientSubscribe } from "#action/client/subscription/ClientSubscribe.js";
+import { IcdSustainedSubscription } from "#action/client/subscription/IcdSustainedSubscription.js";
+import { PeerSubscription } from "#action/client/subscription/PeerSubscription.js";
+import { SustainedSubscription } from "#action/client/subscription/SustainedSubscription.js";
+import { subscriptionFor } from "#action/client/subscription/subscriptionFor.js";
+import { IcdPeerWakefulness } from "#icd/IcdPeerWakefulness.js";
+import { PeerAddress } from "#peer/PeerAddress.js";
+import { Entropy, Lifetime, RetrySchedule, Seconds } from "@matter/general";
+import { FabricIndex, NodeId } from "@matter/types";
+
+function fakePeerSub(): PeerSubscription {
+    return {
+        subscriptionId: 1,
+        maxInterval: 60,
+        interactionModelRevision: 12,
+        close: async () => {},
+    } as unknown as PeerSubscription;
+}
+
+function litWakefulness() {
+    const wakefulness = new IcdPeerWakefulness();
+    wakefulness.setTimings({ activeModeThreshold: Seconds(5), idleModeDuration: Seconds(30) });
+    wakefulness.requiresAwait = true; // start asleep so the parked run loop does not subscribe
+    return wakefulness;
+}
+
+function sustainedConfig(): SustainedSubscription.Configuration {
+    const lifetime = Lifetime("test subscriptionFor");
+    const peer = PeerAddress({ fabricIndex: FabricIndex(1), nodeId: NodeId(BigInt(1)) });
+    const entropy = { randomUint32: 0 } as Entropy;
+
+    return {
+        request: { sustain: true } as SustainedClientSubscribe,
+        peer,
+        closed: () => {},
+        lifetime,
+        subscribe: async () => fakePeerSub(),
+        read: () => {
+            throw new Error("read should not be invoked when bootstrapWithRead is unset");
+        },
+        probe: async () => true,
+        retries: new RetrySchedule(entropy, SustainedSubscription.DefaultRetrySchedule),
+    };
+}
+
+async function dispose(subscription: { close(): void; done?: Promise<unknown> }) {
+    subscription.close();
+    await subscription.done;
+}
+
+describe("subscriptionFor", () => {
+    it("returns an IcdSustainedSubscription for a LIT peer with wakefulness", async () => {
+        const wakefulness = litWakefulness();
+        const subscription = subscriptionFor(
+            { isLongIdleTimeOperating: true },
+            { sustained: sustainedConfig(), wakefulness },
+        );
+
+        expect(subscription instanceof IcdSustainedSubscription).equal(true);
+
+        await dispose(subscription);
+    });
+
+    it("returns a SustainedSubscription for a non-LIT peer", async () => {
+        const subscription = subscriptionFor({ isLongIdleTimeOperating: false }, { sustained: sustainedConfig() });
+
+        expect(subscription instanceof SustainedSubscription).equal(true);
+
+        await dispose(subscription);
+    });
+
+    it("falls back to SustainedSubscription for a LIT peer when wakefulness is missing", async () => {
+        const subscription = subscriptionFor({ isLongIdleTimeOperating: true }, { sustained: sustainedConfig() });
+
+        expect(subscription instanceof SustainedSubscription).equal(true);
+
+        await dispose(subscription);
+    });
+});

--- a/packages/protocol/test/icd/FabricIcdTest.ts
+++ b/packages/protocol/test/icd/FabricIcdTest.ts
@@ -6,6 +6,7 @@
 
 import { CheckInMessage } from "#icd/CheckInMessage.js";
 import { FabricIcd } from "#icd/FabricIcd.js";
+import { IcdPeerWakefulness } from "#icd/IcdPeerWakefulness.js";
 import { Bytes, StandardCrypto } from "@matter/general";
 import { NodeId } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
@@ -133,6 +134,43 @@ describe("FabricIcd", () => {
             const result = await icd.processCheckIn(payload);
 
             expect(result).false;
+        });
+    });
+
+    describe("controller role — wakefulness", () => {
+        it("wakefulnessFor returns an IcdPeerWakefulness after addPeer", () => {
+            const icd = fabricIcd();
+            icd.addPeer({ peerNodeId: NodeId(11), key: KEY_A, counterStart: 10, lastOffset: 0 }, () => {});
+
+            expect(icd.wakefulnessFor(NodeId(11))).instanceof(IcdPeerWakefulness);
+        });
+
+        it("processCheckIn calls noteSignal on the matching peer's wakefulness", async () => {
+            const icd = fabricIcd();
+            icd.addPeer({ peerNodeId: NodeId(11), key: KEY_A, counterStart: 10, lastOffset: 0 }, () => {});
+
+            const wakefulness = icd.wakefulnessFor(NodeId(11))!;
+            wakefulness.requiresAwait = true;
+            expect(wakefulness.awake.value).false;
+
+            const payload = await CheckInMessage.encodeIcd(crypto, KEY_A, 12, 5000);
+            await icd.processCheckIn(payload);
+
+            expect(wakefulness.awake.value).true;
+            wakefulness.close();
+        });
+
+        it("wakefulnessFor returns undefined after deletePeer", () => {
+            const icd = fabricIcd();
+            icd.addPeer({ peerNodeId: NodeId(11), key: KEY_A, counterStart: 10, lastOffset: 0 }, () => {});
+            icd.deletePeer(NodeId(11));
+
+            expect(icd.wakefulnessFor(NodeId(11))).undefined;
+        });
+
+        it("wakefulnessFor returns undefined for unknown peer", () => {
+            const icd = fabricIcd();
+            expect(icd.wakefulnessFor(NodeId(99))).undefined;
         });
     });
 });

--- a/packages/protocol/test/icd/IcdPeerWakefulnessTest.ts
+++ b/packages/protocol/test/icd/IcdPeerWakefulnessTest.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IcdPeerWakefulness } from "#icd/IcdPeerWakefulness.js";
+import { Millis, Seconds } from "@matter/general";
+
+describe("IcdPeerWakefulness", () => {
+    before(MockTime.enable);
+
+    function lit() {
+        const w = new IcdPeerWakefulness();
+        w.setTimings({ activeModeThreshold: Millis(4000), idleModeDuration: Seconds(30) });
+        w.requiresAwait = true;
+        return w;
+    }
+
+    it("non-LIT is always awake and available", () => {
+        const w = new IcdPeerWakefulness();
+        expect(w.awake.value).equals(true);
+        expect(w.available.value).equals(true);
+    });
+
+    it("starts not-awake/not-available for a LIT peer with no signal", () => {
+        const w = lit();
+        expect(w.awake.value).equals(false);
+        expect(w.available.value).equals(false);
+    });
+
+    it("noteSignal makes awake+available true, awake expires after SAT", async () => {
+        const w = lit();
+        w.noteSignal();
+        expect(w.awake.value).equals(true);
+        expect(w.available.value).equals(true);
+        await MockTime.advance(Millis(4001));
+        expect(w.awake.value).equals(false);
+        expect(w.available.value).equals(true);
+    });
+
+    it("available expires after idleModeDuration + margin", async () => {
+        const w = lit();
+        w.noteSignal();
+        await MockTime.advance(Millis(Seconds(30) + IcdPeerWakefulness.AVAILABILITY_MARGIN + 1));
+        expect(w.available.value).equals(false);
+    });
+
+    it("noteStayActive extends the awake window", async () => {
+        const w = lit();
+        w.noteSignal();
+        w.noteStayActive(Seconds(10));
+        await MockTime.advance(Millis(4001));
+        expect(w.awake.value).equals(true);
+        await MockTime.advance(Seconds(7));
+        expect(w.awake.value).equals(false);
+    });
+
+    it("noteStayActive past the idle window keeps available true (awake => available)", async () => {
+        const w = lit();
+        w.noteStayActive(Seconds(60));
+        await MockTime.advance(Millis(Seconds(30) + IcdPeerWakefulness.AVAILABILITY_MARGIN + 1));
+        expect(w.awake.value).equals(true);
+        expect(w.available.value).equals(true);
+        await MockTime.advance(Seconds(30));
+        expect(w.awake.value).equals(false);
+        expect(w.available.value).equals(false);
+    });
+
+    it("a LIT->SIT flip forces both true and cancels timers", () => {
+        const w = lit();
+        w.requiresAwait = false;
+        expect(w.awake.value).equals(true);
+        expect(w.available.value).equals(true);
+    });
+});

--- a/packages/protocol/test/peer/PhysicalDevicePropertiesTest.ts
+++ b/packages/protocol/test/peer/PhysicalDevicePropertiesTest.ts
@@ -18,10 +18,17 @@ const BASE_PROPERTIES: PhysicalDeviceProperties = {
     isMainsPowered: true,
     isBatteryPowered: false,
     isIntermittentlyConnected: false,
+    isLongIdleTimeOperating: false,
     isThreadSleepyEndDevice: false,
 };
 
 describe("PhysicalDeviceProperties", () => {
+    describe("isLongIdleTimeOperating", () => {
+        it("defaults to false in BASE_PROPERTIES", () => {
+            expect(BASE_PROPERTIES.isLongIdleTimeOperating).to.equal(false);
+        });
+    });
+
     describe("subscriptionIntervalBoundsFor", () => {
         describe("minIntervalFloor", () => {
             it("defaults to 1 second when called with no arguments", () => {
@@ -147,7 +154,7 @@ describe("PhysicalDeviceProperties", () => {
                 expect(maxIntervalCeiling).to.equal(Minutes(1));
             });
 
-            it("does not apply jitter when Thread is active for ICD device with Instant floor", () => {
+            it("applies jitter when Thread is active for ICD device with Instant floor", () => {
                 const { minIntervalFloor, maxIntervalCeiling } = subscriptionIntervalBoundsFor({
                     properties: {
                         ...BASE_PROPERTIES,

--- a/packages/protocol/test/protocol/MessageExchangeTest.ts
+++ b/packages/protocol/test/protocol/MessageExchangeTest.ts
@@ -218,4 +218,13 @@ describe("MessageExchange", () => {
             expect(sentMessages[0].payloadHeader.messageType).equals(0x10);
         });
     });
+
+    describe("ICD operational discovery on retry (MRP 4.12)", () => {
+        // TODO(ICD phase 3b-4 follow-up): the retransmission path does not yet start Operational Discovery in parallel
+        // with the first MRP retry for an ICD peer, nor adopt freshly discovered address/MRP parameters mid-exchange
+        // (MessageExchange #addressOverride is fixed at construction). Implement, then un-skip this test.
+        it(
+            "starts operational discovery in parallel with the first retry and adopts discovered params for an ICD peer",
+        );
+    });
 });


### PR DESCRIPTION
## ICD Phase 3b — LIT-aware Interaction

Makes the controller honor the Matter rule that a permanent Check-In client **must await a notification (Check-In or subscription report) before sending to a LIT ICD**. Replaces blind sends / aggressive timed retries with wake-driven transmission: a per-peer wakefulness signal gates outbound interactions and parks lost subscriptions until the peer is reachable. SIT and non-ICD peers are unaffected (byte-for-byte passthrough).

Targets the ICD umbrella branch `feat/icd-protocol`. Builds on phases 1/2/3a.

### 3b-1 — classification + wakefulness
- `isLongIdleTimeOperating` on `PhysicalDeviceProperties`, derived from `IcdManagement.OperatingMode === Lit` (+ LIT feature).
- `IcdPeerWakefulness`: per-peer state machine with two sliding windows — `awake` (send-now, activeModeThreshold) and `available` (not-offline, idleModeDuration + margin). Invariant `awake ⇒ available`; non-LIT ⇒ both constant true.
- `fabric.icd` holds a wakefulness per peer; `processCheckIn` fires `noteSignal()`.
- `IcdClient` exposes a non-persisted `available` state (`available$Changed`), feeds `requiresAwait`/timings into the wakefulness (DSLS-live via an OperatingMode reactor), and feeds `stayActive` → `noteStayActive`.

### 3b-2 — `IcdSustainedSubscription`
- Subclass selected by a `subscriptionFor(physicalProperties)` factory for LIT peers; parks on the `awake` edge instead of timed-retrying, skips the liveness probe, and reports `active`/`inactive` from `available` (a parked-but-expected peer is not "offline").
- SIT/non-ICD peers keep the unchanged `SustainedSubscription` path (probe + retries).

### 3b-3 — interaction hold
- `ClientNodeInteraction` holds read/write/invoke to an idle LIT peer until it wakes (a Check-In re-arms the window), rejecting with `IcdPeerAsleepError` after `idleModeDuration + margin` (per-call overridable via `icdAwaitTimeout`). Gate keys off the live-fed `requiresAwait` and a cached `fabric.icd`; non-LIT/awake/unregistered peers pass through with no facade rebuild and no hot-path microtask.

### 3b-4 — MRP 4.12 (deferred, tracked)
- Operational-discovery-on-retry for ICD peers is **not yet implemented** (`MessageExchange.#addressOverride` is fixed at construction). Marked with a TODO at the retransmission seam + a pending regression test. Follow-up.

### Whole-branch review fixes
- Re-key in place (`FabricIcd.updatePeer`) so the wakefulness survives key refresh — a parked subscription's reference stays valid.
- `IcdSustainedSubscription` no longer strands on a runtime LIT→SIT flip (bounded resume + force-emit on flip).
- Subscription reports / bootstrap-read responses refresh the wakefulness windows.

### Deferred follow-ups (tracked in-repo)
- MRP 4.12 operational-discovery-on-retry.
- General (non-subscription) inbound-activity `noteSignal()` hook (needs a public session/exchange seam).
- Caller-abort surface for the interaction hold (`ActionContext` has none today).

### Testing
Clean build; `@matter/protocol` 1178/1178, `@matter/node` 1278/1278; format + lint green. Unit coverage for the window state machine, fabric.icd wakefulness, classification, the subclass park/active semantics, the factory selection, the hold/timeout, and the review-fix regressions. Live chip-tool interop deferred to chip-testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)