### PR TITLE
fix(node): rebuild client cluster behavior on peer FeatureMap change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 ## __WORK IN PROGRESS__
 
 - @matter/node
+    - Enhancement: Avoid a duplicate in-memory copy of cached peer cluster values while a behavior is active
     - Fix: Ensure that a peer's FeatureMap change rebuilds the affected client cluster behavior
 
 - @matter/nodejs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 ## __WORK IN PROGRESS__
 
+- @matter/node
+    - Fix: Ensure that a peer's FeatureMap change rebuilds the affected client cluster behavior
+
 - @matter/nodejs
     - Fix: On `process.exit`, verifies all storages were properly closed and removes orphaned lock files otherwise, so a forgotten close no longer blocks the next startup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -699,9 +699,9 @@
             }
         },
         "node_modules/@csstools/css-color-parser": {
-            "version": "4.1.7",
-            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.7.tgz",
-            "integrity": "sha512-CmjJFQTFQx/U/xNJhSjCQ0ilpesPmNQ8+eOUeM/+kDOVW33qsIjeOXc27vrQDdWVkf83ZSWwtg7kXSUvKDJ8cQ==",
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.8.tgz",
+            "integrity": "sha512-3chWb7PRLijpJpPIKkDxdu6IBeO5MrFACND57On0j8OPpc0wZibcGc3xAHrSEbOx/KDRyMHoIxGn0w1PhXMYHw==",
             "dev": true,
             "funding": [
                 {
@@ -1866,9 +1866,9 @@
             ]
         },
         "node_modules/@oxlint/binding-android-arm-eabi": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.70.0.tgz",
-            "integrity": "sha512-zFh0P4cswmRvw6nkyb89dr18rRanuaCPAsEXsFDoQY8WdaquI8Pt4NWFjaMJg6L23cy5NeN8J9cBnREbWzZhaw==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.71.0.tgz",
+            "integrity": "sha512-ImGmd1njEg4FEJH03jhRnveEegtO3czCtfptvaHivKAZQIYATbVFBrrzbaYMYv0oJioTnxZAZVSyV+oL7W8S2g==",
             "cpu": [
                 "arm"
             ],
@@ -1883,9 +1883,9 @@
             }
         },
         "node_modules/@oxlint/binding-android-arm64": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.70.0.tgz",
-            "integrity": "sha512-qI8o4HZjeGiBrWv+pJv4lH0Yi2Gl/JSp/EumBUApezJprIKa5PS4nU0lQsQngtky8k+SplQIOjv6hwu0SSxeyg==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.71.0.tgz",
+            "integrity": "sha512-4A5BEexBrwY1YFF8Kiq/lp/wQPRG79G3BWIE1FuWaM5MvmpYSd+7ZySVcKkHdwo0UDzdQGddp6pD9mpctMqLnw==",
             "cpu": [
                 "arm64"
             ],
@@ -1900,9 +1900,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-arm64": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.70.0.tgz",
-            "integrity": "sha512-8KjgVVHI5F9nVwHCRwwA78Ty7zNKP4Wd9OeN5PSv3iu/F/u1RVXoOCgLhWqust6HmwQG6xc8c+RCyaWENy24+w==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.71.0.tgz",
+            "integrity": "sha512-9wJA9GJulLwS2usU3CEisI/ESDO1n1z9eyTCvApMDrAkbJ1ve0mORgTMjcWWsKxkzkeZ2N/Gpra5IQE7x8tYgQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1917,9 +1917,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-x64": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.70.0.tgz",
-            "integrity": "sha512-WVydssv5PSUBXFJTdNBWlmGkbNmvPGaFt/2SUT/EZRB6bq6bEOHmMlbnupZD5jmlEvi9+mZJHi8TCw15lyfSfQ==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.71.0.tgz",
+            "integrity": "sha512-PlLCjS06V0PeJMAJwzjrExw1sYNW9Gch3JtNlcwwZDXGlTYDuwHNN89zYH8LTXFfgkVtsYvs2nv0FqrzyuFDzg==",
             "cpu": [
                 "x64"
             ],
