### PR TITLE
fix(general): evict stale UDP multicast broadcast channel on send failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/general
     - Fix: `log.level` (e.g. `MATTER_LOG_LEVEL`) now accepts string level names like `info` again, not just numeric values
+    - Fix: A failed UDP multicast send now evicts and rebuilds the broadcast channel instead of caching a dead socket
 
 - @matter/protocol
     - Fix: Ensure that the peer-medium-specific `additionalMrpDelay` is also used for executed commands, and added an optional per-request `additionalMrpDelay` override

--- a/packages/general/src/net/udp/UdpMulticastServer.ts
+++ b/packages/general/src/net/udp/UdpMulticastServer.ts
@@ -102,7 +102,7 @@ export class UdpMulticastServer {
         "UDP broadcast channel",
         (netInterface, isIPv4) => this.createBroadcastChannel(netInterface, isIPv4),
         Minutes(5),
-        async (_netInterface, channel) => channel.close(),
+        async (_key, channel) => channel.close(),
     );
 
     private constructor(

--- a/packages/general/src/net/udp/UdpMulticastServer.ts
+++ b/packages/general/src/net/udp/UdpMulticastServer.ts
@@ -9,7 +9,7 @@ import { Minutes } from "#time/TimeUnit.js";
 import { Bytes } from "#util/Bytes.js";
 import { Lifetime } from "#util/Lifetime.js";
 import { Logger } from "../../log/Logger.js";
-import { Cache } from "../../util/Cache.js";
+import { AsyncCache } from "../../util/Cache.js";
 import { asError } from "../../util/Error.js";
 import { isIPv4 } from "../../util/Ip.js";
 import { Network, NoAddressAvailableError } from "../Network.js";
@@ -98,11 +98,11 @@ export class UdpMulticastServer {
         }
     }
 
-    private readonly broadcastChannels = new Cache<Promise<UdpSocket>>(
+    private readonly broadcastChannels = new AsyncCache<UdpSocket>(
         "UDP broadcast channel",
         (netInterface, isIPv4) => this.createBroadcastChannel(netInterface, isIPv4),
         Minutes(5),
-        async (_netInterface, channel) => (await channel).close(),
+        async (_netInterface, channel) => channel.close(),
     );
 
     private constructor(
@@ -151,12 +151,14 @@ export class UdpMulticastServer {
 
         // When we know the network interface and the unicast target, we can send unicast
         if (uniCastTarget !== undefined && netInterface !== undefined) {
+            const ipV4Target = isIPv4(uniCastTarget);
             try {
                 await (
-                    await this.broadcastChannels.get(netInterface, isIPv4(uniCastTarget))
+                    await this.broadcastChannels.get(netInterface, ipV4Target)
                 ).send(uniCastTarget, this.#broadcastPort, message);
             } catch (error) {
                 logger.info(`${netInterface} ${uniCastTarget}: ${asError(error).message}`);
+                await this.#evictBroadcastChannel(netInterface, ipV4Target);
             }
         } else {
             const netInterfaces =
@@ -184,6 +186,7 @@ export class UdpMulticastServer {
                                 ).send(address, this.#broadcastPort, message);
                             } catch (error) {
                                 logger.info(`${netInterface}: ${asError(error).message}`);
+                                await this.#evictBroadcastChannel(netInterface, isIPv4);
                             }
                         }),
                         `Error sending UDP Multicast message on interface ${netInterface}`,
@@ -191,6 +194,19 @@ export class UdpMulticastServer {
                 }),
                 "Error sending UDP Multicast message",
             );
+        }
+    }
+
+    /**
+     * Drop a broadcast channel after a send failure so the next send rebinds it. A failed send can mean the cached
+     * socket is bound to an interface address that no longer exists (e.g. after the host resumed from standby).
+     * Eviction must never escalate a send failure, so closing the stale socket is best-effort.
+     */
+    async #evictBroadcastChannel(netInterface: string, isIPv4: boolean) {
+        try {
+            await this.broadcastChannels.evict(netInterface, isIPv4);
+        } catch (error) {
+            logger.info(`${netInterface}: failed to evict broadcast channel: ${asError(error).message}`);
         }
     }
 

--- a/packages/general/src/util/Cache.ts
+++ b/packages/general/src/util/Cache.ts
@@ -50,6 +50,11 @@ class GenericCache<T> {
         this.timestamps.delete(key);
     }
 
