### PR TITLE
fix(types): validate setup passcodes in onboarding codecs; share PBKDF iteration constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Changed interaction model revision back to 12 because revision 13 only includes a provisional feature
 
 - @matter/node
+    - Fix: Reading `CommissioningServer` pairing codes before commissioning is initialized now throws a clear error instead of emitting a placeholder code
     - Fix: Ensures that the negotiated subscription MaxInterval stays at or above the requested MinIntervalFloor when the floor exceeds the 60-minute publisher limit
     - Fix: Ensures that a repeated atomic-write BeginWrite from the same client on a cluster/endpoint returns INVALID_IN_STATE for any attributes
 
@@ -35,6 +36,8 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Decodes VendorID/ProductID from the "fallback method" (`Mvid:`/`Mpid:` in the commonName) of attestation certificates
 
 - @matter/types
+    - Enhancement: Added `isValidPasscode()`/`assertValidPasscode()` for onboarding passcode validation
+    - Fix: Ensure that passcodes are valid when encoding or decoding pairing codes
     - Fix: Ensures that the most-significant bit of a nullable bitmap is reserved for NULL as defined in the Matter specification
 
 - @project-chip/matter.js

--- a/packages/general/src/crypto/CryptoConstants.ts
+++ b/packages/general/src/crypto/CryptoConstants.ts
@@ -21,3 +21,6 @@ export const CRYPTO_AEAD_MIC_LENGTH_BYTES = 16;
 export const CRYPTO_AEAD_NONCE_LENGTH_BYTES = 13;
 /** @see {@link MatterSpecification.v151.Core} § 3.7 */
 export const CRYPTO_PRIVACY_NONCE_LENGTH_BYTES = CRYPTO_AEAD_NONCE_LENGTH_BYTES;
