### PR TITLE
Node Manager Phase 1: Tier-1 desired-state model

### DIFF
--- a/packages/node/src/behavior/system/desired-state/DesiredStateBehavior.ts
+++ b/packages/node/src/behavior/system/desired-state/DesiredStateBehavior.ts
@@ -23,7 +23,6 @@ export class DesiredStateBehavior extends Behavior {
     declare readonly state: DesiredStateBehavior.State;
     declare readonly events: DesiredStateBehavior.Events;
 
-    // Both collections are nonvolatile (quality "N").
     static override readonly schema = new DatatypeModel({
         name: "DesiredState",
         type: "struct",
@@ -114,7 +113,7 @@ export namespace DesiredStateBehavior {
     }
 
     export class Events extends BaseEvents {
-        itemChanged = new Observable<[item: ManagedItem], unknown>();
-        itemRemoved = new Observable<[kind: string, key: string], unknown>();
+        itemChanged = new Observable<[item: ManagedItem]>();
+        itemRemoved = new Observable<[kind: string, key: string]>();
     }
 }

--- a/packages/node/src/behavior/system/desired-state/DesiredStateBehavior.ts
+++ b/packages/node/src/behavior/system/desired-state/DesiredStateBehavior.ts
@@ -10,7 +10,7 @@ import { Observable } from "@matter/general";
 import { DatatypeModel, FieldElement } from "@matter/model";
 import { assertCapacity, CapacityCache } from "./capacity.js";
 import type { CapacityInfo } from "./ItemKind.js";
-import { ItemMode, ItemState, ManagedItem, itemMapKey, newStatus } from "./types.js";
+import { itemMapKey, ItemMode, ItemState, ManagedItem, newStatus } from "./types.js";
 
 /**
  * Per-ClientNode store of intended state. Holds {@link ManagedItem}s and an observed device

--- a/packages/node/src/behavior/system/desired-state/DesiredStateBehavior.ts
+++ b/packages/node/src/behavior/system/desired-state/DesiredStateBehavior.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Behavior } from "#behavior/Behavior.js";
+import { Events as BaseEvents } from "#behavior/Events.js";
+import { Observable } from "@matter/general";
+import { DatatypeModel, FieldElement } from "@matter/model";
+import { assertCapacity, CapacityCache } from "./capacity.js";
+import type { CapacityInfo } from "./ItemKind.js";
+import { ItemMode, ItemState, ManagedItem, itemMapKey, newStatus } from "./types.js";
+
+/**
+ * Per-ClientNode store of intended state. Holds {@link ManagedItem}s and an observed device
+ * capacity cache, both persisted. Passive: it tracks intent and status but performs no network
+ * I/O. The Reconciler (separate package) drives items toward the node.
+ */
+export class DesiredStateBehavior extends Behavior {
+    static override readonly id = "desiredState";
+
+    declare readonly state: DesiredStateBehavior.State;
+    declare readonly events: DesiredStateBehavior.Events;
+
+    // Both collections are nonvolatile (quality "N").
+    static override readonly schema = new DatatypeModel({
+        name: "DesiredState",
+        type: "struct",
+        children: [
+            FieldElement({
+                name: "items",
+                type: "any",
+                quality: "N",
+                default: { type: "properties", properties: {} },
+            }),
+            FieldElement({
+                name: "capacities",
+                type: "any",
+                quality: "N",
+                default: { type: "properties", properties: {} },
+            }),
+        ],
+    });
+
+    setIntent<I>(kind: string, key: string, intent: I, mode: ItemMode = "converge"): ManagedItem<I> {
+        const item: ManagedItem<I> = { kind, key, intent, mode, status: newStatus("pending") };
+        this.state.items = { ...this.state.items, [itemMapKey(kind, key)]: item };
+        this.events.itemChanged.emit(item);
+        return item;
+    }
+
+    removeIntent(kind: string, key: string): void {
+        const id = itemMapKey(kind, key);
+        const existing = this.state.items[id];
+        if (existing === undefined) {
+            return;
+        }
+        const item: ManagedItem = { ...existing, status: newStatus("deletePending") };
+        this.state.items = { ...this.state.items, [id]: item };
+        this.events.itemChanged.emit(item);
+    }
+
+    updateStatus(kind: string, key: string, state: ItemState, failureCode?: number): void {
+        const id = itemMapKey(kind, key);
+        const existing = this.state.items[id];
+        if (existing === undefined) {
+            return;
+        }
+        const item: ManagedItem = { ...existing, status: newStatus(state, failureCode) };
+        this.state.items = { ...this.state.items, [id]: item };
+        this.events.itemChanged.emit(item);
+    }
+
+    dropItem(kind: string, key: string): void {
+        const id = itemMapKey(kind, key);
+        if (this.state.items[id] === undefined) {
+            return;
+        }
+        const { [id]: _removed, ...rest } = this.state.items;
+        this.state.items = rest;
+        this.events.itemRemoved.emit(kind, key);
+    }
+
+    getItem(kind: string, key: string): ManagedItem | undefined {
+        return this.state.items[itemMapKey(kind, key)];
+    }
+
+    allItems(): ManagedItem[] {
+        return Object.values(this.state.items);
+    }
+
+    itemsByKind(kind: string): ManagedItem[] {
+        return Object.values(this.state.items).filter(item => item.kind === kind);
+    }
+
+    setCapacity(kind: string, info: CapacityInfo): void {
+        this.state.capacities = { ...this.state.capacities, [kind]: info };
+    }
+
+    getCapacity(kind: string): CapacityInfo | undefined {
+        return this.state.capacities[kind];
+    }
+
+    assertCanAdd(kind: string, requested = 1): void {
+        assertCapacity(kind, this.state.capacities, requested);
+    }
+}
+
+export namespace DesiredStateBehavior {
+    export class State {
+        items: Record<string, ManagedItem> = {};
+        capacities: CapacityCache = {};
+    }
+
+    export class Events extends BaseEvents {
+        itemChanged = new Observable<[item: ManagedItem], unknown>();
+        itemRemoved = new Observable<[kind: string, key: string], unknown>();
+    }
+}

--- a/packages/node/src/behavior/system/desired-state/ItemKind.ts
+++ b/packages/node/src/behavior/system/desired-state/ItemKind.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ClientNode } from "#node/ClientNode.js";
+import { DuplicateItemKindError, UnknownItemKindError } from "./errors.js";
+import type { ManagedItem } from "./types.js";
+
+/** Observed device limit and current usage for a kind on one node. */
+export interface CapacityInfo {
+    limit: number;
+    used: number;
+}
+
+export interface ItemKind<I = unknown> {
+    readonly kind: string;
+
+    readonly priority: number;
+
+    apply(node: ClientNode, item: ManagedItem<I>): Promise<void>;
+    read?(node: ClientNode): Promise<ManagedItem<I>[]>;
+    diff?(intent: I, current: I): boolean;
+    remove?(node: ClientNode, item: ManagedItem<I>): Promise<void>;
+    recoverable?(code: number): boolean;
+    capacity?(node: ClientNode): Promise<CapacityInfo>;
+}
+
+export class ItemKindRegistry {
+    readonly #kinds = new Map<string, ItemKind>();
+
+    register(kind: ItemKind): void {
+        if (this.#kinds.has(kind.kind)) {
+            throw new DuplicateItemKindError(`Item kind "${kind.kind}" is already registered`);
+        }
+        this.#kinds.set(kind.kind, kind);
+    }
+
+    get(kind: string): ItemKind | undefined {
+        return this.#kinds.get(kind);
+    }
+
+    require(kind: string): ItemKind {
+        const found = this.#kinds.get(kind);
+        if (found === undefined) {
+            throw new UnknownItemKindError(`No item kind registered for "${kind}"`);
+        }
+        return found;
+    }
+
+    all(): ItemKind[] {
+        return [...this.#kinds.values()].sort((a, b) => a.priority - b.priority);
+    }
+}

--- a/packages/node/src/behavior/system/desired-state/capacity.ts
+++ b/packages/node/src/behavior/system/desired-state/capacity.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    AclCapacityExceededError,
+    CapacityExceededError,
+    GroupCapacityExceededError,
+    GroupKeyCapacityExceededError,
+} from "./errors.js";
+import type { CapacityInfo } from "./ItemKind.js";
+
+/** Observed per-fabric device limits, keyed by item kind. */
+export type CapacityCache = Record<string, CapacityInfo>;
+
+type CapacityErrorCtor = new (kind: string, limit: number, used: number, requested: number) => CapacityExceededError;
+
+const CAPACITY_ERROR_BY_KIND: Record<string, CapacityErrorCtor> = {
+    acl: AclCapacityExceededError,
+    group: GroupCapacityExceededError,
+    groupKey: GroupKeyCapacityExceededError,
+};
+
+export function assertCapacity(kind: string, cache: CapacityCache, requested = 1): void {
+    const info = cache[kind];
+    if (info === undefined) {
+        return;
+    }
+    if (info.used + requested > info.limit) {
+        const Ctor = CAPACITY_ERROR_BY_KIND[kind] ?? CapacityExceededError;
+        throw new Ctor(kind, info.limit, info.used, requested);
+    }
+}

--- a/packages/node/src/behavior/system/desired-state/errors.ts
+++ b/packages/node/src/behavior/system/desired-state/errors.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MatterError } from "@matter/general";
+
+/** Base for all node-manager errors the controller cannot resolve on its own. */
+export class NodeManagerError extends MatterError {}
+
+export class UnknownItemKindError extends NodeManagerError {}
+
+export class DuplicateItemKindError extends NodeManagerError {}
+
+/**
+ * Raised when adding an item would exceed a device's per-fabric limit. Surfaced to the user —
+ * not fixable by the controller alone.
+ */
+export class CapacityExceededError extends NodeManagerError {
+    constructor(
+        readonly kind: string,
+        readonly limit: number,
+        readonly used: number,
+        readonly requested: number,
+    ) {
+        super(`Cannot add ${requested} "${kind}" item(s): would exceed device limit (${used}/${limit} used)`);
+    }
+}
+
+export class AclCapacityExceededError extends CapacityExceededError {}
+
+export class GroupCapacityExceededError extends CapacityExceededError {}
+
+export class GroupKeyCapacityExceededError extends CapacityExceededError {}