@@ -1934,9 +1934,9 @@
             }
         },
         "node_modules/@oxlint/binding-freebsd-x64": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.70.0.tgz",
-            "integrity": "sha512-hJucmUf8OlinHNb1R7fI4Fw6WsAstOz7i8nmkWQfiHoZXtbufNm+MxiDTIMk1ggh2Ro4vLzgQ+bKvRY54MZoRA==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.71.0.tgz",
+            "integrity": "sha512-Lhil7bWre0ncxbUoDoxfS0JzpTz17BRQKW7iwoAUY8GJ66+WwJEfYPCFJ1P0WgVZR5/O/b3Q2pENlHOjeXLOGQ==",
             "cpu": [
                 "x64"
             ],
@@ -1951,9 +1951,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.70.0.tgz",
-            "integrity": "sha512-1BnS7wbCYDSXwWzJJ+mc3NURoha6m6m6RT5c6vgAY3oz7C3OVXP+S0awo2mRq97arrJkVvO3qRQfyAHL+76xtQ==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.71.0.tgz",
+            "integrity": "sha512-Oo9/L58PYD3RC0x05d2upAPLllHytTjHQGsnC06P6Ynn7jKkp5mdImQxXdJ3+FnBaKspNpGogzgVsi6g872LiA==",
             "cpu": [
                 "arm"
             ],
@@ -1968,9 +1968,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.70.0.tgz",
-            "integrity": "sha512-yKy/UdbR55+M2yEcuiV5DCNC/gdQAjr/GioUy50QwBzSrKm8ueWADqyRLS9Xk+qjNeCYGg6A8FvUBds56ttfqg==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.71.0.tgz",
+            "integrity": "sha512-mSHfyfgJrEbyIR29ejaeS50BdPk+GoNPlC1dckpDiUZbJAIel68sjSMdOt4WY0/gva+ECC7FNITQkxMJU+vSBw==",
             "cpu": [
                 "arm"
             ],
@@ -1985,9 +1985,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-gnu": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.70.0.tgz",
-            "integrity": "sha512-0A5XJ4alvmqFUFP/4oYSyaO+qLto/HrKEWTSaegiVl+HOufFngK2BjYw9x4RbwBt/du5QG6l5q1zeWiJYYG5yg==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.71.0.tgz",
+            "integrity": "sha512-n9yY4M2tiy3aij4AqtlnspzpfdpeT5JQfK2/w2d8oyp5W0FRwOb1dIeX99nORNcxGr08iD9bH8N5XFz3I2iy8w==",
             "cpu": [
                 "arm64"
             ],
@@ -2005,9 +2005,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-musl": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.70.0.tgz",
-            "integrity": "sha512-JiylyurlB0CLSedNtx1gzv3FvfWPF1h/2Y3BJszPLNt5XQFlBsH5ke0Jle3iJb3uqu5m2e7A/DwzpuCAHdiU+A==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.71.0.tgz",
+            "integrity": "sha512-fJZrs5sDZtTaPIOiemRQQmo82Ezy+vOGXemPc4Ok7iVVsYsFa7SlW6Z5XN819VfsqBHRm3NJ3rTdnR8+bJYJdQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2025,9 +2025,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.70.0.tgz",
-            "integrity": "sha512-J8VPG7I3/HmgaU4u8pNU2kFx2+0U+vPLS1dXFxXOaR/2TQ0f8AC7DRz0SRGRI1bfphnX2hVYTTtLuhL4nYKL+Q==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.71.0.tgz",
+            "integrity": "sha512-cwl7VKGERIy9p+G+AvZdfy/06q0aHXaTt/mMRReC751iuNYJgqKjB7NydXSS30nBT9vtr2tunciOtrR4fD6FUA==",
             "cpu": [
                 "ppc64"
             ],
