### PR TITLE
fix(protocol): gate MRP kick restarts on retransmission saving and floor the retry cap at idle interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Ensure that the peer-medium-specific `additionalMrpDelay` is also used for executed commands, and added an optional per-request `additionalMrpDelay` override
     - Adjustment: MRP now selects the active/idle retransmission interval by peer activity for every transmission including the first, instead of forcing the first transmission to the idle interval
     - Fix: Prevent a crash when a PASE pairing timeout fires while a previous message is still awaiting acknowledgement
+    - Fix: A discovery kick no longer restarts an in-flight CASE handshake when a restart would barely shorten the next retransmission, avoiding needless teardown of a sleepy peer's exchange
+    - Fix: The MRP retransmission interval is no longer capped below the peer's idle interval
+    - Fix: The connection fallback address is now compared by value, so a rediscovered last-known address is no longer mistaken for an address change
 
 ## 0.17.2 (2026-06-09)
 

--- a/packages/protocol/src/peer/PeerConnection.ts
+++ b/packages/protocol/src/peer/PeerConnection.ts
@@ -306,8 +306,7 @@ export async function PeerConnection(
             return;
         }
         const variants = expandAddresses(fallback);
-        // The interned first variant is the fallback marker; reference equality
-        // must match what comes back out of pendingAddresses.
+        // Intern so attempts/pendingAddresses key on one canonical object; fallback identity is matched by value.
         attemptingFallback = addresses.add(variants[0]);
         for (const variant of variants) {
             pendingAddresses.add(variant);
@@ -409,7 +408,7 @@ export async function PeerConnection(
 
         // If this is not the fallback address but we're still attempting to connect to the fallback, it means that
         // we've discovered addresses that do not include the fallback; terminate the fallback attempt
-        if (attemptingFallback && address !== attemptingFallback) {
+        if (attemptingFallback && !ServerAddress.isEqual(address, attemptingFallback)) {
             deleteAddress(
                 attemptingFallback,
                 "Aborting attempt to last known address because device reports address change",
@@ -479,7 +478,7 @@ export async function PeerConnection(
                 }),
                 Diagnostic.asFlags({
                     [network.id]: true,
-                    fallback: address === attemptingFallback,
+                    fallback: attemptingFallback !== undefined && ServerAddress.isEqual(address, attemptingFallback),
                 }),
             );
 
@@ -498,6 +497,11 @@ export async function PeerConnection(
 
                 kick = kicker?.use((origin: KickOrigin) => {
                     if (exchange.retransmissionCount < context.timing.kickMinRetransmissions) {
+                        return;
+                    }
+
+                    if (exchange.retransmissionRestartSaving < context.timing.kickMinRestartSaving) {
+                        debug(via, address, `Suppressing "${origin}" kick, restart would save too little time`);
                         return;
                     }
 

--- a/packages/protocol/src/peer/PeerTimingParameters.ts
+++ b/packages/protocol/src/peer/PeerTimingParameters.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Duration, merge as mergeObjects, Minutes, Seconds } from "@matter/general";
+import { Duration, merge as mergeObjects, Millis, Minutes, Seconds } from "@matter/general";
 
 /**
  * Parameters that control network timing for Matter sessions controlled by matter.js.
@@ -71,6 +71,16 @@ export interface PeerTimingParameters {
      * has retransmitted fewer than this many times is suppressed.
      */
     kickMinRetransmissions: number;
+
+    /**
+     * Minimum time a kick-initiated restart must shave off the next retransmission to be worthwhile.
+     *
+     * Restarting resets MRP backoff to its base interval, so it only helps once backoff has grown well
+     * beyond that base.  A kick whose restart would save less than this is suppressed — for an idle/sleepy
+     * peer the base interval is already large, so a restart gains nothing and needlessly tears down the
+     * in-flight exchange.
+     */
+    kickMinRestartSaving: Duration;
 
     /**
      * Per-trigger cooldowns for kick-initiated CASE exchange restarts.
@@ -151,10 +161,12 @@ export namespace PeerTimingParameters {
         return result;
     }
 
+    const maxInitialContactRetryInterval = Minutes(2);
+
     // TODO - tune these
     export const defaults: PeerTimingParameters = {
         defaultConnectionTimeout: Seconds(90),
-        maxDelayBetweenInitialContactRetries: Minutes(2),
+        maxDelayBetweenInitialContactRetries: maxInitialContactRetryInterval,
 
         // We assume 30s processing time on peer for single Sigma actions, so give one IP a bit of time
         // to have a chance before potentially adding a load with a second try
@@ -164,6 +176,7 @@ export namespace PeerTimingParameters {
         delayAfterUnhandledError: Minutes(2),
         kickThrottleInterval: Seconds(3),
         kickMinRetransmissions: 2,
+        kickMinRestartSaving: Millis(maxInitialContactRetryInterval / 2),
         kickRestartCooldown: {
             addressChange: Minutes(30),
             connect: Minutes(10),

--- a/packages/protocol/src/protocol/MessageExchange.ts
+++ b/packages/protocol/src/protocol/MessageExchange.ts
@@ -1001,7 +1001,7 @@ export class MessageExchange {
      * The cap never drops below the peer's idle interval: a peer whose idle base backoff already exceeds
      * maxRetransmissionTime must not be retried faster than its own idle cadence.
      */
-    #backOffFor(retransmissionCount: number, calculateMaximum = false) {
+    #backOffFor(retransmissionCount: number) {
         const additionalDelay = Duration.max(
             this.#context.localAdditionalMrpDelay,
             this.#peerAdditionalMrpDelay ?? Millis(0),
@@ -1009,7 +1009,7 @@ export class MessageExchange {
         let backOff = this.channel.getMrpResubmissionBackOffTime(
             retransmissionCount,
             undefined,
-            calculateMaximum,
+            false,
             additionalDelay,
         );
         if (this.#sendOptions.initialRetransmissionTime !== undefined) {
@@ -1024,14 +1024,17 @@ export class MessageExchange {
 
     /**
      * How much restarting the exchange (resetting the retransmission counter to 0) would shorten the wait until
-     * the next (re)transmission.  Zero when current backoff is already at its base — e.g. an idle peer, whose fresh
-     * interval is just as slow, so a restart saves nothing.
+     * the next (re)transmission.  Roughly zero near the base interval — e.g. an idle peer, whose fresh interval is
+     * just as slow.
      */
     get retransmissionRestartSaving(): Duration {
-        return Duration.max(
-            Instant,
-            Millis(this.#backOffFor(this.#retransmissionCounter, true) - this.#backOffFor(0, true)),
-        );
+        // No pending retransmit → nothing for a restart to shorten → report no saving so the kick is suppressed.
+        const currentWait = this.#retransmissionTimer?.interval;
+        if (currentWait === undefined) {
+            return Instant;
+        }
+        // Read the live timer's real interval (margins/jitter/cap baked in), not a freshly recomputed random one.
+        return Duration.max(Instant, Millis(currentWait - this.#backOffFor(0)));
     }
 }
 

--- a/packages/protocol/src/protocol/MessageExchange.ts
+++ b/packages/protocol/src/protocol/MessageExchange.ts
@@ -992,20 +992,46 @@ export class MessageExchange {
     }
 
     get #mrpResubmissionBackOffTime() {
+        return this.#backOffFor(this.#retransmissionCounter);
+    }
+
+    /**
+     * Scheduled MRP backoff for a given (re)transmission number, after the send-option overrides.
+     *
+     * The cap never drops below the peer's idle interval: a peer whose idle base backoff already exceeds
+     * maxRetransmissionTime must not be retried faster than its own idle cadence.
+     */
+    #backOffFor(retransmissionCount: number, calculateMaximum = false) {
         const additionalDelay = Duration.max(
             this.#context.localAdditionalMrpDelay,
             this.#peerAdditionalMrpDelay ?? Millis(0),
         );
         let backOff = this.channel.getMrpResubmissionBackOffTime(
-            this.#retransmissionCounter,
+            retransmissionCount,
             undefined,
-            false,
+            calculateMaximum,
             additionalDelay,
         );
         if (this.#sendOptions.initialRetransmissionTime !== undefined) {
             backOff = Millis(backOff + this.#sendOptions.initialRetransmissionTime);
         }
-        return Duration.min(backOff, this.#sendOptions.maxRetransmissionTime ?? Forever);
+        const cap = Duration.max(
+            this.#sendOptions.maxRetransmissionTime ?? Forever,
+            this.session.parameters.idleInterval ?? Instant,
+        );
+        return Duration.min(backOff, cap);
+    }
+
+    /**
+     * How much restarting the exchange (resetting the retransmission counter to 0) would shorten the wait until
+     * the next (re)transmission.  Zero when current backoff is already at its base — e.g. an idle peer, whose fresh
+     * interval is just as slow, so a restart saves nothing.
+     */
+    get retransmissionRestartSaving(): Duration {
+        return Duration.max(
+            Instant,
+            Millis(this.#backOffFor(this.#retransmissionCounter, true) - this.#backOffFor(0, true)),
+        );
     }
 }
 

--- a/packages/protocol/test/peer/PeerConnectionKickTest.ts
+++ b/packages/protocol/test/peer/PeerConnectionKickTest.ts
@@ -6,7 +6,17 @@
 
 import type { KickOrigin } from "#peer/PeerConnection.js";
 import { PeerTimingParameters } from "#peer/PeerTimingParameters.js";
-import { Abort, AbortedError, Minutes, Observable, QuietObservable, Seconds, Time, Timestamp } from "@matter/general";
+import {
+    Abort,
+    AbortedError,
+    Duration,
+    Minutes,
+    Observable,
+    QuietObservable,
+    Seconds,
+    Time,
+    Timestamp,
+} from "@matter/general";
 
 /**
  * Tests for the MRP kick restart redesign.
@@ -35,6 +45,13 @@ describe("PeerConnection kick redesign", () => {
 
         it("has correct default for kickMinRetransmissions", () => {
             expect(PeerTimingParameters.defaults.kickMinRetransmissions).equals(2);
+        });
+
+        it("has correct default for kickMinRestartSaving (half the max retry interval)", () => {
+            expect(PeerTimingParameters.defaults.kickMinRestartSaving).equals(Seconds(60));
+            expect(PeerTimingParameters.defaults.kickMinRestartSaving).equals(
+                PeerTimingParameters.defaults.maxDelayBetweenInitialContactRetries / 2,
+            );
         });
 
         it("allows overriding kick restart cooldowns", () => {
@@ -253,6 +270,37 @@ describe("PeerConnection kick redesign", () => {
             expect(handleKick("discover")).equals(true); // 60s reached
 
             expect(restarts).deep.equals(["discover", "discover"]);
+        });
+    });
+
+    describe("kick gate (count + saving)", () => {
+        /**
+         * Models PeerConnection.attemptOnce's kick gate: a kick restarts the exchange only once it has
+         * retransmitted enough times AND a restart would shave off enough of the next retransmit to be worth
+         * the teardown.  Extracted here because PeerConnection itself is integration-heavy.
+         */
+        function gate(timing: PeerTimingParameters, retransmissionCount: number, restartSaving: Duration) {
+            if (retransmissionCount < timing.kickMinRetransmissions) {
+                return false;
+            }
+            if (restartSaving < timing.kickMinRestartSaving) {
+                return false;
+            }
+            return true;
+        }
+
+        const timing = PeerTimingParameters();
+
+        it("suppresses while the exchange has not retransmitted enough", () => {
+            expect(gate(timing, 1, Minutes(2))).equals(false);
+        });
+
+        it("suppresses when a restart would save too little time (e.g. idle/sleepy peer)", () => {
+            expect(gate(timing, 5, Seconds(10))).equals(false);
+        });
+
+        it("restarts once both retransmission count and restart saving clear their thresholds", () => {
+            expect(gate(timing, 2, Seconds(90))).equals(true);
         });
     });
 


### PR DESCRIPTION
## Problem

A discovery "kick" restarts the in-flight CASE handshake exchange to pick up fresh MRP backoff. But for a sleepy/ICD peer this is often pure harm:

- When mDNS rediscovers an address that equals the last-known operational address, the fallback bookkeeping (`deleteAddress` keep-as-fallback → re-add) fires a `discover` kick.
- The kick tears down the unsecured session + in-flight Sigma1 that the constrained peer is still tracking, and rebuilds a fresh exchange to the **same** IP.
- The only legitimate benefit of a restart is escaping a backoff interval that has grown large. For an idle/sleepy peer the base interval is already large, so restarting resets to an equally-slow interval — zero timing benefit, real teardown cost.

Separately, the MRP retransmission cap (`maxRetransmissionTime`, 2 min for initial contact) was a hard `min`, so a very sleepy peer whose idle interval exceeds 2 min was retried *faster* than its own idle cadence.

## Fix

- **Gate kick restarts on actual benefit.** New `MessageExchange.retransmissionRestartSaving` reports how much resetting the retransmission counter would shorten the next retransmit. `PeerConnection` only restarts when that exceeds `kickMinRestartSaving` (new timing parameter, default = half of `maxDelayBetweenInitialContactRetries` = 60 s), in addition to the existing `kickMinRetransmissions` gate. An idle/sleepy peer's exchange is left intact.
- **Floor the retransmission cap at the peer's idle interval** so a very sleepy peer is never retried faster than its own idle cadence. Only affects exchanges that set `maxRetransmissionTime` (the initial-contact path); all others leave it `Forever` so the floor is a no-op.
- **Compare the connection fallback address by value** (`ServerAddress.isEqual`) instead of by reference at the two `attemptingFallback` checks, so a rediscovered last-known address (a typeless discovered variant) is not mistaken for an address change.

## Testing

- `PeerConnectionKickTest` extended with the new default and the count+saving gate ordering (the file mirrors the kick logic deliberately, since `PeerConnection` is integration-heavy).
- `packages/protocol` full suite, `format-verify`, `lint`, and a clean build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)