### PR TITLE
fix(model): advertise interaction model revision 12 instead of 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A failed UDP multicast send now evicts and rebuilds the broadcast channel instead of caching a dead socket
     - Fix: SPAKE2+ now samples the ephemeral scalar bounded by the group order `n` instead of the field prime `p`
 
+- @matter/model
+    - Fix: Changed interaction model revision back to 12 because revision 13 only includes a provisional feature
+
 - @matter/protocol
     - Fix: Ensure that the peer-medium-specific `additionalMrpDelay` is also used for executed commands, and added an optional per-request `additionalMrpDelay` override
     - Adjustment: MRP now selects the active/idle retransmission interval by peer activity for every transmission including the first, instead of forcing the first transmission to the idle interval

--- a/packages/model/src/common/Specification.ts
+++ b/packages/model/src/common/Specification.ts
@@ -68,6 +68,10 @@ export namespace Specification {
 
     /**
      * Interaction model revision associated with the default revision of Matter.
+     *
+     * Capped at 12 because rev 13's sole delta over 12 is WildcardFilterConfigurationVersion, which spec
+     * §8.2.1.7.1 marks provisional (not certifiable).
+     * TODO: Bump to 13 once that feature becomes certifiable.
      */
-    export const INTERACTION_MODEL_REVISION = 13;
+    export const INTERACTION_MODEL_REVISION = 12;
 }

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -1878,9 +1878,9 @@ const PEER1_STATE = {
         sessionParameters: {
             activeInterval: 300,
             activeThreshold: 4000,
-            dataModelRevision: 19,
+            dataModelRevision: Specification.DATA_MODEL_REVISION,
             idleInterval: 500,
-            interactionModelRevision: 12,
+            interactionModelRevision: Specification.INTERACTION_MODEL_REVISION,
             maxPathsPerInvoke: 10,
             maxTcpMessageSize: undefined,
             specificationVersion: Specification.SPECIFICATION_VERSION,

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -1880,7 +1880,7 @@ const PEER1_STATE = {
             activeThreshold: 4000,
             dataModelRevision: 19,
             idleInterval: 500,
-            interactionModelRevision: 13,
+            interactionModelRevision: 12,
             maxPathsPerInvoke: 10,
             maxTcpMessageSize: undefined,
             specificationVersion: Specification.SPECIFICATION_VERSION,


### PR DESCRIPTION
## Summary

`INTERACTION_MODEL_REVISION` was set to `13`, but a node should advertise the highest **certifiable** revision.

Per spec §8.1.1 Revision History:
- rev **12** — WildcardPathFlags + multiple CommandDataIB per Invoke (batch invoke is shipped/non-provisional → certifiable)
- rev **13** — sole delta over 12 is `WildcardFilterConfigurationVersion`, and §8.2.1.7.1 NOTE marks it **provisional** (not certifiable)

Since the only feature distinguishing rev 13 from 12 is provisional, the highest legitimate revision is **12**. CHIP reports 12 (`SpecificationDefinedRevisions.h`); matter.js was the outlier. matter.js may still *support* the provisional feature — that doesn't justify advertising rev 13.

## Changes
- `Specification.ts`: `INTERACTION_MODEL_REVISION = 12` + forward-looking TODO to bump back once the feature becomes certifiable
- `ClientNodeTest.ts`: update hardcoded expectation 13→12
- `CHANGELOG.md`: `@matter/model` entry

## Interop
Receive side only logs on revision mismatch, never rejects (`InteractionServer#checkSenderRevision`), so no interop break — correctness-of-claim fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)