### PR TITLE
fix(protocol): apply peer-medium MRP delay to executed commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The main work (all changes without a GitHub username in brackets in the below li
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+
+- @matter/protocol
+    - Fix: Ensure that the peer-medium-specific `additionalMrpDelay` is also used for executed commands, and added an optional per-request `additionalMrpDelay` override
+
 ## 0.17.2 (2026-06-09)
 
 - @matter/general

--- a/packages/protocol/src/action/client/ClientInteraction.ts
+++ b/packages/protocol/src/action/client/ClientInteraction.ts
@@ -97,6 +97,7 @@ interface PendingCommand {
     request: Invoke.ConcreteCommandRequest<any>;
     pathKey: string;
     network?: string;
+    additionalMrpDelay?: Duration;
     resolve: (entry: InvokeResult.DecodedData | undefined) => void;
     reject: (error: Error) => void;
     aborted?: boolean;
@@ -612,6 +613,7 @@ export class ClientInteraction<
             request: { ...cmd, commandRef } as Invoke.ConcreteCommandRequest<any>,
             pathKey,
             network: request.network,
+            additionalMrpDelay: request.additionalMrpDelay,
             resolve: resolver,
             reject: rejecter,
         };
@@ -764,6 +766,9 @@ export class ClientInteraction<
             // Preserve the network profile from the queued commands (all commands in a batch share the same
             // ClientInteraction so they will normally have the same network; pick the first defined value)
             const batchNetwork = commandList.find(c => c.network !== undefined)?.network;
+            const batchAdditionalMrpDelay = commandList.find(
+                c => c.additionalMrpDelay !== undefined,
+            )?.additionalMrpDelay;
 
             // Use #invokeSingle directly to avoid re-entering the batching path in invoke()
             // Skip validation: already validated on submit. timed=false: only non-timed commands
@@ -771,6 +776,7 @@ export class ClientInteraction<
             const batchRequest = {
                 ...Invoke({ commands: invokeRequests, skipValidation: true, timed: false }),
                 network: batchNetwork,
+                additionalMrpDelay: batchAdditionalMrpDelay,
             } as ClientInvoke;
             const maxPathsPerInvoke = this.#exchangeProvider.maxPathsPerInvoke ?? 1;
             const chunks =
@@ -1037,6 +1043,7 @@ export class ClientInteraction<
             try {
                 messenger = await InteractionClientMessenger.create(this.#exchangeProvider, {
                     network: request.network ?? this.#network,
+                    additionalMrpDelay: request.additionalMrpDelay,
                     abort,
                     connectionTimeout: session?.connectionTimeout,
                     addressOverride: request.addressOverride,

--- a/packages/protocol/src/action/client/ClientRequest.ts
+++ b/packages/protocol/src/action/client/ClientRequest.ts
@@ -5,7 +5,7 @@
  */
 
 import type { NetworkProfile } from "#peer/NetworkProfile.js";
-import type { ServerAddressUdp } from "@matter/general";
+import type { Duration, ServerAddressUdp } from "@matter/general";
 
 /**
  * Represents a client request with customizable transmission behavior.
@@ -22,6 +22,14 @@ export interface ClientRequest {
      * @see {@link NetworkProfile}
      */
     network?: string;
+
+    /**
+     * Override the peer-medium MRP retransmission margin for this interaction.
+     *
+     * By default the margin derives from the peer's network medium (e.g. thread's longer margin), independent of
+     * the {@link network} throttle profile.  Set this to override that default for a single interaction.
+     */
+    additionalMrpDelay?: Duration;
 
     /**
      * Override the destination address for this interaction's exchange.

--- a/packages/protocol/src/peer/Peer.ts
+++ b/packages/protocol/src/peer/Peer.ts
@@ -579,6 +579,7 @@ export class Peer {
 
             done: PeerConnection(this, this.#context, {
                 network: options?.network,
+                additionalMrpDelay: options?.additionalMrpDelay,
                 timing: options?.timing,
                 requiredTransport: options?.requiredTransport,
                 preferredTransport: options?.preferredTransport,
@@ -620,6 +621,12 @@ export namespace Peer {
          * Network identifier used for timing parameters.
          */
         network?: string;
+
+        /**
+         * Per-call override for the peer-medium MRP retransmission margin.  When omitted the margin derives from
+         * the peer's network medium, independent of any {@link network} throttle override.
+         */
+        additionalMrpDelay?: Duration;
 
         /**
          * A timeout relative to beginning of connection process.

--- a/packages/protocol/src/peer/PeerConnection.ts
+++ b/packages/protocol/src/peer/PeerConnection.ts
@@ -109,6 +109,9 @@ export async function PeerConnection(
 
     // Reserve network communication slot
     let network = context.networks.select(peer, options?.network);
+    const mediumProfile = context.networks.forPeer(peer);
+    const peerAdditionalMrpDelay =
+        options?.additionalMrpDelay ?? mediumProfile.connect?.additionalMrpDelay ?? mediumProfile.additionalMrpDelay;
     if (network.connect) {
         network = network.connect;
     }
@@ -456,7 +459,13 @@ export async function PeerConnection(
                 isInitiator: true,
             });
 
-            await using exchange = PeerConnection.createExchange(peer, context.exchanges, unsecuredSession, network);
+            await using exchange = PeerConnection.createExchange(
+                peer,
+                context.exchanges,
+                unsecuredSession,
+                network,
+                peerAdditionalMrpDelay,
+            );
 
             info(
                 Diagnostic.via(`${peer.address.toString()}${exchange.via}`),
@@ -691,6 +700,13 @@ export namespace PeerConnection {
     export interface Options {
         abort?: AbortSignal;
         network?: string;
+
+        /**
+         * Per-call override for the peer-medium MRP retransmission margin.  When omitted the margin derives from
+         * the peer's network medium, independent of any {@link network} throttle override.
+         */
+        additionalMrpDelay?: Duration;
+
         kicker?: Observable<[KickOrigin]>;
 
         /** See {@link Peer.ConnectOptions.requiredTransport}. */
@@ -718,10 +734,17 @@ export namespace PeerConnection {
         exchanges: ExchangeManager,
         session: Session,
         network: NetworkProfile,
+        peerAdditionalMrpDelay?: Duration,
         protocol = SECURE_CHANNEL_PROTOCOL_ID,
         addressOverride?: ServerAddressUdp,
     ) {
-        return exchanges.initiateExchangeForSession(session, protocol, { onSend, onReceive, network, addressOverride });
+        return exchanges.initiateExchangeForSession(session, protocol, {
+            onSend,
+            onReceive,
+            network,
+            peerAdditionalMrpDelay,
+            addressOverride,
+        });
 
         function onSend(_message: Message, retransmission: number) {
             if (retransmission) {

--- a/packages/protocol/src/peer/PeerExchangeProvider.ts
+++ b/packages/protocol/src/peer/PeerExchangeProvider.ts
@@ -51,6 +51,7 @@ export class PeerExchangeProvider extends ExchangeProvider {
         await this.#peer.connect({
             abort: options?.abort,
             network: options?.network,
+            additionalMrpDelay: options?.additionalMrpDelay,
             connectionTimeout: options?.connectionTimeout,
             requiredTransport: options?.requiredTransport,
             preferredTransport: options?.preferredTransport,
@@ -72,6 +73,8 @@ export class PeerExchangeProvider extends ExchangeProvider {
             }
 
             const network = this.#context.networks.select(this.#peer, options?.network);
+            const peerAdditionalMrpDelay =
+                options?.additionalMrpDelay ?? this.#context.networks.forPeer(this.#peer).additionalMrpDelay;
             const slot = await network.semaphore.obtainSlot(abort);
 
             try {
@@ -112,6 +115,7 @@ export class PeerExchangeProvider extends ExchangeProvider {
                     this.#context.exchanges,
                     session,
                     network,
+                    peerAdditionalMrpDelay,
                     options?.protocol ?? INTERACTION_PROTOCOL_ID,
                     options?.addressOverride,
                 );

--- a/packages/protocol/src/protocol/ExchangeProvider.ts
+++ b/packages/protocol/src/protocol/ExchangeProvider.ts
@@ -33,6 +33,12 @@ export interface NewExchangeOptions extends Omit<InteractionSettings, "transacti
     network?: string;
 
     /**
+     * Per-call override for the peer-medium MRP retransmission margin.  When omitted the margin derives from the
+     * peer's network medium, independent of any {@link network} throttle override.
+     */
+    additionalMrpDelay?: Duration;
+
+    /**
      * Optional address override for the exchange.  When set, messages are sent to this address
      * instead of the session's default peer address.
      */

--- a/packages/protocol/src/protocol/ExchangeProvider.ts
+++ b/packages/protocol/src/protocol/ExchangeProvider.ts
@@ -106,8 +106,12 @@ export class DedicatedChannelExchangeProvider extends ExchangeProvider {
         return this.#session.parameters.maxPathsPerInvoke;
     }
 
-    async initiateExchange(): Promise<MessageExchange> {
-        return this.exchangeManager.initiateExchangeForSession(this.#session, INTERACTION_PROTOCOL_ID);
+    async initiateExchange(options?: NewExchangeOptions): Promise<MessageExchange> {
+        // This provider has no peer/medium context, so the medium-derived margin is unavailable; only an explicit
+        // per-call override can apply here.
+        return this.exchangeManager.initiateExchangeForSession(this.#session, INTERACTION_PROTOCOL_ID, {
+            peerAdditionalMrpDelay: options?.additionalMrpDelay,
+        });
     }
 
     get channelType() {

--- a/packages/protocol/src/protocol/MessageExchange.ts
+++ b/packages/protocol/src/protocol/MessageExchange.ts
@@ -199,7 +199,7 @@ export class MessageExchange {
     readonly #onSend?: MessageExchange.SendNotifier;
     readonly #onReceive?: MessageExchange.ReceiveNotifier;
     readonly #addressOverride?: ServerAddressUdp;
-    readonly #network?: NetworkProfile;
+    readonly #peerAdditionalMrpDelay?: Duration;
     #receivedMessageToAck: Message | undefined;
     #receivedMessageAckTimer = Time.getTimer("ack receipt timeout", MRP.STANDALONE_ACK_TIMEOUT, () => {
         if (this.#receivedMessageToAck !== undefined) {
@@ -251,6 +251,7 @@ export class MessageExchange {
             onSend,
             onReceive,
             network,
+            peerAdditionalMrpDelay,
             addressOverride,
         } = config;
 
@@ -264,7 +265,7 @@ export class MessageExchange {
         this.#onSend = onSend;
         this.#onReceive = onReceive;
         this.#addressOverride = addressOverride;
-        this.#network = network;
+        this.#peerAdditionalMrpDelay = peerAdditionalMrpDelay;
 
         const { activeThreshold, activeInterval, idleInterval } = this.session.parameters;
 
@@ -993,7 +994,7 @@ export class MessageExchange {
     get #mrpResubmissionBackOffTime() {
         const additionalDelay = Duration.max(
             this.#context.localAdditionalMrpDelay,
-            this.#network?.additionalMrpDelay ?? Millis(0),
+            this.#peerAdditionalMrpDelay ?? Millis(0),
         );
         let backOff = this.channel.getMrpResubmissionBackOffTime(
             this.#retransmissionCounter,
@@ -1021,9 +1022,17 @@ export namespace MessageExchange {
         onReceive?: ReceiveNotifier;
 
         /**
-         * Network Profile used
+         * Network profile governing exchange throttling.  Retained for diagnostics; MRP backoff derives from
+         * {@link peerAdditionalMrpDelay} instead, so an explicit throttle override (e.g. "unlimited") does not
+         * affect retransmission timing.
          */
         network?: NetworkProfile;
+
+        /**
+         * Additive MRP retransmission margin for the peer's network medium.  Sourced independently of
+         * {@link network} so concurrency overrides cannot strip the medium-correct margin (e.g. thread's).
+         */
+        peerAdditionalMrpDelay?: Duration;
 
         /**
          * Optional address override for this exchange.  When set, messages are sent to this address

--- a/packages/protocol/test/protocol/MessageExchangeTest.ts
+++ b/packages/protocol/test/protocol/MessageExchangeTest.ts
@@ -5,10 +5,11 @@
  */
 
 import { Message } from "#codec/MessageCodec.js";
+import { NetworkProfile } from "#peer/NetworkProfile.js";
 import { MessageExchange } from "#protocol/MessageExchange.js";
 import { ProtocolMocks } from "#protocol/ProtocolMocks.js";
 import { SessionParameters } from "#session/SessionParameters.js";
-import { Bytes, MatterFlowError, Millis, NetworkError } from "@matter/general";
+import { Bytes, Duration, MatterFlowError, Millis, NetworkError, Seconds, Semaphore } from "@matter/general";
 import { BDX_PROTOCOL_ID, SECURE_CHANNEL_PROTOCOL_ID, SecureMessageType } from "@matter/types";
 
 /**
@@ -216,6 +217,82 @@ describe("MessageExchange", () => {
             expect(sentMessages.length).equals(1);
             expect(sentMessages[0].payloadHeader.protocolId).equals(BDX_PROTOCOL_ID);
             expect(sentMessages[0].payloadHeader.messageType).equals(0x10);
+        });
+    });
+
+    describe("MRP backoff margin", () => {
+        // A throttle profile whose own additionalMrpDelay is deliberately wrong; the exchange must ignore it.
+        function unlimitedThrottle(): NetworkProfile {
+            return { id: "unlimited", semaphore: new Semaphore("test", Infinity), additionalMrpDelay: Seconds(5) };
+        }
+
+        // Captures the additionalDelay the exchange passes to the channel, then aborts the send before it awaits
+        // an ack so the test does not block.
+        async function captureAdditionalDelay(options: {
+            localAdditionalMrpDelay: Duration;
+            peerAdditionalMrpDelay?: Duration;
+            network?: NetworkProfile;
+        }): Promise<Duration | undefined> {
+            // MRP only engages on unreliable transports; the default mock channel is reliable.
+            const channel = new ProtocolMocks.NetworkChannel({ index: 1 });
+            channel.isReliable = false;
+            const session = new ProtocolMocks.NodeSession({ channel });
+            let captured: Duration | undefined;
+            (session.channel as any).getMrpResubmissionBackOffTime = (
+                _retransmissionCount: number,
+                _sessionParameters: unknown,
+                _calculateMaximum: boolean,
+                additionalDelay?: Duration,
+            ) => {
+                captured = additionalDelay;
+                throw new NetworkError("captured");
+            };
+
+            const exchange = MessageExchange.initiate(
+                {
+                    session,
+                    localSessionParameters: SessionParameters(SessionParameters.defaults),
+                    localAdditionalMrpDelay: options.localAdditionalMrpDelay,
+                    async peerLost() {},
+                    retry() {},
+                },
+                1,
+                SECURE_CHANNEL_PROTOCOL_ID,
+                { network: options.network, peerAdditionalMrpDelay: options.peerAdditionalMrpDelay },
+            );
+
+            await expect(exchange.send(1, Bytes.empty, { requiresAck: true })).to.be.rejectedWith("captured");
+            return captured;
+        }
+
+        it("uses peerAdditionalMrpDelay and ignores the throttle profile margin", async () => {
+            const captured = await captureAdditionalDelay({
+                localAdditionalMrpDelay: Millis(0),
+                peerAdditionalMrpDelay: Seconds(1.5),
+                network: unlimitedThrottle(),
+            });
+
+            expect(captured).equals(Seconds(1.5));
+        });
+
+        it("falls back to localAdditionalMrpDelay as a floor when no peer margin is given", async () => {
+            const captured = await captureAdditionalDelay({
+                localAdditionalMrpDelay: Seconds(1.5),
+                peerAdditionalMrpDelay: undefined,
+                network: unlimitedThrottle(),
+            });
+
+            expect(captured).equals(Seconds(1.5));
+        });
+
+        it("applies no margin when neither local nor peer margin is set", async () => {
+            const captured = await captureAdditionalDelay({
+                localAdditionalMrpDelay: Millis(0),
+                peerAdditionalMrpDelay: undefined,
+                network: unlimitedThrottle(),
+            });
+
+            expect(captured).equals(Millis(0));
         });
     });
 });


### PR DESCRIPTION
## Problem

Command invokes force the `unlimited` network profile to bypass throttling (`ClientNodeInteraction` sets `request.network = "unlimited"` when unset). That profile carries `additionalMrpDelay = 0`, so it stripped the peer medium's MRP retransmission margin — notably Thread's 1.5s — from every invoke. On slow Thread networks this causes premature retransmissions.

Root cause: `unlimited` conflated two orthogonal concerns — exchange **throttling** (semaphore concurrency) and the **MRP backoff margin** (transport-latency correctness). The exchange derived its margin from the selected throttle profile, so a concurrency override silently zeroed the margin.

## Fix

Decouple the MRP margin from the throttle profile:

- `MessageExchange` reads a new `peerAdditionalMrpDelay` field for the backoff `max()` instead of `network.additionalMrpDelay`. The throttle profile (`network`) is retained only for diagnostics.
- `PeerExchangeProvider` (data/invoke) and `PeerConnection` (connect) compute the margin from the peer medium via `networks.forPeer(peer)`, independent of the throttle profile chosen by `select(peer, options.network)`.
- Net behavior: invoke→Thread now keeps the 1.5s margin, invoke→WiFi stays 0, and read/write/subscribe are unchanged (their `select(undefined)` already resolved to the medium profile, the same value).

## Escape hatch

Optional `additionalMrpDelay` is threaded `ClientRequest → ClientInteraction → NewExchangeOptions / Peer.ConnectOptions / PeerConnection.Options → exchange`. A per-call value replaces the medium default; `localAdditionalMrpDelay` remains a floor via `Duration.max`. Batched invokes pick the first defined value, mirroring `network`.

## Tests

- New `MessageExchange` unit tests: margin uses `peerAdditionalMrpDelay` and ignores the throttle profile; `localAdditionalMrpDelay` acts as a floor; zero when neither is set.
- protocol suite (1165) and node suite (1192) pass; clean monorepo build, format-verify, and lint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)