### PR TITLE
fix(protocol, node): honor §8.8.3.2.1 SuppressResponse force-send when a command returns data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Ensure that a peer's FeatureMap change rebuilds the affected client cluster behavior
     - Fix: Ensure to always sanitize fabric-scoped attribute data (e.g. stale AccessControl ACL entries) at node startup
     - Fix: A misconfigured environment/configuration value for a behavior (unknown property or unconvertible value) is now logged and skipped instead of crashing endpoint initialization
+    - Fix: An invoke with SuppressResponse still returns the Invoke Response when a command produces response data, instead of suppressing it unconditionally
 
 - @matter/nodejs
     - Fix: On `process.exit`, verifies all storages were properly closed and removes orphaned lock files otherwise, so a forgotten close no longer blocks the next startup

--- a/packages/node/src/node/server/InteractionServer.ts
+++ b/packages/node/src/node/server/InteractionServer.ts
@@ -29,6 +29,7 @@ import {
     InteractionServerMessenger,
     InvokeRequest,
     InvokeResponseForSend,
+    InvokeResult,
     Mark,
     Message,
     MessageExchange,
@@ -868,8 +869,8 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
         // Get the invoke-results from the server interaction
         const results = this.#serverInteraction.invoke(request, context);
 
-        // For suppressResponse or group sessions, just consume the iterator without sending responses
-        if (suppressResponse || isGroupSession) {
+        // A groupcast invoke never produces a response; just consume the iterator.
+        if (isGroupSession) {
             for await (const _chunk of results);
             return;
         }
@@ -921,7 +922,20 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
             messageSize += invokeResponseBytes;
         };
 
-        // Process all invoke results
+        const toInvokeResponseData = (data: InvokeResult.Data): InvokeResponseData => {
+            if (data.kind === "cmd-response") {
+                const { path: commandPath, commandRef, data: commandFields } = data;
+                return { command: { commandPath, commandFields, commandRef } };
+            }
+            const { path: commandPath, commandRef, status, clusterStatus } = data;
+            return { status: { commandPath, status: { status, clusterStatus }, commandRef } };
+        };
+
+        // Per spec §8.8.3.2.1 a SuppressResponse invoke still sends a response if a CommandDataIB is generated. Until
+        // one is seen we hold generated statuses back; the first CommandDataIB flushes the held statuses and the rest
+        // stream normally. Non-suppressed responses stream from the start.
+        let suppressedBuffer: InvokeResponseData[] | undefined = suppressResponse ? [] : undefined;
+
         for await (const chunk of results) {
             if (chunkedTransmissionTerminated) {
                 // Client terminated the chunked series, continue consuming but don't send
@@ -929,28 +943,28 @@ export class InteractionServer implements ProtocolHandler, InteractionRecipient 
             }
 
             for (const data of chunk) {
-                switch (data.kind) {
-                    case "cmd-response": {
-                        const { path: commandPath, commandRef, data: commandFields } = data;
-                        await sendChunkIfNeeded({
-                            command: {
-                                commandPath,
-                                commandFields,
-                                commandRef,
-                            },
-                        });
-                        break;
-                    }
+                const responseData = toInvokeResponseData(data);
 
-                    case "cmd-status": {
-                        const { path, commandRef, status, clusterStatus } = data;
-                        await sendChunkIfNeeded({
-                            status: { commandPath: path, status: { status, clusterStatus }, commandRef },
-                        });
-                        break;
+                if (suppressedBuffer !== undefined) {
+                    if (data.kind !== "cmd-response") {
+                        suppressedBuffer.push(responseData);
+                        continue;
                     }
+                    // First CommandDataIB: commit to sending. Flush the held statuses, then stream the rest.
+                    for (const held of suppressedBuffer) {
+                        await sendChunkIfNeeded(held);
+                    }
+                    suppressedBuffer = undefined;
                 }
+
+                await sendChunkIfNeeded(responseData);
             }
+        }
+
+        // SuppressResponse and no CommandDataIB was generated — send nothing.
+        if (suppressedBuffer !== undefined) {
+            logger.debug("Invoke (suppressed)", Mark.OUTBOUND, exchange.via, Diagnostic.weak("no response sent"));
+            return;
         }
 
         // Send the final response if not already terminated

--- a/packages/node/test/endpoint/server/InteractionProtocolTest.ts
+++ b/packages/node/test/endpoint/server/InteractionProtocolTest.ts
@@ -57,6 +57,7 @@ import {
 } from "@matter/types";
 import { AdministratorCommissioning } from "@matter/types/clusters/administrator-commissioning";
 import { BasicInformation } from "@matter/types/clusters/basic-information";
+import { GeneralCommissioning } from "@matter/types/clusters/general-commissioning";
 import { GeneralDiagnostics } from "@matter/types/clusters/general-diagnostics";
 import { MockServerNode } from "../../node/mock-server-node.js";
 import { interaction } from "../../node/node-helpers.js";
@@ -67,6 +68,53 @@ const TlvBootReasonEvent = TlvOfModel(GeneralDiagnostics.events.bootReason);
 const TlvOpenBasicCommissioningWindowRequest = TlvOfModel(
     AdministratorCommissioning.commands.openBasicCommissioningWindow,
 );
+const TlvArmFailSafeRequest = TlvOfModel(GeneralCommissioning.commands.armFailSafe);
+
+// GeneralCommissioning.armFailSafe (cluster 0x30, command 0) returns an ArmFailSafeResponse CommandDataIB.
+const INVOKE_ARM_FAILSAFE_SUPPRESSED: InvokeRequest = {
+    interactionModelRevision: Specification.INTERACTION_MODEL_REVISION,
+    suppressResponse: true,
+    timedRequest: false,
+    invokeRequests: [
+        {
+            commandPath: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x30), commandId: CommandId(0) },
+            commandFields: TlvArmFailSafeRequest.encodeTlv({ expiryLengthSeconds: 60, breadcrumb: 0 }),
+        },
+    ],
+};
+
+// OnOff.on (cluster 6, command 1) returns only a success CommandStatusIB.
+const INVOKE_ON_OFF_SUPPRESSED: InvokeRequest = {
+    interactionModelRevision: Specification.INTERACTION_MODEL_REVISION,
+    suppressResponse: true,
+    timedRequest: false,
+    invokeRequests: [
+        {
+            commandPath: { endpointId: EndpointNumber(0), clusterId: ClusterId(6), commandId: CommandId(1) },
+            commandFields: TlvNoArguments.encodeTlv(undefined),
+        },
+    ],
+};
+
+// A suppressed batch where a status-only command precedes a data-returning one: the held status must be flushed
+// together with the forcing CommandDataIB.
+const INVOKE_STATUS_THEN_DATA_SUPPRESSED: InvokeRequest = {
+    interactionModelRevision: Specification.INTERACTION_MODEL_REVISION,
+    suppressResponse: true,
+    timedRequest: false,
+    invokeRequests: [
+        {
+            commandPath: { endpointId: EndpointNumber(0), clusterId: ClusterId(6), commandId: CommandId(1) },
+            commandFields: TlvNoArguments.encodeTlv(undefined),
+            commandRef: 0,
+        },
+        {
+            commandPath: { endpointId: EndpointNumber(0), clusterId: ClusterId(0x30), commandId: CommandId(0) },
+            commandFields: TlvArmFailSafeRequest.encodeTlv({ expiryLengthSeconds: 60, breadcrumb: 0 }),
+            commandRef: 1,
+        },
+    ],
+};
 
 /**
  * Helper to decode pre-encoded InvokeResponseForSend back to InvokeResponse for test comparison.
@@ -1765,6 +1813,58 @@ describe("InteractionProtocol", () => {
             expect(triggeredOn).equals(true);
             expect(triggeredOff).equals(true);
             expect(onOffState).equals(false);
+        });
+
+        it("sends no response under SuppressResponse when only a status is generated", async () => {
+            const exchange = await createDummyMessageExchange(node);
+            const { messenger, getResponse, getChunks } = createMockInvokeMessenger();
+            await interactionProtocol.handleInvokeRequest(
+                exchange,
+                INVOKE_ON_OFF_SUPPRESSED,
+                messenger,
+                interaction.BarelyMockedMessage,
+            );
+
+            expect(getResponse()).equals(undefined);
+            expect(getChunks().length).equals(0);
+            expect(onOffState).equals(true);
+        });
+
+        it("sends the response under SuppressResponse when a CommandDataIB is generated", async () => {
+            const exchange = await createDummyMessageExchange(node);
+            const { messenger, getResponse } = createMockInvokeMessenger();
+            await interactionProtocol.handleInvokeRequest(
+                exchange,
+                INVOKE_ARM_FAILSAFE_SUPPRESSED,
+                messenger,
+                interaction.BarelyMockedMessage,
+            );
+
+            const response = getResponse();
+            expect(response).not.equals(undefined);
+            const decoded = decodeInvokeResponse(response!);
+            expect(decoded.invokeResponses.length).equals(1);
+            expect(decoded.invokeResponses[0].command?.commandPath).deep.equals({
+                endpointId: EndpointNumber(0),
+                clusterId: ClusterId(0x30),
+                commandId: CommandId(1),
+            });
+        });
+
+        it("under SuppressResponse, flushes a held status alongside the forcing CommandDataIB", async () => {
+            const exchange = await createDummyMessageExchange(node);
+            const { messenger, getResponse } = createMockInvokeMessenger();
+            await interactionProtocol.handleInvokeRequest(
+                exchange,
+                INVOKE_STATUS_THEN_DATA_SUPPRESSED,
+                messenger,
+                interaction.BarelyMockedMessage,
+            );
+
+            const decoded = decodeInvokeResponse(getResponse()!);
+            expect(decoded.invokeResponses.length).equals(2);
+            expect(decoded.invokeResponses[0].status?.commandRef).equals(0);
+            expect(decoded.invokeResponses[1].command?.commandRef).equals(1);
         });
 
         it("throws on multi invoke commands with one same commands", async () => {

--- a/packages/node/test/node/CommandInvokeResponseTest.ts
+++ b/packages/node/test/node/CommandInvokeResponseTest.ts
@@ -68,7 +68,10 @@ describe("CommandInvokeResponse", () => {
         expect(response.counts).deep.equals({ status: 0, success: 2, existent: 2 });
     });
 
-    it("invokes existing endpoint wildcard commands with suppressed response", async () => {
+    // process() is now suppress-agnostic: it always produces the results and SuppressResponse is applied by the
+    // messaging layer (so it can honor the §8.8.3.2.1 force-send-on-CommandDataIB clause). The produced data is
+    // therefore identical to the non-suppressed case.
+    it("produces results regardless of suppressResponse", async () => {
         const device = new Endpoint(OnOffLightDevice);
         const node = await MockServerNode.createOnline(undefined, { device });
         await node.add(new Endpoint(OnOffLightDevice));
@@ -82,7 +85,22 @@ describe("CommandInvokeResponse", () => {
             ],
         });
 
-        expect(response.data).deep.equals(undefined);
+        expect(response.data).deep.equals([
+            {
+                kind: "cmd-status",
+                path: { clusterId: 6, commandId: 1, endpointId: 1 },
+                status: 0,
+                clusterStatus: undefined,
+                commandRef: undefined,
+            },
+            {
+                kind: "cmd-status",
+                path: { clusterId: 6, commandId: 1, endpointId: 2 },
+                status: 0,
+                clusterStatus: undefined,
+                commandRef: undefined,
+            },
+        ]);
         expect(response.counts).deep.equals({ status: 0, success: 2, existent: 2 });
     });
 

--- a/packages/protocol/src/action/server/CommandInvokeResponse.ts
+++ b/packages/protocol/src/action/server/CommandInvokeResponse.ts
@@ -61,7 +61,7 @@ export class CommandInvokeResponse<
         this.#fabricIndex = session.fabric ?? FabricIndex.NO_FABRIC;
     }
 
-    async *process<T extends Invoke>({ invokeRequests, suppressResponse }: T): InvokeResult {
+    async *process<T extends Invoke>({ invokeRequests }: T): InvokeResult {
         using _invoking = this.join("invoking");
         const multipleInvokes = invokeRequests.length > 1;
 
@@ -94,16 +94,14 @@ export class CommandInvokeResponse<
         if (this.#invokers) {
             for (const invoker of this.#invokers) {
                 for await (const chunk of invoker.apply(this)) {
-                    if (!suppressResponse) {
-                        yield chunk;
-                    }
+                    yield chunk;
                 }
             }
         }
 
         // We emit chunks lazily when the endpoint changes so there may be one remaining chunk.  There may also be a
         // chunk with errors even if there are no data producers
-        if (!suppressResponse && this.#chunk !== undefined) {
+        if (this.#chunk !== undefined) {
             yield this.#chunk;
         }
     }


### PR DESCRIPTION
## Problem
A `SuppressResponse` invoke dropped the Invoke Response **unconditionally**, both at the protocol producer (`CommandInvokeResponse.process`) and the node messaging layer.

Matter §8.8.3.2.1 is explicit:
> Else if SuppressResponse is FALSE, **or a CommandDataIB was generated**, an Invoke Response action SHALL be generated [including every generated CommandStatusIB and CommandDataIB].

So when a suppressed invoke produces a command **response payload** (CommandDataIB), the full response must still be sent. (Note: CHIP ignores SuppressResponse entirely on the server; this follows the spec instead.)

## Change
- `CommandInvokeResponse.process` is now a **pure producer** — it always yields its results; `SuppressResponse` no longer gates the output.
- `InteractionServer.handleInvokeRequest` owns the send decision:
  - **groupcast** → consume, send nothing (unchanged);
  - **suppressed** → hold generated statuses until the first CommandDataIB; that first data IB flushes the held statuses and the rest stream normally; if no CommandDataIB is ever produced, send nothing (logged at debug);
  - **non-suppressed** → stream as before.

Only the statuses preceding the first data IB are buffered, so a suppressed response that does send still streams.

## Testing
- Protocol: `CommandInvokeResponse` test updated — `process()` is now suppress-agnostic.
- Wire (`InteractionProtocolTest`, via `handleInvokeRequest`):
  - suppress + status-only command → no response sent;
  - suppress + `armFailSafe` (returns a CommandDataIB) → response sent with the data IB;
  - suppress + batch (status precedes data) → held status flushed alongside the forcing data IB.
- protocol 1215/1215, node 1221/1221, format + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)