### PR TITLE
refactor(node): unify read/subscribe valid-path validation

### DIFF
--- a/packages/node/src/node/server/InteractionServer.ts
+++ b/packages/node/src/node/server/InteractionServer.ts
@@ -107,6 +107,19 @@ function validateReadEventPath(path: TypeFromSchema<typeof TlvEventPath>, isGrou
     }
 }
 
+/**
+ * Single early/upfront valid-path gate shared by Read and Subscribe. Per Matter §8.4.3.2 the path
+ * processing is identical for both interaction types, so they validate through one entry point to
+ * keep the rules from drifting.
+ */
+function validateReadPaths(
+    attributeRequests?: TypeFromSchema<typeof TlvAttributePath>[],
+    eventRequests?: TypeFromSchema<typeof TlvEventPath>[],
+) {
+    attributeRequests?.forEach(path => validateReadAttributesPath(path));
+    eventRequests?.forEach(path => validateReadEventPath(path));
+}
+
 function clusterPathToId({ nodeId, endpointId, clusterId }: TypeFromSchema<typeof TlvClusterPath>) {
     return `${nodeId}/${endpointId}/${clusterId}`;
 }
@@ -309,6 +322,8 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
                 Status.InvalidAction,
             );
         }
+
+        validateReadPaths(attributeRequests, eventRequests);
 
         return {
             dataReport: {
@@ -592,9 +607,7 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
             }),
         ]);
 
