### PR TITLE
fix(model): enforce §7.7.9 scene-quality datatype restriction and compare revisions numerically

### DIFF
--- a/packages/model/src/common/Specification.ts
+++ b/packages/model/src/common/Specification.ts
@@ -50,6 +50,26 @@ export namespace Specification {
         | `${number}.${number}.${number}.${number}`;
 
     /**
+     * Compare two specification revisions.
+     *
+     * Revisions are dotted numeric strings of varying length, so we compare segment-by-segment numerically with missing
+     * trailing segments treated as zero.  This makes "1.6" and "1.6.0" equal and orders patch levels intuitively.
+     *
+     * Returns a negative number if {@link a} precedes {@link b}, positive if it follows and zero if they are equal.
+     */
+    export function compareRevisions(a: Revision, b: Revision) {
+        const as = a.split(".");
+        const bs = b.split(".");
+        for (let i = 0; i < Math.max(as.length, bs.length); i++) {
+            const delta = Number(as[i] ?? 0) - Number(bs[i] ?? 0);
+            if (delta) {
+                return delta;
+            }
+        }
+        return 0;
+    }
+
+    /**
      * The default specification revision for Matter.js.
      */
     export const REVISION = "1.5.1";

--- a/packages/model/src/logic/definition-validation/AttributeValidator.ts
+++ b/packages/model/src/logic/definition-validation/AttributeValidator.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Metatype } from "../../common/index.js";
 import { AttributeElement } from "../../elements/index.js";
 import { AttributeModel, FieldModel } from "../../models/index.js";
 import { ModelValidator } from "./ModelValidator.js";
@@ -12,7 +13,40 @@ import { ValueValidator } from "./ValueValidator.js";
 ModelValidator.validators[AttributeElement.Tag] = class AttributeValidator extends ValueValidator<AttributeModel> {
     override validate() {
         this.validateStructure(true, FieldModel);
+        this.#validateSceneType();
 
         super.validate();
+    }
+
+    /**
+     * Per {@link MatterSpecification.v16} § 7.7.9 the Scene ("S") quality may only apply to unsigned integer or boolean
+     * types of at most 4 bytes, or types derived from these (e.g. enum8, map8).
+     */
+    #validateSceneType() {
+        if (!this.model.effectiveQuality.scene) {
+            return;
+        }
+
+        // Unresolved type is reported separately as TYPE_UNKNOWN
+        const primitive = this.model.primitiveBase;
+        if (primitive === undefined) {
+            return;
+        }
+
+        switch (primitive.metatype) {
+            case Metatype.boolean:
+                return;
+
+            case Metatype.integer:
+                if (primitive.name.startsWith("uint") && (primitive.byteSize ?? 0) <= 4) {
+                    return;
+                }
+                break;
+        }
+
+        this.error(
+            "INVALID_SCENE_TYPE",
+            `Scene quality requires an unsigned integer or boolean type of at most 4 bytes, not ${this.model.effectiveType}`,
+        );
     }
 };

--- a/packages/model/src/logic/definition-validation/AttributeValidator.ts
+++ b/packages/model/src/logic/definition-validation/AttributeValidator.ts
@@ -38,7 +38,7 @@ ModelValidator.validators[AttributeElement.Tag] = class AttributeValidator exten
                 return;
 
             case Metatype.integer:
-                if (primitive.name.startsWith("uint") && (primitive.byteSize ?? 0) <= 4) {
+                if (primitive.name.startsWith("uint") && primitive.byteSize !== undefined && primitive.byteSize <= 4) {
                     return;
                 }
                 break;

--- a/packages/model/src/models/Model.ts
+++ b/packages/model/src/models/Model.ts
@@ -330,10 +330,9 @@ export abstract class Model<E extends BaseElement = BaseElement, C extends Model
      * Determine whether this element applies to a specific revision.
      */
     appliesTo(revision: Specification.Revision) {
-        // Stick to simple string comparison for now as it is efficient; update if versioning ever gets more complex
-        // (or Matter reaches version 10)
         return (
-            (this.asOf === undefined || revision >= this.asOf) && (this.until === undefined || revision < this.until)
+            (this.asOf === undefined || Specification.compareRevisions(revision, this.asOf) >= 0) &&
+            (this.until === undefined || Specification.compareRevisions(revision, this.until) < 0)
         );
     }
 

--- a/packages/model/test/common/SpecificationTest.ts
+++ b/packages/model/test/common/SpecificationTest.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Specification } from "#common/index.js";
+import { DatatypeModel } from "#models/index.js";
+
+const { compareRevisions } = Specification;
+
+describe("Specification", () => {
+    describe("compareRevisions", () => {
+        it("orders differing revisions", () => {
+            expect(compareRevisions("1.6", "1.7")).below(0);
+            expect(compareRevisions("1.7", "1.6")).above(0);
+            expect(compareRevisions("1.6.1", "1.6.0")).above(0);
+            expect(compareRevisions("1.6.0.1", "1.6.0.0")).above(0);
+            expect(compareRevisions("2.0", "1.10")).above(0);
+        });
+
+        it("treats missing trailing segments as zero", () => {
+            expect(compareRevisions("1.6", "1.6.0")).equal(0);
+            expect(compareRevisions("1.6.0.0", "1.6")).equal(0);
+            expect(compareRevisions("1.6", "1.6.1")).below(0);
+        });
+
+        it("orders patch levels numerically rather than lexically", () => {
+            // String comparison would place "1.10" before "1.9"
+            expect(compareRevisions("1.10", "1.9")).above(0);
+        });
+    });
+
+    describe("Model.appliesTo", () => {
+        it("applies asOf against a trimmed revision", () => {
+            // Regression: generation revision is trimmed ("1.6.0" -> "1.6") so string comparison made
+            // asOf "1.6.0" silently fail for revision "1.6"
+            const model = new DatatypeModel({ name: "Test", asOf: "1.6.0" });
+            expect(model.appliesTo("1.6")).true;
+            expect(model.appliesTo("1.5.1")).false;
+            expect(model.appliesTo("1.7")).true;
+        });
+
+        it("excludes revisions at or beyond until", () => {
+            const model = new DatatypeModel({ name: "Test", until: "1.6.0" });
+            expect(model.appliesTo("1.5.1")).true;
+            expect(model.appliesTo("1.6")).false;
+            expect(model.appliesTo("1.6.1")).false;
+        });
+    });
+});

