### PR TITLE
fix(node): forward conformance violations on peer writes instead of rejecting locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ The main work (all changes without a GitHub username in brackets in the below li
 ## __WORK IN PROGRESS__
 
 - @matter/node
-    - Enhancement: Free a behavior's persisted seed values from memory once the datasource has loaded them
-    - Adjustment: Reject an invalid Basic Information VendorID (0 or above 0xFFF4) or ProductID (0) as a device identity
+    - Enhancement: Frees a behavior's persisted seed values from memory once the datasource has loaded them
+    - Adjustment: Rejects an invalid Basic Information VendorID (0 or above 0xFFF4) or ProductID (0) as a device identity
+    - Adjustment: A client write to a peer no longer rejects conformance violations locally; the value is forwarded so the device decides, while value-range and datatype errors still fail fast
     - Fix: A peer's mDNS advertisement at the 1-hour SII/SAI cap no longer lowers a higher CASE-negotiated idle/active interval already on record
     - Fix: Ensures that a peer's FeatureMap change rebuilds the affected client cluster behavior
     - Fix: A peer reporting an empty AttributeList no longer breaks client cluster schema generation; the discovered schema falls back to the attributes actually received
@@ -22,7 +23,6 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: An invoke with SuppressResponse still returns the Invoke Response when a command produces response data, instead of suppressing it unconditionally
     - Fix: Aligned Thermostat atomic-write handling with the Matter specification
     - Fix: Ensures that client clusters are never exposed to incoming interactions
-    - Fix: A controller write to a peer no longer rejects conformance violations locally; the value is forwarded so the device decides (e.g. setting FanMode.Auto on a fan that omits the AUT feature), while value-range and datatype errors still fail fast
 
 - @matter/nodejs
     - Fix: On `process.exit`, verifies all storages were properly closed and removes orphaned lock files otherwise, so a forgotten close no longer blocks the next startup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A misconfigured environment/configuration value for a behavior (unknown property or unconvertible value) is now logged and skipped instead of crashing endpoint initialization
     - Fix: An invoke with SuppressResponse still returns the Invoke Response when a command produces response data, instead of suppressing it unconditionally
     - Fix: Ensures that client clusters are never exposed to incoming interactions
+    - Fix: A controller write to a peer no longer rejects conformance violations locally; the value is forwarded so the device decides (e.g. setting FanMode.Auto on a fan that omits the AUT feature), while value-range and datatype errors still fail fast
 
 - @matter/nodejs
     - Fix: On `process.exit`, verifies all storages were properly closed and removes orphaned lock files otherwise, so a forgotten close no longer blocks the next startup

--- a/packages/node/src/behavior/state/validation/ValueValidator.ts
+++ b/packages/node/src/behavior/state/validation/ValueValidator.ts
@@ -32,10 +32,9 @@ import { forwardValidationToPeer } from "./peer-forwarding.js";
 const logger = Logger.get("ValueValidator");
 
 /**
- * Wrap a datatype validator so that writes to peer (client) nodes forward CONSTRAINT_ERROR-coded datatype violations
- * (reserved bitmap bits, undefined enum values) to the device rather than rejecting locally.  Value-range and structural
- * datatype errors still throw.  Conformance violations are forwarded separately in {@link createConformanceValidator} so
- * that datatype validation still runs after a forwarded conformance failure.  Server (non-peer) writes are unaffected.
+ * Wrap a datatype validator so peer (client) writes forward datatype violations the device may still accept (see
+ * {@link forwardValidationToPeer}).  Conformance violations are forwarded separately in {@link createConformanceValidator}
+ * so that datatype validation still runs after a forwarded conformance failure.
  */
 function forwardableForClientPeer(inner: ValueSupervisor.Validate): ValueSupervisor.Validate {
     return (value, session, location) => {

--- a/packages/node/src/behavior/state/validation/ValueValidator.ts
+++ b/packages/node/src/behavior/state/validation/ValueValidator.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { camelize, Diagnostic, InternalError, Logger } from "@matter/general";
+import { camelize, InternalError, Logger } from "@matter/general";
 import type { Schema } from "@matter/model";
 import { AttributeModel, ClusterModel, DataModelPath, FeatureMap, Metatype, ValueModel } from "@matter/model";
 import { ConformanceError, DatatypeError, SchemaImplementationError, Val } from "@matter/protocol";
@@ -27,30 +27,24 @@ import { createConformanceValidator } from "./conformance.js";
 import { createConstraintValidator } from "./constraint.js";
 import { isFabricIndexSentinel } from "./FabricIndexSentinel.js";
 import { ValidationLocation } from "./location.js";
+import { forwardValidationToPeer } from "./peer-forwarding.js";
 
 const logger = Logger.get("ValueValidator");
 
 /**
- * Wrap a validator so that writes to peer (client) nodes forward conformance violations to the device rather than
- * rejecting locally.  The peer is the authority on what it accepts; a non-conformant FeatureMap (e.g. a fan that
- * supports Auto without advertising the AUT feature) must not block an otherwise-valid write.  Value-range constraints
- * and structural datatype errors still throw because they are caller bugs or cannot be encoded for the wire.  Server
- * (non-peer) writes are unaffected.
+ * Wrap a datatype validator so that writes to peer (client) nodes forward CONSTRAINT_ERROR-coded datatype violations
+ * (reserved bitmap bits, undefined enum values) to the device rather than rejecting locally.  Value-range and structural
+ * datatype errors still throw.  Conformance violations are forwarded separately in {@link createConformanceValidator} so
+ * that datatype validation still runs after a forwarded conformance failure.  Server (non-peer) writes are unaffected.
  */
 function forwardableForClientPeer(inner: ValueSupervisor.Validate): ValueSupervisor.Validate {
     return (value, session, location) => {
         try {
             inner(value, session, location);
         } catch (e) {
-            const forwardable =
-                e instanceof ConformanceError || (e instanceof DatatypeError && e.code === Status.ConstraintError);
-            if (session.clientPeerContext === undefined || !forwardable) {
+            if (!forwardValidationToPeer(session, e)) {
                 throw e;
             }
-            logger.notice(
-                "Forwarding non-conformant write to peer; the device may reject it:",
-                Diagnostic.errorMessage(e),
-            );
         }
     };
 }
@@ -134,9 +128,11 @@ export function ValueValidator(schema: Schema, supervisor: RootSupervisor): Valu
 
     validator = createNullValidator(schema, validator);
 
+    validator = validator && forwardableForClientPeer(validator);
+
     validator = createConformanceValidator(schema, supervisor, validator);
 
-    return validator && forwardableForClientPeer(validator);
+    return validator;
 }
 
 function createNullValidator(

--- a/packages/node/src/behavior/state/validation/ValueValidator.ts
+++ b/packages/node/src/behavior/state/validation/ValueValidator.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { camelize, InternalError, Logger } from "@matter/general";
+import { camelize, Diagnostic, InternalError, Logger } from "@matter/general";
 import type { Schema } from "@matter/model";
 import { AttributeModel, ClusterModel, DataModelPath, FeatureMap, Metatype, ValueModel } from "@matter/model";
 import { ConformanceError, DatatypeError, SchemaImplementationError, Val } from "@matter/protocol";
@@ -31,6 +31,31 @@ import { ValidationLocation } from "./location.js";
 const logger = Logger.get("ValueValidator");
 
 /**
+ * Wrap a validator so that writes to peer (client) nodes forward conformance violations to the device rather than
+ * rejecting locally.  The peer is the authority on what it accepts; a non-conformant FeatureMap (e.g. a fan that
+ * supports Auto without advertising the AUT feature) must not block an otherwise-valid write.  Value-range constraints
+ * and structural datatype errors still throw because they are caller bugs or cannot be encoded for the wire.  Server
+ * (non-peer) writes are unaffected.
+ */
+function forwardableForClientPeer(inner: ValueSupervisor.Validate): ValueSupervisor.Validate {
+    return (value, session, location) => {
+        try {
+            inner(value, session, location);
+        } catch (e) {
+            const forwardable =
+                e instanceof ConformanceError || (e instanceof DatatypeError && e.code === Status.ConstraintError);
+            if (session.clientPeerContext === undefined || !forwardable) {
+                throw e;
+            }
+            logger.notice(
+                "Forwarding non-conformant write to peer; the device may reject it:",
+                Diagnostic.errorMessage(e),
+            );
+        }
+    };
+}
+
+/**
  * Generate a function that performs data validation.
  *
  * @param schema the schema against which we validate
@@ -38,7 +63,7 @@ const logger = Logger.get("ValueValidator");
  */
 export function ValueValidator(schema: Schema, supervisor: RootSupervisor): ValueSupervisor.Validate | undefined {
     if (schema instanceof ClusterModel) {
-        return createStructValidator(schema, supervisor);
+        return forwardableForClientPeer(createStructValidator(schema, supervisor));
     }
 
     let validator: ValueSupervisor.Validate | undefined;
@@ -111,7 +136,7 @@ export function ValueValidator(schema: Schema, supervisor: RootSupervisor): Valu
 
     validator = createConformanceValidator(schema, supervisor, validator);
 
-    return validator;
+    return validator && forwardableForClientPeer(validator);
 }
 
 function createNullValidator(

--- a/packages/node/src/behavior/state/validation/ValueValidator.ts
+++ b/packages/node/src/behavior/state/validation/ValueValidator.ts
@@ -223,13 +223,9 @@ function createBitmapValidator(schema: ValueModel, supervisor: RootSupervisor): 
     return (value, _session, location) => {
         assertObject(value, location);
 
-        if (definedMask !== undefined) {
-            const encoded = (value as Record<symbol, unknown>)[BitmapEncodedValue];
-            if (typeof encoded === "number" && (encoded & ~definedMask) >>> 0 !== 0) {
-                throw new DatatypeError(location, "free of reserved bits", encoded, Status.ConstraintError);
-            }
-        }
-
+        // Structural per-field checks run before the reserved-bit check below: the latter is CONSTRAINT_ERROR-coded and
+        // therefore forwarded for peer writes, so it must come last or a forwarded reserved-bit failure would skip the
+        // structural validation that must always fail fast.
         for (const key in value) {
             const field = fields[key];
             const subpath = location.path.at(key);
@@ -251,6 +247,13 @@ function createBitmapValidator(schema: ValueModel, supervisor: RootSupervisor): 
                 if (fieldValue > field.max) {
                     throw new DatatypeError(subpath, "in range of bit field", fieldValue);
                 }
+            }
+        }
+
+        if (definedMask !== undefined) {
+            const encoded = (value as Record<symbol, unknown>)[BitmapEncodedValue];
+            if (typeof encoded === "number" && (encoded & ~definedMask) >>> 0 !== 0) {
+                throw new DatatypeError(location, "free of reserved bits", encoded, Status.ConstraintError);
             }
         }
     };

--- a/packages/node/src/behavior/state/validation/conformance.ts
+++ b/packages/node/src/behavior/state/validation/conformance.ts
@@ -8,6 +8,7 @@ import { RootSupervisor } from "#behavior/supervision/RootSupervisor.js";
 import { ValueModel } from "@matter/model";
 import { ValueSupervisor } from "../../supervision/ValueSupervisor.js";
 import { astToFunction } from "./conformance-compiler.js";
+import { forwardValidationToPeer } from "./peer-forwarding.js";
 
 /**
  * Creates a function that validates a field based on its conformance definition.
@@ -36,7 +37,15 @@ export function createConformanceValidator(
         }
 
         if (cfg?.conformance !== false) {
-            validate?.(value, session, location);
+            try {
+                validate?.(value, session, location);
+            } catch (e) {
+                // For peer writes a forwarded conformance failure must still fall through to datatype validation below,
+                // so a wrong-typed value cannot slip onto the wire.
+                if (!forwardValidationToPeer(session, e)) {
+                    throw e;
+                }
+            }
         }
 
         if (value !== undefined) {

--- a/packages/node/src/behavior/state/validation/peer-forwarding.ts
+++ b/packages/node/src/behavior/state/validation/peer-forwarding.ts
@@ -5,7 +5,7 @@
  */
 
 import { Diagnostic, Logger } from "@matter/general";
-import { ConformanceError, DatatypeError } from "@matter/protocol";
+import { ConformanceError, DatatypeError, UnknownEnumValueError } from "@matter/protocol";
 import { Status } from "@matter/types";
 import type { ValueSupervisor } from "../../supervision/ValueSupervisor.js";
 
@@ -13,10 +13,13 @@ const logger = Logger.get("ValueValidator");
 
 /**
  * Decide whether a validation error on a write to a peer (client) node should be forwarded to the device rather than
- * rejected locally.  The peer is the authority on what it accepts, so conformance violations (and reserved bitmap bits /
- * undefined enum values, both CONSTRAINT_ERROR-coded datatype errors) are sent on for the device to adjudicate; the
- * local mirror compensates if the device rejects.  Value-range constraints and structural datatype errors stay local:
- * they are caller bugs or cannot be encoded for the wire.
+ * rejected locally.  The peer is the authority on what it accepts, so conformance violations and values the local model
+ * cannot vouch for (undefined enum values, reserved bitmap bits) are sent on for the device to adjudicate; the local
+ * mirror compensates if the device rejects.  Value-range constraints and structural datatype errors stay local: they
+ * are caller bugs or cannot be encoded for the wire.
+ *
+ * Only outbound writes reach here: inbound peer reports bypass validation entirely (Datasource.integrateExternalChange),
+ * so the broader presence of clientPeerContext on any client-node act() does not cause inbound data to be swallowed.
  *
  * Returns true if the error was forwarded (and logged); false if the caller should rethrow.
  */
@@ -24,15 +27,21 @@ export function forwardValidationToPeer(session: ValueSupervisor.Session, error:
     if (session.clientPeerContext === undefined) {
         return false;
     }
+
+    // Reserved-bit and undefined-enum violations are the only ConstraintError-coded DatatypeErrors; structural type
+    // mismatches are InvalidDataType-coded and value-range errors are ConstraintError/IntegerRangeError (not
+    // DatatypeError), so both correctly fall through to a rethrow.
     if (
         error instanceof ConformanceError ||
+        error instanceof UnknownEnumValueError ||
         (error instanceof DatatypeError && error.code === Status.ConstraintError)
     ) {
-        logger.notice(
+        logger.debug(
             "Forwarding non-conformant write to peer; the device may reject it:",
             Diagnostic.errorMessage(error),
         );
         return true;
     }
+
     return false;
 }

--- a/packages/node/src/behavior/state/validation/peer-forwarding.ts
+++ b/packages/node/src/behavior/state/validation/peer-forwarding.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Diagnostic, Logger } from "@matter/general";
+import { ConformanceError, DatatypeError } from "@matter/protocol";
+import { Status } from "@matter/types";
+import type { ValueSupervisor } from "../../supervision/ValueSupervisor.js";
+
+const logger = Logger.get("ValueValidator");
+
+/**
+ * Decide whether a validation error on a write to a peer (client) node should be forwarded to the device rather than
+ * rejected locally.  The peer is the authority on what it accepts, so conformance violations (and reserved bitmap bits /
+ * undefined enum values, both CONSTRAINT_ERROR-coded datatype errors) are sent on for the device to adjudicate; the
+ * local mirror compensates if the device rejects.  Value-range constraints and structural datatype errors stay local:
+ * they are caller bugs or cannot be encoded for the wire.
+ *
+ * Returns true if the error was forwarded (and logged); false if the caller should rethrow.
+ */
+export function forwardValidationToPeer(session: ValueSupervisor.Session, error: unknown): boolean {
+    if (session.clientPeerContext === undefined) {
+        return false;
+    }
+    if (
+        error instanceof ConformanceError ||
+        (error instanceof DatatypeError && error.code === Status.ConstraintError)
+    ) {
+        logger.notice(
+            "Forwarding non-conformant write to peer; the device may reject it:",
+            Diagnostic.errorMessage(error),
+        );
+        return true;
+    }
+    return false;
+}

--- a/packages/node/test/behavior/state/validation/ValueValidatorTest.ts
+++ b/packages/node/test/behavior/state/validation/ValueValidatorTest.ts
@@ -14,7 +14,7 @@ import {
     FieldElement as Field,
     FieldModel,
 } from "@matter/model";
-import { DatatypeError, EnumValueConformanceError, IntegerRangeError, Val } from "@matter/protocol";
+import { ConformanceError, DatatypeError, EnumValueConformanceError, IntegerRangeError, Val } from "@matter/protocol";
 import { BitmapEncodedValue } from "@matter/types";
 
 describe("ValueValidator", () => {
@@ -86,6 +86,17 @@ describe("ValueValidator", () => {
         const enumValidator = RootSupervisor.for(enumCluster).get(enumCluster).validate!;
         const enumPath = { path: new DataModelPath(enumCluster.path) };
 
+        // Attribute whose presence is gated by an unsupported feature, so writing it at all is non-conformant.  Used to
+        // prove datatype validation still runs after a forwarded conformance failure.
+        const gatedFeatureMap = FeatureMap.clone();
+        gatedFeatureMap.children = [new FieldModel({ name: "FT", title: "Feature", constraint: "0" })];
+        const gatedCluster = new ClusterModel({
+            name: "Test",
+            children: [gatedFeatureMap, new AttributeModel({ id: 0, name: "Gated", type: "uint8", conformance: "FT" })],
+        });
+        const gatedValidator = RootSupervisor.for(gatedCluster).get(gatedCluster).validate!;
+        const gatedPath = { path: new DataModelPath(gatedCluster.path) };
+
         // Bitmap with a reserved gap (bit 3) and reserved high bit (bit 7).
         const bitmapSchema = new AttributeModel(
             { id: 1, name: "TestBitmap", type: "map8" },
@@ -129,6 +140,18 @@ describe("ValueValidator", () => {
 
         it("still rejects a value-range constraint on a client peer write", () => {
             expect(() => intValidator(0x1ff, peer, intPath)).throws(IntegerRangeError);
+        });
+
+        it("rejects a feature-disallowed attribute on a server write", () => {
+            expect(() => gatedValidator({ gated: 5 }, server, gatedPath)).throws(ConformanceError);
+        });
+
+        it("forwards a feature-disallowed attribute with a valid value on a client peer write", () => {
+            expect(() => gatedValidator({ gated: 5 }, peer, gatedPath)).not.throws();
+        });
+
+        it("still validates datatype when a forwarded conformance failure would otherwise skip it", () => {
+            expect(() => gatedValidator({ gated: "nope" }, peer, gatedPath)).throws(DatatypeError);
         });
     });
 });

--- a/packages/node/test/behavior/state/validation/ValueValidatorTest.ts
+++ b/packages/node/test/behavior/state/validation/ValueValidatorTest.ts
@@ -6,8 +6,15 @@
 
 import { RootSupervisor } from "#behavior/supervision/RootSupervisor.js";
 import { ValueSupervisor } from "#behavior/supervision/ValueSupervisor.js";
-import { AttributeModel, DataModelPath, FieldElement as Field, FieldModel } from "@matter/model";
-import { DatatypeError, IntegerRangeError, Val } from "@matter/protocol";
+import {
+    AttributeModel,
+    ClusterModel,
+    DataModelPath,
+    FeatureMap,
+    FieldElement as Field,
+    FieldModel,
+} from "@matter/model";
+import { DatatypeError, EnumValueConformanceError, IntegerRangeError, Val } from "@matter/protocol";
 import { BitmapEncodedValue } from "@matter/types";
 
 describe("ValueValidator", () => {
@@ -57,6 +64,71 @@ describe("ValueValidator", () => {
                     path: new DataModelPath(schema.path),
                 }),
             ).not.throws();
+        });
+    });
+
+    describe("client peer leniency", () => {
+        // Enum value gated by an unsupported feature, mirroring FanControl FanMode=Auto(5) with conformance "AUT"
+        // when the peer reports FeatureMap=0 (the SwitchBot air purifier case).
+        const featureMap = FeatureMap.clone();
+        featureMap.children = [new FieldModel({ name: "FT", title: "Feature", constraint: "0" })];
+        const enumCluster = new ClusterModel({
+            name: "Test",
+            children: [
+                featureMap,
+                new AttributeModel(
+                    { id: 0, name: "Test", type: "enum8" },
+                    Field({ id: 1, name: "plain" }),
+                    Field({ id: 4, name: "ifFeature", conformance: "FT" }),
+                ),
+            ],
+        });
+        const enumValidator = RootSupervisor.for(enumCluster).get(enumCluster).validate!;
+        const enumPath = { path: new DataModelPath(enumCluster.path) };
+
+        // Bitmap with a reserved gap (bit 3) and reserved high bit (bit 7).
+        const bitmapSchema = new AttributeModel(
+            { id: 1, name: "TestBitmap", type: "map8" },
+            Field({ name: "multiA", constraint: "0 to 2" }),
+            Field({ name: "multiB", constraint: "4 to 6" }),
+        );
+        const bitmapValidator = RootSupervisor.for(bitmapSchema).validate!;
+        const bitmapPath = { path: new DataModelPath(bitmapSchema.path) };
+        function reservedBitmap() {
+            const value: Val.Struct = { multiA: 0, multiB: 0 };
+            Object.defineProperty(value, BitmapEncodedValue, { value: 0b1000_0000 });
+            return value;
+        }
+
+        const intSchema = new FieldModel({ name: "foo", type: "uint8" });
+        const intValidator = RootSupervisor.for(intSchema).validate!;
+        const intPath = { path: new DataModelPath(intSchema.path) };
+
+        const server = {} as ValueSupervisor.Session;
+        const peer = { clientPeerContext: {} } as ValueSupervisor.Session;
+
+        it("rejects a feature-gated enum value on a server write", () => {
+            expect(() => enumValidator({ test: 4 }, server, enumPath)).throws(EnumValueConformanceError);
+        });
+
+        it("forwards a feature-gated enum value on a client peer write", () => {
+            expect(() => enumValidator({ test: 4 }, peer, enumPath)).not.throws();
+        });
+
+        it("rejects reserved bitmap bits on a server write", () => {
+            expect(() => bitmapValidator(reservedBitmap(), server, bitmapPath)).throws(DatatypeError);
+        });
+
+        it("forwards reserved bitmap bits on a client peer write", () => {
+            expect(() => bitmapValidator(reservedBitmap(), peer, bitmapPath)).not.throws();
+        });
+
+        it("still rejects a wrong-datatype value on a client peer write", () => {
+            expect(() => intValidator("nope", peer, intPath)).throws(DatatypeError);
+        });
+
+        it("still rejects a value-range constraint on a client peer write", () => {
+            expect(() => intValidator(0x1ff, peer, intPath)).throws(IntegerRangeError);
         });
     });
 });

--- a/packages/node/test/behavior/state/validation/ValueValidatorTest.ts
+++ b/packages/node/test/behavior/state/validation/ValueValidatorTest.ts
@@ -14,7 +14,14 @@ import {
     FieldElement as Field,
     FieldModel,
 } from "@matter/model";
-import { ConformanceError, DatatypeError, EnumValueConformanceError, IntegerRangeError, Val } from "@matter/protocol";
+import {
+    ConformanceError,
+    DatatypeError,
+    EnumValueConformanceError,
+    IntegerRangeError,
+    UnknownEnumValueError,
+    Val,
+} from "@matter/protocol";
 import { BitmapEncodedValue } from "@matter/types";
 
 describe("ValueValidator", () => {
@@ -124,6 +131,14 @@ describe("ValueValidator", () => {
 
         it("forwards a feature-gated enum value on a client peer write", () => {
             expect(() => enumValidator({ test: 4 }, peer, enumPath)).not.throws();
+        });
+
+        it("rejects an undefined enum value on a server write", () => {
+            expect(() => enumValidator({ test: 99 }, server, enumPath)).throws(UnknownEnumValueError);
+        });
+
+        it("forwards an undefined enum value on a client peer write", () => {
+            expect(() => enumValidator({ test: 99 }, peer, enumPath)).not.throws();
         });
 
         it("rejects reserved bitmap bits on a server write", () => {

--- a/packages/node/test/behavior/state/validation/ValueValidatorTest.ts
+++ b/packages/node/test/behavior/state/validation/ValueValidatorTest.ts
@@ -16,6 +16,7 @@ import {
 } from "@matter/model";
 import {
     ConformanceError,
+    ConstraintError,
     DatatypeError,
     EnumValueConformanceError,
     IntegerRangeError,
@@ -122,6 +123,12 @@ describe("ValueValidator", () => {
         const intValidator = RootSupervisor.for(intSchema).validate!;
         const intPath = { path: new DataModelPath(intSchema.path) };
 
+        // Bounded integer: a value within the type but outside the schema constraint raises a ConstraintError (distinct
+        // from the IntegerRangeError raised by a type-width overflow); both must stay local.
+        const boundedIntSchema = new FieldModel({ name: "foo", type: "uint8", constraint: "0 to 10" });
+        const boundedIntValidator = RootSupervisor.for(boundedIntSchema).validate!;
+        const boundedIntPath = { path: new DataModelPath(boundedIntSchema.path) };
+
         const server = {} as ValueSupervisor.Session;
         const peer = { clientPeerContext: {} } as ValueSupervisor.Session;
 
@@ -162,6 +169,10 @@ describe("ValueValidator", () => {
 
         it("still rejects a value-range constraint on a client peer write", () => {
             expect(() => intValidator(0x1ff, peer, intPath)).throws(IntegerRangeError);
+        });
+
+        it("still rejects a schema-constraint violation on a client peer write", () => {
+            expect(() => boundedIntValidator(20, peer, boundedIntPath)).throws(ConstraintError);
         });
 
         it("rejects a feature-disallowed attribute on a server write", () => {

--- a/packages/node/test/behavior/state/validation/ValueValidatorTest.ts
+++ b/packages/node/test/behavior/state/validation/ValueValidatorTest.ts
@@ -149,6 +149,13 @@ describe("ValueValidator", () => {
             expect(() => bitmapValidator(reservedBitmap(), peer, bitmapPath)).not.throws();
         });
 
+        it("still rejects a structurally invalid bitmap field even alongside reserved bits on a peer write", () => {
+            // multiA spans bits 0-2 (max 7); 99 is out of range.  A forwarded reserved-bit failure must not skip this.
+            const value: Val.Struct = { multiA: 99, multiB: 0 };
+            Object.defineProperty(value, BitmapEncodedValue, { value: 0b1000_0000 });
+            expect(() => bitmapValidator(value, peer, bitmapPath)).throws(DatatypeError, "in range of bit field");
+        });
+
         it("still rejects a wrong-datatype value on a client peer write", () => {
             expect(() => intValidator("nope", peer, intPath)).throws(DatatypeError);
         });

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -51,6 +51,7 @@ import {
     FabricManager,
     PeerSet,
     Val,
+    ValidateError,
 } from "@matter/protocol";
 import { FabricIndex, NodeId, Status, StatusResponseError } from "@matter/types";
 import { AccessControl } from "@matter/types/clusters/access-control";
@@ -823,6 +824,37 @@ describe("ClientNode", () => {
             expect(caught).instanceOf(StatusResponseError);
             expect((caught as StatusResponseError).code).equals(Status.ConstraintError);
             expect(ep1Server.stateOf(DecliningBscWithLevels).currentSensitivityLevel).equals(0);
+        });
+    });
+
+    describe("forwards a model-invalid write so the peer device adjudicates", () => {
+        // A value the local model rejects on conformance/spec grounds (here an enum value not defined in the model) is
+        // forwarded to the peer rather than rejected during local validation.  The device declines it via its own
+        // validation, the rejection surfaces to the caller as the device's status, and the local cache is rolled back.
+
+        it("device rejects the value and the local cache is compensated", async () => {
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair();
+            const peer1 = await subscribedPeer(controller, "peer1");
+            const ep1Client = peer1.parts.get("ep1")!;
+            const ep1Server = device.parts.get(1) as Endpoint<OnOffLightDevice>;
+
+            const before = ep1Server.state.onOff.startUpOnOff;
+
+            const caught = await captureRejection(() =>
+                ep1Client.setStateOf(OnOffClient, { startUpOnOff: 99 as OnOff.StartUpOnOff }),
+            );
+
+            // The rejection is the device's write-response status, not a local ValidateError, proving the value was
+            // forwarded to the device rather than rejected during local validation (which would throw before any
+            // exchange and never contact the device).
+            expect(caught).instanceOf(StatusResponseError);
+            expect(caught).not.instanceOf(ValidateError);
+            expect((caught as StatusResponseError).code).equals(Status.ConstraintError);
+
+            // The device did not apply the value and the local cache was rolled back to match.
+            expect(ep1Server.state.onOff.startUpOnOff).equals(before);
+            expect(ep1Client.stateOf(OnOffClient).startUpOnOff).equals(before);
         });
     });
 


### PR DESCRIPTION
## Problem

When matter.js acts as a controller and writes an attribute to a peer (client) node, it validated the value against conformance derived from the peer's **self-reported FeatureMap** and rejected non-conformant writes **locally, before sending**. Non-compliant devices that work in their vendor app were blocked.

Reported case ([home-assistant/core#174674](https://github.com/home-assistant/core/issues/174674)): a SwitchBot air purifier reports `FanControl` `FeatureMap=0` (no `AUT`) yet `fanModeSequence=2` (`OffLowMedHighAuto`, which requires `AUT`) and even reports `fanMode=5` (Auto). Writing `FanMode.Auto` was rejected with `CONSTRAINT_ERROR (135)` and never reached the device. The model is correct; the device is non-compliant; the controller enforced the spec harder than the device honors it.

## Fix

Writes to client/peer nodes (`session.clientPeerContext` present) now **forward conformance violations** (and reserved bitmap bits) to the device, which adjudicates. The existing `RemoteWriteParticipant.compensate()` rolls the local mirror back if the device rejects. This also matches the read path, which already tolerates non-conformant peer values.

Kept **hard** even for peer writes:
- value-range constraints (e.g. fabric-index bounds, §7.5.2 — an intentional caller-bug guard)
- structural datatype errors (can't be encoded for the wire)

Server (device-role) writes are unaffected.

## Tests

- feature-gated enum (the Auto/AUT case): rejected server-side, forwarded peer-side
- reserved bitmap bits: rejected server-side, forwarded peer-side
- wrong datatype + value-range constraint: still rejected on peer writes

protocol `1231/1231`, node `1223/1223`, format + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)