### PR TITLE
fix(types): honor §7.19.2.40 Information Separator 1 (0x1F) in TLV character strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A stray StatusReport arriving as an exchange's initial message (e.g. a retransmitted CASE/PASE completion) is now ignored instead of logging an "Unhandled error"
     - Fix: The BLE Extended-Announcement flag is only set during the extended-announcement period, no longer when private details are omitted outside that window
 
+- @matter/types
+    - Fix: TLV character strings are truncated at the first Information Separator 1 (0x1F) on decode, and a character string containing IS1 is rejected on validation
+
 - @project-chip/matter.js
     - Fix: `PairedNode.connect()` now applies the subscription interval options passed to it, instead of ignoring them
 

--- a/packages/types/src/tlv/TlvString.ts
+++ b/packages/types/src/tlv/TlvString.ts
@@ -24,6 +24,13 @@ const stringBoundCache = new WeakMap<StringSchema<any>, Map<string, StringSchema
 
 const DEFAULT_MAX_STRING_LENGTH = 65_536;
 
+/**
+ * Unicode `INFORMATION SEPARATOR 1` / ASCII `Unit Separator`. Per {@link MatterSpecification.v16.Core} § 7.19.2.40,
+ * only the code points before the first IS1 are the textual content of a character string, and conformant
+ * implementations never emit IS1.
+ */
+const INFORMATION_SEPARATOR_1 = "\u001f";
+
 export class StringSchema<T extends TlvType.ByteString | TlvType.Utf8String> extends TlvSchema<TlvToPrimitive[T]> {
     constructor(
         readonly type: T,
@@ -49,7 +56,18 @@ export class StringSchema<T extends TlvType.ByteString | TlvType.Utf8String> ext
 
     override decodeTlvInternalValue(reader: TlvReader, typeLength: TlvTypeLength): TlvToPrimitive[T] {
         if (typeLength.type !== this.type) throw new UnexpectedDataError(`Unexpected type ${typeLength.type}.`);
-        return reader.readPrimitive(typeLength);
+        const value: TlvToPrimitive[T] = reader.readPrimitive(typeLength);
+        if (this.type === TlvType.Utf8String && typeof value === "string") {
+            const separatorIndex = value.indexOf(INFORMATION_SEPARATOR_1);
+            if (separatorIndex !== -1) {
+                if (value.length > this.maxLength)
+                    throw new ValidationOutOfBoundsError(
+                        `String ${serialize(value)} is too long: ${value.length}, max ${this.maxLength}.`,
+                    );
+                return value.slice(0, separatorIndex) as TlvToPrimitive[T];
+            }
+        }
+        return value;
     }
 
     override validate(value: TlvToPrimitive[T]): void {
@@ -57,6 +75,10 @@ export class StringSchema<T extends TlvType.ByteString | TlvType.Utf8String> ext
             throw new ValidationDatatypeMismatchError(`Expected string, got ${typeof value}.`);
         if (this.type === TlvType.ByteString && !Bytes.isBytes(value))
             throw new ValidationDatatypeMismatchError(`Expected bytes, got ${typeof value}.`);
+        if (this.type === TlvType.Utf8String && typeof value === "string" && value.includes(INFORMATION_SEPARATOR_1))
+            throw new ValidationDatatypeMismatchError(
+                "Character string must not contain Information Separator 1 (0x1F).",
+            );
         const length = typeof value === "string" ? value.length : value.byteLength;
         if (length > this.maxLength)
             throw new ValidationOutOfBoundsError(

--- a/packages/types/test/tlv/TlvStringTest.ts
+++ b/packages/types/test/tlv/TlvStringTest.ts
@@ -50,6 +50,24 @@ describe("TlvString", () => {
 
             expect(result).equal("testè");
         });
+
+        it("truncates a character string at the first Information Separator 1 (0x1F)", () => {
+            const result = TlvString.decode(Bytes.fromHex("0c0561621f6364"));
+
+            expect(result).equal("ab");
+        });
+
+        it("returns an empty string when Information Separator 1 (0x1F) is the first code point", () => {
+            const result = TlvString.decode(Bytes.fromHex("0c031f6364"));
+
+            expect(result).equal("");
+        });
+
+        it("enforces maxLength against the raw on-wire string, not the truncated prefix", () => {
+            const Bounded = TlvString.bound({ maxLength: 4 });
+
+            expect(() => Bounded.decode(Bytes.fromHex("0c0661621f636465"))).throw(ValidationError, "too long");
+        });
     });
 
     describe("calculate byte size", () => {
@@ -96,6 +114,12 @@ describe("TlvByteString", () => {
 
             expect(Bytes.toHex(result)).equal("0001");
         });
+
+        it("does not truncate a byte string at 0x1F (IS1 rule is character-string only)", () => {
+            const result = TlvByteString.decode(Bytes.fromHex("1003001f02"));
+
+            expect(Bytes.toHex(result)).equal("001f02");
+        });
     });
 
     describe("validate ByteString", () => {
@@ -121,6 +145,17 @@ describe("TlvByteString", () => {
 
         it("throws an error if the value is not a String", () => {
             expect(() => TlvString.validate(true as any)).throw(ValidationError, "Expected string, got boolean.");
+        });
+
+        it("throws an error if a character string contains Information Separator 1 (0x1F)", () => {
+            expect(() => TlvString.validate("ab\u001fcd")).throw(
+                ValidationError,
+                "Character string must not contain Information Separator 1 (0x1F).",
+            );
+        });
+
+        it("does not reject a byte string containing 0x1F", () => {
+            expect(() => TlvByteString.validate(Bytes.fromHex("001f02"))).not.throw();
         });
     });
 });


### PR DESCRIPTION
## Summary

Implements the Matter spec §7.19.2.40 (Character String Type) Information Separator 1 (0x1F) rule, previously absent in matter.js (CHIP implements it).

Per spec: a client SHALL consider only the code points before the first IS1 as the textual content of a character string, comparisons SHALL use that prefix, and conformant implementations SHALL NOT produce strings containing IS1.

## Changes (`packages/types/src/tlv/TlvString.ts`)

- **decode**: a `Utf8String` is truncated at the first IS1 (0x1F). `ByteString` is left untouched (the rule is character-string-only). Truncating at decode satisfies both the interpretation and the comparison SHALLs at once — the stored value is already the textual prefix, so attribute change-detection compares prefixes for free.
- **validate**: a `Utf8String` containing IS1 is rejected with `ValidationDatatypeMismatchError` (covers attribute-write / command-argument paths). Encoding is otherwise untouched.

No LSID (Localized String Identifier) feature exists in matter.js, and the spec marks the post-IS1 remainder as reserved for future use, so discarding it on decode is safe today.

## Severity

Low — not a wire interop break: both stacks transmit identical octets, and conformant peers never emit IS1. The gap was matter.js, as a client, failing to truncate a non-conformant/future peer's IS1-bearing string.

## Tests

New cases in `TlvStringTest.ts`: decode truncation, IS1-first → empty string, ByteString not truncated, validate rejects IS1, ByteString with 0x1F accepted. Gates green (types 334/334, protocol 1223/1223, node 1214/1214), format + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)