### PR TITLE
fix(node): keep subscription MaxInterval >= MinIntervalFloor above 60-min publisher limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/model
     - Fix: Changed interaction model revision back to 12 because revision 13 only includes a provisional feature
 
+- @matter/node
+    - Fix: Ensure that the negotiated subscription MaxInterval stays at or above the requested MinIntervalFloor when the floor exceeds the 60-minute publisher limit
+
 - @matter/protocol
     - Fix: Ensure that the peer-medium-specific `additionalMrpDelay` is also used for executed commands, and added an optional per-request `additionalMrpDelay` override
     - Adjustment: MRP now selects the active/idle retransmission interval by peer activity for every transmission including the first, instead of forcing the first transmission to the idle interval

--- a/packages/node/src/node/server/ServerSubscription.ts
+++ b/packages/node/src/node/server/ServerSubscription.ts
@@ -266,20 +266,25 @@ export class ServerSubscription implements Subscription {
         // controller minimum. But in general never faster than minimum interval configured or 2 seconds
         // (SUBSCRIPTION_MIN_INTERVAL_S). Additionally, we add a randomization window to the max interval to avoid all
         // devices sending at the same time. But we make sure not to exceed the global max interval.
-        const maxInterval = Duration.min(
-            Millis.floor(
-                Millis(
-                    Duration.max(
-                        subscriptionMinInterval,
+        // Spec §8.5.3.2 lower bound: MaxInterval must stay >= MinIntervalFloor even when the floor
+        // exceeds the publisher limit, so re-raise after the MAX_INTERVAL_PUBLISHER_LIMIT cap.
+        const maxInterval = Duration.max(
+            this.minIntervalFloor,
+            Duration.min(
+                Millis.floor(
+                    Millis(
                         Duration.max(
-                            this.minIntervalFloor,
-                            Duration.min(subscriptionMaxInterval, this.maxIntervalCeiling),
-                        ),
-                    ) +
-                        subscriptionRandomizationWindow * Math.random(),
+                            subscriptionMinInterval,
+                            Duration.max(
+                                this.minIntervalFloor,
+                                Duration.min(subscriptionMaxInterval, this.maxIntervalCeiling),
+                            ),
+                        ) +
+                            subscriptionRandomizationWindow * Math.random(),
+                    ),
                 ),
+                MAX_INTERVAL_PUBLISHER_LIMIT,
             ),
-            MAX_INTERVAL_PUBLISHER_LIMIT,
         );
         let sendInterval = Millis.floor(Millis(maxInterval / 2)); // Ideally we send at half the max interval
         if (sendInterval < Minutes.one) {

--- a/packages/node/src/node/server/ServerSubscription.ts
+++ b/packages/node/src/node/server/ServerSubscription.ts
@@ -460,7 +460,7 @@ export class ServerSubscription implements Subscription {
                 break;
             }
 
-            this.#lastUpdateTime = Time.nowMs; // TODO Count time from here or from "receive of the ack"?
+            this.#lastUpdateTime = Time.nowMs;
 
             try {
                 using sending = updating?.join("sending");

--- a/packages/node/test/node/ServerSubscriptionTest.ts
+++ b/packages/node/test/node/ServerSubscriptionTest.ts
@@ -5,7 +5,7 @@
  */
 
 import { ServerSubscription, ServerSubscriptionConfig } from "#node/server/ServerSubscription.js";
-import { DataReadQueue, Millis } from "@matter/general";
+import { DataReadQueue, Millis, Seconds } from "@matter/general";
 import { MessageExchange, NodeSession } from "@matter/protocol";
 import { MockServerNode } from "./mock-server-node.js";
 
@@ -20,6 +20,11 @@ describe("ServerSubscription", () => {
     async function createSubscription(
         node: MockServerNode,
         makeExchange: () => MessageExchange,
+        overrides?: {
+            minIntervalFloorSeconds?: number;
+            maxIntervalCeilingSeconds?: number;
+            negotiateIntervals?: boolean;
+        },
     ): Promise<ServerSubscription> {
         const fabric = await node.addFabric();
         const session = (await node.createExchange({ fabric })).session as NodeSession;
@@ -33,15 +38,15 @@ describe("ServerSubscription", () => {
                 initiateExchange: makeExchange,
             },
             request: {
-                minIntervalFloorSeconds: 0,
-                maxIntervalCeilingSeconds: 60,
+                minIntervalFloorSeconds: overrides?.minIntervalFloorSeconds ?? 0,
+                maxIntervalCeilingSeconds: overrides?.maxIntervalCeilingSeconds ?? 60,
                 // No attributeRequests / eventRequests → keepalive-only sends, no RemoteActorContext needed
                 isFabricFiltered: false,
             },
             subscriptionOptions: ServerSubscriptionConfig.of(),
-            // Use fixed short intervals so tests don't depend on randomization
-            useAsMaxInterval: Millis(200),
-            useAsSendInterval: Millis(100),
+            // Use fixed short intervals so tests don't depend on randomization, unless a test wants the
+            // real #determineSendingIntervals negotiation exercised.
+            ...(overrides?.negotiateIntervals ? {} : { useAsMaxInterval: Millis(200), useAsSendInterval: Millis(100) }),
         });
     }
 
@@ -60,6 +65,23 @@ describe("ServerSubscription", () => {
 
         expect(subscription.isCanceledByPeer).is.true;
         expect([...session.subscriptions]).is.empty;
+
+        await MockTime.resolve(node.close());
+    });
+
+    it("keeps negotiated maxInterval >= minIntervalFloor when floor exceeds the 60-min publisher limit", async () => {
+        // Spec §8.5.3.2: MinIntervalFloor <= MaxInterval. A floor above MAX_INTERVAL_PUBLISHER_LIMIT
+        // (60 min) must not be capped below the floor.
+        const node = await MockServerNode.createOnline();
+
+        const floorSeconds = 65535; // uint16 max, ~18.2 h
+        const subscription = await createSubscription(node, () => ({}) as any, {
+            minIntervalFloorSeconds: floorSeconds,
+            maxIntervalCeilingSeconds: floorSeconds,
+            negotiateIntervals: true,
+        });
+
+        expect(subscription.maxInterval).to.be.at.least(Seconds(floorSeconds));
 
         await MockTime.resolve(node.close());
     });


### PR DESCRIPTION
## Summary

Per Matter §8.5.3.2, the publisher-chosen MaxInterval must satisfy `MinIntervalFloor <= MaxInterval <= MAX(SUBSCRIPTION_MAX_INTERVAL_PUBLISHER_LIMIT, MaxIntervalCeiling)`.

`ServerSubscription.#determineSendingIntervals` computed the lower bound correctly, then applied an **unconditional** outer cap `Duration.min(…, MAX_INTERVAL_PUBLISHER_LIMIT)` (60 min). When `MinIntervalFloor > 60 min` (e.g. 65535 s ≈ 18.2 h, ceiling ≥ floor so the early `floor > ceiling → INVALID_ACTION` guard passes), the cap dropped the result to 3600 s `< 65535 s` → **MaxInterval < MinIntervalFloor**, violating the lower bound.

## Fix

Re-raise `maxInterval` to at least `minIntervalFloor` after the publisher-limit cap (`Duration.max(this.minIntervalFloor, Duration.min(…, MAX_INTERVAL_PUBLISHER_LIMIT))`). No-op in the normal case (floor < 60 min). One guard.

## Impact

None in practice — a subscriber requesting a min reporting interval > 60 min is pathological; no interop break. CHIP returns the requested ceiling unmodified for non-ICD, so its lower bound always holds. This is a strict-conformance / hygiene fix.

## Test

Added regression test (`ServerSubscriptionTest`): subscribe with `MinIntervalFloor = 65535 s` exercising the real `#determineSendingIntervals` → asserts negotiated `MaxInterval >= MinIntervalFloor`. Verified to fail without the fix.

build ✓ · format ✓ · lint ✓ · `@matter/node` 1196/1196 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)