### PR TITLE
fix(general): throw CryptoDecryptError on AEAD tag-verify failure

### DIFF
--- a/packages/general/src/crypto/aes/Ccm.ts
+++ b/packages/general/src/crypto/aes/Ccm.ts
@@ -13,7 +13,7 @@
  */
 
 import { CRYPTO_AEAD_MIC_LENGTH_BYTES, CRYPTO_AEAD_NONCE_LENGTH_BYTES } from "#crypto/CryptoConstants.js";
-import { CryptoInputError } from "#crypto/CryptoError.js";
+import { CryptoDecryptError, CryptoInputError } from "#crypto/CryptoError.js";
 import { Bytes } from "#util/Bytes.js";
 import { Aes } from "./Aes.js";
 import { WordArray } from "./WordArray.js";
@@ -129,7 +129,7 @@ export function Ccm(key: Bytes) {
 
             for (let i = 0; i < computedMic.words.length; i++) {
                 if (inputMic.words[i] !== computedMic.words[i]) {
-                    throw new CryptoInputError("Message authentication failed due to invalid signature");
+                    throw new CryptoDecryptError("Message authentication failed due to invalid signature");
                 }
             }
 

--- a/packages/general/src/crypto/aes/Ccm.ts
+++ b/packages/general/src/crypto/aes/Ccm.ts
@@ -127,10 +127,14 @@ export function Ccm(key: Bytes) {
             // Compute MIC using CBC-MAC
             cbcMac(input, ptView, ptLength);
 
+            // Constant-time tag comparison: accumulate all word differences and check once, so timing does not leak
+            // how many leading tag words matched.
+            let micDiff = 0;
             for (let i = 0; i < computedMic.words.length; i++) {
-                if (inputMic.words[i] !== computedMic.words[i]) {
-                    throw new CryptoDecryptError("Message authentication failed due to invalid signature");
-                }
+                micDiff |= inputMic.words[i] ^ computedMic.words[i];
+            }
+            if (micDiff !== 0) {
+                throw new CryptoDecryptError("Message authentication failed: tag mismatch");
             }
 
             return pt;

--- a/packages/general/test/crypto/aes/CcmTest.ts
+++ b/packages/general/test/crypto/aes/CcmTest.ts
@@ -204,12 +204,18 @@ describe("Ccm", () => {
         const ccm = Ccm(Bytes.fromHex(v.key));
         const input = { adata: Bytes.of(Bytes.fromHex(v.adata)), nonce: Bytes.of(Bytes.fromHex(v.nonce)) };
 
-        it("throws CryptoDecryptError on a tampered tag", () => {
-            const corrupted = Bytes.of(Bytes.fromHex(v.ct + v.tag));
-            corrupted[corrupted.length - 1] ^= 0xff;
+        const ctLength = Bytes.of(Bytes.fromHex(v.ct)).length;
+        const tagLength = Bytes.of(Bytes.fromHex(v.tag)).length;
 
-            expect(() => ccm.decrypt({ ...input, ct: corrupted })).throws(CryptoDecryptError);
-        });
+        // Flip one byte in each 32-bit tag word so a comparison that only checked some words would not catch them all.
+        for (let word = 0; word < tagLength / 4; word++) {
+            it(`throws CryptoDecryptError on a tag tampered in word ${word}`, () => {
+                const corrupted = Bytes.of(Bytes.fromHex(v.ct + v.tag));
+                corrupted[ctLength + word * 4] ^= 0xff;
+
+                expect(() => ccm.decrypt({ ...input, ct: corrupted })).throws(CryptoDecryptError);
+            });
+        }
 
         it("throws CryptoDecryptError when decrypting with the wrong key", () => {
             const wrongCcm = Ccm(Bytes.fromHex("ffffffffffffffffffffffffffffffff"));

--- a/packages/general/test/crypto/aes/CcmTest.ts
+++ b/packages/general/test/crypto/aes/CcmTest.ts
@@ -5,6 +5,7 @@
  */
 
 import { Ccm } from "#crypto/aes/Ccm.js";
+import { CryptoDecryptError } from "#crypto/CryptoError.js";
 import { Bytes } from "#util/Bytes.js";
 
 /**
@@ -193,6 +194,29 @@ describe("Ccm", () => {
             );
 
             expect(result).equals(v.ct + v.tag);
+        });
+    });
+
+    describe("tag verification", () => {
+        // A wrong key (or any tampered tag) must surface as CryptoDecryptError so the group-session multi-key
+        // candidate loop treats it as "wrong key, try next" rather than propagating an uncaught error.
+        const v = vectors.find(entry => entry.name === "NIST tcId 10")!;
+        const ccm = Ccm(Bytes.fromHex(v.key));
+        const input = { adata: Bytes.of(Bytes.fromHex(v.adata)), nonce: Bytes.of(Bytes.fromHex(v.nonce)) };
+
+        it("throws CryptoDecryptError on a tampered tag", () => {
+            const corrupted = Bytes.of(Bytes.fromHex(v.ct + v.tag));
+            corrupted[corrupted.length - 1] ^= 0xff;
+
+            expect(() => ccm.decrypt({ ...input, ct: corrupted })).throws(CryptoDecryptError);
+        });
+
+        it("throws CryptoDecryptError when decrypting with the wrong key", () => {
+            const wrongCcm = Ccm(Bytes.fromHex("ffffffffffffffffffffffffffffffff"));
+
+            expect(() => wrongCcm.decrypt({ ...input, ct: Bytes.of(Bytes.fromHex(v.ct + v.tag)) })).throws(
+                CryptoDecryptError,
+            );
         });
     });
 });


### PR DESCRIPTION
## Problem

The pure-JS AEAD backend (`Ccm.ts`, used on browsers/Deno/non-Node.js platforms via `StandardCrypto`) threw `CryptoInputError` on AEAD tag-verify failure. `CryptoInputError extends MatterError` — **not** `CryptoError` — so the group-session multi-key candidate loop in `GroupSession.ts`:

```typescript
} catch (error) {
    CryptoDecryptError.accept(error);   // re-throws anything that is NOT a CryptoDecryptError
}
```

could not treat a bad tag during a wrong-key trial as "wrong key, try next". The error propagated uncaught → group multicast decode failed on those platforms.

`NodeJsStyleCrypto` already throws `CryptoDecryptError` on tag failure, so Node.js was unaffected — which is why the Node-based test suite never caught it.

## Fix

`Ccm.ts` bad-tag branch now throws `CryptoDecryptError` (matches the Node backend contract — a tag-verify failure is a decrypt failure, not malformed input). The length/nonce-format checks in the same file correctly remain `CryptoInputError`.

Added bad-tag and wrong-key rejection tests to `CcmTest.ts` (previously zero bad-tag coverage).

**Source:** Matter 1.6.0 spec↔impl verification, finding Q-01 (`core-03-06-conf-integrity`).

## Test

`@matter/general` 1147/1147 (ESM/CJS/Web), format + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)