### PR TITLE
fix(nodejs): remove orphaned storage lock files on process exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 ## __WORK IN PROGRESS__
 
 - @matter/nodejs
-    - Fix: Verifies on `process.exit` that all storages were properly closed and remove orphaned lock files otherwise, so a forgotten close no longer blocks the next startup
+    - Fix: On `process.exit`, verifies all storages were properly closed and removes orphaned lock files otherwise, so a forgotten close no longer blocks the next startup
 
 ## 0.17.3 (2026-06-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The main work (all changes without a GitHub username in brackets in the below li
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+
+- @matter/nodejs
+    - Fix: Verify on `process.exit` that all storages were properly closed and remove orphaned lock files otherwise, so a forgotten close no longer blocks the next startup
+
 ## 0.17.3 (2026-06-17)
 
 - @matter/general

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 ## __WORK IN PROGRESS__
 
 - @matter/nodejs
-    - Fix: Verify on `process.exit` that all storages were properly closed and remove orphaned lock files otherwise, so a forgotten close no longer blocks the next startup
+    - Fix: Verifies on `process.exit` that all storages were properly closed and remove orphaned lock files otherwise, so a forgotten close no longer blocks the next startup
 
 ## 0.17.3 (2026-06-17)
 

--- a/packages/general/src/storage/DatafileRoot.ts
+++ b/packages/general/src/storage/DatafileRoot.ts
@@ -41,6 +41,14 @@ export class DatafileRoot extends DataNamespace {
     }
 
     /**
+     * Number of outstanding {@link DatafileRoot.Lock} references.  Surfaced for diagnostics so an unbalanced
+     * acquire/release shows up in storage open/close logs.
+     */
+    get lockCount(): number {
+        return this.#refs;
+    }
+
+    /**
      * Acquire a reference-counted lock.  The physical directory lock is acquired on the first call and released when
      * the last {@link DatafileRoot.Lock} closes.
      */

--- a/packages/node/src/storage/server/ServerNodeStore.ts
+++ b/packages/node/src/storage/server/ServerNodeStore.ts
@@ -105,7 +105,8 @@ export class ServerNodeStore extends NodeStore implements Destructable {
             Diagnostic.dict({
                 location: root?.path ?? "(unknown location)",
                 driver: this.#storageManager?.driverId ?? "unknown",
-                ...(root ? { locks: root.lockCount } : {}),
+                // Only meaningful on close, where a non-zero count means a holder did not release
+                ...(what === "Closed" && root ? { locks: root.lockCount } : {}),
             }),
         );
     }

--- a/packages/node/src/storage/server/ServerNodeStore.ts
+++ b/packages/node/src/storage/server/ServerNodeStore.ts
@@ -105,6 +105,7 @@ export class ServerNodeStore extends NodeStore implements Destructable {
             Diagnostic.dict({
                 location: root?.path ?? "(unknown location)",
                 driver: this.#storageManager?.driverId ?? "unknown",
+                ...(root ? { locks: root.lockCount } : {}),
             }),
         );
     }

--- a/packages/nodejs/src/fs/lock-utils.ts
+++ b/packages/nodejs/src/fs/lock-utils.ts
@@ -59,8 +59,8 @@ function removeOrphanedLocks() {
         } catch {
             // ignore
         }
-        unlinkSyncSafe(pidPath);
         unlinkSyncSafe(lockPath);
+        unlinkSyncSafe(pidPath);
     }
 }
 
@@ -96,9 +96,11 @@ export async function acquireDirectoryLock(dirPath: string, dirName: string): Pr
     logger.debug("Acquired storage lock for", dirName, "pid", process.pid);
 
     return async () => {
-        activeLocks.delete(tracked);
-        await safeUnlink(pidPath);
+        // Remove the lock (the gate) first: if the second unlink fails, a leftover pid file is harmless (the next
+        // start reacquires and overwrites it), whereas a leftover lock file would force stale detection
         await safeUnlink(lockPath);
+        await safeUnlink(pidPath);
+        activeLocks.delete(tracked);
         logger.debug("Released storage lock for", dirName);
     };
 }

--- a/packages/nodejs/src/fs/lock-utils.ts
+++ b/packages/nodejs/src/fs/lock-utils.ts
@@ -87,7 +87,7 @@ export async function acquireDirectoryLock(dirPath: string, dirName: string): Pr
         return async () => {};
     }
 
-    await acquireLock(lockPath, pidPath);
+    await acquireLock(lockPath, pidPath, dirName);
     await writeFile(pidPath, `${process.pid} ${PROCESS_TOKEN}`);
 
     const tracked: ActiveLock = { lockPath, pidPath, name: dirName };
@@ -105,7 +105,7 @@ export async function acquireDirectoryLock(dirPath: string, dirName: string): Pr
     };
 }
 
