### PR TITLE
fix(types): reserve MSB of nullable bitmaps for NULL (§7.19.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Decodes VendorID/ProductID from the "fallback method" (`Mvid:`/`Mpid:` in the commonName) of attestation certificates
 
 - @matter/types
-    - Fix: Ensures that the most-significant bit of a nullable bitmap is reserved for NULL as defined in matter spec
+    - Fix: Ensures that the most-significant bit of a nullable bitmap is reserved for NULL as defined in the Matter specification
 
 - @project-chip/matter.js
     - Fix: Ensure that `PairedNode.connect()` reconnects a node that was previously disconnected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Ensures spec-compliant read/subscribe/write/invoke responses for a model-known but absent high-privilege attribute, event or command
     - Fix: Decodes VendorID/ProductID from the "fallback method" (`Mvid:`/`Mpid:` in the commonName) of attestation certificates
 
+- @matter/types
+    - Fix: Ensures that the most-significant bit of a nullable bitmap is reserved for NULL as defined in matter spec
+
 - @project-chip/matter.js
     - Fix: Ensure that `PairedNode.connect()` reconnects a node that was previously disconnected
 

--- a/packages/types/src/tlv/TlvNullable.ts
+++ b/packages/types/src/tlv/TlvNullable.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { TlvNumericSchema } from "#tlv/TlvNumber.js";
+import { BitmapWrapper, TlvNumericSchema } from "#tlv/TlvNumber.js";
 import { ArraySchema } from "./TlvArray.js";
 import { TlvTag, TlvType, TlvTypeLength } from "./TlvCodec.js";
 import { TlvEncodingOptions, TlvReader, TlvSchema, TlvWriter } from "./TlvSchema.js";
@@ -40,6 +40,9 @@ export class NullableSchema<T> extends TlvSchema<T | null> {
                     schema = schema.bound({ min: schema.baseTypeMin + BigInt(1), max: schema.max });
                 }
             }
+        } else if (schema instanceof BitmapWrapper) {
+            // Nullable bitmaps reserve the most-significant bit to encode null.
+            schema = schema.withReservedMsb();
         }
         this.schema = schema;
     }

