### PR TITLE
fix(node): exclude client clusters from the server protocol view so they are not invocable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,12 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Aligned Thermostat atomic-write handling with the Matter specification
     - Enhancement: Free a behavior's persisted seed values from memory once the datasource has loaded them
     - Fix: A peer's mDNS advertisement at the 1-hour SII/SAI cap no longer lowers a higher CASE-negotiated idle/active interval already on record
-    - Fix: Ensure that a peer's FeatureMap change rebuilds the affected client cluster behavior
+    - Fix: Ensures that a peer's FeatureMap change rebuilds the affected client cluster behavior
     - Fix: A peer reporting an empty AttributeList no longer breaks client cluster schema generation; the discovered schema falls back to the attributes actually received
-    - Fix: Ensure to always sanitize fabric-scoped attribute data (e.g. stale AccessControl ACL entries) at node startup
+    - Fix: Ensures to always sanitize fabric-scoped attribute data (e.g. stale AccessControl ACL entries) at node startup
     - Fix: A misconfigured environment/configuration value for a behavior (unknown property or unconvertible value) is now logged and skipped instead of crashing endpoint initialization
     - Fix: An invoke with SuppressResponse still returns the Invoke Response when a command produces response data, instead of suppressing it unconditionally
+    - Fix: Ensures that client clusters are never exposed to incoming interactions
 
 - @matter/nodejs
     - Fix: On `process.exit`, verifies all storages were properly closed and removes orphaned lock files otherwise, so a forgotten close no longer blocks the next startup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A peer's mDNS advertisement at the 1-hour SII/SAI cap no longer lowers a higher CASE-negotiated idle/active interval already on record
     - Fix: Ensures that a peer's FeatureMap change rebuilds the affected client cluster behavior
     - Fix: A peer reporting an empty AttributeList no longer breaks client cluster schema generation; the discovered schema falls back to the attributes actually received
-    - Fix: Ensures to always sanitize fabric-scoped attribute data (e.g. stale AccessControl ACL entries) at node startup
+    - Fix: Ensures that fabric-scoped attribute data (e.g. stale AccessControl ACL entries) is always sanitized at node startup
     - Fix: A misconfigured environment/configuration value for a behavior (unknown property or unconvertible value) is now logged and skipped instead of crashing endpoint initialization
     - Fix: An invoke with SuppressResponse still returns the Invoke Response when a command produces response data, instead of suppressing it unconditionally
     - Fix: Ensures that client clusters are never exposed to incoming interactions

--- a/packages/node/src/node/integration/ProtocolService.ts
+++ b/packages/node/src/node/integration/ProtocolService.ts
@@ -75,8 +75,9 @@ const logger = Logger.get("ProtocolService");
  *
  * This service maintains an optimized {@link NodeProtocol} that maps to the state of a {@link Node}.
  *
