### PR TITLE
feat(node-manager): endpointGroupMembership ItemKind (Phase 2b-2b)

### DIFF
--- a/packages/node-manager/src/ReconcilerBehavior.ts
+++ b/packages/node-manager/src/ReconcilerBehavior.ts
@@ -8,6 +8,7 @@ import { AclItemKind } from "#reconcile/AclItemKind.js";
 import { BindingItemKind } from "#reconcile/BindingItemKind.js";
 import { GroupKeyItemKind } from "#reconcile/GroupKeyItemKind.js";
 import { GroupKeyMapItemKind } from "#reconcile/GroupKeyMapItemKind.js";
+import { GroupMembershipItemKind } from "#reconcile/GroupMembershipItemKind.js";
 import { executeActions, ReconcileTarget } from "#reconcile/executeActions.js";
 import { planActions, PlannedAction, VerifyResult } from "#reconcile/planActions.js";
 import { Duration, Logger, Minutes, Mutex, ObserverGroup, Seconds, Time, Timer } from "@matter/general";
@@ -96,6 +97,7 @@ export class ReconcilerBehavior extends Behavior {
     override async initialize() {
         this.internal.registry.register(new GroupKeyItemKind());
         this.internal.registry.register(new GroupKeyMapItemKind());
+        this.internal.registry.register(new GroupMembershipItemKind());
         this.internal.registry.register(new AclItemKind());
         this.internal.registry.register(new BindingItemKind());
         this.internal.peerObservers = new Map();

--- a/packages/node-manager/src/reconcile/GroupMembershipItemKind.ts
+++ b/packages/node-manager/src/reconcile/GroupMembershipItemKind.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ImplementationError } from "@matter/general";
+import type { CapacityInfo, ClientNode, ItemKind, ManagedItem } from "@matter/node";
+import { GroupKeyManagementClient } from "@matter/node/behaviors/group-key-management";
+import { GroupsClient } from "@matter/node/behaviors/groups";
+import { GroupId, Status, StatusResponseError } from "@matter/types";
+import { PRIORITY_BANDS } from "./priority.js";
+
+export interface GroupMembershipGrant {
+    localEndpoint: number;
+    groupId: GroupId;
+    groupName?: string;
+}
+
+// GroupKeyManagement §4.16: MaxGroupsPerFabric is at least 4. Assume that floor if momentarily unread.
+const MIN_GROUPS_PER_FABRIC = 4;
+
+/**
+ * The `endpointGroupMembership` ItemKind: adds a peer endpoint to a Groups-cluster group. Per-endpoint
+ * and command-based (AddGroup / GetGroupMembership / RemoveGroup). The Groups commands carry their
+ * application status in the response payload, so non-success statuses are re-thrown as
+ * StatusResponseError to drive the engine's retry/drop handling. The group name is written but not
+ * verified — GetGroupMembership returns only group IDs. Requires the group's key set and map to exist
+ * first; the keyset(10) < group(20) < membership(30) priority bands enforce that order.
+ */
+export class GroupMembershipItemKind implements ItemKind<GroupMembershipGrant> {
+    readonly kind = "endpointGroupMembership";
+    readonly priority = PRIORITY_BANDS.membership;
+
+    #commands(node: ClientNode, localEndpoint: number) {
+        return node.endpoints.for(localEndpoint).commandsOf(GroupsClient);
+    }
+
+    async apply(node: ClientNode, item: ManagedItem<GroupMembershipGrant>): Promise<void> {
+        const { localEndpoint, groupId, groupName } = item.intent;
+        if (!node.endpoints.has(localEndpoint)) {
+            throw new ImplementationError(`Group membership endpoint ${localEndpoint} not present on peer`);
+        }
+        const { status } = await this.#commands(node, localEndpoint).addGroup({ groupId, groupName: groupName ?? "" });
+        if (status !== Status.Success) {
+            throw new StatusResponseError(`AddGroup(${groupId}) on endpoint ${localEndpoint} failed`, status);
+        }
+    }
+
+    async verify(node: ClientNode, item: ManagedItem<GroupMembershipGrant>): Promise<boolean> {
+        const { localEndpoint, groupId } = item.intent;
+        if (!node.endpoints.has(localEndpoint)) {
+            return false;
+        }
+        const { groupList } = await this.#commands(node, localEndpoint).getGroupMembership({ groupList: [groupId] });
+        return groupList.includes(groupId);
+    }
+
+    async remove(node: ClientNode, item: ManagedItem<GroupMembershipGrant>): Promise<void> {
+        const { localEndpoint, groupId } = item.intent;
+        if (!node.endpoints.has(localEndpoint)) {
+            return;
+        }
+        const { status } = await this.#commands(node, localEndpoint).removeGroup({ groupId });
+        if (status !== Status.Success && status !== Status.NotFound) {
+            throw new StatusResponseError(`RemoveGroup(${groupId}) on endpoint ${localEndpoint} failed`, status);
+        }
+    }
+
+    async capacity(node: ClientNode): Promise<CapacityInfo> {
+        // Capacity reads the subscription-cached state — no live device read just to count.
+        const { groupTable, maxGroupsPerFabric } = node.stateOf(GroupKeyManagementClient);
+        return { limit: maxGroupsPerFabric ?? MIN_GROUPS_PER_FABRIC, used: (groupTable ?? []).length };
+    }
+
+    recoverable(code: number): boolean {
+        return code === Status.Timeout || code === Status.Busy;
+    }
+}