+/** @see {@link MatterSpecification.v10.Core} § 3.9 */
+export const CRYPTO_PBKDF_ITERATIONS_MIN = 1000;
+export const CRYPTO_PBKDF_ITERATIONS_MAX = 100000;

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -14,6 +14,7 @@ import {
     camelize,
     Construction,
     Crypto,
+    CRYPTO_PBKDF_ITERATIONS_MIN,
     Diagnostic,
     Immutable,
     ImplementationError,
@@ -1356,7 +1357,7 @@ export class PairedNode {
         const discriminator = PaseClient.generateRandomDiscriminator(this.#crypto);
         const passcode = PaseClient.generateRandomPasscode(this.#crypto);
         const salt = this.#crypto.randomBytes(32);
-        const iterations = 1_000; // Minimum 1_000, Maximum 100_000
+        const iterations = CRYPTO_PBKDF_ITERATIONS_MIN;
         const pakePasscodeVerifier = await PaseClient.generatePakePasscodeVerifier(this.#crypto, passcode, {
             iterations,
             salt,

--- a/packages/node/src/behavior/system/commissioning/CommissioningServer.ts
+++ b/packages/node/src/behavior/system/commissioning/CommissioningServer.ts
@@ -357,6 +357,11 @@ export namespace CommissioningServer {
             const comm = this;
             return {
                 get pairingCodes() {
+                    // passcode/discriminator default to -1 until initialize() generates them
+                    if (comm.passcode < 0 || comm.discriminator < 0) {
+                        throw new ImplementationError("pairingCodes read before commissioning was initialized");
+                    }
+
                     const bi = endpoint.stateOf(BasicInformationBehavior);
                     const net = endpoint.stateOf(NetworkServer);
 
@@ -374,10 +379,8 @@ export namespace CommissioningServer {
 
                     return {
                         manualPairingCode: ManualPairingCodeCodec.encode({
-                            // We use -1 to flag "need generated value" but this will crash the pairing code generator.  So use 0
-                            // so we don't throw an error during initialization
-                            discriminator: comm.discriminator < 0 ? 0 : comm.discriminator,
-                            passcode: comm.passcode < 0 ? 0 : comm.passcode,
+                            discriminator: comm.discriminator,
+                            passcode: comm.passcode,
                         }),
                         qrPairingCode,
                     };

--- a/packages/node/src/behaviors/administrator-commissioning/AdministratorCommissioningServer.ts
+++ b/packages/node/src/behaviors/administrator-commissioning/AdministratorCommissioningServer.ts
@@ -5,7 +5,17 @@
  */
 
 import type { RemoteActorContext } from "#behavior/context/server/RemoteActorContext.js";
-import { Duration, InternalError, Logger, Seconds, Time, Timer, Worker } from "@matter/general";
+import {
+    CRYPTO_PBKDF_ITERATIONS_MAX,
+    CRYPTO_PBKDF_ITERATIONS_MIN,
+    Duration,
+    InternalError,
+    Logger,
+    Seconds,
+    Time,
+    Timer,
+    Worker,
+} from "@matter/general";
 import {
     assertRemoteActor,
     DeviceCommissioner,
@@ -73,7 +83,7 @@ export class AdministratorCommissioningServer extends AdministratorCommissioning
         if (pakePasscodeVerifier.byteLength !== PAKE_PASSCODE_VERIFIER_LENGTH) {
             throw new AdministratorCommissioning.PakeParameterError("PAKE passcode verifier length is invalid");
         }
-        if (iterations < 1000 || iterations > 100_000) {
+        if (iterations < CRYPTO_PBKDF_ITERATIONS_MIN || iterations > CRYPTO_PBKDF_ITERATIONS_MAX) {
             throw new AdministratorCommissioning.PakeParameterError("PAKE iterations invalid");
         }
         if (salt.byteLength < 16 || salt.byteLength > 32) {

--- a/packages/protocol/src/protocol/DeviceCommissioner.ts
+++ b/packages/protocol/src/protocol/DeviceCommissioner.ts
@@ -12,6 +12,7 @@ import { SecureChannelProtocol } from "#securechannel/SecureChannelProtocol.js";
 import { PaseServer } from "#session/pase/PaseServer.js";
 import { SessionManager } from "#session/SessionManager.js";
 import {
+    CRYPTO_PBKDF_ITERATIONS_MIN,
     Environment,
     Environmental,
     InternalError,
@@ -117,7 +118,7 @@ export class DeviceCommissioner {
 
         this.#context.secureChannelProtocol.setPaseCommissioner(
             await PaseServer.fromPin(this.#context.sessions, this.#context.commissioningConfig.values.passcode, {
-                iterations: 1000,
+                iterations: CRYPTO_PBKDF_ITERATIONS_MIN,
                 salt: this.#context.fabrics.crypto.randomBytes(32),
             }),
         );

--- a/packages/protocol/src/session/pase/PaseClient.ts
+++ b/packages/protocol/src/session/pase/PaseClient.ts
@@ -21,7 +21,7 @@ import {
     Spake2p,
     UnexpectedDataError,
 } from "@matter/general";
-import { CommissioningOptions, NodeId, SecureChannelStatusCode } from "@matter/types";
+import { isValidPasscode, NodeId, SecureChannelStatusCode } from "@matter/types";
 import { TransientPeerCommunicationError } from "../../peer/PeerCommunicationError.js";
 import { MessageExchange } from "../../protocol/MessageExchange.js";
 import { RetransmissionLimitReachedError } from "../../protocol/errors.js";
@@ -47,11 +47,7 @@ export class PaseClient {
         // Generate 27-bit random candidates and reject invalid values to avoid modulo bias.
         for (let i = 0; i < MAX_PASSCODE_GENERATION_ATTEMPTS; i++) {
             const passcode = crypto.randomUint32 & 0x07ff_ffff;
-            if (
-                passcode >= 1 &&
-                passcode <= 99_999_998 &&
-                !CommissioningOptions.FORBIDDEN_PASSCODES.includes(passcode)
-            ) {
+            if (isValidPasscode(passcode)) {
                 return passcode;
             }
         }

--- a/packages/types/src/commissioning/CommissioningOptions.ts
+++ b/packages/types/src/commissioning/CommissioningOptions.ts
@@ -6,7 +6,7 @@
 
 import { Bytes, Duration } from "@matter/general";
 import { ProductDescription } from "../common/ProductDescription.js";
-import { CommissioningFlowType } from "../schema/PairingCodeSchema.js";
+import { CommissioningFlowType, INVALID_PASSCODES } from "../schema/PairingCodeSchema.js";
 
 /**
  * Configuration for initial node commissioning.
@@ -14,9 +14,7 @@ import { CommissioningFlowType } from "../schema/PairingCodeSchema.js";
 export interface CommissioningOptions extends Partial<CommissioningOptions.Configuration> {}
 
 export namespace CommissioningOptions {
-    export const FORBIDDEN_PASSCODES = [
-        0, 11111111, 22222222, 33333333, 44444444, 55555555, 66666666, 77777777, 88888888, 99999999, 12345678, 87654321,
-    ];
+    export const FORBIDDEN_PASSCODES = INVALID_PASSCODES;
 
     export interface Configuration {
         /**

--- a/packages/types/src/schema/PairingCodeSchema.ts
+++ b/packages/types/src/schema/PairingCodeSchema.ts
@@ -4,7 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, deepCopy, ImplementationError, UnexpectedDataError, Verhoeff } from "@matter/general";
+import {
+    Bytes,
+    CRYPTO_PBKDF_ITERATIONS_MAX,
+    CRYPTO_PBKDF_ITERATIONS_MIN,
+    deepCopy,
+    ImplementationError,
+    UnexpectedDataError,
+    Verhoeff,
+} from "@matter/general";
 import { VendorId } from "../datatype/VendorId.js";
 import { TlvAny } from "../tlv/TlvAny.js";
 import { TlvType } from "../tlv/TlvCodec.js";
@@ -93,7 +101,10 @@ export type QrCodeData = TypeFromBitmapSchema<typeof QrCodeDataSchema> & {
 export const QrCodeTlvDataDefaultFields = {
     /** Device Serial # */
     serialNumber: TlvOptionalField(0x00, TlvAny), // can be TlvString with up to 32 bytes or Unsigned Int up to 8 bytes
-    pbkdfIterations: TlvOptionalField(0x01, TlvUInt32.bound({ min: 1000, max: 100_000 })), // Or could also be UInt 16?
+    pbkdfIterations: TlvOptionalField(
+        0x01,
+        TlvUInt32.bound({ min: CRYPTO_PBKDF_ITERATIONS_MIN, max: CRYPTO_PBKDF_ITERATIONS_MAX }),
+    ),
     pbkdfSalt: TlvOptionalField(0x02, TlvByteString.bound({ minLength: 16, maxLength: 32 })),
 
     /**
@@ -109,9 +120,59 @@ export const QrCodeTlvDataDefaultFields = {
     commissioningTimeout: TlvOptionalField(0x04, TlvUInt16),
 };
 
+/**
+ * Inclusive lower bound of the valid passcode range `0x0000001..0x5F5E0FE`.
+ * See {@link MatterSpecification.v13.Core} § 5.1.1.6.
+ */
+export const PASSCODE_MIN = 0x0000001;
+
+/**
+ * Inclusive upper bound of the valid passcode range `0x0000001..0x5F5E0FE`.
+ * See {@link MatterSpecification.v13.Core} § 5.1.1.6.
+ */
+export const PASSCODE_MAX = 0x5f5e0fe;
+
+/**
+ * Trivial/insecure passcodes that SHALL NOT be used for PASE.
+ * See {@link MatterSpecification.v13.Core} § 5.1.7.1.
+ */
+export const INVALID_PASSCODES: readonly number[] = [
+    0, 11111111, 22222222, 33333333, 44444444, 55555555, 66666666, 77777777, 88888888, 99999999, 12345678, 87654321,
+];
+
+/**
+ * Returns true when the passcode is a valid setup passcode: within the {@link PASSCODE_MIN}..{@link PASSCODE_MAX} range
+ * and not one of the {@link INVALID_PASSCODES}. Mirrors CHIP's `PayloadContents::IsValidSetupPIN`.
+ *
+ * The onboarding codecs round-trip arbitrary 27-bit passcodes; use this to validate a decoded payload at parse time
+ * rather than deferring to the PASE layer. See {@link MatterSpecification.v13.Core} § 5.1.1.6 / § 5.1.7.1.
+ */
+export function isValidPasscode(passcode: number): boolean {
+    return (
+        Number.isInteger(passcode) &&
+        passcode >= PASSCODE_MIN &&
+        passcode <= PASSCODE_MAX &&
+        !INVALID_PASSCODES.includes(passcode)
+    );
+}
+
+/** Throws {@link UnexpectedDataError} when {@link isValidPasscode} returns false. */
+export function assertValidPasscode(passcode: number): void {
+    if (!isValidPasscode(passcode)) {
+        throw new UnexpectedDataError(`Invalid passcode ${passcode}`);
+    }
+}
+
 const PREFIX = "MT:";
 
 class QrPairingCodeSchema extends Schema<QrCodeData[], string> {
+    /** Rejects payloads carrying an invalid passcode per § 5.1.1.6 / § 5.1.7.1. */
+    override validate(payloadData: QrCodeData[]): void {
+        for (const { passcode } of payloadData) {
+            assertValidPasscode(passcode);
+        }
+    }
+
     protected encodeInternal(payloadData: QrCodeData[]): string {
         if (payloadData.length === 0) throw new ImplementationError("Provided Payload data is empty");
         const result =
@@ -221,6 +282,11 @@ export type ManualPairingData = {
 
 /** See {@link MatterSpecification.v10.Core} § 5.1.4.1 Table 38/39/40 */
 class ManualPairingCodeSchema extends Schema<ManualPairingData, string> {
+    /** Rejects payloads carrying an invalid passcode per § 5.1.1.6 / § 5.1.7.1. */
+    override validate({ passcode }: ManualPairingData): void {
+        assertValidPasscode(passcode);
+    }
+
     protected encodeInternal({ discriminator, passcode, vendorId, productId }: ManualPairingData): string {
         if (discriminator === undefined) throw new UnexpectedDataError("discriminator is required");
         if (discriminator > 4095) throw new UnexpectedDataError("discriminator value must be less than 4096");

--- a/packages/types/test/schema/PairingCodeSchemaTest.ts
+++ b/packages/types/test/schema/PairingCodeSchemaTest.ts
@@ -7,8 +7,12 @@
 import {
     CommissioningFlowType,
     DiscoveryCapabilitiesSchema,
+    INVALID_PASSCODES,
+    isValidPasscode,
     ManualPairingCodeCodec,
     ManualPairingData,
+    PASSCODE_MAX,
+    PASSCODE_MIN,
     QrCodeData,
     QrCodeTlvDataDefaultFields,
     QrPairingCodeCodec,
@@ -59,9 +63,9 @@ const MANUAL_PAIRING_DATA_CODES: Array<MANUAL_PAIRING_DATA_CODE> = [
         data: {
             discriminator: 10,
             shortDiscriminator: 0,
-            passcode: 12345678,
+            passcode: 23456780,
         },
-        code: "0085 260 7537",
+        code: "0112 761 4316",
     },
     {
         data: {
@@ -124,6 +128,24 @@ describe("QrPairingCodeCodec", () => {
             const encoded = QrPairingCodeCodec.encode([shortPasscodeQr]);
             const decoded = QrPairingCodeCodec.decode(encoded);
             expect(decoded[0].passcode).equal(1);
+        });
+    });
+
+    describe("passcode validation", () => {
+        it("rejects encoding an invalid passcode", () => {
+            expect(() => QrPairingCodeCodec.encode([{ ...QR_CODE_DATA, passcode: 12345678 }])).throw(
+                "Invalid passcode 12345678",
+            );
+        });
+
+        it("rejects decoding an invalid passcode", () => {
+            // MT:YNJV7VSC00ANG46Y900 carries passcode 12345678
+            expect(() => QrPairingCodeCodec.decode("MT:YNJV7VSC00ANG46Y900")).throw("Invalid passcode 12345678");
+        });
+
+        it("decodes an invalid passcode when validation is disabled", () => {
+            const decoded = QrPairingCodeCodec.decode("MT:YNJV7VSC00ANG46Y900", false);
+            expect(decoded[0].passcode).equal(12345678);
         });
     });
 
@@ -217,5 +239,48 @@ describe("ManualPairingCodeCodec", () => {
             const decoded = ManualPairingCodeCodec.decode(encoded);
             expect(decoded.passcode).equal(1);
         });
+    });
+
+    describe("passcode validation", () => {
+        it("rejects encoding an invalid passcode", () => {
+            expect(() => ManualPairingCodeCodec.encode({ discriminator: 10, passcode: 12345678 })).throw(
+                "Invalid passcode 12345678",
+            );
+        });
+
+        it("rejects decoding an invalid passcode", () => {
+            // 00852607537 carries passcode 12345678
+            expect(() => ManualPairingCodeCodec.decode("00852607537")).throw("Invalid passcode 12345678");
+        });
+
+        it("decodes an invalid passcode when validation is disabled", () => {
+            const decoded = ManualPairingCodeCodec.decode("00852607537", false);
+            expect(decoded.passcode).equal(12345678);
+        });
+    });
+});
+
+describe("isValidPasscode", () => {
+    it("accepts the range bounds", () => {
+        expect(isValidPasscode(PASSCODE_MIN)).equal(true);
+        expect(isValidPasscode(PASSCODE_MAX)).equal(true);
+        expect(isValidPasscode(20202021)).equal(true);
+    });
+
+    it("rejects out-of-range values", () => {
+        expect(isValidPasscode(PASSCODE_MIN - 1)).equal(false);
+        expect(isValidPasscode(PASSCODE_MAX + 1)).equal(false);
+        expect(isValidPasscode(-1)).equal(false);
+    });
+
+    it("rejects non-integers", () => {
+        expect(isValidPasscode(1.5)).equal(false);
+        expect(isValidPasscode(NaN)).equal(false);
+    });
+
+    it("rejects the invalid-passcode list", () => {
+        for (const passcode of INVALID_PASSCODES) {
+            expect(isValidPasscode(passcode)).equal(false);
+        }
     });
 });


### PR DESCRIPTION
## Summary

Two onboarding-payload refactors from the Matter 1.6.0 spec↔impl verification (`core-05-01-onboarding-payload` Q-01 / Q-02), bundled.

### Shared PBKDF iteration constants (Q-02)
- Add `CRYPTO_PBKDF_ITERATIONS_MIN` (1000) / `CRYPTO_PBKDF_ITERATIONS_MAX` (100000) — spec §3.9 names these literally.
- Reference them from the onboarding `pbkdfIterations` TLV bound, `DeviceCommissioner` (PASE iterations), `AdministratorCommissioningServer` (bounds check) and `PairedNode` — removing scattered `1000`/`100_000` literals.

### Setup-passcode validation (Q-01)
- Add `PASSCODE_MIN`/`PASSCODE_MAX` (§5.1.1.6 range `0x0000001..0x5F5E0FE`), `INVALID_PASSCODES` (§5.1.7.1), `isValidPasscode()` and `assertValidPasscode()` — mirrors CHIP `PayloadContents::IsValidSetupPIN`.
- The QR and manual pairing-code codecs now `validate()` the passcode, so **encode and decode reject** out-of-range or invalid-list passcodes (parse-time parity with CHIP). `decode(code, false)` opts out.
- Dedup: `CommissioningOptions.FORBIDDEN_PASSCODES` and `PaseClient.generateRandomPasscode` now use the single shared list / helper.

### Drive-by
- `CommissioningServer.pairingCodes` previously fell back to `0` on the `-1` "needs generation" placeholder to avoid a codec crash. With passcode validation `0` is itself invalid, so the fallback was dead and broken; the getter now throws a clear error if read before `initialize()` runs (which always replaces `-1`).

## Testing
- New tests: `isValidPasscode` bounds/range/non-integer/invalid-list; encode+decode rejection and `validate=false` opt-out for both codecs.
- Clean build, format-verify, lint, and full `types` / `protocol` / `node` / `matter.js` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
