### PR TITLE
Task layer Increment 2a: prior-state changeset + auto-rollback

### DIFF
--- a/packages/node-manager/src/ReconcilerBehavior.ts
+++ b/packages/node-manager/src/ReconcilerBehavior.ts
@@ -252,6 +252,11 @@ export class ReconcilerBehavior extends Behavior {
         this.internal.registry.register(kind);
     }
 
+    /** Look up a registered ItemKind (e.g. for a task's shared-entry reference check). */
+    itemKind(kind: string): ItemKind | undefined {
+        return this.internal.registry.get(kind);
+    }
+
     async #runExecutor(peer: ClientNode, planned: PlannedAction[], registry: ItemKindRegistry): Promise<void> {
         const target: ReconcileTarget = {
             node: peer,

--- a/packages/node-manager/src/ReconcilerBehavior.ts
+++ b/packages/node-manager/src/ReconcilerBehavior.ts
@@ -267,6 +267,9 @@ export class ReconcilerBehavior extends Behavior {
             dropItem(kind, key) {
                 return Promise.resolve(peer.act(agent => agent.get(DesiredStateBehavior).dropItem(kind, key)));
             },
+            currentState(kind, key) {
+                return peer.stateOf(DesiredStateBehavior).items[itemMapKey(kind, key)]?.status.state;
+            },
         };
         await executeActions(target, planned, registry);
     }

--- a/packages/node-manager/src/ReconcilerBehavior.ts
+++ b/packages/node-manager/src/ReconcilerBehavior.ts
@@ -252,7 +252,6 @@ export class ReconcilerBehavior extends Behavior {
         this.internal.registry.register(kind);
     }
 
-    /** Look up a registered ItemKind (e.g. for a task's shared-entry reference check). */
     itemKind(kind: string): ItemKind | undefined {
         return this.internal.registry.get(kind);
     }

--- a/packages/node-manager/src/reconcile/GroupKeyItemKind.ts
+++ b/packages/node-manager/src/reconcile/GroupKeyItemKind.ts
@@ -15,10 +15,11 @@ import { PRIORITY_BANDS } from "./priority.js";
 export type GroupKeyGrant = GroupKeyManagement.GroupKeySet;
 
 /**
- * The `groupKey` ItemKind: provisions group key sets via GroupKeyManagement commands. Always writes
- * on apply (KeySetWrite is an idempotent overwrite and key material cannot be read back to compare);
- * verify confirms presence only — KeySetRead returns epoch keys as null, so key material is
- * unverifiable. Epoch-key rotation is driven by the intent changing, not by verify.
+ * The `groupKey` ItemKind: provisions group key sets via GroupKeyManagement commands. Apply is
+ * create-if-absent: skips KeySetWrite when the id is already present because key material is
+ * unreadable and a re-apply would clobber a richer set with our minimal one. Verify confirms
+ * presence only — KeySetRead returns epoch keys as null, so key material is unverifiable.
+ * Epoch-key rotation is driven by the intent changing, not by verify.
  */
 export class GroupKeyItemKind implements ItemKind<GroupKeyGrant> {
     readonly kind = "groupKey";
@@ -34,7 +35,14 @@ export class GroupKeyItemKind implements ItemKind<GroupKeyGrant> {
                 "groupKeySetId 0 is the IPK and is managed by commissioning, not the reconciler",
             );
         }
