### PR TITLE
fix(protocol): spec two-pass ACL for write and invoke (base-privilege pass then actual)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: The MRP retransmission interval is no longer capped below the peer's idle interval
     - Fix: The connection fallback address is now compared by value, so a rediscovered last-known address is no longer mistaken for an address change
     - Fix: Ensure that subscriptions established through an interaction are closed when the interaction closes (e.g. node disable/disconnect or decommission)
-    - Fix: Ensure spec-compliant read/subscribe/write responses for a model-known but absent high-privilege attribute or event
+    - Fix: Ensure spec-compliant read/subscribe/write/invoke responses for a model-known but absent high-privilege attribute, event or command
 
 - @project-chip/matter.js
     - Fix: Ensure that `PairedNode.connect()` reconnects a node that was previously disconnected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: The MRP retransmission interval is no longer capped below the peer's idle interval
     - Fix: The connection fallback address is now compared by value, so a rediscovered last-known address is no longer mistaken for an address change
     - Fix: Ensure that subscriptions established through an interaction are closed when the interaction closes (e.g. node disable/disconnect or decommission)
-    - Fix: Ensure spec-compliant read/subscribe responses for a model-known but absent high-privilege attribute or event
+    - Fix: Ensure spec-compliant read/subscribe/write responses for a model-known but absent high-privilege attribute or event
 
 - @project-chip/matter.js
     - Fix: Ensure that `PairedNode.connect()` reconnects a node that was previously disconnected

--- a/packages/node/test/node/AttributeWriteResponseTest.ts
+++ b/packages/node/test/node/AttributeWriteResponseTest.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { AccessLevel } from "@matter/model";
 import { AttributeWriteResponse, Write } from "@matter/protocol";
 import { EndpointNumber, Status, TlvString, WriteRequest } from "@matter/types";
 import { BasicInformation } from "@matter/types/clusters/basic-information";
@@ -84,6 +85,38 @@ describe("AttributeWriteRequest", () => {
                     endpointId: 0,
                 },
                 status: Status.UnsupportedAccess,
+                clusterStatus: undefined,
+            },
+        ]);
+        expect(response.counts).deep.equals({ status: 1, success: 0, existent: 0 });
+    });
+
+    // Spec 8.7.3.2: a View-privilege subject may learn element existence, so a model-known but absent
+    // attribute whose actual write privilege exceeds View resolves to UNSUPPORTED_ATTRIBUTE (existence),
+    // not UNSUPPORTED_ACCESS (the View pass grants before the existence check fires).
+    it("writes model-known absent high-privilege attribute as unsupported attribute for view-only subject", async () => {
+        const node = await MockServerNode.createOnline();
+        // BasicInformation.localConfigDisabled (id 0x10): optional (absent here), write privilege Manage
+        const response = await writeAttrAs(
+            node,
+            AccessLevel.View,
+            Write.Attribute({
+                endpoint: node,
+                cluster: BasicInformation,
+                attributes: "localConfigDisabled",
+                value: true,
+            }),
+        );
+
+        expect(response.data).deep.equals([
+            {
+                kind: "attr-status",
+                path: {
+                    attributeId: 0x10,
+                    clusterId: 40,
+                    endpointId: 0,
+                },
+                status: Status.UnsupportedAttribute,
                 clusterStatus: undefined,
             },
         ]);
@@ -288,6 +321,15 @@ async function writeAttrRaw(node: MockServerNode, data: Partial<WriteRequest>) {
     } as Write;
 
     return node.online({ command: true }, async ({ context }) => {
+        const response = new AttributeWriteResponse(node.protocol, context);
+        return { data: await response.process(request), counts: response.counts };
+    });
+}
+
+async function writeAttrAs(node: MockServerNode, accessLevel: AccessLevel, ...args: Parameters<typeof Write>) {
+    const request = { suppressResponse: false, ...Write(...args) } as Write;
+
+    return node.online({ command: true, accessLevel }, async ({ context }) => {
         const response = new AttributeWriteResponse(node.protocol, context);
         return { data: await response.process(request), counts: response.counts };
     });

--- a/packages/node/test/node/CommandInvokeResponseTest.ts
+++ b/packages/node/test/node/CommandInvokeResponseTest.ts
@@ -6,7 +6,9 @@
 
 import { OnOffLightDevice } from "#devices/on-off-light";
 import { Endpoint } from "#endpoint/index.js";
+import { AccessLevel } from "@matter/model";
 import { CommandInvokeResponse, Invoke, InvokeRequest, InvokeResult } from "@matter/protocol";
+import { ClusterId, CommandId, EndpointNumber, Status } from "@matter/types";
 import { OnOff } from "@matter/types/clusters/on-off";
 import { MockServerNode } from "./mock-server-node.js";
 
@@ -121,6 +123,37 @@ describe("CommandInvokeResponse", () => {
         expect(response.counts).deep.equals({ status: 1, success: 0, existent: 0 });
     });
 
+    // Spec 8.8.3.2: an Operate-privilege subject may learn element existence, so a model-known but absent
+    // command whose actual invoke privilege exceeds Operate resolves to an existence status (here
+    // UNSUPPORTED_CLUSTER), not UNSUPPORTED_ACCESS (the Operate pass grants before the existence check fires).
+    it("invokes model-known absent high-privilege command as existence status for operate-only subject", async () => {
+        const node = await MockServerNode.createOnline(undefined, { device: undefined });
+        // Groups.AddGroup (cluster 0x4, command 0x0): invoke privilege Manage, cluster absent on the root node
+        const response = await invokeCmdRawAs(node, AccessLevel.Operate, {
+            invokeRequests: [
+                {
+                    commandPath: {
+                        endpointId: EndpointNumber(0),
+                        clusterId: ClusterId(0x4),
+                        commandId: CommandId(0x0),
+                    },
+                    commandFields: undefined,
+                },
+            ],
+        });
+
+        expect(response.data).deep.equals([
+            {
+                kind: "cmd-status",
+                path: { clusterId: 0x4, commandId: 0x0, endpointId: 0 },
+                status: Status.UnsupportedCluster,
+                clusterStatus: undefined,
+                commandRef: undefined,
+            },
+        ]);
+        expect(response.counts).deep.equals({ status: 1, success: 0, existent: 0 });
+    });
+
     // TODO - more tests and Migrate some from InteractionProtocolTest
 });
 
