### PR TITLE
feat(shell): ICD controller commands for nodejs-shell

### DIFF
--- a/packages/node/src/behavior/system/icd/IcdClient.ts
+++ b/packages/node/src/behavior/system/icd/IcdClient.ts
@@ -63,6 +63,14 @@ export class IcdClient extends Behavior {
         return this.peerSupportsLit;
     }
 
+    /**
+     * Whether the peer is currently awake (send-now). Mirrors the per-peer wakefulness; a non-LIT or not-yet-fed peer
+     * has nothing to await and reads true. Read-only observability — hold/park still consume the signal in protocol.
+     */
+    get awake() {
+        return this.#fedWakefulness()?.awake.value ?? true;
+    }
+
     /** Whether the peer is currently operating in LIT mode (LIT-capable AND OperatingMode === Lit; a DSLS flip changes this at runtime). */
     get #peerIsLongIdleTimeOperating() {
         return (

--- a/packages/node/test/behavior/system/icd/IcdClientTest.ts
+++ b/packages/node/test/behavior/system/icd/IcdClientTest.ts
@@ -523,6 +523,27 @@ describe("IcdClient", () => {
         });
     });
 
+    describe("awake getter", () => {
+        it("defaults true unregistered, mirrors the wakefulness once registered", async () => {
+            await using site = new MockSite();
+            const { device, peer1 } = await litOperatingPair(site);
+
+            // Not registered -> no fed wakefulness -> defaults awake (nothing to await).
+            expect(await peer1.act(agent => agent.get(IcdClient).awake)).equals(true);
+
+            await peer1.act(agent => agent.get(IcdClient).register({ monitoredSubject: SubjectId(NodeId(0xabcdn)) }));
+            expect(await peer1.act(agent => agent.get(IcdClient).awake)).equals(true); // seeded on register
+
+            await MockTime.advance(Seconds(3700)); // past idle+margin, no check-in
+            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+            expect(await peer1.act(agent => agent.get(IcdClient).awake)).equals(false);
+
+            await wakeDevice(device); // device Check-In re-arms awake
+            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+            expect(await peer1.act(agent => agent.get(IcdClient).awake)).equals(true);
+        });
+    });
+
     describe("decommission cleanup", () => {
         it("unregisters locally when the node is decommissioned", async () => {
             await using site = new MockSite();

--- a/packages/nodejs-shell/src/shell/Shell.ts
+++ b/packages/nodejs-shell/src/shell/Shell.ts
@@ -21,6 +21,7 @@ import cmdCommission from "./cmd_commission.js";
 import cmdConfig from "./cmd_config.js";
 import cmdDcl from "./cmd_dcl.js";
 import cmdDiscover from "./cmd_discover.js";
+import cmdIcd from "./cmd_icd.js";
 import cmdIdentify from "./cmd_identify.js";
 import cmdNodes from "./cmd_nodes.js";
 import cmdOta from "./cmd_ota.js";
@@ -171,6 +172,7 @@ export class Shell {
                     cmdVendor(this.theNode),
                     cmdTlv(),
                     cmdDcl(),
+                    cmdIcd(this.theNode),
                     exitCommand(),
                 ])
                 .command({

--- a/packages/nodejs-shell/src/shell/cmd_icd.ts
+++ b/packages/nodejs-shell/src/shell/cmd_icd.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Duration, Millis } from "@matter/general";
 import { IcdClient, IcdMultiAdminError } from "@matter/node";
 import { IcdManagementClient } from "@matter/node/behaviors/icd-management";
 import { NodeId, SubjectId, VendorId } from "@matter/types";
@@ -115,6 +116,25 @@ export default function commands(theNode: MatterNode) {
                         const clientNode = await clientNodeFor(theNode, argv.nodeId);
                         await clientNode.act(agent => agent.get(IcdClient).unregister());
                         console.log(`Unregistered Check-In client on node ${argv.nodeId}`);
+                    },
+                })
+                .command({
+                    command: "stay-active <node-id> [duration-ms]",
+                    describe: "Ask the peer to stay in Active mode; prints the promised duration",
+                    builder: (y: Argv) =>
+                        y
+                            .positional("node-id", { describe: "node id", type: "string", demandOption: true })
+                            .positional("duration-ms", {
+                                describe: "requested active duration (ms)",
+                                type: "number",
+                                default: 30000,
+                            }),
+                    handler: async (argv: any) => {
+                        const clientNode = await clientNodeFor(theNode, argv.nodeId);
+                        const promised = await clientNode.act(agent =>
+                            agent.get(IcdClient).stayActive(Millis(argv.durationMs)),
+                        );
+                        console.log(`Node ${argv.nodeId} promised active for ${Duration.format(promised)}`);
                     },
                 })
                 .command({

--- a/packages/nodejs-shell/src/shell/cmd_icd.ts
+++ b/packages/nodejs-shell/src/shell/cmd_icd.ts
@@ -5,10 +5,41 @@
  */
 
 import { IcdClient, IcdMultiAdminError } from "@matter/node";
+import { IcdManagementClient } from "@matter/node/behaviors/icd-management";
 import { NodeId, SubjectId, VendorId } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
+import { PairedNode } from "@project-chip/matter.js/device";
 import type { Argv } from "yargs";
 import { MatterNode } from "../MatterNode.js";
+
+async function printStatus(paired: PairedNode) {
+    const clientNode = paired.node;
+    if (!clientNode.behaviors.has(IcdClient)) {
+        return;
+    }
+    const icd = clientNode.stateOf(IcdClient);
+    const mgmt = clientNode.maybeStateOf(IcdManagementClient);
+    const supportsLit = clientNode.maybeFeaturesOf(IcdManagementClient)?.longIdleTimeSupport === true;
+    const awake = await clientNode.act(agent => agent.get(IcdClient).awake);
+    const operatingModeLabel =
+        mgmt === undefined
+            ? "n/a"
+            : (IcdManagement.OperatingMode[mgmt.operatingMode ?? -1] ?? mgmt.operatingMode ?? "unknown");
+    console.log(
+        [
+            `node ${paired.nodeId}:`,
+            `  registered=${icd.registered}`,
+            `  available=${icd.available}`,
+            `  awake=${awake}`,
+            `  supportsLit=${supportsLit}`,
+            `  operatingMode=${operatingModeLabel}`,
+            `  activeModeThreshold(ms)=${mgmt?.activeModeThreshold ?? "n/a"}`,
+            `  idleModeDuration(s)=${mgmt?.idleModeDuration ?? "n/a"}`,
+            `  lastCheckIn=${icd.lastCheckInReceivedAt ?? "never"}`,
+            `  counterStart=${icd.counterStart ?? "n/a"} lastOffset=${icd.lastOffset ?? "n/a"}`,
+        ].join("\n"),
+    );
+}
 
 async function clientNodeFor(theNode: MatterNode, nodeIdStr: string) {
     const paired = (await theNode.connectAndGetNodes(nodeIdStr))[0];
@@ -84,6 +115,18 @@ export default function commands(theNode: MatterNode) {
                         const clientNode = await clientNodeFor(theNode, argv.nodeId);
                         await clientNode.act(agent => agent.get(IcdClient).unregister());
                         console.log(`Unregistered Check-In client on node ${argv.nodeId}`);
+                    },
+                })
+                .command({
+                    command: "status [node-id]",
+                    describe: "Show ICD state for one peer, or all ICD peers if no id",
+                    builder: (y: Argv) =>
+                        y.positional("node-id", { describe: "node id", type: "string", default: undefined }),
+                    handler: async (argv: any) => {
+                        const nodes = await theNode.connectAndGetNodes(argv.nodeId);
+                        for (const paired of nodes) {
+                            await printStatus(paired);
+                        }
                     },
                 })
                 .demandCommand(1, "You must specify an icd subcommand"),

--- a/packages/nodejs-shell/src/shell/cmd_icd.ts
+++ b/packages/nodejs-shell/src/shell/cmd_icd.ts
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IcdClient, IcdMultiAdminError } from "@matter/node";
+import { NodeId, SubjectId, VendorId } from "@matter/types";
+import { IcdManagement } from "@matter/types/clusters/icd-management";
+import type { Argv } from "yargs";
+import { MatterNode } from "../MatterNode.js";
+
+async function clientNodeFor(theNode: MatterNode, nodeIdStr: string) {
+    const paired = (await theNode.connectAndGetNodes(nodeIdStr))[0];
+    if (paired === undefined) {
+        throw new Error(`Node ${nodeIdStr} not found / not connected`);
+    }
+    const clientNode = paired.node;
+    if (!clientNode.behaviors.has(IcdClient)) {
+        throw new Error(`Node ${nodeIdStr} is not an ICD device (no IcdManagement cluster)`);
+    }
+    return clientNode;
+}
+
+export default function commands(theNode: MatterNode) {
+    return {
+        command: "icd",
+        describe: "Controller-side ICD (Intermittently Connected Device) operations",
+        builder: (yargs: Argv) =>
+            yargs
+                .command({
+                    command: "register <node-id>",
+                    describe: "Register this controller as a Check-In client on the peer",
+                    builder: (y: Argv) =>
+                        y
+                            .positional("node-id", { describe: "node id", type: "string", demandOption: true })
+                            .option("subject", { describe: "monitored subject id", type: "string" })
+                            .option("type", {
+                                describe: "client type",
+                                choices: ["permanent", "ephemeral"] as const,
+                                default: "permanent" as const,
+                            })
+                            .option("allow-multi-admin", {
+                                describe: "allow registering alongside other-vendor admins",
+                                type: "boolean",
+                                default: false,
+                            })
+                            .option("ignore-vendor", {
+                                describe: "vendor id(s) to treat as trusted",
+                                type: "array",
+                            }),
+                    handler: async (argv: any) => {
+                        const clientNode = await clientNodeFor(theNode, argv.nodeId);
+                        const options = {
+                            monitoredSubject:
+                                argv.subject === undefined ? undefined : SubjectId(NodeId(BigInt(argv.subject))),
+                            clientType:
+                                argv.type === "ephemeral"
+                                    ? IcdManagement.ClientType.Ephemeral
+                                    : IcdManagement.ClientType.Permanent,
+                            allowMultiAdmin: argv.allowMultiAdmin,
+                            ignoredVendors: argv.ignoreVendor?.map((v: string | number) => VendorId(Number(v))),
+                        };
+                        try {
+                            await clientNode.act(agent => agent.get(IcdClient).register(options));
+                            console.log(`Registered as Check-In client on node ${argv.nodeId}`);
+                        } catch (e) {
+                            if (e instanceof IcdMultiAdminError) {
+                                console.log(
+                                    `Refused: peer has other-vendor admins (${e.adminVendorIds.join(", ")}). Re-run with --allow-multi-admin to proceed.`,
+                                );
+                                return;
+                            }
+                            throw e;
+                        }
+                    },
+                })
+                .command({
+                    command: "unregister <node-id>",
+                    describe: "Remove this controller's Check-In registration from the peer",
+                    builder: (y: Argv) =>
+                        y.positional("node-id", { describe: "node id", type: "string", demandOption: true }),
+                    handler: async (argv: any) => {
+                        const clientNode = await clientNodeFor(theNode, argv.nodeId);
+                        await clientNode.act(agent => agent.get(IcdClient).unregister());
+                        console.log(`Unregistered Check-In client on node ${argv.nodeId}`);
+                    },
+                })
+                .demandCommand(1, "You must specify an icd subcommand"),
+        handler: async (argv: any) => {
+            argv.unhandled = true;
+        },
+    };
+}

--- a/packages/nodejs-shell/src/shell/cmd_icd.ts
+++ b/packages/nodejs-shell/src/shell/cmd_icd.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Duration, Millis } from "@matter/general";
+import { Duration, Millis, ObserverGroup } from "@matter/general";
 import { IcdClient, IcdMultiAdminError } from "@matter/node";
 import { IcdManagementClient } from "@matter/node/behaviors/icd-management";
 import { NodeId, SubjectId, VendorId } from "@matter/types";
@@ -12,6 +12,8 @@ import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { PairedNode } from "@project-chip/matter.js/device";
 import type { Argv } from "yargs";
 import { MatterNode } from "../MatterNode.js";
+
+const watchers = new Map<string, ObserverGroup>();
 
 async function printStatus(paired: PairedNode) {
     const clientNode = paired.node;
@@ -147,6 +149,41 @@ export default function commands(theNode: MatterNode) {
                         for (const paired of nodes) {
                             await printStatus(paired);
                         }
+                    },
+                })
+                .command({
+                    command: "watch <node-id> [state]",
+                    describe:
+                        "Stream ICD events for a peer live (state: on|off, default on); awake is shown by `icd status`",
+                    builder: (y: Argv) =>
+                        y
+                            .positional("node-id", { describe: "node id", type: "string", demandOption: true })
+                            .positional("state", {
+                                describe: "on|off",
+                                choices: ["on", "off"] as const,
+                                default: "on" as const,
+                            }),
+                    handler: async (argv: any) => {
+                        const key = String(argv.nodeId);
+                        watchers.get(key)?.close();
+                        watchers.delete(key);
+                        if (argv.state === "off") {
+                            console.log(`Stopped watching node ${argv.nodeId}`);
+                            return;
+                        }
+                        const clientNode = await clientNodeFor(theNode, argv.nodeId);
+                        const observers = new ObserverGroup();
+                        const stamp = (msg: string) => console.log(`[icd ${argv.nodeId}] ${msg}`);
+                        const events = clientNode.eventsOf(IcdClient);
+                        observers.on(events.registered, () => stamp("registered"));
+                        observers.on(events.unregistered, () => stamp("unregistered"));
+                        observers.on(events.checkedIn, ({ counter, activeModeThreshold }) =>
+                            stamp(`check-in counter=${counter} SAT(ms)=${activeModeThreshold}`),
+                        );
+                        observers.on(events.keyRefreshed, () => stamp("key refreshed"));
+                        observers.on(events.available$Changed, (value: boolean) => stamp(`available=${value}`));
+                        watchers.set(key, observers);
+                        console.log(`Watching node ${argv.nodeId} (run \`icd watch ${argv.nodeId} off\` to stop)`);
                     },
                 })
                 .demandCommand(1, "You must specify an icd subcommand"),