@@ -2045,9 +2045,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.70.0.tgz",
-            "integrity": "sha512-N2+4lV2KLN+oXTIIIwmWDhwkrnvqf5oX7Hw0zPjk+RuIVgiBQSOlJWF7uQoFx2siEYX0ZQ5cfSbEAHm+J3t7Wg==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.71.0.tgz",
+            "integrity": "sha512-eZ8ieVXvzGi8jr7+ybQGPK2STw3mldfxZlgA2738iflfB/rzA69sE6m5rDRpQaxC7dpm745Enlh1Tod0QAk9Gg==",
             "cpu": [
                 "riscv64"
             ],
@@ -2065,9 +2065,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-musl": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.70.0.tgz",
-            "integrity": "sha512-1e2L7cFCvx9QDzq6NPP+0tABKb5z6nWHyddWTNKprEsjO9xNrAtPowuCGpjNXxkTdsMiZ4jc8YQ5SstZd4XK6g==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.71.0.tgz",
+            "integrity": "sha512-puMDbQYe6+NXwfMusojoA7CXGn2b3utukmd23PQqc1E3XhVCwyZ+FueSMzDYeNgDV2dUfIVXAAKZBcFDeCL6sA==",
             "cpu": [
                 "riscv64"
             ],
@@ -2085,9 +2085,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-s390x-gnu": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.70.0.tgz",
-            "integrity": "sha512-Kwu/l/8GcYibCWA9m9N5pRXMIKVSsL/YbgpLzYkqDhWTiqdRfnNJ/+nqIKRKQiFbHWsdlHEhzMwruJK+qcEruA==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.71.0.tgz",
+            "integrity": "sha512-4NJLxBs1ujISCt3L/1FcywLs73PWtJuw+piD6feK2V6h6OS6P7xu9/sWt1DTRLibe6QCzmfZzmM/2HPORoV/Lg==",
             "cpu": [
                 "s390x"
             ],
@@ -2105,9 +2105,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-gnu": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.70.0.tgz",
-            "integrity": "sha512-tap04CsHYOl0nSAQJfPNIuBxqEPB2HnhQqwaOXLg1jnp2XfRo8Fa814dA4QC4zpvTWXCjAAaCY1W5LOORkEQuQ==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.71.0.tgz",
+            "integrity": "sha512-cFDaiR8L3430qp88tfZnvFlt3KotFhR/DlbIL0nHOMMYiG/9Wy4l+6f7t8G8pTa9bd8Lt8+M0y/qjRQ/xcB74g==",
             "cpu": [
                 "x64"
             ],
@@ -2125,9 +2125,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-musl": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.70.0.tgz",
-            "integrity": "sha512-hzJa/WgvtJpbBD9rgfy0qe+MjbxOXNUT0bfR1S6EQQzfTtBFA9xg5q8KSwRrQ2QfSS+TaP4j+4mVPQrfNc6UNg==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.71.0.tgz",
+            "integrity": "sha512-orfixdt76KlpNly9z0PkWBBNfwjKz+JFVLP/7wnVchlKNU9Dpt9InU/ZggeSej6fC7qwHmHNOGlhLnQXcYoGuA==",
             "cpu": [
                 "x64"
             ],
@@ -2145,9 +2145,9 @@
             }
         },
         "node_modules/@oxlint/binding-openharmony-arm64": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.70.0.tgz",
-            "integrity": "sha512-xbsaNSNzVSnaJACCUYr1HQMyY/Q/Q1LkePmHG3UvZPvGCYGNxrsZp9OmtA6ick8xH47ltRRbRrPCM1YXYcyC+A==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.71.0.tgz",
+            "integrity": "sha512-9emQu2lAp6yhPB3XuI+++vR+l/o6JR1X+EpxwcumPdQXBWXEPAsquPGL7l158EqU8SebQMXTUa/S5zN98juyHw==",
             "cpu": [
                 "arm64"
             ],
