### PR TITLE
feat(protocol): default subscription minIntervalFloor to 0s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,8 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Manufacturer-specific attributes in standard clusters are now filtered by the `WildcardSkipCustomElements` flag instead of `WildcardSkipGlobalAttributes` during wildcard path expansion
 
 - @matter/nodejs-shell
-  - Fix: Close a path-containment gap in the optional web server that let requests reach sibling directories sharing the web-root name prefix, and resolve symlinks before serving (reported by tonghuaroot)
-  - Fix: Bind the WebSocket/web server to loopback (127.0.0.1) by default instead of all interfaces; added a `--webAddress` option to choose the listen address
+    - Fix: Close a path-containment gap in the optional web server that let requests reach sibling directories sharing the web-root name prefix, and resolve symlinks before serving (reported by tonghuaroot)
+    - Fix: Bind the WebSocket/web server to loopback (127.0.0.1) by default instead of all interfaces; added a `--webAddress` option to choose the listen address
 
 - @matter/protocol
     - Feature: Preparations for Groupcast support (provisional in Matter 1.6.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: Optimized Subscription minIntervalFloor: now defaults to 0s; only Thread devices older than Matter 1.3.0 keep a 1s floor, and any node with a Generic Switch endpoint opts back into 0s for faster switch events
 
 - @matter/types
-  - Enhancement: Added the NFC Transport Layer (NTL, bit 4) capability to the onboarding payload Discovery Capabilities bitmap
+    - Enhancement: Added the NFC Transport Layer (NTL, bit 4) capability to the onboarding payload Discovery Capabilities bitmap
 
 ## 0.17.4 (2026-07-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/\*:
     - Upgraded to Matter specification version 1.6.0. Newly-mandatory attributes are seeded with conservative defaults, and new/provisional clusters stay behind feature guards, so existing code should remain backward compatible.
 
-- @matter/types
-    - Enhancement: Added the NFC Transport Layer (NTL, bit 4) capability to the onboarding payload Discovery Capabilities bitmap
+- @matter/general
+    - Enhancement: `deepCopy` now clones `Set` and `Map` values instead of turning them into empty objects
 
 - @matter/model
     - Enhancement: Added cluster-variance rules for the Matter 1.6 conformance idioms
@@ -33,13 +33,17 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Tag manufacturer-extension (MEI) attributes with `WildcardSkipCustomElements` so wildcard reads skip them
     - Fix: Manufacturer-specific attributes in standard clusters are now filtered by the `WildcardSkipCustomElements` flag instead of `WildcardSkipGlobalAttributes` during wildcard path expansion
 
+- @matter/nodejs-shell
+  - Fix: Close a path-containment gap in the optional web server that let requests reach sibling directories sharing the web-root name prefix, and resolve symlinks before serving (reported by tonghuaroot)
+  - Fix: Bind the WebSocket/web server to loopback (127.0.0.1) by default instead of all interfaces; added a `--webAddress` option to choose the listen address
+
 - @matter/protocol
     - Feature: Preparations for Groupcast support (provisional in Matter 1.6.0)
     - Feature: Source the client read path-count hint from the peer's advertised CapabilityMinima floors
+    - Enhancement: Optimized Subscription minIntervalFloor: now defaults to 0s; only Thread devices older than Matter 1.3.0 keep a 1s floor, and any node with a Generic Switch endpoint opts back into 0s for faster switch events
 
-- @matter/nodejs-shell
-    - Fix: Close a path-containment gap in the optional web server that let requests reach sibling directories sharing the web-root name prefix, and resolve symlinks before serving (reported by tonghuaroot)
-    - Fix: Bind the WebSocket/web server to loopback (127.0.0.1) by default instead of all interfaces; added a `--webAddress` option to choose the listen address
+- @matter/types
+  - Enhancement: Added the NFC Transport Layer (NTL, bit 4) capability to the onboarding payload Discovery Capabilities bitmap
 
 ## 0.17.4 (2026-07-01)
 

--- a/packages/general/src/util/DeepCopy.ts
+++ b/packages/general/src/util/DeepCopy.ts
@@ -7,7 +7,7 @@
 /**
  * Create a deep copy of a data structure.
  *
- * Only copies enumerable properties.  Handles typed arrays and graphs.
+ * Only copies enumerable properties.  Handles typed arrays, Sets, Maps and graphs.
  */
 export function deepCopy<T>(value: T): T {
     let clones: undefined | Map<unknown, unknown>;
@@ -28,6 +28,10 @@ export function deepCopy<T>(value: T): T {
             } else if (ArrayBuffer.isView(value)) {
                 const ViewType = value.constructor as unknown as { from(v: typeof value): typeof value };
                 clone = ViewType.from(value);
+            } else if (value instanceof Set) {
+                clone = new Set([...value].map(copy));
+            } else if (value instanceof Map) {
+                clone = new Map([...value].map(([k, v]) => [copy(k), copy(v)]));
             } else {
                 clone = Object.fromEntries(Object.entries(value).map(([k, v]) => [k, copy(v)]));
             }

--- a/packages/general/src/util/DeepCopy.ts
+++ b/packages/general/src/util/DeepCopy.ts
@@ -29,22 +29,31 @@ export function deepCopy<T>(value: T): T {
                 const ViewType = value.constructor as unknown as { from(v: typeof value): typeof value };
                 clone = ViewType.from(value);
             } else if (value instanceof Set) {
-                clone = new Set([...value].map(copy));
+                // Register the empty clone before recursing so a cyclic member resolves to the clone, not an infinite loop.
+                const set = remember(value, new Set());
+                for (const member of value) {
+                    set.add(copy(member));
+                }
+                return set;
             } else if (value instanceof Map) {
-                clone = new Map([...value].map(([k, v]) => [copy(k), copy(v)]));
+                const map = remember(value, new Map());
+                for (const [k, v] of value) {
+                    map.set(copy(k), copy(v));
+                }
+                return map;
             } else {
                 clone = Object.fromEntries(Object.entries(value).map(([k, v]) => [k, copy(v)]));
             }
 
-            if (!clones) {
-                clones = new Map();
-            }
-            clones.set(value, clone);
-
-            return clone;
+            return remember(value, clone);
         }
 
         return value;
+    }
+
+    function remember<C>(original: unknown, clone: C): C {
+        (clones ??= new Map()).set(original, clone);
+        return clone;
     }
 
     return copy(value) as T;

