### PR TITLE
fix(model): include atomic (T) flag in Quality.extend() merge

### DIFF
--- a/packages/model/src/aspects/Quality.ts
+++ b/packages/model/src/aspects/Quality.ts
@@ -146,6 +146,7 @@ export class Quality extends Aspect<Quality.Definition> implements Quality.Ast {
             quieter: other.quieter ?? this.quieter,
             largeMessage: other.largeMessage ?? this.largeMessage,
             diagnostics: other.diagnostics ?? this.diagnostics,
+            atomic: other.atomic ?? this.atomic,
             disallowed: other.disallowed ?? this.disallowed,
         });
     }

--- a/packages/model/test/aspects/QualityTest.ts
+++ b/packages/model/test/aspects/QualityTest.ts
@@ -61,12 +61,14 @@ describe("Quality", () => {
         Quality.FlagNames.forEach(flag => {
             const field = Quality.Flag[flag];
 
+            const otherField = field === "reportable" ? "singleton" : "reportable";
+
             it(`preserves ${field} from base through merge`, () => {
                 const base = new Quality({ [field]: true });
-                const other = new Quality({ reportable: true });
+                const other = new Quality({ [otherField]: true });
                 const merged = base.extend(other);
                 expect(merged[field]).equal(true);
-                expect(merged.reportable).equal(true);
+                expect(merged[otherField]).equal(true);
             });
         });
     });

--- a/packages/model/test/aspects/QualityTest.ts
+++ b/packages/model/test/aspects/QualityTest.ts
@@ -57,6 +57,20 @@ describe("Quality", () => {
         });
     });
 
+    describe("extend", () => {
+        Quality.FlagNames.forEach(flag => {
+            const field = Quality.Flag[flag];
+
+            it(`preserves ${field} from base through merge`, () => {
+                const base = new Quality({ [field]: true });
+                const other = new Quality({ reportable: true });
+                const merged = base.extend(other);
+                expect(merged[field]).equal(true);
+                expect(merged.reportable).equal(true);
+            });
+        });
+    });
+
     describe("mixed flags", () => {
         it("parse correctly", () => {
             const quality = new Quality("X !N F !S P");


### PR DESCRIPTION
## Problem

`Quality.extend()` built its merged `Quality` from every other-quality flag — `nullable`, `nonvolatile`, `fixed`, `changesOmitted`, `scene`, `reportable`, `singleton`, `quieter`, `largeMessage`, `diagnostics`, `disallowed` — **except `atomic` (T)**. Any `atomic` quality on `this` or `other` was silently dropped whenever `extend()` produced the merged result.

§7.7 blank-quality inheritance flows through `extend()`, so the §7.7.11 Atomic quality could be lost on inheritance, exposing/validating an attribute without its required atomic-write constraint.

Low severity (Atomic is rare and usually set directly on the leaf attribute), but a clear omission — the other 10 flags were merged.

## Fix

- Add `atomic: other.atomic ?? this.atomic` to the `extend()` merge object, mirroring the surrounding flags.
- `QualityTest.ts` had **no** `extend()` test (which masked the drop). Added a flag-agnostic `extend` test looping `FlagNames` that asserts every flag — including `atomic` — survives a base→derived merge.

## Verification

- `npm test -- -p packages/model -g Quality` — 48/48 green
- `npm run format-verify` + `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)