### PR TITLE
fix(node): sanitize orphaned fabric-scoped data at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/node
     - Enhancement: Avoid a duplicate in-memory copy of cached peer cluster values while a behavior is active
     - Fix: Ensure that a peer's FeatureMap change rebuilds the affected client cluster behavior
+    - Fix: Ensure to always sanitize fabric-scoped attribute data (e.g. stale AccessControl ACL entries) at node startup
 
 - @matter/nodejs
     - Fix: On `process.exit`, verifies all storages were properly closed and removes orphaned lock files otherwise, so a forgotten close no longer blocks the next startup

--- a/packages/node/src/behavior/cluster/FabricScopedDataHandler.ts
+++ b/packages/node/src/behavior/cluster/FabricScopedDataHandler.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Behavior } from "#behavior/Behavior.js";
+import type { Agent } from "#endpoint/Agent.js";
 import type { Endpoint } from "#endpoint/Endpoint.js";
 import type { SupportedElements } from "#endpoint/properties/Behaviors.js";
 import type { ServerNode } from "#node/ServerNode.js";
@@ -34,18 +35,15 @@ async function forBehaviors(
 }
 
 /**
- * Sanitize fabric-scoped attributes for a given endpoint and cluster.
- * The changed state is returned in an array of promises and should be awaited to ensure the state is updated.
+ * Compute a state patch that strips fabric-scoped attribute entries no longer belonging to an allowed fabric.
+ * Returns `undefined` when nothing needs to change.
  */