@@ -2162,9 +2162,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-arm64-msvc": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.70.0.tgz",
-            "integrity": "sha512-icAEsUI7JbW1TMRdEXV83mVAInhRVQYuuAlPpxdGwJ95chNdnCzjloRW8GglT0WvzOEZSio6fnYSk2DJ2Hv7LQ==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.71.0.tgz",
+            "integrity": "sha512-bd5kI8spYwTm3BILDtGhi73zoup5dw8MlPQNT8YB3BD5UIsjNe3K9/4ctrzQMX4SZMoK5HgzVLkLJzacEXB7fA==",
             "cpu": [
                 "arm64"
             ],
@@ -2179,9 +2179,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-ia32-msvc": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.70.0.tgz",
-            "integrity": "sha512-FHMSWbVsPVs/f+Jcl04ws4JJ2wUnauyTzlpxWRG/lSO/8GpX08Fo2gQZqdA6CrRFI+zvkxl+N/KwJGWfUwYVZA==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.71.0.tgz",
+            "integrity": "sha512-W4HvOHGzVLHcrmFu+bMrJlho+/yrlX5ZNdJZqGe8MEldkQG+RHYhxxad9P4jvWAYFmIqUA5i9DQ8QsJqSU9GIw==",
             "cpu": [
                 "ia32"
             ],
@@ -2196,9 +2196,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-x64-msvc": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.70.0.tgz",
-            "integrity": "sha512-ptOlKwCz7n4AKs5VweMqG6DAg677FmKOK+vBkkL9DMNgFATIQ+upqUYBTOEwRQyRAx1ncGlPlXleV2hIcm3z4g==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.71.0.tgz",
+            "integrity": "sha512-D2kyEIPHk/G/wiZLnwTVC/sVst+T/lKldVOjAFpgTIBUAOlry72e5OiapDbDBF4LfJLkN5ypJb/8Eu6yJzkveQ==",
             "cpu": [
                 "x64"
             ],
@@ -3219,9 +3219,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.9.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-            "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+            "version": "25.9.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+            "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": ">=7.24.0 <7.24.7"
@@ -3382,13 +3382,13 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
-            "integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
+            "version": "8.61.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
+            "integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.61.0",
-                "@typescript-eslint/types": "^8.61.0",
+                "@typescript-eslint/tsconfig-utils": "^8.61.1",
+                "@typescript-eslint/types": "^8.61.1",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -3403,9 +3403,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
-            "integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
+            "version": "8.61.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
+            "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3419,9 +3419,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
-            "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
+            "version": "8.61.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+            "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3432,15 +3432,15 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
-            "integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
+            "version": "8.61.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
+            "integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.61.0",
-                "@typescript-eslint/tsconfig-utils": "8.61.0",
-                "@typescript-eslint/types": "8.61.0",
-                "@typescript-eslint/visitor-keys": "8.61.0",
+                "@typescript-eslint/project-service": "8.61.1",
+                "@typescript-eslint/tsconfig-utils": "8.61.1",
+                "@typescript-eslint/types": "8.61.1",
+                "@typescript-eslint/visitor-keys": "8.61.1",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -3459,12 +3459,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
-            "integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
+            "version": "8.61.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+            "integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.61.0",
+                "@typescript-eslint/types": "8.61.1",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -4014,9 +4014,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.37",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
-            "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
+            "version": "2.10.38",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+            "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
             "license": "Apache-2.0",
             "peer": true,
             "bin": {
@@ -4157,9 +4157,9 @@
             "license": "ISC"
         },
         "node_modules/browserslist": {
-            "version": "4.28.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+            "version": "4.28.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+            "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -4177,10 +4177,10 @@
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.12",
-                "caniuse-lite": "^1.0.30001782",
-                "electron-to-chromium": "^1.5.328",
-                "node-releases": "^2.0.36",
+                "baseline-browser-mapping": "^2.10.38",
+                "caniuse-lite": "^1.0.30001799",
+                "electron-to-chromium": "^1.5.376",
+                "node-releases": "^2.0.48",
                 "update-browserslist-db": "^1.2.3"
             },
             "bin": {
@@ -5129,9 +5129,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.372",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
-            "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
+            "version": "1.5.376",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
+            "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
             "license": "ISC",
             "peer": true
         },
