### PR TITLE
fix(node): keep Schrödinger clusters across re-interview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A peer's mDNS advertisement at the 1-hour SII/SAI cap no longer lowers a higher CASE-negotiated idle/active interval already on record
     - Fix: Ensures that a peer's FeatureMap change rebuilds the affected client cluster behavior
     - Fix: A peer reporting an empty AttributeList no longer breaks client cluster schema generation; the discovered schema falls back to the attributes actually received
+    - Fix: A client cluster the peer still serves data for but omits from its descriptor server list is no longer dropped when subsequent endpoint data is processed
     - Fix: Ensures that fabric-scoped attribute data (e.g. stale AccessControl ACL entries) is always sanitized at node startup
     - Fix: A misconfigured environment/configuration value for a behavior (unknown property or unconvertible value) is now logged and skipped instead of crashing endpoint initialization
     - Fix: An invoke with SuppressResponse still returns the Invoke Response when a command produces response data, instead of suppressing it unconditionally

--- a/packages/node/src/node/client/ClientStructure.ts
+++ b/packages/node/src/node/client/ClientStructure.ts
@@ -76,6 +76,7 @@ export class ClientStructure {
     #pendingChanges = new Map<EndpointStructure, PendingChange>();
     #pendingStructureEvents = Array<PendingEvent>();
     #delayedClusterEvents = new Array<ReadResult.EventValue>();
+    #clustersWithDataThisInteraction = new Set<ClusterStructure>();
     #events: ClientStructureEvents;
     #changed = Observable<[void]>();
     #commandFactory?: ClusterBehaviorType.CommandFactory;
@@ -212,6 +213,10 @@ export class ClientStructure {
      * Update the node structure by applying attribute changes from a Matter protocol interaction.
      */
     async *mutate(request: Read, changes: ReadResult) {
+        // Track which clusters the peer sends data for so a descriptor omitting them doesn't delete them.  Reset at the
+        // start so a prior interaction that threw mid-stream can't leave stale entries blocking a legitimate deletion.
+        this.#clustersWithDataThisInteraction.clear();
+
         // We collect updates and only apply when we transition clusters
         let currentUpdates: AttributeUpdates | undefined;
 
@@ -280,6 +285,8 @@ export class ClientStructure {
      * Values are keyed by property name (not attribute ID).
      */
     async applyWireChanges(changes: StateStream.WireChange[]) {
+        this.#clustersWithDataThisInteraction.clear();
+
         for (const change of changes) {
             switch (change.kind) {
                 case "update": {
@@ -292,6 +299,9 @@ export class ClientStructure {
                     if (typeof change.version === "number") {
                         values.set(DatasourceCache.VERSION_KEY, change.version);
                     }
+
+                    this.#clustersWithDataThisInteraction.add(cluster);
+                    this.#preserveAbsentCluster(endpoint.endpoint, cluster);
 
                     await cluster.store.externalSet(values);
                     this.#synchronizeCluster(endpoint, cluster);
@@ -444,6 +454,24 @@ export class ClientStructure {
     }
 
     /**
+     * Cancel a deletion scheduled for a cluster the peer is still sending data for.
+     *
+     * A peer that omits a cluster from its descriptor server list but continues to report the cluster's attributes is
+     * buggy, but we tolerate it by keeping the cluster — aka "Schrödinger's cluster".
+     */
+    #preserveAbsentCluster(endpoint: Endpoint, cluster: ClusterStructure) {
+        if (!cluster.pendingDelete) {
+            return;
+        }
+
+        logger.warn(
+            `Cluster 0x${hex.fixed(cluster.id, 8)} on ${endpoint} is absent from descriptor server list but peer` +
+                " sent attribute data for it; keeping cluster",
+        );
+        delete cluster.pendingDelete;
+    }
+
+    /**
      * Apply new attribute values for a specific endpoint / cluster.
      *
      * This is invoked in a batch when we've collected all sequential values for the current endpoint/cluster.
@@ -451,6 +479,12 @@ export class ClientStructure {
     async #updateCluster(attrs: AttributeUpdates) {
         const endpoint = this.#endpointFor(attrs.endpointId);
         const cluster = this.#clusterFor(endpoint, attrs.clusterId);
+
+        // Receiving attribute data for a cluster is authoritative evidence the peer still has it, even when its
+        // descriptor server list omits it.  Record this and cancel any deletion already scheduled by a descriptor
+        // processed earlier in this same interaction — "Schrödinger's cluster".
+        this.#clustersWithDataThisInteraction.add(cluster);
+        this.#preserveAbsentCluster(endpoint.endpoint, cluster);
 
         if (cluster.behavior && attrs.values.has(FeatureMap.id)) {
             if (!isDeepEqual(cluster.features, attrs.values.get(FeatureMap.id))) {
@@ -565,15 +599,7 @@ export class ClientStructure {
 
                 if (endpoint.lifecycle.isInstalled) {
                     cluster.pendingBehavior = behaviorType;
-                    if (cluster.pendingDelete) {
-                        // Peer sent data for a cluster absent from its descriptor server list; the device is buggy, but
-                        // we tolerate it by cancelling the pending deletion, aka "Schrödinger's cluster".
-                        logger.warn(
-                            `Cluster 0x${hex.fixed(cluster.id, 8)} on ${endpoint} is absent from` +
-                                " descriptor server list but peer sent attribute data for it; keeping cluster",
-                        );
-                        delete cluster.pendingDelete;
-                    }
+                    this.#preserveAbsentCluster(endpoint, cluster);
                     this.#scheduleStructureChange(
                         structure,
                         endpoint.behaviors.supported[behaviorType.id] ? "rebuild" : "install",
@@ -659,10 +685,14 @@ export class ClientStructure {
                 let anyPendingDelete = false;
                 for (const id of currentlySupported) {
                     const clusterStructure = this.#clusterFor(structure, id);
-                    // Only delete it when peer did not sent attribute data for this cluster in the same interaction
+                    // Only delete it when peer did not send attribute data for this cluster in the same interaction
                     // despite it not being in the server list; a device is buggy but we tolerate it by skipping the
-                    // deletion, aka "Schrödinger's cluster"
-                    if (!clusterStructure.pendingBehavior) {
+                    // deletion, aka "Schrödinger's cluster".  Data arriving later in the interaction cancels the
+                    // deletion via #preserveAbsentCluster; data already seen is skipped here.
+                    if (
+                        !clusterStructure.pendingBehavior &&
+                        !this.#clustersWithDataThisInteraction.has(clusterStructure)
+                    ) {
                         clusterStructure.pendingDelete = true;
                         anyPendingDelete = true;
                     }

--- a/packages/node/src/node/client/ClientStructure.ts
+++ b/packages/node/src/node/client/ClientStructure.ts
@@ -464,7 +464,7 @@ export class ClientStructure {
             return;
         }
 
-        logger.warn(
+        logger.info(
             `Cluster 0x${hex.fixed(cluster.id, 8)} on ${endpoint} is absent from descriptor server list but peer` +
                 " sent attribute data for it; keeping cluster",
         );

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -23,7 +23,9 @@ import { ContactSensorDevice } from "#devices/contact-sensor";
 import { OnOffLightDevice } from "#devices/on-off-light";
 import { WindowCoveringDevice } from "#devices/window-covering";
 import { Endpoint } from "#endpoint/Endpoint.js";
+import { EndpointInitializer } from "#endpoint/properties/EndpointInitializer.js";
 import { AggregatorEndpoint } from "#endpoints/aggregator";
+import type { ClientEndpointInitializer } from "#node/client/ClientEndpointInitializer.js";
 import { ClientNodeFactory } from "#node/client/ClientNodeFactory.js";
 import { ClientStructureEvents } from "#node/client/ClientStructureEvents.js";
 import { ServerNode } from "#node/ServerNode.js";
@@ -43,18 +45,37 @@ import {
     Time,
     Timestamp,
 } from "@matter/general";
-import { Specification } from "@matter/model";
+import {
+    AcceptedCommandList,
+    AttributeList,
+    ClusterRevision,
+    FeatureMap,
+    GeneratedCommandList,
+    Specification,
+} from "@matter/model";
 import {
     CommissioningError,
     ControllerCommissioner,
     FabricAuthority,
     FabricManager,
     PeerSet,
+    Read,
+    ReadResult,
     Val,
     ValidateError,
 } from "@matter/protocol";
-import { FabricIndex, NodeId, Status, StatusResponseError } from "@matter/types";
+import {
+    AttributeId,
+    ClusterId,
+    EndpointNumber,
+    FabricIndex,
+    NodeId,
+    Status,
+    StatusResponseError,
+    TlvAny,
+} from "@matter/types";
 import { AccessControl } from "@matter/types/clusters/access-control";
+import { Descriptor } from "@matter/types/clusters/descriptor";
 import { OnOff } from "@matter/types/clusters/on-off";
 import { WindowCovering } from "@matter/types/clusters/window-covering";
 import { MyBehavior } from "../behavior/cluster/cluster-behavior-test-util.js";
@@ -1868,6 +1889,101 @@ describe("ClientNode", () => {
 
             expect(() => peer1.state.commissioning).not.throws();
             expect(peer1.state.commissioning).to.be.undefined;
+        });
+    });
+
+    describe("Schrödinger's cluster", () => {
+        // A manufacturer-specific cluster the peer serves attribute data for but omits from its descriptor serverList.
+        const NEO = 0x125dfc11 as ClusterId;
+        const EP1 = EndpointNumber(1);
+
+        // EP1's real serverList from EP1_STATE (identify, groups, onOff, scenesManagement, descriptor) - notably
+        // without NEO.
+        const EP1_SERVER_LIST = [3, 4, 6, 0x62, 0x1d];
+
+        function attr(clusterId: ClusterId, attributeId: number, value: unknown, version: number): ReadResult.Report {
+            return {
+                kind: "attr-value",
+                path: { endpointId: EP1, clusterId, attributeId: attributeId as AttributeId },
+                value,
+                version,
+                tlv: TlvAny,
+            };
+        }
+
+        function neoReports(version: number): ReadResult.Report[] {
+            return [
+                attr(NEO, ClusterRevision.id, 1, version),
+                attr(NEO, FeatureMap.id, {}, version),
+                attr(
+                    NEO,
+                    AttributeList.id,
+                    [
+                        0,
+                        GeneratedCommandList.id,
+                        AcceptedCommandList.id,
+                        AttributeList.id,
+                        FeatureMap.id,
+                        ClusterRevision.id,
+                    ],
+                    version,
+                ),
+                attr(NEO, AcceptedCommandList.id, [], version),
+                attr(NEO, GeneratedCommandList.id, [], version),
+                attr(NEO, 0, 1234, version),
+            ];
+        }
+
+        function descriptorServerListReport(version: number): ReadResult.Report[] {
+            return [attr(Descriptor.id, Descriptor.attributes.serverList.id, EP1_SERVER_LIST, version)];
+        }
+
+        async function* readResult(...chunks: ReadResult.Report[][]): ReadResult {
+            for (const chunk of chunks) {
+                yield chunk;
+            }
+        }
+
+        async function drain(updates: AsyncGenerator<unknown>) {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            for await (const _ of updates) {
+            }
+        }
+
+        it("survives a re-interview where the descriptor precedes the absent cluster's data", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair();
+            const peer1 = await subscribedPeer(controller, "peer1");
+
+            const initializer = peer1.env.get(EndpointInitializer) as ClientEndpointInitializer;
+            const structure = initializer.structure;
+
+            const request = Read({ attributes: [{}], fabricFilter: structure.subscribedFabricFiltered });
+
+            const neoBehaviorId = () => {
+                const endpoint = structure.endpointFor(EP1);
+                return endpoint === undefined
+                    ? undefined
+                    : Object.values(endpoint.behaviors.supported).find(
+                          type => (type as ClusterBehavior.Type).cluster?.id === NEO,
+                      )?.id;
+            };
+
+            // *** ESTABLISH SCHRÖDINGER STATE ***
+
+            // First interaction delivers data for NEO while the descriptor omits it.  Because NEO isn't yet an active
+            // behavior, it is kept (matches the startup loadCache path).
+            await drain(structure.mutate(request, readResult(neoReports(10), descriptorServerListReport(10))));
+
+            expect(neoBehaviorId(), "NEO should be active after the initial interaction").not.undefined;
+
+            // *** RE-INTERVIEW ***
+
+            // Full wildcard read where the descriptor chunk (serverList without NEO) arrives before NEO's attribute
+            // data.  NEO must survive because the peer still serves its data.
+            await drain(structure.mutate(request, readResult(descriptorServerListReport(11), neoReports(11))));
+
+            expect(neoBehaviorId(), "NEO must survive a re-interview that serves its data").not.undefined;
         });
     });
 });

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -29,6 +29,7 @@ import type { ClientEndpointInitializer } from "#node/client/ClientEndpointIniti
 import { ClientNodeFactory } from "#node/client/ClientNodeFactory.js";
 import { ClientStructureEvents } from "#node/client/ClientStructureEvents.js";
 import { ServerNode } from "#node/ServerNode.js";
+import { ClientCacheBuffer } from "#storage/client/ClientCacheBuffer.js";
 import {
     b$,
     Bytes,
@@ -1984,6 +1985,47 @@ describe("ClientNode", () => {
             await drain(structure.mutate(request, readResult(descriptorServerListReport(11), neoReports(11))));
 
             expect(neoBehaviorId(), "NEO must survive a re-interview that serves its data").not.undefined;
+        });
+
+        it("erases persisted storage when the peer genuinely drops the cluster", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair();
+            const peer1 = await subscribedPeer(controller, "peer1");
+
+            const initializer = peer1.env.get(EndpointInitializer) as ClientEndpointInitializer;
+            const structure = initializer.structure;
+            const request = Read({ attributes: [{}], fabricFilter: structure.subscribedFabricFiltered });
+            const buffer = controller.env.get(ClientCacheBuffer);
+
+            const neoStorageKeys = () =>
+                Object.keys(site.storageFor("controller1")).filter(key => key.includes(NEO.toString()));
+
+            const neoActive = () => {
+                const endpoint = structure.endpointFor(EP1);
+                return (
+                    endpoint !== undefined &&
+                    Object.values(endpoint.behaviors.supported).some(
+                        type => (type as ClusterBehavior.Type).cluster?.id === NEO,
+                    )
+                );
+            };
+
+            // *** ESTABLISH AND PERSIST NEO ***
+
+            await drain(structure.mutate(request, readResult(neoReports(10), descriptorServerListReport(10))));
+            await MockTime.resolve(buffer.flush());
+            expect(neoActive(), "NEO should be active").true;
+            expect(neoStorageKeys(), "NEO data should be persisted").not.empty;
+
+            // *** PEER DROPS NEO ***
+
+            // The descriptor still omits NEO and no attribute data is served this interaction, so NEO is genuinely
+            // gone and must be removed from both memory and storage.
+            await drain(structure.mutate(request, readResult(descriptorServerListReport(11))));
+            await MockTime.resolve(buffer.flush());
+
+            expect(neoActive(), "NEO behavior should be dropped").false;
+            expect(neoStorageKeys(), "NEO storage should be erased").empty;
         });
     });
 });


### PR DESCRIPTION
## Problem

A client cluster present in local storage but absent from the peer's descriptor `serverList` ("Schrödinger's cluster") survived **startup** (`loadCache`) but was deleted on the **first live wildcard read** after a fresh data migration. A server restart re-loaded it correctly — the deletion only struck the live read path.

Observed in matterjs-server (see https://github.com/home-assistant/addons/issues/4668): a migrated node's EP1 carries data for manufacturer cluster `0x125dfc11` while its descriptor `serverList` omits it; the first re-interview logged `Removing ...ep1.neoCluster from active endpoint`.

## Root cause

Asymmetry between `loadCache` and live `mutate`:

- `loadCache` processes the descriptor **before** injecting the endpoint's cluster behaviors, so the Schrödinger cluster is never in `currentlySupported` and is kept.
- In `mutate`, the endpoint is already active. When the descriptor chunk (server list without the cluster) arrives **before** the cluster's attribute data, `#synchronizeDescriptor` schedules the cluster for deletion. The cancel-pending-delete logic lived only inside `#synchronizeCluster`'s `if (cluster.behavior === undefined)` branch — unreachable for an already-active cluster — so the later attribute data never cleared the deletion and `#rebuild` dropped it.

Storage is not truly erased, so the next `loadCache` restores the cluster, which is why a restart "fixed" it.

## Fix

`ClientStructure`:
- New `#clustersWithDataThisInteraction` set + `#preserveAbsentCluster` helper (clears `pendingDelete`, warns once).
- Populate the set and call the helper in `#updateCluster` and the `applyWireChanges` update branch → cancels a deletion a descriptor scheduled earlier in the same interaction (descriptor-first ordering).
- `#synchronizeDescriptor` skips scheduling `pendingDelete` for a cluster already in the set → handles data-first ordering.
- The set is cleared at the **start** of `mutate`/`applyWireChanges` (exception-safe; no cross-interaction leak).

Live `mutate` is now symmetric with `loadCache`: a cluster the peer still serves data for survives a re-interview regardless of chunk order.

## Test

New `ClientNodeTest` case "Schrödinger's cluster": establishes the cluster active-but-absent-from-`serverList` in one interaction, then re-interviews with descriptor-first ordering. Reproduces the exact deletion before the fix; passes after.

## Verification

- Full `packages/node` suite: 1251/1251 (ESM/CJS), 1242/1242 (Web)
- `format-verify` clean, `lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)