--- a/packages/node-manager/test/GroupMembershipIntegrationTest.ts
+++ b/packages/node-manager/test/GroupMembershipIntegrationTest.ts
@@ -1,0 +1,132 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
+import { DesiredStateBehavior, itemMapKey, ServerNode } from "@matter/node";
+import { GroupKeyManagementServer } from "@matter/node/behaviors/group-key-management";
+import { GroupsServer } from "@matter/node/behaviors/groups";
+import { OnOffLightSwitchDevice } from "@matter/node/devices/on-off-light-switch";
+import { MockServerNode, MockSite, subscribedPeer } from "@matter/node/testing";
+import { EndpointNumber, GroupId } from "@matter/types";
+import { GroupKeyManagement } from "@matter/types/clusters/group-key-management";
+
+const { TrustFirst } = GroupKeyManagement.GroupKeySecurityPolicy;
+
+const LOCAL_EP = EndpointNumber(1);
+const GROUP = GroupId(0x101);
+
+const keySet = {
+    groupKeySetId: 42,
+    groupKeySecurityPolicy: TrustFirst,
+    epochKey0: new Uint8Array(16).fill(0xab),
+    epochStartTime0: 946684800000001n, // must be > IPK_DEFAULT_EPOCH_START_TIME
+    epochKey1: null,
+    epochStartTime1: null,
+    epochKey2: null,
+    epochStartTime2: null,
+};
+const mapping = { groupId: GROUP, groupKeySetId: 42 };
+const membership = { localEndpoint: LOCAL_EP, groupId: GROUP, groupName: "kitchen" };
+
+function isMember(device: ServerNode): boolean {
+    const { groupTable } = device.stateOf(GroupKeyManagementServer);
+    return groupTable.some(e => e.groupId === GROUP && e.endpoints.includes(LOCAL_EP));
+}
+
+describe("Group membership reconcile integration (single peer)", () => {
+    before(() => {
+        MockTime.init();
+    });
+
+    it("adds an endpoint to a group after provisioning its key set and map", async () => {
+        await using site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair({
+            controller: { type: MockServerNode.RootEndpoint.with(ReconcilerBehavior) },
+            device: { type: MockServerNode.RootEndpoint, device: OnOffLightSwitchDevice.with(GroupsServer) },
+        });
+        const peer = await subscribedPeer(controller, "peer1");
+
+        await peer.act(agent => {
+            const ds = agent.get(DesiredStateBehavior);
+            ds.setIntent("groupKey", "42", keySet, "converge");
+            ds.setIntent("groupKeyMap", String(GROUP), mapping, "converge");
+            ds.setIntent("endpointGroupMembership", String(GROUP), membership, "converge");
+        });
+        await MockTime.resolve(controller.act(agent => agent.get(ReconcilerBehavior).reconcile(peer)));
+
+        expect(
+            peer.stateOf(DesiredStateBehavior).items[itemMapKey("endpointGroupMembership", String(GROUP))]?.status
+                .state,
+        ).equals("committed");
+        expect(isMember(device)).equals(true);
+    });
+
+    it("re-adds the endpoint to the group when verify detects a behind-the-back removal", async () => {
+        await using site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair({
+            controller: { type: MockServerNode.RootEndpoint.with(ReconcilerBehavior) },
+            device: { type: MockServerNode.RootEndpoint, device: OnOffLightSwitchDevice.with(GroupsServer) },
+        });
+        const peer = await subscribedPeer(controller, "peer1");
+
+        await peer.act(agent => {
+            const ds = agent.get(DesiredStateBehavior);
+            ds.setIntent("groupKey", "42", keySet, "converge");
+            ds.setIntent("groupKeyMap", String(GROUP), mapping, "converge");
+            ds.setIntent("endpointGroupMembership", String(GROUP), membership, "converge");
+        });
+        await MockTime.resolve(controller.act(agent => agent.get(ReconcilerBehavior).reconcile(peer)));
+        expect(isMember(device)).equals(true);
+
+        // Drain ~5 s of virtual time so the subscription-active verify pass (Groups commands are INVOKEs,
+        // slow under MRP backoff) finishes while membership is intact, before we mutate below.
+        for (let i = 0; i < 50; i++) {
+            await MockTime.advance(100);
+            await MockTime.macrotask;
+        }
+
+        // GroupsServer.removeGroup calls assertRemoteActor, so we can't use a local act. Mutate groupTable
+        // directly (same idiom as GroupKeyIntegrationTest dropping a keyset).
+        await MockTime.resolve(
+            device.act("drop-membership", agent => {
+                const gkm = agent.get(GroupKeyManagementServer);
+                gkm.state.groupTable = gkm.state.groupTable.filter(
+                    e => !(e.groupId === GROUP && e.endpoints.includes(LOCAL_EP)),
+                );
+            }),
+        );
+        expect(isMember(device)).equals(false);
+
+        await MockTime.resolve(
+            controller.act(agent => agent.get(ReconcilerBehavior).reconcile(peer, { verify: true })),
+        );
+
+        expect(isMember(device)).equals(true);
+    });
+
+    it("removes the endpoint from the group on a removeIntent", async () => {
+        await using site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair({
+            controller: { type: MockServerNode.RootEndpoint.with(ReconcilerBehavior) },
+            device: { type: MockServerNode.RootEndpoint, device: OnOffLightSwitchDevice.with(GroupsServer) },
+        });
+        const peer = await subscribedPeer(controller, "peer1");
+
+        await peer.act(agent => {
+            const ds = agent.get(DesiredStateBehavior);
+            ds.setIntent("groupKey", "42", keySet, "converge");
+            ds.setIntent("groupKeyMap", String(GROUP), mapping, "converge");
+            ds.setIntent("endpointGroupMembership", String(GROUP), membership, "converge");
+        });
+        await MockTime.resolve(controller.act(agent => agent.get(ReconcilerBehavior).reconcile(peer)));
+        expect(isMember(device)).equals(true);
+
+        await peer.act(agent => agent.get(DesiredStateBehavior).removeIntent("endpointGroupMembership", String(GROUP)));
+        await MockTime.resolve(controller.act(agent => agent.get(ReconcilerBehavior).reconcile(peer)));
+
+        expect(isMember(device)).equals(false);
+    });
+});

