### PR TITLE
fix(protocol): drop stack traces from DCL error logs

### DIFF
--- a/packages/protocol/src/dcl/DclOtaUpdateService.ts
+++ b/packages/protocol/src/dcl/DclOtaUpdateService.ts
@@ -8,6 +8,7 @@ import { PersistedFileDesignator } from "#bdx/PersistedFileDesignator.js";
 import { ScopedStorage } from "#bdx/ScopedStorage.js";
 import { DclErrorCodes } from "#dcl/DclRestApiTypes.js";
 import {
+    asError,
     BlobStorageDriver,
     Construction,
     Crypto,
@@ -488,7 +489,10 @@ export class DclOtaUpdateService {
                     logger.info(`Existing OTA image validated successfully`, Diagnostic.dict(diagnosticInfo));
                     return fileDesignator;
                 } catch (error) {
-                    logger.info(`Existing OTA image validation failed, Re-downloading ...`, error);
+                    logger.info(
+                        `Existing OTA image validation failed, Re-downloading ...`,
+                        Diagnostic.errorMessage(asError(error)),
+                    );
                 }
             }
 
@@ -940,7 +944,7 @@ export class DclOtaUpdateService {
                 size: blob.size,
             };
         } catch (error) {
-            logger.warn(`Failed to read OTA file ${fileDesignator.text}:`, error);
+            logger.warn(`Failed to read OTA file ${fileDesignator.text}:`, Diagnostic.errorMessage(asError(error)));
         }
     }
 

--- a/packages/protocol/src/dcl/DclVendorInfoService.ts
+++ b/packages/protocol/src/dcl/DclVendorInfoService.ts
@@ -220,7 +220,7 @@ export class DclVendorInfoService {
             });
             await this.#fetchPromise;
         } catch (error) {
-            logger.info("Error updating vendor information", error);
+            logger.info("Error updating vendor information", Diagnostic.errorMessage(asError(error)));
         }
     }
 


### PR DESCRIPTION
## Summary

DCL download/update errors logged the full error object, dumping multi-line stack traces for routine transient failures (e.g. DCL timeouts). Now they log the message + cause chain via `Diagnostic.errorMessage`, no stack.

Before:
```
INFO DclVendorInfoService Error updating vendor information [dcl-response] Error fetching /dcl/vendorinfo/vendors from DCL: 500 - The operation was aborted due to timeout
    at DclClient.#fetchJson (.../DclClient.ts:97:19)
    at async DclClient.#fetchPaginatedJson (.../DclClient.ts:63:30)
    ... (full stack)
  Caused by: The operation was aborted due to timeout
```

After:
```
INFO DclVendorInfoService Error updating vendor information [dcl-response] Error fetching /dcl/vendorinfo/vendors from DCL: 500 - The operation was aborted due to timeout: The operation was aborted due to timeout
```

## Changes

- `DclVendorInfoService.ts` — vendor-info update failure
- `DclOtaUpdateService.ts` — OTA image validation/re-download + OTA file read failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)