### PR TITLE
fix(protocol): gate BLE Extended-Announcement flag on the extended-announcement period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Certificates are rejected on decode when exceeding the size limits (400 bytes TLV for the NOC chain and VVSC, 600 bytes DER for the NOC and DAC chains)
     - Fix: OTA image digest type identifiers follow the IANA Named Information Hash Algorithm Registry (RFC 6920), and the digest algorithm is validated when reading an image
     - Fix: A stray StatusReport arriving as an exchange's initial message (e.g. a retransmitted CASE/PASE completion) is now ignored instead of logging an "Unhandled error"
+    - Fix: The BLE Extended-Announcement flag is only set during the extended-announcement period, no longer when private details are omitted outside that window
 
 - @project-chip/matter.js
     - Fix: `PairedNode.connect()` now applies the subscription interval options passed to it, instead of ignoring them

--- a/packages/protocol/src/advertisement/Advertisement.ts
+++ b/packages/protocol/src/advertisement/Advertisement.ts
@@ -175,20 +175,19 @@ export abstract class Advertisement<T extends ServiceDescription = ServiceDescri
     protected async onClose() {}
 
     /**
+     * Indicates the advertisement has entered the extended-announcement period per core spec 5.4.2.5.
+     */
+    protected get isExtendedAnnouncement() {
+        return this.duration >= STANDARD_COMMISSIONING_TIMEOUT;
+    }
+
+    /**
      * Indicates that broadcasts should omit private details.
+     *
+     * True during the extended-announcement period or when forced via {@link Advertisement.Options.omitPrivateDetails}.
      */
     protected get isPrivacyMasked() {
-        // Private broadcast configured explicitly
-        if (this.options.omitPrivateDetails) {
-            return true;
-        }
-
-        // Extended announcement
-        if (this.duration >= STANDARD_COMMISSIONING_TIMEOUT) {
-            return true;
-        }
-
-        return false;
+        return !!this.options.omitPrivateDetails || this.isExtendedAnnouncement;
     }
 
     /**

--- a/packages/protocol/src/advertisement/ble/BleAdvertisement.ts
+++ b/packages/protocol/src/advertisement/ble/BleAdvertisement.ts
@@ -32,7 +32,7 @@ export class BleAdvertisement extends Advertisement<ServiceDescription.Commissio
             config: { earlyInterval, lateInterval, extendedInterval },
         } = this.advertiser;
 
-        let aad = this.advertiser.config.aad;
+        let aad = this.isPrivacyMasked ? undefined : this.advertiser.config.aad;
 
         let timeout = this.advertiser.config.timeout;
 

--- a/packages/protocol/src/advertisement/ble/BleAdvertisement.ts
+++ b/packages/protocol/src/advertisement/ble/BleAdvertisement.ts
@@ -49,7 +49,7 @@ export class BleAdvertisement extends Advertisement<ServiceDescription.Commissio
         try {
             for (const { sleepTime, broadcastInterval } of intervals) {
                 // Recreate advertisement data for an extended announcement
-                if (!isExtended && this.isPrivacyMasked) {
+                if (!isExtended && this.isExtendedAnnouncement) {
                     isExtended = true;
                     advertisementData = this.#encodedAdvertisement;
                     aad = undefined;
@@ -73,13 +73,13 @@ export class BleAdvertisement extends Advertisement<ServiceDescription.Commissio
 
     get #encodedAdvertisement() {
         const { discriminator, vendorId, productId } = this.description;
-        const { isPrivacyMasked: isExtendedAnnouncement } = this;
+        const { isPrivacyMasked, isExtendedAnnouncement } = this;
 
         return BtpCodec.encodeBleAdvertisementData(
             discriminator,
-            isExtendedAnnouncement ? 0 : vendorId,
-            isExtendedAnnouncement ? 0 : productId,
-            !isExtendedAnnouncement && !!this.advertiser.config.aad?.byteLength,
+            isPrivacyMasked ? 0 : vendorId,
+            isPrivacyMasked ? 0 : productId,
+            !isPrivacyMasked && !!this.advertiser.config.aad?.byteLength,
             isExtendedAnnouncement,
         );
     }

--- a/packages/protocol/test/advertisement/AdvertisementTest.ts
+++ b/packages/protocol/test/advertisement/AdvertisementTest.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Advertisement } from "#advertisement/Advertisement.js";
+import { Advertiser } from "#advertisement/Advertiser.js";
+import { ServiceDescription } from "#advertisement/ServiceDescription.js";
+import { Minutes } from "@matter/general";
+import { VendorId } from "@matter/types";
+
+const DESCRIPTION = ServiceDescription.Commissionable({
+    name: "Test",
+    deviceType: 1,
+    vendorId: VendorId(1),
+    productId: 1,
+    mode: 1,
+    discriminator: 0xf00,
+});
+
+class TestAdvertiser extends Advertiser {
+    protected getAdvertisement() {
+        return undefined;
+    }
+}
+
+class TestAdvertisement extends Advertisement<ServiceDescription.Commissionable> {
+    constructor(advertiser: Advertiser, options?: Advertisement.Options) {
+        super(advertiser, "test", DESCRIPTION, options);
+    }
+
+    get extendedAnnouncement() {
+        return this.isExtendedAnnouncement;
+    }
+
+    get privacyMasked() {
+        return this.isPrivacyMasked;
+    }
+
+    protected async run() {}
+
+    isDuplicate() {
+        return false;
+    }
+}
+
+describe("Advertisement", () => {
+    before(() => {
+        MockTime.enable();
+    });
+
+    describe("privacy masking", () => {
+        it("masks nothing before the extended-announcement period", async () => {
+            const ad = new TestAdvertisement(new TestAdvertiser());
+            try {
+                expect(ad.privacyMasked).false;
+                expect(ad.extendedAnnouncement).false;
+            } finally {
+                await ad.close();
+            }
+        });
+
+        it("masks private details but does not signal extended announcement when forced via omitPrivateDetails", async () => {
+            const ad = new TestAdvertisement(new TestAdvertiser(), { omitPrivateDetails: true });
+            try {
+                expect(ad.privacyMasked).true;
+                expect(ad.extendedAnnouncement).false;
+            } finally {
+                await ad.close();
+            }
+        });
+
+        it("masks and signals extended announcement once the extended-announcement period begins", async () => {
+            const ad = new TestAdvertisement(new TestAdvertiser());
+            try {
+                await MockTime.advance(Minutes(15));
+                expect(ad.privacyMasked).true;
+                expect(ad.extendedAnnouncement).true;
+            } finally {
+                await ad.close();
+            }
+        });
+
+        it("signals extended announcement in the extended-announcement period even with omitPrivateDetails set", async () => {
+            const ad = new TestAdvertisement(new TestAdvertiser(), { omitPrivateDetails: true });
+            try {
+                await MockTime.advance(Minutes(15));
+                expect(ad.privacyMasked).true;
+                expect(ad.extendedAnnouncement).true;
+            } finally {
+                await ad.close();
+            }
+        });
+    });
+});


### PR DESCRIPTION
## Problem

The Extended-Announcement flag in the BLE service-data advertisement was derived from the privacy-mask state. Forcing `omitPrivateDetails` outside the extended-announcement period (`duration < STANDARD_COMMISSIONING_TIMEOUT`, 15 min) therefore set the flag even though core spec §5.4.2.5 makes it meaningful only during that window — mis-signaling to scanners.

Found during Matter 1.6.0 spec↔impl verification (core-05-04-device-discovery, finding Q-01). Latent today: the `omitPrivateDetails` knob has no setters, so there is no runtime impact — the fix makes the path correct if/when the knob is wired up.

A second latent bug shared the root cause: the run-loop's extended-announcement recreate transition keyed on `isPrivacyMasked`, so with `omitPrivateDetails` set, `isExtended` latched on the first interval and the flag would never toggle on at the real 15-min boundary.

## Fix

- `Advertisement.ts`: split `isExtendedAnnouncement` (duration-only) out of `isPrivacyMasked` (omit VID/PID via the knob **or** during extended announcement).
- `BleAdvertisement.ts`: `#encodedAdvertisement` masks VID/PID by `isPrivacyMasked` and drives the EA flag by `isExtendedAnnouncement`; the recreate transition now keys on `isExtendedAnnouncement`.

mDNS path unaffected — it only uses `isPrivacyMasked` for VID/PID masking, monotonically.

Resulting behavior:
- pre-EA, no knob: VID/PID present, EA flag clear (unchanged)
- pre-EA, `omitPrivateDetails`: VID/PID masked, **EA flag clear** (was wrongly set)
- in EA (either path): VID/PID masked, EA flag set

## Tests

New `AdvertisementTest.ts`, 4 cases covering the getter invariant across knob × EA-period. Full protocol suite green (1218/1218), format + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)