### PR TITLE
fix(protocol, node): accept CASE/PASE session intervals above the 1-hour DNS-SD cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/node
     - Enhancement: Free a behavior's persisted seed values from memory once the datasource has loaded them
+    - Fix: A peer's mDNS advertisement at the 1-hour SII/SAI cap no longer lowers a higher CASE-negotiated idle/active interval already on record
     - Fix: Ensure that a peer's FeatureMap change rebuilds the affected client cluster behavior
     - Fix: Ensure to always sanitize fabric-scoped attribute data (e.g. stale AccessControl ACL entries) at node startup
 
@@ -21,6 +22,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/protocol
     - Enhancement: Unified peer device probing across the mDNS address-change and subscription-liveness cases so they no longer probe independently
+    - Fix: CASE/PASE session parameters with idle/active intervals above one hour are now accepted instead of declining the session; the one-hour cap is applied only when advertising over DNS-SD
     - Fix: The operational (fallback) address now updates when the session channel follows a peer's new source address, instead of going stale
     - Fix: Certificate SubjectKeyIdentifier and AuthorityKeyIdentifier are derived as 160-bit SHA-1
     - Fix: Certificates are rejected on decode when exceeding the size limits (400 bytes TLV for the NOC chain and VVSC, 600 bytes DER for the NOC and DAC chains)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/protocol
     - Enhancement: Unified peer device probing across the mDNS address-change and subscription-liveness cases so they no longer probe independently
     - Fix: CASE/PASE session parameters with idle/active intervals above one hour are now accepted instead of declining the session; the one-hour cap is applied only when advertising over DNS-SD
+    - Fix: A local Session Active Threshold above its 65535ms (uint16) maximum is now rejected up front with a clear error instead of failing later during message encoding
     - Fix: The operational (fallback) address now updates when the session channel follows a peer's new source address, instead of going stale
     - Fix: Certificate SubjectKeyIdentifier and AuthorityKeyIdentifier are derived as 160-bit SHA-1
     - Fix: Certificates are rejected on decode when exceeding the size limits (400 bytes TLV for the NOC chain and VVSC, 600 bytes DER for the NOC and DAC chains)

--- a/packages/node/src/behavior/system/commissioning/RemoteDescriptor.ts
+++ b/packages/node/src/behavior/system/commissioning/RemoteDescriptor.ts
@@ -5,7 +5,13 @@
  */
 
 import { Immutable, ServerAddress } from "@matter/general";
-import { CommissionableDevice, OperationalDevice, PeerAddress, SupportedTransportsSchema } from "@matter/protocol";
+import {
+    CommissionableDevice,
+    OperationalDevice,
+    PeerAddress,
+    SessionIntervals,
+    SupportedTransportsSchema,
+} from "@matter/protocol";
 import { DeviceTypeId, VendorId } from "@matter/types";
 import type { CommissioningClient } from "./CommissioningClient.js";
 
@@ -183,10 +189,12 @@ export namespace RemoteDescriptor {
             long.productId = Number.isFinite(product) ? product : undefined;
         }
 
