### PR TITLE
perf(node): free behavior seed values from memory after datasource load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 ## __WORK IN PROGRESS__
 
 - @matter/node
-    - Enhancement: Avoid a duplicate in-memory copy of cached peer cluster values while a behavior is active
+    - Enhancement: Free a behavior's persisted seed values from memory once the datasource has loaded them
     - Fix: Ensure that a peer's FeatureMap change rebuilds the affected client cluster behavior
     - Fix: Ensure to always sanitize fabric-scoped attribute data (e.g. stale AccessControl ACL entries) at node startup
 

--- a/packages/node/src/behavior/state/managed/Datasource.ts
+++ b/packages/node/src/behavior/state/managed/Datasource.ts
@@ -351,6 +351,11 @@ class DatasourceImpl implements Datasource, Datasource.ExternallyMutableStore.Co
         this.persistentFields = options.supervisor.persistentKeys(options.primaryKey);
 
         this.#configureExternalChanges();
+
+        // Seed consumed into #values; release the store's copy (client stores already drop theirs on consumer attach).
+        if (this.store) {
+            this.store.initialValues = undefined;
+        }
     }
 
     // -- Datasource interface --

--- a/packages/node/test/node/ServerNodeTest.ts
+++ b/packages/node/test/node/ServerNodeTest.ts
@@ -634,6 +634,44 @@ describe("ServerNode", () => {
         }
     });
 
+    it("restores persisted attribute values after restart", async () => {
+        const environment = new Environment("test");
+        const service = environment.get(StorageService);
+
+        // Configure storage that will survive node replacement
+        const storage = new StorageManager(new MemoryStorageDriver());
+        storage.close = () => {};
+        await storage.initialize();
+        service.open = () => Promise.resolve(storage);
+
+        const colorControl = {
+            colorMode: 0,
+            colorTempPhysicalMinMireds: 1,
+            colorTempPhysicalMaxMireds: 65279,
+            startUpColorTemperatureMireds: 1,
+            coupleColorTempToLevelMinMireds: 1,
+        };
+
+        {
+            const node = new MockServerNode({ id: "node0", environment });
+            await node.construction.ready;
+            const endpoint = await node.add(ExtendedColorLightDevice, { id: "foo", number: 1, colorControl });
+            await endpoint.set({ colorControl: { currentX: 12 } });
+            await node.close();
+        }
+
+        {
+            const node = new MockServerNode({ id: "node0", environment });
+            await node.construction.ready;
+            const endpoint = await node.add(ExtendedColorLightDevice, { id: "foo", number: 1, colorControl });
+
+            // The datasource drops its store seed after construction; the persisted value must still load.
+            expect(endpoint.state.colorControl.currentX).equals(12);
+
+            await node.close();
+        }
+    });
+
     describe("initializes protocol", () => {
         it("with part at startup", async () => {
             const node = new MockServerNode({ parts: [OnOffLightDevice] });


### PR DESCRIPTION
## What

The `Datasource` constructor copies `store.initialValues` into its live `#values`. This frees the store's seed copy once construction has consumed it, so it is no longer held in memory for the datasource's lifetime.

## Why

For **server** datasources nothing released the seed afterward: server uses a plain `Store` (no `externalSet`), so no consumer attaches and the client-side clear-on-attach (added in #3955) never runs. The seed lingered alongside `#values` for the whole lifetime — a duplicate in-memory copy per behavior.

## Safety

- `store.initialValues` is read only at the ctor seed and at migration (which runs *before* the Datasource is created), so nothing reads it after construction.
- `consumeInitialValues` is one-shot (removed from the storage map) and a fresh store is built per backing — nothing relies on the store's copy persisting.
- Client path already drops it on consumer attach; `close()`/`reclaimValues()` repopulate it from the consumer on detach.
- No reader of `store.initialValues` exists outside `@matter/node`; no reset/re-seed path re-reads it.

## Test

Adds a server restart roundtrip test: write `colorControl.currentX = 12` → close → reopen the same storage → assert the value reloads as `12`. Complements the existing client-side `ClientCacheBuffer` "persists buffered data across restart" coverage.

Full `@matter/node` suite green (server + client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)