- * The protocol view only contains endpoints and clusters with active backings.  {@link Behaviors} conveys backing
- * state via the public interface.
+ * The protocol view only contains endpoints and server clusters with active backings; client clusters are excluded
+ * as they are not part of the node's server-facing data model.  {@link Behaviors} conveys backing state via the
+ * public interface.
  */
 export class ProtocolService {
     readonly #state: NodeState;

--- a/packages/node/src/node/integration/ProtocolService.ts
+++ b/packages/node/src/node/integration/ProtocolService.ts
@@ -6,6 +6,7 @@
 
 import type { Behavior } from "#behavior/Behavior.js";
 import { ClusterBehavior } from "#behavior/cluster/ClusterBehavior.js";
+import { isClientBehavior } from "#behavior/cluster/cluster-behavior-utils.js";
 import { ActionContext } from "#behavior/context/ActionContext.js";
 import { LocalActorContext } from "#behavior/context/server/LocalActorContext.js";
 import type { BehaviorBacking } from "#behavior/internal/BehaviorBacking.js";
@@ -90,6 +91,11 @@ export class ProtocolService {
     addCluster(backing: BehaviorBacking) {
         const { schema } = backing.type;
         if (schema?.tag !== ElementTag.Cluster || schema.id === undefined) {
+            return;
+        }
+
+        // Client clusters are not server-facing and must not be exposed to incoming interactions.
+        if (isClientBehavior(backing.type)) {
             return;
         }
 

--- a/packages/node/test/node/CommandInvokeResponseTest.ts
+++ b/packages/node/test/node/CommandInvokeResponseTest.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { ClientBehavior } from "#behavior/cluster/ClientBehavior.js";
+import { OnOffClient } from "#behaviors/on-off";
 import { OnOffLightDevice } from "#devices/on-off-light";
 import { Endpoint } from "#endpoint/index.js";
 import { AccessLevel } from "@matter/model";
@@ -170,6 +172,74 @@ describe("CommandInvokeResponse", () => {
             },
         ]);
         expect(response.counts).deep.equals({ status: 1, success: 0, existent: 0 });
+    });
+
+    // §8.8.2.3: an invoke path must indicate a server cluster, so a client cluster must yield UNSUPPORTED_CLUSTER.
+    // Covered for both ways a client cluster can be added.
+    it("does not invoke a command on a client cluster declared via withClientClusters", async () => {
+        const node = await MockServerNode.createOnline(MockServerNode.RootEndpoint.withClientClusters(OnOffClient));
+        try {
+            const response = await invokeCmdRawAs(node, AccessLevel.Operate, {
+                invokeRequests: [
+                    {
+                        commandPath: {
+                            endpointId: EndpointNumber(0),
+                            clusterId: ClusterId(6),
+                            commandId: CommandId(1),
+                        },
+                        commandFields: undefined,
+                    },
+                ],
+            });
+
+            expect(response.data).deep.equals([
+                {
+                    kind: "cmd-status",
+                    path: { clusterId: 6, commandId: 1, endpointId: 0 },
+                    status: Status.UnsupportedCluster,
+                    clusterStatus: undefined,
+                    commandRef: undefined,
+                },
+            ]);
+            expect(response.counts).deep.equals({ status: 1, success: 0, existent: 0 });
+        } finally {
+            await node.close();
+        }
+    });
+
+    // `require` injects the client behavior as a backing, which previously made it invocable.
+    it("does not invoke a command on a client cluster added via require", async () => {
+        const node = await MockServerNode.createOnline();
+        try {
+            // Fresh instance so the require does not mutate the shared OnOffClient singleton.
+            node.behaviors.require(ClientBehavior(OnOff));
+
+            const response = await invokeCmdRawAs(node, AccessLevel.Operate, {
+                invokeRequests: [
+                    {
+                        commandPath: {
+                            endpointId: EndpointNumber(0),
+                            clusterId: ClusterId(6),
+                            commandId: CommandId(1),
+                        },
+                        commandFields: undefined,
+                    },
+                ],
+            });
+
+            expect(response.data).deep.equals([
+                {
+                    kind: "cmd-status",
+                    path: { clusterId: 6, commandId: 1, endpointId: 0 },
+                    status: Status.UnsupportedCluster,
+                    clusterStatus: undefined,
+                    commandRef: undefined,
+                },
+            ]);
+            expect(response.counts).deep.equals({ status: 1, success: 0, existent: 0 });
+        } finally {
+            await node.close();
+        }
     });
 
     // TODO - more tests and Migrate some from InteractionProtocolTest


### PR DESCRIPTION
## Problem
Matter §8.8.2.3 requires an invoke command path to indicate a **server** cluster. Client clusters declared via `withClientClusters` were already kept out of the node's server-facing protocol view — but a client behavior injected via `behaviors.require(...)` entered it and became resolvable. Invoking its command then dispatched to the client behavior (which has no server handler) and returned a generic **Failure** instead of `UNSUPPORTED_CLUSTER`. The same exposure applied to reads/subscribes.

## Fix
`ProtocolService.addCluster` now early-returns when `isClientBehavior(backing.type)`, so client clusters never enter the protocol view and all incoming interactions (invoke/read/subscribe) treat them as absent → `UNSUPPORTED_CLUSTER`.

## Testing
Both ways a client cluster can be added, in `CommandInvokeResponseTest`:
- **`withClientClusters`** (official declaration) — already safe; regression guard.
- **`require`** (was the bug) — uses a fresh `ClientBehavior(OnOff)` to avoid mutating the shared singleton; verified RED without the fix (returned Failure 129) → GREEN with it.

node 1225/1225, format + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)