-        if (SII !== undefined) {
+        // DNS-SD caps SII/SAI at 1 hour, so a value at the cap may be a clamped advertisement of a larger
+        // CASE-negotiated interval. Don't let it lower a higher session-derived value already on record.
+        if (SII !== undefined && !isCappedBelow(SII, long.sessionParameters?.idleInterval)) {
             (long.sessionParameters ??= {}).idleInterval = SII;
         }
-        if (SAI !== undefined) {
+        if (SAI !== undefined && !isCappedBelow(SAI, long.sessionParameters?.activeInterval)) {
             (long.sessionParameters ??= {}).activeInterval = SAI;
         }
         if (SAT !== undefined) {
@@ -211,4 +219,9 @@ export namespace RemoteDescriptor {
 
         return long;
     }
+}
+
+/** True when `advertised` is at the DNS-SD 1-hour cap and `current` already exceeds it. */
+function isCappedBelow(advertised: number, current: number | undefined) {
+    return current !== undefined && advertised === SessionIntervals.maxAdvertisedInterval && current > advertised;
 }

--- a/packages/node/test/behavior/system/commissioning/RemoteDescriptorTest.ts
+++ b/packages/node/test/behavior/system/commissioning/RemoteDescriptorTest.ts
@@ -5,7 +5,7 @@
  */
 
 import { RemoteDescriptor } from "#behavior/system/commissioning/RemoteDescriptor.js";
-import { ServerAddressUdp } from "@matter/general";
+import { Hours, Millis, ServerAddressUdp } from "@matter/general";
 import { CommissionableDevice } from "@matter/protocol";
 
 function udp(ip: string, port = 5540): ServerAddressUdp {
@@ -103,6 +103,39 @@ describe("RemoteDescriptor", () => {
             expect(back.deviceIdentifier).equals("minimal");
             expect(back.D).equals(1000);
             expect(back.CM).equals(1);
+        });
+    });
+
+    describe("session interval cap handling", () => {
+        function longWith(idleInterval?: number, activeInterval?: number): RemoteDescriptor.Long {
+            return { sessionParameters: { idleInterval, activeInterval } } as RemoteDescriptor.Long;
+        }
+
+        it("keeps a higher session-derived interval when the advertisement is at the 1-hour cap", () => {
+            const long = longWith(Hours(2), Hours(2));
+
+            RemoteDescriptor.toLongForm({ SII: Hours.one, SAI: Hours.one }, long);
+
+            expect(long.sessionParameters?.idleInterval).equals(Hours(2));
+            expect(long.sessionParameters?.activeInterval).equals(Hours(2));
+        });
+
+        it("applies an advertised interval below the cap even over a higher value", () => {
+            const long = longWith(Hours(2), Hours(2));
+
+            RemoteDescriptor.toLongForm({ SII: Millis(1800000), SAI: Millis(1800000) }, long);
+
+            expect(long.sessionParameters?.idleInterval).equals(Millis(1800000));
+            expect(long.sessionParameters?.activeInterval).equals(Millis(1800000));
+        });
+
+        it("applies a capped advertisement when no higher value is on record", () => {
+            const long = longWith();
+
+            RemoteDescriptor.toLongForm({ SII: Hours.one, SAI: Hours.one }, long);
+
+            expect(long.sessionParameters?.idleInterval).equals(Hours.one);
+            expect(long.sessionParameters?.activeInterval).equals(Hours.one);
         });
     });
 });

