### PR TITLE
fix: stop subscriptions retrying against a closed interaction; reconnect PairedNode after disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: The connection fallback address is now compared by value, so a rediscovered last-known address is no longer mistaken for an address change
     - Fix: Ensure that subscriptions established through an interaction are closed when the interaction closes (e.g. node disable/disconnect or decommission)
 
+- @project-chip/matter.js
+    - Fix: Ensure that `PairedNode.connect()` reconnects a node that was previously disconnected
+
 ## 0.17.2 (2026-06-09)
 
 - @matter/general

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A discovery kick no longer restarts an in-flight CASE handshake when a restart would barely shorten the next retransmission, avoiding needless teardown of a sleepy peer's exchange
     - Fix: The MRP retransmission interval is no longer capped below the peer's idle interval
     - Fix: The connection fallback address is now compared by value, so a rediscovered last-known address is no longer mistaken for an address change
+    - Fix: Ensure that subscriptions established through an interaction are closed when the interaction closes (e.g. node disable/disconnect or decommission)
 
 ## 0.17.2 (2026-06-09)
 

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -1398,8 +1398,6 @@ export class PairedNode {
         // Unlike close() this keeps the instance (observers, construction) intact so connect() can reconnect it; the
         // node is disabled via disconnectNode() which ends the subscription.
         this.#updateEndpointStructureTimer.stop();
-        // Set Disconnected before disabling: disconnectNode() ends the subscription, which fires
-        // subscriptionStatusChanged(false); were the state still Connected the handler would flip it to Reconnecting.
         this.#setConnectionState(NodeStates.Disconnected);
         await this.#commissioningController.disconnectNode(this.nodeId);
     }

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -1398,6 +1398,8 @@ export class PairedNode {
         // Unlike close() this keeps the instance (observers, construction) intact so connect() can reconnect it; the
         // node is disabled via disconnectNode() which ends the subscription.
         this.#updateEndpointStructureTimer.stop();
+        // Set Disconnected before disabling: disconnectNode() ends the subscription, which fires
+        // subscriptionStatusChanged(false); were the state still Connected the handler would flip it to Reconnecting.
         this.#setConnectionState(NodeStates.Disconnected);
         await this.#commissioningController.disconnectNode(this.nodeId);
     }

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -513,6 +513,22 @@ export class PairedNode {
         if (connectOptions !== undefined) {
             this.#options = connectOptions;
         }
+
+        // disconnect() disables the underlying node; re-enable it so the node restarts and NetworkClient can
+        // (re)subscribe.  Without this a connect() after disconnect() is a no-op because isDisabled stays set.
+        if (this.#clientNode.stateOf(NetworkClient).isDisabled) {
+            this.#clientNode
+                .enable()
+                .then(() => {
+                    if (this.#options.autoSubscribe === false) {
+                        return this.#initializeWithRead();
+                    }
+                    this.#activateSubscription();
+                })
+                .catch(error => logger.warn(this.#peerAddress, `Error connecting to node`, error));
+            return;
+        }
+
         if (this.#options.autoSubscribe === false) {
             this.#initializeWithRead().catch(error => {
                 logger.warn(this.#peerAddress, `Error during read-only initialization`, error);
@@ -1377,9 +1393,12 @@ export class PairedNode {
         };
     }
 
-    /** Closes the current session, ends the subscription and disconnects the device. */
+    /** Closes the current session, ends the subscription and disconnects the device. The node can be reconnected via connect(). */
     async disconnect() {
-        this.close();
+        // Unlike close() this keeps the instance (observers, construction) intact so connect() can reconnect it; the
+        // node is disabled via disconnectNode() which ends the subscription.
+        this.#updateEndpointStructureTimer.stop();
+        this.#setConnectionState(NodeStates.Disconnected);
         await this.#commissioningController.disconnectNode(this.nodeId);
     }
 

--- a/packages/node/test/node/ClientConnectivityTest.ts
+++ b/packages/node/test/node/ClientConnectivityTest.ts
@@ -22,7 +22,14 @@ import {
     ServerAddress,
     Time,
 } from "@matter/general";
-import { ClientSubscription, Peer, PeerUnreachableError, SustainedSubscription } from "@matter/protocol";
+import {
+    ClientSubscribe,
+    ClientSubscription,
+    Peer,
+    PeerUnreachableError,
+    Subscribe,
+    SustainedSubscription,
+} from "@matter/protocol";
 import { MockServerNode } from "./mock-server-node.js";
 import { MockSite } from "./mock-site.js";
 import { subscribedPeer } from "./node-helpers.js";
@@ -504,6 +511,84 @@ describe("ClientConnectivityTest", () => {
         // In-progress reconnection attempts must be abortable so that closing the controller
         // cancels them cleanly rather than timing out with PeerUnreachableError
         expect(errorsLogged).equals(0);
+    });
+
+    it("terminates the sustained subscription when the node is disabled", async () => {
+        // *** SETUP ***
+
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+        const peer1 = await subscribedPeer(controller, "peer1");
+
+        const subscription = peer1.behaviors.internalsOf(NetworkClient).activeSubscription!;
+        SustainedSubscription.assert(subscription);
+        expect(subscription.active.value).equals(true);
+
+        // *** DISABLE ***
+
+        // disable() closes the ClientInteraction the subscription was built from; the subscription must terminate
+        // with it rather than orphan and retry forever against the closed interaction.
+        await MockTime.resolve(peer1.disable());
+
+        await MockTime.resolve(subscription.done!);
+        expect(peer1.behaviors.internalsOf(NetworkClient).activeSubscription).undefined;
+    });
+
+    it("establishes a fresh sustained subscription after disable/enable", async () => {
+        // *** SETUP ***
+
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+        const peer1 = await subscribedPeer(controller, "peer1");
+
+        const initial = peer1.behaviors.internalsOf(NetworkClient).activeSubscription!;
+        SustainedSubscription.assert(initial);
+        const initialSubscriptionId = initial.subscriptionId;
+        expect(initialSubscriptionId).not.equals(ClientSubscription.NO_SUBSCRIPTION);
+
+        // *** DISABLE then ENABLE ***
+
+        await MockTime.resolve(peer1.disable());
+        expect(peer1.behaviors.internalsOf(NetworkClient).activeSubscription).undefined;
+
+        (peer1.parts.get("ep1")!.env.get(Crypto) as MockCrypto).entropic = true;
+        await MockTime.resolve(peer1.enable());
+
+        // A stale orphan would wedge the re-subscribe gate; a fresh subscription must establish on a new interaction.
+        const resumed = await subscribedPeer(controller, "peer1");
+        const next = resumed.behaviors.internalsOf(NetworkClient).activeSubscription!;
+        SustainedSubscription.assert(next);
+        expect(next.active.value).equals(true);
+        expect(next.subscriptionId).not.equals(ClientSubscription.NO_SUBSCRIPTION);
+        expect(next.subscriptionId).not.equals(initialSubscriptionId);
+    });
+
+    it("closes a non-sustained subscription when the node is disabled", async () => {
+        // *** SETUP ***
+
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+        const peer1 = await subscribedPeer(controller, "peer1");
+
+        // A manually established, non-sustained subscription returns a one-shot PeerSubscription owned by the caller.
+        let closed = false;
+        const request: ClientSubscribe = {
+            ...Subscribe({ attributes: [{}], events: [{ isUrgent: true }] }),
+            sustain: false,
+            closed: () => {
+                closed = true;
+            },
+        };
+        const subscription = await MockTime.resolve(peer1.interaction.subscribe(request));
+        expect(subscription).instanceOf(ClientSubscription);
+        expect(closed).false;
+
+        // *** DISABLE ***
+
+        // Closing the interaction must close every subscription it owns, not only the sustained one.
+        await MockTime.resolve(peer1.disable());
+
+        expect(closed).true;
     });
 
     it("does not crash on restart when uncommissioned peer exists", async () => {

--- a/packages/protocol/src/action/client/ClientInteraction.ts
+++ b/packages/protocol/src/action/client/ClientInteraction.ts
@@ -186,6 +186,17 @@ export class ClientInteraction<
 
         using _closing = this.#lifetime.closing();
 
+        // Close subscriptions established through this interaction so they do not outlive the interactable; a
+        // sustained subscription would otherwise retry forever against a closed interactable.
+        const peer = this.#exchangeProvider.peerAddress;
+        if (this.#subscriptions !== undefined && peer !== undefined) {
+            for (const subscription of [...this.#subscriptions]) {
+                if (PeerAddress.is(peer, subscription.peer)) {
+                    subscription.close();
+                }
+            }
+        }
+
         // Close batching
         this.#batchTimer?.stop();
         for (const [, pending] of this.#pendingCommands) {
@@ -1034,7 +1045,7 @@ export class ClientInteraction<
         try {
             if (this.#abort.aborted) {
                 throw new ImplementationError(
-                    `Cannot ${what} ${this.#address ?? "uncommissioned node"} because interactable is closed`,
+                    `Cannot ${what} ${this.#address ?? this.#exchangeProvider.peerAddress ?? "uncommissioned node"} because interactable is closed`,
                 );
             }
 

--- a/packages/protocol/src/action/client/ClientInteraction.ts
+++ b/packages/protocol/src/action/client/ClientInteraction.ts
@@ -1045,7 +1045,7 @@ export class ClientInteraction<
         try {
             if (this.#abort.aborted) {
                 throw new ImplementationError(
-                    `Cannot ${what} ${this.#address ?? this.#exchangeProvider.peerAddress ?? "uncommissioned node"} because interactable is closed`,
+                    `Cannot start ${what} ${this.#address ?? this.#exchangeProvider.peerAddress ?? "uncommissioned node"} because interactable is closed`,
                 );
             }
 


### PR DESCRIPTION
## Problem

After an app-initiated disconnect (e.g. openHAB `disconnectNode`), a node's `SustainedSubscription` was orphaned against a **closed** `ClientInteraction` and retried forever:

```
Cannot subscribing uncommissioned node because interactable is closed
```

Backoff grew to the 1h cap and never recovered; the node was dead until a process restart. Diagnosed from real controller logs.

## Root causes & fixes

**1. `@matter/protocol` — subscriptions outlived their interaction**

`ClientInteraction.close()` fired its abort and drained in-flight requests but never closed the subscriptions it had created. The `SustainedSubscription`'s abort was the *session* abort, not the interaction's, so closing the interaction (node disable/disconnect, decommission) left the retry loop running against a dead interactable. Non-sustained `PeerSubscription`s were likewise orphaned (their per-request abort is disposed when the subscribe call returns).

`close()` now closes every subscription it owns for the peer (same peer-scoped pattern already used by the resubscribe-replacement path). The "interactable is closed" error now reports the real peer address instead of always "uncommissioned node".

**2. `@project-chip/matter.js` — `PairedNode` could not reconnect**

`disconnect()` ran the destructive `close()` (closing the wrapper's observers/construction, setting `#closing`) and disabled the underlying `ClientNode`, but `connect()` only toggled `autoSubscribe` and never re-enabled the node — so a `connect()` after `disconnect()` was a silent no-op (`isDisabled` stayed set, no subscription, wrapper torn down).

`disconnect()` now keeps the instance reusable (stops the structure timer, sets `Disconnected`) instead of `close()`-ing it; `close()` remains the destruction path for `removeNode`. `connect()` re-enables a disabled node before (re)subscribing.

## Tests

Three new `ClientConnectivityTest` cases (each verified failing before the fix):
- sustained subscription terminates when the node is disabled
- a fresh sustained subscription establishes after disable/enable
- a non-sustained subscription is closed when the node is disabled

The `PairedNode` reconnect path has no automated coverage (no live `CommissioningController`/`PairedNode` mock-device harness exists); the underlying `disable→enable→fresh sub` behavior is covered by the ClientNode tests, and the end-to-end reconnect was verified manually in the matter shell.

## Verification

`@matter/protocol` 1175/1175, `@matter/node` 1196/1196, `@project-chip/matter.js` green; format + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)