### PR TITLE
fix(protocol): prevent crash on PASE pairing timeout with unacked message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/protocol
     - Fix: Ensure that the peer-medium-specific `additionalMrpDelay` is also used for executed commands, and added an optional per-request `additionalMrpDelay` override
     - Adjustment: MRP now selects the active/idle retransmission interval by peer activity for every transmission including the first, instead of forcing the first transmission to the idle interval
+    - Fix: Prevent a crash when a PASE pairing timeout fires while a previous message is still awaiting acknowledgement
 
 ## 0.17.2 (2026-06-09)
 

--- a/packages/protocol/src/session/pase/PaseServer.ts
+++ b/packages/protocol/src/session/pase/PaseServer.ts
@@ -7,6 +7,7 @@
 import { Mark } from "#common/Mark.js";
 import { SessionManager } from "#session/SessionManager.js";
 import {
+    asError,
     Bytes,
     causedBy,
     Channel,
@@ -124,7 +125,9 @@ export class PaseServer implements ProtocolHandler {
         logger.info("Received pairing request", Mark.INBOUND, Diagnostic.via(messenger.channelName));
 
         this.#pairingTimer = Time.getTimer("PASE pairing timeout", PASE_PAIRING_TIMEOUT, () =>
-            this.cancelPairing(messenger),
+            this.cancelPairing(messenger).catch(error =>
+                logger.warn("Error cancelling PASE pairing after timeout:", Diagnostic.errorMessage(asError(error))),
+            ),
         ).start();
 
         // Read pbkdfRequest and send pbkdfResponse
@@ -203,7 +206,14 @@ export class PaseServer implements ProtocolHandler {
 
     async cancelPairing(messenger: PaseServerMessenger, sendError = true) {
         if (sendError) {
-            await messenger.sendError(SecureChannelStatusCode.InvalidParam);
+            try {
+                await messenger.sendError(SecureChannelStatusCode.InvalidParam);
+            } catch (error) {
+                logger.info(
+                    "Could not send pairing-cancellation status report to peer:",
+                    Diagnostic.errorMessage(asError(error)),
+                );
+            }
         }
         await messenger.close();
     }

--- a/packages/protocol/test/session/secure/PasePairingTest.ts
+++ b/packages/protocol/test/session/secure/PasePairingTest.ts
@@ -6,10 +6,32 @@
 
 import { PaseClient } from "#session/pase/PaseClient.js";
 import { SPAKE_CONTEXT } from "#session/pase/PaseMessenger.js";
-import { Bytes, Spake2p, StandardCrypto } from "@matter/general";
+import { PaseServer } from "#session/pase/PaseServer.js";
+import { Bytes, MatterFlowError, Spake2p, StandardCrypto } from "@matter/general";
 
 describe("PasePairing", () => {
     const crypto = new StandardCrypto();
+
+    describe("cancelPairing", () => {
+        it("does not throw when sending the error status report fails", async () => {
+            const server = new PaseServer({} as any, 0n, new Uint8Array());
+            let closed = false;
+            const messenger = {
+                sendError: () =>
+                    Promise.reject(
+                        new MatterFlowError("The previous message has not been acked yet, cannot send a new message"),
+                    ),
+                close: () => {
+                    closed = true;
+                    return Promise.resolve();
+                },
+            };
+
+            await server.cancelPairing(messenger as any);
+
+            expect(closed).true;
+        });
+    });
 
     describe("random passcode generation", () => {
         it("uses 27-bit candidates and rejects out-of-range and forbidden values", () => {


### PR DESCRIPTION
## Problem

A user reported a `FATAL Unhandled` crash after commissioning many nodes:

```
MatterFlowError: The previous message •unsecured#…✉… has not been acked yet, cannot send a new message
    at MessageExchange.#send (MessageExchange.ts:502)
    at PaseServerMessenger.#sendStatusReport (SecureChannelMessenger.ts:179)
    at PaseServer.cancelPairing (PaseServer.ts:206)
    at StandardTimer.callback (PaseServer.ts:127)
```

## Root cause

The PASE pairing-timeout timer ran `cancelPairing()` as an async callback whose rejection was never caught. On timeout `cancelPairing` sends an error status report (`sendError` → `exchange.send`), which throws `MatterFlowError` when a previous unsecured message is still awaiting acknowledgement — likely under mass-commissioning network congestion. The rejection escaped the timer → unhandled → process crash.

Every other async timer callback in `MessageExchange.ts` catches its own errors; this one did not.

## Fix

- Catch errors in the timer callback (matching the established convention).
- Make the status report best-effort inside `cancelPairing` (try/catch + log), so an abort-time send failure no longer propagates. This also hardens the other caller (`onNewExchange` error path).
- Both paths log via `Diagnostic.errorMessage(asError(...))` (message only, no stack).

## Test

Added a unit test asserting `cancelPairing` does not throw when the status report send rejects, and still closes the messenger.

## Verification

- `npm run build -p packages/protocol` ✓
- full `@matter/protocol` suite 1171/1171 ✓
- `format-verify` ✓, `lint` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)