--- a/packages/protocol/src/advertisement/mdns/MdnsAdvertisement.ts
+++ b/packages/protocol/src/advertisement/mdns/MdnsAdvertisement.ts
@@ -47,7 +47,7 @@ export abstract class MdnsAdvertisement<T extends ServiceDescription = ServiceDe
     constructor(advertiser: MdnsAdvertiser, qname: string, description: T) {
         description = {
             ...description,
-            ...SessionIntervals(description),
+            ...SessionIntervals.forAdvertisement(description),
         };
         super(advertiser, `mdns:${qname}`, description, { omitPrivateDetails: advertiser.omitPrivateDetails });
         this.qname = qname;

--- a/packages/protocol/src/session/SessionIntervals.ts
+++ b/packages/protocol/src/session/SessionIntervals.ts
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Duration, Hours, ImplementationError, Millis, Seconds } from "@matter/general";
+import { Duration, Hours, Logger, Millis, Seconds } from "@matter/general";
+
+const logger = Logger.get("SessionIntervals");
 
 export interface SessionIntervals {
     /**
@@ -32,23 +34,11 @@ export interface SessionIntervals {
 }
 
 export function SessionIntervals(intervals?: Partial<SessionIntervals>): SessionIntervals {
-    const {
-        idleInterval = SessionIntervals.defaults.idleInterval,
-        activeInterval = SessionIntervals.defaults.activeInterval,
-        activeThreshold = SessionIntervals.defaults.activeThreshold,
-    } = intervals ?? {};
-
-    if (idleInterval > Hours.one) {
-        throw new ImplementationError("Session Idle Interval must be less than 1 hour");
-    }
-    if (activeInterval > Hours.one) {
-        throw new ImplementationError("Session Active Interval must be less than 1 hour");
-    }
-    if (activeThreshold > Millis(65535)) {
-        throw new ImplementationError("Session Active Threshold must not exceed 65535 milliseconds");
-    }
-
-    return { idleInterval, activeInterval, activeThreshold };
+    return {
+        idleInterval: intervals?.idleInterval ?? SessionIntervals.defaults.idleInterval,
+        activeInterval: intervals?.activeInterval ?? SessionIntervals.defaults.activeInterval,
+        activeThreshold: intervals?.activeThreshold ?? SessionIntervals.defaults.activeThreshold,
+    };
 }
 
 export namespace SessionIntervals {
@@ -57,4 +47,42 @@ export namespace SessionIntervals {
         activeInterval: Millis(300),
         activeThreshold: Seconds(4),
     };
+
+    /**
+     * Maximum SII/SAI the DNS-SD operational advertisement may carry. This bound is a property of the advertisement
+     * encoding only; SII/SAI in the CASE/PASE session-parameter struct are uint32 and accepted unbounded.
+     *
+     * @see {@link MatterSpecification.v13.Core} § 4.3.4
+     */
+    export const maxAdvertisedInterval = Hours.one;
+
+    /** Maximum SAT the DNS-SD operational advertisement may carry (SAT is a uint16 millisecond value). */
+    export const maxAdvertisedActiveThreshold = Millis(65535);
+
+    /**
+     * Resolve intervals for DNS-SD advertisement, clamping each to its spec maximum. Out-of-range values are reduced to
+     * the maximum rather than rejected, matching the reference SDK.
+     */
+    export function forAdvertisement(intervals?: Partial<SessionIntervals>): SessionIntervals {
+        const resolved = SessionIntervals(intervals);
+
+        if (resolved.idleInterval > maxAdvertisedInterval) {
+            logger.info(`Capping advertised Session Idle Interval ${Duration.format(resolved.idleInterval)} to 1 hour`);
+            resolved.idleInterval = maxAdvertisedInterval;
+        }
+        if (resolved.activeInterval > maxAdvertisedInterval) {
+            logger.info(
+                `Capping advertised Session Active Interval ${Duration.format(resolved.activeInterval)} to 1 hour`,
+            );
+            resolved.activeInterval = maxAdvertisedInterval;
+        }
+        if (resolved.activeThreshold > maxAdvertisedActiveThreshold) {
+            logger.info(
+                `Capping advertised Session Active Threshold ${Duration.format(resolved.activeThreshold)} to 65535ms`,
+            );
+            resolved.activeThreshold = maxAdvertisedActiveThreshold;
+        }
+
+        return resolved;
+    }
 }

