### PR TITLE
fix(protocol): decode fallback-method VID/PID from attestation certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,17 +20,18 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Changed interaction model revision back to 12 because revision 13 only includes a provisional feature
 
 - @matter/node
-    - Fix: Ensure that the negotiated subscription MaxInterval stays at or above the requested MinIntervalFloor when the floor exceeds the 60-minute publisher limit
+    - Fix: Ensures that the negotiated subscription MaxInterval stays at or above the requested MinIntervalFloor when the floor exceeds the 60-minute publisher limit
 
 - @matter/protocol
-    - Fix: Ensure that the peer-medium-specific `additionalMrpDelay` is also used for executed commands, and added an optional per-request `additionalMrpDelay` override
+    - Fix: Ensures that the peer-medium-specific `additionalMrpDelay` is also used for executed commands, and added an optional per-request `additionalMrpDelay` override
     - Adjustment: MRP now selects the active/idle retransmission interval by peer activity for every transmission including the first, instead of forcing the first transmission to the idle interval
-    - Fix: Prevent a crash when a PASE pairing timeout fires while a previous message is still awaiting acknowledgement
+    - Fix: Prevents a crash when a PASE pairing timeout fires while a previous message is still awaiting acknowledgement
     - Fix: A discovery kick no longer restarts an in-flight CASE handshake when a restart would barely shorten the next retransmission, avoiding needless teardown of a sleepy peer's exchange
     - Fix: The MRP retransmission interval is no longer capped below the peer's idle interval
     - Fix: The connection fallback address is now compared by value, so a rediscovered last-known address is no longer mistaken for an address change
-    - Fix: Ensure that subscriptions established through an interaction are closed when the interaction closes (e.g. node disable/disconnect or decommission)
-    - Fix: Ensure spec-compliant read/subscribe/write/invoke responses for a model-known but absent high-privilege attribute, event or command
+    - Fix: Ensures that subscriptions established through an interaction are closed when the interaction closes (e.g. node disable/disconnect or decommission)
+    - Fix: Ensures spec-compliant read/subscribe/write/invoke responses for a model-known but absent high-privilege attribute, event or command
+    - Fix: Decodes VendorID/ProductID from the "fallback method" (`Mvid:`/`Mpid:` in the commonName) of attestation certificates
 
 - @project-chip/matter.js
     - Fix: Ensure that `PairedNode.connect()` reconnects a node that was previously disconnected

--- a/packages/protocol/src/certificate/DeviceAttestationValidator.ts
+++ b/packages/protocol/src/certificate/DeviceAttestationValidator.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, Crypto, EcdsaSignature, MaybePromise, PublicKey } from "@matter/general";
+import { Bytes, Crypto, Diagnostic, EcdsaSignature, MaybePromise, PublicKey } from "@matter/general";
 import { MATTER_EPOCH_OFFSET_S, VendorId } from "@matter/types";
 import { TlvAttestation } from "../common/OperationalCredentialsTypes.js";
 import { DclCertificateService } from "../dcl/DclCertificateService.js";
@@ -59,9 +59,8 @@ export class DeviceAttestationError extends CommissioningError {
     }
 }
 
