### PR TITLE
feat(protocol): tolerate signed/unsigned int mismatch in data report decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,9 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: On `process.exit`, verifies all storages were properly closed and removes orphaned lock files otherwise, so a forgotten close no longer blocks the next startup
 
 - @matter/protocol
+    - Enhancement: Incoming read/subscription data reports now tolerate signed/unsigned integer encoding mismatches within defined bounds. Such cases are still non-compliant and are logged
     - Enhancement: The mDNS responder and scanners declare the service types and hostnames they care about so the socket can pre-filter irrelevant traffic before decoding
-    - Enhancement: Unified peer device probing across the mDNS address-change and subscription-liveness cases so they no longer probe independently
+    - Enhancement: Unified peer device-probing across the mDNS address-change and subscription-liveness cases so they no longer probe independently
     - Adjustment: A GitHub rate-limit response while downloading certificates now skips the remaining GitHub fetches for that run, and is logged at debug instead of info when matching test certificates are already cached
     - Fix: CASE/PASE session parameters with idle/active intervals above one hour are now accepted instead of declining the session; the one-hour cap is applied only when advertising over DNS-SD
     - Fix: A local Session Active Threshold above its 65535ms (uint16) maximum is now rejected up front with a clear error instead of failing later during message encoding

--- a/packages/protocol/src/action/client/InputChunk.ts
+++ b/packages/protocol/src/action/client/InputChunk.ts
@@ -32,7 +32,8 @@ const logger = Logger.get("InputChunk");
 
 /**
  * Decode options for incoming data reports. Integer signed/unsigned mismatches from non-compliant devices are tolerated
- * here (and only here) so a single malformed value does not drop the whole report; the value is still range-validated.
+ * here (and only here) so a single malformed value does not cause the affected attribute/event entry to be dropped; the
+ * value is still range-validated.
  */
 const DATA_REPORT_DECODE_OPTIONS: TlvDecodingOptions = { relaxNumberTypeChecks: true };
 