-async function sanitizeAttributeData(
+function computeFabricScopedUpdate(
     endpoint: Endpoint,
     type: Behavior.Type,
-    cluster: ClusterType,
     supportedAttributes: Set<string>,
     allowedIndices: FabricIndex[],
-) {
-    const stateUpdatePromises = new Array<Promise<void>>();
-
+): Val.Struct | undefined {
     // Build a set of fabric-scoped attribute names from the schema
     const fabricScopedAttrs = new Set<string>();
     const schema = Schema(type) as ClusterModel;
@@ -58,11 +56,11 @@ async function sanitizeAttributeData(
     }
 
     const stateUpdate = {} as Val.Struct;
-    // Iterate over all attributes and check if they are fabric-scoped
+    const state = endpoint.stateOf(type) as Val.Struct;
     for (const attributeName of supportedAttributes) {
         if (fabricScopedAttrs.has(attributeName)) {
-            const value = (endpoint.stateOf(type) as Val.Struct)[attributeName];
-            // If the value contains data for the fabric being removed, remove the data
+            const value = state[attributeName];
+            // If the value contains data for a fabric no longer present, remove that data
             if (Array.isArray(value) && value.length > 0) {
                 const filtered = value.filter(entry => allowedIndices.includes(entry.fabricIndex));
                 if (filtered.length !== value.length) {
@@ -71,20 +69,38 @@ async function sanitizeAttributeData(
             }
         }
     }
-    // If we have any state updates for this behavior, we need to set the state.
-    // Errors are being logged and ignored
-    if (Object.keys(stateUpdate).length > 0) {
-        const { resolver, promise } = createPromise<void>();
-        (endpoint.eventsOf(type) as Behavior.EventsOf<any>).stateChanged?.on(resolver);
-        try {
-            await endpoint.setStateOf(type, stateUpdate);
-            stateUpdatePromises.push(withTimeout(Seconds(5), promise)); // 5s should be enough for state change
-        } catch (error) {
-            logger.warn(
-                `Could not sanitize fabric-scoped attributes for cluster ${cluster.name} on endpoint ${endpoint.id}`,
-                error,
-            );
-        }
+    return Object.keys(stateUpdate).length > 0 ? stateUpdate : undefined;
+}
+
+/**
+ * Sanitize fabric-scoped attributes for an already-active endpoint via {@link Endpoint.setStateOf}.
+ * The changed state is returned in an array of promises and should be awaited to ensure the state is updated.
+ */
+async function sanitizeAttributeData(
+    endpoint: Endpoint,
+    type: Behavior.Type,
+    cluster: ClusterType,
+    supportedAttributes: Set<string>,
+    allowedIndices: FabricIndex[],
+) {
+    const stateUpdate = computeFabricScopedUpdate(endpoint, type, supportedAttributes, allowedIndices);
+    if (stateUpdate === undefined) {
+        return [];
+    }
+
+    const stateUpdatePromises = new Array<Promise<void>>();
+    // Best-effort during online fabric removal: a per-cluster failure must not abort the removal already in progress.
+    // The startup path (limitEndpointAttributeDataToAllowedFabrics) instead lets failures throw.
+    const { resolver, promise } = createPromise<void>();
+    (endpoint.eventsOf(type) as Behavior.EventsOf<any>).stateChanged?.on(resolver);
+    try {
+        await endpoint.setStateOf(type, stateUpdate);
+        stateUpdatePromises.push(withTimeout(Seconds(5), promise)); // 5s should be enough for state change
+    } catch (error) {
+        logger.warn(
+            `Could not sanitize fabric-scoped attributes for cluster ${cluster.name} on endpoint ${endpoint.id}`,
+            error,
+        );
     }
 
     return stateUpdatePromises;
@@ -151,16 +167,24 @@ export async function limitNodeDataToAllowedFabrics(node: ServerNode, allowedInd
     }
 }
 
-export async function limitEndpointAttributeDataToAllowedFabrics(endpoint: Endpoint, allowedIndices: FabricIndex[]) {
-    const stateUpdatePromises = new Array<Promise<void>>();
-    await forBehaviors(endpoint, async (type, cluster, elements) => {
-        if (elements.attributes.size) {
-            stateUpdatePromises.push(
-                ...(await sanitizeAttributeData(endpoint, type, cluster, elements.attributes, allowedIndices)),
-            );
+/**
+ * Sanitize fabric-scoped attributes for a single endpoint while it is still initializing.
+ *
+ * Invoked from {@link EndpointInitializer.behaviorsInitialized}, which runs inside the endpoint's construction
+ * context. The endpoint is not yet active, so {@link Endpoint.setStateOf} (which opens a fresh action that asserts an
+ * active endpoint) would throw. Instead we patch state through the supplied {@link Agent}, whose context is the
+ * construction transaction that commits when initialization completes.
+ */
+export async function limitEndpointAttributeDataToAllowedFabrics(agent: Agent, allowedIndices: FabricIndex[]) {
+    await forBehaviors(agent.endpoint, async (type, _cluster, elements) => {
+        if (!elements.attributes.size) {
+            return;
         }
+        const stateUpdate = computeFabricScopedUpdate(agent.endpoint, type, elements.attributes, allowedIndices);
+        if (stateUpdate === undefined) {
+            return;
+        }
+        const behavior = agent.get(type);
+        behavior.type.supervisor.patch(stateUpdate, behavior.state, agent.endpoint.path);
     });
-
-    // Wait for all state changed to be executed before processing events
-    await Promise.allSettled(stateUpdatePromises);
 }

--- a/packages/node/src/node/server/ServerEndpointInitializer.ts
+++ b/packages/node/src/node/server/ServerEndpointInitializer.ts
@@ -116,7 +116,7 @@ export class ServerEndpointInitializer extends EndpointInitializer {
         if (agent.env.has(FabricManager)) {
             const fabricIndices = agent.env.get(FabricManager).fabrics.map(fabric => fabric.fabricIndex);
             if (fabricIndices.length > 0) {
-                return limitEndpointAttributeDataToAllowedFabrics(agent.endpoint, fabricIndices);
+                return limitEndpointAttributeDataToAllowedFabrics(agent, fabricIndices);
             }
         }
     }

--- a/packages/node/test/node/ServerNodeTest.ts
+++ b/packages/node/test/node/ServerNodeTest.ts
@@ -445,6 +445,47 @@ describe("ServerNode", () => {
         await node.close();
     });
 
+    it("sanitizes orphaned fabric-scoped data at startup", async () => {
+        const environment = new Environment("test");
+        const service = environment.get(StorageService);
+
+        // Configure storage that survives node replacement
+        const storage = new StorageManager(new MemoryStorageDriver());
+        storage.close = () => {};
+        await storage.initialize();
+        service.open = () => Promise.resolve(storage);
+
+        // Commission a single fabric, then inject an ACL entry referencing a fabric that does not exist and persist it
+        {
+            const node = new MockServerNode({ id: "node0", environment });
+            await node.start();
+            await commissioning.commission(node);
+
+            const acl = node.state.accessControl.acl;
+            expect(acl.length).equals(1);
+            expect(acl[0].fabricIndex).equals(FabricIndex(1));
+
+            await node.set({
+                accessControl: { acl: [...acl, { ...acl[0], fabricIndex: FabricIndex(2) }] },
+            });
+            expect(node.state.accessControl.acl.length).equals(2);
+
+            await node.close();
+        }
+
+        // Reopen: startup sanitization must strip the orphaned fabric-2 entry without requiring an active endpoint
+        {
+            const node = new MockServerNode({ id: "node0", environment });
+            await node.start();
+
+            const acl = node.state.accessControl.acl;
+            expect(acl.filter(({ fabricIndex }) => fabricIndex === 2).length).equals(0);
+            expect(acl.filter(({ fabricIndex }) => fabricIndex === 1).length).equals(1);
+
+            await node.close();
+        }
+    });
+
     it("properly deploys aggregator", async () => {
         const aggregator = new Endpoint(AggregatorEndpoint);
 


### PR DESCRIPTION
## Problem

`ServerEndpointInitializer.behaviorsInitialized` runs **inside** the endpoint's construction action (`Behaviors.ts` initializes with `lifetime: construction`). The endpoint-level sanitizer `limitEndpointAttributeDataToAllowedFabrics` called `Endpoint.setStateOf`, which opens a fresh action that asserts the endpoint is active. Mid-construction the status is `Initializing`, so the call threw:

```
WARN FabricScopedDataHandler Could not sanitize fabric-scoped attributes for cluster AccessControl on endpoint <id> [uninitialized-dependency] <id> is still initializing
```

The throw was caught, logged at WARN and swallowed. Net effect: **orphaned fabric-scoped attribute data was never actually stripped** — e.g. `AccessControl.acl` entries for a fabric removed while the node was offline. The stale data persisted and re-triggered the warning on every startup. Reported from an ioBroker matter adapter log.

## Fix

Patch state through the active `agent` supplied to `behaviorsInitialized` instead of `setStateOf`. The agent's context **is** the construction transaction (it commits when initialization completes), so the write needs no separate action and no active-endpoint assertion — mirroring how behaviors write their own `this.state` during init. Fabric-scoped attributes are persistent fields, so the patch persists to disk on commit.

The online fabric-removal path (`limitNodeDataToAllowedFabrics`, triggered on the fabric `deleting` event) is unchanged and still uses `setStateOf` — endpoints are active there.

Shared filtering logic is factored into `computeFabricScopedUpdate`; the two apply paths differ only in how they write.

## Test

Adds a regression test: commission a node, inject an orphaned `fabricIndex` ACL entry on the live node, persist, reopen over the same storage, assert startup sanitization strips it. Verified it fails against the pre-fix code (`expected 1 to equal 0`) and passes with the fix. Full `@matter/node` suite green (ESM/CJS/Web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)