--- a/packages/node/src/behavior/system/desired-state/index.ts
+++ b/packages/node/src/behavior/system/desired-state/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from "./capacity.js";
+export * from "./DesiredStateBehavior.js";
+export * from "./errors.js";
+export * from "./ItemKind.js";
+export * from "./types.js";

--- a/packages/node/src/behavior/system/desired-state/types.ts
+++ b/packages/node/src/behavior/system/desired-state/types.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Time, Timestamp } from "@matter/general";
+
+/** Lifecycle state of a managed item, mirroring the JFDS DatastoreStateEnum. */
+export type ItemState = "pending" | "committed" | "deletePending" | "commitFailed";
+
+/** Whether an item is pushed once (`converge`) or continuously enforced (`maintain`). */
+export type ItemMode = "converge" | "maintain";
+
+export interface StatusEntry {
+    state: ItemState;
+    updateTimestamp: Timestamp;
+    failureCode?: number;
+}
+
+export interface ManagedItem<I = unknown> {
+    kind: string;
+    key: string;
+    intent: I;
+    mode: ItemMode;
+    status: StatusEntry;
+}
+
+export function newStatus(state: ItemState, failureCode?: number): StatusEntry {
+    return { state, updateTimestamp: Time.nowMs, failureCode };
+}
+
+export function itemMapKey(kind: string, key: string): string {
+    return `${kind}:${key}`;
+}