--- a/packages/protocol/test/peer/PhysicalDevicePropertiesTest.ts
+++ b/packages/protocol/test/peer/PhysicalDevicePropertiesTest.ts
@@ -5,7 +5,7 @@
  */
 
 import { PhysicalDeviceProperties } from "#peer/PhysicalDeviceProperties.js";
-import { Instant, Minutes, Seconds } from "@matter/general";
+import { Instant, Seconds } from "@matter/general";
 
 const { subscriptionIntervalBoundsFor } = PhysicalDeviceProperties;
 
@@ -151,12 +151,12 @@ describe("PhysicalDeviceProperties", () => {
                 expectJittered(maxIntervalCeiling, 60);
             });
 
-            it("does not apply jitter when Thread is not active", () => {
+            it("applies jitter when Thread is not active", () => {
                 const { maxIntervalCeiling } = subscriptionIntervalBoundsFor({
                     properties: { ...BASE_PROPERTIES, supportsThread: true, threadActive: false },
                 });
 
-                expect(maxIntervalCeiling).to.equal(Minutes(1));
+                expectJittered(maxIntervalCeiling, 60);
             });
 
             it("applies jitter for an ICD device while keeping the Instant floor", () => {


### PR DESCRIPTION
## ICD shell commands

Adds an `icd` command group to the nodejs-shell so a developer can drive and observe controller-side ICD behavior against **real devices**. Reaches the existing `IcdClient` behavior through `pairedNode.node` (the peer's `ClientNode`); no new protocol behavior beyond one read-only getter.

Targets `feat/icd-protocol` (builds on ICD 3a/3b).

### Commands
- `icd register <node-id> [--subject <id>] [--type permanent|ephemeral] [--allow-multi-admin] [--ignore-vendor <id>…]` — register as a Check-In client. On `IcdMultiAdminError`, prints the offending vendors + the `--allow-multi-admin` hint.
- `icd unregister <node-id>` — remove the registration (best-effort on peer).
- `icd status [node-id]` — snapshot: registered, available, awake, supportsLit, operatingMode, activeModeThreshold (SAT), idleModeDuration, lastCheckIn, counter. All ICD peers if no id.
- `icd stay-active <node-id> [duration-ms=30000]` — prints the promised active duration.
- `icd watch <node-id> [on|off]` — streams `registered`/`unregistered`/`checkedIn`/`keyRefreshed`/`available` events live until turned off (per-node observer teardown). `awake` is a point-in-time value shown by `icd status`.

### Supporting changes
- `IcdClient.awake` — small read-only getter mirroring the peer's fed `fabric.icd` wakefulness (defaults true when non-LIT / unfed). Lets `status`/`watch` show awake without the shell reaching into protocol internals.
- Fixes a flaky `PhysicalDevicePropertiesTest` jitter expectation left by a branch merge (production always applies jitter; the test asserted an exact ceiling and passed only when `Math.random()` rounded to 0).

### Notes
- Shell-only convention: command handlers let errors (unknown / non-ICD peer) propagate to the shell's top-level try/catch, which prints them. No casts; public `ClientNode`/`IcdClient` API only.
- The shell wraps the legacy `CommissioningController`; ICD is reached via `PairedNode.node`. No legacy-path ICD APIs.

### Testing
`IcdClient.awake` unit-tested (24/24 IcdClient). Shell commands are gated on `npm run build -- --clean`, `npm run format-verify`, `npm run lint` (the shell has no per-command unit harness) and a manual real-device checklist (register → status → watch a Check-In → stay-active → unregister).

🤖 Generated with [Claude Code](https://claude.com/claude-code)