### PR TITLE
fix(node): tolerate peers reporting an empty AttributeList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: Free a behavior's persisted seed values from memory once the datasource has loaded them
     - Fix: A peer's mDNS advertisement at the 1-hour SII/SAI cap no longer lowers a higher CASE-negotiated idle/active interval already on record
     - Fix: Ensure that a peer's FeatureMap change rebuilds the affected client cluster behavior
+    - Fix: A peer reporting an empty AttributeList no longer breaks client cluster schema generation; the discovered schema falls back to the attributes actually received
     - Fix: Ensure to always sanitize fabric-scoped attribute data (e.g. stale AccessControl ACL entries) at node startup
 
 - @matter/nodejs

--- a/packages/node/src/node/client/ClientStructure.ts
+++ b/packages/node/src/node/client/ClientStructure.ts
@@ -460,11 +460,14 @@ export class ClientStructure {
 
         if (cluster.behavior && attrs.values.has(AttributeList.id)) {
             const attributeList = attrs.values.get(AttributeList.id);
+            // A non-empty AttributeList is authoritative: rebuilding on any difference honors both added and removed
+            // attributes.  An empty list is ignored here so it doesn't churn against the received-attribute fallback.
             if (
                 Array.isArray(attributeList) &&
+                attributeList.length &&
                 !isDeepEqual(
                     cluster.attributes,
-                    attributeList.sort((a, b) => a - b),
+                    [...attributeList].sort((a, b) => a - b),
                 )
             ) {
                 cluster.behavior = undefined;
@@ -477,7 +480,7 @@ export class ClientStructure {
                 Array.isArray(acceptedCommands) &&
                 !isDeepEqual(
                     cluster.commands,
-                    acceptedCommands.sort((a, b) => a - b),
+                    [...acceptedCommands].sort((a, b) => a - b),
                 )
             ) {
                 cluster.behavior = undefined;
@@ -517,10 +520,20 @@ export class ClientStructure {
                     cluster.features = features as FeatureBitmap;
                 }
 
-                if (Array.isArray(attributeList)) {
+                if (Array.isArray(attributeList) && attributeList.length) {
                     cluster.attributes = (attributeList.filter(attr => typeof attr === "number") as AttributeId[]).sort(
                         (a, b) => a - b,
                     );
+                } else {
+                    // Some devices report an empty (or omit the) AttributeList despite returning attribute data.  Fall
+                    // back to the attribute IDs we actually received so the discovered schema reflects the device
+                    // rather than "supports nothing", which would mark mandatory globals unsupported.
+                    const received = Object.keys(values)
+                        .map(Number)
+                        .filter(id => Number.isInteger(id) && id >= 0) as AttributeId[];
+                    if (received.length) {
+                        cluster.attributes = received.sort((a, b) => a - b);
+                    }
                 }
 
                 if (Array.isArray(commandList)) {

--- a/packages/node/src/node/client/PeerBehavior.ts
+++ b/packages/node/src/node/client/PeerBehavior.ts
@@ -417,6 +417,12 @@ function maybeOverrideSupport<T extends AttributeModel | CommandModel | EventMod
         return;
     }
 
+    // Global attributes are injected into cluster members independent of conformance (see Scope.injectGlobalAttributes),
+    // so a support override would push a second, undeconflictable definition.  Their support is never in question.
+    if (AttributeModel.isGlobal(element)) {
+        return;
+    }
+
     const isSupported = supported === true || supported.has(element.id);
     const applicability = element.effectiveConformance.applicabilityFor(standardCluster);
     if (!isSupported) {

--- a/packages/node/test/node/PeerBehaviorTest.ts
+++ b/packages/node/test/node/PeerBehaviorTest.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PeerBehavior } from "#node/client/PeerBehavior.js";
+import { AttributeId, ClusterId, CommandId } from "@matter/types";
+
+// NetworkCommissioning (0x31) with the EthernetNetworkInterface feature (bit 2).
+const NETWORK_COMMISSIONING = ClusterId(0x31);
+const ETHERNET_FEATURE = 4;
+
+describe("PeerBehavior", () => {
+    describe("discovered schema generation", () => {
+        it("builds a cluster even when the peer reports an empty AttributeList", () => {
+            // Some device firmware returns an empty AttributeList (0xFFFB) despite serving attribute data.  Pre-fix
+            // this marked every standard attribute — including mandatory globals such as FeatureMap — as unsupported,
+            // producing a duplicate definition that broke schema generation (home-assistant/addons#4673).
+            const shape: PeerBehavior.DiscoveredClusterShape = {
+                kind: "discovered",
+                id: NETWORK_COMMISSIONING,
+                revision: 1,
+                features: ETHERNET_FEATURE,
+                attributes: [] as AttributeId[],
+                generatedCommands: [] as CommandId[],
+            };
+
+            const behaviorType = PeerBehavior(shape);
+
+            expect(behaviorType).not.undefined;
+            expect(behaviorType.cluster.attributes?.interfaceEnabled).not.undefined;
+        });
+
+        it("builds a cluster from a well-formed AttributeList", () => {
+            // Differentiate the cache fingerprint from the empty-list case above via a distinct attribute set.
+            const shape: PeerBehavior.DiscoveredClusterShape = {
+                kind: "discovered",
+                id: NETWORK_COMMISSIONING,
+                revision: 1,
+                features: ETHERNET_FEATURE,
+                attributes: [4, 65528, 65529, 65530, 65531, 65532, 65533].map(n => AttributeId(n)),
+                commands: [] as CommandId[],
+            };
+
+            const behaviorType = PeerBehavior(shape);
+
+            expect(behaviorType).not.undefined;
+            expect(behaviorType.cluster.attributes?.interfaceEnabled).not.undefined;
+        });
+    });
+});


### PR DESCRIPTION
## Problem

A commissioned device that reports an **empty `AttributeList` (0xFFFB)** crashes `ClientNode.initialize`, taking down the whole server:

```
ERROR ClientNode [schema-implementation] Definition of NetworkCommissioning:
There are multiple definitions of "FeatureMap" that cannot be differentiated by conformance
  at filterWithConformance (@matter/model/.../Scope.ts)
  at createDerivedState (@matter/node/.../ClusterBehaviorType.ts)
  at generateDiscoveredType (@matter/node/.../PeerBehavior.ts)
  at ClientNode.initialize (@matter/node/.../ClientNode.ts)
```

Reported via home-assistant/addons#4673 (matter-server upgrade migrating real device data). The offending device reports an empty `AttributeList` on every cluster (and misfiles its attribute IDs into `GeneratedCommandList`).

## Root cause

With an empty `AttributeList`, `DiscoveredShapeAnalysis` treats *every* standard attribute — including mandatory **global** attributes (FeatureMap, ClusterRevision, …) — as unsupported. `maybeOverrideSupport` then records a support-override for them, and `generateDiscoveredType` appends `attr.extend(...)` as a second child named `FeatureMap`. Because global attributes are injected into the member list by `Scope.injectGlobalAttributes` (bypassing conformance-dedup), the two definitions collide and `Scope` throws.

Cluster-specific overrides don't crash because they are deconflicted via `operationalShadow`; only the always-injected globals collide.

## Fix

- **PeerBehavior**: never create support-overrides for global attributes — they are structurally always present, so marking them is meaningless and is the only thing that duplicates.
- **ClientStructure**: when the reported `AttributeList` is empty/absent, fall back to the attribute IDs actually received, so the discovered schema reflects the device instead of "supports nothing". A non-empty list stays authoritative, so attribute removals are still honored.
- **ClientStructure**: copy the incoming list before sorting in change-detection (was mutating the array that gets persisted).

## Test

New `PeerBehaviorTest.ts` reconstructs the failing shape (empty AttributeList + Ethernet feature) and asserts the cluster builds. It reproduces the exact production error without the fix and passes with it.

Full `@matter/node` suite green; format, lint and clean build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)