-async function acquireLock(lockPath: string, pidPath: string) {
+async function acquireLock(lockPath: string, pidPath: string, dirName: string) {
     try {
         const fd = await fsOpen(lockPath, "wx");
         await fd.close();
@@ -116,9 +116,10 @@ async function acquireLock(lockPath: string, pidPath: string) {
 
         // Lock file exists — check if the owning process is still alive
         const info = await readLockInfo(pidPath);
+        const reason = staleReason(info);
 
-        if (isStale(info)) {
-            logger.info("Cleaning stale storage lock");
+        if (reason !== undefined) {
+            logger.info("Cleaning stale storage lock for", dirName, "-", reason);
             await safeUnlink(pidPath);
             await safeUnlink(lockPath);
 
@@ -141,34 +142,30 @@ async function acquireLock(lockPath: string, pidPath: string) {
 }
 
 /**
- * A lock is stale if:
- *
- * - There is no PID file (crash between lock creation and PID write)
- * - The owning process no longer exists
- * - The PID matches ours but the token differs (PID reuse, e.g. Docker container restart)
+ * Returns why a lock is stale, or `undefined` if it is held by a live owner.  The reason is logged so the cause of a
+ * reclaim (and any failure to release) is visible in the storage logs.
  */
-function isStale(info: LockInfo | undefined): boolean {
+function staleReason(info: LockInfo | undefined): string | undefined {
     if (info === undefined) {
-        return true;
+        return "no PID file (owner crashed before writing it)";
     }
 
     if (info.pid === process.pid) {
         // Same PID — check whether it's actually us via the token.  If the token matches, the lock is held by another
         // call site in this process.  If it differs (or is missing from an old-format file), the PID was reused.
-        return info.token !== PROCESS_TOKEN;
+        return info.token !== PROCESS_TOKEN ? `PID ${info.pid} reused (token mismatch)` : undefined;
     }
 
     try {
         process.kill(info.pid, 0);
-        // Process exists and we have permission to signal it — lock is not stale
-        return false;
+        // Process exists and we have permission to signal it (or EPERM below) — lock is not stale
+        return undefined;
     } catch (error) {
         if ((error as NodeJS.ErrnoException).code === "ESRCH") {
-            // Process does not exist — lock is stale
-            return true;
+            return `owner process ${info.pid} no longer exists`;
         }
         // EPERM — process exists but we can't signal it — lock is not stale
-        return false;
+        return undefined;
     }
 }
 

--- a/packages/nodejs/src/fs/lock-utils.ts
+++ b/packages/nodejs/src/fs/lock-utils.ts
@@ -6,6 +6,7 @@
 
 import { Logger, StorageLockError } from "@matter/general";
 import { randomBytes } from "node:crypto";
+import { unlinkSync } from "node:fs";
 import { open as fsOpen, readFile, stat, unlink, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
@@ -23,6 +24,52 @@ const PROCESS_TOKEN = randomBytes(8).toString("hex");
 interface LockInfo {
     pid: number;
     token?: string;
+}
+
+interface ActiveLock {
+    lockPath: string;
+    pidPath: string;
+    name: string;
+}
+
+/**
+ * Locks held by this process that have not yet been released.  A `process.exit` backstop removes the files for any
+ * survivors so a caller that forgets to close storage does not orphan a lock that blocks the next startup.
+ */
+const activeLocks = new Set<ActiveLock>();
+let exitHandlerInstalled = false;
+
+function trackLock(lock: ActiveLock) {
+    activeLocks.add(lock);
+    if (!exitHandlerInstalled) {
+        exitHandlerInstalled = true;
+        // 'exit' is synchronous-only, so cleanup is limited to unlinking the lock files; it cannot flush storage.
+        process.on("exit", removeOrphanedLocks);
+    }
+}
+
+function removeOrphanedLocks() {
+    for (const { lockPath, pidPath, name } of activeLocks) {
+        // Cleanup is the critical action; logging is advisory and must not prevent it if the logger throws
+        try {
+            logger.warn(
+                `Storage "${name}" was not closed before process exit; removing orphaned lock.`,
+                "Please close any opened storage during shutdown.",
+            );
+        } catch {
+            // ignore
+        }
+        unlinkSyncSafe(pidPath);
+        unlinkSyncSafe(lockPath);
+    }
+}
+
+function unlinkSyncSafe(path: string) {
+    try {
+        unlinkSync(path);
+    } catch {
+        // Best-effort cleanup during exit
+    }
 }
 
 /**
@@ -43,9 +90,13 @@ export async function acquireDirectoryLock(dirPath: string, dirName: string): Pr
     await acquireLock(lockPath, pidPath);
     await writeFile(pidPath, `${process.pid} ${PROCESS_TOKEN}`);
 
+    const tracked: ActiveLock = { lockPath, pidPath, name: dirName };
+    trackLock(tracked);
+
     logger.debug("Acquired storage lock for", dirName, "pid", process.pid);
 
     return async () => {
+        activeLocks.delete(tracked);
         await safeUnlink(pidPath);
         await safeUnlink(lockPath);
         logger.debug("Released storage lock for", dirName);

--- a/packages/nodejs/test/fs/DirectoryLockTest.ts
+++ b/packages/nodejs/test/fs/DirectoryLockTest.ts
@@ -104,6 +104,26 @@ describe("DirectoryLock", () => {
         }
     });
 
+    it("removes orphaned lock files when the owning process exits without releasing", async () => {
+        // Spawn a real process that acquires a lock and exits without releasing it, then assert the exit backstop
+        // removed the lock files.  The child uses the built module (it runs outside the test loader) and resolves it
+        // from the package entry so the path holds regardless of where the test itself runs from.
+        const script = `
+            import { createRequire } from "node:module";
+            import { dirname, resolve } from "node:path";
+            const mod = resolve(dirname(createRequire(import.meta.url).resolve("@matter/nodejs")), "../esm/fs/lock-utils.js");
+            const { acquireDirectoryLock } = await import(mod);
+            await acquireDirectoryLock(process.env.LOCK_DIR, "leaktest");
+        `;
+
+        const { code, output } = await runNode(script, { ...process.env, LOCK_DIR: rootDir });
+
+        expect(code, `child output:\n${output}`).equal(0);
+        await expectFileNotExists(join(rootDir, "matter.lock"));
+        await expectFileNotExists(join(rootDir, "matter.pid"));
+        expect(output).contains("orphaned lock");
+    });
+
     it("cleans up stale lock with old PID-only format", async () => {
         // Backward compat: old lock files without a token should be treated as stale when the process is dead
         await writeFile(join(rootDir, "matter.lock"), "");
@@ -113,6 +133,17 @@ describe("DirectoryLock", () => {
         await release();
     });
 });
+
+async function runNode(script: string, env: NodeJS.ProcessEnv): Promise<{ code: number | null; output: string }> {
+    return new Promise((res, rej) => {
+        const child = spawn(process.argv[0], ["--input-type=module", "-e", script], { env });
+        let output = "";
+        child.stdout.on("data", d => (output += d));
+        child.stderr.on("data", d => (output += d));
+        child.on("error", rej);
+        child.on("close", code => res({ code, output }));
+    });
+}
 
 async function expectFileExists(path: string) {
     try {

--- a/packages/nodejs/test/fs/DirectoryLockTest.ts
+++ b/packages/nodejs/test/fs/DirectoryLockTest.ts
@@ -111,8 +111,9 @@ describe("DirectoryLock", () => {
         const script = `
             import { createRequire } from "node:module";
             import { dirname, resolve } from "node:path";
+            import { pathToFileURL } from "node:url";
             const mod = resolve(dirname(createRequire(import.meta.url).resolve("@matter/nodejs")), "../esm/fs/lock-utils.js");
-            const { acquireDirectoryLock } = await import(mod);
+            const { acquireDirectoryLock } = await import(pathToFileURL(mod).href);
             await acquireDirectoryLock(process.env.LOCK_DIR, "leaktest");
         `;
 


### PR DESCRIPTION
## Summary

Improves resilience and diagnosability of the storage directory lock (`matter.lock`/`matter.pid`), motivated by #3945 where orphaned lock files block startup.

matter.js's storage `close()` path releases the lock correctly, but an ungraceful or incomplete shutdown (process exits without awaiting `close()`, or a caller still holding the lock) can leave the files behind. This PR adds a cleanup backstop plus logging so the cause is visible from the logs.

## Changes

**1. `process.exit` backstop** — a module-global registry tracks held directory locks (acquire adds, release removes). On process exit, any survivor's lock files are `unlinkSync`'d and a warning naming the unclosed storage is logged.

**2. Gate-first release ordering** — release removes the lock file (the O_EXCL gate) before the pid file, and deregisters from the tracker only after both unlinks succeed. A partial-failure leftover is then a harmless orphan pid (next start reacquires and overwrites it) instead of a lone lock that would force stale detection; a failed release keeps the lock registered so the exit backstop retries.

**3. Diagnostics — carried on existing log lines, no new lines:**
- Stale reclaim now logs the directory and the **reason** (`no PID file` / `owner process N no longer exists` / `PID N reused`) instead of a bare "Cleaning stale storage lock".
- The storage **`Closed`** log carries `locks: N` (`DatafileRoot.lockCount`). It is read after the node releases its own ref, so `0` = fully released (clean) and `≥1` = another holder did not release — directly distinguishing a matter.js release-path issue from a caller (e.g. Matterbridge) that opened the same storage and never closed its handle. Not logged on `Opened` (always 1 — no signal).

## Scope / limits
- `process.on("exit")` is synchronous-only → the backstop unlinks lock files; it cannot flush storage.
- It catches normal exit / `process.exit()` / uncaughtException-exit. It does **not** cover SIGKILL / OOM / power loss / reboot (uncatchable) — those orphans still require stale-lock detection on next start. PID-liveness across reboot/containers is unreliable and a lease/heartbeat is the robust fix; tracked as a follow-up, out of scope here.

## Test plan
- New test spawns a real child process that acquires a lock and exits without releasing, asserting the lock files are removed and the warning emitted (imports via `pathToFileURL` for Windows).
- `@matter/nodejs` 307/307, `@matter/general` storage 93/93 (ESM + CJS). Format + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)