### PR TITLE
fix(node): defer BasicInformation.location write until SetRegulatoryConfig validation passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: An invoke with SuppressResponse still returns the Invoke Response when a command produces response data, instead of suppressing it unconditionally
     - Fix: Aligned Thermostat atomic-write handling with the Matter specification
     - Fix: Ensures that client clusters are never exposed to incoming interactions
+    - Fix: Ensures that a rejected SetRegulatoryConfig leaves BasicInformation.location unchanged, instead of writing the country code before validating the regulatory config
 
 - @matter/nodejs
     - Fix: On `process.exit`, verifies all storages were properly closed and removes orphaned lock files otherwise, so a forgotten close no longer blocks the next startup

--- a/packages/node/src/behaviors/general-commissioning/GeneralCommissioningServer.ts
+++ b/packages/node/src/behaviors/general-commissioning/GeneralCommissioningServer.ts
@@ -150,6 +150,7 @@ export class GeneralCommissioningServer extends GeneralCommissioningBehavior {
         const basicInformation = this.agent.get(BasicInformationServer);
         const currentLocationCountryCode = basicInformation.state.location;
 
+        let locationToApply: string | undefined;
         if (currentLocationCountryCode !== countryCode) {
             if (this.state.allowCountryCodeChange === false && countryCode !== "XX") {
                 return {
@@ -167,7 +168,7 @@ export class GeneralCommissioningServer extends GeneralCommissioningBehavior {
                 };
             }
             if (countryCode !== "XX") {
-                basicInformation.state.location = countryCode;
+                locationToApply = countryCode;
             }
         }
 
@@ -204,6 +205,10 @@ export class GeneralCommissioningServer extends GeneralCommissioningBehavior {
                     newRegulatoryConfig === GeneralCommissioning.RegulatoryLocationType.Indoor ? "Indoor" : "Outdoor"
                 }`,
             };
+        }
+
+        if (locationToApply !== undefined) {
+            basicInformation.state.location = locationToApply;
         }
 
         this.state.regulatoryConfig = newRegulatoryConfig;

--- a/packages/node/test/node/SetRegulatoryConfigSideEffectTest.ts
+++ b/packages/node/test/node/SetRegulatoryConfigSideEffectTest.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BasicInformationServer } from "#behaviors/basic-information";
+import { GeneralCommissioningServer } from "#behaviors/general-commissioning";
+import { GeneralCommissioning } from "@matter/types/clusters/general-commissioning";
+import { MockServerNode } from "./mock-server-node.js";
+import { FAILSAFE_LENGTH_S } from "./node-helpers.js";
+
+const IndoorOnlyCommissioning = GeneralCommissioningServer.set({
+    locationCapability: GeneralCommissioning.RegulatoryLocationType.Indoor,
+});
+
+describe("SetRegulatoryConfig side effects", () => {
+    it("does not write BasicInformation.location when newRegulatoryConfig validation fails", async () => {
+        const node = await MockServerNode.createOnline({
+            type: MockServerNode.RootEndpoint.with(IndoorOnlyCommissioning),
+        });
+
+        const contextOptions = { command: true } as const;
+
+        await node.online(contextOptions, async agent => {
+            await agent.generalCommissioning.armFailSafe({
+                expiryLengthSeconds: FAILSAFE_LENGTH_S,
+                breadcrumb: 1,
+            });
+        });
+
+        const locationBefore = await node.online(
+            contextOptions,
+            async agent => agent.get(BasicInformationServer).state.location,
+        );
+
+        // Outdoor is invalid for an Indoor-only capability, so validation must reject.  countryCode differs from the
+        // default to exercise the location write path.
+        const result = await node.online(contextOptions, async agent =>
+            agent.generalCommissioning.setRegulatoryConfig({
+                newRegulatoryConfig: GeneralCommissioning.RegulatoryLocationType.Outdoor,
+                countryCode: "DE",
+                breadcrumb: 2,
+            }),
+        );
+
+        expect(result.errorCode).equals(GeneralCommissioning.CommissioningError.ValueOutsideRange);
+
+        const locationAfter = await node.online(
+            contextOptions,
+            async agent => agent.get(BasicInformationServer).state.location,
+        );
+
+        expect(locationAfter).equals(locationBefore);
+
+        await node.close();
+    });
+});


### PR DESCRIPTION
## Problem

`GeneralCommissioningServer.setRegulatoryConfig` applied the `BasicInformation.location` country-code write **before** validating `newRegulatoryConfig`. If regulatory-config validation failed, the location had already been written — a partial side-effect on a command that returns a failure status.

Found during 1.6.0 spec↔impl verification of core-05-05-commissioning-flows (Q-01), §11.10 General Commissioning.

## Fix

Defer the location write (via a `locationToApply` local) until after all validation gates pass. A rejected `SetRegulatoryConfig` now leaves no state change. The `regulatoryConfig`/`breadcrumb` writes were already correctly last; only the location write was mis-ordered.

## Test

New `SetRegulatoryConfigSideEffectTest.ts`: an Indoor-only device receiving `Outdoor` with a changed country code must reject **and** leave `BasicInformation.location` unchanged. TDD red→green proven (`expected 'DE' to equal 'XX'` before the fix).

## Gates

- node suite 1233/1233 green (ESM/CJS/Web)
- format-verify clean
- lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)