+    /** Evict the entry addressed by the same params passed to {@link Cache.get}/{@link AsyncCache.get}. */
+    async evict(...params: unknown[]) {
+        await this.delete(this.keyFor(params));
+    }
+
     async clear() {
         for (const key of this.values.keys()) {
             await this.delete(key);

--- a/packages/general/test/net/udp/UdpMulticastServerTest.ts
+++ b/packages/general/test/net/udp/UdpMulticastServerTest.ts
@@ -11,6 +11,25 @@ const BROADCAST_IPV4 = "224.0.0.251";
 const BROADCAST_IPV6 = "ff02::fb";
 const NET_INTERFACE = "fake0";
 
+/** A network whose sockets fail their sends on demand, mimicking an interface address that vanished after wake. */
+class FaultyMockNetwork extends MockNetwork {
+    createCount = 0;
+    failSends = false;
+
+    override async createUdpSocket(options: Parameters<MockNetwork["createUdpSocket"]>[0]) {
+        this.createCount++;
+        const socket = await super.createUdpSocket(options);
+        const send = socket.send.bind(socket);
+        socket.send = async (host, port, payload) => {
+            if (this.failSends) {
+                throw new Error("setMulticastInterface EADDRNOTAVAIL");
+            }
+            return send(host, port, payload);
+        };
+        return socket;
+    }
+}
+
 describe("UdpMulticastServer", () => {
     it("sends at most once per IP family when an interface has multiple same-family addresses", async () => {
         const simulator = new NetworkSimulator();
@@ -74,5 +93,45 @@ describe("UdpMulticastServer", () => {
         }
 
         expect(broadcastDestinations).to.deep.equal([BROADCAST_IPV6]);
+    });
+
+    it("evicts a broadcast channel after a send failure and rebinds on the next send", async () => {
+        const simulator = new NetworkSimulator();
+        const network = new FaultyMockNetwork(simulator, "00:11:22:33:44:03", ["192.168.1.4", "fe80::3"]);
+
+        const broadcastDestinations = new Array<string>();
+        simulator.router.intercept((packet, next) => {
+            if (packet.kind === "udp" && packet.destPort === BROADCAST_PORT) {
+                broadcastDestinations.push(packet.destAddress);
+            }
+            next(packet);
+        });
+
+        const server = await UdpMulticastServer.create({
+            network,
+            listeningPort: BROADCAST_PORT,
+            broadcastAddressIpv4: BROADCAST_IPV4,
+            broadcastAddressIpv6: BROADCAST_IPV6,
+            netInterface: NET_INTERFACE,
+        });
+
+        try {
+            // Ignore the listening sockets created during setup; only count broadcast channels from here on.
+            network.createCount = 0;
+
+            network.failSends = true;
+            await server.send(new Uint8Array([1, 2, 3]));
+            expect(broadcastDestinations).deep.equals([]);
+            expect(network.createCount).equals(2);
+
+            network.failSends = false;
+            await server.send(new Uint8Array([1, 2, 3]));
+            // createCount === 4 (not 2) proves the failed channels were evicted and rebuilt rather than reused.
+            expect(network.createCount).equals(4);
+            expect(broadcastDestinations.sort()).deep.equals([BROADCAST_IPV4, BROADCAST_IPV6]);
+        } finally {
+            await server.close();
+            await network.close();
+        }
     });
 });

--- a/packages/general/test/util/CacheTest.ts
+++ b/packages/general/test/util/CacheTest.ts
@@ -298,4 +298,31 @@ describe("AsyncCache", () => {
             await cache.close();
         });
     });
+
+    describe("evict()", () => {
+        it("closes the cached resource and regenerates on the next get() for the same params", async () => {
+            let calls = 0;
+            const expired = new Array<string>();
+            const cache = new AsyncCache<string>(
+                "test",
+                async (netInterface: string, isIPv4: boolean) => `${netInterface}-${isIPv4}-${++calls}`,
+                Minutes(5),
+                async (_key, value) => {
+                    expired.push(value);
+                },
+            );
+
+            expect(await cache.get("eth0", true)).equals("eth0-true-1");
+            expect(await cache.get("eth0", true)).equals("eth0-true-1");
+            expect(calls).equals(1);
+
+            await cache.evict("eth0", true);
+            expect(expired).deep.equals(["eth0-true-1"]);
+
+            expect(await cache.get("eth0", true)).equals("eth0-true-2");
+            expect(calls).equals(2);
+
+            await cache.close();
+        });
+    });
 });


### PR DESCRIPTION
## Problem

`UdpMulticastServer` cached its broadcast channels in a `Cache<Promise<UdpSocket>>`. When a send failed because the cached socket was bound to an interface address that no longer existed (e.g. `setMulticastInterface EADDRNOTAVAIL` after the host resumed from standby), the dead socket stayed cached and every subsequent send on that interface kept failing. Caching the in-flight `Promise` also meant a rejected creation could surface as an unhandled rejection.

This bites hardest when many nodes share one `Environment`: they all share the single `MdnsService` → single `UdpMulticastServer`, so one poisoned channel breaks broadcasts for every node at once.

## Fix

- Switch `UdpMulticastServer.broadcastChannels` from `Cache<Promise<UdpSocket>>` to `AsyncCache<UdpSocket>`.
- On a send failure, evict the channel so the next send rebinds a fresh socket. Eviction is best-effort — it never escalates the original send failure.
- Add `AsyncCache.evict(...params)` to drop a single entry addressed by the same params passed to `get()`.

## Testing

- New `UdpMulticastServer` test: a faulty network whose sends fail proves the channel is evicted and rebuilt on the next send (rather than reused).
- New `AsyncCache.evict()` test: closes the cached resource and regenerates on the next `get()`.
- `format-verify`, `lint`, and `packages/general` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)