--- a/packages/node-manager/test/reconcile/GroupMembershipItemKindTest.ts
+++ b/packages/node-manager/test/reconcile/GroupMembershipItemKindTest.ts
@@ -1,0 +1,185 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GroupMembershipGrant, GroupMembershipItemKind } from "#reconcile/GroupMembershipItemKind.js";
+import { ImplementationError } from "@matter/general";
+import { ClientNode, ManagedItem } from "@matter/node";
+import { GroupId, Status, StatusResponseError } from "@matter/types";
+
+const LOCAL_EP = 1;
+const GROUP = GroupId(0x101);
+
+// Fake peer: per-endpoint Groups commands over an in-memory membership set, plus a
+// GroupKeyManagement cache for capacity. addStatus lets a test force a non-SUCCESS AddGroup.
+function fakePeer(opts?: {
+    localEp?: number;
+    members?: GroupId[];
+    addStatus?: Status;
+    removeStatus?: Status;
+    groupTableLen?: number;
+    maxGroupsPerFabric?: number;
+}) {
+    const localEp = opts?.localEp ?? LOCAL_EP;
+    const members = new Set<number>((opts?.members ?? []).map(Number));
+    const calls = { added: new Array<{ groupId: number; groupName: string }>(), removed: new Array<number>() };
+
+    const commands = {
+        async addGroup(req: { groupId: GroupId; groupName: string }) {
+            const status = opts?.addStatus ?? Status.Success;
+            if (status === Status.Success) {
+                members.add(Number(req.groupId));
+                calls.added.push({ groupId: Number(req.groupId), groupName: req.groupName });
+            }
+            return { status, groupId: req.groupId };
+        },
+        async removeGroup(req: { groupId: GroupId }) {
+            const status = opts?.removeStatus ?? Status.Success;
+            if (status === Status.Success) {
+                members.delete(Number(req.groupId));
+                calls.removed.push(Number(req.groupId));
+            }
+            return { status, groupId: req.groupId };
+        },
+        async getGroupMembership(req: { groupList: GroupId[] }) {
+            const all = [...members].map(n => GroupId(n));
+            const groupList = req.groupList.length === 0 ? all : all.filter(g => req.groupList.includes(g));
+            return { capacity: null, groupList };
+        },
+    };
+
+    const endpoint = { commandsOf: () => commands };
+    const node = {
+        endpoints: {
+            has: (n: number) => n === localEp,
+            for: (n: number) => {
+                if (n !== localEp) {
+                    throw new Error(`no endpoint ${n}`);
+                }
+                return endpoint;
+            },
+        },
+        stateOf: () => ({
+            groupTable: new Array(opts?.groupTableLen ?? 0).fill({}),
+            maxGroupsPerFabric: opts?.maxGroupsPerFabric ?? 8,
+        }),
+    } as unknown as ClientNode;
+
+    return { node, members, calls };
+}
+
+const grant: GroupMembershipGrant = { localEndpoint: LOCAL_EP, groupId: GROUP, groupName: "kitchen" };
+
+function item(g: GroupMembershipGrant): ManagedItem<GroupMembershipGrant> {
+    return {
+        kind: "endpointGroupMembership",
+        key: String(g.groupId),
+        intent: g,
+        mode: "converge",
+        status: { state: "pending", updateTimestamp: 0 },
+    };
+}
+
+describe("GroupMembershipItemKind", () => {
+    it("apply adds the endpoint to the group with its name", async () => {
+        const kind = new GroupMembershipItemKind();
+        const { node, calls, members } = fakePeer();
+        await kind.apply(node, item(grant));
+        expect(calls.added).deep.equals([{ groupId: 0x101, groupName: "kitchen" }]);
+        expect(members.has(0x101)).equals(true);
+    });
+
+    it("apply sends an empty name when none is given", async () => {
+        const kind = new GroupMembershipItemKind();
+        const { node, calls } = fakePeer();
+        await kind.apply(node, item({ localEndpoint: LOCAL_EP, groupId: GROUP }));
+        expect(calls.added[0].groupName).equals("");
+    });
+
+    it("apply throws StatusResponseError on a non-success status", async () => {
+        const kind = new GroupMembershipItemKind();
+        const { node } = fakePeer({ addStatus: Status.ResourceExhausted });
+        let err: unknown;
+        try {
+            await kind.apply(node, item(grant));
+        } catch (e) {
+            err = e;
+        }
+        expect(err).instanceOf(StatusResponseError);
+        expect((err as StatusResponseError).code).equals(Status.ResourceExhausted);
+    });
+
+    it("apply throws ImplementationError when the endpoint is absent", async () => {
+        const kind = new GroupMembershipItemKind();
+        const { node } = fakePeer();
+        let err: unknown;
+        try {
+            await kind.apply(node, item({ ...grant, localEndpoint: 99 }));
+        } catch (e) {
+            err = e;
+        }
+        expect(err).instanceOf(ImplementationError);
+    });
+
+    it("verify is true when a member, false when not", async () => {
+        const kind = new GroupMembershipItemKind();
+        expect(await new GroupMembershipItemKind().verify(fakePeer({ members: [GROUP] }).node, item(grant))).equals(
+            true,
+        );
+        expect(await kind.verify(fakePeer().node, item(grant))).equals(false);
+    });
+
+    it("verify returns false when the endpoint is absent", async () => {
+        const kind = new GroupMembershipItemKind();
+        const { node } = fakePeer({ members: [GROUP] });
+        expect(await kind.verify(node, item({ ...grant, localEndpoint: 99 }))).equals(false);
+    });
+
+    it("remove drops the endpoint from the group", async () => {
+        const kind = new GroupMembershipItemKind();
+        const { node, calls, members } = fakePeer({ members: [GROUP] });
+        await kind.remove(node, item(grant));
+        expect(calls.removed).deep.equals([0x101]);
+        expect(members.has(0x101)).equals(false);
+    });
+
+    it("remove treats NOT_FOUND as success", async () => {
+        const kind = new GroupMembershipItemKind();
+        const { node } = fakePeer({ removeStatus: Status.NotFound });
+        await kind.remove(node, item(grant)); // must not throw
+    });
+
+    it("remove throws StatusResponseError on other failures", async () => {
+        const kind = new GroupMembershipItemKind();
+        const { node } = fakePeer({ removeStatus: Status.Busy });
+        let err: unknown;
+        try {
+            await kind.remove(node, item(grant));
+        } catch (e) {
+            err = e;
+        }
+        expect(err).instanceOf(StatusResponseError);
+    });
+
+    it("remove is a no-op when the endpoint is absent", async () => {
+        const kind = new GroupMembershipItemKind();
+        const { node, calls } = fakePeer();
+        await kind.remove(node, item({ ...grant, localEndpoint: 99 }));
+        expect(calls.removed.length).equals(0);
+    });
+
+    it("capacity reads limit and used from the cached group table", async () => {
+        const kind = new GroupMembershipItemKind();
+        const { node } = fakePeer({ groupTableLen: 2, maxGroupsPerFabric: 5 });
+        expect(await kind.capacity(node)).deep.equals({ limit: 5, used: 2 });
+    });
+
+    it("recoverable is true only for Timeout and Busy", () => {
+        const kind = new GroupMembershipItemKind();
+        expect(kind.recoverable(Status.Timeout)).equals(true);
+        expect(kind.recoverable(Status.Busy)).equals(true);
+        expect(kind.recoverable(Status.ResourceExhausted)).equals(false);
+    });
+});