@@ -5268,6 +5268,24 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/es-abstract-get": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+            "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.2",
+                "is-callable": "^1.2.7",
+                "object-inspect": "^1.13.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/es-array-method-boxes-properly": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
@@ -5320,14 +5338,16 @@
             }
         },
         "node_modules/es-to-primitive": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-            "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.1.tgz",
+            "integrity": "sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g==",
             "license": "MIT",
             "dependencies": {
+                "es-abstract-get": "^1.0.0",
+                "es-errors": "^1.3.0",
                 "is-callable": "^1.2.7",
-                "is-date-object": "^1.0.5",
-                "is-symbol": "^1.0.4"
+                "is-date-object": "^1.1.0",
+                "is-symbol": "^1.1.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -8304,9 +8324,9 @@
             "peer": true
         },
         "node_modules/node-releases": {
-            "version": "2.0.47",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-            "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+            "version": "2.0.48",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+            "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -8472,9 +8492,9 @@
             }
         },
         "node_modules/oxlint": {
-            "version": "1.70.0",
-            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.70.0.tgz",
-            "integrity": "sha512-D6JgHtzkhRwvEC+A0Nw5AEc5bk8x5i1pHzvZIEf/a0C4hOzmAACNGtkDGPyFaxxX3ZVGxCPeig3P3rMM8XU3/g==",
+            "version": "1.71.0",
+            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.71.0.tgz",
+            "integrity": "sha512-U1m1X+C0vDj7DC1e13IoZULzEcPczE7UOMTs8VlZGHUEIUaSTZKo5qkPsQEfzpgnQ29Pea/w3Xntk62UCecxZw==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -8487,25 +8507,25 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxlint/binding-android-arm-eabi": "1.70.0",
-                "@oxlint/binding-android-arm64": "1.70.0",
-                "@oxlint/binding-darwin-arm64": "1.70.0",
-                "@oxlint/binding-darwin-x64": "1.70.0",
-                "@oxlint/binding-freebsd-x64": "1.70.0",
-                "@oxlint/binding-linux-arm-gnueabihf": "1.70.0",
-                "@oxlint/binding-linux-arm-musleabihf": "1.70.0",
-                "@oxlint/binding-linux-arm64-gnu": "1.70.0",
-                "@oxlint/binding-linux-arm64-musl": "1.70.0",
-                "@oxlint/binding-linux-ppc64-gnu": "1.70.0",
-                "@oxlint/binding-linux-riscv64-gnu": "1.70.0",
-                "@oxlint/binding-linux-riscv64-musl": "1.70.0",
-                "@oxlint/binding-linux-s390x-gnu": "1.70.0",
-                "@oxlint/binding-linux-x64-gnu": "1.70.0",
-                "@oxlint/binding-linux-x64-musl": "1.70.0",
-                "@oxlint/binding-openharmony-arm64": "1.70.0",
-                "@oxlint/binding-win32-arm64-msvc": "1.70.0",
-                "@oxlint/binding-win32-ia32-msvc": "1.70.0",
-                "@oxlint/binding-win32-x64-msvc": "1.70.0"
+                "@oxlint/binding-android-arm-eabi": "1.71.0",
+                "@oxlint/binding-android-arm64": "1.71.0",
+                "@oxlint/binding-darwin-arm64": "1.71.0",
+                "@oxlint/binding-darwin-x64": "1.71.0",
+                "@oxlint/binding-freebsd-x64": "1.71.0",
+                "@oxlint/binding-linux-arm-gnueabihf": "1.71.0",
+                "@oxlint/binding-linux-arm-musleabihf": "1.71.0",
+                "@oxlint/binding-linux-arm64-gnu": "1.71.0",
+                "@oxlint/binding-linux-arm64-musl": "1.71.0",
+                "@oxlint/binding-linux-ppc64-gnu": "1.71.0",
+                "@oxlint/binding-linux-riscv64-gnu": "1.71.0",
+                "@oxlint/binding-linux-riscv64-musl": "1.71.0",
+                "@oxlint/binding-linux-s390x-gnu": "1.71.0",
+                "@oxlint/binding-linux-x64-gnu": "1.71.0",
+                "@oxlint/binding-linux-x64-musl": "1.71.0",
+                "@oxlint/binding-openharmony-arm64": "1.71.0",
+                "@oxlint/binding-win32-arm64-msvc": "1.71.0",
+                "@oxlint/binding-win32-ia32-msvc": "1.71.0",
+                "@oxlint/binding-win32-x64-msvc": "1.71.0"
             },
             "peerDependencies": {
                 "oxlint-tsgolint": ">=0.22.1",
@@ -9841,9 +9861,9 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
-            "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
+            "integrity": "sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=20.0.0"
@@ -10710,22 +10730,22 @@
             }
         },
         "node_modules/tldts": {
-            "version": "7.4.2",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
-            "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+            "version": "7.4.3",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.3.tgz",
+            "integrity": "sha512-A3BDQBeeukYPzB4QdQ1DtdlUmp4x2OCH8n5UVhEWbyANxNep8GavottKzd1xYKFJKjUgMyPT7EzOfnBO55s8Sg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "tldts-core": "^7.4.2"
+                "tldts-core": "^7.4.3"
             },
             "bin": {
                 "tldts": "bin/cli.js"
             }
         },
         "node_modules/tldts-core": {
-            "version": "7.4.2",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
-            "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+            "version": "7.4.3",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.3.tgz",
+            "integrity": "sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==",
             "dev": true,
             "license": "MIT"
         },