-/** Format a VendorID/ProductID as a 4-digit hex string for diagnostics, matching Matter convention. */
 function idHex(id?: number) {
-    return id === undefined ? "undefined" : `0x${id.toString(16).toUpperCase().padStart(4, "0")}`;
+    return id === undefined ? "undefined" : Diagnostic.hex(id);
 }
 
 export namespace DeviceAttestationValidator {

--- a/packages/protocol/src/certificate/DeviceAttestationValidator.ts
+++ b/packages/protocol/src/certificate/DeviceAttestationValidator.ts
@@ -60,7 +60,7 @@ export class DeviceAttestationError extends CommissioningError {
 }
 
 function idHex(id?: number) {
-    return id === undefined ? "undefined" : Diagnostic.hex(id);
+    return id === undefined ? "undefined" : `0x${Diagnostic.hex(id, 4).toUpperCase()}`;
 }
 
 export namespace DeviceAttestationValidator {

--- a/packages/protocol/src/certificate/DeviceAttestationValidator.ts
+++ b/packages/protocol/src/certificate/DeviceAttestationValidator.ts
@@ -59,6 +59,11 @@ export class DeviceAttestationError extends CommissioningError {
     }
 }
 
+/** Format a VendorID/ProductID as a 4-digit hex string for diagnostics, matching Matter convention. */
+function idHex(id?: number) {
+    return id === undefined ? "undefined" : `0x${id.toString(16).toUpperCase().padStart(4, "0")}`;
+}
+
 export namespace DeviceAttestationValidator {
     export interface Context {
         crypto: Crypto;
@@ -131,7 +136,7 @@ export namespace DeviceAttestationValidator {
         if (dac.cert.subject.vendorId !== pai.cert.subject.vendorId) {
             throw new DeviceAttestationError(
                 DeviceAttestationCheck.VendorIdMismatch,
-                `DAC vendorId ${dac.cert.subject.vendorId} does not match PAI vendorId ${pai.cert.subject.vendorId}`,
+                `DAC vendorId ${idHex(dac.cert.subject.vendorId)} does not match PAI vendorId ${idHex(pai.cert.subject.vendorId)}`,
             );
         }
 
@@ -270,7 +275,7 @@ export namespace DeviceAttestationValidator {
             if (paaVendorId !== undefined && paaVendorId !== pai.cert.subject.vendorId) {
                 throw new DeviceAttestationError(
                     DeviceAttestationCheck.VendorIdMismatch,
-                    `PAA vendorId ${paaVendorId} does not match PAI vendorId ${pai.cert.subject.vendorId}`,
+                    `PAA vendorId ${idHex(paaVendorId)} does not match PAI vendorId ${idHex(pai.cert.subject.vendorId)}`,
                 );
             }
 
@@ -356,7 +361,7 @@ export namespace DeviceAttestationValidator {
         if (cdContent.vendorId !== data.vendorId) {
             throw new DeviceAttestationError(
                 DeviceAttestationCheck.CertificationDeclarationFieldMismatch,
-                `CD vendor_id ${cdContent.vendorId} does not match BasicInformation VendorID ${data.vendorId}`,
+                `CD vendor_id ${idHex(cdContent.vendorId)} does not match BasicInformation VendorID ${idHex(data.vendorId)}`,
             );
         }
 
@@ -364,7 +369,7 @@ export namespace DeviceAttestationValidator {
         if (!cdContent.produceIdArray.includes(data.productId)) {
             throw new DeviceAttestationError(
                 DeviceAttestationCheck.CertificationDeclarationFieldMismatch,
-                `CD product_id_array does not contain BasicInformation ProductID ${data.productId}`,
+                `CD product_id_array [${cdContent.produceIdArray.map(idHex).join(", ")}] does not contain BasicInformation ProductID ${idHex(data.productId)}`,
             );
         }
 
@@ -383,27 +388,27 @@ export namespace DeviceAttestationValidator {
             if (dac.cert.subject.vendorId !== cdContent.dacOriginVendorId) {
                 throw new DeviceAttestationError(
                     DeviceAttestationCheck.CertificationDeclarationFieldMismatch,
-                    "DAC vendorId does not match CD dac_origin_vendor_id",
+                    `DAC vendorId ${idHex(dac.cert.subject.vendorId)} does not match CD dac_origin_vendor_id ${idHex(cdContent.dacOriginVendorId)}`,
                 );
             }
             if (pai.cert.subject.vendorId !== cdContent.dacOriginVendorId) {
                 throw new DeviceAttestationError(
                     DeviceAttestationCheck.CertificationDeclarationFieldMismatch,
-                    "PAI vendorId does not match CD dac_origin_vendor_id",
+                    `PAI vendorId ${idHex(pai.cert.subject.vendorId)} does not match CD dac_origin_vendor_id ${idHex(cdContent.dacOriginVendorId)}`,
                 );
             }
             const dacProductId = dac.cert.subject.productId;
             if (dacProductId !== undefined && dacProductId !== cdContent.dacOriginProductId) {
                 throw new DeviceAttestationError(
                     DeviceAttestationCheck.CertificationDeclarationFieldMismatch,
-                    "DAC productId does not match CD dac_origin_product_id",
+                    `DAC productId ${idHex(dacProductId)} does not match CD dac_origin_product_id ${idHex(cdContent.dacOriginProductId)}`,
                 );
             }
             const paiProductId = pai.cert.subject.productId;
             if (paiProductId !== undefined && paiProductId !== cdContent.dacOriginProductId) {
                 throw new DeviceAttestationError(
                     DeviceAttestationCheck.CertificationDeclarationFieldMismatch,
-                    "PAI productId does not match CD dac_origin_product_id",
+                    `PAI productId ${idHex(paiProductId)} does not match CD dac_origin_product_id ${idHex(cdContent.dacOriginProductId)}`,
                 );
             }
         } else {
@@ -411,27 +416,27 @@ export namespace DeviceAttestationValidator {
             if (dac.cert.subject.vendorId !== cdContent.vendorId) {
                 throw new DeviceAttestationError(
                     DeviceAttestationCheck.CertificationDeclarationFieldMismatch,
-                    "DAC vendorId does not match CD vendor_id",
+                    `DAC vendorId ${idHex(dac.cert.subject.vendorId)} does not match CD vendor_id ${idHex(cdContent.vendorId)}`,
                 );
             }
             if (pai.cert.subject.vendorId !== cdContent.vendorId) {
                 throw new DeviceAttestationError(
                     DeviceAttestationCheck.CertificationDeclarationFieldMismatch,
-                    "PAI vendorId does not match CD vendor_id",
+                    `PAI vendorId ${idHex(pai.cert.subject.vendorId)} does not match CD vendor_id ${idHex(cdContent.vendorId)}`,
                 );
             }
             const dacProductId = dac.cert.subject.productId;
             if (dacProductId !== undefined && !cdContent.produceIdArray.includes(dacProductId)) {
                 throw new DeviceAttestationError(
                     DeviceAttestationCheck.CertificationDeclarationFieldMismatch,
-                    "DAC productId not found in CD product_id_array",
+                    `DAC productId ${idHex(dacProductId)} not found in CD product_id_array [${cdContent.produceIdArray.map(idHex).join(", ")}]`,
                 );
             }
             const paiProductId = pai.cert.subject.productId;
             if (paiProductId !== undefined && !cdContent.produceIdArray.includes(paiProductId)) {
                 throw new DeviceAttestationError(
                     DeviceAttestationCheck.CertificationDeclarationFieldMismatch,
-                    "PAI productId not found in CD product_id_array",
+                    `PAI productId ${idHex(paiProductId)} not found in CD product_id_array [${cdContent.produceIdArray.map(idHex).join(", ")}]`,
                 );
             }
         }

--- a/packages/protocol/src/certificate/kinds/Certificate.ts
+++ b/packages/protocol/src/certificate/kinds/Certificate.ts
@@ -166,6 +166,23 @@ export abstract class Certificate<CT extends MatterCertificate> {
     }
 }
 
+/**
+ * Extract a VendorID or ProductID encoded via the "fallback method" (Matter spec 6.2.2.2): the
+ * prefix `Mvid:`/`Mpid:` followed by exactly 4 uppercase hexadecimal characters, anywhere within a
+ * `commonName`. Returns the leftmost correctly-encoded value, or `undefined` if the prefix is
+ * absent. Throws if the prefix appears but no correctly-encoded value exists (spec 6.2.2.2.1).
+ */
+export function parseMatterFallbackVidPid(commonName: string, prefix: "Mvid:" | "Mpid:"): number | undefined {
+    const match = commonName.match(new RegExp(`${prefix}([0-9A-F]{4})`));
+    if (match !== null) {
+        return parseInt(match[1], 16);
+    }
+    if (commonName.includes(prefix)) {
+        throw new CertificateError(`Malformed ${prefix} VendorID/ProductID fallback encoding in commonName`);
+    }
+    return undefined;
+}
+
 export namespace Certificate {
     /**
      * Create a Certificate Signing Request (CSR) in ASN.1 DER format.
@@ -282,6 +299,21 @@ export namespace Certificate {
                     }
                 }
                 result[field] = value;
+            }
+        }
+
+        // Spec 6.2.2.2: an OID VID/PID anywhere in the field disables fallback parsing for that field.
+        if (result.vendorId === undefined && result.productId === undefined) {
+            const commonName = (result.commonName ?? result.commonNamePs) as string | undefined;
+            if (commonName !== undefined) {
+                const vendorId = parseMatterFallbackVidPid(commonName, "Mvid:");
+                if (vendorId !== undefined) {
+                    result.vendorId = vendorId;
+                }
+                const productId = parseMatterFallbackVidPid(commonName, "Mpid:");
+                if (productId !== undefined) {
+                    result.productId = productId;
+                }
             }
         }
 
@@ -677,8 +709,19 @@ function matterToX509(cert: Unsigned<MatterCertificate>): X509.UnsignedCertifica
  */
 function astOfDistinguishedName(data: { [field: string]: any }) {
     const ast = {} as { [field: string]: any[] };
+
+    // Spec 6.2.2.2 forbids mixing fallback (Mvid:/Mpid: in commonName) and OID VID/PID in one field.
+    const commonName = (data.commonName ?? data.commonNamePs) as string | undefined;
+    const usesFallbackVidPid =
+        commonName !== undefined &&
+        (parseMatterFallbackVidPid(commonName, "Mvid:") !== undefined ||
+            parseMatterFallbackVidPid(commonName, "Mpid:") !== undefined);
+
     Object.entries(data).forEach(([key, value]) => {
         if (value === undefined) {
+            return;
+        }
+        if (usesFallbackVidPid && (key === "vendorId" || key === "productId")) {
             return;
         }
         switch (key) {

--- a/packages/protocol/src/certificate/kinds/Certificate.ts
+++ b/packages/protocol/src/certificate/kinds/Certificate.ts
@@ -168,9 +168,12 @@ export abstract class Certificate<CT extends MatterCertificate> {
 
 /**
  * Extract a VendorID or ProductID encoded via the "fallback method" (Matter spec 6.2.2.2): the
- * prefix `Mvid:`/`Mpid:` followed by exactly 4 uppercase hexadecimal characters, anywhere within a
+ * prefix `Mvid:`/`Mpid:` followed by 4 uppercase hexadecimal characters, anywhere within a
  * `commonName`. Returns the leftmost correctly-encoded value, or `undefined` if the prefix is
  * absent. Throws if the prefix appears but no correctly-encoded value exists (spec 6.2.2.2.1).
+ *
+ * A 5th or later hex digit immediately following the value is ignored (the first 4 are used),
+ * matching the dominant CHIP implementation.
  */
 export function parseMatterFallbackVidPid(commonName: string, prefix: "Mvid:" | "Mpid:"): number | undefined {
     const match = commonName.match(new RegExp(`${prefix}([0-9A-F]{4})`));
@@ -178,7 +181,7 @@ export function parseMatterFallbackVidPid(commonName: string, prefix: "Mvid:" | 
         return parseInt(match[1], 16);
     }
     if (commonName.includes(prefix)) {
-        throw new CertificateError(`Malformed ${prefix} VendorID/ProductID fallback encoding in commonName`);
+        throw new CertificateError(`commonName contains ${prefix} not followed by 4 uppercase hex digits`);
     }
     return undefined;
 }

--- a/packages/protocol/src/certificate/kinds/Certificate.ts
+++ b/packages/protocol/src/certificate/kinds/Certificate.ts
@@ -171,9 +171,6 @@ export abstract class Certificate<CT extends MatterCertificate> {
  * prefix `Mvid:`/`Mpid:` followed by 4 uppercase hexadecimal characters, anywhere within a
  * `commonName`. Returns the leftmost correctly-encoded value, or `undefined` if the prefix is
  * absent. Throws if the prefix appears but no correctly-encoded value exists (spec 6.2.2.2.1).
- *
- * A 5th or later hex digit immediately following the value is ignored (the first 4 are used),
- * matching the dominant CHIP implementation.
  */
 export function parseMatterFallbackVidPid(commonName: string, prefix: "Mvid:" | "Mpid:"): number | undefined {
     const match = commonName.match(new RegExp(`${prefix}([0-9A-F]{4})`));

--- a/packages/protocol/test/certificate/CertificatesTest.ts
+++ b/packages/protocol/test/certificate/CertificatesTest.ts
@@ -290,34 +290,37 @@ describe("Certificates", () => {
     });
 
     describe("parseMatterFallbackVidPid", () => {
-        it("extracts the value following a valid prefix", () => {
-            expect(parseMatterFallbackVidPid("ACME DAC Mvid:FFF1 Mpid:00B1", "Mvid:")).to.equal(0xfff1);
-            expect(parseMatterFallbackVidPid("ACME DAC Mvid:FFF1 Mpid:00B1", "Mpid:")).to.equal(0x00b1);
-        });
-
         it("returns undefined when the prefix is absent", () => {
             expect(parseMatterFallbackVidPid("Matter Test Cert", "Mvid:")).to.be.undefined;
         });
 
-        it("ignores separators and ordering", () => {
-            expect(parseMatterFallbackVidPid("Mpid:00B1,ACME,Mvid:FFF1", "Mvid:")).to.equal(0xfff1);
-            expect(parseMatterFallbackVidPid("Mvid:FFF1Mpid:00B1", "Mpid:")).to.equal(0x00b1);
+        // Valid examples from spec 6.2.2.2.1, all claiming VendorID 0xFFF1 and ProductID 0x00B1
+        it("parses the spec's valid encodings (VID 0xFFF1, PID 0x00B1)", () => {
+            for (const cn of [
+                "ACME Matter Devel DAC 5CDA9899 Mvid:FFF1 Mpid:00B1",
+                "ACME Matter Devel DAC 5CDA9899 Mpid:00B1 Mvid:FFF1", // order irrelevant
+                "Mpid:00B1,ACME Matter Devel DAC 5CDA9899,Mvid:FFF1", // separators irrelevant
+                "ACME Matter Devel DAC 5CDA9899 Mvid:FFF1Mpid:00B1", // adjacent
+                "Mvid:FFF1ACME Matter Devel DAC 5CDAMpid:00B19899", // trailing hex ignored (consume exactly 4)
+            ]) {
+                expect(parseMatterFallbackVidPid(cn, "Mvid:")).to.equal(0xfff1);
+                expect(parseMatterFallbackVidPid(cn, "Mpid:")).to.equal(0x00b1);
+            }
         });
 
         it("uses the leftmost correctly-encoded match", () => {
-            // Spec 6.2.2.2.1 example: VID 0xFFF1, PID 0xFE67 (earlier Mpid: prefixes are not valid encodings)
+            // Spec 6.2.2.2.1: PID 0xFE67 — earlier Mpid: prefixes are not valid encodings
             expect(parseMatterFallbackVidPid("Mpid:Mvid:FFF1 Mpid:12cd Matter Test Mpid:FE67", "Mpid:")).to.equal(
                 0xfe67,
             );
         });
 
-        it("extracts the first 4 hex chars when more follow, matching CHIP", () => {
-            expect(parseMatterFallbackVidPid("Mvid:135DA", "Mvid:")).to.equal(0x135d);
-        });
-
-        it("throws when a prefix appears but no value is correctly encoded", () => {
-            expect(() => parseMatterFallbackVidPid("ACME DAC Mvid:FF1 Mpid:00B1", "Mvid:")).to.throw(CertificateError);
-            expect(() => parseMatterFallbackVidPid("ACME DAC Mvid:fff1", "Mvid:")).to.throw(CertificateError);
+        // Invalid examples from spec 6.2.2.2.1: prefix present but no correctly-encoded value
+        it("throws on the spec's malformed encodings", () => {
+            expect(() => parseMatterFallbackVidPid("DAC Mvid:FF1 Mpid:00B1", "Mvid:")).to.throw(CertificateError); // 3 digits
+            expect(() => parseMatterFallbackVidPid("DAC Mvid:fff1 Mpid:00B1", "Mvid:")).to.throw(CertificateError); // lowercase
+            expect(() => parseMatterFallbackVidPid("DAC Mvid:FFF1 Mpid:B1", "Mpid:")).to.throw(CertificateError); // 2 digits
+            expect(() => parseMatterFallbackVidPid("DAC Mpid: Mvid:FFF1", "Mpid:")).to.throw(CertificateError); // prefix only
         });
     });
 

--- a/packages/protocol/test/certificate/CertificatesTest.ts
+++ b/packages/protocol/test/certificate/CertificatesTest.ts
@@ -9,8 +9,8 @@ import {
     TestCert_PAA_NoVID_Cert,
     TestCert_WithoutAuthKeyId,
 } from "#certificate/ChipPAAuthorities.js";
-import { Paa } from "#certificate/kinds/AttestationCertificates.js";
-import { Certificate } from "#certificate/kinds/Certificate.js";
+import { Dac, Paa, Pai } from "#certificate/kinds/AttestationCertificates.js";
+import { Certificate, parseMatterFallbackVidPid } from "#certificate/kinds/Certificate.js";
 import { Icac } from "#certificate/kinds/Icac.js";
 import { Noc } from "#certificate/kinds/Noc.js";
 import { Rcac } from "#certificate/kinds/Rcac.js";
@@ -231,6 +231,93 @@ describe("Certificates", () => {
             await rcac.verify(crypto);
             await icac.verify(crypto, rcac);
             await noc.verify(crypto, rcac, icac);
+        });
+    });
+
+    describe("parses VendorID/ProductID encoded via the fallback method (spec 6.2.2.2)", () => {
+        // Real Nuki DAC/PAI: VID/PID are embedded in the commonName ("Mvid:135D Mpid:00A1")
+        // rather than the Matter-specific OIDs. Captured from a live commissioning attempt.
+        const NUKI_DAC_ASN1 = Bytes.fromHex(
+            "308201c130820167a003020102020e03ff135d00a1001b000802d19da9300a06082a8648ce3d040302303431323030060355040313294b7564656c736b69204d61747465722050414920666f72204e756b69204d7669643a313335442030313020170d3236303532323039313332365a180f39393939313233313233353935395a302f312d302b060355040313244d7669643a31333544204d7069643a3030413120303031623030303830326431396461393059301306072a8648ce3d020106082a8648ce3d0301070342000494f0ff20d3df40660f59e3838a97b26188d6004db8f670b6ff7b1f1b952cfcb63516bbc379204ec542fdaf5809360b28c76d1b2b30862a6dafaf0454b301921ea360305e300e0603551d0f0101ff040403020780300c0603551d130101ff04023000301d0603551d0e041604140ac17a032b81fd47c00388872acae54850b231c3301f0603551d2304183016801448fd5991116b0a91759346351ea4728e51fb7c39300a06082a8648ce3d0403020348003045022012e4f811b5b2d14feeb86c28ba744895e5bd1925506a4f9bdb130b4366b3f45a022100f4b82b41df0b14aeea9eaa1ef95439ac75d687199c53e6369da8cf9047f36e51",
+        );
+        const NUKI_PAI_ASN1 = Bytes.fromHex(
+            "308201b83082015da003020102020e02ff135d000001897333e3210001300a06082a8648ce3d0403023021311f301d060355040313164b7564656c736b69204d617474657220504141203031301e170d3233303732303132303834375a170d3238303732303132303834375a303431323030060355040313294b7564656c736b69204d61747465722050414920666f72204e756b69204d7669643a313335442030313059301306072a8648ce3d020106082a8648ce3d0301070342000455687c57f5c97097b23945b5fbd3578b53038cfae793a098771e7f88337fe694e26b441f75939e574b21126fc4c947c29658fe1cb085c2c4b2b2a92cb728c073a3663064300e0603551d0f0101ff04040302010630120603551d130101ff040830060101ff020100301d0603551d0e0416041448fd5991116b0a91759346351ea4728e51fb7c39301f0603551d23041830168014a607c3607b7150e3622ab0ba889e6cbc3fc552f9300a06082a8648ce3d0403020349003046022100caef1def29bf5069f1ae3928f3cab0ba88171f65bb5ee98fdf549f0e1ec5cb5b022100897030f94de3efcb5ff0b1ceb6a755edc811a9559f3048d129fc26c61462d631",
+        );
+
+        it("parses fallback VendorID and ProductID from a DAC commonName", () => {
+            const dac = Dac.fromAsn1(NUKI_DAC_ASN1);
+
+            expect(dac.cert.subject.vendorId).to.equal(0x135d);
+            expect(dac.cert.subject.productId).to.equal(0x00a1);
+        });
+
+        it("parses fallback VendorID from a PAI commonName", () => {
+            const pai = Pai.fromAsn1(NUKI_PAI_ASN1);
+
+            expect(pai.cert.subject.vendorId).to.equal(0x135d);
+        });
+
+        it("parses fallback VendorID from a DAC issuer commonName", () => {
+            const dac = Dac.fromAsn1(NUKI_DAC_ASN1);
+
+            expect(dac.cert.issuer.vendorId).to.equal(0x135d);
+            expect(dac.cert.issuer.productId).to.be.undefined;
+        });
+
+        // Matter-specific VID/PID OID arc 1.3.6.1.4.1.37244.2.* (spec appendix E)
+        const MATTER_ATT_CERT_OID_BASE = "2b0601040182a27c02";
+
+        it("re-encodes a fallback DAC without injecting Matter VID/PID OIDs", () => {
+            const dac = Dac.fromAsn1(NUKI_DAC_ASN1);
+
+            const reEncoded = Bytes.toHex(dac.asSignedDer());
+            expect(reEncoded).to.not.contain(MATTER_ATT_CERT_OID_BASE);
+
+            const reParsed = Dac.fromAsn1(Bytes.fromHex(reEncoded));
+            expect(reParsed.cert.subject.vendorId).to.equal(0x135d);
+            expect(reParsed.cert.subject.productId).to.equal(0x00a1);
+        });
+
+        it("re-encodes a fallback PAI without injecting Matter VID/PID OIDs", () => {
+            const pai = Pai.fromAsn1(NUKI_PAI_ASN1);
+
+            const reEncoded = Bytes.toHex(pai.asSignedDer());
+            expect(reEncoded).to.not.contain(MATTER_ATT_CERT_OID_BASE);
+
+            const reParsed = Pai.fromAsn1(Bytes.fromHex(reEncoded));
+            expect(reParsed.cert.subject.vendorId).to.equal(0x135d);
+        });
+    });
+
+    describe("parseMatterFallbackVidPid", () => {
+        it("extracts the value following a valid prefix", () => {
+            expect(parseMatterFallbackVidPid("ACME DAC Mvid:FFF1 Mpid:00B1", "Mvid:")).to.equal(0xfff1);
+            expect(parseMatterFallbackVidPid("ACME DAC Mvid:FFF1 Mpid:00B1", "Mpid:")).to.equal(0x00b1);
+        });
+
+        it("returns undefined when the prefix is absent", () => {
+            expect(parseMatterFallbackVidPid("Matter Test Cert", "Mvid:")).to.be.undefined;
+        });
+
+        it("ignores separators and ordering", () => {
+            expect(parseMatterFallbackVidPid("Mpid:00B1,ACME,Mvid:FFF1", "Mvid:")).to.equal(0xfff1);
+            expect(parseMatterFallbackVidPid("Mvid:FFF1Mpid:00B1", "Mpid:")).to.equal(0x00b1);
+        });
+
+        it("uses the leftmost correctly-encoded match", () => {
+            // Spec 6.2.2.2.1 example: VID 0xFFF1, PID 0xFE67 (earlier Mpid: prefixes are not valid encodings)
+            expect(parseMatterFallbackVidPid("Mpid:Mvid:FFF1 Mpid:12cd Matter Test Mpid:FE67", "Mpid:")).to.equal(
+                0xfe67,
+            );
+        });
+
+        it("extracts the first 4 hex chars when more follow, matching CHIP", () => {
+            expect(parseMatterFallbackVidPid("Mvid:135DA", "Mvid:")).to.equal(0x135d);
+        });
+
+        it("throws when a prefix appears but no value is correctly encoded", () => {
+            expect(() => parseMatterFallbackVidPid("ACME DAC Mvid:FF1 Mpid:00B1", "Mvid:")).to.throw(CertificateError);
+            expect(() => parseMatterFallbackVidPid("ACME DAC Mvid:fff1", "Mvid:")).to.throw(CertificateError);
         });
     });
 

--- a/packages/protocol/test/certificate/CertificatesTest.ts
+++ b/packages/protocol/test/certificate/CertificatesTest.ts
@@ -264,8 +264,9 @@ describe("Certificates", () => {
             expect(dac.cert.issuer.productId).to.be.undefined;
         });
 
-        // Matter-specific VID/PID OID arc 1.3.6.1.4.1.37244.2.* (spec appendix E)
-        const MATTER_ATT_CERT_OID_BASE = "2b0601040182a27c02";
+        // Matter-specific VID/PID OID arc 1.3.6.1.4.1.37244.2.* (spec appendix E), with the DER
+        // OBJECT IDENTIFIER tag (0x06) and length (0x0a) prefixed to avoid a coincidental match.
+        const MATTER_ATT_CERT_OID_BASE = "060a2b0601040182a27c02";
 
         it("re-encodes a fallback DAC without injecting Matter VID/PID OIDs", () => {
             const dac = Dac.fromAsn1(NUKI_DAC_ASN1);

--- a/packages/protocol/test/certificate/DeviceAttestationValidatorTest.ts
+++ b/packages/protocol/test/certificate/DeviceAttestationValidatorTest.ts
@@ -432,7 +432,7 @@ describe("DeviceAttestationValidator", () => {
                 ),
             ).to.be.rejectedWith(
                 DeviceAttestationError,
-                /CD product_id_array does not contain BasicInformation ProductID/,
+                /CD product_id_array.*does not contain BasicInformation ProductID/,
             );
         });
 
@@ -453,7 +453,7 @@ describe("DeviceAttestationValidator", () => {
                     buildContext(dclService),
                     buildData({ attestationElements, attestationSignature, vendorId: altVendorId }),
                 ),
-            ).to.be.rejectedWith(DeviceAttestationError, /DAC vendorId does not match CD vendor_id/);
+            ).to.be.rejectedWith(DeviceAttestationError, /DAC vendorId.*does not match CD vendor_id/);
         });
     });
 

--- a/packages/protocol/test/certificate/DeviceAttestationValidatorTest.ts
+++ b/packages/protocol/test/certificate/DeviceAttestationValidatorTest.ts
@@ -263,7 +263,11 @@ describe("DeviceAttestationValidator", () => {
             // Use the pre-generated DAC with wrong vendorId (created at same time as PAI in before())
             await expect(
                 DeviceAttestationValidator.validate(buildContext(dclService), buildData({ dac: wrongVendorDacDer })),
-            ).to.be.rejectedWith(DeviceAttestationError, /DAC vendorId.*does not match PAI vendorId/);
+                // VendorIDs are reported as fixed-width 4-digit uppercase hex with a 0x prefix
+            ).to.be.rejectedWith(
+                DeviceAttestationError,
+                /DAC vendorId 0x[0-9A-F]{4} does not match PAI vendorId 0x[0-9A-F]{4}/,
+            );
         });
     });
 


### PR DESCRIPTION
## Problem

Commissioning genuine devices (e.g. Nuki) failed at device attestation step 10.1 with `DAC vendorId does not match CD vendor_id`, even though the VendorIDs matched.

Root cause: the DAC/PAI encode VendorID/ProductID via the Matter spec **"fallback method"** (§6.2.2.2) — `Mvid:XXXX`/`Mpid:XXXX` substrings inside the X.509 `commonName` — instead of the Matter-specific OIDs (arc `1.3.6.1.4.1.37244.2.*`). The certificate parser only read the OIDs, so `subject.vendorId`/`productId` stayed `undefined`; the (spec-correct) CD field check then compared `undefined !== <vid>` and rejected the device.

## Fix

- **Decode:** new `parseMatterFallbackVidPid()` extracts `Mvid:`/`Mpid:` + exactly 4 uppercase hex (leftmost valid match; throws on a present-but-malformed marker, per §6.2.2.2.1). Wired into subject/issuer parsing, gated so an OID VID/PID anywhere in a field disables fallback parsing for that field.
- **Encode:** `astOfDistinguishedName` skips emitting the Matter VID/PID OID when the `commonName` already carries the marker, avoiding a spec-forbidden mixed (OID + fallback) encoding and keeping the model round-trippable.

Behavior on `Mvid:` + 5+ hex follows CHIP (takes the first 4) for interop. Uppercase-only is per §6.2.2.2.1.

## Tests

Real Nuki DAC/PAI fixtures (subject + issuer), helper edge cases (valid, absent, separators/ordering, leftmost-correct, CHIP-compat 5+hex, malformed→throw), and re-encode tests asserting no Matter OID arc is injected and values survive a re-parse.

Full `@matter/protocol` suite green (1186/1186), lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)