--- a/packages/general/test/util/DeepCopyTest.ts
+++ b/packages/general/test/util/DeepCopyTest.ts
@@ -70,6 +70,27 @@ describe("DeepCopy", () => {
         expect(copiedMember).to.not.equal(member);
     });
 
+    it("should handle a Set that participates in a cycle", () => {
+        const set = new Set<unknown>();
+        const member = { set };
+        set.add(member);
+
+        const copiedSet = deepCopy(set);
+        expect(copiedSet).to.be.instanceOf(Set);
+        const copiedMember = [...copiedSet][0] as { set: Set<unknown> };
+        expect(copiedMember).to.not.equal(member);
+        expect(copiedMember.set).to.equal(copiedSet);
+    });
+
+    it("should handle a Map that participates in a cycle", () => {
+        const map = new Map<string, unknown>();
+        map.set("self", map);
+
+        const copiedMap = deepCopy(map);
+        expect(copiedMap).to.be.instanceOf(Map);
+        expect(copiedMap.get("self")).to.equal(copiedMap);
+    });
+
     it("should correctly copy Map values", () => {
         const map = new Map<string, { v: number }>([
             ["a", { v: 1 }],

--- a/packages/general/test/util/DeepCopyTest.ts
+++ b/packages/general/test/util/DeepCopyTest.ts
@@ -52,4 +52,33 @@ describe("DeepCopy", () => {
             expect(copiedArr[i]).to.not.equal(arr[i]);
         }
     });
+
+    it("should correctly copy Set values", () => {
+        const set = new Set([1, 2, 3]);
+        const copiedSet = deepCopy(set);
+        expect(copiedSet).to.be.instanceOf(Set);
+        expect([...copiedSet]).to.deep.equal([...set]);
+        expect(copiedSet).to.not.equal(set);
+    });
+
+    it("should deeply copy the members of a Set", () => {
+        const member = { a: 1 };
+        const set = new Set([member]);
+        const copiedSet = deepCopy(set);
+        const copiedMember = [...copiedSet][0];
+        expect(copiedMember).to.deep.equal(member);
+        expect(copiedMember).to.not.equal(member);
+    });
+
+    it("should correctly copy Map values", () => {
+        const map = new Map<string, { v: number }>([
+            ["a", { v: 1 }],
+            ["b", { v: 2 }],
+        ]);
+        const copiedMap = deepCopy(map);
+        expect(copiedMap).to.be.instanceOf(Map);
+        expect([...copiedMap]).to.deep.equal([...map]);
+        expect(copiedMap).to.not.equal(map);
+        expect(copiedMap.get("a")).to.not.equal(map.get("a"));
+    });
 });

--- a/packages/node/src/node/NodePhysicalProperties.ts
+++ b/packages/node/src/node/NodePhysicalProperties.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { BasicInformationClient } from "#behaviors/basic-information";
 import { DescriptorClient } from "#behaviors/descriptor";
 import { NetworkCommissioningClient } from "#behaviors/network-commissioning";
 import { PowerSourceClient } from "#behaviors/power-source";
@@ -13,7 +14,7 @@ import { AggregatorEndpoint } from "#endpoints/aggregator";
 import { Node } from "#node/Node.js";
 import { IcdManagement } from "@matter/model";
 import { PhysicalDeviceProperties } from "@matter/protocol";
-import { ClusterId } from "@matter/types";
+import { ClusterId, DeviceTypeId } from "@matter/types";
 import { PowerSource } from "@matter/types/clusters/power-source";
 import { ThreadNetworkDiagnostics } from "@matter/types/clusters/thread-network-diagnostics";
 
@@ -32,6 +33,8 @@ export function NodePhysicalProperties(node: Node) {
         isBatteryPowered: false,
         isIntermittentlyConnected: rootEndpointServerList.includes(IcdManagement.id as ClusterId),
         isThreadSleepyEndDevice: false,
+        specificationVersion: node.maybeStateOf(BasicInformationClient)?.specificationVersion,
+        deviceTypes: new Set<DeviceTypeId>(),
     };
 
     inspectEndpoint(node, properties);
@@ -39,83 +42,80 @@ export function NodePhysicalProperties(node: Node) {
     return properties;
 }
 
-function inspectEndpoint(endpoint: Endpoint, properties: PhysicalDeviceProperties) {
-    // Network interface support
-    const networkFeatures = endpoint.maybeFeaturesOf(NetworkCommissioningClient);
-    if (networkFeatures) {
-        if (networkFeatures.wiFiNetworkInterface) {
-            properties.supportsWifi = true;
-        }
-        if (networkFeatures.threadNetworkInterface) {
-            properties.supportsThread = true;
-        }
-        if (networkFeatures.ethernetNetworkInterface) {
-            properties.supportsEthernet = true;
-        }
+// Device types are collected node-wide (including bridged endpoints behind an aggregator) so consumers such as the
+// subscription-interval policy can react to them.  Power/network/thread properties describe the physical node itself,
+// so bridged endpoints (behindAggregator) must not contribute to them.
+function inspectEndpoint(endpoint: Endpoint, properties: PhysicalDeviceProperties, behindAggregator = false) {
+    // Device types present on this endpoint
+    const deviceTypes = (properties.deviceTypes ??= new Set<DeviceTypeId>());
+    for (const { deviceType } of endpoint.maybeStateOf(DescriptorClient)?.deviceTypeList ?? []) {
+        deviceTypes.add(deviceType);
     }
 
-    // Battery power
-    const powerSourceFeatures = endpoint.maybeFeaturesOf(PowerSourceClient);
-    const powerSourceState = powerSourceFeatures ? endpoint.maybeStateOf(PowerSourceClient) : undefined;
-    if (powerSourceFeatures && powerSourceState) {
-        const { status } = powerSourceState;
-        if (powerSourceFeatures.wired) {
-            if (status === PowerSource.PowerSourceStatus.Active) {
-                // Should we only consider A/C "mains" powered?  What is a DC adapter?  What is an external battery?
-                // For now assuming "wired" means "don't worry about power consumption"
-                properties.isMainsPowered = true;
+    if (!behindAggregator) {
+        // Network interface support
+        const networkFeatures = endpoint.maybeFeaturesOf(NetworkCommissioningClient);
+        if (networkFeatures) {
+            if (networkFeatures.wiFiNetworkInterface) {
+                properties.supportsWifi = true;
             }
-        } else if (
-            powerSourceFeatures.battery ||
-            // Perform additional checks because we've encountered devices with incorrect features
-            !powerSourceFeatures.wired ||
-            endpoint.behaviors.elementsOf(PowerSourceClient).attributes.has("batChargeLevel")
-        ) {
-            if (
-                status === PowerSource.PowerSourceStatus.Active ||
-                // Some devices do not properly specify state as active
-                status === PowerSource.PowerSourceStatus.Unspecified
+            if (networkFeatures.threadNetworkInterface) {
+                properties.supportsThread = true;
+            }
+            if (networkFeatures.ethernetNetworkInterface) {
+                properties.supportsEthernet = true;
+            }
+        }
+
+        // Battery power
+        const powerSourceFeatures = endpoint.maybeFeaturesOf(PowerSourceClient);
+        const powerSourceState = powerSourceFeatures ? endpoint.maybeStateOf(PowerSourceClient) : undefined;
+        if (powerSourceFeatures && powerSourceState) {
+            const { status } = powerSourceState;
+            if (powerSourceFeatures.wired) {
+                if (status === PowerSource.PowerSourceStatus.Active) {
+                    // Should we only consider A/C "mains" powered?  What is a DC adapter?  What is an external battery?
+                    // For now assuming "wired" means "don't worry about power consumption"
+                    properties.isMainsPowered = true;
+                }
+            } else if (
+                powerSourceFeatures.battery ||
+                // Perform additional checks because we've encountered devices with incorrect features
+                !powerSourceFeatures.wired ||
+                endpoint.behaviors.elementsOf(PowerSourceClient).attributes.has("batChargeLevel")
             ) {
-                properties.isBatteryPowered = true;
+                if (
+                    status === PowerSource.PowerSourceStatus.Active ||
+                    // Some devices do not properly specify state as active
+                    status === PowerSource.PowerSourceStatus.Unspecified
+                ) {
+                    properties.isBatteryPowered = true;
+                }
+            }
+        }
+
+        // Sleepy thread device
+        const threadNetworkDiagnostics = endpoint.behaviors.typeFor(ThreadNetworkDiagnosticsClient);
+        const tnd = threadNetworkDiagnostics ? endpoint.maybeStateOf(threadNetworkDiagnostics) : undefined;
+        if (tnd) {
+            if (tnd.routingRole === ThreadNetworkDiagnostics.RoutingRole.SleepyEndDevice) {
+                properties.isThreadSleepyEndDevice = true;
+            }
+            if (tnd.extendedPanId !== undefined && tnd.extendedPanId !== null) {
+                properties.threadActive = true;
+                properties.threadPan = BigInt(tnd.extendedPanId);
+                properties.threadChannel = tnd.channel ?? undefined;
+            } else {
+                properties.threadActive = false;
             }
         }
     }
 
-    // Sleepy thread device
-    const threadNetworkDiagnostics = endpoint.behaviors.typeFor(ThreadNetworkDiagnosticsClient);
-    const tnd = threadNetworkDiagnostics ? endpoint.maybeStateOf(threadNetworkDiagnostics) : undefined;
-    if (tnd) {
-        if (tnd.routingRole === ThreadNetworkDiagnostics.RoutingRole.SleepyEndDevice) {
-            properties.isThreadSleepyEndDevice = true;
-        }
-        if (tnd.extendedPanId !== undefined && tnd.extendedPanId !== null) {
-            properties.threadActive = true;
-            properties.threadPan = BigInt(tnd.extendedPanId);
-            properties.threadChannel = tnd.channel ?? undefined;
-        } else {
-            properties.threadActive = false;
-        }
-    }
-
-    // Recurse into children
-    //
-    // Do not recurse into aggregator endpoints as bridged nodes are not relevant.  The check for mains power should
-    // otherwise cover us for properly structured devices.  For other devices err on the side of caution and assume
-    // mention of a battery on any endpoint means the entire node is battery powered.
-    //
-    // Technically according to spec we are handling the following incorrectly:
-    //
-    //   * Power source on application endpoint without EndpointList attribute (per spec power source does not apply to
-    //     node as a whole)
-    //
-    //   * Power source on any endpoint with non-empty EndpointList that does not include endpoint 0 (per spec this does
-    //     not indicate node is battery powered)
-    //
-    // The only downside of getting this wrong is that we will operate with degraded response time to changes.
+    // Recurse into children.  Endpoints at or below an aggregator are bridged nodes: their device types are still
+    // collected, but they do not describe the physical node so power/network/thread inspection is suppressed for them.
     for (const part of endpoint.parts) {
-        if (part.number !== 0 && part.type.deviceType === AggregatorEndpoint.deviceType) {
-            continue;
-        }
-        inspectEndpoint(part, properties);
+        const partBehindAggregator =
+            behindAggregator || (part.number !== 0 && part.type.deviceType === AggregatorEndpoint.deviceType);
+        inspectEndpoint(part, properties, partBehindAggregator);
     }
 }

--- a/packages/node/src/node/client/ClientNodePhysicalProperties.ts
+++ b/packages/node/src/node/client/ClientNodePhysicalProperties.ts
@@ -58,6 +58,14 @@ export function ClientNodePhysicalProperties(node: ClientNode) {
             return props().isThreadSleepyEndDevice;
         },
 
+        get specificationVersion() {
+            return props().specificationVersion;
+        },
+
+        get deviceTypes() {
+            return props().deviceTypes;
+        },
+
         get threadActive() {
             return props().threadActive;
         },

--- a/packages/node/test/node/NodePhysicalPropertiesTest.ts
+++ b/packages/node/test/node/NodePhysicalPropertiesTest.ts
@@ -7,8 +7,10 @@
 import { ClusterBehavior } from "#behavior/cluster/ClusterBehavior.js";
 import { IcdManagementServer } from "#behaviors/icd-management";
 import { PowerSourceServer } from "#behaviors/power-source";
+import { SwitchServer } from "#behaviors/switch";
 import { ThreadNetworkDiagnosticsServer } from "#behaviors/thread-network-diagnostics";
 import { WiFiNetworkDiagnosticsServer } from "#behaviors/wi-fi-network-diagnostics";
+import { GenericSwitchDevice } from "#devices/generic-switch";
 import { Endpoint } from "#endpoint/Endpoint.js";
 import { EndpointType } from "#endpoint/type/EndpointType.js";
 import { AggregatorEndpoint } from "#endpoints/aggregator";
@@ -17,9 +19,10 @@ import { SecondaryNetworkInterfaceEndpoint } from "#endpoints/secondary-network-
 import { Node } from "#node/Node.js";
 import { NodePhysicalProperties } from "#node/NodePhysicalProperties.js";
 import { ServerNode } from "#node/ServerNode.js";
-import { Minutes, Seconds } from "@matter/general";
+import { Instant, Minutes, Seconds } from "@matter/general";
 import { PhysicalDeviceProperties, Subscribe } from "@matter/protocol";
 import { PowerSource } from "@matter/types/clusters/power-source";
+import { Switch } from "@matter/types/clusters/switch";
 import { ThreadNetworkDiagnostics } from "@matter/types/clusters/thread-network-diagnostics";
 import { MockServerNode } from "./mock-server-node.js";
 
@@ -27,7 +30,7 @@ describe("NodePhysicalProperties", () => {
     it("chooses correct default intervals", async () => {
         const node = await MockServerNode.create();
         expectParams(node, {
-            minIntervalFloor: Seconds(1),
+            minIntervalFloor: Instant,
             maxIntervalCeiling: Minutes(1),
         });
     });
@@ -62,7 +65,7 @@ describe("NodePhysicalProperties", () => {
         const BatteryEndpoint = PowerSourceEndpoint.with(BatteryServer);
         await expectParamsWithCluster(BatteryServer, BatteryEndpoint, {
             maxIntervalCeiling: Minutes(10),
-            minIntervalFloor: Seconds(1),
+            minIntervalFloor: Instant,
         });
     });
 
@@ -81,7 +84,7 @@ describe("NodePhysicalProperties", () => {
         });
         expectParams(node, {
             maxIntervalCeiling: Minutes(1),
-            minIntervalFloor: Seconds(1),
+            minIntervalFloor: Instant,
         });
     });
 
@@ -89,7 +92,7 @@ describe("NodePhysicalProperties", () => {
         const WifiEndpoint = SecondaryNetworkInterfaceEndpoint.with(WiFiNetworkDiagnosticsServer);
         await expectParamsWithCluster(WiFiNetworkDiagnosticsServer, WifiEndpoint, {
             maxIntervalCeiling: Minutes(1),
-            minIntervalFloor: Seconds(1),
+            minIntervalFloor: Instant,
         });
     });
 
@@ -100,7 +103,7 @@ describe("NodePhysicalProperties", () => {
         const ThreadEndpoint = SecondaryNetworkInterfaceEndpoint.with(ThreadServer);
         await expectParamsWithCluster(ThreadServer, ThreadEndpoint, {
             maxIntervalCeiling: Minutes(3),
-            minIntervalFloor: Seconds(1),
+            minIntervalFloor: Instant,
         });
     });
 
@@ -108,8 +111,40 @@ describe("NodePhysicalProperties", () => {
         const ThreadEndpoint = SecondaryNetworkInterfaceEndpoint.with(ThreadNetworkDiagnosticsServer);
         await expectParamsWithCluster(ThreadNetworkDiagnosticsServer, ThreadEndpoint, {
             maxIntervalCeiling: Minutes(1),
-            minIntervalFloor: Seconds(1),
+            minIntervalFloor: Instant,
         });
+    });
+
+    it("reports the specification version and no Generic Switch by default", async () => {
+        const node = await MockServerNode.create();
+        const props = NodePhysicalProperties(node);
+
+        // A mock node reports the current (>= 1.3) specification version, which is why Thread devices above still
+        // receive a 0s floor.
+        expect(props.specificationVersion).to.be.at.least(0x0103_0000);
+        expect(props.deviceTypes).to.not.include(GenericSwitchDevice.deviceType);
+    });
+
+    it("collects the device types present on endpoints", async () => {
+        const node = await MockServerNode.create({
+            parts: [new Endpoint(GenericSwitchDevice.with(SwitchServer.with(Switch.Feature.MomentarySwitch)))],
+        });
+        const props = NodePhysicalProperties(node);
+
+        expect(props.deviceTypes).to.include(GenericSwitchDevice.deviceType);
+    });
+
+    it("collects device types behind an aggregator", async () => {
+        const node = await MockServerNode.create({
+            parts: [
+                new Endpoint(AggregatorEndpoint, {
+                    parts: [new Endpoint(GenericSwitchDevice.with(SwitchServer.with(Switch.Feature.MomentarySwitch)))],
+                }),
+            ],
+        });
+        const props = NodePhysicalProperties(node);
+
+        expect(props.deviceTypes).to.include(GenericSwitchDevice.deviceType);
     });
 });
 
@@ -139,7 +174,7 @@ async function expectParamsWithCluster(
         ],
     });
     expectParams(node, {
-        minIntervalFloor: Seconds(1),
+        minIntervalFloor: Instant,
         maxIntervalCeiling: Minutes(1),
     });
 }

--- a/packages/protocol/src/peer/PhysicalDeviceProperties.ts
+++ b/packages/protocol/src/peer/PhysicalDeviceProperties.ts
@@ -77,7 +77,8 @@ export namespace PhysicalDeviceProperties {
         } = properties ?? {};
 
         if (isIntermittentlyConnected && minIntervalFloor !== DEFAULT_SUBSCRIPTION_FLOOR_ICD) {
-            if (minIntervalFloor !== undefined) {
+            // Only announce the override when the caller supplied the floor; our own defaulting runs afterwards.
+            if (request?.minIntervalFloor !== undefined) {
                 logger.info(
                     `${description}: Overwriting minIntervalFloorSeconds for intermittently connected device to ${Duration.format(DEFAULT_SUBSCRIPTION_FLOOR_ICD)}`,
                 );

--- a/packages/protocol/src/peer/PhysicalDeviceProperties.ts
+++ b/packages/protocol/src/peer/PhysicalDeviceProperties.ts
@@ -5,11 +5,22 @@
  */
 
 import { Duration, Instant, Logger, Millis, Minutes, Seconds } from "@matter/general";
+import { GenericSwitchDt } from "@matter/model";
+import { DeviceTypeId } from "@matter/types";
 
 const logger = Logger.get("PhysicalDeviceProperties");
 
-const DEFAULT_SUBSCRIPTION_FLOOR_DEFAULT = Seconds(1);
+const DEFAULT_SUBSCRIPTION_FLOOR_DEFAULT = Instant;
+const DEFAULT_SUBSCRIPTION_FLOOR_THREAD_LEGACY = Seconds(1);
 const DEFAULT_SUBSCRIPTION_FLOOR_ICD = Instant;
+
+// specificationVersion encoding for Matter 1.3.0; the attribute was introduced in 1.3, so an absent/lower value means
+// the peer predates 1.3.
+const SPEC_VERSION_1_3 = 0x0103_0000;
+
+// A Generic Switch endpoint opts a legacy-Thread device back into a 0s floor so switch events are delivered without
+// delay.
+const GENERIC_SWITCH_DEVICE_TYPE = DeviceTypeId(GenericSwitchDt.id);
 const DEFAULT_SUBSCRIPTION_CEILING_WIFI = Minutes(1);
 const DEFAULT_SUBSCRIPTION_CEILING_THREAD = Minutes(1);
 const DEFAULT_SUBSCRIPTION_CEILING_THREAD_SLEEPY = Minutes(3);
@@ -26,6 +37,10 @@ export interface PhysicalDeviceProperties {
     isBatteryPowered: boolean;
     isIntermittentlyConnected: boolean;
     isThreadSleepyEndDevice: boolean;
+    specificationVersion?: number;
+
+    /** Device type IDs present on any endpoint of the node. */
+    deviceTypes?: Set<DeviceTypeId>;
     threadActive?: boolean;
     threadPan?: bigint;
     threadChannel?: number;
@@ -50,8 +65,16 @@ export namespace PhysicalDeviceProperties {
             description = "Node";
         }
 
-        const { isMainsPowered, isBatteryPowered, isIntermittentlyConnected, supportsThread, isThreadSleepyEndDevice } =
-            properties ?? {};
+        const {
+            isMainsPowered,
+            isBatteryPowered,
+            isIntermittentlyConnected,
+            supportsThread,
+            isThreadSleepyEndDevice,
+            threadActive,
+            specificationVersion,
+            deviceTypes,
+        } = properties ?? {};
 
         if (isIntermittentlyConnected && minIntervalFloor !== DEFAULT_SUBSCRIPTION_FLOOR_ICD) {
             if (minIntervalFloor !== undefined) {
@@ -62,7 +85,17 @@ export namespace PhysicalDeviceProperties {
             minIntervalFloor = DEFAULT_SUBSCRIPTION_FLOOR_ICD;
         }
         if (minIntervalFloor === undefined) {
-            minIntervalFloor = DEFAULT_SUBSCRIPTION_FLOOR_DEFAULT;
+            // Only pre-1.3 Thread devices keep a 1s floor to spare the mesh; a Generic Switch endpoint opts back into a
+            // 0s floor so switch events are delivered without delay.
+            const onThread =
+                threadActive === true ||
+                (threadActive === undefined && (supportsThread === true || isThreadSleepyEndDevice === true));
+            const preMatter13 = (specificationVersion ?? 0) < SPEC_VERSION_1_3;
+            const hasGenericSwitch = deviceTypes?.has(GENERIC_SWITCH_DEVICE_TYPE) ?? false;
+            minIntervalFloor =
+                onThread && preMatter13 && !hasGenericSwitch
+                    ? DEFAULT_SUBSCRIPTION_FLOOR_THREAD_LEGACY
+                    : DEFAULT_SUBSCRIPTION_FLOOR_DEFAULT;
         }
 
         const defaultCeiling =

--- a/packages/protocol/test/peer/PhysicalDevicePropertiesTest.ts
+++ b/packages/protocol/test/peer/PhysicalDevicePropertiesTest.ts
@@ -6,6 +6,8 @@
 
 import { PhysicalDeviceProperties } from "#peer/PhysicalDeviceProperties.js";
 import { Instant, Seconds } from "@matter/general";
+import { GenericSwitchDt } from "@matter/model";
+import { DeviceTypeId } from "@matter/types";
 
 const { subscriptionIntervalBoundsFor } = PhysicalDeviceProperties;
 
@@ -23,19 +25,60 @@ const BASE_PROPERTIES: PhysicalDeviceProperties = {
 
 describe("PhysicalDeviceProperties", () => {
     describe("subscriptionIntervalBoundsFor", () => {
+        // specificationVersion encoding for Matter 1.3.0.
+        const SPEC_1_3 = 0x0103_0000;
+        const THREAD_PRE_1_3: PhysicalDeviceProperties = {
+            ...BASE_PROPERTIES,
+            supportsWifi: false,
+            supportsThread: true,
+            threadActive: true,
+        };
+
         describe("minIntervalFloor", () => {
-            it("defaults to 1 second when called with no arguments", () => {
+            it("defaults to Instant (0) when called with no arguments", () => {
                 const { minIntervalFloor } = subscriptionIntervalBoundsFor();
 
-                expect(minIntervalFloor).to.equal(Seconds(1));
+                expect(minIntervalFloor).to.equal(Instant);
             });
 
-            it("defaults to 1 second for a non-ICD device with no floor requested", () => {
+            it("defaults to Instant (0) for a non-Thread device with no floor requested", () => {
                 const { minIntervalFloor } = subscriptionIntervalBoundsFor({
                     properties: { ...BASE_PROPERTIES, isIntermittentlyConnected: false },
                 });
 
+                expect(minIntervalFloor).to.equal(Instant);
+            });
+
+            it("uses 1 second for a pre-1.3 Thread device with no floor requested", () => {
+                const { minIntervalFloor } = subscriptionIntervalBoundsFor({
+                    properties: THREAD_PRE_1_3,
+                });
+
                 expect(minIntervalFloor).to.equal(Seconds(1));
+            });
+
+            it("uses 1 second for a Thread device that only supports Thread but is not yet active", () => {
+                const { minIntervalFloor } = subscriptionIntervalBoundsFor({
+                    properties: { ...BASE_PROPERTIES, supportsWifi: false, supportsThread: true },
+                });
+
+                expect(minIntervalFloor).to.equal(Seconds(1));
+            });
+
+            it("uses Instant (0) for a Thread device on Matter 1.3 or later", () => {
+                const { minIntervalFloor } = subscriptionIntervalBoundsFor({
+                    properties: { ...THREAD_PRE_1_3, specificationVersion: SPEC_1_3 },
+                });
+
+                expect(minIntervalFloor).to.equal(Instant);
+            });
+
+            it("uses Instant (0) for a pre-1.3 Thread device that has a Generic Switch endpoint", () => {
+                const { minIntervalFloor } = subscriptionIntervalBoundsFor({
+                    properties: { ...THREAD_PRE_1_3, deviceTypes: new Set([DeviceTypeId(GenericSwitchDt.id)]) },
+                });
+
+                expect(minIntervalFloor).to.equal(Instant);
             });
 
             it("respects a custom floor requested for a non-ICD device", () => {


### PR DESCRIPTION
## What

Reworks how the minimum subscription interval floor for a node is chosen.

**New policy** (`PhysicalDeviceProperties.subscriptionIntervalBoundsFor`):
- Default floor is **0s** for every device.
- **Exception:** a Thread device on **Matter < 1.3.0** *without* a Generic Switch endpoint keeps a **1s** floor (spares the mesh).
- A **Generic Switch** endpoint anywhere on the node (including bridged, behind an aggregator) opts back into **0s** so switch events arrive without delay.
- **ICD** devices remain **0s** (unchanged).

Previously the floor was a blanket 1s (0s only for ICD).

## How

- `PhysicalDeviceProperties` gains `specificationVersion` and a generic `deviceTypes: Set<DeviceTypeId>` (reusable for other device-type-driven policy).
- `NodePhysicalProperties` populates both. Device types are now collected **node-wide including bridged endpoints**; power/network/thread inference stays blind to bridged subtrees via a `behindAggregator` recursion flag (previously aggregators were skipped entirely, so their device types were invisible).
- `deepCopy` extended to clone `Set`/`Map` (previously silently turned them into `{}`) — required because `ClientNodePhysicalProperties.freeze()` snapshots via `deepCopy`.

Thread-ness uses `threadActive` with a `supportsThread`/`isThreadSleepyEndDevice` fallback; pre-1.3 is detected via `specificationVersion` (< `0x01030000`; absent ⇒ pre-1.3).

## Tests

- `PhysicalDevicePropertiesTest` — full min-floor decision matrix (WiFi, pre-1.3 Thread, 1.3+ Thread, Generic Switch opt-out, ICD).
- `NodePhysicalPropertiesTest` — device-type collection incl. behind an aggregator; spec-version reporting.
- `DeepCopyTest` — Set/Map cloning + deep member copy.

All suites green (general/protocol/node), format + lint clean. Three adversarial reviews clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)