@@ -11046,9 +11066,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-            "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+            "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -11056,9 +11076,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.27.2.tgz",
-            "integrity": "sha512-cH9f42mHuljpNuoS47sWDDWXVxWnJgYCzHVUlr3tn7+HVx0L6QSO+VG5qgzT4kXkR2K8ZsReaT5bupam6RNAEQ==",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.28.0.tgz",
+            "integrity": "sha512-LJAfY+2w6HGeT8d8J1wNQsUGUEGio6NWWpwdwurQe4f6oojzCFuGLizl1KSve4irsTxyLly1QhEeE6iapdaIvQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -11449,12 +11469,12 @@
             }
         },
         "node_modules/worker-timers": {
-            "version": "8.0.31",
-            "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-8.0.31.tgz",
-            "integrity": "sha512-ngkq5S6JuZyztom8tDgBzorLo9byhBMko/sXfgiUD945AuzKGg1GCgDMCC3NaYkicLpGKXutONM36wEX8UbBCA==",
+            "version": "8.0.32",
+            "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-8.0.32.tgz",
+            "integrity": "sha512-huEv5mB6xIqcadsZ8SuuFQH9Lg9Hq0h0xD9vAZZsLPNw0aLxoDWyjTALAUD3hAA4cuKbKaqrjbBcbEYClwSh3w==",
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.29.2",
+                "@babel/runtime": "^7.29.7",
                 "tslib": "^2.8.1",
                 "worker-timers-broker": "^8.0.16",
                 "worker-timers-worker": "^9.0.14"
@@ -11700,9 +11720,9 @@
             }
         },
         "node_modules/yargs": {
-            "version": "17.7.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "version": "17.7.3",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+            "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
             "license": "MIT",
             "dependencies": {
                 "cliui": "^8.0.1",
@@ -11920,8 +11940,7 @@
             "dependencies": {
                 "@matter/general": "*",
                 "@matter/protocol": "*",
-                "@matter/types": "*",
-                "@stoprocent/noble": "2.5.5"
+                "@matter/types": "*"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"

--- a/packages/node/src/behavior/state/managed/Datasource.ts
+++ b/packages/node/src/behavior/state/managed/Datasource.ts
@@ -193,6 +193,12 @@ export namespace Datasource {
         consumer?: ExternallyMutableStore.Consumer;
 
         /**
+         * Current values, preferring the live consumer over {@link Store.initialValues}.  Reflects up-to-date
+         * data while a consumer is attached, where {@link Store.initialValues} may be absent.
+         */
+        currentValues?: Val.Struct;
+
+        /**
          * The current version of the data.
          */
         version: number;
@@ -212,6 +218,11 @@ export namespace Datasource {
              * Read current values for the specified keys.
              */
             readValues(keys: Set<string>): Val.Struct;
+
+            /**
+             * Read a non-destructive copy of all current values.
+             */
+            snapshot(): Val.Struct;
 
             /**
              * Release all values from the datasource, transferring ownership back to the store.
@@ -555,6 +566,10 @@ class DatasourceImpl implements Datasource, Datasource.ExternallyMutableStore.Co
             }
         }
         return result;
+    }
+
+    snapshot() {
+        return { ...this.#values };
     }
 
     releaseValues() {

--- a/packages/node/src/node/client/ClientStructure.ts
+++ b/packages/node/src/node/client/ClientStructure.ts
@@ -501,9 +501,8 @@ export class ClientStructure {
 
         // Generate a behavior if enough information is available
         if (cluster.behavior === undefined) {
-            if (cluster.store.initialValues) {
-                const values = cluster.store.initialValues;
-
+            const values = cluster.store.currentValues;
+            if (values) {
                 const clusterRevision = getStoreValue(values, ClusterRevision.id, "clusterRevision");
                 const features = getStoreValue(values, FeatureMap.id, "featureMap");
                 const attributeList = getStoreValue(values, AttributeList.id, "attributeList");
@@ -579,7 +578,7 @@ export class ClientStructure {
             if (cluster.behavior && endpoint.behaviors.isActive(cluster.behavior.id)) {
                 attrs = endpoint.stateOf(cluster.behavior);
             } else {
-                attrs = cluster.store.initialValues ?? {};
+                attrs = cluster.store.currentValues ?? {};
             }
             this.#synchronizeDescriptor(structure, attrs);
         }

--- a/packages/node/src/storage/client/DatasourceCache.ts
+++ b/packages/node/src/storage/client/DatasourceCache.ts
@@ -122,13 +122,14 @@ export class DatasourceCache implements Datasource.ExternallyMutableStore, Remot
 
         if (this.consumer) {
             await this.consumer.integrateExternalChange(values);
-        } else {
-            if (!this.initialValues) {
-                this.initialValues = {};
-            }
-            const valuesStruct = Object.fromEntries(values) as Val.Struct;
-            Object.assign(this.initialValues, valuesStruct);
         }
+
+        // Keep initialValues current even while a consumer owns the datasource so a later behavior rebuild
+        // (e.g. a featureMap change replacing the cluster) seeds from fresh data, not the stale bind-time snapshot.
+        if (!this.initialValues) {
+            this.initialValues = {};
+        }
+        Object.assign(this.initialValues, Object.fromEntries(values));
     }
 
     /**

--- a/packages/node/src/storage/client/DatasourceCache.ts
+++ b/packages/node/src/storage/client/DatasourceCache.ts
@@ -52,7 +52,18 @@ export class DatasourceCache implements Datasource.ExternallyMutableStore, Remot
         this.#consumer = consumer;
         if (consumer !== undefined) {
             this.#reclaimed = false;
+
+            // Consumer owns the values while attached; drop our seed copy so we don't shadow it.
+            this.initialValues = undefined;
         }
+    }
+
+    /**
+     * Current values, preferring the live consumer over the seed snapshot, so cluster structure can rebuild from
+     * up-to-date data while a behavior is active.
+     */
+    get currentValues(): Val.Struct | undefined {
+        return this.#consumer && !this.#reclaimed ? this.#consumer.snapshot() : this.initialValues;
     }
 
     async set(transaction: Transaction, values: Val.Struct) {
@@ -122,14 +133,12 @@ export class DatasourceCache implements Datasource.ExternallyMutableStore, Remot
 
         if (this.consumer) {
             await this.consumer.integrateExternalChange(values);
+        } else {
+            if (!this.initialValues) {
+                this.initialValues = {};
+            }
+            Object.assign(this.initialValues, Object.fromEntries(values));
         }
-
-        // Keep initialValues current even while a consumer owns the datasource so a later behavior rebuild
-        // (e.g. a featureMap change replacing the cluster) seeds from fresh data, not the stale bind-time snapshot.
-        if (!this.initialValues) {
-            this.initialValues = {};
-        }
-        Object.assign(this.initialValues, Object.fromEntries(values));
     }
 
     /**

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -1373,6 +1373,14 @@ describe("ClientNode", () => {
             positionAwareTilt: true,
         });
 
+        // featuresOf reflects the installed behavior's schema, so a stale rebuild seeded from the bind-time
+        // snapshot would still report the old Lift-only feature set here even though the featureMap value updated.
+        const features = clientEp1.featuresOf(WindowCoveringClient);
+        expect(features.lift).equals(true);
+        expect(features.positionAwareLift).equals(true);
+        expect(features.tilt).equals(true);
+        expect(features.positionAwareTilt).equals(true);
+
         sawChange = new Promise<number | null>(resolve => liftChanged.once(resolve));
         await serverEp1b.setStateOf(WindowCoveringClient, { currentPositionLiftPercent100ths: 1200 });
 


### PR DESCRIPTION
## Problem

A client peer's FeatureMap change was not reflected in the cluster behavior until a server restart (matter-js/matterjs-server#760). The featureMap **value** updated live, but the behavior's feature-gated schema kept the old feature set.

## Root cause

Detection in `ClientStructure.#updateCluster` fires correctly and clears the behavior. The rebuild in `#synchronizeCluster` reads the cluster's stored values to rebuild the feature-gated behavior. `DatasourceCache` only refreshed `initialValues` while **no** consumer was attached, so once a behavior was installed the snapshot froze at its bind-time state and the rebuild re-seeded from stale features. Storage still received the new value, which is why a restart fixed it.

## Fix

Single-owner handoff for the client cache:

- `DatasourceCache` drops `initialValues` once a consumer (live `Datasource`) attaches — the consumer is the sole holder of cluster values while a behavior is active (no duplicate in-memory copy).
- Cluster structure rebuilds read current values via a new non-destructive `Consumer.snapshot()`, exposed as `store.currentValues` (live consumer when attached, else the seed snapshot).
- `close()`/`reclaimValues()` restore `initialValues` from the consumer on detach (existing machinery).

A behavior rebuild reuses the backing (`Behaviors.inject` swaps `activeBacking.type`) rather than recreating the `Datasource`, so the live values carry over and only the feature-gated schema changes.

## Test

Strengthens the `ClientNode` "correctly replaces behavior" test with a `featuresOf(WindowCoveringClient)` assertion that inspects the **installed behavior's** feature set (a state-value read does not catch this — the value updates live regardless). Verified to fail without the fix (`expected false to equal true` on `features.tilt`) and pass with it.

## Server impact

None — servers use `DatasourceStore` (a plain `Store` with no `externalSet`/`consumer`), so they never attach as a consumer and never exercise `snapshot()`/`currentValues`/the clear-on-attach path. The `Datasource` interface additions are additive and unused server-side.

## Notes

- Includes unrelated dependency lockfile updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)