--- a/packages/model/test/logic/definition-validation/AttributeValidatorTest.ts
+++ b/packages/model/test/logic/definition-validation/AttributeValidatorTest.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    AttributeElement as Attribute,
+    bool,
+    enum8,
+    int8,
+    map8,
+    string,
+    uint32,
+    uint64,
+    uint8,
+    ValidateModel,
+} from "#index.js";
+import { ClusterModel, MatterModel } from "#models/index.js";
+
+function validateScene(type: string) {
+    const Matter = new MatterModel(
+        {},
+        bool.clone(),
+        uint8.clone(),
+        uint32.clone(),
+        uint64.clone(),
+        int8.clone(),
+        enum8.clone(),
+        map8.clone(),
+        string.clone(),
+        new ClusterModel({ name: "Test", id: 0xfff1 }, Attribute({ name: "Scenable", id: 1, type, quality: "S" })),
+    );
+    Matter.finalize();
+
+    return ValidateModel(Matter).errors.filter(e => e.code === "INVALID_SCENE_TYPE");
+}
+
+describe("AttributeValidator", () => {
+    describe("scene quality datatype restriction (§7.7.9)", () => {
+        for (const type of ["bool", "uint8", "uint32", "enum8", "map8"]) {
+            it(`accepts ${type}`, () => {
+                expect(validateScene(type)).deep.equals([]);
+            });
+        }
+
+        for (const type of ["uint64", "int8", "string"]) {
+            it(`rejects ${type}`, () => {
+                expect(validateScene(type).length).equals(1);
+            });
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Two model-layer fixes (from todo backlog).

### 1. §7.7.9 scene-quality datatype restriction
`AttributeValidator` now validates that an attribute carrying the Scene (`S`) quality resolves to an **unsigned integer or boolean type of at most 4 bytes** (derived types such as `enum8`/`map8` resolve through `primitiveBase` to their underlying `uint` and pass). Violations emit `INVALID_SCENE_TYPE`.

Per spec §7.7.9: *"This quality SHALL only apply to attributes having unsigned integer or boolean data types of size at most 4 bytes from the Base Data Types list (e.g. bool, uint8, uint16, uint32), or derived types thereof (e.g. enum8, map8)."*

The current standard model already satisfies this — codegen `generate-model` validation reports zero `INVALID_SCENE_TYPE`, so this is a guard for future/custom definitions.

### 2. Numeric (semver-style) revision comparison
`Model.appliesTo()` previously compared spec revisions with raw string comparison. Because the generation revision is trimmed (`"1.6.0"` → `"1.6"`), a natural `asOf: "1.6.0"` evaluated `"1.6" >= "1.6.0"` === `false` and silently disabled the override. Added `Specification.compareRevisions(a, b)` — segment-by-segment numeric compare, missing trailing segments treated as zero — and switched `appliesTo()` to use it.

Verified safe: re-running `generate-model` produces **byte-identical** generated output, so all existing `asOf`/`until` overrides resolve unchanged; only the patch-length-mismatch trap is fixed.

## Tests
- New `AttributeValidatorTest.ts` — 5 accept (bool, uint8, uint32, enum8, map8) / 3 reject (uint64, int8, string).
- New `SpecificationTest.ts` — `compareRevisions` ordering/equality + `appliesTo` regression cases.
- Model package: 466/466 (ESM/CJS/Web). Full monorepo suite green. format-verify + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)