--- a/packages/types/src/tlv/TlvNumber.ts
+++ b/packages/types/src/tlv/TlvNumber.ts
@@ -273,6 +273,34 @@ export const TlvUInt64 = new TlvLongNumberSchema(
 // We use internally 32bit here - in fact encoding is done by real value length anyway
 export const TlvEnum = <T>() => TlvUInt32 as TlvSchema<number> as TlvSchema<T>;
 
+/**
+ * TLV wrapper for a bitmap. Tracks the underlying numeric schema and the bit schema so a nullable
+ * variant can reserve the most-significant bit per spec.
+ */
+export class BitmapWrapper<D> extends TlvWrapper<D, number> {
+    constructor(
+        readonly numericSchema: TlvNumericSchema<number>,
+        private readonly bitmapSchema: Schema<D, number>,
+    ) {
+        super(
+            numericSchema,
+            bitmapData => bitmapSchema.encode(bitmapData),
+            value => bitmapSchema.decode(value),
+        );
+    }
+
+    /**
+     * Returns a variant that reserves the most-significant bit (it encodes NULL for nullable
+     * bitmaps, shrinking the usable range).
+     *
+     * @see {@link MatterSpecification.v16.Core} § 7.19.1.2
+     */
+    withReservedMsb(): BitmapWrapper<D> {
+        const { baseTypeMax } = this.numericSchema;
+        return new BitmapWrapper(this.numericSchema.bound({ max: Math.floor(baseTypeMax / 2) }), this.bitmapSchema);
+    }
+}
+
 export const TlvBitmap = <T extends BitSchema>(underlyingSchema: TlvNumberSchema, bitSchema: T) => {
     // BitmapSchema supports encoding partial bit schemas but specifies its
     // type as TypeFromBitSchema.  Changing to TypeFromPartialBitSchema there
@@ -284,11 +312,7 @@ export const TlvBitmap = <T extends BitSchema>(underlyingSchema: TlvNumberSchema
     // only used in places where we want to support partial bitmaps.
     const bitmapSchema = BitmapSchema(bitSchema) as Schema<TypeFromPartialBitSchema<T>, number>;
 
-    return new TlvWrapper(
-        underlyingSchema,
-        (bitmapData: TypeFromPartialBitSchema<T>) => bitmapSchema.encode(bitmapData),
-        value => bitmapSchema.decode(value),
-    );
+    return new BitmapWrapper(underlyingSchema, bitmapSchema);
 };
 
 // Relative Number types

--- a/packages/types/test/tlv/TlvNullableTest.ts
+++ b/packages/types/test/tlv/TlvNullableTest.ts
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { BitFlag } from "#schema/BitmapSchema.js";
 import { TlvAny } from "#tlv/TlvAny.js";
 import { TlvArray } from "#tlv/TlvArray.js";
 import { TlvNullable } from "#tlv/TlvNullable.js";
+import { TlvBitmap, TlvUInt16, TlvUInt8 } from "#tlv/TlvNumber.js";
 import { TlvString } from "#tlv/TlvString.js";
 import { TlvByteString } from "#tlv/index.js";
 import { Bytes } from "@matter/general";
@@ -92,6 +94,27 @@ describe("TlvNullable", () => {
             const encoded = schemaArray.encode([]);
             const schemaWithConstraint = TlvNullable(TlvArray(TlvString, { minLength: 1 }));
             expect(schemaWithConstraint.decode(encoded)).equal(null);
+        });
+    });
+
+    describe("nullable bitmap reserves the most-significant bit (§7.19.1.2)", () => {
+        const map8 = TlvNullable(TlvBitmap(TlvUInt8, { lsb: BitFlag(0), msb: BitFlag(7) }));
+        const map16 = TlvNullable(TlvBitmap(TlvUInt16, { lsb: BitFlag(0), msb: BitFlag(15) }));
+
+        it("rejects map8 with the reserved MSB set", () => {
+            expect(() => map8.validate({ msb: true })).throw();
+        });
+
+        it("accepts map8 with only lower bits set", () => {
+            expect(() => map8.validate({ lsb: true })).not.throw();
+        });
+
+        it("rejects map16 with the reserved MSB set", () => {
+            expect(() => map16.validate({ msb: true })).throw();
+        });
+
+        it("accepts map16 with only lower bits set", () => {
+            expect(() => map16.validate({ lsb: true })).not.throw();
         });
     });
 });


### PR DESCRIPTION
## Problem

Matter spec §7.19.1.2: a nullable bitmap SHALL NOT permit the most-significant bit — it is reserved to encode NULL, shrinking the usable range. matter.js did not enforce this.

`TlvBitmap` was built as a plain `TlvWrapper` (not a `TlvNumericSchema`), so the numeric-shrink branch in `TlvNullable` never fired for bitmaps. A nullable `map8` therefore accepted `0xFF` instead of reserving the MSB.

Latent today — no standard 1.6 cluster defines a nullable bitmap — but CHIP reserves the MSB (`attribute-storage-null-handling.h`), so matter.js should match.

## Fix

- New `BitmapWrapper<D>` subclass of `TlvWrapper`, parameterized by its data type so `instanceof` binds cleanly (no casts). It exposes the underlying `numericSchema` and a `withReservedMsb()` variant.
- `NullableSchema` detects a `BitmapWrapper` and bounds the underlying numeric to `Math.floor(baseTypeMax / 2)`, reserving the top bit (map8 → max `0x7F`, map16 → `0x7FFF`, …). Mirrors CHIP.

Both `encode()` and `decode()` validate, so a reserved-MSB value is rejected on each path.

## Tests

`packages/types/test/tlv/TlvNullableTest.ts`: nullable map8/map16 reject the reserved MSB and accept lower bits. Written failing-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)