### PR TITLE
fix(general): sample SPAKE2+ ephemeral scalar bounded by group order n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/general
     - Fix: `log.level` (e.g. `MATTER_LOG_LEVEL`) now accepts string level names like `info` again, not just numeric values
     - Fix: A failed UDP multicast send now evicts and rebuilds the broadcast channel instead of caching a dead socket
+    - Fix: SPAKE2+ now samples the ephemeral scalar bounded by the group order `n` instead of the field prime `p`
 
 - @matter/protocol
     - Fix: Ensure that the peer-medium-specific `additionalMrpDelay` is also used for executed commands, and added an optional per-request `additionalMrpDelay` override

--- a/packages/general/src/crypto/Spake2p.ts
+++ b/packages/general/src/crypto/Spake2p.ts
@@ -57,7 +57,7 @@ export class Spake2p {
 
     static create(crypto: Crypto, context: Bytes, w0: bigint) {
         const curve = Point.CURVE();
-        const random = crypto.randomBigInt(32, curve.p);
+        const random = crypto.randomBigInt(32, curve.n);
         return new Spake2p(crypto, context, random, w0);
     }
 

--- a/packages/general/test/crypto/Spake2pTest.ts
+++ b/packages/general/test/crypto/Spake2pTest.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ec } from "#crypto/Crypto.js";
 import { Spake2p } from "#crypto/Spake2p.js";
 import { MockCrypto } from "#index.js";
 import { Bytes } from "#util/Bytes.js";
@@ -59,6 +60,28 @@ describe("Spake2p", () => {
             expect(Bytes.toHex(result.hAY)).equals(Bytes.toHex(hAY));
             expect(Bytes.toHex(result.hBX)).equals(Bytes.toHex(hBX));
         }).timeout(20000);
+    });
+
+    describe("ephemeral scalar", () => {
+        it("samples bounded by the group order n, not the field prime p", () => {
+            const context = Bytes.fromString("SPAKE2+-P256-SHA256-HKDF draft-01");
+            const w0 = BigInt("0xe6887cf9bdfb7579c69bf47928a84514b5e355ac034863f7ffaf4390e67d798c");
+            const curve = ec.p256.Point.CURVE();
+
+            let capturedBound: bigint | undefined;
+            const original = crypto.randomBigInt;
+            crypto.randomBigInt = (size, maxValue) => {
+                capturedBound = maxValue;
+                return original.call(crypto, size, maxValue);
+            };
+            try {
+                Spake2p.create(crypto, context, w0);
+            } finally {
+                crypto.randomBigInt = original;
+            }
+
+            expect(capturedBound).equals(curve.n);
+        });
     });
 
     describe("context hash test", () => {


### PR DESCRIPTION
## Summary

`Spake2p.create` sampled the per-session ephemeral scalar (x for prover / y for verifier) with `randomBigInt(32, curve.p)` — bound by the **field prime `p`**. SPAKE2+ and CHIP (`FEGenerate` = `BN_rand_range(order)`) sample from `[0, n)`, the **group order**.

Fix: `randomBigInt(32, curve.n)` at `Spake2p.ts:60`.

**Impact: none in practice.** `n < p` with `p − n ≈ 2^126.4`, so a draw landing in `[n, p)` has prob ≈ 2^−129.6, and even then the value reduces mod `n` implicitly during scalar point-mult. This is a correctness-of-intent / hygiene fix, not a bug with observable consequences.

Source: Matter 1.6.0 spec↔impl verification, finding Q-01 (unit `core-03-10-pake`).

## Test

Adds a scalar-bound assertion in `Spake2pTest.ts` that captures the bound passed to `crypto.randomBigInt` by `Spake2p.create` and asserts it equals `curve.n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)