### PR TITLE
fix(protocol): always filter fabric-sensitive events to accessing fabric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Certificate SubjectKeyIdentifier and AuthorityKeyIdentifier are derived as 160-bit SHA-1
     - Fix: Certificates are rejected on decode when exceeding the size limits (400 bytes TLV for the NOC chain and VVSC, 600 bytes DER for the NOC and DAC chains)
     - Fix: OTA image digest type identifiers follow the IANA Named Information Hash Algorithm Registry (RFC 6920), and the digest algorithm is validated when reading an image
+    - Fix: Fabric-sensitive events are now always filtered to the accessing fabric on read and subscribe, regardless of the FabricFiltered flag
     - Fix: A stray StatusReport arriving as an exchange's initial message (e.g. a retransmitted CASE/PASE completion) is now ignored instead of logging an "Unhandled error"
     - Fix: An invoke client now reports `NoCommandResponse` for sent commands that receive no response, and discards unexpected/unmatched response entries instead of throwing
     - Fix: The BLE Extended-Announcement flag is only set during the extended-announcement period, no longer when private details are omitted outside that window

--- a/packages/node/test/node/EventReadResponseTest.ts
+++ b/packages/node/test/node/EventReadResponseTest.ts
@@ -11,9 +11,10 @@ import { ServerNode } from "#index.js";
 import { Bytes, Seconds } from "@matter/general";
 import { AccessLevel, Specification } from "@matter/model";
 import { EventReadResponse, Read, ReadResult } from "@matter/protocol";
-import { ClusterId, EndpointNumber, EventId, EventNumber, FabricIndex, Status } from "@matter/types";
+import { ClusterId, EndpointNumber, EventId, EventNumber, FabricIndex, NodeId, Status } from "@matter/types";
 import { BasicInformation } from "@matter/types/clusters/basic-information";
 import { Messages } from "@matter/types/clusters/messages";
+import { MockExchange } from "./mock-exchange.js";
 import { MockServerNode } from "./mock-server-node.js";
 import { MockSite } from "./mock-site.js";
 
@@ -133,7 +134,10 @@ describe("EventReadResponse", () => {
                 expect(response.counts).deep.equals({ status: 0, success: 1, existent: 1 });
             });
 
-            it(`reads fabric-scoped concrete event with payload`, async () => {
+            // messageComplete is fabric-sensitive (access "S V").  Per core §8.4.3.2 such records are filtered to
+            // the accessing fabric regardless of the FabricFiltered request flag.  The read session is on NO_FABRIC
+            // here, so an event owned by fabric 5 is always filtered out.
+            it(`filters fabric-sensitive concrete event not owned by the accessing fabric`, async () => {
                 const node = await MockServerNode.createOnline(
                     MockServerNode.RootEndpoint.with(MessagesServer.with("ReceivedConfirmation")),
                 );
@@ -157,33 +161,58 @@ describe("EventReadResponse", () => {
                     }),
                 );
 
-                if (fabricScoped) {
-                    expect(response.data).deep.equals([]);
-                    expect(response.counts).deep.equals({ status: 0, success: 0, existent: 1 });
-                } else {
-                    expect(response.data).deep.equals([
-                        [
-                            {
-                                kind: "event-value",
-                                path: {
-                                    eventId: 2,
-                                    clusterId: 0x97,
-                                    endpointId: 0,
-                                },
-                                number: 3n,
-                                priority: 1,
-                                timestamp: -1,
-                                tlv: {},
-                                value: {
-                                    messageId: Bytes.fromHex("0011223344556677889900aabbccddeeff"),
-                                    futureMessagesPreference: Messages.FutureMessagePreference.Allowed,
-                                    fabricIndex: FabricIndex(5),
-                                },
+                expect(response.data).deep.equals([]);
+                expect(response.counts).deep.equals({ status: 0, success: 0, existent: 1 });
+            });
+
+            // Counterpart to the above: when the accessing fabric owns the record it is reported in both
+            // FabricFiltered and non-FabricFiltered reads.
+            it(`reads fabric-sensitive concrete event owned by the accessing fabric`, async () => {
+                const node = await MockServerNode.createOnline(
+                    MockServerNode.RootEndpoint.with(MessagesServer.with("ReceivedConfirmation")),
+                );
+                await node.act(agent =>
+                    node.events.messages.messageComplete.emit(
+                        {
+                            messageId: Bytes.fromHex("0011223344556677889900aabbccddeeff"),
+                            futureMessagesPreference: Messages.FutureMessagePreference.Allowed,
+                            fabricIndex: FabricIndex(5),
+                        },
+                        agent.context,
+                    ),
+                );
+
+                const response = await readEvRaw(
+                    node,
+                    {
+                        isFabricFiltered: fabricScoped,
+                        eventRequests: [{ clusterId: ClusterId(0x97), eventId: EventId(2) }],
+                    },
+                    FabricIndex(5),
+                );
+
+                expect(response.data).deep.equals([
+                    [
+                        {
+                            kind: "event-value",
+                            path: {
+                                eventId: 2,
+                                clusterId: 0x97,
+                                endpointId: 0,
                             },
-                        ],
-                    ]);
-                    expect(response.counts).deep.equals({ status: 0, success: 1, existent: 1 });
-                }
+                            number: 3n,
+                            priority: 1,
+                            timestamp: -1,
+                            tlv: {},
+                            value: {
+                                messageId: Bytes.fromHex("0011223344556677889900aabbccddeeff"),
+                                futureMessagesPreference: Messages.FutureMessagePreference.Allowed,
+                                fabricIndex: FabricIndex(5),
+                            },
+                        },
+                    ],
+                ]);
+                expect(response.counts).deep.equals({ status: 0, success: 1, existent: 1 });
             });
         }),
     );
