### PR TITLE
fix(protocol): encode payload-header Vendor ID before Protocol ID (§4.4.3.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: OTA image digest type identifiers follow the IANA Named Information Hash Algorithm Registry (RFC 6920), and the digest algorithm is validated when reading an image
     - Fix: A stray StatusReport arriving as an exchange's initial message (e.g. a retransmitted CASE/PASE completion) is now ignored instead of logging an "Unhandled error"
     - Fix: The BLE Extended-Announcement flag is only set during the extended-announcement period, no longer when private details are omitted outside that window
+    - Fix: Fixes encoding and decoding of a message payload header carrying a vendor Protocol ID
 
 - @project-chip/matter.js
     - Fix: `PairedNode.connect()` now applies the subscription interval options passed to it, instead of ignoring them

--- a/packages/protocol/src/codec/MessageCodec.ts
+++ b/packages/protocol/src/codec/MessageCodec.ts
@@ -375,7 +375,7 @@ export class MessageCodec {
         const messageType = reader.readUInt8(); // Protocol Opcode
         const exchangeId = reader.readUInt16();
         const vendorId = hasVendorId ? reader.readUInt16() : COMMON_VENDOR_ID;
-        const protocolId = (vendorId << 16) | reader.readUInt16();
+        const protocolId = vendorId * 0x10000 + reader.readUInt16();
         const ackedMessageId = isAckMessage ? reader.readUInt32() : undefined;
 
         return {
@@ -433,7 +433,7 @@ export class MessageCodec {
         ackedMessageId: ackedMessageCounter,
     }: PayloadHeader) {
         const writer = new DataWriter(Endian.Little);
-        const vendorId = (protocolId & 0xffff0000) >> 16;
+        const vendorId = (protocolId & 0xffff0000) >>> 16;
         const flags =
             (isInitiatorMessage ? PayloadHeaderFlag.IsInitiatorMessage : 0) |
             (ackedMessageCounter !== undefined ? PayloadHeaderFlag.IsAckMessage : 0) |
@@ -444,10 +444,9 @@ export class MessageCodec {
         writer.writeUInt8(messageType);
         writer.writeUInt16(exchangeId);
         if (vendorId !== COMMON_VENDOR_ID) {
-            writer.writeUInt32(protocolId);
-        } else {
-            writer.writeUInt16(protocolId);
+            writer.writeUInt16(vendorId);
         }
+        writer.writeUInt16(protocolId & 0xffff);
         if (ackedMessageCounter !== undefined) writer.writeUInt32(ackedMessageCounter);
         return writer.toByteArray();
     }

--- a/packages/protocol/test/codec/MessageCodecTest.ts
+++ b/packages/protocol/test/codec/MessageCodecTest.ts
@@ -233,6 +233,24 @@ describe("MessageCodec", () => {
             expect(result).deep.equal(ENCODED_2);
         });
 
+        it("writes vendor id before protocol id and round-trips (§4.4.3.4)", () => {
+            const message = {
+                ...DECODED,
+                payloadHeader: { ...DECODED.payloadHeader, protocolId: 0xfff11234 },
+            } as Message;
+
+            const { applicationPayload } = MessageCodec.encodePayload(message);
+
+            // flags[0] type[1] exchangeId[2..3] vendorId[4..5] protocolId[6..7], all little-endian.
+            // Vendor id has its high bit set to also guard decode against sign-extension.
+            expect(Bytes.toHex(Bytes.of(applicationPayload).slice(4, 8))).equals("f1ff3412");
+
+            const decoded = MessageCodec.decodePayload(
+                MessageCodec.decodePacket(MessageCodec.encodePacket(MessageCodec.encodePayload(message))),
+            );
+            expect(decoded.payloadHeader.protocolId).equals(0xfff11234);
+        });
+
         it("throws when encoding a message with securityExtensions data", () => {
             expect(() =>
                 MessageCodec.encodePayload({


### PR DESCRIPTION
## Problem

`encodePayloadHeader` wrote the 32-bit Vendor ID / Protocol ID field of the message payload header via a single little-endian `writeUInt32((vendorId << 16) | protocolId)`. On the wire this places the **Protocol ID bytes before the Vendor ID** — reversed from spec §4.4.3.4 / Table 9 (Vendor ID first), from `decodePayloadHeader` (reads Vendor ID then Protocol ID), and from CHIP (writes two separate 16-bit values).

While reviewing the fix, a related latent bug surfaced in the decode path: `protocolId = (vendorId << 16) | reader.readUInt16()` sign-extends for Vendor IDs ≥ `0x8000`, yielding a negative `protocolId`.

Both are **latent** — no matter.js protocol currently uses a non-zero vendor Protocol ID, so neither triggers in practice.

## Fix

- Encode: write Vendor ID (16b) then Protocol ID (16b) as two values, matching decode + spec + CHIP. The `COMMON_VENDOR_ID` (0) path still writes only the 16-bit Protocol ID.
- Decode: reconstruct `protocolId` with unsigned arithmetic (`vendorId * 0x10000 + low16`) so high Vendor IDs no longer sign-extend.

## Test

New `MessageCodecTest` case asserts the wire byte order and a full encode→decode round-trip using vendor id `0xfff1` (high bit set), covering both the ordering fix and the decode sign case. Verified it fails on the old code.

Gates: `@matter/protocol` 1224/1224, format, lint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)