--- a/packages/protocol/src/session/SessionIntervals.ts
+++ b/packages/protocol/src/session/SessionIntervals.ts
@@ -56,8 +56,11 @@ export namespace SessionIntervals {
      */
     export const maxAdvertisedInterval = Hours.one;
 
-    /** Maximum SAT the DNS-SD operational advertisement may carry (SAT is a uint16 millisecond value). */
-    export const maxAdvertisedActiveThreshold = Millis(65535);
+    /**
+     * Maximum Session Active Threshold. Unlike SII/SAI this bound applies everywhere: SAT is a uint16 millisecond
+     * value both in the DNS-SD advertisement and in the CASE/PASE session-parameter struct.
+     */
+    export const maxActiveThreshold = Millis(65535);
 
     /**
      * Resolve intervals for DNS-SD advertisement, clamping each to its spec maximum. Out-of-range values are reduced to
@@ -67,20 +70,22 @@ export namespace SessionIntervals {
         const resolved = SessionIntervals(intervals);
 
         if (resolved.idleInterval > maxAdvertisedInterval) {
-            logger.info(`Capping advertised Session Idle Interval ${Duration.format(resolved.idleInterval)} to 1 hour`);
+            logger.info(
+                `Capping advertised Session Idle Interval ${Duration.format(resolved.idleInterval)} to ${Duration.format(maxAdvertisedInterval)}`,
+            );
             resolved.idleInterval = maxAdvertisedInterval;
         }
         if (resolved.activeInterval > maxAdvertisedInterval) {
             logger.info(
-                `Capping advertised Session Active Interval ${Duration.format(resolved.activeInterval)} to 1 hour`,
+                `Capping advertised Session Active Interval ${Duration.format(resolved.activeInterval)} to ${Duration.format(maxAdvertisedInterval)}`,
             );
             resolved.activeInterval = maxAdvertisedInterval;
         }
-        if (resolved.activeThreshold > maxAdvertisedActiveThreshold) {
+        if (resolved.activeThreshold > maxActiveThreshold) {
             logger.info(
-                `Capping advertised Session Active Threshold ${Duration.format(resolved.activeThreshold)} to 65535ms`,
+                `Capping advertised Session Active Threshold ${Duration.format(resolved.activeThreshold)} to ${Duration.format(maxActiveThreshold)}`,
             );
-            resolved.activeThreshold = maxAdvertisedActiveThreshold;
+            resolved.activeThreshold = maxActiveThreshold;
         }
 
         return resolved;

--- a/packages/protocol/src/session/SessionManager.ts
+++ b/packages/protocol/src/session/SessionManager.ts
@@ -23,6 +23,7 @@ import {
     Duration,
     Environment,
     Environmental,
+    ImplementationError,
     InternalError,
     Lifecycle,
     Logger,
@@ -46,10 +47,23 @@ import { MessageCounter, PersistedMessageCounter } from "../protocol/MessageCoun
 import { NodeSession } from "./NodeSession.js";
 import { SecureSession } from "./SecureSession.js";
 import type { Session } from "./Session.js";
+import { SessionIntervals } from "./SessionIntervals.js";
 import { SessionParameters } from "./SessionParameters.js";
 import { UnsecuredSession } from "./UnsecuredSession.js";
 
 const logger = Logger.get("SessionManager");
+
+/**
+ * Reject a locally-configured Session Active Threshold that cannot be encoded: SAT is a uint16 millisecond value on the
+ * wire. SII/SAI are uint32 and intentionally not bounded here.
+ */
+function assertActiveThreshold(activeThreshold: Duration) {
+    if (activeThreshold > SessionIntervals.maxActiveThreshold) {
+        throw new ImplementationError(
+            `Session Active Threshold ${activeThreshold}ms exceeds the maximum of ${SessionIntervals.maxActiveThreshold}ms`,
+        );
+    }
+}
 
 /** Resumption record without a fabric reference but relevant lookup data used internally in SessionManager */
 interface InternalResumptionRecord {
@@ -173,6 +187,7 @@ export class SessionManager {
             fabrics: { crypto },
         } = context;
         this.#sessionParameters = SessionParameters({ ...SessionParameters.defaults, ...context.parameters });
+        assertActiveThreshold(this.#sessionParameters.activeThreshold);
         this.#nextSessionId = crypto.randomUint16;
         this.#globalUnencryptedMessageCounter = new MessageCounter(crypto);
 
@@ -266,6 +281,9 @@ export class SessionManager {
      * sessions.
      */
     set sessionParameters(parameters: Partial<SessionParameters>) {
+        if (parameters.activeThreshold !== undefined) {
+            assertActiveThreshold(parameters.activeThreshold);
+        }
         this.#sessionParameters = {
             ...this.#sessionParameters,
             ...parameters,

--- a/packages/protocol/test/session/SessionIntervalsTest.ts
+++ b/packages/protocol/test/session/SessionIntervalsTest.ts
@@ -5,7 +5,7 @@
  */
 
 import { SessionIntervals } from "#session/SessionIntervals.js";
-import { Hours, ImplementationError, Millis, Seconds } from "@matter/general";
+import { Hours, Millis, Seconds } from "@matter/general";
 
 describe("SessionIntervals", () => {
     it("applies defaults when nothing is provided", () => {
@@ -24,22 +24,45 @@ describe("SessionIntervals", () => {
         expect(intervals.activeThreshold).equal(Seconds(4));
     });
 
-    it("rejects an idle interval over one hour", () => {
-        expect(() => SessionIntervals({ idleInterval: Hours(2) })).throws(ImplementationError, "Idle Interval");
+    it("accepts an idle interval over one hour", () => {
+        expect(SessionIntervals({ idleInterval: Hours(2) }).idleInterval).equal(Hours(2));
     });
 
-    it("rejects an active interval over one hour", () => {
-        expect(() => SessionIntervals({ activeInterval: Hours(2) })).throws(ImplementationError, "Active Interval");
+    it("accepts an active interval over one hour", () => {
+        expect(SessionIntervals({ activeInterval: Hours(2) }).activeInterval).equal(Hours(2));
     });
 
-    it("accepts an active threshold of exactly 65535 milliseconds", () => {
-        expect(SessionIntervals({ activeThreshold: Millis(65535) }).activeThreshold).equal(Millis(65535));
+    it("accepts an active threshold over 65535 milliseconds", () => {
+        expect(SessionIntervals({ activeThreshold: Millis(65536) }).activeThreshold).equal(Millis(65536));
     });
 
-    it("rejects an active threshold over 65535 milliseconds", () => {
-        expect(() => SessionIntervals({ activeThreshold: Millis(65536) })).throws(
-            ImplementationError,
-            "Active Threshold",
-        );
+    describe("forAdvertisement", () => {
+        it("passes through values within the spec maxima", () => {
+            expect(SessionIntervals.forAdvertisement({ idleInterval: Hours.one })).deep.equal({
+                idleInterval: Hours.one,
+                activeInterval: Millis(300),
+                activeThreshold: Seconds(4),
+            });
+        });
+
+        it("clamps an idle interval over one hour to one hour", () => {
+            expect(SessionIntervals.forAdvertisement({ idleInterval: Hours(2) }).idleInterval).equal(Hours.one);
+        });
+
+        it("clamps an active interval over one hour to one hour", () => {
+            expect(SessionIntervals.forAdvertisement({ activeInterval: Hours(2) }).activeInterval).equal(Hours.one);
+        });
+
+        it("clamps an active threshold over 65535 milliseconds", () => {
+            expect(SessionIntervals.forAdvertisement({ activeThreshold: Millis(65536) }).activeThreshold).equal(
+                Millis(65535),
+            );
+        });
+
+        it("accepts an active threshold of exactly 65535 milliseconds", () => {
+            expect(SessionIntervals.forAdvertisement({ activeThreshold: Millis(65535) }).activeThreshold).equal(
+                Millis(65535),
+            );
+        });
     });
 });

--- a/packages/protocol/test/session/SessionManagerTest.ts
+++ b/packages/protocol/test/session/SessionManagerTest.ts
@@ -11,8 +11,10 @@ import { SessionManager } from "#session/SessionManager.js";
 import {
     b$,
     Bytes,
+    ImplementationError,
     Key,
     MemoryStorageDriver,
+    Millis,
     PrivateKey,
     StandardCrypto,
     StorageContext,
@@ -293,6 +295,42 @@ describe("SessionManager", () => {
             fabric.groups.removeGroupKeySet(1);
             const after = await sessionManager.groupDataMessageCounter.getIncrementedCounter();
             expect(after).greaterThan(before);
+        });
+    });
+
+    describe("active threshold validation", () => {
+        function newManager(parameters: Partial<SessionParameters>) {
+            const storage = new MemoryStorageDriver();
+            storage.initialize();
+            return new SessionManager({
+                parameters: parameters as SessionParameters,
+                fabrics: new FabricManager(new StandardCrypto()),
+                storage: new StorageContext(storage, ["context"]),
+            });
+        }
+
+        it("rejects a local active threshold over 65535 milliseconds on construction", () => {
+            expect(() => newManager({ activeThreshold: Millis(65536) })).throws(
+                ImplementationError,
+                "Active Threshold",
+            );
+        });
+
+        it("rejects a local active threshold over 65535 milliseconds via the setter", async () => {
+            const sessionManager = newManager({});
+            await sessionManager.construction.ready;
+
+            expect(() => (sessionManager.sessionParameters = { activeThreshold: Millis(65536) })).throws(
+                ImplementationError,
+                "Active Threshold",
+            );
+        });
+
+        it("accepts a local active threshold of exactly 65535 milliseconds", async () => {
+            const sessionManager = newManager({ activeThreshold: Millis(65535) });
+            await sessionManager.construction.ready;
+
+            expect(sessionManager.sessionParameters.activeThreshold).equal(Millis(65535));
         });
     });
 });

--- a/packages/protocol/test/session/SessionParametersTest.ts
+++ b/packages/protocol/test/session/SessionParametersTest.ts
@@ -5,8 +5,15 @@
  */
 
 import { MIN_TCP_SPEC_VERSION, SessionParameters } from "#session/SessionParameters.js";
+import { Hours } from "@matter/general";
 
 describe("SessionParameters", () => {
+    it("accepts idle/active intervals above one hour", () => {
+        const params = SessionParameters({ idleInterval: Hours(2), activeInterval: Hours(2) });
+        expect(params.idleInterval).equal(Hours(2));
+        expect(params.activeInterval).equal(Hours(2));
+    });
+
     describe("TCP spec-version gate", () => {
         it("keeps TCP support for peers reporting spec version >= 1.5.0", () => {
             const params = SessionParameters({


### PR DESCRIPTION
## Problem

A device whose CASE session parameters carry an idle/active interval **above one hour** was declined by matter.js during PASE/CASE establishment (see home-assistant/core#174542). The 1-hour `SII`/`SAI` maximum is a property of the **DNS-SD advertisement encoding only** — the CASE/PASE `session-parameter-struct` carries `SESSION_IDLE_INTERVAL`/`SESSION_ACTIVE_INTERVAL` as full-range `uint32` values with no bound. This matches the reference SDK (see CHIP-Specifications/connectedhomeip-spec#13177, Reading A).

fixes matter-js/matter.js#3962

## Changes

- **`SessionIntervals()`** no longer throws on out-of-range intervals; it applies defaults only. The receive path (`Session.timingParameters` setter, fed by peer Sigma1/Sigma2/PBKDFParamReq/Resp) now accepts the peer's full-range values. `SAT` stays naturally bounded by its `uint16` wire type.
- **`SessionIntervals.forAdvertisement()`** (new) clamps `SII`/`SAI` to one hour and `SAT` to 65535 ms for DNS-SD advertisement — capping instead of rejecting, matching the SDK. `MdnsAdvertisement` uses it.
- **Controller side** (`RemoteDescriptor.toLongForm`): a peer's mDNS advertisement at the one-hour cap no longer lowers a higher CASE-negotiated interval already on record. The guard only triggers when the advertised value is exactly the cap **and** the stored value is higher; a genuine interval change (re-advertised below the cap) still applies.

## Tests

- `SessionIntervalsTest`: accept >1h intervals / >65535 ms threshold via the base function; `forAdvertisement` clamps each to its spec maximum.
- `RemoteDescriptorTest`: capped advertisement does not lower a higher session-derived value; a below-cap advertisement still applies; a capped value applies when nothing higher is on record.

Full `@matter/protocol` and `@matter/node` suites pass (ESM/CJS/Web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)