-        await this.#commands(node).keySetWrite({ groupKeySet: item.intent });
+        const commands = this.#commands(node);
+        // Create-if-absent: never overwrite an existing key set (key material is unreadable, so a re-apply
+        // would clobber a richer set with our minimal one). Updates/rotation are the dedicated ipk task.
+        const { groupKeySetIDs } = await commands.keySetReadAllIndices();
+        if (groupKeySetIDs.includes(item.intent.groupKeySetId)) {
+            return;
+        }
+        await commands.keySetWrite({ groupKeySet: item.intent });
     }
 
     async verify(node: ClientNode, item: ManagedItem<GroupKeyGrant>): Promise<boolean> {

--- a/packages/node-manager/src/reconcile/GroupKeyItemKind.ts
+++ b/packages/node-manager/src/reconcile/GroupKeyItemKind.ts
@@ -6,6 +6,7 @@
 
 import { ImplementationError } from "@matter/general";
 import type { ClientNode, ItemKind, ManagedItem } from "@matter/node";
+import { DesiredStateBehavior } from "@matter/node";
 import { GroupKeyManagementClient } from "@matter/node/behaviors/group-key-management";
 import { Status } from "@matter/types";
 import { GroupKeyManagement } from "@matter/types/clusters/group-key-management";
@@ -43,6 +44,16 @@ export class GroupKeyItemKind implements ItemKind<GroupKeyGrant> {
 
     async remove(node: ClientNode, item: ManagedItem<GroupKeyGrant>): Promise<void> {
         await this.#commands(node).keySetRemove({ groupKeySetId: item.intent.groupKeySetId });
+    }
+
+    isReferenced(node: ClientNode, key: string): boolean {
+        const keySetId = Number(key);
+        return Object.values(node.stateOf(DesiredStateBehavior).items).some(
+            item =>
+                item.kind === "groupKeyMap" &&
+                item.status.state !== "deletePending" &&
+                (item.intent as { groupKeySetId: number }).groupKeySetId === keySetId,
+        );
     }
 
     // No capacity(): the key-set count has no subscribed attribute (only the KeySetReadAllIndices command),

--- a/packages/node-manager/src/reconcile/GroupKeyItemKind.ts
+++ b/packages/node-manager/src/reconcile/GroupKeyItemKind.ts
@@ -36,8 +36,6 @@ export class GroupKeyItemKind implements ItemKind<GroupKeyGrant> {
             );
         }
         const commands = this.#commands(node);
-        // Create-if-absent: never overwrite an existing key set (key material is unreadable, so a re-apply
-        // would clobber a richer set with our minimal one). Updates/rotation are the dedicated ipk task.
         const { groupKeySetIDs } = await commands.keySetReadAllIndices();
         if (groupKeySetIDs.includes(item.intent.groupKeySetId)) {
             return;

--- a/packages/node-manager/src/reconcile/GroupKeyMapItemKind.ts
+++ b/packages/node-manager/src/reconcile/GroupKeyMapItemKind.ts
@@ -6,6 +6,7 @@
 
 import { ImplementationError } from "@matter/general";
 import type { CapacityInfo, ClientNode, ItemKind, ManagedItem } from "@matter/node";
+import { DesiredStateBehavior } from "@matter/node";
 import { GroupKeyManagementClient } from "@matter/node/behaviors/group-key-management";
 import { FabricIndex, GroupId, Status } from "@matter/types";
 import { GroupKeyManagement } from "@matter/types/clusters/group-key-management";
@@ -70,6 +71,16 @@ export class GroupKeyMapItemKind implements ItemKind<GroupKeyMapGrant> {
             return;
         }
         await this.#write(node, kept);
+    }
+
+    isReferenced(node: ClientNode, key: string): boolean {
+        const groupId = Number(key);
+        return Object.values(node.stateOf(DesiredStateBehavior).items).some(
+            item =>
+                item.kind === "endpointGroupMembership" &&
+                item.status.state !== "deletePending" &&
+                Number((item.intent as { groupId: number }).groupId) === groupId,
+        );
     }
 
     async capacity(node: ClientNode): Promise<CapacityInfo> {

--- a/packages/node-manager/src/reconcile/executeActions.ts
+++ b/packages/node-manager/src/reconcile/executeActions.ts
@@ -5,7 +5,7 @@
  */
 
 import type { ClientNode } from "@matter/node";
-import { ItemKindRegistry, ManagedItem } from "@matter/node";
+import { ItemKindRegistry, ItemState, ManagedItem } from "@matter/node";
 import { PlannedAction } from "./planActions.js";
 
 /**
@@ -23,6 +23,8 @@ export interface ReconcileTarget {
         code?: number,
     ): Promise<void>;
     dropItem(kind: string, key: string): Promise<void>;
+    /** Live item state, re-read after a slow apply to detect a concurrent delete. */
+    currentState(kind: string, key: string): ItemState | undefined;
 }
 
 /**
@@ -51,8 +53,16 @@ export async function executeActions(
                     if (kind !== undefined) {
                         await kind.apply(target.node, item);
                     }
+                    // A revert that flipped the intent to delete during this apply must win: a status
+                    // write here would resurrect the item the revert is trying to remove.
+                    if (target.currentState(item.kind, item.key) === "deletePending") {
+                        break;
+                    }
                     await target.updateStatus(item.kind, item.key, "committed");
                 } catch (e) {
+                    if (target.currentState(item.kind, item.key) === "deletePending") {
+                        break;
+                    }
                     await target.updateStatus(item.kind, item.key, "commitFailed", extractStatusCode(e));
                 }
                 break;
@@ -62,8 +72,16 @@ export async function executeActions(
                     if (kind?.remove !== undefined) {
                         await kind.remove(target.node, item);
                     }
+                    // A re-add that flipped the intent back during this remove must win: dropping here
+                    // would discard the freshly re-applied intent.
+                    if (target.currentState(item.kind, item.key) !== "deletePending") {
+                        break;
+                    }
                     await target.dropItem(item.kind, item.key);
                 } catch (e) {
+                    if (target.currentState(item.kind, item.key) !== "deletePending") {
+                        break;
+                    }
                     await target.updateStatus(item.kind, item.key, "commitFailed", extractStatusCode(e));
                 }
                 break;

--- a/packages/node-manager/src/task/Revert.ts
+++ b/packages/node-manager/src/task/Revert.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ClientNode } from "@matter/node";
+import { Task } from "./Task.js";
+import { ChangeEntry, TaskContext, TaskPhase } from "./types.js";
+
+export const REVERT_TYPE = "revert";
+
+export interface RevertParams {
+    originalId: string;
+    entries: ChangeEntry[];
+}
+
+/**
+ * Generic, changeset-driven undo. Restores each touched `(peer,kind,key)` to its prior state in reverse
+ * order: a recorded prior intent is re-applied, an absent prior is removed (unless the entry is still
+ * referenced by another group). Runs as an ordinary task, so it parks on offline peers and resumes after
+ * restart. Spawned by the manager on a hard forward failure or on cancel.
+ */
+export class Revert extends Task<RevertParams> {
+    readonly type = REVERT_TYPE;
+
+    static override idFor(params: RevertParams): string {
+        return `revert:${params.originalId}`;
+    }
+
+    get phases(): TaskPhase[] {
+        return [{ name: "revert", run: ctx => this.#revert(ctx) }];
+    }
+
+    async #revert(ctx: TaskContext): Promise<void> {
+        const restored = new Array<{ peer: ClientNode; kind: string; key: string }>();
+        const removed = new Array<{ peer: ClientNode; kind: string; key: string }>();
+
+        for (const entry of [...this.params.entries].reverse()) {
+            const peer = ctx.tryResolvePeer(entry.peerId);
+            // A decommissioned peer's intent is GC'd with the node, so its revert is moot.
+            if (peer === undefined) {
+                continue;
+            }
+            if (entry.prior !== undefined) {
+                await ctx.setIntent(peer, entry.kind, entry.key, entry.prior.intent, entry.prior.mode);
+                restored.push({ peer, kind: entry.kind, key: entry.key });
+            } else if (await ctx.removeIntentIfUnreferenced(peer, entry.kind, entry.key)) {
+                removed.push({ peer, kind: entry.kind, key: entry.key });
+            }
+        }
+
+        if (restored.length > 0) {
+            await ctx.awaitCommitted(restored);
+        }
+        if (removed.length > 0) {
+            const peers = [...new Set(removed.map(r => r.peer))];
+            await ctx.awaitGate(peers, () => removed.every(r => ctx.itemAbsent(r.peer, r.kind, r.key)));
+        }
+    }
+}

--- a/packages/node-manager/src/task/RunningTaskContext.ts
+++ b/packages/node-manager/src/task/RunningTaskContext.ts
@@ -193,6 +193,10 @@ export class RunningTaskContext implements TaskContext {
         this.setState(nodes.some(node => !this.#reachable(node)) ? "parked" : "running");
     }
 
+    itemAbsent(peer: ClientNode, kind: string, key: string): boolean {
+        return peer.stateOf(DesiredStateBehavior).items[itemMapKey(kind, key)] === undefined;
+    }
+
     #itemState(peer: ClientNode, kind: string, key: string) {
         return peer.stateOf(DesiredStateBehavior).items[itemMapKey(kind, key)]?.status.state;
     }

--- a/packages/node-manager/src/task/RunningTaskContext.ts
+++ b/packages/node-manager/src/task/RunningTaskContext.ts
@@ -45,6 +45,10 @@ export class RunningTaskContext implements TaskContext {
         return peer;
     }
 
+    tryResolvePeer(peerId: string): ClientNode | undefined {
+        return this.peerResolver(peerId);
+    }
+
     async setIntent(peer: ClientNode, kind: string, key: string, intent: unknown, mode: ItemMode = "converge") {
         await peer.act(agent => {
             agent.get(DesiredStateBehavior).setIntent(kind, key, intent, mode);
@@ -58,6 +62,15 @@ export class RunningTaskContext implements TaskContext {
         await peer.act(agent => {
             agent.get(DesiredStateBehavior).removeIntent(kind, key);
         });
+    }
+
+    async removeIntentIfUnreferenced(peer: ClientNode, kind: string, key: string): Promise<boolean> {
+        if (this.reconciler.itemKind(kind)?.isReferenced?.(peer, key)) {
+            logger.debug(`Task ${this.task.id}: keep ${kind}:${key} on ${peer.id} (still referenced)`);
+            return false;
+        }
+        await this.removeIntent(peer, kind, key);
+        return true;
     }
 
     async awaitCommitted(items: Array<{ peer: ClientNode; kind: string; key: string }>): Promise<void> {

--- a/packages/node-manager/src/task/RunningTaskContext.ts
+++ b/packages/node-manager/src/task/RunningTaskContext.ts
@@ -178,7 +178,7 @@ export class RunningTaskContext implements TaskContext {
     }
 
     async #evaluate(nodes: ClientNode[], until: (items: ManagedItem[]) => boolean): Promise<boolean> {
-        // A gate resolves only on freshly verified state; an unreachable node cannot be re-verified.
+        // A gate resolves only on freshly verified state, never on trust-stored committed items.
         if (nodes.some(node => !this.#reachable(node))) {
             return false;
         }

--- a/packages/node-manager/src/task/RunningTaskContext.ts
+++ b/packages/node-manager/src/task/RunningTaskContext.ts
@@ -178,12 +178,12 @@ export class RunningTaskContext implements TaskContext {
     }
 
     async #evaluate(nodes: ClientNode[], until: (items: ManagedItem[]) => boolean): Promise<boolean> {
-        // Reconcile is not reachability-guarded and would throw on an unreachable peer. Skip it for such peers
-        // so the gate parks (predicate left unsatisfied) and waits for the reachability-change wake.
+        // A gate resolves only on freshly verified state; an unreachable node cannot be re-verified.
+        if (nodes.some(node => !this.#reachable(node))) {
+            return false;
+        }
         for (const node of nodes) {
-            if (this.#reachable(node)) {
-                await this.reconciler.reconcile(node, { verify: true });
-            }
+            await this.reconciler.reconcile(node, { verify: true });
         }
         const items = nodes.flatMap(node => Object.values(node.stateOf(DesiredStateBehavior).items));
         return until(items);

--- a/packages/node-manager/src/task/RunningTaskContext.ts
+++ b/packages/node-manager/src/task/RunningTaskContext.ts
@@ -25,7 +25,7 @@ export interface GateControl {
 }
 
 /**
- * TaskContext bound to a running task. Records created items into the task's addLog so cancel can revert them.
+ * TaskContext bound to a running task. Records pre-mutation state into the task's changeSet so cancel can revert.
  * Peers are resolved through an injected resolver so the manager controls peer lookup.
  */
 export class RunningTaskContext implements TaskContext {
@@ -50,18 +50,27 @@ export class RunningTaskContext implements TaskContext {
     }
 
     async setIntent(peer: ClientNode, kind: string, key: string, intent: unknown, mode: ItemMode = "converge") {
+        this.#record(peer, kind, key);
         await peer.act(agent => {
             agent.get(DesiredStateBehavior).setIntent(kind, key, intent, mode);
         });
-        if (!this.task.addLog.some(e => e.peerId === peer.id && e.kind === kind && e.key === key)) {
-            this.task.addLog.push({ peerId: peer.id, kind, key });
-        }
     }
 
     async removeIntent(peer: ClientNode, kind: string, key: string) {
+        this.#record(peer, kind, key);
         await peer.act(agent => {
             agent.get(DesiredStateBehavior).removeIntent(kind, key);
         });
+    }
+
+    /** Record the pre-mutation state of a (peer, kind, key) triple on first touch; first-touch-wins. */
+    #record(peer: ClientNode, kind: string, key: string) {
+        if (this.task.changeSet.some(e => e.peerId === peer.id && e.kind === kind && e.key === key)) {
+            return;
+        }
+        const existing = peer.stateOf(DesiredStateBehavior).items[itemMapKey(kind, key)];
+        const prior = existing === undefined ? undefined : { intent: existing.intent, mode: existing.mode };
+        this.task.changeSet.push({ peerId: peer.id, kind, key, prior });
     }
 
     async removeIntentIfUnreferenced(peer: ClientNode, kind: string, key: string): Promise<boolean> {

--- a/packages/node-manager/src/task/RunningTaskContext.ts
+++ b/packages/node-manager/src/task/RunningTaskContext.ts
@@ -63,7 +63,7 @@ export class RunningTaskContext implements TaskContext {
         });
     }
 
-    /** Record the pre-mutation state of a (peer, kind, key) triple on first touch; first-touch-wins. */
+    // First touch wins: records the pre-task state so a revert restores that, not an intermediate touch.
     #record(peer: ClientNode, kind: string, key: string) {
         if (this.task.changeSet.some(e => e.peerId === peer.id && e.kind === kind && e.key === key)) {
             return;

--- a/packages/node-manager/src/task/Task.ts
+++ b/packages/node-manager/src/task/Task.ts
@@ -5,7 +5,7 @@
  */
 
 import { ImplementationError } from "@matter/general";
-import { AddLogEntry, TaskPhase, TaskState, TaskStatus } from "./types.js";
+import { ChangeEntry, TaskPhase, TaskState, TaskStatus } from "./types.js";
 
 export interface TaskPersistence {
     type: string;
@@ -13,7 +13,7 @@ export interface TaskPersistence {
     phaseIndex: number;
     state: TaskState;
     externalId?: string;
-    addLog: AddLogEntry[];
+    changeSet: ChangeEntry[];
     error?: string;
 }
 
@@ -25,7 +25,7 @@ export abstract class Task<P = unknown> {
     readonly params: P;
     readonly externalId?: string;
     progress: { phaseIndex: number; state: TaskState };
-    addLog: AddLogEntry[];
+    changeSet: ChangeEntry[];
     error?: string;
 
     constructor(id: string, params: P, persisted?: Partial<TaskPersistence>) {
@@ -33,7 +33,7 @@ export abstract class Task<P = unknown> {
         this.params = params;
         this.externalId = persisted?.externalId;
         this.progress = { phaseIndex: persisted?.phaseIndex ?? 0, state: persisted?.state ?? "running" };
-        this.addLog = persisted?.addLog ?? new Array<AddLogEntry>();
+        this.changeSet = persisted?.changeSet ?? new Array<ChangeEntry>();
         this.error = persisted?.error;
     }
 
@@ -59,7 +59,7 @@ export abstract class Task<P = unknown> {
             phaseIndex: this.progress.phaseIndex,
             state: this.progress.state,
             externalId: this.externalId,
-            addLog: this.addLog,
+            changeSet: this.changeSet,
             error: this.error,
         };
     }

--- a/packages/node-manager/src/task/Task.ts
+++ b/packages/node-manager/src/task/Task.ts
@@ -15,6 +15,8 @@ export interface TaskPersistence {
     externalId?: string;
     changeSet: ChangeEntry[];
     error?: string;
+    revertTaskId?: string;
+    revertOf?: string;
 }
 
 export abstract class Task<P = unknown> {
@@ -27,6 +29,8 @@ export abstract class Task<P = unknown> {
     progress: { phaseIndex: number; state: TaskState };
     changeSet: ChangeEntry[];
     error?: string;
+    revertTaskId?: string;
+    revertOf?: string;
 
     constructor(id: string, params: P, persisted?: Partial<TaskPersistence>) {
         this.id = id;
@@ -35,6 +39,8 @@ export abstract class Task<P = unknown> {
         this.progress = { phaseIndex: persisted?.phaseIndex ?? 0, state: persisted?.state ?? "running" };
         this.changeSet = persisted?.changeSet ?? new Array<ChangeEntry>();
         this.error = persisted?.error;
+        this.revertTaskId = persisted?.revertTaskId;
+        this.revertOf = persisted?.revertOf;
     }
 
     get status(): TaskStatus {
@@ -44,6 +50,8 @@ export abstract class Task<P = unknown> {
             phaseIndex: this.progress.phaseIndex,
             externalId: this.externalId,
             error: this.error,
+            revertTaskId: this.revertTaskId,
+            revertOf: this.revertOf,
         };
     }
 
@@ -61,6 +69,8 @@ export abstract class Task<P = unknown> {
             externalId: this.externalId,
             changeSet: this.changeSet,
             error: this.error,
+            revertTaskId: this.revertTaskId,
+            revertOf: this.revertOf,
         };
     }
 }

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -162,7 +162,7 @@ export class TaskManagerBehavior extends Behavior {
     }
 
     /**
-     * Cancel a task: stop forward driving and best-effort revert its add-log in reverse order. An offline peer
+     * Cancel a task: stop forward driving and best-effort revert its changeSet in reverse order. An offline peer
      * parks the revert (best-effort, not a failure); a terminal revert error yields `cancelFailed`.
      *
      * If a peer is permanently offline during revert, cancel parks and the awaiting caller has no independent
@@ -184,7 +184,7 @@ export class TaskManagerBehavior extends Behavior {
         const ctx = await this.endpoint.act(agent => this.#contextFor(task, this.taskReconciler(agent)));
         try {
             const reverted = new Array<{ peer: ClientNode; kind: string; key: string }>();
-            for (const entry of [...task.addLog].reverse()) {
+            for (const entry of [...task.changeSet].reverse()) {
                 const peer = this.resolvePeerNode(entry.peerId);
                 if (peer === undefined) {
                     continue;

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -7,7 +7,7 @@
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
 import { Logger, Mutex, Observable } from "@matter/general";
 import { DatatypeModel, FieldElement } from "@matter/model";
-import { Agent, Behavior, ClientNode, DesiredStateBehavior, itemMapKey, Node, ServerNode } from "@matter/node";
+import { Agent, Behavior, ClientNode, Node, ServerNode } from "@matter/node";
 import { TaskCancelledSignal, TaskSuspendedSignal } from "./errors.js";
 import { ADD_NODE_TO_GROUP_TYPE, AddNodeToGroup } from "./groups/AddNodeToGroup.js";
 import { Revert, REVERT_TYPE } from "./Revert.js";
@@ -16,12 +16,7 @@ import { Task, TaskPersistence } from "./Task.js";
 import { TaskCtor, TaskRegistry } from "./TaskRegistry.js";
 import { TaskState, TaskStatus } from "./types.js";
 
-const TERMINAL_STATES: ReadonlySet<TaskState> = new Set<TaskState>([
-    "completed",
-    "failed",
-    "cancelled",
-    "cancelFailed",
-]);
+const TERMINAL_STATES: ReadonlySet<TaskState> = new Set<TaskState>(["completed", "failed", "cancelled"]);
 
 const logger = Logger.get("TaskManager");
 
@@ -164,51 +159,45 @@ export class TaskManagerBehavior extends Behavior {
     }
 
     /**
-     * Cancel a task: stop forward driving and best-effort revert its changeSet in reverse order. An offline peer
-     * parks the revert (best-effort, not a failure); a terminal revert error yields `cancelFailed`.
-     *
-     * If a peer is permanently offline during revert, cancel parks and the awaiting caller has no independent
-     * abort — it is released only on node dispose. Reserved follow-up.
+     * Cancel a task: stop forward driving, then spawn a revert task that rolls back the changeSet as an ordinary
+     * task (parks on offline peers, resumes after restart). Returns the revert handle, or `undefined` if there
+     * was nothing to revert. Does not await the revert — the caller observes it via the returned handle.
      */
-    async cancel(idOrExternalId: string): Promise<void> {
+    async cancel(idOrExternalId: string): Promise<TaskHandle | undefined> {
         const task = this.#find(idOrExternalId);
-        // A completed/running/parked task is still revertible; only an already-cancelled task is a no-op.
-        if (task === undefined || task.progress.state === "cancelled" || task.progress.state === "cancelFailed") {
-            return;
+        if (task === undefined || task.progress.state === "cancelled") {
+            return task?.revertTaskId === undefined ? undefined : this.get(task.revertTaskId);
         }
 
-        // Abort any in-flight gate and wait for forward driving to settle so revert does not race it.
+        // Stop forward driving so the changeset is final before we revert it.
         this.#abortGate(task.id, new TaskCancelledSignal(`Task ${task.id} cancelled`));
         await this.internal.driving.get(task.id);
+        this.internal.gates.delete(task.id);
 
-        // Clear the abort so the revert gate below is not itself short-circuited by the cancel signal.
-        this.internal.gates.delete(task.id);
-        const ctx = await this.endpoint.act(agent => this.#contextFor(task, this.taskReconciler(agent)));
-        try {
-            const reverted = new Array<{ peer: ClientNode; kind: string; key: string }>();
-            for (const entry of [...task.changeSet].reverse()) {
-                const peer = this.resolvePeerNode(entry.peerId);
-                if (peer === undefined) {
-                    continue;
-                }
-                await ctx.removeIntent(peer, entry.kind, entry.key);
-                reverted.push({ peer, kind: entry.kind, key: entry.key });
-            }
-            const peers = [...new Set(reverted.map(r => r.peer))];
-            await ctx.awaitGate(peers, () =>
-                reverted.every(
-                    r => r.peer.stateOf(DesiredStateBehavior).items[itemMapKey(r.kind, r.key)] === undefined,
-                ),
-            );
+        // running/parked → cancelled; an already-terminal (completed/failed) task keeps its truthful state.
+        if (task.progress.state === "running" || task.progress.state === "parked") {
             task.progress.state = "cancelled";
-            task.error = undefined;
-        } catch (e) {
-            task.progress.state = "cancelFailed";
-            task.error = e instanceof Error ? e.message : String(e);
-            logger.error(`Task ${task.id}: cancel revert failed`, e);
         }
-        this.internal.gates.delete(task.id);
+        const handle = this.#spawnRevert(task);
         await this.#persist(task);
+        return handle;
+    }
+
+    /** Spawn (or reuse) the revert task for `task`, linking both directions. Returns undefined if no changeSet. */
+    #spawnRevert(task: Task): TaskHandle | undefined {
+        if (task.revertTaskId !== undefined) {
+            return this.get(task.revertTaskId);
+        }
+        if (task.changeSet.length === 0) {
+            return undefined;
+        }
+        const handle = this.run(REVERT_TYPE, { originalId: task.id, entries: task.changeSet });
+        const revert = this.internal.live.get(handle.id);
+        if (revert !== undefined) {
+            revert.revertOf = task.id;
+        }
+        task.revertTaskId = handle.id;
+        return handle;
     }
 
     #abortGate(id: string, reason: unknown): void {
@@ -243,6 +232,7 @@ export class TaskManagerBehavior extends Behavior {
             task.progress.state = "failed";
             task.error = e instanceof Error ? e.message : String(e);
             logger.error(`Task ${task.id} failed`, e);
+            this.#spawnRevert(task);
             // A failing persist here must not re-reject the (otherwise handled) drive promise.
             try {
                 await this.#persist(task);
@@ -262,7 +252,7 @@ export class TaskManagerBehavior extends Behavior {
                 return;
             }
             task.progress.state = state;
-            this.#mutex.run(() => this.#persist(task));
+            this.#mutex.run(() => this.#writeRecord(task));
         };
         return new RunningTaskContext(
             task,
@@ -299,7 +289,13 @@ export class TaskManagerBehavior extends Behavior {
         return this.#rootNode.peers.get(peerId);
     }
 
+    // Serialized through the mutex: a spawned revert drives (and persists) concurrently with the original's
+    // own persist, so direct concurrent state writes would conflict on the synchronous transaction lock.
     async #persist(task: Task): Promise<void> {
+        await this.#mutex.produce(() => this.#writeRecord(task));
+    }
+
+    async #writeRecord(task: Task): Promise<void> {
         const record = task.toPersistence();
         await this.endpoint.act(agent => {
             const self = agent.get(TaskManagerBehavior);

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -185,6 +185,10 @@ export class TaskManagerBehavior extends Behavior {
 
     /** Spawn (or reuse) the revert task for `task`, linking both directions. Returns undefined if no changeSet. */
     #spawnRevert(task: Task): TaskHandle | undefined {
+        // A failed revert surfaces as `failed` for operator attention; reverting a revert would recurse unbounded.
+        if (task.type === REVERT_TYPE) {
+            return undefined;
+        }
         if (task.revertTaskId !== undefined) {
             return this.get(task.revertTaskId);
         }

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -10,6 +10,7 @@ import { DatatypeModel, FieldElement } from "@matter/model";
 import { Agent, Behavior, ClientNode, DesiredStateBehavior, itemMapKey, Node, ServerNode } from "@matter/node";
 import { TaskCancelledSignal, TaskSuspendedSignal } from "./errors.js";
 import { ADD_NODE_TO_GROUP_TYPE, AddNodeToGroup } from "./groups/AddNodeToGroup.js";
+import { Revert, REVERT_TYPE } from "./Revert.js";
 import { GateControl, RunningTaskContext } from "./RunningTaskContext.js";
 import { Task, TaskPersistence } from "./Task.js";
 import { TaskCtor, TaskRegistry } from "./TaskRegistry.js";
@@ -72,6 +73,7 @@ export class TaskManagerBehavior extends Behavior {
     /** Built-in task types registered before the resume pass. */
     protected registerBuiltins(): void {
         this.internal.registry.register(ADD_NODE_TO_GROUP_TYPE, AddNodeToGroup);
+        this.internal.registry.register(REVERT_TYPE, Revert);
     }
 
     #registerBuiltins(): void {

--- a/packages/node-manager/src/task/errors.ts
+++ b/packages/node-manager/src/task/errors.ts
@@ -11,11 +11,8 @@ export class TaskError extends MatterError {}
 /** A task referenced a peer that is not commissioned / not present. */
 export class TaskPeerUnavailableError extends TaskError {}
 
-/** A task's forward work failed terminally (no auto-rollback in this increment). */
+/** A task's forward work failed terminally; the manager spawns a revert task to roll back its changeSet. */
 export class TaskFailedError extends TaskError {}
-
-/** A cancel could not revert the task's changes (reserved; not reachable by AddNodeToGroup). */
-export class TaskCancelFailedError extends TaskError {}
 
 /** Internal signal a running gate throws when cancel is requested, so #drive stops cleanly (not "failed"). */
 export class TaskCancelledSignal extends TaskError {}

--- a/packages/node-manager/src/task/types.ts
+++ b/packages/node-manager/src/task/types.ts
@@ -6,7 +6,7 @@
 
 import type { ClientNode, ItemMode, ManagedItem } from "@matter/node";
 
-export type TaskState = "running" | "parked" | "completed" | "failed" | "cancelled" | "cancelFailed";
+export type TaskState = "running" | "parked" | "completed" | "failed" | "cancelled";
 
 export interface TaskStatus {
     type: string;
@@ -14,6 +14,8 @@ export interface TaskStatus {
     phaseIndex: number;
     externalId?: string;
     error?: string;
+    revertTaskId?: string;
+    revertOf?: string;
 }
 
 export interface ChangeEntry {

--- a/packages/node-manager/src/task/types.ts
+++ b/packages/node-manager/src/task/types.ts
@@ -29,8 +29,10 @@ export interface TaskPhase {
 
 export interface TaskContext {
     resolvePeer(peerId: string): ClientNode;
+    tryResolvePeer(peerId: string): ClientNode | undefined;
     setIntent(peer: ClientNode, kind: string, key: string, intent: unknown, mode?: ItemMode): Promise<void>;
     removeIntent(peer: ClientNode, kind: string, key: string): Promise<void>;
+    removeIntentIfUnreferenced(peer: ClientNode, kind: string, key: string): Promise<boolean>;
     awaitGate(nodes: ClientNode[], until: (items: ManagedItem[]) => boolean): Promise<void>;
     awaitCommitted(items: Array<{ peer: ClientNode; kind: string; key: string }>): Promise<void>;
 }

--- a/packages/node-manager/src/task/types.ts
+++ b/packages/node-manager/src/task/types.ts
@@ -36,4 +36,5 @@ export interface TaskContext {
     removeIntentIfUnreferenced(peer: ClientNode, kind: string, key: string): Promise<boolean>;
     awaitGate(nodes: ClientNode[], until: (items: ManagedItem[]) => boolean): Promise<void>;
     awaitCommitted(items: Array<{ peer: ClientNode; kind: string; key: string }>): Promise<void>;
+    itemAbsent(peer: ClientNode, kind: string, key: string): boolean;
 }

--- a/packages/node-manager/src/task/types.ts
+++ b/packages/node-manager/src/task/types.ts
@@ -16,10 +16,11 @@ export interface TaskStatus {
     error?: string;
 }
 
-export interface AddLogEntry {
+export interface ChangeEntry {
     peerId: string;
     kind: string;
     key: string;
+    prior?: { intent: unknown; mode: ItemMode };
 }
 
 export interface TaskPhase {

--- a/packages/node-manager/test/ReconcilerBehaviorTest.ts
+++ b/packages/node-manager/test/ReconcilerBehaviorTest.ts
@@ -65,6 +65,9 @@ function makeTarget(items: Record<string, ManagedItem> = {}): ReconcileTarget & 
         async dropItem(kind, key) {
             delete state[`${kind}:${key}`];
         },
+        currentState(kind, key) {
+            return state[`${kind}:${key}`]?.status.state;
+        },
     };
 }
 

--- a/packages/node-manager/test/reconcile/GroupKeyItemKindTest.ts
+++ b/packages/node-manager/test/reconcile/GroupKeyItemKindTest.ts
@@ -6,7 +6,7 @@
 
 import { GroupKeyGrant, GroupKeyItemKind } from "#reconcile/GroupKeyItemKind.js";
 import { ImplementationError } from "@matter/general";
-import { ClientNode, ManagedItem } from "@matter/node";
+import { ClientNode, DesiredStateBehavior, ItemState, ManagedItem, itemMapKey } from "@matter/node";
 import { GroupKeyManagement } from "@matter/types/clusters/group-key-management";
 
 const { TrustFirst } = GroupKeyManagement.GroupKeySecurityPolicy;
@@ -91,5 +91,46 @@ describe("GroupKeyItemKind", () => {
             err = e;
         }
         expect(err).instanceOf(ImplementationError);
+    });
+});
+
+/** Node stub exposing only the desired-state item map that isReferenced scans. */
+function nodeWithItems(items: ManagedItem[]): ClientNode {
+    const map: Record<string, ManagedItem> = {};
+    for (const i of items) {
+        map[itemMapKey(i.kind, i.key)] = i;
+    }
+    return {
+        stateOf: (type: unknown) => (type === DesiredStateBehavior ? { items: map } : {}),
+    } as unknown as ClientNode;
+}
+
+function mapItem(groupId: number, groupKeySetId: number, state: ItemState = "committed"): ManagedItem {
+    return {
+        kind: "groupKeyMap",
+        key: String(groupId),
+        intent: { groupId, groupKeySetId },
+        mode: "converge",
+        status: { state, updateTimestamp: 0 },
+    };
+}
+
+describe("GroupKeyItemKind.isReferenced", () => {
+    it("is referenced while a live groupKeyMap points at the key set", () => {
+        const kind = new GroupKeyItemKind();
+        const node = nodeWithItems([mapItem(0x101, 42)]);
+        expect(kind.isReferenced(node, "42")).equals(true);
+    });
+
+    it("is not referenced when no map points at the key set", () => {
+        const kind = new GroupKeyItemKind();
+        const node = nodeWithItems([mapItem(0x101, 7)]);
+        expect(kind.isReferenced(node, "42")).equals(false);
+    });
+
+    it("ignores a deletePending map (not a live reference)", () => {
+        const kind = new GroupKeyItemKind();
+        const node = nodeWithItems([mapItem(0x101, 42, "deletePending")]);
+        expect(kind.isReferenced(node, "42")).equals(false);
     });
 });

--- a/packages/node-manager/test/reconcile/GroupKeyItemKindTest.ts
+++ b/packages/node-manager/test/reconcile/GroupKeyItemKindTest.ts
@@ -116,32 +116,16 @@ function mapItem(groupId: number, groupKeySetId: number, state: ItemState = "com
 }
 
 describe("GroupKeyItemKind.apply create-if-absent", () => {
-    function commandsNode(present: number[]) {
-        const calls = { write: 0 };
-        const node = {
-            commandsOf: () => ({
-                keySetReadAllIndices: async () => ({ groupKeySetIDs: present }),
-                keySetWrite: async () => {
-                    calls.write++;
-                },
-            }),
-        } as unknown as ClientNode;
-        return { node, calls };
-    }
-    function gkItem(id: number): ManagedItem<GroupKeyGrant> {
-        return item(keySet(id));
-    }
-
     it("writes when the key set is absent", async () => {
-        const { node, calls } = commandsNode([]);
-        await new GroupKeyItemKind().apply(node, gkItem(42));
-        expect(calls.write).equals(1);
+        const { node, calls } = fakePeer([]);
+        await new GroupKeyItemKind().apply(node, item(keySet(42)));
+        expect(calls.wrote).deep.equals([42]);
     });
 
     it("skips the write when the key set already exists", async () => {
-        const { node, calls } = commandsNode([42]);
-        await new GroupKeyItemKind().apply(node, gkItem(42));
-        expect(calls.write).equals(0);
+        const { node, calls } = fakePeer([42]);
+        await new GroupKeyItemKind().apply(node, item(keySet(42)));
+        expect(calls.wrote).deep.equals([]);
     });
 });
 

--- a/packages/node-manager/test/reconcile/GroupKeyItemKindTest.ts
+++ b/packages/node-manager/test/reconcile/GroupKeyItemKindTest.ts
@@ -115,6 +115,36 @@ function mapItem(groupId: number, groupKeySetId: number, state: ItemState = "com
     };
 }
 
+describe("GroupKeyItemKind.apply create-if-absent", () => {
+    function commandsNode(present: number[]) {
+        const calls = { write: 0 };
+        const node = {
+            commandsOf: () => ({
+                keySetReadAllIndices: async () => ({ groupKeySetIDs: present }),
+                keySetWrite: async () => {
+                    calls.write++;
+                },
+            }),
+        } as unknown as ClientNode;
+        return { node, calls };
+    }
+    function gkItem(id: number): ManagedItem<GroupKeyGrant> {
+        return item(keySet(id));
+    }
+
+    it("writes when the key set is absent", async () => {
+        const { node, calls } = commandsNode([]);
+        await new GroupKeyItemKind().apply(node, gkItem(42));
+        expect(calls.write).equals(1);
+    });
+
+    it("skips the write when the key set already exists", async () => {
+        const { node, calls } = commandsNode([42]);
+        await new GroupKeyItemKind().apply(node, gkItem(42));
+        expect(calls.write).equals(0);
+    });
+});
+
 describe("GroupKeyItemKind.isReferenced", () => {
     it("is referenced while a live groupKeyMap points at the key set", () => {
         const kind = new GroupKeyItemKind();

--- a/packages/node-manager/test/reconcile/GroupKeyMapItemKindTest.ts
+++ b/packages/node-manager/test/reconcile/GroupKeyMapItemKindTest.ts
@@ -5,7 +5,7 @@
  */
 
 import { GroupKeyMapGrant, GroupKeyMapItemKind } from "#reconcile/GroupKeyMapItemKind.js";
-import { ClientNode, ManagedItem } from "@matter/node";
+import { ClientNode, DesiredStateBehavior, ManagedItem, itemMapKey } from "@matter/node";
 import { FabricIndex, GroupId } from "@matter/types";
 import { GroupKeyManagement } from "@matter/types/clusters/group-key-management";
 
@@ -102,5 +102,30 @@ describe("GroupKeyMapItemKind", () => {
         const { node } = fakePeer([]);
         const ipkItem = item({ groupId: GroupId(0x101), groupKeySetId: 0 });
         await expect(kind.apply(node, ipkItem)).rejectedWith("groupKeySetId 0");
+    });
+});
+
+describe("GroupKeyMapItemKind.isReferenced", () => {
+    function membershipItem(groupId: number, state = "committed" as const) {
+        return {
+            kind: "endpointGroupMembership",
+            key: `${groupId}:1`,
+            intent: { localEndpoint: 1, groupId },
+            mode: "converge" as const,
+            status: { state, updateTimestamp: 0 },
+        };
+    }
+    function node(items: unknown[]) {
+        const map: Record<string, unknown> = {};
+        for (const i of items as { kind: string; key: string }[]) {
+            map[itemMapKey(i.kind, i.key)] = i;
+        }
+        return { stateOf: (t: unknown) => (t === DesiredStateBehavior ? { items: map } : {}) } as unknown as ClientNode;
+    }
+    it("is referenced while a live membership names the group", () => {
+        expect(new GroupKeyMapItemKind().isReferenced(node([membershipItem(0x101)]), "257")).equals(true);
+    });
+    it("is not referenced when no membership names the group", () => {
+        expect(new GroupKeyMapItemKind().isReferenced(node([membershipItem(0x200)]), "257")).equals(false);
     });
 });

--- a/packages/node-manager/test/reconcile/GroupKeyMapItemKindTest.ts
+++ b/packages/node-manager/test/reconcile/GroupKeyMapItemKindTest.ts
@@ -106,7 +106,7 @@ describe("GroupKeyMapItemKind", () => {
 });
 
 describe("GroupKeyMapItemKind.isReferenced", () => {
-    function membershipItem(groupId: number, state = "committed" as const) {
+    function membershipItem(groupId: number, state: "committed" | "deletePending" = "committed") {
         return {
             kind: "endpointGroupMembership",
             key: `${groupId}:1`,
@@ -127,5 +127,10 @@ describe("GroupKeyMapItemKind.isReferenced", () => {
     });
     it("is not referenced when no membership names the group", () => {
         expect(new GroupKeyMapItemKind().isReferenced(node([membershipItem(0x200)]), "257")).equals(false);
+    });
+    it("ignores a deletePending membership (not a live reference)", () => {
+        expect(new GroupKeyMapItemKind().isReferenced(node([membershipItem(0x101, "deletePending")]), "257")).equals(
+            false,
+        );
     });
 });

--- a/packages/node-manager/test/task/ChangesetTest.ts
+++ b/packages/node-manager/test/task/ChangesetTest.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
+import { RunningTaskContext } from "#task/RunningTaskContext.js";
+import { Task } from "#task/Task.js";
+import { TaskState } from "#task/types.js";
+import { FakePeer } from "./helpers.js";
+
+class CsTask extends Task {
+    override readonly type = "cs-test";
+    override get phases() {
+        return [];
+    }
+}
+
+function makeContext(peer: FakePeer) {
+    const task = new CsTask("cs-test:1", {});
+    const setState = (s: TaskState) => {
+        task.progress.state = s;
+    };
+    const ctx = new RunningTaskContext(task, () => peer.asNode(), peer as unknown as ReconcilerBehavior, setState);
+    return { task, ctx };
+}
+
+describe("changeSet prior capture", () => {
+    it("records prior undefined when no item existed", async () => {
+        const peer = new FakePeer("p1");
+        const { task, ctx } = makeContext(peer);
+        await ctx.setIntent(peer.asNode(), "groupKey", "42", { a: 1 }, "converge");
+        expect(task.changeSet).deep.equals([{ peerId: "p1", kind: "groupKey", key: "42", prior: undefined }]);
+    });
+
+    it("records prior intent+mode when an item existed", async () => {
+        const peer = new FakePeer("p1");
+        peer.setIntent("groupKey", "42", { old: true }, "maintain");
+        const { task, ctx } = makeContext(peer);
+        await ctx.setIntent(peer.asNode(), "groupKey", "42", { new: true }, "converge");
+        expect(task.changeSet[0].prior).deep.equals({ intent: { old: true }, mode: "maintain" });
+    });
+
+    it("first-touch-wins: a second touch does not overwrite the recorded prior", async () => {
+        const peer = new FakePeer("p1");
+        const { task, ctx } = makeContext(peer);
+        await ctx.setIntent(peer.asNode(), "groupKey", "42", { a: 1 });
+        await ctx.setIntent(peer.asNode(), "groupKey", "42", { a: 2 });
+        expect(task.changeSet.length).equals(1);
+        expect(task.changeSet[0].prior).equals(undefined);
+    });
+
+    it("removeIntent is logged too", async () => {
+        const peer = new FakePeer("p1");
+        peer.setIntent("groupKey", "42", { old: true }, "converge");
+        const { task, ctx } = makeContext(peer);
+        await ctx.removeIntent(peer.asNode(), "groupKey", "42");
+        expect(task.changeSet[0].prior).deep.equals({ intent: { old: true }, mode: "converge" });
+    });
+});

--- a/packages/node-manager/test/task/RemoveIntentTest.ts
+++ b/packages/node-manager/test/task/RemoveIntentTest.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
+import { RunningTaskContext } from "#task/RunningTaskContext.js";
+import { Task } from "#task/Task.js";
+import { TaskState } from "#task/types.js";
+import { itemMapKey } from "@matter/node";
+import { FakePeer } from "./helpers.js";
+
+class CtxTask extends Task {
+    override readonly type = "ctx-test";
+    override get phases() {
+        return [];
+    }
+}
+
+function makeContext(peer: FakePeer, referenced: boolean) {
+    const task = new CtxTask("ctx-test:1", {});
+    const setState = (s: TaskState) => {
+        task.progress.state = s;
+    };
+    (peer as unknown as { itemKind(kind: string): unknown }).itemKind = () => ({
+        isReferenced: () => referenced,
+    });
+    const ctx = new RunningTaskContext(task, () => peer.asNode(), peer as unknown as ReconcilerBehavior, setState);
+    return { task, ctx };
+}
+
+describe("removeIntentIfUnreferenced", () => {
+    it("removes and returns true when not referenced", async () => {
+        const peer = new FakePeer("p1");
+        peer.addItem("groupKey", "42", "committed");
+        const { ctx } = makeContext(peer, false);
+        const removed = await ctx.removeIntentIfUnreferenced(peer.asNode(), "groupKey", "42");
+        expect(removed).equals(true);
+        expect(peer.removeOrder).contains(itemMapKey("groupKey", "42"));
+    });
+
+    it("skips and returns false when still referenced", async () => {
+        const peer = new FakePeer("p1");
+        peer.addItem("groupKey", "42", "committed");
+        const { ctx } = makeContext(peer, true);
+        const removed = await ctx.removeIntentIfUnreferenced(peer.asNode(), "groupKey", "42");
+        expect(removed).equals(false);
+        expect(peer.removeOrder.length).equals(0);
+    });
+});

--- a/packages/node-manager/test/task/RevertTaskTest.ts
+++ b/packages/node-manager/test/task/RevertTaskTest.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
+import { Revert, RevertParams } from "#task/Revert.js";
+import { RunningTaskContext } from "#task/RunningTaskContext.js";
+import { TaskState } from "#task/types.js";
+import { itemMapKey } from "@matter/node";
+import { FakePeer } from "./helpers.js";
+
+function runRevert(peer: FakePeer, params: RevertParams, referenced = new Set<string>()) {
+    const task = new Revert("revert:orig", params);
+    const setState = (s: TaskState) => {
+        task.progress.state = s;
+    };
+    (peer as unknown as { itemKind(kind: string): unknown }).itemKind = (kind: string) => ({
+        isReferenced: (_n: unknown, key: string) => referenced.has(`${kind}:${key}`),
+    });
+    const ctx = new RunningTaskContext(task, () => peer.asNode(), peer as unknown as ReconcilerBehavior, setState);
+    return task.phases[0].run(ctx);
+}
+
+describe("Revert task", () => {
+    before(() => MockTime.init());
+
+    it("removes an added (prior-absent) entry", async () => {
+        const peer = new FakePeer("p1");
+        peer.addItem("groupKey", "42", "committed");
+        await MockTime.resolve(
+            runRevert(peer, { originalId: "orig", entries: [{ peerId: "p1", kind: "groupKey", key: "42" }] }),
+        );
+        expect(peer.items[itemMapKey("groupKey", "42")]).equals(undefined);
+    });
+
+    it("restores a prior intent rather than deleting", async () => {
+        const peer = new FakePeer("p1");
+        peer.setIntent("groupKeyMap", "257", { current: true });
+        peer.markHas("groupKeyMap", "257");
+        await MockTime.resolve(
+            runRevert(peer, {
+                originalId: "orig",
+                entries: [
+                    {
+                        peerId: "p1",
+                        kind: "groupKeyMap",
+                        key: "257",
+                        prior: { intent: { old: true }, mode: "converge" },
+                    },
+                ],
+            }),
+        );
+        expect(peer.items[itemMapKey("groupKeyMap", "257")]?.intent).deep.equals({ old: true });
+        expect(peer.items[itemMapKey("groupKeyMap", "257")]?.status.state).equals("committed");
+    });
+
+    it("keeps a still-referenced shared entry (gate does not wait on it)", async () => {
+        const peer = new FakePeer("p1");
+        peer.addItem("groupKey", "42", "committed");
+        await MockTime.resolve(
+            runRevert(
+                peer,
+                { originalId: "orig", entries: [{ peerId: "p1", kind: "groupKey", key: "42" }] },
+                new Set(["groupKey:42"]),
+            ),
+        );
+        expect(peer.items[itemMapKey("groupKey", "42")]).not.equals(undefined);
+    });
+});

--- a/packages/node-manager/test/task/RollbackIntegrationTest.ts
+++ b/packages/node-manager/test/task/RollbackIntegrationTest.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
+import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
+import { TaskFailedError } from "#task/errors.js";
+import { Environment } from "@matter/general";
+import { ClientNode, itemMapKey, ServerNode } from "@matter/node";
+import { MockServerNode } from "@matter/node/testing";
+import { FakePeer, SyntheticTask } from "./helpers.js";
+
+class TestTaskManager extends TaskManagerBehavior {
+    static override readonly schema = TaskManagerBehavior.schema;
+    static peers = new Map<string, FakePeer>();
+    static reconcilerPeer?: FakePeer;
+    protected override resolvePeerNode(peerId: string): ClientNode | undefined {
+        return TestTaskManager.peers.get(peerId)?.asNode();
+    }
+    protected override taskReconciler(): ReconcilerBehavior {
+        return TestTaskManager.reconcilerPeer as unknown as ReconcilerBehavior;
+    }
+}
+
+const RootEndpoint = MockServerNode.RootEndpoint.with(TestTaskManager);
+
+async function awaitState(node: ServerNode, id: string, ...states: string[]): Promise<void> {
+    for (let i = 0; i < 10_000; i++) {
+        const state = await node.act(a => a.get(TestTaskManager).state.tasks[id]?.state);
+        if (state !== undefined && states.includes(state)) return;
+        await MockTime.advance(1);
+    }
+    throw new Error(`Task ${id} did not reach state ${states.join("|")}`);
+}
+
+describe("auto-rollback", () => {
+    before(() => MockTime.init());
+
+    it("hard failure spawns a linked revert task that removes the changeset", async () => {
+        const environment = new Environment("test");
+        const peer = new FakePeer("rp");
+        peer.markHas("groupKey", "42");
+        TestTaskManager.peers.set("rp", peer);
+        TestTaskManager.reconcilerPeer = peer;
+        SyntheticTask.phasesByTag["boom"] = [
+            {
+                name: "set-then-fail",
+                run: async ctx => {
+                    const p = ctx.resolvePeer("rp");
+                    await ctx.setIntent(p, "groupKey", "42", { a: 1 });
+                    throw new TaskFailedError("boom");
+                },
+            },
+        ];
+
+        const node = await MockServerNode.create(RootEndpoint, { environment, id: "rb" });
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+        await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "boom" }));
+
+        await awaitState(node, "synthetic:boom", "failed");
+        const original = node.stateOf(TestTaskManager).tasks["synthetic:boom"];
+        expect(original.revertTaskId).equals("revert:synthetic:boom");
+
+        await awaitState(node, "revert:synthetic:boom", "completed");
+        expect(peer.items[itemMapKey("groupKey", "42")]).equals(undefined);
+        await node.close();
+    });
+});

--- a/packages/node-manager/test/task/RollbackIntegrationTest.ts
+++ b/packages/node-manager/test/task/RollbackIntegrationTest.ts
@@ -67,4 +67,43 @@ describe("auto-rollback", () => {
         expect(peer.items[itemMapKey("groupKey", "42")]).equals(undefined);
         await node.close();
     });
+
+    it("does not spawn a revert-of-revert when the revert itself fails terminally", async () => {
+        const environment = new Environment("test");
+        const peer = new FakePeer("rp");
+        TestTaskManager.peers.set("rp", peer);
+        TestTaskManager.reconcilerPeer = peer;
+        SyntheticTask.phasesByTag["boom2"] = [
+            {
+                name: "set-then-fail",
+                run: async ctx => {
+                    const p = ctx.resolvePeer("rp");
+                    await ctx.setIntent(p, "groupKey", "99", { a: 1 });
+                    throw new TaskFailedError("boom2");
+                },
+            },
+        ];
+
+        const node = await MockServerNode.create(RootEndpoint, { environment, id: "rb2" });
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+
+        // The revert's forward work (awaitGate -> verify-reconcile over its deletePending intent) rejects.
+        const realReconcile = peer.reconcile.bind(peer);
+        peer.reconcile = async (n, options) => {
+            if (Object.values(peer.items).some(i => i.status.state === "deletePending")) {
+                throw new TaskFailedError("revert boom");
+            }
+            return realReconcile(n, options);
+        };
+
+        await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "boom2" }));
+
+        await awaitState(node, "synthetic:boom2", "failed");
+        const original = node.stateOf(TestTaskManager).tasks["synthetic:boom2"];
+        expect(original.revertTaskId).equals("revert:synthetic:boom2");
+
+        await awaitState(node, "revert:synthetic:boom2", "failed");
+        expect(node.stateOf(TestTaskManager).tasks["revert:revert:synthetic:boom2"]).equals(undefined);
+        await node.close();
+    });
 });

--- a/packages/node-manager/test/task/TaskContextGateTest.ts
+++ b/packages/node-manager/test/task/TaskContextGateTest.ts
@@ -83,8 +83,8 @@ describe("TaskContext gates", () => {
 
     it("does not resolve on cached committed state while a node is unreachable", async () => {
         const peer = new FakePeer("p1");
-        peer.addItem("groupMembership", "1", "committed"); // cached committed, but...
-        peer.setReachable(false); // ...node is offline, so the gate must park, not resolve
+        peer.addItem("groupMembership", "1", "committed");
+        peer.setReachable(false);
         const { ctx, task } = makeContext(peer);
 
         let settled = false;

--- a/packages/node-manager/test/task/TaskContextGateTest.ts
+++ b/packages/node-manager/test/task/TaskContextGateTest.ts
@@ -80,4 +80,24 @@ describe("TaskContext gates", () => {
         expect(states).contains("running");
         expect(task.progress.state).equals("running");
     });
+
+    it("does not resolve on cached committed state while a node is unreachable", async () => {
+        const peer = new FakePeer("p1");
+        peer.addItem("groupMembership", "1", "committed"); // cached committed, but...
+        peer.setReachable(false); // ...node is offline, so the gate must park, not resolve
+        const { ctx, task } = makeContext(peer);
+
+        let settled = false;
+        const gate = ctx.awaitCommitted([{ peer: peer.asNode(), kind: "groupMembership", key: "1" }]).then(() => {
+            settled = true;
+        });
+
+        await MockTime.resolve(Promise.resolve());
+        expect(settled).equals(false);
+        expect(task.progress.state).equals("parked");
+
+        peer.setReachable(true);
+        await MockTime.resolve(gate);
+        expect(settled).equals(true);
+    });
 });

--- a/packages/node-manager/test/task/TaskLifecycleTest.ts
+++ b/packages/node-manager/test/task/TaskLifecycleTest.ts
@@ -152,7 +152,7 @@ describe("Task lifecycle", () => {
     });
 
     describe("cancel", () => {
-        it("reverts created items in reverse order and ends cancelled", async () => {
+        it("cancelling a completed task spawns a revert that removes items in reverse order", async () => {
             const environment = new Environment("test");
             const peer = new FakePeer("cp");
             TestTaskManager.peers.set("cp", peer);
@@ -176,8 +176,9 @@ describe("Task lifecycle", () => {
             await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "cancel" }));
             await awaitState(node, "synthetic:cancel", "completed");
 
-            const cancelDone = node.act(a => a.get(TestTaskManager).cancel("synthetic:cancel"));
-            await MockTime.resolve(cancelDone);
+            const handle = await node.act(a => a.get(TestTaskManager).cancel("synthetic:cancel"));
+            expect(handle?.id).equals("revert:synthetic:cancel");
+            await awaitState(node, "revert:synthetic:cancel", "completed");
 
             // Items are removed in REVERSE add order (B added last → reverted first).
             expect(peer.removeOrder).deep.equals([
@@ -186,8 +187,10 @@ describe("Task lifecycle", () => {
             ]);
             expect(peer.items[itemMapKey("groupMembership", "A")]).equals(undefined);
             expect(peer.items[itemMapKey("groupMembership", "B")]).equals(undefined);
+            // Cancelling an already-completed task spawns the revert but leaves the original's truthful state.
             const status = await node.act(a => a.get(TestTaskManager).get("synthetic:cancel")?.status);
-            expect(status?.state).equals("cancelled");
+            expect(status?.state).equals("completed");
+            expect(status?.revertTaskId).equals("revert:synthetic:cancel");
             await node.close();
         });
 
@@ -209,12 +212,15 @@ describe("Task lifecycle", () => {
             }
             expect(peer.items[itemMapKey("groupMembership", "X")]?.status.state).equals("pending");
 
-            const cancelDone = node.act(a => a.get(TestTaskManager).cancel("synthetic:inflight"));
-            await MockTime.resolve(cancelDone);
+            const handle = await node.act(a => a.get(TestTaskManager).cancel("synthetic:inflight"));
+            expect(handle?.id).equals("revert:synthetic:inflight");
 
             const status = await node.act(a => a.get(TestTaskManager).get("synthetic:inflight")?.status);
             expect(status?.state).equals("cancelled");
             expect(status?.error).equals(undefined);
+
+            await awaitState(node, "revert:synthetic:inflight", "completed");
+            expect(peer.items[itemMapKey("groupMembership", "X")]).equals(undefined);
             await node.close();
         });
     });

--- a/packages/node-manager/test/task/groups/AddNodeToGroupIntegrationTest.ts
+++ b/packages/node-manager/test/task/groups/AddNodeToGroupIntegrationTest.ts
@@ -120,19 +120,23 @@ describe("AddNodeToGroup task integration (single peer)", () => {
         await awaitState(controller, TASK_ID, "completed");
         expect(isMember(device)).equals(true);
 
-        await MockTime.resolve(
+        const handle = await MockTime.resolve(
             controller.act(agent => agent.get(TaskManagerBehavior).cancel(TASK_ID)),
             {
                 macrotasks: true,
             },
         );
+        expect(handle?.id).equals(`revert:${TASK_ID}`);
+        await awaitState(controller, `revert:${TASK_ID}`, "completed");
 
         expect(itemState(peer, "groupKey", String(GROUP_KEY_SET_ID))).equals(undefined);
         expect(itemState(peer, "groupKeyMap", String(GROUP))).equals(undefined);
         expect(itemState(peer, "endpointGroupMembership", String(GROUP))).equals(undefined);
         expect(isMember(device)).equals(false);
+        // Cancelling an already-completed task spawns the revert but leaves the original's truthful state.
         const status = await controller.act(agent => agent.get(TaskManagerBehavior).get(TASK_ID)?.status);
-        expect(status?.state).equals("cancelled");
+        expect(status?.state).equals("completed");
+        expect(status?.revertTaskId).equals(`revert:${TASK_ID}`);
     });
 
     it("resumes a parked task across a controller restart", async () => {

--- a/packages/node-manager/test/task/groups/RollbackIntegrationTest.ts
+++ b/packages/node-manager/test/task/groups/RollbackIntegrationTest.ts
@@ -1,0 +1,262 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TaskFailedError } from "#task/errors.js";
+import { ADD_NODE_TO_GROUP_TYPE, AddNodeToGroupParams } from "#task/groups/AddNodeToGroup.js";
+import { Task } from "#task/Task.js";
+import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
+import { TaskContext, TaskPhase } from "#task/types.js";
+import { DesiredStateBehavior, itemMapKey, NetworkClient, ServerNode } from "@matter/node";
+import { GroupKeyManagementClient, GroupKeyManagementServer } from "@matter/node/behaviors/group-key-management";
+import { GroupsServer } from "@matter/node/behaviors/groups";
+import { OnOffLightSwitchDevice } from "@matter/node/devices/on-off-light-switch";
+import { MockServerNode, MockSite, subscribedPeer } from "@matter/node/testing";
+import { SustainedSubscription } from "@matter/protocol";
+import { EndpointNumber, GroupId } from "@matter/types";
+import { GroupKeyManagement } from "@matter/types/clusters/group-key-management";
+
+const { TrustFirst } = GroupKeyManagement.GroupKeySecurityPolicy;
+
+const LOCAL_EP = EndpointNumber(1);
+const GROUP = GroupId(0x101);
+const GROUP_KEY_SET_ID = 42;
+
+const PARAMS: AddNodeToGroupParams = {
+    peerId: "peer1",
+    endpoint: 1,
+    groupId: 0x101,
+    groupName: "kitchen",
+    groupKeySetId: GROUP_KEY_SET_ID,
+    groupKeySecurityPolicy: TrustFirst,
+    epochKey0: new Uint8Array(16).fill(0xab),
+    epochStartTime0: 946684800000001n, // must be > IPK_DEFAULT_EPOCH_START_TIME
+};
+
+const TASK_ID = `${ADD_NODE_TO_GROUP_TYPE}:peer1:${0x101}`;
+
+const FAILING_TYPE = "failingProvision";
+const FAILING_ID = `${FAILING_TYPE}:peer1:${0x101}`;
+
+/**
+ * Provisions the three AddNodeToGroup intents, then fails hard. Used to drive auto-rollback: the manager
+ * spawns `revert:<id>` to undo the recorded changeSet.
+ */
+class FailingProvision extends Task<AddNodeToGroupParams> {
+    readonly type = FAILING_TYPE;
+
+    static override idFor(params: AddNodeToGroupParams): string {
+        return `${FAILING_TYPE}:${params.peerId}:${params.groupId}`;
+    }
+
+    get phases(): TaskPhase[] {
+        return [{ name: "provision", run: ctx => this.#provision(ctx) }];
+    }
+
+    async #provision(ctx: TaskContext): Promise<void> {
+        const p = this.params;
+        const peer = ctx.resolvePeer(p.peerId);
+        const groupId = GroupId(p.groupId);
+
+        await ctx.setIntent(
+            peer,
+            "groupKey",
+            String(p.groupKeySetId),
+            {
+                groupKeySetId: p.groupKeySetId,
+                groupKeySecurityPolicy: p.groupKeySecurityPolicy,
+                epochKey0: p.epochKey0,
+                epochStartTime0: p.epochStartTime0,
+                epochKey1: null,
+                epochStartTime1: null,
+                epochKey2: null,
+                epochStartTime2: null,
+            },
+            "converge",
+        );
+        await ctx.setIntent(
+            peer,
+            "groupKeyMap",
+            String(p.groupId),
+            { groupId, groupKeySetId: p.groupKeySetId },
+            "converge",
+        );
+        await ctx.setIntent(
+            peer,
+            "endpointGroupMembership",
+            String(p.groupId),
+            { localEndpoint: p.endpoint, groupId, groupName: p.groupName },
+            "converge",
+        );
+
+        throw new TaskFailedError("forced provisioning failure");
+    }
+}
+
+const ControllerRoot = MockServerNode.RootEndpoint.with(TaskManagerBehavior);
+
+function isMember(device: ServerNode): boolean {
+    const { groupTable } = device.stateOf(GroupKeyManagementServer);
+    return groupTable.some(e => e.groupId === GROUP && e.endpoints.includes(LOCAL_EP));
+}
+
+function keySetCount(device: ServerNode, id: number): number {
+    return device.stateOf(GroupKeyManagementServer).groupKeySets.filter(ks => ks.groupKeySetId === id).length;
+}
+
+function itemState(
+    peer: { stateOf(type: unknown): { items: Record<string, { status: { state: string } }> } },
+    kind: string,
+    key: string,
+) {
+    return peer.stateOf(DesiredStateBehavior).items[itemMapKey(kind, key)]?.status.state;
+}
+
+/** Pump virtual time + macrotasks until the persisted task state is one of `states` (else throw). */
+async function awaitState(node: ServerNode, id: string, ...states: string[]): Promise<void> {
+    for (let i = 0; i < 2_000; i++) {
+        const state = await node.act(a => a.get(TaskManagerBehavior).state.tasks[id]?.state);
+        if (state !== undefined && states.includes(state)) {
+            return;
+        }
+        await MockTime.advance(100);
+        await MockTime.macrotask;
+    }
+    throw new Error(`Task ${id} did not reach state ${states.join("|")}`);
+}
+
+describe("Rollback task integration (single peer)", () => {
+    before(() => {
+        MockTime.init();
+    });
+
+    it("auto-rollback removes provisioned intents on a hard failure", async () => {
+        await using site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair({
+            controller: { type: ControllerRoot },
+            device: { type: MockServerNode.RootEndpoint, device: OnOffLightSwitchDevice.with(GroupsServer) },
+        });
+        const peer = await subscribedPeer(controller, "peer1");
+
+        await controller.act(agent => agent.get(TaskManagerBehavior).register(FAILING_TYPE, FailingProvision));
+        await controller.act(agent => agent.get(TaskManagerBehavior).run(FAILING_TYPE, PARAMS));
+        await awaitState(controller, FAILING_ID, "failed");
+
+        const revertId = await controller.act(
+            agent => agent.get(TaskManagerBehavior).get(FAILING_ID)?.status.revertTaskId,
+        );
+        expect(revertId).equals(`revert:${FAILING_ID}`);
+
+        await awaitState(controller, `revert:${FAILING_ID}`, "completed");
+
+        expect(itemState(peer, "groupKey", String(GROUP_KEY_SET_ID))).equals(undefined);
+        expect(itemState(peer, "groupKeyMap", String(GROUP))).equals(undefined);
+        expect(itemState(peer, "endpointGroupMembership", String(GROUP))).equals(undefined);
+        expect(isMember(device)).equals(false);
+    });
+
+    it("cancel returns a revert handle that completes and leaves the original truthful", async () => {
+        await using site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair({
+            controller: { type: ControllerRoot },
+            device: { type: MockServerNode.RootEndpoint, device: OnOffLightSwitchDevice.with(GroupsServer) },
+        });
+        const peer = await subscribedPeer(controller, "peer1");
+
+        await controller.act(agent => agent.get(TaskManagerBehavior).run(ADD_NODE_TO_GROUP_TYPE, PARAMS));
+        await awaitState(controller, TASK_ID, "completed");
+        expect(isMember(device)).equals(true);
+
+        const handle = await MockTime.resolve(
+            controller.act(agent => agent.get(TaskManagerBehavior).cancel(TASK_ID)),
+            { macrotasks: true },
+        );
+        expect(handle?.id).equals(`revert:${TASK_ID}`);
+
+        await awaitState(controller, `revert:${TASK_ID}`, "completed");
+
+        expect(itemState(peer, "groupKey", String(GROUP_KEY_SET_ID))).equals(undefined);
+        expect(itemState(peer, "groupKeyMap", String(GROUP))).equals(undefined);
+        expect(itemState(peer, "endpointGroupMembership", String(GROUP))).equals(undefined);
+        expect(isMember(device)).equals(false);
+
+        const status = await controller.act(agent => agent.get(TaskManagerBehavior).get(TASK_ID)?.status);
+        expect(status?.state).equals("completed");
+    });
+
+    it("create-if-absent provisions membership when the key set already exists on the device", async () => {
+        await using site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair({
+            controller: { type: ControllerRoot },
+            device: { type: MockServerNode.RootEndpoint, device: OnOffLightSwitchDevice.with(GroupsServer) },
+        });
+
+        const peer = await subscribedPeer(controller, "peer1");
+
+        // Pre-seed key set 42 on the device via the fabric-scoped command so apply hits the create-if-absent skip.
+        await MockTime.resolve(
+            peer.act(agent =>
+                agent.get(GroupKeyManagementClient).keySetWrite({
+                    groupKeySet: {
+                        groupKeySetId: GROUP_KEY_SET_ID,
+                        groupKeySecurityPolicy: TrustFirst,
+                        epochKey0: new Uint8Array(16).fill(0xcd),
+                        epochStartTime0: 946684800000001n,
+                        epochKey1: null,
+                        epochStartTime1: null,
+                        epochKey2: null,
+                        epochStartTime2: null,
+                    },
+                }),
+            ),
+            { macrotasks: true },
+        );
+        expect(keySetCount(device, GROUP_KEY_SET_ID)).equals(1);
+
+        await controller.act(agent => agent.get(TaskManagerBehavior).run(ADD_NODE_TO_GROUP_TYPE, PARAMS));
+        await awaitState(controller, TASK_ID, "completed");
+
+        expect(isMember(device)).equals(true);
+        // Epoch-key content preservation (write-skip) is covered by the Task 6 unit test; unreadable here.
+        expect(keySetCount(device, GROUP_KEY_SET_ID)).equals(1);
+    });
+
+    it("resumes a parked revert across a controller restart", async () => {
+        await using site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair({
+            controller: { type: ControllerRoot },
+            device: { type: MockServerNode.RootEndpoint, device: OnOffLightSwitchDevice.with(GroupsServer) },
+        });
+
+        const peer = await subscribedPeer(controller, "peer1");
+        const subscription = peer.behaviors.internalsOf(NetworkClient).activeSubscription as SustainedSubscription;
+
+        // Peer unreachable: failingProvision still sets intents, then the spawned revert parks on the offline peer.
+        await MockTime.resolve(subscription.active.emit(false), { macrotasks: true });
+
+        await controller.act(agent => agent.get(TaskManagerBehavior).register(FAILING_TYPE, FailingProvision));
+        await controller.act(agent => agent.get(TaskManagerBehavior).run(FAILING_TYPE, PARAMS));
+        await awaitState(controller, FAILING_ID, "failed");
+        await awaitState(controller, `revert:${FAILING_ID}`, "parked");
+
+        const id = controller.id;
+        await MockTime.resolve(controller.close(), { macrotasks: true });
+
+        const controller2 = await site.addNode(ControllerRoot, { id, index: 1 });
+        await controller2.act(agent => agent.get(TaskManagerBehavior).register(FAILING_TYPE, FailingProvision));
+        const resumed = await controller2.act(
+            agent => agent.get(TaskManagerBehavior).state.tasks[`revert:${FAILING_ID}`]?.state,
+        );
+        expect(["running", "parked"]).contains(resumed);
+
+        const peer2 = await subscribedPeer(controller2, "peer1");
+        await awaitState(controller2, `revert:${FAILING_ID}`, "completed");
+
+        expect(itemState(peer2, "groupKey", String(GROUP_KEY_SET_ID))).equals(undefined);
+        expect(itemState(peer2, "groupKeyMap", String(GROUP))).equals(undefined);
+        expect(itemState(peer2, "endpointGroupMembership", String(GROUP))).equals(undefined);
+        expect(isMember(device)).equals(false);
+    });
+});

--- a/packages/node-manager/test/task/helpers.ts
+++ b/packages/node-manager/test/task/helpers.ts
@@ -118,6 +118,11 @@ export class FakePeer {
         }
     }
 
+    /** Reconciler stand-in: no kind has dependents by default (tests override per case). */
+    itemKind(_kind: string): unknown {
+        return undefined;
+    }
+
     eventsOf(type: unknown): unknown {
         return type === DesiredStateBehavior
             ? { itemChanged: this.itemChanged }

--- a/packages/node-manager/test/task/helpers.ts
+++ b/packages/node-manager/test/task/helpers.ts
@@ -63,11 +63,18 @@ export class FakePeer {
     /** Record the desired-state mutations the gate observes so cancel-revert order can be asserted. */
     readonly removeOrder = new Array<string>();
 
-    /** DesiredStateBehavior.setIntent stand-in: upsert a pending item. */
-    setIntent(kind: string, key: string, _intent: unknown, _mode: ItemMode = "converge") {
-        if (this.items[itemMapKey(kind, key)] === undefined) {
-            this.addItem(kind, key, "pending");
-        }
+    /** DesiredStateBehavior.setIntent stand-in: upsert with real intent and mode so prior-capture can read them. */
+    setIntent(kind: string, key: string, intent: unknown = {}, mode: ItemMode = "converge") {
+        const existing = this.items[itemMapKey(kind, key)];
+        const item: ManagedItem = {
+            kind,
+            key,
+            intent,
+            mode,
+            status: existing?.status ?? { state: "pending", updateTimestamp: 0 },
+        };
+        this.items[itemMapKey(kind, key)] = item;
+        this.itemChanged.emit(item);
     }
 
     /** DesiredStateBehavior.removeIntent stand-in: flag deletePending, then drop on the next reconcile. */

--- a/packages/node-manager/test/task/helpers.ts
+++ b/packages/node-manager/test/task/helpers.ts
@@ -63,7 +63,7 @@ export class FakePeer {
     /** Record the desired-state mutations the gate observes so cancel-revert order can be asserted. */
     readonly removeOrder = new Array<string>();
 
-    /** DesiredStateBehavior.setIntent stand-in: upsert with real intent and mode so prior-capture can read them. */
+    // Stores real intent+mode (not a placeholder) so the context's prior-capture reads true values.
     setIntent(kind: string, key: string, intent: unknown = {}, mode: ItemMode = "converge") {
         const existing = this.items[itemMapKey(kind, key)];
         const item: ManagedItem = {

--- a/packages/node/src/behavior/system/desired-state/ItemKind.ts
+++ b/packages/node/src/behavior/system/desired-state/ItemKind.ts
@@ -33,6 +33,12 @@ export interface ItemKind<I = unknown> {
     remove?(node: ClientNode, item: ManagedItem<I>): Promise<void>;
     recoverable?(code: number): boolean;
     capacity?(node: ClientNode): Promise<CapacityInfo>;
+
+    /**
+     * Report whether another live desired-state intent still depends on the `(kind, key)` entry, so a
+     * shared entry is not deleted while referenced. Unimplemented ⇒ no dependents ⇒ always removable.
+     */
+    isReferenced?(node: ClientNode, key: string): boolean;
 }
 
 export class ItemKindRegistry {


### PR DESCRIPTION
Sub-PR into `node-manager` (umbrella PR #3948 carries CI). Increment 2a of the imperative Task layer — the **rollback-safety core**. Pre-flight capacity admission (C) and `RemoveNodeFromGroup` (D) are deferred to 2b.

Spec: `docs/superpowers/specs/2026-06-26-node-manager-task-layer-2-design.md`

## What lands
- **Prior-state changeset** — `Task.addLog`→`changeSet`; each entry captures the prior `ManagedItem` state (intent+mode, or absent) on first touch, for both `setIntent` and `removeIntent`. First-touch-wins.
- **Auto-rollback via a generic `revert` task** — a hard forward failure (and `cancel()`) spawns a changeset-driven `revert` task that restores prior state in reverse order. It's an ordinary task, so it parks/resumes for free. `cancel()` now returns the revert `TaskHandle` instead of awaiting inline (resolves the unbounded-park caller-abort follow-up). `cancelFailed` retired; revert-of-revert guarded.
- **Shared-entry safety** — `ItemKind.isReferenced` + `removeIntentIfUnreferenced`: a `groupKey`/`groupKeyMap` referenced by another live intent is never deleted. Scan-based ownership (no stored refcount).
- **`groupKey` create-if-absent** — `apply` skips `KeySetWrite` when the key set already exists (no clobber of a richer set; update/rotation is the dedicated Inc3 `ipk` task).
- **`#evaluate` reachability guard** — a gate resolves only when every target node was verify-reconciled this pass; an unreachable node parks instead of resolving on trust-stored state.
- **Reconcile stale-write fix** — a slow forward `apply()` could write `committed` after a concurrent revert flipped the intent to `deletePending`, resurrecting the removed item. The executor now re-reads live state after the device op and skips the stale status write.

## Tests / gate
- 4 commissioned-peer integration scenarios (auto-rollback, cancel-handle, create-if-absent, restart-mid-revert) + unit coverage per piece.
- `build --clean` ✓ · `format-verify` ✓ · `lint` ✓ · node-manager 116/116 · node 1264/1264.

## Follow-ups (2b backlog, non-blocking)
- Pass `revertOf` into the task at creation (currently set just after `run()` — works, but timing-fragile).
- Post-restart `cancel()` link query returns undefined for a terminal revert task.
- Add a `revertOf` round-trip assertion; narrow `ReconcilerSurface` interface to drop test casts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)