### PR TITLE
fix(protocol): select MRP retransmission interval by PeerActiveMode for every transmission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/protocol
     - Fix: Ensure that the peer-medium-specific `additionalMrpDelay` is also used for executed commands, and added an optional per-request `additionalMrpDelay` override
+    - Adjustment: MRP now selects the active/idle retransmission interval by peer activity for every transmission including the first, instead of forcing the first transmission to the idle interval
 
 ## 0.17.2 (2026-06-09)
 

--- a/packages/protocol/src/protocol/MRP.ts
+++ b/packages/protocol/src/protocol/MRP.ts
@@ -20,7 +20,7 @@ export namespace MRP {
     /** The scaler for random jitter in the backoff equation. */
     export const BACKOFF_JITTER = 0.25;
 
-    /** The scaler margin increase to backoff over the peer sleepy interval. */
+    /** The scaler margin increase to backoff over the applicable (active/idle) interval. */
     export const BACKOFF_MARGIN = 1.1;
 
     /** The number of retransmissions before transitioning from linear to exponential backoff. */
@@ -128,11 +128,10 @@ export namespace MRP {
     ) {
         const { activeInterval, idleInterval } = sessionParameters;
 
-        // The first message of an exchange SHALL use the idle interval; subsequent ones SHOULD use the active
-        // interval "unless the sender has other means to determine whether the device is active or idle" —
-        // isPeerActive is that means, so honor it per retransmission like CHIP does (ICD correctness)
-        const peerActive = transmissionNumber > 0 && isPeerActive;
-        let baseInterval = peerActive ? activeInterval : idleInterval;
+        // Every transmission (including the initial one) selects its interval by PeerActiveMode, re-evaluated
+        // per (re)transmission, matching CHIP GetMRPBaseTimeout(). isPeerActive already yields idle for a
+        // genuinely quiet peer, so no position-based first-message rule is needed.
+        let baseInterval = isPeerActive ? activeInterval : idleInterval;
         if (!calculateMaximum) {
             baseInterval += additionalDelay;
         }

--- a/packages/protocol/test/protocol/MRPTest.ts
+++ b/packages/protocol/test/protocol/MRPTest.ts
@@ -31,11 +31,22 @@ describe("MRP", () => {
             expect(value).to.be.at.most(max);
         }
 
-        it("uses the idle interval for the first transmission even when the peer is active", () => {
+        it("uses the active interval for the first transmission when the peer is active", () => {
             const interval = MRP.retransmissionIntervalOf({
                 transmissionNumber: 0,
                 sessionParameters,
                 isPeerActive: true,
+                additionalDelay: ADDITIONAL,
+            });
+
+            expectWithin(interval, runtimeRangeFor(Millis(500), 0, ADDITIONAL));
+        });
+
+        it("uses the idle interval for the first transmission when the peer is inactive", () => {
+            const interval = MRP.retransmissionIntervalOf({
+                transmissionNumber: 0,
+                sessionParameters,
+                isPeerActive: false,
                 additionalDelay: ADDITIONAL,
             });
 
@@ -71,7 +82,7 @@ describe("MRP", () => {
                 isPeerActive: true,
             });
 
-            expectWithin(interval, runtimeRangeFor(Seconds(10), 0, 0));
+            expectWithin(interval, runtimeRangeFor(Millis(500), 0, 0));
         });
     });
 
@@ -90,11 +101,21 @@ describe("MRP", () => {
             );
         }
 
-        it("uses the idle interval for the first transmission even when the peer is active", () => {
+        it("uses the active interval for the first transmission when the peer is active", () => {
             const interval = MRP.maxRetransmissionIntervalOf({
                 transmissionNumber: 0,
                 sessionParameters,
                 isPeerActive: true,
+            });
+
+            expect(interval).to.equal(maximumFor(Millis(500), 0));
+        });
+
+        it("uses the idle interval for the first transmission when the peer is inactive", () => {
+            const interval = MRP.maxRetransmissionIntervalOf({
+                transmissionNumber: 0,
+                sessionParameters,
+                isPeerActive: false,
             });
 
             expect(interval).to.equal(maximumFor(Seconds(10), 0));
@@ -155,6 +176,46 @@ describe("MRP", () => {
                 });
 
                 expect(timeout).to.equal(Seconds(35));
+            });
+        });
+
+        describe("UDP channel", () => {
+            // Both legs use SessionIntervals defaults (idle 500ms, active 300ms, threshold 4000ms). The numbers are
+            // the deterministic maximum-backoff sums for five transmissions, so the first transmission of each leg now
+            // honors PeerActiveMode (active leg starts at 300ms, idle leg at 500ms).
+            it("composes the active peer leg, the active return leg, processing time and buffer", () => {
+                const timeout = MRP.maxPeerResponseTimeOf({
+                    peerSessionParameters: SessionParameters(),
+                    localSessionParameters,
+                    channelType: ChannelType.UDP,
+                    isPeerActive: true,
+                });
+
+                // 4229 (peer, active) + 4229 (return, active) + 2000 (processing) + 5000 (buffer)
+                expect(timeout).to.equal(Millis(15458));
+            });
+
+            it("uses the idle peer leg when the peer is inactive while the return leg stays active", () => {
+                const timeout = MRP.maxPeerResponseTimeOf({
+                    peerSessionParameters: SessionParameters(),
+                    localSessionParameters,
+                    channelType: ChannelType.UDP,
+                    isPeerActive: false,
+                });
+
+                // 7050 (peer, idle) + 4229 (return, active) + 2000 (processing) + 5000 (buffer)
+                expect(timeout).to.equal(Millis(18279));
+            });
+
+            it("drops the peer leg when peer session parameters are unknown", () => {
+                const timeout = MRP.maxPeerResponseTimeOf({
+                    localSessionParameters,
+                    channelType: ChannelType.UDP,
+                    isPeerActive: true,
+                });
+
+                // 4229 (return, active) + 2000 (processing) + 5000 (buffer)
+                expect(timeout).to.equal(Millis(11229));
             });
         });
 


### PR DESCRIPTION
## Summary

Drops the first-transmission idle gate in `retransmissionIntervalOf` (`packages/protocol/src/protocol/MRP.ts`). Previously tx0 was forced to the idle interval regardless of peer activity; now **every** transmission (including the first) selects the active/idle interval by `isPeerActive` (PeerActiveMode), re-evaluated per (re)transmission — matching CHIP `GetMRPBaseTimeout()` (no `sendCount==0` branch).

This is the deferred `n=0` follow-up to #3839 (which fixed `n>0` and explicitly left `n=0` blocked on spec).

## Changes

- `MRP.ts` — drop `transmissionNumber > 0 &&` gate; `isPeerActive` already yields idle for a genuinely quiet peer, so no position-based rule is needed. Rewrote the stale comment and the `BACKOFF_MARGIN` doc.
- `maxResponseTimeOf` inherits the change automatically via its call chain (`maxResponseTimeOf → maxRetransmissionIntervalOf → retransmissionIntervalOf`) — no separate edit.
- `MRPTest.ts` — inverted the two idle-first assertions, added inactive-peer first-tx cases, and added **new UDP-path coverage** for `maxPeerResponseTimeOf` (previously untested). Worked numbers verified by hand and by temporary revert.

## Impact

Active-peer bounds shorten modestly (return leg 4504→4229ms; full UDP active round-trip 16008→15458ms). The `expectedProcessingTime` + 5s buffer absorbs it; inactive-peer bound stays 18279ms.

## Verification

- protocol suite 1170/1170 ✓
- format ✓ · lint ✓ · code review clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)