--- a/packages/node/src/behavior/system/index.ts
+++ b/packages/node/src/behavior/system/index.ts
@@ -7,6 +7,7 @@
 export * from "./commissioning/index.js";
 export * from "./controller/index.js";
 export * from "./dcl/index.js";
+export * from "./desired-state/index.js";
 export * from "./events/index.js";
 export * from "./http/index.js";
 export * from "./index/index.js";

--- a/packages/node/src/node/ClientNode.ts
+++ b/packages/node/src/node/ClientNode.ts
@@ -6,6 +6,7 @@
 
 import { ActionContext } from "#behavior/context/ActionContext.js";
 import { CommissioningClient } from "#behavior/system/commissioning/CommissioningClient.js";
+import { DesiredStateBehavior } from "#behavior/system/desired-state/DesiredStateBehavior.js";
 import { ClientNetworkRuntime } from "#behavior/system/network/ClientNetworkRuntime.js";
 import { NetworkClient } from "#behavior/system/network/NetworkClient.js";
 import { NetworkRuntime } from "#behavior/system/network/NetworkRuntime.js";
@@ -330,7 +331,7 @@ export namespace ClientNode {
     export const RootEndpoint = MutableEndpoint({
         ...Node.CommonRootEndpoint,
         deviceRevision: EndpointType.UNKNOWN_DEVICE_REVISION,
-    }).with(CommissioningClient, NetworkClient);
+    }).with(CommissioningClient, NetworkClient, DesiredStateBehavior);
 
     export interface RootEndpoint extends Identity<typeof RootEndpoint> {}
 }

