### PR TITLE
fix(protocol): spec two-pass ACL for read/subscribe (View then actual privilege)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: The MRP retransmission interval is no longer capped below the peer's idle interval
     - Fix: The connection fallback address is now compared by value, so a rediscovered last-known address is no longer mistaken for an address change
     - Fix: Ensure that subscriptions established through an interaction are closed when the interaction closes (e.g. node disable/disconnect or decommission)
+    - Fix: Ensure spec-compliant read/subscribe responses for a model-known but absent high-privilege attribute or event
 
 - @project-chip/matter.js
     - Fix: Ensure that `PairedNode.connect()` reconnects a node that was previously disconnected

--- a/packages/node/test/node/AttributeReadResponseTest.ts
+++ b/packages/node/test/node/AttributeReadResponseTest.ts
@@ -5,6 +5,7 @@
  */
 
 import { OnOffLightDevice } from "#devices/on-off-light";
+import { AccessLevel } from "@matter/model";
 import { Read } from "@matter/protocol";
 import { AttributeId, ClusterId, EndpointNumber, Status } from "@matter/types";
 import { BasicInformation } from "@matter/types/clusters/basic-information";
@@ -147,6 +148,42 @@ describe("AttributeReadResponse", () => {
                     path: {
                         attributeId: 15,
                         clusterId: 40,
+                        endpointId: 0,
+                    },
+                    status: Status.UnsupportedAttribute,
+                },
+            ],
+        ]);
+        expect(response.counts).deep.equals({ status: 1, success: 0, existent: 0 });
+    });
+
+    // Spec 8.4.3.2 step 1: a View-privilege subject may learn element existence, so a model-known but
+    // absent attribute whose actual read privilege exceeds View resolves to UNSUPPORTED_ATTRIBUTE (existence),
+    // not UNSUPPORTED_ACCESS (the View pass grants before the existence check fires).
+    it("reads model-known absent high-privilege attribute as unsupported attribute for view-only subject", async () => {
+        const node = await MockServerNode.createOnline();
+        const response = await readAttrRaw(
+            node,
+            {
+                attributeRequests: [
+                    {
+                        // GeneralCommissioning.TcAcceptedVersion: read privilege Administer, absent when TC feature is off
+                        endpointId: EndpointNumber(0),
+                        clusterId: ClusterId(48),
+                        attributeId: AttributeId(5),
+                    },
+                ],
+            },
+            AccessLevel.View,
+        );
+
+        expect(response.data).deep.equals([
+            [
+                {
+                    kind: "attr-status",
+                    path: {
+                        attributeId: 5,
+                        clusterId: 48,
                         endpointId: 0,
                     },
                     status: Status.UnsupportedAttribute,

--- a/packages/node/test/node/read-helpers.ts
+++ b/packages/node/test/node/read-helpers.ts
@@ -12,7 +12,11 @@ export function readAttr(node: MockServerNode, ...args: Parameters<typeof Read>)
     return readAttrRaw(node, request);
 }
 
-export async function readAttrRaw(node: MockServerNode, data: Partial<Read.Attributes>) {
+export async function readAttrRaw(
+    node: MockServerNode,
+    data: Partial<Read.Attributes>,
+    accessLevel = AccessLevel.Administer,
+) {
     const request = {
         isFabricFiltered: false,
         interactionModelRevision: Specification.INTERACTION_MODEL_REVISION,
@@ -21,7 +25,7 @@ export async function readAttrRaw(node: MockServerNode, data: Partial<Read.Attri
     if (!Read.containsAttribute(request)) {
         throw new Error("Expected an attribute request");
     }
-    return node.online({ accessLevel: AccessLevel.Administer }, ({ context }) => {
+    return node.online({ accessLevel }, ({ context }) => {
         const response = new AttributeReadResponse(node.protocol, context);
         const data = [...response.process(request)];
         data.forEach(chunks => {

--- a/packages/protocol/src/action/server/AttributeReadResponse.ts
+++ b/packages/protocol/src/action/server/AttributeReadResponse.ts
@@ -12,7 +12,7 @@ import { AccessControl, hasLocalActor, hasRemoteActor } from "#action/server/Acc
 import { DataResponse, FallbackLimits, WildcardPathFlagsCodec } from "#action/server/DataResponse.js";
 import { Val } from "#action/Val.js";
 import { InternalError, Logger, serialize } from "@matter/general";
-import { AttributeModel, DataModelPath, ElementTag } from "@matter/model";
+import { AccessLevel, AttributeModel, DataModelPath, ElementTag } from "@matter/model";
 import {
     AttributePath,
     ClusterId,
@@ -204,8 +204,10 @@ export class AttributeReadResponse<
             limits = attribute.limits;
         }
 
+        // Order prescribed by core spec 8.4.3.2: a View-privilege pass gates element-existence disclosure,
+        // existence checks follow, then the actual-privilege pass gates the data.
+        let access: { session: AccessControl.RemoteActorSession; location: AccessControl.Location } | undefined;
         if (hasRemoteActor(this.session)) {
-            // Validate access.  Order here prescribed by 1.4 core spec 8.4.3.2
             // We need some fallback location if cluster is not defined
             const location: AccessControl.Location = {
                 ...(cluster?.location ?? {
@@ -215,23 +217,10 @@ export class AttributeReadResponse<
                 }),
                 owningFabric: this.session.fabric,
             };
+            access = { session: this.session, location };
 
-            const permission = this.session.authorityAt(limits.readLevel, location);
-
-            switch (permission) {
-                case AccessControl.Authority.Granted:
-                    break;
-
-                case AccessControl.Authority.Unauthorized:
-                    this.addStatus(path, Status.UnsupportedAccess);
-                    return;
-
-                case AccessControl.Authority.Restricted:
-                    this.addStatus(path, Status.AccessRestricted);
-                    return;
-
-                default:
-                    throw new InternalError(`Unsupported authorization state ${permission}`);
+            if (!this.#authorize(access.session, path, AccessLevel.View, location)) {
+                return;
             }
         }
 
@@ -249,6 +238,10 @@ export class AttributeReadResponse<
         }
         if (!limits.readable) {
             this.addStatus(path, Status.UnsupportedRead);
+            return;
+        }
+
+        if (access !== undefined && !this.#authorize(access.session, path, limits.readLevel, access.location)) {
             return;
         }
 
@@ -431,6 +424,34 @@ export class AttributeReadResponse<
             this.#chunk.push(report);
         } else {
             this.#chunk = [report];
+        }
+    }
+
+    /**
+     * Validate access at {@link level}.  Returns true if granted; otherwise records the appropriate status and
+     * returns false.
+     */
+    #authorize(
+        session: AccessControl.RemoteActorSession,
+        path: ReadResult.ConcreteAttributePath,
+        level: AccessLevel,
+        location: AccessControl.Location,
+    ) {
+        const permission = session.authorityAt(level, location);
+        switch (permission) {
+            case AccessControl.Authority.Granted:
+                return true;
+
+            case AccessControl.Authority.Unauthorized:
+                this.addStatus(path, Status.UnsupportedAccess);
+                return false;
+
+            case AccessControl.Authority.Restricted:
+                this.addStatus(path, Status.AccessRestricted);
+                return false;
+
+            default:
+                throw new InternalError(`Unsupported authorization state ${permission}`);
         }
     }
 

--- a/packages/protocol/src/action/server/EventReadResponse.ts
+++ b/packages/protocol/src/action/server/EventReadResponse.ts
@@ -12,7 +12,7 @@ import { AccessControl, hasRemoteActor } from "#action/server/AccessControl.js";
 import { DataResponse, FallbackLimits } from "#action/server/DataResponse.js";
 import { NumberedOccurrence } from "#events/Occurrence.js";
 import { InternalError, isObject, Logger } from "@matter/general";
-import { DataModelPath, ElementTag, EventModel } from "@matter/model";
+import { AccessLevel, DataModelPath, ElementTag, EventModel } from "@matter/model";
 import {
     EventNumber,
     EventPath,
@@ -185,10 +185,12 @@ export class EventReadResponse<
             limits = event.limits;
         }
 
-        // Validate access.  Order here prescribed by 1.4 core spec 8.4.3.2
-        // We need some fallback location if cluster is not defined
+        // Order prescribed by core spec 8.4.3.2: a View-privilege pass gates element-existence disclosure,
+        // existence checks follow, then the actual-privilege pass gates the data.
+        let access: { session: AccessControl.RemoteActorSession; location: AccessControl.Location } | undefined;
         if (hasRemoteActor(this.session)) {
-            const location = {
+            // We need some fallback location if cluster is not defined
+            const location: AccessControl.Location = {
                 ...(cluster?.location ?? {
                     path: DataModelPath.none,
                     endpoint: endpointId,
@@ -196,19 +198,11 @@ export class EventReadResponse<
                 }),
                 owningFabric: this.session.fabric,
             };
-            const permission = this.session.authorityAt(limits.readLevel, location);
-            switch (permission) {
-                case AccessControl.Authority.Granted:
-                    break;
+            access = { session: this.session, location };
 
-                case AccessControl.Authority.Unauthorized:
-                    return this.#asStatus(path, Status.UnsupportedAccess);
-
-                case AccessControl.Authority.Restricted:
-                    return this.#asStatus(path, Status.AccessRestricted);
-
-                default:
-                    throw new InternalError(`Unsupported authorization state ${permission}`);
+            const denied = this.#authorize(access.session, path, AccessLevel.View, location);
+            if (denied !== undefined) {
+                return denied;
             }
         }
 
@@ -220,6 +214,13 @@ export class EventReadResponse<
         }
         if (event === undefined || !cluster.type.events[event.id]) {
             return this.#asStatus(path, Status.UnsupportedEvent);
+        }
+
+        if (access !== undefined) {
+            const denied = this.#authorize(access.session, path, limits.readLevel, access.location);
+            if (denied !== undefined) {
+                return denied;
+            }
         }
 
         if (this.#currentEndpoint !== endpoint) {
@@ -351,6 +352,31 @@ export class EventReadResponse<
                 }
             }
             yield this.#asValue(event, tlv);
+        }
+    }
+
+    /**
+     * Validate access at {@link level}.  Returns undefined if granted; otherwise a status report to return.
+     */
+    #authorize(
+        session: AccessControl.RemoteActorSession,
+        path: ReadResult.ConcreteEventPath,
+        level: AccessLevel,
+        location: AccessControl.Location,
+    ) {
+        const permission = session.authorityAt(level, location);
+        switch (permission) {
+            case AccessControl.Authority.Granted:
+                return undefined;
+
+            case AccessControl.Authority.Unauthorized:
+                return this.#asStatus(path, Status.UnsupportedAccess);
+
+            case AccessControl.Authority.Restricted:
+                return this.#asStatus(path, Status.AccessRestricted);
+
+            default:
+                throw new InternalError(`Unsupported authorization state ${permission}`);
         }
     }
 


### PR DESCRIPTION
## Summary

Implements Matter core spec §8.4.3.2 step 1 two-pass ACL for **read and subscribe** in `AttributeReadResponse` and `EventReadResponse`.

Previously both ran a **single** ACL check at the element's **actual** read privilege **before** the element-existence checks. For a **model-known but absent** element whose read privilege exceeds View, this returned `UNSUPPORTED_ACCESS` instead of `UNSUPPORTED_ATTRIBUTE`/`UNSUPPORTED_EVENT`, diverging from the spec and from CHIP (`Engine.cpp`).

Now the spec ordering applies:
1. **View-privilege pass** — gates whether the subject may learn element existence (`AccessDenied → UNSUPPORTED_ACCESS`, `AccessRestricted → ACCESS_RESTRICTED`).
2. **Existence checks** — `UNSUPPORTED_ENDPOINT/CLUSTER/ATTRIBUTE/READ` (events: `UNSUPPORTED_EVENT`).
3. **Actual-privilege pass** — gates reading the data.

Since View is the floor of the privilege hierarchy, any subject holding the actual read privilege also passes the View pass; the two passes only differ for a subject with View but not the higher read privilege.

## Behavior change (the only observable one)

Subject has **View** but not the element's actual read privilege, reading a **model-known but absent-at-location** element:
- before → `UNSUPPORTED_ACCESS`
- after → `UNSUPPORTED_ATTRIBUTE` / `UNSUPPORTED_EVENT` (matches spec + CHIP)

No security regression: matter.js never over-grants and never returns data the subject can't read. Local actors and present/fully-denied elements are unaffected. Wildcard reads are unchanged (they enumerate only existing elements and filter by actual read privilege, so they cannot leak existence of absent elements).

## Test

`AttributeReadResponseTest.ts`: a View-only subject reading `GeneralCommissioning.TcAcceptedVersion` (read priv Administer, absent when the TC feature is off) now asserts `UnsupportedAttribute`. `readAttrRaw` gained an optional `accessLevel` parameter (default `Administer`).

## Verification

- `@matter/protocol` tests: 1175/1175
- `@matter/node` tests: 1196/1196
- format-verify + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)