-        // Validate of the paths before proceeding
-        attributeRequests?.forEach(path => validateReadAttributesPath(path));
-        eventRequests?.forEach(path => validateReadEventPath(path));
+        validateReadPaths(attributeRequests, eventRequests);
 
         if (minIntervalFloorSeconds < 0) {
             throw new StatusResponseError(

--- a/packages/node/src/node/server/InteractionServer.ts
+++ b/packages/node/src/node/server/InteractionServer.ts
@@ -82,10 +82,7 @@ export interface PeerSubscription {
     sendInterval: Duration;
 }
 
-function validateReadAttributesPath(path: AttributePath, isGroupSession = false) {
-    if (isGroupSession) {
-        throw new StatusResponseError("Illegal read request with group session", Status.InvalidAction);
-    }
+function validateReadAttributesPath(path: AttributePath) {
     const { clusterId, attributeId } = path;
     if (clusterId === undefined && attributeId !== undefined) {
         if (!GLOBAL_IDS.has(attributeId)) {
@@ -97,21 +94,14 @@ function validateReadAttributesPath(path: AttributePath, isGroupSession = false)
     }
 }
 
-function validateReadEventPath(path: EventPath, isGroupSession = false) {
+function validateReadEventPath(path: EventPath) {
     const { clusterId, eventId } = path;
     if (clusterId === undefined && eventId !== undefined) {
         throw new StatusResponseError("Illegal read request with wildcard cluster ID", Status.InvalidAction);
     }
-    if (isGroupSession) {
-        throw new StatusResponseError("Illegal read request with group session", Status.InvalidAction);
-    }
 }
 
-/**
- * Single early/upfront valid-path gate shared by Read and Subscribe. Per Matter §8.4.3.2 the path
- * processing is identical for both interaction types, so they validate through one entry point to
- * keep the rules from drifting.
- */
+/** Per Matter §8.4.3.2, Read and Subscribe share one valid-path algorithm. */
 function validateReadPaths(attributeRequests?: AttributePath[], eventRequests?: EventPath[]) {
     attributeRequests?.forEach(path => validateReadAttributesPath(path));
     eventRequests?.forEach(path => validateReadEventPath(path));

--- a/packages/node/src/node/server/InteractionServer.ts
+++ b/packages/node/src/node/server/InteractionServer.ts
@@ -49,16 +49,16 @@ import {
 } from "@matter/protocol";
 import {
     AttributeData,
+    AttributePath,
     DEFAULT_MAX_PATHS_PER_INVOKE,
+    EventPath,
     INTERACTION_PROTOCOL_ID,
     InvokeResponseData,
     ReceivedStatusResponseError,
     Status,
     StatusResponseError,
     TlvAny,
-    TlvAttributePath,
     TlvClusterPath,
-    TlvEventPath,
     TlvInvokeResponseData,
     TlvInvokeResponseForSend,
     TlvSubscribeResponse,
@@ -75,14 +75,14 @@ export interface PeerSubscription {
     peerAddress: PeerAddress;
     minIntervalFloor: Duration;
     maxIntervalCeiling: Duration;
-    attributeRequests?: TypeFromSchema<typeof TlvAttributePath>[];
-    eventRequests?: TypeFromSchema<typeof TlvEventPath>[];
+    attributeRequests?: AttributePath[];
+    eventRequests?: EventPath[];
     isFabricFiltered: boolean;
     maxInterval: Duration;
     sendInterval: Duration;
 }
 
-function validateReadAttributesPath(path: TypeFromSchema<typeof TlvAttributePath>, isGroupSession = false) {
+function validateReadAttributesPath(path: AttributePath, isGroupSession = false) {
     if (isGroupSession) {
         throw new StatusResponseError("Illegal read request with group session", Status.InvalidAction);
     }
@@ -97,7 +97,7 @@ function validateReadAttributesPath(path: TypeFromSchema<typeof TlvAttributePath
     }
 }
 
-function validateReadEventPath(path: TypeFromSchema<typeof TlvEventPath>, isGroupSession = false) {
+function validateReadEventPath(path: EventPath, isGroupSession = false) {
     const { clusterId, eventId } = path;
     if (clusterId === undefined && eventId !== undefined) {
         throw new StatusResponseError("Illegal read request with wildcard cluster ID", Status.InvalidAction);
@@ -112,10 +112,7 @@ function validateReadEventPath(path: TypeFromSchema<typeof TlvEventPath>, isGrou
  * processing is identical for both interaction types, so they validate through one entry point to
  * keep the rules from drifting.
  */
-function validateReadPaths(
-    attributeRequests?: TypeFromSchema<typeof TlvAttributePath>[],
-    eventRequests?: TypeFromSchema<typeof TlvEventPath>[],
-) {
+function validateReadPaths(attributeRequests?: AttributePath[], eventRequests?: EventPath[]) {
     attributeRequests?.forEach(path => validateReadAttributesPath(path));
     eventRequests?.forEach(path => validateReadEventPath(path));
 }

--- a/packages/protocol/src/events/OccurrenceManager.ts
+++ b/packages/protocol/src/events/OccurrenceManager.ts
@@ -18,11 +18,11 @@ import {
 } from "@matter/general";
 import {
     EventNumber,
+    EventPath,
     FabricIndex,
     Priority,
     resolveEventName,
     TlvEventFilter,
-    TlvEventPath,
     TypeFromSchema,
 } from "@matter/types";
 import { EventStore, OccurrenceSummary } from "./EventStore.js";
@@ -151,7 +151,7 @@ export class OccurrenceManager {
      * @deprecated
      */
     query(
-        eventPath: TypeFromSchema<typeof TlvEventPath>,
+        eventPath: EventPath,
         filters?: TypeFromSchema<typeof TlvEventFilter>[],
         filterForFabricIndex?: FabricIndex,
     ): MaybePromise<NumberedOccurrence[]> {

--- a/packages/protocol/src/interaction/AttributeDataEncoder.ts
+++ b/packages/protocol/src/interaction/AttributeDataEncoder.ts
@@ -7,10 +7,10 @@ import { Diagnostic, MatterFlowError } from "@matter/general";
 import {
     ArraySchema,
     AttributeId,
+    AttributePath,
     ClusterId,
     EndpointNumber,
     NodeId,
-    TlvAttributePath,
     TlvAttributeReport,
     TlvAttributeReportData,
     TlvDataReport,
@@ -245,10 +245,10 @@ export function compressAttributeDataReportTags(data: AttributeReportPayload[]) 
 
 /** Helper method to compress one path and preserve the state for the next path. */
 function compressPath(
-    path: TypeFromSchema<typeof TlvAttributePath>,
+    path: AttributePath,
     dataVersion: number | undefined,
     lastFullPath: FullAttributePath | undefined,
-): { path: TypeFromSchema<typeof TlvAttributePath>; lastFullPath?: FullAttributePath } {
+): { path: AttributePath; lastFullPath?: FullAttributePath } {
     const { nodeId, endpointId, clusterId, attributeId } = path;
 
     // Should never happen but typing likes it better that way

--- a/packages/types/src/cluster/ClusterHelper.ts
+++ b/packages/types/src/cluster/ClusterHelper.ts
@@ -8,8 +8,7 @@ import { AttributeModel, ClusterModel, CommandModel, EventModel, Matter } from "
 import { ClusterId } from "../datatype/ClusterId.js";
 import { EndpointNumber } from "../datatype/EndpointNumber.js";
 import { NodeId } from "../datatype/NodeId.js";
-import { TlvAttributePath, TlvCommandPath, TlvEventPath } from "../protocol/index.js";
-import { TypeFromSchema } from "../tlv/TlvSchema.js";
+import { AttributePath, CommandPath, EventPath } from "../protocol/index.js";
 
 function toHex(value: number | bigint | undefined) {
     return value === undefined ? "*" : `0x${value.toString(16)}`;
@@ -53,12 +52,7 @@ function resolveElementName(cluster: ClusterModel | undefined, tag: string, elem
     return undefined;
 }
 
-export function resolveAttributeName({
-    nodeId,
-    endpointId,
-    clusterId,
-    attributeId,
-}: TypeFromSchema<typeof TlvAttributePath>) {
+export function resolveAttributeName({ nodeId, endpointId, clusterId, attributeId }: AttributePath) {
     const endpointClusterName = resolveEndpointClusterName(nodeId, endpointId, clusterId);
     if (endpointId === undefined || clusterId === undefined || attributeId === undefined) {
         return `${endpointClusterName}/${toHex(attributeId)}`;
@@ -71,13 +65,7 @@ export function resolveAttributeName({
     return `${endpointClusterName}/${name}(${toHex(attributeId)})`;
 }
 
-export function resolveEventName({
-    nodeId,
-    endpointId,
-    clusterId,
-    eventId,
-    isUrgent,
-}: TypeFromSchema<typeof TlvEventPath>) {
+export function resolveEventName({ nodeId, endpointId, clusterId, eventId, isUrgent }: EventPath) {
     const isUrgentStr = isUrgent ? "!" : "";
     const endpointClusterName = resolveEndpointClusterName(nodeId, endpointId, clusterId);
     if (endpointId === undefined || clusterId === undefined || eventId === undefined) {
@@ -91,7 +79,7 @@ export function resolveEventName({
     return `${isUrgentStr}${endpointClusterName}/${name}(${toHex(eventId)})`;
 }
 
-export function resolveCommandName({ endpointId, clusterId, commandId }: TypeFromSchema<typeof TlvCommandPath>) {
+export function resolveCommandName({ endpointId, clusterId, commandId }: CommandPath) {
     const endpointClusterName = resolveEndpointClusterName(undefined, endpointId, clusterId);
     if (endpointId === undefined || clusterId === undefined || commandId === undefined) {
         return `${endpointClusterName}/${toHex(commandId)}`;


### PR DESCRIPTION
## Summary

Read and subscribe enforce the same Matter §8.4.2.2 valid-path rule (wildcard cluster + non-global attribute → INVALID_ACTION; wildcard cluster + eventId → INVALID_ACTION), but at two layers:

- **Subscribe** validated **early/upfront** via `validateRead*Path`.
- **Read** had **no early check** — enforced **late/deep** per-path inside report assembly (`AttributeReadResponse.addWildcard` / `EventReadResponse.#addWildcard`).

Behavior was already equivalent (both terminate with INVALID_ACTION), but two parallel call sites of one spec-shared rule risk drift. Per §8.4.3.2 the path-processing algorithm is identical for read and subscribe.

## Change

- New shared `validateReadPaths(attributeRequests, eventRequests)` gate.
- `handleReadRequest` now validates **early** (after the unicast check, before assembling any report) — fails fast with INVALID_ACTION instead of late inside `addWildcard`.
- `handleSubscribeRequest` uses the same helper.
- Protocol-layer `addWildcard` deep checks left intact — defense for direct `@matter/protocol` callers.
- Subscribe-only request-level checks (interval floor/ceiling, both-empty, subscriptionId) untouched.

## Test

- build ✓ · format ✓ · lint ✓
- `@matter/node` full suite 1196/1196 ✓ (ESM/CJS/Web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)