@@ -130,7 +163,11 @@ function invokeCmd(node: MockServerNode, ...args: Parameters<typeof Invoke>) {
     return invokeCmdRaw(node, request);
 }
 
-async function invokeCmdRaw(node: MockServerNode, data: Partial<InvokeRequest>) {
+function invokeCmdRaw(node: MockServerNode, data: Partial<InvokeRequest>) {
+    return invokeCmdRawAs(node, AccessLevel.Operate, data);
+}
+
+async function invokeCmdRawAs(node: MockServerNode, accessLevel: AccessLevel, data: Partial<InvokeRequest>) {
     const request = {
         suppressResponse: false,
         ...data,
@@ -138,7 +175,7 @@ async function invokeCmdRaw(node: MockServerNode, data: Partial<InvokeRequest>) 
 
     const fabric = await node.addFabric();
     const exchange = await node.createExchange({ fabric });
-    return node.online({ command: true, exchange }, async ({ context }) => {
+    return node.online({ command: true, exchange, accessLevel }, async ({ context }) => {
         const response = new CommandInvokeResponse(node.protocol, context);
         let chunks: InvokeResult.Data[] | undefined;
         for await (const chunk of response.process(request)) {

--- a/packages/protocol/src/action/server/AttributeWriteResponse.ts
+++ b/packages/protocol/src/action/server/AttributeWriteResponse.ts
@@ -238,10 +238,6 @@ export class AttributeWriteResponse<
             }
         }
 
-        // Old implementation aka Matter 1.2 and lower need the ACL check moved here.
-        // see https://github.com/project-chip/connectedhomeip/issues/33735
-        // We have patched our tests for now
-
         if (hasRemoteActor(this.session)) {
             if (limits.timed && !this.session.timed) {
                 this.#errorCount++;

--- a/packages/protocol/src/action/server/AttributeWriteResponse.ts
+++ b/packages/protocol/src/action/server/AttributeWriteResponse.ts
@@ -11,7 +11,7 @@ import { WriteResult } from "#action/response/WriteResult.js";
 import { AccessControl, hasRemoteActor } from "#action/server/AccessControl.js";
 import { DataResponse, FallbackLimits } from "#action/server/DataResponse.js";
 import { Diagnostic, InternalError, Logger, serialize, toHex } from "@matter/general";
-import { AttributeModel, DataModelPath, ElementTag, FabricIndex as FabricIndexField } from "@matter/model";
+import { AccessLevel, AttributeModel, DataModelPath, ElementTag, FabricIndex as FabricIndexField } from "@matter/model";
 import {
     ArraySchema,
     AttributePath,
@@ -195,10 +195,12 @@ export class AttributeWriteResponse<
             limits = attribute.limits;
         }
 
+        // Order prescribed by core spec 8.7.3.2: a View-privilege pass gates element-existence disclosure,
+        // existence checks follow, then the actual-privilege pass gates the write.
+        let access: { session: AccessControl.RemoteActorSession; location: AccessControl.Location } | undefined;
         if (hasRemoteActor(this.session)) {
-            // Validate access.  Order here prescribed by 1.4 core spec 8.4.3.2
             // We need some fallback location if cluster is not defined
-            const location = {
+            const location: AccessControl.Location = {
                 ...(cluster?.location ?? {
                     path: DataModelPath.none,
                     endpoint: endpointId,
@@ -206,20 +208,11 @@ export class AttributeWriteResponse<
                 }),
                 owningFabric: this.session.fabric,
             };
+            access = { session: this.session, location };
 
-            const permission = this.session.authorityAt(limits.writeLevel, location);
-            switch (permission) {
-                case AccessControl.Authority.Granted:
-                    break;
-
-                case AccessControl.Authority.Unauthorized:
-                    return this.#asStatus(path, Status.UnsupportedAccess);
-
-                case AccessControl.Authority.Restricted:
-                    return this.#asStatus(path, Status.AccessRestricted);
-
-                default:
-                    throw new InternalError(`Unsupported authorization state ${permission}`);
+            const denial = this.#authorize(access.session, AccessLevel.View, location);
+            if (denial !== undefined) {
+                return this.#asStatus(path, denial);
             }
         }
 
@@ -236,6 +229,13 @@ export class AttributeWriteResponse<
         if (!limits.writable) {
             this.#errorCount++;
             return this.#asStatus(path, Status.UnsupportedWrite);
+        }
+
+        if (access !== undefined) {
+            const denial = this.#authorize(access.session, limits.writeLevel, access.location);
+            if (denial !== undefined) {
+                return this.#asStatus(path, denial);
+            }
         }
 
         // Old implementation aka Matter 1.2 and lower need the ACL check moved here.
@@ -357,6 +357,26 @@ export class AttributeWriteResponse<
             },
             value,
         );
+    }
+
+    /**
+     * Validate access at {@link level}.  Returns undefined if granted; otherwise the status to report.
+     */
+    #authorize(session: AccessControl.RemoteActorSession, level: AccessLevel, location: AccessControl.Location) {
+        const permission = session.authorityAt(level, location);
+        switch (permission) {
+            case AccessControl.Authority.Granted:
+                return undefined;
+
+            case AccessControl.Authority.Unauthorized:
+                return Status.UnsupportedAccess;
+
+            case AccessControl.Authority.Restricted:
+                return Status.AccessRestricted;
+
+            default:
+                throw new InternalError(`Unsupported authorization state ${permission}`);
+        }
     }
 
     /**

--- a/packages/protocol/src/action/server/CommandInvokeResponse.ts
+++ b/packages/protocol/src/action/server/CommandInvokeResponse.ts
@@ -11,7 +11,7 @@ import { InvokeResult } from "#action/response/InvokeResult.js";
 import { AccessControl, hasRemoteActor } from "#action/server/AccessControl.js";
 import { DataResponse, FallbackLimits } from "#action/server/DataResponse.js";
 import { Diagnostic, InternalError, Logger } from "@matter/general";
-import { CommandModel, DataModelPath, ElementTag, FabricIndex as FabricIndexField } from "@matter/model";
+import { AccessLevel, CommandModel, DataModelPath, ElementTag, FabricIndex as FabricIndexField } from "@matter/model";
 import {
     CommandPath,
     EndpointNumber,
@@ -214,9 +214,10 @@ export class CommandInvokeResponse<
             limits = command.limits;
         }
 
-        // Validate access.  Order here prescribed by 1.4 core spec 8.4.3.2
+        // Order prescribed by core spec 8.8.3.2: an Operate-privilege pass gates element-existence disclosure,
+        // existence checks follow, then the actual-privilege pass gates the invoke.
         // We need some fallback location if cluster is not defined
-        const location = {
+        const location: AccessControl.Location = {
             ...(cluster?.location ?? {
                 path: DataModelPath.none,
                 endpoint: endpointId,
@@ -225,20 +226,13 @@ export class CommandInvokeResponse<
             owningFabric: this.session.fabric,
         };
 
+        let access: { session: AccessControl.RemoteActorSession; location: AccessControl.Location } | undefined;
         if (hasRemoteActor(this.session)) {
-            const permission = this.session.authorityAt(limits.writeLevel, location);
-            switch (permission) {
-                case AccessControl.Authority.Granted:
-                    break;
+            access = { session: this.session, location };
 
-                case AccessControl.Authority.Unauthorized:
-                    return this.#addStatus(path, commandRef, Status.UnsupportedAccess);
-
-                case AccessControl.Authority.Restricted:
-                    return this.#addStatus(path, commandRef, Status.AccessRestricted);
-
-                default:
-                    throw new InternalError(`Unsupported authorization state ${permission}`);
+            const denial = this.#authorize(access.session, AccessLevel.Operate, location);
+            if (denial !== undefined) {
+                return this.#addStatus(path, commandRef, denial);
             }
         }
 
@@ -250,6 +244,13 @@ export class CommandInvokeResponse<
         }
         if (command === undefined || !cluster.type.commands[command.id]) {
             return this.#addStatus(path, commandRef, Status.UnsupportedCommand);
+        }
+
+        if (access !== undefined) {
+            const denial = this.#authorize(access.session, limits.writeLevel, access.location);
+            if (denial !== undefined) {
+                return this.#addStatus(path, commandRef, denial);
+            }
         }
 
         if (hasRemoteActor(this.session)) {
@@ -366,6 +367,26 @@ export class CommandInvokeResponse<
             this.#invokers.push(producer);
         } else {
             this.#invokers = [producer];
+        }
+    }
+
+    /**
+     * Validate access at {@link level}.  Returns undefined if granted; otherwise the status to report.
+     */
+    #authorize(session: AccessControl.RemoteActorSession, level: AccessLevel, location: AccessControl.Location) {
+        const permission = session.authorityAt(level, location);
+        switch (permission) {
+            case AccessControl.Authority.Granted:
+                return undefined;
+
+            case AccessControl.Authority.Unauthorized:
+                return Status.UnsupportedAccess;
+
+            case AccessControl.Authority.Restricted:
+                return Status.AccessRestricted;
+
+            default:
+                throw new InternalError(`Unsupported authorization state ${permission}`);
         }
     }
 


### PR DESCRIPTION
Extends the read/subscribe two-pass ACL fix (#3925) to the **write** and **invoke** interaction paths.

## Problem
For a concrete path, both `AttributeWriteResponse.#writeConcrete` and `CommandInvokeResponse.#processConcrete` ran a **single** ACL check at the element's **actual** privilege **before** the element-existence checks. For a subject that holds the spec's base privilege but not the element's actual (higher) privilege, targeting a **model-known but absent-at-location** element, matter.js returned `UNSUPPORTED_ACCESS` instead of the existence status — diverging from core spec and CHIP.

#3925 fixed read/subscribe (`AttributeReadResponse`/`EventReadResponse`) only; write and invoke were untouched.

## Fix
Implement the spec two-pass, mirroring #3925's `#authorize` helper in each handler:
1. **base-privilege** ACL pass → gates element-existence disclosure
2. existence checks (endpoint/cluster/attribute|command, + not-writable on write)
3. **actual**-privilege ACL pass → gates the operation

then timed / fabric-scoped / data-version (write) and large-message / fabric-scoped / timed (invoke), all unchanged.

**Base privilege differs per spec:**
- Write — `View` (§8.7.3.2)
- Invoke — `Operate` (§8.8.3.2, "assuming the required_privilege for the element is Operate")

Wildcard/group paths are unchanged: the spec prescribes a single actual-privilege pass with silent discard there. Stale `1.4 §8.4.3.2` comments corrected to the governing sections; an obsolete pre-1.3 ACL-ordering comment in the write path removed.

No security regression — matter.js never over-grants; it leaked *less* existence info than the spec mandates. Write/invoke privileges are commonly above the base, so this edge is more reachable than on the read side.

## Tests
- Write: View-only subject writing `BasicInformation.localConfigDisabled` (optional → absent, write-priv Manage) → now `UNSUPPORTED_ATTRIBUTE`.
- Invoke: Operate-only subject invoking `Groups.AddGroup` (cluster absent on root, invoke-priv Manage) → now `UNSUPPORTED_CLUSTER` (was `UNSUPPORTED_ACCESS`).

Behavior unchanged for local actors and present/fully-denied elements.

## Verification
- full protocol suite (1175) ✓ · node invoke+write+interaction ✓
- lint (oxlint) ✓ · format-verify ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)