### PR TITLE
fix(protocol): ignore stray initial StatusReport instead of erroring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Certificate SubjectKeyIdentifier and AuthorityKeyIdentifier are derived as 160-bit SHA-1
     - Fix: Certificates are rejected on decode when exceeding the size limits (400 bytes TLV for the NOC chain and VVSC, 600 bytes DER for the NOC and DAC chains)
     - Fix: OTA image digest type identifiers follow the IANA Named Information Hash Algorithm Registry (RFC 6920), and the digest algorithm is validated when reading an image
+    - Fix: A stray StatusReport arriving as an exchange's initial message (e.g. a retransmitted CASE/PASE completion) is now ignored instead of logging an "Unhandled error"
 
 - @project-chip/matter.js
     - Fix: `PairedNode.connect()` now applies the subscription interval options passed to it, instead of ignoring them

--- a/packages/protocol/src/securechannel/SecureChannelProtocol.ts
+++ b/packages/protocol/src/securechannel/SecureChannelProtocol.ts
@@ -22,7 +22,7 @@ import { MessageExchange } from "../protocol/MessageExchange.js";
 import { ProtocolHandler } from "../protocol/ProtocolHandler.js";
 import { CaseServer } from "../session/case/CaseServer.js";
 import { MaximumPasePairingErrorsReachedError, PaseServer } from "../session/pase/PaseServer.js";
-import { ChannelStatusResponseError, SecureChannelMessenger } from "./SecureChannelMessenger.js";
+import { SecureChannelMessenger } from "./SecureChannelMessenger.js";
 import { SecureChannelStatusMessage } from "./SecureChannelStatusMessageSchema.js";
 
 const logger = Logger.get("SecureChannelProtocol");
@@ -64,22 +64,16 @@ export class StatusReportOnlySecureChannelProtocol implements ProtocolHandler {
             );
         }
 
-        const { generalStatus, protocolId, protocolStatus } = SecureChannelStatusMessage.decode(payload);
-        if (generalStatus !== GeneralStatusCode.Success) {
-            throw new ChannelStatusResponseError(
-                `Received general error status (${protocolId})`,
-                generalStatus,
-                protocolStatus,
-            );
-        }
+        const { generalStatus, protocolStatus } = SecureChannelStatusMessage.decode(payload);
 
-        // CloseSession is the only case where a StatusReport comes as initial message
-        if (protocolStatus !== SecureChannelStatusCode.CloseSession) {
-            throw new ChannelStatusResponseError(
-                `Received general success status, but protocol status is not CloseSession`,
-                generalStatus,
-                protocolStatus,
+        // Only CloseSession is expected as an initial StatusReport; anything else is a stray peer retransmit.
+        if (generalStatus !== GeneralStatusCode.Success || protocolStatus !== SecureChannelStatusCode.CloseSession) {
+            logger.debug(
+                exchange.via,
+                `Ignoring unexpected initial StatusReport (general: ${generalStatus}, protocol: ${protocolStatus})`,
             );
+            await exchange.close();
+            return;
         }
 
         const { session } = exchange;


### PR DESCRIPTION
## Problem

A `StatusReport` arriving as an exchange's **initial** message is only valid as `CloseSession`. When a peer retransmits its final CASE/PASE completion `StatusReport` (general `Success` / protocol `Success`) via MRP *after* we already closed the establishment exchange, `ExchangeManager` finds no matching exchange and routes it as a new exchange to `SecureChannelProtocol.handleInitialStatusReport`, which threw `ChannelStatusResponseError`. That surfaced as a noisy false-positive:

```
WARN ExchangeManager •unsecured#…⇵…✉… Unhandled error handling incoming message: [channel-status-response] (Success (0) / Success (0)) Received general success status, but protocol status is not CloseSession
```

## Fix

`handleInitialStatusReport` now treats any initial `StatusReport` that isn't a `CloseSession` (success or error) as a stray peer retransmit: log at debug, `await exchange.close()` (which flushes the pending standalone ack so the peer stops retransmitting), and return — instead of throwing.

- Closing the stray exchange also fixes a minor leak (previously the bare path left the exchange around until its ack timer fired).
- Real handshake errors are unaffected — those are still raised by `SecureChannelMessenger.throwIfErrorStatusReport` within an active exchange.
- Removed now-unused `ChannelStatusResponseError` import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)