--- a/packages/protocol/src/action/client/InputChunk.ts
+++ b/packages/protocol/src/action/client/InputChunk.ts
@@ -20,6 +20,7 @@ import {
     TlvAttributeData,
     TlvAttributeReport,
     TlvAttributeStatus,
+    TlvDecodingOptions,
     TlvEventData,
     TlvEventStatus,
     TlvOfModel,
@@ -28,6 +29,12 @@ import {
 } from "@matter/types";
 
 const logger = Logger.get("InputChunk");
+
+/**
+ * Decode options for incoming data reports. Integer signed/unsigned mismatches from non-compliant devices are tolerated
+ * here (and only here) so a single malformed value does not drop the whole report; the value is still range-validated.
+ */
+const DATA_REPORT_DECODE_OPTIONS: TlvDecodingOptions = { relaxNumberTypeChecks: true };
 
 interface ResolvedAttributePath {
     nodeId?: NodeId;
@@ -197,7 +204,7 @@ function decodeAttributeGroup(
             value =
                 schema === undefined
                     ? decodeUnknownAttributeValue(entries)
-                    : decodeAttributeValueWithSchema(schema, entries);
+                    : decodeAttributeValueWithSchema(schema, entries, undefined, DATA_REPORT_DECODE_OPTIONS);
         }
         return {
             kind: "attr-value",
@@ -273,7 +280,7 @@ function decodeEventValue(eventData: TypeFromSchema<typeof TlvEventData>): ReadR
             value = data === undefined ? undefined : decodeUnknownEventValue(data);
         } else {
             const schema = TlvOfModel(eventModel);
-            value = data === undefined ? undefined : schema.decodeTlv(data);
+            value = data === undefined ? undefined : schema.decodeTlv(data, DATA_REPORT_DECODE_OPTIONS);
         }
 
         // `timestamp` is a lossy convenience: callers needing the specific wire variant read the explicit field below.

--- a/packages/protocol/src/interaction/AttributeDataDecoder.ts
+++ b/packages/protocol/src/interaction/AttributeDataDecoder.ts
@@ -17,6 +17,7 @@ import {
     TlvAttributeData,
     TlvAttributeReport,
     TlvAttributeStatus,
+    TlvDecodingOptions,
     TlvOfModel,
     TlvSchema,
     TlvType,
@@ -293,6 +294,7 @@ export function decodeListAttributeValueWithSchema<T>(
     schema: ArraySchema<T>,
     values: TypeFromSchema<typeof TlvAttributeData>[],
     currentValue?: T[],
+    options?: TlvDecodingOptions,
 ): T[] | undefined {
     // Return contained multiple tlv values as an array
     if (!(schema instanceof ArraySchema)) {
@@ -301,6 +303,7 @@ export function decodeListAttributeValueWithSchema<T>(
     return schema.decodeFromChunkedArray(
         values.map(({ data, path: { listIndex } }) => ({ listIndex, element: data })),
         currentValue,
+        options,
     );
 }
 
@@ -309,6 +312,7 @@ export function decodeAttributeValueWithSchema<T>(
     schema: TlvSchema<T>,
     values: TypeFromSchema<typeof TlvAttributeData>[],
     defaultValue?: T,
+    options?: TlvDecodingOptions,
 ): T | undefined {
     // No values, so use default value if available
     if (!values.length) {
@@ -322,12 +326,12 @@ export function decodeAttributeValueWithSchema<T>(
 
     // We got multiple values, so assume duplicates of the same attribute
     if (schema instanceof ArraySchema) {
-        return decodeListAttributeValueWithSchema<T>(schema, values, defaultValue as T[]) as T;
+        return decodeListAttributeValueWithSchema<T>(schema, values, defaultValue as T[], options) as T;
     }
 
     // The value was returned as one Tlv value, so decode it normally
     if (values.length === 1 && values[0].path.listIndex === undefined) {
-        return schema.decodeTlv(values[0].data);
+        return schema.decodeTlv(values[0].data, options);
     }
 
     // We got multiple entries but it is no array, so validate that no array action entries are there, this would be invalid
@@ -336,7 +340,7 @@ export function decodeAttributeValueWithSchema<T>(
     }
     // Sort values by highest dataVersion first
     const bestDataVersionValue = values.sort(({ dataVersion: a }, { dataVersion: b }) => (b ?? 0) - (a ?? 0));
-    return schema.decodeTlv(bestDataVersionValue[0].data);
+    return schema.decodeTlv(bestDataVersionValue[0].data, options);
 }
 
 /** Decodes the data for one unknown attribute via the AnySchema including array un-chunking. */

--- a/packages/protocol/test/action/client/InputChunkTest.ts
+++ b/packages/protocol/test/action/client/InputChunkTest.ts
@@ -18,6 +18,7 @@ import {
     TlvAttributeReport,
     TlvBoolean,
     TlvEventData,
+    TlvInt32,
     TlvOfModel,
     TlvUInt32,
     TlvVoid,
@@ -533,6 +534,32 @@ describe("InputChunk", () => {
 
             const chunks = await collect(report);
             expect(chunks.map(c => c.kind)).deep.equal(["attr-value", "event-value"]);
+        });
+    });
+
+    describe("relaxed integer type checks", () => {
+        // dataModelRevision is an unsigned attribute; encode its value as a signed integer to mimic a non-compliant
+        // device. Data report decode tolerates the mismatch so the entry is not dropped.
+        it("decodes a signed-encoded value for an unsigned attribute", async () => {
+            const report = buildReport({
+                attributeReports: [
+                    {
+                        attributeData: {
+                            path: {
+                                endpointId: EndpointNumber(0),
+                                clusterId: ClusterId(BasicInformation.id),
+                                attributeId: AttributeId(BasicInformation.attributes.dataModelRevision.id),
+                            },
+                            dataVersion: 1,
+                            data: TlvInt32.encodeTlv(17),
+                        },
+                    },
+                ],
+            });
+
+            const chunks = await collect(report);
+            expect(chunks.length).equal(1);
+            expect((chunks[0] as ReadResult.AttributeValue).value).equal(17);
         });
     });
 });

--- a/packages/types/src/tlv/TlvArray.ts
+++ b/packages/types/src/tlv/TlvArray.ts
@@ -12,7 +12,7 @@ import {
     ValidationOutOfBoundsError,
 } from "../common/ValidationError.js";
 import { TlvTag, TlvType, TlvTypeLength } from "./TlvCodec.js";
-import { TlvEncodingOptions, TlvReader, TlvSchema, TlvStream, TlvWriter } from "./TlvSchema.js";
+import { TlvDecodingOptions, TlvEncodingOptions, TlvReader, TlvSchema, TlvStream, TlvWriter } from "./TlvSchema.js";
 
 export type LengthConstraints = {
     minLength?: number;
@@ -127,7 +127,7 @@ export class ArraySchema<T> extends TlvSchema<T[]> {
         });
     }
 
-    decodeFromChunkedArray(chunks: ArrayAsChunked, currentValue?: T[]): T[] {
+    decodeFromChunkedArray(chunks: ArrayAsChunked, currentValue?: T[], options?: TlvDecodingOptions): T[] {
         if (currentValue === undefined && chunks[0].listIndex !== undefined) {
             throw new UnexpectedDataError(
                 `When no current value is supplied the first chunked element needs to have a list index of undefined, but received ${chunks[0].listIndex}.`,
@@ -137,17 +137,17 @@ export class ArraySchema<T> extends TlvSchema<T[]> {
         for (const { listIndex, element } of chunks) {
             if (listIndex === undefined) {
                 // not set listIndex means "Override the whole array"
-                currentValue = this.decodeTlv(element);
+                currentValue = this.decodeTlv(element, options);
             } else if (listIndex === null) {
                 // null listIndex means "Append to the array"
-                const decodedElement = this.elementSchema.decodeTlv(element);
+                const decodedElement = this.elementSchema.decodeTlv(element, options);
                 currentValue.push(decodedElement);
             } else if (element[0].typeLength.type === TlvType.Null) {
                 // null element means "Remove from the array"
                 currentValue.splice(listIndex, 1);
             } else {
                 // otherwise, set the element at the given index
-                currentValue[listIndex] = this.elementSchema.decodeTlv(element);
+                currentValue[listIndex] = this.elementSchema.decodeTlv(element, options);
             }
         }
         return currentValue;

--- a/packages/types/src/tlv/TlvNumber.ts
+++ b/packages/types/src/tlv/TlvNumber.ts
@@ -18,6 +18,7 @@ import {
     INT8_MAX,
     INT8_MIN,
     ImplementationError,
+    Logger,
     Seconds,
     UINT16_MAX,
     UINT24_MAX,
@@ -35,6 +36,10 @@ import { Schema } from "../schema/Schema.js";
 import { TlvCodec, TlvLength, TlvTag, TlvType, TlvTypeLength } from "./TlvCodec.js";
 import { TlvReader, TlvSchema, TlvWriter } from "./TlvSchema.js";
 import { TlvWrapper } from "./TlvWrapper.js";
+
+const logger = Logger.get("TlvCodec");
+
+const isIntegerType = (type: TlvType) => type === TlvType.SignedInt || type === TlvType.UnsignedInt;
 
 const numericTypeByMax = new Map<number | bigint, string>([
     [UINT8_MAX, "uint8"],
@@ -116,8 +121,23 @@ export class TlvNumericSchema<T extends bigint | number> extends TlvSchema<T> {
     }
 
     override decodeTlvInternalValue(reader: TlvReader, typeLength: TlvTypeLength): T {
-        if (typeLength.type !== this.type)
-            throw new UnexpectedDataError(`Unexpected type ${typeLength.type}, was expecting ${this.type}.`);
+        if (typeLength.type !== this.type) {
+            if (
+                !reader.options?.relaxNumberTypeChecks ||
+                !isIntegerType(this.type) ||
+                !isIntegerType(typeLength.type)
+            ) {
+                throw new UnexpectedDataError(`Unexpected type ${typeLength.type}, was expecting ${this.type}.`);
+            }
+            // Tolerate signed/unsigned mismatch from non-compliant devices; the boundary check below rejects values
+            // that do not fit the schema (e.g. a negative value for an unsigned field).
+            const value = reader.readPrimitive<TlvTypeLength, T>(typeLength);
+            this.validateBoundaries(value);
+            logger.info(
+                `Relaxed integer decode: accepted ${TlvType[typeLength.type]} for ${TlvType[this.type]} schema (value ${value}). Still non-compliant, report to vendor.`,
+            );
+            return value;
+        }
         return reader.readPrimitive(typeLength);
     }
 

--- a/packages/types/src/tlv/TlvSchema.ts
+++ b/packages/types/src/tlv/TlvSchema.ts
@@ -23,6 +23,16 @@ export type TlvEncodingOptions = {
     allowMissingFieldsForNonFabricFilteredRead?: boolean;
 };
 
+export type TlvDecodingOptions = {
+    /**
+     * Relax signed/unsigned integer type checking during decode. When set, an integer encoded with the "wrong"
+     * signedness — a signed element for an unsigned schema or vice-versa — is accepted as long as the decoded value
+     * satisfies the schema's numeric bounds. Mirrors the wire-driven decode of CHIP's generic/controller path and
+     * tolerates non-compliant devices. Off by default (strict per spec).
+     */
+    relaxNumberTypeChecks?: boolean;
+};
+
 export abstract class TlvSchema<T> extends Schema<T> implements TlvSchema<T> {
     /**
      * Reverse-maps this TLV schema to model element fields.
@@ -52,8 +62,8 @@ export abstract class TlvSchema<T> extends Schema<T> implements TlvSchema<T> {
         return writer.toTlvArray();
     }
 
-    decodeTlv(encoded: TlvStream): T {
-        return this.decodeTlvInternal(new TlvArrayReader(encoded)).value;
+    decodeTlv(encoded: TlvStream, options?: TlvDecodingOptions): T {
+        return this.decodeTlvInternal(new TlvArrayReader(encoded, options)).value;
     }
 
     decodeTlvInternal(reader: TlvReader): { value: T; tag?: TlvTag } {
@@ -117,7 +127,10 @@ export class TlvArrayWriter implements TlvWriter {
 export class TlvArrayReader implements TlvReader {
     private index = -1;
 
-    constructor(private readonly tlvElements: TlvElement<any>[]) {}
+    constructor(
+        private readonly tlvElements: TlvElement<any>[],
+        readonly options?: TlvDecodingOptions,
+    ) {}
 
     readTagType() {
         this.index++;
@@ -133,6 +146,8 @@ export class TlvArrayReader implements TlvReader {
 export type TypeFromSchema<S extends TlvSchema<any>> = S extends TlvSchema<infer T> ? T : never;
 
 export interface TlvReader {
+    readonly options?: TlvDecodingOptions;
+
     readTagType(): { tag?: TlvTag; typeLength: TlvTypeLength };
 
     readPrimitive<T extends TlvTypeLength, V = TlvToPrimitive[T["type"]]>(typeLength: T): V;
@@ -163,7 +178,10 @@ export class TlvByteArrayWriter implements TlvWriter {
 export class TlvByteArrayReader implements TlvReader {
     private readonly reader: DataReader<Endian.Little>;
 
-    constructor(byteArray: Bytes) {
+    constructor(
+        byteArray: Bytes,
+        readonly options?: TlvDecodingOptions,
+    ) {
         this.reader = new DataReader(byteArray, Endian.Little);
     }
 

--- a/packages/types/test/tlv/TlvNumberTest.ts
+++ b/packages/types/test/tlv/TlvNumberTest.ts
@@ -6,6 +6,7 @@
 
 import { ValidationError } from "#common/ValidationError.js";
 import { TlvAny } from "#tlv/TlvAny.js";
+import { ArraySchema } from "#tlv/TlvArray.js";
 import {
     MATTER_EPOCH_OFFSET_S,
     MATTER_EPOCH_OFFSET_US,
@@ -14,11 +15,14 @@ import {
     TlvEpochUs,
     TlvFloat,
     TlvInt64,
+    TlvInt8,
     TlvNumberSchema,
     TlvNumericSchema,
     TlvUInt32,
     TlvUInt64,
+    TlvUInt8,
 } from "#tlv/TlvNumber.js";
+import { TlvByteArrayReader, TlvSchema } from "#tlv/TlvSchema.js";
 import { Bytes } from "@matter/general";
 
 type CodecVectorNumber<I, E> = {
@@ -181,6 +185,51 @@ describe("TlvNumber", () => {
             expect(() => TlvEpochUs.encode(nowUs - MATTER_EPOCH_OFFSET_US)).throw(
                 "Do not convert Epoch-values yourself, use TlvEpochUs directly with unix epoch values.",
             );
+        });
+    });
+
+    describe("relaxNumberTypeChecks", () => {
+        function decode(schema: TlvSchema<any>, hex: string, relaxNumberTypeChecks = false) {
+            return schema.decodeTlvInternal(new TlvByteArrayReader(Bytes.fromHex(hex), { relaxNumberTypeChecks }))
+                .value;
+        }
+
+        it("accepts a signed-encoded positive value for an unsigned schema when relaxed", () => {
+            expect(decode(TlvUInt8, "0005", true)).equal(5);
+        });
+
+        it("rejects a signed-encoded value for an unsigned schema by default", () => {
+            expect(() => decode(TlvUInt8, "0005")).throw("Unexpected type 0, was expecting 4.");
+        });
+
+        it("rejects a signed-encoded negative value for an unsigned schema even when relaxed", () => {
+            expect(() => decode(TlvUInt8, "00ff", true)).throw(ValidationError);
+        });
+
+        it("accepts an unsigned-encoded in-range value for a signed schema when relaxed", () => {
+            expect(decode(TlvInt8, "0405", true)).equal(5);
+        });
+
+        it("rejects an unsigned-encoded out-of-range value for a signed schema even when relaxed", () => {
+            expect(() => decode(TlvInt8, "04c8", true)).throw(ValidationError);
+        });
+
+        it("rejects a float-encoded value for an integer schema even when relaxed", () => {
+            expect(() => decode(TlvUInt8, "0a0892cc45", true)).throw("Unexpected type 10, was expecting 4.");
+        });
+
+        it("accepts a signed-encoded enum value when relaxed", () => {
+            expect(decode(TlvUInt32, "0005", true)).equal(5);
+        });
+
+        it("threads relax options through chunked array element decode", () => {
+            const arr = new ArraySchema(TlvUInt8);
+            const chunks = () => [
+                { listIndex: undefined, element: arr.encodeTlv([]) },
+                { listIndex: null, element: TlvInt8.encodeTlv(5) },
+            ];
+            expect(() => arr.decodeFromChunkedArray(chunks())).throw("Unexpected type 0, was expecting 4.");
+            expect(arr.decodeFromChunkedArray(chunks(), undefined, { relaxNumberTypeChecks: true })).deep.equal([5]);
         });
     });
 });


### PR DESCRIPTION
## Problem

Some production devices encode an integer attribute/event value with the wrong TLV signedness — e.g. a `uint8` value sent as a signed integer:

```
InputChunk Error decoding event 44/0x3b/0x1:
Unexpected type 0, was expecting 4.
```

matter.js decode is schema-driven and strictly required the on-wire type to match the schema type, so the whole attribute/event entry was dropped. The wider ecosystem ingests these reports via wire-driven generic decode (chip-tool JSON, Apple data-value dictionaries) and keeps the value, so matter.js was the outlier dropping data.

## Change

Incoming **read/subscription data reports** now tolerate signed↔unsigned integer encoding mismatches:

- New internal `TlvDecodingOptions.relaxNumberTypeChecks`, threaded via the `TlvReader`, so no decode-method signature churn across schema subclasses.
- Enabled **only** on the `InputChunk` data report path (`DATA_REPORT_DECODE_OPTIONS`) — not user-configurable, not applied to encode or any other decode.
- Relax is limited to the **integer family** (Signed/Unsigned). Float stays strict.
- The decoded value is still **range-validated** (`validateBoundaries`), so a negative value into a `uint` or an out-of-range value is still rejected.
- Each tolerated mismatch is logged at `info` (still non-compliant — report to vendor).

This covers the reported case (signed→uint, positive) plus the reverse (uint→signed, in-range) and enums (`TlvEnum` = `TlvUInt32`).

### Why this matches the ecosystem, not just leniency
CHIP's typed decoders (C++ `Get`, python controller) are strict on signed→uint, but the generic wire-driven path every hub actually uses to ingest device reports is type-agnostic. This change mirrors that wire-driven behavior for the data report path while keeping range safety.

## Tests
- `TlvNumber`: signed→uint (accept positive / reject negative), uint→signed (accept in-range / reject out-of-range), float stays strict, enum, chunked-array element threading.
- `InputChunk`: a signed-encoded `uint` attribute in a data report now decodes instead of being dropped.
- Full gates green: types 360/360, protocol 1243/1243, clean build, format, lint.