--- a/packages/node/test/behavior/system/desired-state/CapacityTest.ts
+++ b/packages/node/test/behavior/system/desired-state/CapacityTest.ts
@@ -8,6 +8,7 @@ import { assertCapacity, CapacityCache } from "#behavior/system/desired-state/ca
 import {
     AclCapacityExceededError,
     CapacityExceededError,
+    GroupCapacityExceededError,
     GroupKeyCapacityExceededError,
 } from "#behavior/system/desired-state/errors.js";
 
@@ -15,7 +16,7 @@ describe("assertCapacity", () => {
     const cache: CapacityCache = {
         acl: { limit: 4, used: 3 },
         groupKey: { limit: 2, used: 2 },
-        unknownKindMapped: { limit: 5, used: 0 },
+        group: { limit: 4, used: 4 },
     };
 
     it("permits an add that stays within the limit", () => {
@@ -28,6 +29,10 @@ describe("assertCapacity", () => {
 
     it("throws the group-key-specific error at a full limit", () => {
         expect(() => assertCapacity("groupKey", cache, 1)).throws(GroupKeyCapacityExceededError);
+    });
+
+    it("throws the group-specific error when the add would exceed the limit", () => {
+        expect(() => assertCapacity("group", cache, 1)).throws(GroupCapacityExceededError);
     });
 
     it("throws the generic error for a kind with no specific subclass", () => {

--- a/packages/node/test/behavior/system/desired-state/CapacityTest.ts
+++ b/packages/node/test/behavior/system/desired-state/CapacityTest.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { assertCapacity, CapacityCache } from "#behavior/system/desired-state/capacity.js";
+import {
+    AclCapacityExceededError,
+    CapacityExceededError,
+    GroupKeyCapacityExceededError,
+} from "#behavior/system/desired-state/errors.js";
+
+describe("assertCapacity", () => {
+    const cache: CapacityCache = {
+        acl: { limit: 4, used: 3 },
+        groupKey: { limit: 2, used: 2 },
+        unknownKindMapped: { limit: 5, used: 0 },
+    };
+
+    it("permits an add that stays within the limit", () => {
+        expect(() => assertCapacity("acl", cache, 1)).not.throws();
+    });
+
+    it("throws the ACL-specific error when the add would exceed the limit", () => {
+        expect(() => assertCapacity("acl", cache, 2)).throws(AclCapacityExceededError);
+    });
+
+    it("throws the group-key-specific error at a full limit", () => {
+        expect(() => assertCapacity("groupKey", cache, 1)).throws(GroupKeyCapacityExceededError);
+    });
+
+    it("throws the generic error for a kind with no specific subclass", () => {
+        const full: CapacityCache = { binding: { limit: 1, used: 1 } };
+        let thrown: unknown;
+        try {
+            assertCapacity("binding", full, 1);
+        } catch (e) {
+            thrown = e;
+        }
+        expect(thrown).instanceOf(CapacityExceededError);
+        expect(thrown).not.instanceOf(AclCapacityExceededError);
+    });
+
+    it("is a no-op when the kind's capacity is unknown", () => {
+        expect(() => assertCapacity("neverSeen", cache, 100)).not.throws();
+    });
+});

--- a/packages/node/test/behavior/system/desired-state/DesiredStateBehaviorTest.ts
+++ b/packages/node/test/behavior/system/desired-state/DesiredStateBehaviorTest.ts
@@ -15,7 +15,9 @@ describe("DesiredStateBehavior", () => {
         await endpoint.act(agent => {
             const ds = agent.get(DesiredStateBehavior);
             const events = new Array<ManagedItem>();
-            ds.events.itemChanged.on(item => { events.push(item); });
+            ds.events.itemChanged.on(item => {
+                events.push(item);
+            });
 
             const item = ds.setIntent("acl", "1", { privilege: 5 }, "converge");
 
@@ -57,7 +59,9 @@ describe("DesiredStateBehavior", () => {
             const ds = agent.get(DesiredStateBehavior);
             ds.setIntent("binding", "7", { node: 2 });
             const removed = new Array<string>();
-            ds.events.itemRemoved.on((kind, key) => { removed.push(`${kind}/${key}`); });
+            ds.events.itemRemoved.on((kind, key) => {
+                removed.push(`${kind}/${key}`);
+            });
             ds.dropItem("binding", "7");
             expect(ds.getItem("binding", "7")).equals(undefined);
             expect(removed).deep.equals(["binding/7"]);

--- a/packages/node/test/behavior/system/desired-state/DesiredStateBehaviorTest.ts
+++ b/packages/node/test/behavior/system/desired-state/DesiredStateBehaviorTest.ts
@@ -15,7 +15,7 @@ describe("DesiredStateBehavior", () => {
         await endpoint.act(agent => {
             const ds = agent.get(DesiredStateBehavior);
             const events = new Array<ManagedItem>();
-            ds.events.itemChanged.on(item => events.push(item));
+            ds.events.itemChanged.on(item => { events.push(item); });
 
             const item = ds.setIntent("acl", "1", { privilege: 5 }, "converge");
 
@@ -57,7 +57,7 @@ describe("DesiredStateBehavior", () => {
             const ds = agent.get(DesiredStateBehavior);
             ds.setIntent("binding", "7", { node: 2 });
             const removed = new Array<string>();
-            ds.events.itemRemoved.on((kind, key) => removed.push(`${kind}/${key}`));
+            ds.events.itemRemoved.on((kind, key) => { removed.push(`${kind}/${key}`); });
             ds.dropItem("binding", "7");
             expect(ds.getItem("binding", "7")).equals(undefined);
             expect(removed).deep.equals(["binding/7"]);

--- a/packages/node/test/behavior/system/desired-state/DesiredStateBehaviorTest.ts
+++ b/packages/node/test/behavior/system/desired-state/DesiredStateBehaviorTest.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DesiredStateBehavior } from "#behavior/system/desired-state/DesiredStateBehavior.js";
+import { AclCapacityExceededError } from "#behavior/system/desired-state/errors.js";
+import { ManagedItem } from "#behavior/system/desired-state/types.js";
+import { MockEndpoint } from "../../../endpoint/mock-endpoint.js";
+
+describe("DesiredStateBehavior", () => {
+    it("setIntent creates a pending item and emits itemChanged", async () => {
+        await using endpoint = await MockEndpoint.createWith(DesiredStateBehavior);
+        await endpoint.act(agent => {
+            const ds = agent.get(DesiredStateBehavior);
+            const events = new Array<ManagedItem>();
+            ds.events.itemChanged.on(item => events.push(item));
+
+            const item = ds.setIntent("acl", "1", { privilege: 5 }, "converge");
+
+            expect(item.status.state).equals("pending");
+            expect(item.mode).equals("converge");
+            expect(ds.getItem("acl", "1")?.intent).deep.equals({ privilege: 5 });
+            expect(events.length).equals(1);
+            expect(events[0].kind).equals("acl");
+        });
+    });
+
+    it("setIntent defaults mode to converge and re-pends on update", async () => {
+        await using endpoint = await MockEndpoint.createWith(DesiredStateBehavior);
+        await endpoint.act(agent => {
+            const ds = agent.get(DesiredStateBehavior);
+            ds.setIntent("nodeLabel", "0", "Kitchen");
+            expect(ds.getItem("nodeLabel", "0")?.mode).equals("converge");
+            ds.updateStatus("nodeLabel", "0", "committed");
+            expect(ds.getItem("nodeLabel", "0")?.status.state).equals("committed");
+            ds.setIntent("nodeLabel", "0", "Living Room");
+            expect(ds.getItem("nodeLabel", "0")?.status.state).equals("pending");
+            expect(ds.getItem("nodeLabel", "0")?.intent).equals("Living Room");
+        });
+    });
+
+    it("removeIntent marks the item deletePending", async () => {
+        await using endpoint = await MockEndpoint.createWith(DesiredStateBehavior);
+        await endpoint.act(agent => {
+            const ds = agent.get(DesiredStateBehavior);
+            ds.setIntent("binding", "7", { node: 2 });
+            ds.removeIntent("binding", "7");
+            expect(ds.getItem("binding", "7")?.status.state).equals("deletePending");
+        });
+    });
+
+    it("dropItem removes the item and emits itemRemoved", async () => {
+        await using endpoint = await MockEndpoint.createWith(DesiredStateBehavior);
+        await endpoint.act(agent => {
+            const ds = agent.get(DesiredStateBehavior);
+            ds.setIntent("binding", "7", { node: 2 });
+            const removed = new Array<string>();
+            ds.events.itemRemoved.on((kind, key) => removed.push(`${kind}/${key}`));
+            ds.dropItem("binding", "7");
+            expect(ds.getItem("binding", "7")).equals(undefined);
+            expect(removed).deep.equals(["binding/7"]);
+        });
+    });
+
+    it("query helpers filter by kind", async () => {
+        await using endpoint = await MockEndpoint.createWith(DesiredStateBehavior);
+        await endpoint.act(agent => {
+            const ds = agent.get(DesiredStateBehavior);
+            ds.setIntent("acl", "1", {});
+            ds.setIntent("acl", "2", {});
+            ds.setIntent("binding", "1", {});
+            expect(ds.allItems().length).equals(3);
+            expect(ds.itemsByKind("acl").length).equals(2);
+        });
+    });
+
+    it("assertCanAdd enforces the capacity cache", async () => {
+        await using endpoint = await MockEndpoint.createWith(DesiredStateBehavior);
+        await endpoint.act(agent => {
+            const ds = agent.get(DesiredStateBehavior);
+            ds.setCapacity("acl", { limit: 4, used: 3 });
+            expect(ds.getCapacity("acl")).deep.equals({ limit: 4, used: 3 });
+            expect(() => ds.assertCanAdd("acl", 1)).not.throws();
+            expect(() => ds.assertCanAdd("acl", 2)).throws(AclCapacityExceededError);
+        });
+    });
+});

--- a/packages/node/test/behavior/system/desired-state/DesiredStatePersistenceTest.ts
+++ b/packages/node/test/behavior/system/desired-state/DesiredStatePersistenceTest.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DesiredStateBehavior } from "#behavior/system/desired-state/DesiredStateBehavior.js";
+import { ClientNode } from "#node/ClientNode.js";
+import { Environment } from "@matter/general";
+import { MockServerNode } from "../../../node/mock-server-node.js";
+
+describe("DesiredState integration", () => {
+    it("is mounted on every ClientNode", () => {
+        expect(ClientNode.RootEndpoint.behaviors.desiredState).equals(DesiredStateBehavior);
+    });
+
+    it("persists intent across a node restart", async () => {
+        const environment = new Environment("test");
+        const RootEndpoint = MockServerNode.RootEndpoint.with(DesiredStateBehavior);
+
+        const node1 = await MockServerNode.create(RootEndpoint, { environment, id: "testnode" });
+        await node1.act(agent => {
+            agent.get(DesiredStateBehavior).setIntent("acl", "1", { privilege: 5 }, "converge");
+        });
+        await node1.close();
+
+        const node2 = await MockServerNode.create(RootEndpoint, { environment, id: "testnode" });
+        await node2.act(agent => {
+            const item = agent.get(DesiredStateBehavior).getItem("acl", "1");
+            expect(item?.intent).deep.equals({ privilege: 5 });
+            expect(item?.status.state).equals("pending");
+        });
+        await node2.close();
+    });
+});

--- a/packages/node/test/behavior/system/desired-state/ErrorsTest.ts
+++ b/packages/node/test/behavior/system/desired-state/ErrorsTest.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    AclCapacityExceededError,
+    CapacityExceededError,
+    NodeManagerError,
+} from "#behavior/system/desired-state/errors.js";
+import { MatterError } from "@matter/general";
+
+describe("desired-state errors", () => {
+    it("CapacityExceededError carries the limit detail and message", () => {
+        const err = new AclCapacityExceededError("acl", 3, 3, 1);
+        expect(err).instanceOf(CapacityExceededError);
+        expect(err).instanceOf(NodeManagerError);
+        expect(err).instanceOf(MatterError);
+        expect(err.kind).equals("acl");
+        expect(err.limit).equals(3);
+        expect(err.used).equals(3);
+        expect(err.requested).equals(1);
+        expect(err.message).contains("acl");
+        expect(err.message).contains("3");
+    });
+});

--- a/packages/node/test/behavior/system/desired-state/ItemKindRegistryTest.ts
+++ b/packages/node/test/behavior/system/desired-state/ItemKindRegistryTest.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ItemKind, ItemKindRegistry } from "#behavior/system/desired-state/ItemKind.js";
+import { DuplicateItemKindError, UnknownItemKindError } from "#behavior/system/desired-state/errors.js";
+
+function fakeKind(kind: string, priority: number): ItemKind {
+    return {
+        kind,
+        priority,
+        async apply() {},
+    };
+}
+
+describe("ItemKindRegistry", () => {
+    it("registers and retrieves a kind", () => {
+        const registry = new ItemKindRegistry();
+        const acl = fakeKind("acl", 50);
+        registry.register(acl);
+        expect(registry.get("acl")).equals(acl);
+        expect(registry.require("acl")).equals(acl);
+    });
+
+    it("returns undefined for an unknown get and throws on require", () => {
+        const registry = new ItemKindRegistry();
+        expect(registry.get("nope")).equals(undefined);
+        expect(() => registry.require("nope")).throws(UnknownItemKindError);
+    });
+
+    it("rejects duplicate registration", () => {
+        const registry = new ItemKindRegistry();
+        registry.register(fakeKind("acl", 50));
+        expect(() => registry.register(fakeKind("acl", 99))).throws(DuplicateItemKindError);
+    });
+
+    it("lists kinds sorted by ascending priority", () => {
+        const registry = new ItemKindRegistry();
+        registry.register(fakeKind("acl", 50));
+        registry.register(fakeKind("groupKey", 10));
+        registry.register(fakeKind("binding", 30));
+        expect(registry.all().map(k => k.kind)).deep.equals(["groupKey", "binding", "acl"]);
+    });
+});

--- a/packages/node/test/behavior/system/desired-state/TypesTest.ts
+++ b/packages/node/test/behavior/system/desired-state/TypesTest.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { itemMapKey, newStatus } from "#behavior/system/desired-state/types.js";
+
+describe("desired-state types", () => {
+    it("newStatus stamps state and current time", () => {
+        MockTime.reset(1000);
+        const status = newStatus("pending");
+        expect(status.state).equals("pending");
+        expect(status.updateTimestamp).equals(1000);
+        expect(status.failureCode).equals(undefined);
+    });
+
+    it("newStatus records a failure code", () => {
+        const status = newStatus("commitFailed", 0x86);
+        expect(status.state).equals("commitFailed");
+        expect(status.failureCode).equals(0x86);
+    });
+
+    it("itemMapKey composes a unique key per kind+key", () => {
+        expect(itemMapKey("acl", "5")).equals(itemMapKey("acl", "5"));
+        expect(itemMapKey("acl", "5")).not.equals(itemMapKey("acl", "6"));
+        expect(itemMapKey("acl", "5")).not.equals(itemMapKey("binding", "5"));
+    });
+});

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -2065,6 +2065,10 @@ const PEER1_STATE = {
         acceptedCommandList: [],
         generatedCommandList: [],
     },
+    desiredState: {
+        items: {},
+        capacities: {},
+    },
 };
 
 const EP1_STATE = {


### PR DESCRIPTION
First step of the **Node Manager** umbrella (`node-manager` base branch). Adds a passive, per-`ClientNode` desired-state model to `@matter/node` — the foundation the reconciliation engine and multi-step Task layer build on. Design: `docs/superpowers/specs/2026-06-14-node-manager-desired-state-design.md`.

## What this adds (`packages/node/src/behavior/system/desired-state/`)
- **Types** — `ManagedItem`, `StatusEntry` (JFDS 4-state: pending/committed/deletePending/commitFailed), `converge`/`maintain` mode, `newStatus()`.
- **Error hierarchy** — `NodeManagerError` → `CapacityExceededError` family (Acl/Group/GroupKey) + registry errors.
- **ItemKind interface + registry** — open extension point (apply/read/diff/remove/recoverable/capacity, priority-ordered).
- **Capacity admission** — `assertCapacity()` fail-fast with kind-specific typed errors.
- **`DesiredStateBehavior`** — mounted on every `ClientNode`; persistent intent store (nonvolatile schema), set/remove/status/query API, `itemChanged`/`itemRemoved` events. GC'd with the node.

Passive by design: no network I/O, no timers (those are the Reconciler phase).

## Scope / not included
Reconciler + triggers + concrete ItemKinds, subscription drift, Task layer, JFDS 0x0752 facade, policy/optimizer — later phases, each its own PR into `node-manager`.

## Tests
Full `@matter/node` suite green (1230/1230 ESM/CJS, 1221/1221 Web); clean build + lint pass.

## Known follow-ups (tracked for the Reconciler phase)
- Capacity cache should be **ephemeral** (refresh on connect / subscription re-establish), not persisted; cache `limit` only, derive `used` fresh at admission. Phase 1 currently persists it — deferred cleanup.
- `itemMapKey` separator is unescaped — fine for fixed-identifier kinds; escape/document before non-identifier keys land.
- Public-API surface: barrel currently exports the full Tier-1 surface from `@matter/node`; confirm public vs internal when the Reconciler package forces the boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)