### PR TITLE
fix(thread-br-client): support post-2024 OTBR REST schema in probe

### DIFF
--- a/packages/thread-br-client/src/otbr-rest/OtbrRestCapability.ts
+++ b/packages/thread-br-client/src/otbr-rest/OtbrRestCapability.ts
@@ -11,13 +11,11 @@ import type { Bytes } from "@matter/general";
  *
  * `keyFormat` reflects the case convention the BR's REST surface uses on the
  * wire (older OTBR builds = pascal, post-2024 builds = camel). The probe
- * detects this from the presence/absence of `/api/actions` — see
- * python-otbr-api `_async_detect_case`.
+ * detects this from the key casing of the `/node` response.
  */
 export interface OtbrRestCapability {
     baseUrl: string;
     keyFormat: "camel" | "pascal";
-    apiVersion?: string;
     probedAt: number;
     networkName: string;
     extPanId: Bytes;

--- a/packages/thread-br-client/src/otbr-rest/OtbrRestClient.ts
+++ b/packages/thread-br-client/src/otbr-rest/OtbrRestClient.ts
@@ -6,9 +6,9 @@
 
 import { Bytes, type Duration, ImplementationError, Millis, Seconds, Time, Timer } from "@matter/general";
 import { OperationalDataset } from "../dataset/OperationalDataset.js";
-import { normalizeKeys } from "./caseNormalizer.js";
+import { detectKeyFormat, normalizeKeys } from "./caseNormalizer.js";
 import { OtbrRestError, type OtbrRestErrorCode } from "./OtbrRestError.js";
-import { parseHexBytes } from "./parseHexBytes.js";
+import { parseHexBytes, parseRloc16 } from "./parseHexBytes.js";
 
 export interface OtbrLeaderData {
     partitionId: number;
@@ -21,7 +21,8 @@ export interface OtbrLeaderData {
 export interface OtbrNodeInfo {
     baId: Bytes;
     state: string;
-    numOfRouter: number;
+    /** Router count. Undefined on builds that omit both `numOfRouter` and its post-2024 alias `routerCount`. */
+    numOfRouter?: number;
     rlocAddress: string;
     extAddress: Bytes;
     networkName: string;
@@ -81,6 +82,7 @@ function errorCodeForStatus(status: number): OtbrRestErrorCode {
 interface FetchedJson {
     status: number;
     body: unknown;
+    keyFormat: "camel" | "pascal" | null;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -101,6 +103,23 @@ function expectNumber(record: Record<string, unknown>, key: string, where: strin
         throw new OtbrRestError("rest_protocol", `${where}: missing or non-numeric field ${key}`);
     }
     return value;
+}
+
+/** First finite number found under any of `keys`, else `undefined`. */
+function optionalNumber(record: Record<string, unknown>, ...keys: string[]): number | undefined {
+    for (const key of keys) {
+        const value = record[key];
+        if (typeof value === "number" && Number.isFinite(value)) return value;
+    }
+    return undefined;
+}
+
+function expectRloc16(record: Record<string, unknown>, where: string): number {
+    const parsed = parseRloc16(record["rloc16"]);
+    if (parsed === undefined) {
+        throw new OtbrRestError("rest_protocol", `${where}: missing or invalid field rloc16`);
+    }
+    return parsed;
 }
 
 function expectRecord(record: Record<string, unknown>, key: string, where: string): Record<string, unknown> {
@@ -168,13 +187,37 @@ export class OtbrRestClient {
         return {
             baId: parseHexBytes(expectString(body, "baId", where), `${where}.baId`, 16),
             state: expectString(body, "state", where),
-            numOfRouter: expectNumber(body, "numOfRouter", where),
+            numOfRouter: optionalNumber(body, "numOfRouter", "routerCount"),
             rlocAddress: expectString(body, "rlocAddress", where),
             extAddress: parseHexBytes(expectString(body, "extAddress", where), `${where}.extAddress`, 8),
             networkName: expectString(body, "networkName", where),
-            rloc16: expectNumber(body, "rloc16", where),
+            rloc16: expectRloc16(body, where),
             leaderData,
             extPanId: parseHexBytes(expectString(body, "extPanId", where), `${where}.extPanId`, 8),
+        };
+    }
+
+    /**
+     * Lightweight probe of the `/node` endpoint for {@link OtbrRestProbe}.
+     *
+     * Fetches `/node` once and returns only the fields needed to identify an
+     * OTBR REST surface — the observed key casing plus the network name and
+     * Extended PAN ID. Unlike {@link getNode} it does not validate the full
+     * node schema, so a build that reshapes non-essential fields still probes
+     * cleanly.
+     *
+     * @throws {@link OtbrRestError} `"rest_protocol"` when the response is not an
+     *   OTBR node object or lacks `networkName`/`extPanId`.
+     */
+    async probeNode(): Promise<{ keyFormat: "camel" | "pascal"; networkName: string; extPanId: Bytes }> {
+        const { body, keyFormat } = await this.#fetchJson("/node");
+        if (!isRecord(body) || keyFormat === null) {
+            throw new OtbrRestError("rest_protocol", "/node did not return an OTBR node object");
+        }
+        return {
+            keyFormat,
+            networkName: expectString(body, "networkName", "/node"),
+            extPanId: parseHexBytes(expectString(body, "extPanId", "/node"), "/node.extPanId", 8),
         };
     }
 
@@ -546,7 +589,7 @@ export class OtbrRestClient {
     async #fetchJson(path: string): Promise<FetchedJson> {
         const response = await this.#doFetch(path, "application/json");
         if (response.status === HTTP_NO_CONTENT) {
-            return { status: response.status, body: null };
+            return { status: response.status, body: null, keyFormat: null };
         }
         if (!response.ok) {
             throw new OtbrRestError(errorCodeForStatus(response.status), `GET ${path} returned ${response.status}`, {
@@ -561,7 +604,8 @@ export class OtbrRestClient {
                 cause: err instanceof Error ? err : undefined,
             });
         }
-        return { status: response.status, body: normalizeKeys(parsed) };
+        const keyFormat = isRecord(parsed) ? detectKeyFormat(parsed) : null;
+        return { status: response.status, body: normalizeKeys(parsed), keyFormat };
     }
 
     async #fetchText(path: string): Promise<string | undefined> {

--- a/packages/thread-br-client/src/otbr-rest/OtbrRestProbe.ts
+++ b/packages/thread-br-client/src/otbr-rest/OtbrRestProbe.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, Logger, Millis, Seconds, Time, Timer } from "@matter/general";
+import { Bytes, Logger, Seconds } from "@matter/general";
 import type { OtbrRestCapability } from "./OtbrRestCapability.js";
 import { OtbrRestClient } from "./OtbrRestClient.js";
 import { OtbrRestError } from "./OtbrRestError.js";
@@ -14,16 +14,15 @@ const logger = Logger.get("OtbrRestProbe");
 const DEFAULT_PROBE_PORT = 8081;
 const DEFAULT_PROBE_TIMEOUT = Seconds(1);
 
-const HTTP_OK = 200;
-const HTTP_NOT_FOUND = 404;
-
 export class OtbrRestProbe {
     /**
      * Probe a host:port for OTBR REST. Returns the detected capability or
-     * `null` if the endpoint is not OTBR or not reachable within
-     * `timeoutMs`. Detection mirrors python-otbr-api: a 200 on
-     * `/api/actions` indicates the modern camelCase backend, a 404 the
-     * legacy pascalCase backend; everything else is "not OTBR".
+     * `null` if the endpoint is not OTBR or not reachable within `timeoutMs`.
+     *
+     * A single `GET /node` both confirms the endpoint is OTBR and reveals its
+     * key casing: legacy builds emit PascalCase keys, post-2024 builds
+     * camelCase. Anything that is not a JSON object carrying `networkName` and
+     * `extPanId` is treated as "not OTBR".
      */
     static async probe(
         host: string,
@@ -34,24 +33,12 @@ export class OtbrRestProbe {
         const baseUrl = client.baseUrl;
         logger.debug(`probe START ${baseUrl} timeout=${timeoutMs}ms`);
 
-        const keyFormat = await detectCase(baseUrl, timeoutMs);
-        if (keyFormat === null) {
-            logger.debug(`probe MISS ${baseUrl} (case detect failed)`);
-            return null;
-        }
-
         try {
-            const node = await client.getNode();
+            const { keyFormat, networkName, extPanId } = await client.probeNode();
             logger.debug(
-                `probe OK ${baseUrl} keyFormat=${keyFormat} xp=${Bytes.toHex(node.extPanId).toUpperCase()} network="${node.networkName}"`,
+                `probe OK ${baseUrl} keyFormat=${keyFormat} xp=${Bytes.toHex(extPanId).toUpperCase()} network="${networkName}"`,
             );
-            return {
-                baseUrl,
-                keyFormat,
-                probedAt: Date.now(),
-                networkName: node.networkName,
-                extPanId: node.extPanId,
-            };
+            return { baseUrl, keyFormat, probedAt: Date.now(), networkName, extPanId };
         } catch (err) {
             if (err instanceof OtbrRestError) {
                 logger.debug(`probe MISS ${baseUrl} /node ${err.code} (${err.message})`);
@@ -59,27 +46,5 @@ export class OtbrRestProbe {
             }
             throw err;
         }
-    }
-}
-
-async function detectCase(baseUrl: string, timeoutMs: number): Promise<"camel" | "pascal" | null> {
-    const controller = new AbortController();
-    const timer: Timer = Time.getTimer("otbr-probe-timeout", Millis(timeoutMs), () => controller.abort()).start();
-    try {
-        const response = await fetch(`${baseUrl}/api/actions`, {
-            method: "GET",
-            headers: { Accept: "application/json" },
-            signal: controller.signal,
-        });
-        if (response.status === HTTP_OK) return "camel";
-        if (response.status === HTTP_NOT_FOUND) return "pascal";
-        logger.debug(`probe of ${baseUrl} rejected: /api/actions returned ${response.status}`);
-        return null;
-    } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        logger.debug(`probe of ${baseUrl} rejected: /api/actions ${message}`);
-        return null;
-    } finally {
-        timer.stop();
     }
 }

--- a/packages/thread-br-client/src/otbr-rest/caseNormalizer.ts
+++ b/packages/thread-br-client/src/otbr-rest/caseNormalizer.ts
@@ -30,6 +30,23 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
+ * Classify an OTBR REST response object by its key casing: legacy builds emit
+ * PascalCase (`NetworkName`), post-2024 builds camelCase (`networkName`). Any
+ * uppercase-first key marks the object as pascal; a non-empty object with only
+ * lowercase-first keys is camel. An empty object yields `null` — no signal.
+ */
+export function detectKeyFormat(raw: Record<string, unknown>): "camel" | "pascal" | null {
+    let sawKey = false;
+    for (const key of Object.keys(raw)) {
+        if (key.length === 0) continue;
+        sawKey = true;
+        const first = key.charCodeAt(0);
+        if (first >= 65 && first <= 90) return "pascal";
+    }
+    return sawKey ? "camel" : null;
+}
+
+/**
  * Recursively rewrites object keys from PascalCase (or already-camelCase) to
  * camelCase. Idempotent — running it twice yields identical output. Arrays,
  * primitives and `null` pass through unchanged.

--- a/packages/thread-br-client/src/otbr-rest/parseHexBytes.ts
+++ b/packages/thread-br-client/src/otbr-rest/parseHexBytes.ts
@@ -26,3 +26,22 @@ export function parseHexBytes(hex: string, where: string, expectedLen?: number):
     }
     return Bytes.fromHex(hex);
 }
+
+const RLOC16_MAX = 0xffff;
+const RLOC16_STRING = /^(?:0x[0-9a-fA-F]{1,4}|[0-9]{1,5})$/;
+
+/**
+ * Parse a 16-bit RLOC, accepting either a JSON number (legacy builds) or a hex
+ * string like `"0x4800"` (post-2024 builds). Returns `undefined` for absent,
+ * malformed, or out-of-16-bit-range input — callers decide whether that is an
+ * error (`/node`) or a skippable field (`/diagnostics`).
+ */
+export function parseRloc16(value: unknown): number | undefined {
+    const parsed =
+        typeof value === "number"
+            ? value
+            : typeof value === "string" && RLOC16_STRING.test(value)
+              ? Number(value)
+              : NaN;
+    return Number.isInteger(parsed) && parsed >= 0 && parsed <= RLOC16_MAX ? parsed : undefined;
+}

--- a/packages/thread-br-client/src/otbr-rest/translation.ts
+++ b/packages/thread-br-client/src/otbr-rest/translation.ts
@@ -15,7 +15,7 @@ import type { Mode } from "../tlv/diag/Mode.js";
 import { NetworkData } from "../tlv/diag/NetworkData.js";
 import type { Route64, Route64Entry } from "../tlv/diag/Route64.js";
 import { OtbrRestError } from "./OtbrRestError.js";
-import { parseHexBytes } from "./parseHexBytes.js";
+import { parseHexBytes, parseRloc16 } from "./parseHexBytes.js";
 
 const TIMEOUT_EXP_MIN = 4;
 const IPV6_BYTES = 16;
@@ -245,7 +245,7 @@ export function translateNodeJson(json: unknown): DiagnosticResponse {
         result.extMacAddress = parseHexBytes(extAddress, "extAddress", 8);
     }
 
-    const rloc16 = asNumber(json["rloc16"]);
+    const rloc16 = parseRloc16(json["rloc16"]);
     if (rloc16 !== undefined) result.rloc16 = rloc16;
 
     const mode = asRecord(json["mode"]);

--- a/packages/thread-br-client/test/OtbrRestClientTest.ts
+++ b/packages/thread-br-client/test/OtbrRestClientTest.ts
@@ -19,6 +19,7 @@ function fixture(name: string): string {
 }
 
 const NODE_FIXTURE = readFileSync(resolve(FIXTURE_DIR, "node.json"), "utf8");
+const NODE_CAMEL_FIXTURE = readFileSync(resolve(FIXTURE_DIR, "node-camel.json"), "utf8");
 const DIAGNOSTICS_FIXTURE = readFileSync(resolve(FIXTURE_DIR, "diagnostics.json"), "utf8");
 
 // A valid, decodable active-dataset TLV blob (synthetic network "MockThread") — no real network data.
@@ -129,6 +130,55 @@ describe("OtbrRestClient", () => {
             expect(Bytes.toHex(node.baId)).to.equal("00112233445566778899aabbccddeeff");
             expect(node.leaderData.partitionId).to.equal(305419896);
             expect(node.leaderData.leaderRouterId).to.equal(61);
+        } finally {
+            restore();
+        }
+    });
+
+    it("getNode parses post-2024 camelCase /node payload (routerCount, hex-string rloc16)", async () => {
+        const restore = installFetch(async url => {
+            expect(url).to.equal("http://br.example:8081/node");
+            return new Response(NODE_CAMEL_FIXTURE, { status: 200, headers: { "Content-Type": "application/json" } });
+        });
+        try {
+            const client = new OtbrRestClient({ host: "br.example" });
+            const node = await client.getNode();
+            expect(node.networkName).to.equal("MockThread");
+            expect(node.state).to.equal("router");
+            expect(node.numOfRouter).to.equal(7);
+            expect(node.rloc16).to.equal(0x4800);
+            expect(Bytes.toHex(node.extPanId)).to.equal("1122334455667799");
+            expect(Bytes.toHex(node.extAddress)).to.equal("0011223344556602");
+            expect(Bytes.toHex(node.baId)).to.equal("0011223344556677889900aabbccddee");
+            expect(node.leaderData.leaderRouterId).to.equal(5);
+        } finally {
+            restore();
+        }
+    });
+
+    for (const bad of ["", "-5", "1e2", "0x10000", "99999", "0xzzzz", -1, 0x10000, 1.5] as const) {
+        it(`getNode rejects out-of-range/malformed rloc16 ${JSON.stringify(bad)}`, async () => {
+            const payload = JSON.parse(NODE_CAMEL_FIXTURE) as Record<string, unknown>;
+            payload.rloc16 = bad;
+            const restore = installFetch(async () => new Response(JSON.stringify(payload), { status: 200 }));
+            try {
+                const client = new OtbrRestClient({ host: "br.example" });
+                await expectRestError(client.getNode(), "rest_protocol");
+            } finally {
+                restore();
+            }
+        });
+    }
+
+    it("getNode leaves numOfRouter undefined when neither numOfRouter nor routerCount present", async () => {
+        const payload = JSON.parse(NODE_CAMEL_FIXTURE) as Record<string, unknown>;
+        delete payload.routerCount;
+        const restore = installFetch(async () => new Response(JSON.stringify(payload), { status: 200 }));
+        try {
+            const client = new OtbrRestClient({ host: "br.example" });
+            const node = await client.getNode();
+            expect(node.numOfRouter).to.be.undefined;
+            expect(node.networkName).to.equal("MockThread");
         } finally {
             restore();
         }

--- a/packages/thread-br-client/test/OtbrRestProbeTest.ts
+++ b/packages/thread-br-client/test/OtbrRestProbeTest.ts
@@ -11,7 +11,8 @@ import { OtbrRestProbe } from "../src/otbr-rest/OtbrRestProbe.js";
 
 const PACKAGE_ROOT = process.cwd();
 const FIXTURE_DIR = resolve(PACKAGE_ROOT, "test/fixtures/otbr-rest");
-const NODE_FIXTURE = readFileSync(resolve(FIXTURE_DIR, "node.json"), "utf8");
+const NODE_PASCAL_FIXTURE = readFileSync(resolve(FIXTURE_DIR, "node.json"), "utf8");
+const NODE_CAMEL_FIXTURE = readFileSync(resolve(FIXTURE_DIR, "node-camel.json"), "utf8");
 
 type FetchHandler = (url: string, init?: RequestInit) => Promise<Response>;
 
@@ -30,17 +31,16 @@ function installFetch(handler: FetchHandler): () => void {
 describe("OtbrRestProbe", () => {
     before(MockTime.enable);
 
-    it("returns capability with keyFormat=camel when /api/actions returns 200", async () => {
+    it("detects keyFormat=pascal from PascalCase /node keys", async () => {
         const restore = installFetch(async url => {
-            if (url.endsWith("/api/actions")) return new Response("[]", { status: 200 });
-            if (url.endsWith("/node")) return new Response(NODE_FIXTURE, { status: 200 });
+            if (url.endsWith("/node")) return new Response(NODE_PASCAL_FIXTURE, { status: 200 });
             throw new Error(`unexpected url: ${url}`);
         });
         try {
             const cap = await OtbrRestProbe.probe("br.example", 8081, 500);
             expect(cap).to.not.be.null;
             if (cap === null) return;
-            expect(cap.keyFormat).to.equal("camel");
+            expect(cap.keyFormat).to.equal("pascal");
             expect(cap.networkName).to.equal("TestNet");
             expect(Bytes.toHex(cap.extPanId)).to.equal("1122334455667788");
             expect(cap.baseUrl).to.equal("http://br.example:8081");
@@ -50,37 +50,41 @@ describe("OtbrRestProbe", () => {
         }
     });
 
-    it("returns capability with keyFormat=pascal when /api/actions returns 404", async () => {
+    it("detects keyFormat=camel from camelCase /node keys", async () => {
         const restore = installFetch(async url => {
-            if (url.endsWith("/api/actions")) return new Response("not found", { status: 404 });
-            if (url.endsWith("/node")) return new Response(NODE_FIXTURE, { status: 200 });
+            if (url.endsWith("/node")) return new Response(NODE_CAMEL_FIXTURE, { status: 200 });
             throw new Error(`unexpected url: ${url}`);
         });
         try {
             const cap = await OtbrRestProbe.probe("br.example", 8081, 500);
             expect(cap).to.not.be.null;
             if (cap === null) return;
-            expect(cap.keyFormat).to.equal("pascal");
+            expect(cap.keyFormat).to.equal("camel");
+            expect(cap.networkName).to.equal("MockThread");
+            expect(Bytes.toHex(cap.extPanId)).to.equal("1122334455667799");
         } finally {
             restore();
         }
     });
 
-    it("returns null when /api/actions network errors", async () => {
-        const restore = installFetch(async () => {
-            throw new TypeError("fetch failed");
+    it("never fetches /api/actions", async () => {
+        const seen = new Array<string>();
+        const restore = installFetch(async url => {
+            seen.push(url);
+            if (url.endsWith("/node")) return new Response(NODE_CAMEL_FIXTURE, { status: 200 });
+            throw new Error(`unexpected url: ${url}`);
         });
         try {
-            const cap = await OtbrRestProbe.probe("br.example", 8081, 500);
-            expect(cap).to.be.null;
+            await OtbrRestProbe.probe("br.example", 8081, 500);
+            expect(seen.some(u => u.includes("/api/actions"))).to.be.false;
+            expect(seen).to.deep.equal(["http://br.example:8081/node"]);
         } finally {
             restore();
         }
     });
 
     it("returns null when /node network errors", async () => {
-        const restore = installFetch(async url => {
-            if (url.endsWith("/api/actions")) return new Response("[]", { status: 200 });
+        const restore = installFetch(async () => {
             throw new TypeError("fetch failed");
         });
         try {
@@ -93,7 +97,6 @@ describe("OtbrRestProbe", () => {
 
     it("returns null when /node returns garbage shape", async () => {
         const restore = installFetch(async url => {
-            if (url.endsWith("/api/actions")) return new Response("[]", { status: 200 });
             if (url.endsWith("/node")) return new Response("not even json", { status: 200 });
             throw new Error(`unexpected url: ${url}`);
         });
@@ -107,7 +110,6 @@ describe("OtbrRestProbe", () => {
 
     it("returns null when /node 200 but missing networkName/extPanId", async () => {
         const restore = installFetch(async url => {
-            if (url.endsWith("/api/actions")) return new Response("[]", { status: 200 });
             if (url.endsWith("/node")) return new Response(JSON.stringify({ foo: 1 }), { status: 200 });
             throw new Error(`unexpected url: ${url}`);
         });
@@ -119,9 +121,22 @@ describe("OtbrRestProbe", () => {
         }
     });
 
-    it("returns null when /api/actions returns unexpected status (e.g. 500)", async () => {
+    it("returns null when /node returns an empty object", async () => {
         const restore = installFetch(async url => {
-            if (url.endsWith("/api/actions")) return new Response("err", { status: 500 });
+            if (url.endsWith("/node")) return new Response("{}", { status: 200 });
+            throw new Error(`unexpected url: ${url}`);
+        });
+        try {
+            const cap = await OtbrRestProbe.probe("br.example", 8081, 500);
+            expect(cap).to.be.null;
+        } finally {
+            restore();
+        }
+    });
+
+    it("returns null when /node returns a non-OTBR error status", async () => {
+        const restore = installFetch(async url => {
+            if (url.endsWith("/node")) return new Response("err", { status: 500 });
             throw new Error(`unexpected url: ${url}`);
         });
         try {

--- a/packages/thread-br-client/test/TranslationTest.ts
+++ b/packages/thread-br-client/test/TranslationTest.ts
@@ -99,6 +99,15 @@ describe("translateNodeJson", () => {
         expect(decoded.maxChildTimeout).to.be.undefined;
     });
 
+    it("decodes hex-string rloc16 from post-2024 OTBR builds", () => {
+        expect(translateNodeJson({ rloc16: "0x4800" }).rloc16).to.equal(18432);
+    });
+
+    it("omits rloc16 when malformed rather than mis-decoding", () => {
+        expect(translateNodeJson({ rloc16: "0x10000" }).rloc16).to.be.undefined;
+        expect(translateNodeJson({ rloc16: "garbage" }).rloc16).to.be.undefined;
+    });
+
     it("returns response with empty unknown[] (rest never produces unknown TLVs)", () => {
         const list = loadDiagnosticsArray();
         const decoded = translateNodeJson(list[0]);

--- a/packages/thread-br-client/test/fixtures/otbr-rest/node-camel.json
+++ b/packages/thread-br-client/test/fixtures/otbr-rest/node-camel.json
@@ -1,0 +1,19 @@
+{
+	"baId":	"0011223344556677889900aabbccddee",
+	"baState":	"",
+	"state":	"router",
+	"routerCount":	7,
+	"rlocAddress":	"fd00:0:0:1:0:ff:fe00:4800",
+	"extAddress":	"0011223344556602",
+	"networkName":	"MockThread",
+	"rloc16":	"0x4800",
+	"routerId":	18,
+	"leaderData":	{
+		"partitionId":	305419896,
+		"weighting":	64,
+		"dataVersion":	147,
+		"stableDataVersion":	205,
+		"leaderRouterId":	5
+	},
+	"extPanId":	"1122334455667799"
+}


### PR DESCRIPTION
## Problem

`OtbrRestProbe` rejected current Home Assistant OTBR builds, killing the REST diagnostics/commissioning path. Verified against two real border routers (an older build and a current HA build):

| | older build | current HA build |
|---|---|---|
| `/api/actions` | 404 | **400** |
| `/node` keys | PascalCase | camelCase |
| router count | `NumOfRouter` | **`routerCount`** |
| `rloc16` | number | **string** `"0x…"` |

Two independent breaks, detection first:

1. **Case detection.** The probe classified the backend from `/api/actions` status (200→camel, 404→pascal). Current OTBR builds answer **400**, so the probe bailed before ever reading `/node`. The heuristic had no basis — python-otbr-api (2.7.0) has no `/api/actions` and no camel/pascal concept at all; it reads granular sub-endpoints. The "mirrors python-otbr-api" comments were inaccurate and are removed.
2. **`/node` schema drift.** Even past detection, `getNode` threw: `numOfRouter` was renamed `routerCount`, and `rloc16` became a hex string.

## Fix

- **Detection** now derives key casing from the `/node` response itself (`detectKeyFormat`): any PascalCase key → `pascal`, otherwise `camel`. `/api/actions` dropped. New `OtbrRestClient.probeNode()` does a single `GET /node` and returns only what the probe needs (`keyFormat`, `networkName`, `extPanId`), so non-essential field drift can't fail a probe.
- **`getNode` tolerance:** `numOfRouter` is now optional, sourced from `numOfRouter ?? routerCount`. `rloc16` is parsed by a shared `parseRloc16` accepting a number or a `"0x…"` hex string, range-checked to 16-bit unsigned. The same helper is used by the `/diagnostics` translation so both paths agree (previously `/diagnostics` would silently drop a hex-string `rloc16`).
- Removed the dead `OtbrRestCapability.apiVersion` field (only ever came from the dropped `/api/actions`).

## Testing

- 742/742 package tests (esm), format + lint clean, clean build.
- Live-verified against both real border routers: both probe cleanly and `getNode` parses. Fixtures use synthetic Thread network data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)