@@ -407,7 +436,7 @@ export function readEv(node: MockServerNode, isFabricFiltered: boolean, ...args:
     });
 }
 
-export async function readEvRaw(node: MockServerNode, data: Partial<Read.Events>) {
+export async function readEvRaw(node: MockServerNode, data: Partial<Read.Events>, sessionFabricIndex?: FabricIndex) {
     const request = {
         isFabricFiltered: false,
         interactionModelRevision: Specification.INTERACTION_MODEL_REVISION,
@@ -416,7 +445,14 @@ export async function readEvRaw(node: MockServerNode, data: Partial<Read.Events>
     if (!Read.containsEvent(request)) {
         throw new Error("Expected an event request");
     }
-    return node.online({ accessLevel: AccessLevel.Administer }, async ({ context }) => {
+    const exchange =
+        sessionFabricIndex === undefined
+            ? undefined
+            : new MockExchange(
+                  { fabricIndex: sessionFabricIndex, nodeId: NodeId(1) },
+                  { accessLevel: AccessLevel.Administer },
+              );
+    return node.online({ accessLevel: AccessLevel.Administer, exchange }, async ({ context }) => {
         const response = new EventReadResponse(node.protocol, context);
         const responseChunks = [];
         for await (const chunks of response.process(request)) {

--- a/packages/protocol/src/action/server/EventReadResponse.ts
+++ b/packages/protocol/src/action/server/EventReadResponse.ts
@@ -39,8 +39,10 @@ export class EventReadResponse<
     // Normalized Event Filter to just our node-id
     #eventMinVersion?: EventNumber;
 
-    // The Fabric filtering is done when we read the data from OccurrenceManager, so we can determine the parameter once
-    #filteredForFabricIndex?: FabricIndex;
+    // Accessing fabric of the read.  Fabric-sensitive event records are always filtered to this fabric; fabric-scoped
+    // records are filtered to it only when the read requests fabric filtering (core §8.4.3.2)
+    #accessingFabricIndex: FabricIndex = FabricIndex.NO_FABRIC;
+    #isFabricFiltered = false;
 
     // The following state updates as data producers execute.  This serves both to convey state between functions and as
     // a cache between producers that touch the same endpoint and/or cluster
@@ -48,7 +50,7 @@ export class EventReadResponse<
     #currentCluster?: ClusterProtocol;
 
     // Collected allowed and existing event paths to consider when reading events
-    #allowedEventPaths = new Map<string, TlvSchema<unknown>>();
+    #allowedEventPaths = new Map<string, { tlv: TlvSchema<unknown>; fabricSensitive: boolean }>();
 
     // Count how many events status (on error) and event values (on success) we have emitted
     #statusCount = 0;
@@ -74,9 +76,8 @@ export class EventReadResponse<
             }
         }
 
-        if (isFabricFiltered) {
-            this.#filteredForFabricIndex = this.session.fabric ?? FabricIndex.NO_FABRIC;
-        }
+        this.#accessingFabricIndex = this.session.fabric ?? FabricIndex.NO_FABRIC;
+        this.#isFabricFiltered = isFabricFiltered;
 
         // This path contributes an event value
         // Register paths
@@ -319,6 +320,7 @@ export class EventReadResponse<
 
     #registerEventPath(path: ReadResult.ConcreteEventPath) {
         const { eventId } = path;
+        const event = this.#guardedCurrentCluster.type.events[eventId]!;
         this.#allowedEventPaths.set(
             this.#createEventKey({
                 ...path,
@@ -326,28 +328,37 @@ export class EventReadResponse<
                 clusterId: this.#guardedCurrentCluster.type.id,
                 eventId,
             }),
-            this.#guardedCurrentCluster.type.events[eventId]!.tlv,
+            { tlv: event.tlv, fabricSensitive: event.limits.fabricSensitive },
         );
     }
 
     async *#readAllowedEvents() {
         for await (const event of this.node.eventHandler.get(this.#eventMinVersion)) {
-            const tlv = this.#allowedEventPaths.get(this.#createEventKey(event));
-            if (tlv === undefined) {
+            const allowed = this.#allowedEventPaths.get(this.#createEventKey(event));
+            if (allowed === undefined) {
                 // This event is not in the allowed list, so skip it
                 continue;
             }
-            // Filter out if we need to do fabric filtering and the event is not for the current fabric
-            // TODO adjust this to get the information correctly out of the Model bits when model is enhanced
-            // Right now it works because the ObjectSchema analyzes the fields and sets this whenever the FabricIndex
-            // field is included as fieldId 0xfe
-            if (this.#filteredForFabricIndex !== undefined && tlv instanceof ObjectSchema && tlv.isFabricScoped) {
+            const { tlv, fabricSensitive } = allowed;
+
+            if (fabricSensitive) {
+                // Fabric-sensitive event records are always filtered to the accessing fabric (core §8.4.3.2),
+                // independent of the read's FabricFiltered flag.  We fail closed: a record whose associated fabric
+                // cannot be positively matched to the accessing fabric is never disclosed.
+                const { payload } = event;
+                const fabricIndex = isObject(payload) ? payload.fabricIndex : undefined;
+                if (fabricIndex !== this.#accessingFabricIndex) {
+                    continue;
+                }
+            } else if (this.#isFabricFiltered && tlv instanceof ObjectSchema && tlv.isFabricScoped) {
+                // Fabric-scoped (but not fabric-sensitive) records are filtered only when the read requests fabric
+                // filtering.  isFabricScoped is set by ObjectSchema whenever the FabricIndex field 0xfe is present.
                 const { payload } = event;
                 if (!isObject(payload)) {
-                    throw new InternalError("Fabric sensitive event payload is not an object. Should never happen.");
+                    throw new InternalError("Fabric scoped event payload is not an object. Should never happen.");
                 }
                 const { fabricIndex } = payload;
-                if (fabricIndex !== undefined && fabricIndex !== this.#filteredForFabricIndex) {
+                if (fabricIndex !== undefined && fabricIndex !== this.#accessingFabricIndex) {
                     continue;
                 }
             }


### PR DESCRIPTION
## Problem

Core spec §8.4.3.2 step 6.1.3 requires fabric-sensitive (S-modifier) event records to be filtered to the accessing fabric **unconditionally** — independent of the read's `FabricFiltered` flag. `EventReadResponse` only filtered when `isFabricFiltered=true`.

This was **not** a theoretical issue: `Messages.MessageComplete` is `access: "S V"` (genuinely fabric-sensitive), so the gap was a **live cross-fabric event-data leak** on both read and subscribe (`ServerSubscription` reuses `EventReadResponse`).

## Fix

`packages/protocol/src/action/server/EventReadResponse.ts`:
- Store per-path `fabricSensitive` from `EventTypeProtocol.limits.fabricSensitive` (model truth, not the TLV `isFabricScoped` proxy).
- Fabric-sensitive records are filtered to the accessing fabric **always**, **failing closed** — a record is disclosed only when its owning fabric positively matches the accessing fabric (covers missing `fabricIndex` / non-`isFabricScoped` edge cases).
- The fabric-scoped-but-not-sensitive path stays gated on `FabricFiltered` (backward-compatible).

## Tests

`packages/node/test/node/EventReadResponseTest.ts`:
- Flipped the `messageComplete` assertion that encoded the buggy behavior — now filtered in both modes when not owned by the accessing fabric.
- Added an owning-fabric positive case (returned in both `FabricFiltered` modes) via `MockExchange` with a matching read-session fabric.

## Verification

- `@matter/protocol` 1234/1234, `@matter/node` 1240/1240
- format-verify clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)