### PR TITLE
perf(node): optimize incoming DataReport processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: Inbound mDNS packets are dropped before a full decode when none of the names any subscriber registered appear in them, cutting CPU on busy networks
 
 - @matter/node
+    - Enhancement: Optimizes incoming DataReport processing
     - Enhancement: Frees a behavior's persisted seed values from memory once the datasource has loaded them
     - Adjustment: Rejects an invalid Basic Information VendorID (0 or above 0xFFF4) or ProductID (0) as a device identity
     - Adjustment: A client write to a peer no longer rejects conformance violations locally; the value is forwarded so the device decides, while value-range and datatype errors still fail fast

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Ensures that client clusters are never exposed to incoming interactions
     - Fix: The generated manual pairing code now reflects the configured commissioning flow, including Vendor ID and Product ID for non-Standard flows
     - Fix: Ensures that a rejected SetRegulatoryConfig leaves BasicInformation.location unchanged, instead of writing the country code before validating the regulatory config
+    - Fix: Diagnostics now log endpoint number 0 instead of "(unassigned)"
 
 - @matter/nodejs
     - Fix: On `process.exit`, verifies all storages were properly closed and removes orphaned lock files otherwise, so a forgotten close no longer blocks the next startup

--- a/packages/node/src/endpoint/Endpoint.ts
+++ b/packages/node/src/endpoint/Endpoint.ts
@@ -1336,7 +1336,7 @@ export class Endpoint<T extends EndpointType = EndpointType.Empty> {
     get #diagnosticProps() {
         const type = this.type;
         return {
-            "endpoint#": this.#number ? this.number : "(unassigned)",
+            "endpoint#": typeof this.#number === "number" ? this.number : "(unassigned)",
             type: `${type.name} (${
                 type.deviceType === EndpointType.UNKNOWN_DEVICE_TYPE
                     ? "unknown"

--- a/packages/node/src/node/client/ClientStructure.ts
+++ b/packages/node/src/node/client/ClientStructure.ts
@@ -46,7 +46,7 @@ import { PeerBehavior } from "./PeerBehavior.js";
 const logger = Logger.get("ClientStructure");
 
 /** Max deferred persist/emit jobs allowed in flight before the decode loop applies back-pressure. */
-export const MAX_PENDING_JOBS = 100;
+const MAX_PENDING_JOBS = 100;
 
 interface MutateContext {
     enqueue(job: () => Promise<void>): void;
@@ -477,12 +477,14 @@ export class ClientStructure {
 
         const endpoint = this.#endpoints.get(endpointId);
         // Delay emission until end-of-interaction (after persist + structural changes) when this endpoint received
-        // attribute data this interaction, is the cluster currently being accumulated, or has a pending structural
-        // change.  This keeps events ordered after consistent state without depending on the deferred #pendingChanges.
+        // attribute data this interaction, is the cluster currently being accumulated, has a pending structural
+        // change, or is not yet installed — events must not arrive before the endpoint exists.
         if (
+            endpoint === undefined ||
+            !endpoint.endpoint.lifecycle.isInstalled ||
             q.endpointsWithData.has(endpointId) ||
             (currentUpdates && (currentUpdates.endpointId === endpointId || currentUpdates.clusterId === clusterId)) ||
-            (endpoint !== undefined && this.#pendingChanges?.has(endpoint))
+            this.#pendingChanges?.has(endpoint)
         ) {
             this.#delayedClusterEvents.push(occurrence);
         } else {

--- a/packages/node/src/node/client/ClientStructure.ts
+++ b/packages/node/src/node/client/ClientStructure.ts
@@ -253,47 +253,50 @@ export class ClientStructure {
 
         // Apply changes
         const scope = ReadScope(request);
-        for await (const chunk of changes) {
-            const chunkData = new Array<ReadResult.Report>();
-            for await (const change of chunk) {
-                chunkData.push(change);
-                switch (change.kind) {
-                    case "attr-value":
-                        currentUpdates = this.#mutateAttribute(change, scope, currentUpdates, q);
-                        break;
+        try {
+            for await (const chunk of changes) {
+                const chunkData = new Array<ReadResult.Report>();
+                for await (const change of chunk) {
+                    chunkData.push(change);
+                    switch (change.kind) {
+                        case "attr-value":
+                            currentUpdates = this.#mutateAttribute(change, scope, currentUpdates, q);
+                            break;
 
-                    case "event-value":
-                        this.#emitEvent(change, q);
-                        break;
+                        case "event-value":
+                            this.#emitEvent(change, q);
+                            break;
 
-                    case "attr-status":
-                    case "event-status":
-                        logger.debug(
-                            "Received status for",
-                            change.kind === "attr-status" ? "attribute" : "event",
-                            Diagnostic.strong(Diagnostic.dict(change.path)),
-                            `: ${Status[change.status]}#${change.status}${change.clusterStatus !== undefined ? `/${Status[change.clusterStatus]}#${change.clusterStatus}` : ""}`,
-                        );
-                        break;
+                        case "attr-status":
+                        case "event-status":
+                            logger.debug(
+                                "Received status for",
+                                change.kind === "attr-status" ? "attribute" : "event",
+                                Diagnostic.strong(Diagnostic.dict(change.path)),
+                                `: ${Status[change.status]}#${change.status}${change.clusterStatus !== undefined ? `/${Status[change.clusterStatus]}#${change.clusterStatus}` : ""}`,
+                            );
+                            break;
+                    }
+
+                    if (pendingJobs > MAX_PENDING_JOBS) {
+                        await queue;
+                    }
                 }
 