### PR DESCRIPTION
Phase 2b-2b of Node Manager. Adds the fifth reconciler `ItemKind`, `endpointGroupMembership`, completing the group-provisioning chain (keyset → groupKeyMap → membership).

## What

- **`GroupMembershipItemKind`** — per-endpoint Groups cluster (0x0004) membership. Resolves a per-endpoint command target (`node.endpoints.for(ep).commandsOf(GroupsClient)`) like `BindingItemKind`, command-based like `GroupKeyItemKind`:
  - **apply** — `AddGroup({groupId, groupName ?? ""})`, always-write (idempotent); `groupName` sent but not verified.
  - **verify** — `GetGroupMembership({groupList:[groupId]})`, presence-only (member iff `groupId ∈ response.groupList`).
  - **remove** — `RemoveGroup({groupId})`; `NotFound` treated as success. Never `RemoveAllGroups`.
  - **capacity** — from subscription cache: `limit = maxGroupsPerFabric ?? 4`, `used = groupTable.length`.
  - priority `PRIORITY_BANDS.membership` (30); `recoverable` = Timeout/Busy.
- Registered in `ReconcilerBehavior.initialize()`. **No engine changes** — reuses the mutex-queue reconcile path + `planActions`/`executeActions`.

## New mechanic vs prior kinds

Groups commands return application status in the **response payload** (`AddGroupResponse.status`), not as a thrown `StatusResponseError` (KeySetWrite had no payload). So `apply`/`remove` inspect `response.status` and re-throw non-SUCCESS as `StatusResponseError(msg, status)`, routing through the executor's `extractStatusCode` → `recoverable` → retry/drop uniformly. `ResourceExhausted` → drop; `Timeout`/`Busy` → retry.

Device dependency: `GroupsServer.addGroup` returns `UnsupportedAccess` unless the group is already keyset-mapped — the priority bands keyset(10) < group(20) < membership(30) enforce that order in one reconcile pass.

## Tests

- 12 unit tests (fake peer: status-payload branches, NotFound→success, endpoint-absent paths, capacity-from-cache).
- 3 integration scenarios on a commissioned `OnOffLightSwitchDevice.with(GroupsServer)` (ep1): apply → member; behind-the-back removal → verify pass re-applies; deletePending → removed. All assert real device `groupTable` state.

## Gates

build --clean ✓ · format ✓ · lint ✓ · node-manager 75/75 · node 1227/1227 (no regression). Whole-branch review: zero Critical/Important.

Base = `node-manager` (sub-PR; CI runs on umbrella #3948 → main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)