-                if (pendingJobs > MAX_PENDING_JOBS) {
-                    await queue;
-                }
+                yield chunkData;
             }
 
-            yield chunkData;
+            // The last cluster still needs its changes applied
+            if (currentUpdates) {
+                const toFlush = currentUpdates;
+                q.enqueue(() => this.#updateCluster(toFlush));
+            }
+        } finally {
+            // Drain deferred jobs on every exit path (normal completion, consumer break/throw, or a `changes`
+            // error) so no enqueued persist/emit work runs detached after the interaction ends.  Structural changes
+            // below read #pendingChanges, which the drained #updateCluster jobs populate.
+            await queue;
         }
-
-        // The last cluster still needs its changes applied
-        if (currentUpdates) {
-            const toFlush = currentUpdates;
-            q.enqueue(() => this.#updateCluster(toFlush));
-        }
-
-        // Drain all deferred attribute/event jobs before structural changes, which read #pendingChanges
-        // populated by #updateCluster.
-        await queue;
 
         if (jobErrors.length) {
             logger.warn(`${jobErrors.length} deferred data report job(s) failed during interaction`);

--- a/packages/node/src/node/client/ClientStructure.ts
+++ b/packages/node/src/node/client/ClientStructure.ts
@@ -229,7 +229,7 @@ export class ClientStructure {
         // We collect updates and only apply when we transition clusters
         let currentUpdates: AttributeUpdates | undefined;
 
-        // Serial FIFO for deferred persist/emit so Status.Success is not gated on store I/O.
+        // Serial FIFO for deferred persist/emit so Status.Success is not gated on internal and consumer data processing.
         // Ordering is preserved by insertion order; the Mutex runs one job at a time.
         const queue = new Mutex(this);
         const jobErrors = new Array<unknown>();

--- a/packages/node/src/node/client/ClientStructure.ts
+++ b/packages/node/src/node/client/ClientStructure.ts
@@ -22,6 +22,7 @@ import {
     Lifecycle,
     Logger,
     MaybePromise,
+    Mutex,
     Observable,
 } from "@matter/general";
 import {
@@ -43,6 +44,14 @@ import { ClientStructureEvents } from "./ClientStructureEvents.js";
 import { PeerBehavior } from "./PeerBehavior.js";
 
 const logger = Logger.get("ClientStructure");
+
+/** Max deferred persist/emit jobs allowed in flight before the decode loop applies back-pressure. */
+export const MAX_PENDING_JOBS = 100;
+
+interface MutateContext {
+    enqueue(job: () => Promise<void>): void;
+    endpointsWithData: Set<EndpointNumber>;
+}
 
 const DESCRIPTOR_ID = Descriptor.id;
 const DEVICE_TYPE_LIST_ATTR_ID = Descriptor.attributes.deviceTypeList.id;
@@ -220,6 +229,28 @@ export class ClientStructure {
         // We collect updates and only apply when we transition clusters
         let currentUpdates: AttributeUpdates | undefined;
 
+        // Serial FIFO for deferred persist/emit so Status.Success is not gated on store I/O.
+        // Ordering is preserved by insertion order; the Mutex runs one job at a time.
+        const queue = new Mutex(this);
+        const jobErrors = new Array<unknown>();
+        let pendingJobs = 0;
+        const q: MutateContext = {
+            endpointsWithData: new Set<EndpointNumber>(),
+            enqueue: job => {
+                pendingJobs++;
+                queue.run(async () => {
+                    try {
+                        await job();
+                    } catch (error) {
+                        jobErrors.push(error);
+                        logger.warn("Deferred data report job failed:", error);
+                    } finally {
+                        pendingJobs--;
+                    }
+                });
+            },
+        };
+
         // Apply changes
         const scope = ReadScope(request);
         for await (const chunk of changes) {
@@ -228,11 +259,11 @@ export class ClientStructure {
                 chunkData.push(change);
                 switch (change.kind) {
                     case "attr-value":
-                        currentUpdates = await this.#mutateAttribute(change, scope, currentUpdates);
+                        currentUpdates = this.#mutateAttribute(change, scope, currentUpdates, q);
                         break;
 
                     case "event-value":
-                        await this.#emitEvent(change, currentUpdates);
+                        this.#emitEvent(change, currentUpdates, q);
                         break;
 
                     case "attr-status":
@@ -245,6 +276,10 @@ export class ClientStructure {
                         );
                         break;
                 }
+
+                if (pendingJobs > MAX_PENDING_JOBS) {
+                    await queue;
+                }
             }
 
             yield chunkData;
@@ -252,7 +287,16 @@ export class ClientStructure {
 
         // The last cluster still needs its changes applied
         if (currentUpdates) {
-            await this.#updateCluster(currentUpdates);
+            const toFlush = currentUpdates;
+            q.enqueue(() => this.#updateCluster(toFlush));
+        }
+
+        // Drain all deferred attribute/event jobs before structural changes, which read #pendingChanges
+        // populated by #updateCluster.
+        await queue;
+
+        if (jobErrors.length) {
+            logger.warn(`${jobErrors.length} deferred data report job(s) failed during interaction`);
         }
 
         // We don't apply structural changes until we've processed all attribute data if a.) listeners might otherwise
@@ -375,11 +419,12 @@ export class ClientStructure {
         return this.#subscribedFabricFiltered;
     }
 
-    async #mutateAttribute(
+    #mutateAttribute(
         change: ReadResult.AttributeValue,
         scope: ReadScope,
         currentUpdates: undefined | AttributeUpdates,
-    ) {
+        q: MutateContext,
+    ): AttributeUpdates | undefined {
         // We only store values when an initial subscription is defined and the fabric filter matches
         if (this.subscribedFabricFiltered !== scope.isFabricFiltered) {
             return currentUpdates;
@@ -387,10 +432,14 @@ export class ClientStructure {
 
         const { endpointId, clusterId, attributeId } = change.path;
 
-        // If we are building updates to a cluster and the cluster/endpoint changes, apply the current update
-        // set
+        // Record synchronously so #emitEvent can classify events against data touched this interaction,
+        // independent of the now-deferred #pendingChanges population.
+        q.endpointsWithData.add(endpointId);
+
+        // If we are building updates to a cluster and the cluster/endpoint changes, apply the current update set
         if (currentUpdates && (currentUpdates.endpointId !== endpointId || currentUpdates.clusterId !== clusterId)) {
-            await this.#updateCluster(currentUpdates);
+            const toFlush = currentUpdates;
+            q.enqueue(() => this.#updateCluster(toFlush));
             currentUpdates = undefined;
         }
 
@@ -414,22 +463,30 @@ export class ClientStructure {
         return currentUpdates;
     }
 
-    async #emitEvent(occurrence: ReadResult.EventValue, currentUpdates?: AttributeUpdates) {
-        if (!this.eventEmitter) {
+    #emitEvent(
+        occurrence: ReadResult.EventValue,
+        currentUpdates: AttributeUpdates | undefined,
+        q: MutateContext,
+    ): void {
+        const emitter = this.eventEmitter;
+        if (!emitter) {
             return;
         }
 
         const { endpointId, clusterId } = occurrence.path;
 
         const endpoint = this.#endpoints.get(endpointId);
-        // If we are building updates on the current cluster or endpoint has pending changes, delay event emission
+        // Delay emission until end-of-interaction (after persist + structural changes) when this endpoint received
+        // attribute data this interaction, is the cluster currently being accumulated, or has a pending structural
+        // change.  This keeps events ordered after consistent state without depending on the deferred #pendingChanges.
         if (
+            q.endpointsWithData.has(endpointId) ||
             (currentUpdates && (currentUpdates.endpointId === endpointId || currentUpdates.clusterId === clusterId)) ||
             (endpoint !== undefined && this.#pendingChanges?.has(endpoint))
         ) {
             this.#delayedClusterEvents.push(occurrence);
         } else {
-            await this.eventEmitter(occurrence);
+            q.enqueue(() => Promise.resolve(emitter(occurrence)));
         }
     }
 

--- a/packages/node/src/node/client/ClientStructure.ts
+++ b/packages/node/src/node/client/ClientStructure.ts
@@ -263,7 +263,7 @@ export class ClientStructure {
                         break;
 
                     case "event-value":
-                        this.#emitEvent(change, currentUpdates, q);
+                        this.#emitEvent(change, q);
                         break;
 
                     case "attr-status":
@@ -463,27 +463,22 @@ export class ClientStructure {
         return currentUpdates;
     }
 
-    #emitEvent(
-        occurrence: ReadResult.EventValue,
-        currentUpdates: AttributeUpdates | undefined,
-        q: MutateContext,
-    ): void {
+    #emitEvent(occurrence: ReadResult.EventValue, q: MutateContext): void {
         const emitter = this.eventEmitter;
         if (!emitter) {
             return;
         }
 
-        const { endpointId, clusterId } = occurrence.path;
+        const { endpointId } = occurrence.path;
 
         const endpoint = this.#endpoints.get(endpointId);
         // Delay emission until end-of-interaction (after persist + structural changes) when this endpoint received
-        // attribute data this interaction, is the cluster currently being accumulated, has a pending structural
-        // change, or is not yet installed — events must not arrive before the endpoint exists.
+        // attribute data this interaction, has a pending structural change, or is not yet installed — events must not
+        // arrive before the endpoint exists or before its own attribute state is applied.
         if (
             endpoint === undefined ||
             !endpoint.endpoint.lifecycle.isInstalled ||
             q.endpointsWithData.has(endpointId) ||
-            (currentUpdates && (currentUpdates.endpointId === endpointId || currentUpdates.clusterId === clusterId)) ||
             this.#pendingChanges?.has(endpoint)
         ) {
             this.#delayedClusterEvents.push(occurrence);

--- a/packages/node/test/node/ClientStructureOffloadTest.ts
+++ b/packages/node/test/node/ClientStructureOffloadTest.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BasicInformationClient } from "#behaviors/basic-information";
+import { OnOffClient } from "#behaviors/on-off";
+import { SwitchClient, SwitchServer } from "#behaviors/switch";
+import { OnOffLightDevice } from "#devices/on-off-light";
+import { ServerNode } from "#node/ServerNode.js";
+import { Switch } from "@matter/types/clusters/switch";
+import { MockSite } from "./mock-site.js";
+import { subscribedPeer } from "./node-helpers.js";
+
+describe("ClientStructureOffload", () => {
+    before(() => {
+        MockTime.init();
+    });
+
+    it("applies all values from a multi-cluster subscription priming", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair({
+            device: {
+                type: ServerNode.RootEndpoint,
+                device: OnOffLightDevice,
+            },
+        });
+
+        const peer = await subscribedPeer(controller, "peer1");
+        const ep1 = peer.parts.get("ep1")!;
+        expect(ep1).not.undefined;
+
+        // OnOff attribute landed on the discovered cluster
+        const onOff = ep1.stateOf(OnOffClient);
+        expect(onOff.onOff).equal(false);
+
+        // Root endpoint BasicInformation also primed
+        const basics = peer.stateOf(BasicInformationClient);
+        expect(typeof basics.dataModelRevision).equal("number");
+    });
+
+    it("delivers events emitted during the same interaction as attribute data", async () => {
+        await using site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair({
+            device: {
+                type: ServerNode.RootEndpoint.with(
+                    SwitchServer.with(Switch.Feature.MomentarySwitch, Switch.Feature.MomentarySwitchRelease),
+                ),
+            },
+        });
+
+        const peer = await subscribedPeer(controller, "peer1");
+
+        const received = new Promise<{ newPosition: number }>(resolve =>
+            peer.eventsOf(SwitchClient).initialPress!.on(resolve),
+        );
+
+        await device.act(agent => {
+            (agent as any).switch.events.initialPress.emit({ newPosition: 1 }, agent.context);
+        });
+
+        expect(await MockTime.resolve(received)).deep.equals({ newPosition: 1 });
+        expect(peer.construction.status).not.equal("failed");
+    });
+});

--- a/packages/protocol/src/action/client/InputChunk.ts
+++ b/packages/protocol/src/action/client/InputChunk.ts
@@ -84,41 +84,45 @@ function* emitAttributes(
     let group: AttributeDataGroup | undefined;
 
     for (const entry of attrs) {
-        if (entry.attributeData !== undefined) {
-            const data = entry.attributeData;
-            const resolved = resolvePath(data.path, lastPath);
-            if (
-                data.path.enableTagCompression &&
-                data.dataVersion === undefined &&
-                lastPath?.dataVersion !== undefined
-            ) {
-                data.dataVersion = lastPath.dataVersion;
+        try {
+            if (entry.attributeData !== undefined) {
+                const data = entry.attributeData;
+                const resolved = resolvePath(data.path, lastPath);
+                if (
+                    data.path.enableTagCompression &&
+                    data.dataVersion === undefined &&
+                    lastPath?.dataVersion !== undefined
+                ) {
+                    data.dataVersion = lastPath.dataVersion;
+                }
+                if (!data.path.enableTagCompression) {
+                    lastPath = { ...resolved, dataVersion: data.dataVersion };
+                }
+                if (group !== undefined && !samePath(group.path, resolved)) {
+                    yield* flushDataGroup(group);
+                    group = undefined;
+                }
+                if (group === undefined) {
+                    group = { path: resolved, dataVersion: data.dataVersion, entries: [data] };
+                } else {
+                    group.entries.push(data);
+                    if (group.dataVersion === undefined) group.dataVersion = data.dataVersion;
+                }
+            } else if (entry.attributeStatus !== undefined) {
+                const statusSrc = entry.attributeStatus;
+                const resolved = resolvePath(statusSrc.path, lastPath);
+                if (!statusSrc.path.enableTagCompression) {
+                    lastPath = { ...resolved, dataVersion: lastPath?.dataVersion };
+                }
+                if (group !== undefined) {
+                    yield* flushDataGroup(group);
+                    group = undefined;
+                }
+                yield buildAttrStatus(resolved, statusSrc);
             }
-            if (!data.path.enableTagCompression) {
-                lastPath = { ...resolved, dataVersion: data.dataVersion };
-            }
-            if (group !== undefined && !samePath(group.path, resolved)) {
-                yield* flushDataGroup(group);
-                group = undefined;
-            }
-            if (group === undefined) {
-                group = { path: resolved, dataVersion: data.dataVersion, entries: [data] };
-            } else {
-                group.entries.push(data);
-                if (group.dataVersion === undefined) group.dataVersion = data.dataVersion;
-            }
-        } else if (entry.attributeStatus !== undefined) {
-            const statusSrc = entry.attributeStatus;
-            const resolved = resolvePath(statusSrc.path, lastPath);
-            // Status entry has no dataVersion of its own; preserve whatever the previous data entry installed.
-            if (!statusSrc.path.enableTagCompression) {
-                lastPath = { ...resolved, dataVersion: lastPath?.dataVersion };
-            }
-            if (group !== undefined) {
-                yield* flushDataGroup(group);
-                group = undefined;
-            }
-            yield buildAttrStatus(resolved, statusSrc);
+        } catch (error) {
+            UnexpectedDataError.accept(error);
+            logger.warn(`Skipping malformed attribute report entry: ${error.message}`);
         }
     }
 
@@ -243,12 +247,17 @@ function* emitEvents(input: DataReport): Generator<ReadResult.EventValue | ReadR
     if (events === undefined || events.length === 0) return;
 
     for (const entry of events) {
-        if (entry.eventData !== undefined) {
-            const value = decodeEventValue(entry.eventData);
-            if (value !== undefined) yield value;
-        } else if (entry.eventStatus !== undefined) {
-            const status = buildEventStatus(entry.eventStatus);
-            if (status !== undefined) yield status;
+        try {
+            if (entry.eventData !== undefined) {
+                const value = decodeEventValue(entry.eventData);
+                if (value !== undefined) yield value;
+            } else if (entry.eventStatus !== undefined) {
+                const status = buildEventStatus(entry.eventStatus);
+                if (status !== undefined) yield status;
+            }
+        } catch (error) {
+            UnexpectedDataError.accept(error);
+            logger.warn(`Skipping malformed event report entry: ${error.message}`);
         }
     }
 }

--- a/packages/protocol/src/action/client/InputChunk.ts
+++ b/packages/protocol/src/action/client/InputChunk.ts
@@ -122,7 +122,7 @@ function* emitAttributes(
             }
         } catch (error) {
             UnexpectedDataError.accept(error);
-            logger.warn(`Skipping malformed attribute report entry: ${error.message}`);
+            logger.warn("Skipping malformed attribute report entry:", Diagnostic.errorMessage(error));
         }
     }
 
@@ -223,7 +223,8 @@ function decodeAttributeGroup(
         // Skip a malformed entry; unrelated errors re-throw.
         UnexpectedDataError.accept(error);
         logger.warn(
-            `Error decoding attribute ${endpointId}/${Diagnostic.hex(clusterId)}/${Diagnostic.hex(attributeId)}: ${error.message}`,
+            `Error decoding attribute ${endpointId}/${Diagnostic.hex(clusterId)}/${Diagnostic.hex(attributeId)}:`,
+            Diagnostic.errorMessage(error),
         );
         return undefined;
     }
@@ -257,7 +258,7 @@ function* emitEvents(input: DataReport): Generator<ReadResult.EventValue | ReadR
             }
         } catch (error) {
             UnexpectedDataError.accept(error);
-            logger.warn(`Skipping malformed event report entry: ${error.message}`);
+            logger.warn("Skipping malformed event report entry:", Diagnostic.errorMessage(error));
         }
     }
 }
@@ -313,7 +314,8 @@ function decodeEventValue(eventData: TypeFromSchema<typeof TlvEventData>): ReadR
         // Skip a malformed entry; unrelated errors re-throw.
         UnexpectedDataError.accept(error);
         logger.warn(
-            `Error decoding event ${endpointId}/${Diagnostic.hex(clusterId)}/${Diagnostic.hex(eventId)}: ${error.message}`,
+            `Error decoding event ${endpointId}/${Diagnostic.hex(clusterId)}/${Diagnostic.hex(eventId)}:`,
+            Diagnostic.errorMessage(error),
         );
         return undefined;
     }

--- a/packages/protocol/test/action/client/InputChunkTest.ts
+++ b/packages/protocol/test/action/client/InputChunkTest.ts
@@ -399,7 +399,6 @@ describe("InputChunk", () => {
                 attributeReports: [
                     {
                         attributeData: {
-                            // enableTagCompression with no preceding fully-qualified path is malformed
                             path: {
                                 enableTagCompression: true,
                                 attributeId: AttributeId(BasicInformation.attributes.dataModelRevision.id),
@@ -436,7 +435,6 @@ describe("InputChunk", () => {
                 attributeReports: [
                     {
                         attributeData: {
-                            // tag compression disabled but clusterId missing -> incomplete path
                             path: {
                                 endpointId: EndpointNumber(0),
                                 attributeId: AttributeId(BasicInformation.attributes.dataModelRevision.id),
@@ -583,7 +581,6 @@ describe("InputChunk", () => {
                 eventReports: [
                     {
                         eventData: {
-                            // clusterId missing -> invalid event path
                             path: { endpointId: EndpointNumber(0), eventId: startUp },
                             eventNumber: EventNumber(1),
                             priority: 1,

--- a/packages/protocol/test/action/client/InputChunkTest.ts
+++ b/packages/protocol/test/action/client/InputChunkTest.ts
@@ -393,6 +393,79 @@ describe("InputChunk", () => {
             expect(chunks).has.length(1);
             expect(leftover).has.length(0);
         });
+
+        it("skips a tag-compressed leading entry with no prior path and still yields the next", async () => {
+            const report = buildReport({
+                attributeReports: [
+                    {
+                        attributeData: {
+                            // enableTagCompression with no preceding fully-qualified path is malformed
+                            path: {
+                                enableTagCompression: true,
+                                attributeId: AttributeId(BasicInformation.attributes.dataModelRevision.id),
+                            },
+                            dataVersion: 1,
+                            data: TlvUInt32.encodeTlv(7),
+                        },
+                    },
+                    {
+                        attributeData: {
+                            path: {
+                                endpointId: EndpointNumber(0),
+                                clusterId: ClusterId(BasicInformation.id),
+                                attributeId: AttributeId(BasicInformation.attributes.vendorId.id),
+                            },
+                            dataVersion: 1,
+                            data: TlvUInt32.encodeTlv(0xfff1),
+                        },
+                    },
+                ],
+            });
+
+            const chunks = await collect(report);
+
+            expect(chunks).has.length(1);
+            expect(chunks[0].kind).equal("attr-value");
+            if (chunks[0].kind !== "attr-value") return;
+            expect(chunks[0].path.attributeId).equal(AttributeId(BasicInformation.attributes.vendorId.id));
+            expect(chunks[0].value).equal(0xfff1);
+        });
+
+        it("skips an entry with an incomplete uncompressed path and still yields the next", async () => {
+            const report = buildReport({
+                attributeReports: [
+                    {
+                        attributeData: {
+                            // tag compression disabled but clusterId missing -> incomplete path
+                            path: {
+                                endpointId: EndpointNumber(0),
+                                attributeId: AttributeId(BasicInformation.attributes.dataModelRevision.id),
+                            },
+                            dataVersion: 1,
+                            data: TlvUInt32.encodeTlv(7),
+                        },
+                    },
+                    {
+                        attributeData: {
+                            path: {
+                                endpointId: EndpointNumber(0),
+                                clusterId: ClusterId(BasicInformation.id),
+                                attributeId: AttributeId(BasicInformation.attributes.vendorId.id),
+                            },
+                            dataVersion: 1,
+                            data: TlvUInt32.encodeTlv(0xfff1),
+                        },
+                    },
+                ],
+            });
+
+            const chunks = await collect(report);
+
+            expect(chunks).has.length(1);
+            expect(chunks[0].kind).equal("attr-value");
+            if (chunks[0].kind !== "attr-value") return;
+            expect(chunks[0].path.attributeId).equal(AttributeId(BasicInformation.attributes.vendorId.id));
+        });
     });
 
     describe("events", () => {
@@ -501,6 +574,41 @@ describe("InputChunk", () => {
             if (only.kind !== "event-status") return;
             expect(only.status).equal(Status.Failure);
             expect(only.clusterStatus).equal(clusterStatus);
+        });
+
+        it("skips an event entry with an invalid path and still yields the next", async () => {
+            const clusterId = ClusterId(BasicInformation.id);
+            const startUp = EventId(BasicInformation.events.startUp.id);
+            const report = buildReport({
+                eventReports: [
+                    {
+                        eventData: {
+                            // clusterId missing -> invalid event path
+                            path: { endpointId: EndpointNumber(0), eventId: startUp },
+                            eventNumber: EventNumber(1),
+                            priority: 1,
+                            epochTimestamp: 0,
+                            data: TlvStartUpEvent.encodeTlv({ softwareVersion: 1 }),
+                        },
+                    },
+                    {
+                        eventData: {
+                            path: { endpointId: EndpointNumber(0), clusterId, eventId: startUp },
+                            eventNumber: EventNumber(2),
+                            priority: 1,
+                            epochTimestamp: 0,
+                            data: TlvStartUpEvent.encodeTlv({ softwareVersion: 2 }),
+                        },
+                    },
+                ],
+            });
+
+            const chunks = await collect(report);
+
+            expect(chunks).has.length(1);
+            expect(chunks[0].kind).equal("event-value");
+            if (chunks[0].kind !== "event-value") return;
+            expect(chunks[0].number).equal(EventNumber(2));
         });
     });
 


### PR DESCRIPTION
Moves the client-side DataReport `Status.Success` acknowledgement off the path that gates full local processing, so multi-chunk reads/subscriptions are no longer serialized behind persist + event-emit.

### Changes

- **@matter/protocol:** `InputChunk` decode now skips malformed attribute/event entries (log + continue) instead of throwing, so a single bad entry no longer tears down the exchange. Only raw TLV decode (already caught per-entry) and structural-path errors are swallowed; everything else still propagates.
- **@matter/node:** `ClientStructure.mutate` enqueues store-persist (`#updateCluster`) and event-emit onto a single serial FIFO (`Mutex`), drained once at end-of-interaction before structural changes. `Status.Success` now fires after cheap decode/reassembly rather than after persist + emit.
  - Ordering preserved (FIFO insertion + the contiguous endpoint+cluster rule).
  - Back-pressure cap (`MAX_PENDING_JOBS = 100`) so the decode loop can't grow the queue unbounded under a flood.
  - Per-job errors are caught, logged, and non-fatal (a persist failure after Success re-syncs on the next report).
  - Events for not-yet-installed endpoints are delayed to end-of-interaction so they are never emitted before `#install` (which would drop them).
- **@matter/node:** drive-by fix — diagnostics now log endpoint number `0` (root) instead of `"(unassigned)"`.

`readDataReports` and the consumer-controlled Success gate (including invalid-subscription handling) are untouched.

### Testing

Full suites green: `@matter/node` 1245/1245, `@matter/protocol` 1246/1246 (ESM + CJS + Web). Clean build, format, lint all pass.

### Follow-up (separate)

Validate `externalSet` write-amplification: `#updateCluster` writes the full value map every report; if `DatasourceCache`/`externalSet` doesn't diff, always-included unchanged globals are re-persisted every subscription tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
