### PR TITLE
feat(thread-br-client): post-2024 OTBR REST diagnostics + hybrid CoAP/REST source

### DIFF
--- a/packages/thread-br-client/src/diagnostic/HybridDiagnosticSource.ts
+++ b/packages/thread-br-client/src/diagnostic/HybridDiagnosticSource.ts
@@ -56,7 +56,8 @@ export class HybridDiagnosticSource implements DiagnosticSource {
     }
 
     canQuery(extPanId: Bytes): boolean {
-        return this.#coap?.canQuery(extPanId) === true || this.#rest?.canQuery(extPanId) === true;
+        // Must reflect the transport that will actually serve queries, since every op routes to it.
+        return this.#preferred.canQuery(extPanId);
     }
 
     queryUnicast(target: { rloc16?: number; ip?: string }, tlvTypes: number[]): Promise<DiagnosticResponse> {

--- a/packages/thread-br-client/src/diagnostic/HybridDiagnosticSource.ts
+++ b/packages/thread-br-client/src/diagnostic/HybridDiagnosticSource.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type Bytes, ImplementationError } from "@matter/general";
+import type { DiagnosticResponse } from "./DiagnosticResponse.js";
+import type { DiagnosticSource, QueryMulticastHandle, QueryMulticastOptions } from "./DiagnosticSource.js";
+
+/** Which transport performs the diagnostic queries. */
+export type DiagnosticDetailTransport = "coap" | "rest";
+
+export interface HybridDiagnosticOptions {
+    /** MeshCoP (CoAP-over-DTLS) source, when Thread credentials are available for the network. */
+    coap?: DiagnosticSource;
+    /** OTBR REST source, when a REST endpoint was probed for the network. */
+    rest?: DiagnosticSource;
+    /**
+     * Preferred transport for diagnostic queries. Defaults to `"coap"`: the REST collection API
+     * runs one BR-managed action per node and is markedly slower than direct CoAP unicast/multicast,
+     * so CoAP is preferred whenever credentials exist. The non-preferred transport is used only when
+     * the preferred one is absent.
+     */
+    detailTransport?: DiagnosticDetailTransport;
+}
+
+/**
+ * A {@link DiagnosticSource} that composes the MeshCoP (CoAP) and OTBR REST sources and routes every
+ * query to the configured preferred transport, falling back to the other only when the preferred is
+ * absent for this network.
+ *
+ * CoAP is preferred by default because it queries nodes directly under our own timeout/window,
+ * whereas the REST collection API delegates to the BR as async per-node actions (much slower). REST
+ * is used when there are no Thread credentials for CoAP, or when explicitly selected via
+ * {@link HybridDiagnosticOptions.detailTransport}.
+ */
+export class HybridDiagnosticSource implements DiagnosticSource {
+    readonly #coap?: DiagnosticSource;
+    readonly #rest?: DiagnosticSource;
+    readonly #preferred: DiagnosticSource;
+
+    constructor(options: HybridDiagnosticOptions) {
+        this.#coap = options.coap;
+        this.#rest = options.rest;
+        const detailTransport = options.detailTransport ?? "coap";
+        const preferred = detailTransport === "rest" ? (this.#rest ?? this.#coap) : (this.#coap ?? this.#rest);
+        if (preferred === undefined) {
+            throw new ImplementationError("HybridDiagnosticSource requires at least one of { coap, rest }");
+        }
+        this.#preferred = preferred;
+    }
+
+    get kind(): "meshcop" | "otbr-rest" {
+        return this.#preferred.kind;
+    }
+
+    canQuery(extPanId: Bytes): boolean {
+        return this.#coap?.canQuery(extPanId) === true || this.#rest?.canQuery(extPanId) === true;
+    }
+
+    queryUnicast(target: { rloc16?: number; ip?: string }, tlvTypes: number[]): Promise<DiagnosticResponse> {
+        return this.#preferred.queryUnicast(target, tlvTypes);
+    }
+
+    queryMulticast(scope: "ff03::1" | "ff03::2", opts: QueryMulticastOptions): QueryMulticastHandle {
+        return this.#preferred.queryMulticast(scope, opts);
+    }
+
+    resetCounters(target: { rloc16?: number; ip?: string }, tlvTypes?: ReadonlyArray<number>): Promise<void> {
+        return this.#preferred.resetCounters(target, tlvTypes);
+    }
+}

--- a/packages/thread-br-client/src/diagnostic/index.ts
+++ b/packages/thread-br-client/src/diagnostic/index.ts
@@ -9,5 +9,7 @@ export type { ConnectMeshcopOpts, MeshcopHandle } from "./connectMeshcop.js";
 export { DefaultTlvSet } from "./DefaultTlvSet.js";
 export type { DiagnosticResponse } from "./DiagnosticResponse.js";
 export type { DiagnosticSource, QueryMulticastHandle, QueryMulticastOptions } from "./DiagnosticSource.js";
+export { HybridDiagnosticSource } from "./HybridDiagnosticSource.js";
+export type { DiagnosticDetailTransport, HybridDiagnosticOptions } from "./HybridDiagnosticSource.js";
 export { MeshCopDiagnosticSource, ThreadDiagError } from "./MeshCopDiagnosticSource.js";
 export type { EnergyScanEntry, EnergyScanOpts, PanIdConflict, PanIdQueryOpts } from "./MeshCopDiagnosticSource.js";

--- a/packages/thread-br-client/src/index.ts
+++ b/packages/thread-br-client/src/index.ts
@@ -25,13 +25,21 @@ export {
 } from "./util/meshLocalAddr.js";
 
 // Diagnostics: the source abstraction, response shape, and its structured sub-types.
-export { DefaultTlvSet, MeshCopDiagnosticSource, ThreadDiagError, connectMeshcop } from "./diagnostic/index.js";
+export {
+    DefaultTlvSet,
+    HybridDiagnosticSource,
+    MeshCopDiagnosticSource,
+    ThreadDiagError,
+    connectMeshcop,
+} from "./diagnostic/index.js";
 export type {
     ConnectMeshcopOpts,
+    DiagnosticDetailTransport,
     DiagnosticResponse,
     DiagnosticSource,
     EnergyScanEntry,
     EnergyScanOpts,
+    HybridDiagnosticOptions,
     MeshcopHandle,
     PanIdConflict,
     PanIdQueryOpts,
@@ -76,6 +84,7 @@ export type {
     OtbrNodeInfo,
     OtbrRestCapability,
     OtbrRestClientOptions,
+    OtbrRestDiagnosticOptions,
     OtbrRestErrorCode,
     OtbrRestErrorOptions,
 } from "./otbr-rest/index.js";

--- a/packages/thread-br-client/src/otbr-rest/OtbrRestActionRunner.ts
+++ b/packages/thread-br-client/src/otbr-rest/OtbrRestActionRunner.ts
@@ -25,7 +25,12 @@ function isTerminal(status: string): status is ActionTerminalStatus {
  *
  * Uses the injectable matter.js {@link Time} so tests drive it under MockTime.
  *
- * @throws {@link OtbrRestError} `"rest_protocol"` if the action does not settle before `timeout`.
+ * `timeout` bounds polling, not the result: a terminal status observed on a poll is always honored
+ * (a result seen on the same poll the deadline elapses is returned, not discarded — the work is
+ * already done). The throw fires only when a poll after the deadline is still non-terminal.
+ *
+ * @throws {@link OtbrRestError} `"rest_protocol"` if a poll after `timeout` still finds the action
+ *   non-terminal.
  */
 export async function runActionToCompletion(
     client: Pick<OtbrRestClient, "getAction">,

--- a/packages/thread-br-client/src/otbr-rest/OtbrRestActionRunner.ts
+++ b/packages/thread-br-client/src/otbr-rest/OtbrRestActionRunner.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type Duration, Time, type Timer } from "@matter/general";
+import type { OtbrRestClient } from "./OtbrRestClient.js";
+import { OtbrRestError } from "./OtbrRestError.js";
+
+/** Terminal states a collection-API action can settle into. */
+export type ActionTerminalStatus = "completed" | "stopped" | "failed";
+
+function isTerminal(status: string): status is ActionTerminalStatus {
+    return status === "completed" || status === "stopped" || status === "failed";
+}
+
+/**
+ * Poll a collection-API action to a terminal state.
+ *
+ * The OTBR REST collection API runs `getNetworkDiagnosticTask` / `updateDeviceCollectionTask`
+ * asynchronously: the initial POST returns immediately with `pending`, and the caller polls the
+ * action resource until it settles. Returns the terminal status and, for a completed diagnostic
+ * task, the result-collection id from `relationships.result.data.id`.
+ *
+ * Uses the injectable matter.js {@link Time} so tests drive it under MockTime.
+ *
+ * @throws {@link OtbrRestError} `"rest_protocol"` if the action does not settle before `timeout`.
+ */
+export async function runActionToCompletion(
+    client: Pick<OtbrRestClient, "getAction">,
+    id: string,
+    opts: { pollInterval: Duration; timeout: Duration },
+): Promise<{ status: ActionTerminalStatus; resultId?: string }> {
+    let timedOut = false;
+    const timer: Timer = Time.getTimer("otbr-action-poll-timeout", opts.timeout, () => {
+        timedOut = true;
+    }).start();
+    try {
+        for (;;) {
+            const { status, resultId } = await client.getAction(id);
+            if (isTerminal(status)) {
+                return { status, resultId };
+            }
+            if (timedOut) {
+                throw new OtbrRestError(
+                    "rest_protocol",
+                    `OTBR action ${id} did not complete within timeout (last status: ${status})`,
+                );
+            }
+            await Time.sleep("otbr-action-poll", opts.pollInterval);
+        }
+    } finally {
+        timer.stop();
+    }
+}

--- a/packages/thread-br-client/src/otbr-rest/OtbrRestCapability.ts
+++ b/packages/thread-br-client/src/otbr-rest/OtbrRestCapability.ts
@@ -19,4 +19,11 @@ export interface OtbrRestCapability {
     probedAt: number;
     networkName: string;
     extPanId: Bytes;
+
+    /**
+     * Which diagnostics REST flavor the BR serves: `"collection"` (post-2024 action model under
+     * `/api/diagnostics`), `"legacy"` (the `GET /diagnostics` snapshot), or `"none"` (neither —
+     * REST cannot serve diagnostics, so the consumer must fall back to MeshCoP).
+     */
+    diagnosticsApi: "legacy" | "collection" | "none";
 }

--- a/packages/thread-br-client/src/otbr-rest/OtbrRestClient.ts
+++ b/packages/thread-br-client/src/otbr-rest/OtbrRestClient.ts
@@ -89,6 +89,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
     return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+/**
+ * Read a collection response as an array, tolerating both the bare-array form and the JSON:API
+ * envelope `{ data: [...] }` that some OTBR builds return depending on the negotiated media type.
+ */
+function asCollectionArray(body: unknown, where: string): unknown[] {
+    if (Array.isArray(body)) return body;
+    if (isRecord(body) && Array.isArray(body["data"])) return body["data"];
+    throw new OtbrRestError("rest_protocol", `${where} did not return a JSON array`);
+}
+
 function expectString(record: Record<string, unknown>, key: string, where: string): string {
     const value = record[key];
     if (typeof value !== "string") {
@@ -615,24 +625,18 @@ export class OtbrRestClient {
     }
 
     /**
-     * GET the aggregated network-diagnostics collection (`/api/diagnostics`) as a bare array of
-     * per-node entries. Keys are normalized; feed each entry to {@link translateNodeJson}.
+     * GET the aggregated network-diagnostics collection (`/api/diagnostics`). Keys are normalized;
+     * feed each entry to {@link translateNodeJson}.
      */
     async getDiagnosticsCollection(): Promise<unknown[]> {
         const { body } = await this.#fetchJson("/api/diagnostics");
-        if (!Array.isArray(body)) {
-            throw new OtbrRestError("rest_protocol", "/api/diagnostics did not return a JSON array");
-        }
-        return body;
+        return asCollectionArray(body, "/api/diagnostics");
     }
 
-    /** GET the discovered-device directory (`/api/devices`) as a bare array. */
+    /** GET the discovered-device directory (`/api/devices`). */
     async listDevices(): Promise<unknown[]> {
         const { body } = await this.#fetchJson("/api/devices");
-        if (!Array.isArray(body)) {
-            throw new OtbrRestError("rest_protocol", "/api/devices did not return a JSON array");
-        }
-        return body;
+        return asCollectionArray(body, "/api/devices");
     }
 
     /** DELETE the diagnostics result cache so a subsequent collection reflects only fresh results. */

--- a/packages/thread-br-client/src/otbr-rest/OtbrRestClient.ts
+++ b/packages/thread-br-client/src/otbr-rest/OtbrRestClient.ts
@@ -557,6 +557,145 @@ export class OtbrRestClient {
         await this.#postActions(body);
     }
 
+    /**
+     * POST a JSON:API action task to `/api/actions` and return the created action's id.
+     *
+     * The collection-based (post-2024) OTBR REST API models network-diagnostic queries and
+     * device discovery as asynchronous actions. Poll {@link getAction} until the returned id
+     * reaches a terminal status.
+     *
+     * @param type - Action type, e.g. `"getNetworkDiagnosticTask"` or `"updateDeviceCollectionTask"`.
+     * @param attributes - Task attributes (destination, types, timeout, …).
+     * @throws {@link OtbrRestError} `"rest_protocol"` when the response carries no action id.
+     */
+    async postAction(type: string, attributes: Record<string, unknown>): Promise<string> {
+        const body = await this.#postJson("/api/actions", { data: [{ type, attributes }] });
+        const data = isRecord(body) ? body["data"] : undefined;
+        const first = Array.isArray(data) ? data[0] : undefined;
+        const id = isRecord(first) ? first["id"] : undefined;
+        if (typeof id !== "string") {
+            throw new OtbrRestError("rest_protocol", "POST /api/actions returned no action id");
+        }
+        return id;
+    }
+
+    /**
+     * GET an action's current status and, once completed, the id of its result item in the
+     * diagnostics collection (`relationships.result.data.id`).
+     *
+     * @param id - Action id returned by {@link postAction}.
+     */
+    async getAction(id: string): Promise<{ status: string; resultId?: string }> {
+        const path = `/api/actions/${id}`;
+        const response = await this.#doFetch(path, "application/vnd.api+json");
+        if (!response.ok) {
+            throw new OtbrRestError(errorCodeForStatus(response.status), `GET ${path} returned ${response.status}`, {
+                httpStatus: response.status,
+            });
+        }
+        let parsed: unknown;
+        try {
+            parsed = normalizeKeys(JSON.parse(response.text));
+        } catch (err) {
+            throw new OtbrRestError("rest_protocol", `GET ${path} returned non-JSON body`, {
+                cause: err instanceof Error ? err : undefined,
+            });
+        }
+        const data = isRecord(parsed) ? parsed["data"] : undefined;
+        const attributes = isRecord(data) ? data["attributes"] : undefined;
+        const status = isRecord(attributes) ? attributes["status"] : undefined;
+        if (typeof status !== "string") {
+            throw new OtbrRestError("rest_protocol", `GET ${path} returned no action status`);
+        }
+        const relationships = isRecord(data) ? data["relationships"] : undefined;
+        const result = isRecord(relationships) ? relationships["result"] : undefined;
+        const resultData = isRecord(result) ? result["data"] : undefined;
+        const resultId = isRecord(resultData) && typeof resultData["id"] === "string" ? resultData["id"] : undefined;
+        return { status, resultId };
+    }
+
+    /**
+     * GET the aggregated network-diagnostics collection (`/api/diagnostics`) as a bare array of
+     * per-node entries. Keys are normalized; feed each entry to {@link translateNodeJson}.
+     */
+    async getDiagnosticsCollection(): Promise<unknown[]> {
+        const { body } = await this.#fetchJson("/api/diagnostics");
+        if (!Array.isArray(body)) {
+            throw new OtbrRestError("rest_protocol", "/api/diagnostics did not return a JSON array");
+        }
+        return body;
+    }
+
+    /** GET the discovered-device directory (`/api/devices`) as a bare array. */
+    async listDevices(): Promise<unknown[]> {
+        const { body } = await this.#fetchJson("/api/devices");
+        if (!Array.isArray(body)) {
+            throw new OtbrRestError("rest_protocol", "/api/devices did not return a JSON array");
+        }
+        return body;
+    }
+
+    /** DELETE the diagnostics result cache so a subsequent collection reflects only fresh results. */
+    async clearDiagnostics(): Promise<void> {
+        await this.#mutate("DELETE", "/api/diagnostics");
+    }
+
+    /**
+     * Detect which diagnostics REST flavor the BR serves: `"collection"` (post-2024 action model
+     * under `/api/diagnostics`), `"legacy"` (the pre-collection `GET /diagnostics` snapshot), or
+     * `"none"` (neither — diagnostics must go via MeshCoP).
+     *
+     * Uses the endpoint's HTTP status only (a 404 is a normal negative signal, not an error), so it
+     * does not throw on the expected misses; genuine network failure still rejects.
+     */
+    async detectDiagnosticsApi(): Promise<"legacy" | "collection" | "none"> {
+        const collection = await this.#doFetch("/api/diagnostics", "application/json");
+        if (collection.ok) return "collection";
+        const legacy = await this.#doFetch("/diagnostics", "application/json");
+        if (legacy.ok) return "legacy";
+        return "none";
+    }
+
+    async #postJson(path: string, body: unknown): Promise<unknown> {
+        const url = `${this.#baseUrl}${path}`;
+        const controller = new AbortController();
+        const timer: Timer = Time.getTimer("otbr-post-json-timeout", this.#timeout, () => controller.abort()).start();
+        try {
+            const response = await fetch(url, {
+                method: "POST",
+                // The collection API mandates the JSON:API media type on both request and response.
+                headers: { "Content-Type": "application/vnd.api+json", Accept: "application/vnd.api+json" },
+                body: JSON.stringify(body),
+                signal: controller.signal,
+            });
+            const text = await response.text();
+            if (!response.ok) {
+                throw new OtbrRestError(
+                    errorCodeForStatus(response.status),
+                    `POST ${path} returned ${response.status}`,
+                    {
+                        httpStatus: response.status,
+                    },
+                );
+            }
+            try {
+                return normalizeKeys(JSON.parse(text));
+            } catch (err) {
+                throw new OtbrRestError("rest_protocol", `POST ${path} returned non-JSON body`, {
+                    cause: err instanceof Error ? err : undefined,
+                });
+            }
+        } catch (err) {
+            if (err instanceof OtbrRestError) throw err;
+            const message = err instanceof Error ? err.message : String(err);
+            throw new OtbrRestError("rest_unreachable", `POST ${path} failed: ${message}`, {
+                cause: err instanceof Error ? err : undefined,
+            });
+        } finally {
+            timer.stop();
+        }
+    }
+
     async #postActions(body: Record<string, unknown>): Promise<void> {
         const url = `${this.#baseUrl}/api/actions`;
         const controller = new AbortController();

--- a/packages/thread-br-client/src/otbr-rest/OtbrRestClient.ts
+++ b/packages/thread-br-client/src/otbr-rest/OtbrRestClient.ts
@@ -653,11 +653,36 @@ export class OtbrRestClient {
      * does not throw on the expected misses; genuine network failure still rejects.
      */
     async detectDiagnosticsApi(): Promise<"legacy" | "collection" | "none"> {
-        const collection = await this.#doFetch("/api/diagnostics", "application/json");
-        if (collection.ok) return "collection";
-        const legacy = await this.#doFetch("/diagnostics", "application/json");
-        if (legacy.ok) return "legacy";
+        if (await this.#probeOk("/api/diagnostics")) return "collection";
+        if (await this.#probeOk("/diagnostics")) return "legacy";
         return "none";
+    }
+
+    /**
+     * Status-only probe: whether `path` responds 2xx. Cancels the response body without buffering it
+     * — capability detection needs only the status, and a real `/diagnostics` snapshot can be large.
+     * A 404/other status is a normal negative signal (returns false); only a network failure rejects.
+     */
+    async #probeOk(path: string): Promise<boolean> {
+        const url = `${this.#baseUrl}${path}`;
+        const controller = new AbortController();
+        const timer: Timer = Time.getTimer("otbr-probe-timeout", this.#timeout, () => controller.abort()).start();
+        try {
+            const response = await fetch(url, {
+                method: "GET",
+                headers: { Accept: "application/json" },
+                signal: controller.signal,
+            });
+            await response.body?.cancel().catch(() => {});
+            return response.ok;
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            throw new OtbrRestError("rest_unreachable", `GET ${path} failed: ${message}`, {
+                cause: err instanceof Error ? err : undefined,
+            });
+        } finally {
+            timer.stop();
+        }
     }
 
     async #postJson(path: string, body: unknown): Promise<unknown> {

--- a/packages/thread-br-client/src/otbr-rest/OtbrRestDiagnosticSource.ts
+++ b/packages/thread-br-client/src/otbr-rest/OtbrRestDiagnosticSource.ts
@@ -200,6 +200,12 @@ export class OtbrRestDiagnosticSource implements DiagnosticSource {
 
     /** Fetch and decode the full mesh view via the build-appropriate REST flavor. */
     async #collect(): Promise<DiagnosticResponse[]> {
+        if (this.#capability.diagnosticsApi === "none") {
+            throw new OtbrRestError(
+                "rest_unsupported",
+                "OtbrRestDiagnosticSource: this Border Router does not serve diagnostics over REST",
+            );
+        }
         const entries =
             this.#capability.diagnosticsApi === "collection"
                 ? await this.#collectViaActions()

--- a/packages/thread-br-client/src/otbr-rest/OtbrRestDiagnosticSource.ts
+++ b/packages/thread-br-client/src/otbr-rest/OtbrRestDiagnosticSource.ts
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, errorOf, Logger, Observable } from "@matter/general";
+import { Bytes, type Duration, errorOf, Logger, Observable, Seconds } from "@matter/general";
 import type { DiagnosticResponse } from "../diagnostic/DiagnosticResponse.js";
 import type { DiagnosticSource, QueryMulticastHandle, QueryMulticastOptions } from "../diagnostic/DiagnosticSource.js";
 import { DEFAULT_RESET_TLV_TYPES } from "../diagnostic/DiagnosticSource.js";
+import { runActionToCompletion } from "./OtbrRestActionRunner.js";
 import type { OtbrRestCapability } from "./OtbrRestCapability.js";
 import type { OtbrRestClient } from "./OtbrRestClient.js";
 import { OtbrRestError } from "./OtbrRestError.js";
@@ -15,39 +16,118 @@ import { translateNodeJson } from "./translation.js";
 
 const logger = Logger.get("OtbrRestDiagnosticSource");
 
-type ClientLike = Pick<OtbrRestClient, "getDiagnostics" | "getNode" | "resetDiagnosticCounters">;
+type ClientLike = Pick<
+    OtbrRestClient,
+    | "getDiagnostics"
+    | "resetDiagnosticCounters"
+    | "postAction"
+    | "getAction"
+    | "getDiagnosticsCollection"
+    | "listDevices"
+    | "clearDiagnostics"
+>;
 
 /**
- * {@link DiagnosticSource} implementation that wraps the OTBR REST `/diagnostics`
- * endpoint.
+ * Network-diagnostic TLV types requested per node on the collection API. This is the authoritative
+ * queryable set from ot-br-posix's own REST test suite (`getNetworkDiagnosticTask` AllTLVs) — every
+ * key here is a valid request type; a type the build rejects fails the whole action with 400.
+ */
+const DEFAULT_DIAG_TYPES: readonly string[] = [
+    "extAddress",
+    "rloc16",
+    "leaderData",
+    "ipv6Addresses",
+    "macCounters",
+    "childTable",
+    "route",
+    "eui64",
+    "version",
+    "vendorName",
+    "vendorModel",
+    "vendorSwVersion",
+    "threadStackVersion",
+    "children",
+    "childIpv6Addresses",
+    "routerNeighbors",
+    "mleCounters",
+];
+
+/** BR-side mesh-query timeouts (seconds), passed as the action `timeout` attribute. */
+const DISCOVER_TASK_TIMEOUT_S = 15;
+const DIAG_TASK_TIMEOUT_S = 10;
+
+/**
+ * `updateDeviceCollectionTask` requires `maxAge`, `maxRetries`, `deviceCount` and `timeout` — the
+ * BR rejects the action (422) if any is absent. `maxAge`/`maxRetries` use the values from
+ * ot-br-posix's own REST examples; `deviceCount` is an upper-bound hint (see options).
+ */
+const DISCOVER_MAX_AGE_S = 30;
+const DISCOVER_MAX_RETRIES = 5;
+const DEFAULT_DEVICE_COUNT = 64;
+
+const DEFAULT_POLL_INTERVAL = Seconds(0.5);
+const DEFAULT_ACTION_TIMEOUT = Seconds(15);
+const DEFAULT_DISCOVER_TIMEOUT = Seconds(20);
+const DEFAULT_MAX_CONCURRENT = 4;
+const DEFAULT_RETRIES = 2;
+
+/** Tunables for the collection-API orchestration; all optional with sensible defaults. */
+export interface OtbrRestDiagnosticOptions {
+    /** Delay between action-status polls. */
+    pollInterval?: Duration;
+    /** How long to wait for a single per-node diagnostic action to settle. */
+    actionTimeout?: Duration;
+    /** How long to wait for the device-discovery action to settle. */
+    discoverTimeout?: Duration;
+    /** Maximum concurrent per-node diagnostic actions in flight. */
+    maxConcurrent?: number;
+    /** Extra attempts for a node whose diagnostic action stops/fails (transient; the BR retries too). */
+    retries?: number;
+    /** Diagnostic TLV types to request per node. Defaults to the full queryable set. */
+    types?: readonly string[];
+    /** Upper-bound hint for the number of devices to discover. */
+    deviceCount?: number;
+}
+
+/**
+ * {@link DiagnosticSource} over the OTBR REST surface.
  *
- * Unlike the MeshCoP path (DTLS + CoAP), this source requires no DTLS handshake;
- * the BR exposes a pre-collected mesh-wide diagnostic snapshot over plain HTTP.
- * TLV type filtering and multicast scoping are not supported on the wire — the
- * full snapshot is always fetched and filtered client-side.
+ * Two build families are supported, selected by {@link OtbrRestCapability.diagnosticsApi}:
+ * - `"legacy"` — the pre-collection `GET /diagnostics` snapshot (older BRs).
+ * - `"collection"` — the post-2024 action model: discover devices, issue a per-node
+ *   `getNetworkDiagnosticTask`, poll each to completion, then read the aggregated
+ *   `/api/diagnostics` collection.
  *
- * Bind one instance per discovered OTBR REST endpoint. The `capability` object
- * from {@link OtbrRestProbe} records which network this source covers.
+ * Nodes whose per-node action stops or fails are skipped (partial results are valid — the OTBR web
+ * UI behaves the same). Bind one instance per discovered OTBR REST endpoint.
  */
 export class OtbrRestDiagnosticSource implements DiagnosticSource {
     readonly kind = "otbr-rest" as const;
 
     readonly #client: ClientLike;
     readonly #capability: OtbrRestCapability;
+    readonly #pollInterval: Duration;
+    readonly #actionTimeout: Duration;
+    readonly #discoverTimeout: Duration;
+    readonly #maxConcurrent: number;
+    readonly #types: readonly string[];
+    readonly #deviceCount: number;
+    readonly #retries: number;
 
-    /**
-     * @param client - REST client (or compatible duck type) for the target BR.
-     * @param capability - Probed metadata identifying the network this source covers.
-     */
-    constructor(client: ClientLike, capability: OtbrRestCapability) {
+    constructor(client: ClientLike, capability: OtbrRestCapability, options: OtbrRestDiagnosticOptions = {}) {
         this.#client = client;
         this.#capability = capability;
+        this.#pollInterval = options.pollInterval ?? DEFAULT_POLL_INTERVAL;
+        this.#actionTimeout = options.actionTimeout ?? DEFAULT_ACTION_TIMEOUT;
+        this.#discoverTimeout = options.discoverTimeout ?? DEFAULT_DISCOVER_TIMEOUT;
+        this.#maxConcurrent = options.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
+        this.#types = options.types ?? DEFAULT_DIAG_TYPES;
+        this.#deviceCount = options.deviceCount ?? DEFAULT_DEVICE_COUNT;
+        this.#retries = options.retries ?? DEFAULT_RETRIES;
     }
 
     /**
      * Returns `true` when `extPanId` matches the network this source was probed for.
-     *
-     * @param extPanId - 8-byte Extended PAN ID of the network to query.
      */
     canQuery(extPanId: Bytes): boolean {
         return Bytes.areEqual(extPanId, this.#capability.extPanId);
@@ -56,15 +136,12 @@ export class OtbrRestDiagnosticSource implements DiagnosticSource {
     /**
      * Query diagnostics for a single mesh node by RLOC16.
      *
-     * Fetches the full `/diagnostics` snapshot from the BR and returns the entry
-     * matching `target.rloc16`. IP-only targets are not supported via REST — the
-     * OTBR per-RLOC16 endpoint is not universally available.
+     * Both build families fetch the full mesh view and filter by `rloc16` (the collection API has no
+     * cheap per-RLOC16 query — the device directory carries no rloc16 — so it runs the same populate
+     * flow as {@link queryMulticast}).
      *
-     * @param target - Must include `rloc16`; `ip` without `rloc16` is rejected.
-     * @param _tlvTypes - Ignored; REST returns the BR's full snapshot unconditionally.
-     * @throws {@link OtbrRestError} with code `"rest_protocol"` when `rloc16` is
-     *   missing, when an ip-only target is supplied, or when no entry matches `rloc16`.
-     * @throws {@link OtbrRestError} when the underlying REST fetch fails.
+     * @throws {@link OtbrRestError} `"rest_protocol"` for an ip-only target, a missing `rloc16`, or
+     *   when no entry matches `rloc16`.
      */
     async queryUnicast(target: { rloc16?: number; ip?: string }, _tlvTypes: number[]): Promise<DiagnosticResponse> {
         if (target.ip !== undefined && target.rloc16 === undefined) {
@@ -76,36 +153,20 @@ export class OtbrRestDiagnosticSource implements DiagnosticSource {
         if (target.rloc16 === undefined) {
             throw new OtbrRestError("rest_protocol", "OtbrRestDiagnosticSource: rloc16 required for unicast query");
         }
-        // Per-RLOC16 endpoint (`/diagnostics/<rloc16>`) is not universally
-        // supported — fetch the full mesh dump and filter client-side.
-        // tlvTypes is ignored: REST returns the BR's full diagnostic snapshot
-        // with no per-TLV filtering on the wire.
-        const list = await this.#client.getDiagnostics();
-        for (const entry of list) {
-            const decoded = translateNodeJson(entry);
-            if (decoded.rloc16 === target.rloc16) return decoded;
+        const nodes = await this.#collect();
+        const match = nodes.find(node => node.rloc16 === target.rloc16);
+        if (match === undefined) {
+            throw new OtbrRestError("rest_protocol", `rloc16 0x${target.rloc16.toString(16)} not found in diagnostics`);
         }
-        throw new OtbrRestError("rest_protocol", `rloc16 0x${target.rloc16.toString(16)} not found in /diagnostics`);
+        return match;
     }
 
     /**
-     * Stream all mesh-node diagnostics from the OTBR `/diagnostics` endpoint.
-     *
-     * Because the REST surface returns a pre-collected snapshot in a single HTTP
-     * response, multicast scope and `opts.windowMs` have no effect — all nodes are
-     * emitted in one burst and `done` resolves immediately after. The returned
-     * handle is still conformant to {@link QueryMulticastHandle}; callers may
-     * call `close()` before `done` resolves with no ill effect.
-     *
-     * @param _scope - Ignored; REST has no per-scope filtering.
-     * @param _opts - Ignored; see above.
-     * @returns Handle with `onNode`, `onError`, `done`, and `close`.
+     * Stream all mesh-node diagnostics. The REST surface has no per-scope filtering, so `scope`,
+     * `tlvTypes` and `windowMs` are ignored; all nodes are emitted in one burst and `done` resolves
+     * once the collection is complete.
      */
     queryMulticast(_scope: "ff03::1" | "ff03::2", _opts: QueryMulticastOptions): QueryMulticastHandle {
-        // scope/tlvTypes/windowMs are no-ops for REST: the BR has already
-        // collected diagnostics for the whole mesh and exposes the snapshot
-        // via /diagnostics. REST emits all nodes in a single burst and resolves
-        // `done` immediately after — windowMs is irrelevant.
         const onNode = new Observable<[DiagnosticResponse]>();
         const onError = new Observable<[Error]>();
         let resolveDone!: () => void;
@@ -115,15 +176,10 @@ export class OtbrRestDiagnosticSource implements DiagnosticSource {
             rejectDone = reject;
         });
 
-        const start = Date.now();
-        logger.debug(`REST GET /diagnostics ${this.#capability.baseUrl}`);
         void (async () => {
             try {
-                const list = await this.#client.getDiagnostics();
-                for (const entry of list) {
-                    onNode.emit(translateNodeJson(entry));
-                }
-                logger.debug(`REST /diagnostics OK nodes=${list.length} duration=${Date.now() - start}ms`);
+                const nodes = await this.#collect();
+                for (const node of nodes) onNode.emit(node);
                 resolveDone();
             } catch (err) {
                 const e = errorOf(err);
@@ -137,25 +193,95 @@ export class OtbrRestDiagnosticSource implements DiagnosticSource {
             onError,
             done,
             close: async () => {
-                // The fetch is in-flight — let it complete; ignore the outcome.
                 await done.catch(() => {});
             },
         };
     }
 
+    /** Fetch and decode the full mesh view via the build-appropriate REST flavor. */
+    async #collect(): Promise<DiagnosticResponse[]> {
+        const entries =
+            this.#capability.diagnosticsApi === "collection"
+                ? await this.#collectViaActions()
+                : await this.#client.getDiagnostics();
+        const decoded = new Array<DiagnosticResponse>();
+        for (const entry of entries) {
+            try {
+                decoded.push(translateNodeJson(entry));
+            } catch (err) {
+                // One undecodable node must not drop the whole mesh view.
+                logger.debug(`skipping undecodable diagnostic entry: ${errorOf(err).message}`);
+            }
+        }
+        return dedupeByRloc16(decoded);
+    }
+
     /**
-     * Zero MAC and MLE counters on a single mesh node via the OTBR REST API.
-     *
-     * Posts a `resetNetworkDiagCounterTask` action to `/api/actions`. Only
-     * available on camelCase OTBR backends (post-2024 builds detected as
-     * `keyFormat === "camel"` during probing). Throws {@link OtbrRestError}
-     * with code `"rest_disabled"` when the backend does not support this
-     * endpoint. Mutating but low-risk — counters only, no network state altered.
-     *
-     * @param _target - Accepted for interface compatibility; REST resets all
-     *   nodes atomically, so target is not forwarded on the wire.
-     * @param _tlvTypes - Accepted for interface compatibility; the REST action
-     *   always resets all diagnostic counters regardless of tlvTypes.
+     * Collection-API flow: clear stale results, discover the device directory, issue a per-node
+     * diagnostic action (bounded concurrency), then read the aggregated collection.
+     */
+    async #collectViaActions(): Promise<unknown[]> {
+        await this.#client.clearDiagnostics();
+
+        const discoverId = await this.#client.postAction("updateDeviceCollectionTask", {
+            maxAge: DISCOVER_MAX_AGE_S,
+            maxRetries: DISCOVER_MAX_RETRIES,
+            deviceCount: this.#deviceCount,
+            timeout: DISCOVER_TASK_TIMEOUT_S,
+        });
+        const discover = await runActionToCompletion(this.#client, discoverId, {
+            pollInterval: this.#pollInterval,
+            timeout: this.#discoverTimeout,
+        });
+        if (discover.status !== "completed") {
+            logger.debug(`OTBR device discovery ended ${discover.status}; device directory may be incomplete`);
+        }
+
+        const devices = await this.#client.listDevices();
+        const extAddresses = devices
+            .map(device => (isRecord(device) ? device["extAddress"] : undefined))
+            .filter((value): value is string => typeof value === "string");
+
+        await runBounded(extAddresses, this.#maxConcurrent, async extAddress => {
+            // A node whose action stops is usually transient (mesh busy) — the OTBR web UI retries
+            // too. Retry up to #retries times; a node that still won't answer is skipped so one
+            // unreachable node never aborts the sweep.
+            for (let attempt = 0; attempt <= this.#retries; attempt++) {
+                try {
+                    const id = await this.#client.postAction("getNetworkDiagnosticTask", {
+                        destination: extAddress,
+                        types: [...this.#types],
+                        timeout: DIAG_TASK_TIMEOUT_S,
+                    });
+                    const { status } = await runActionToCompletion(this.#client, id, {
+                        pollInterval: this.#pollInterval,
+                        timeout: this.#actionTimeout,
+                    });
+                    if (status === "completed") return;
+                    logger.debug(
+                        `diagnostic action for ${extAddress} ended ${status} (attempt ${attempt + 1}/${this.#retries + 1})`,
+                    );
+                } catch (err) {
+                    logger.debug(
+                        `diagnostic action for ${extAddress} failed (attempt ${attempt + 1}/${this.#retries + 1}): ${errorOf(err).message}`,
+                    );
+                }
+            }
+        });
+
+        const results = await this.#client.getDiagnosticsCollection();
+        if (extAddresses.length > 0 && results.length === 0) {
+            // Distinguish a systemic failure from an empty mesh (a bare "0 nodes" otherwise hides it).
+            logger.warn(
+                `OTBR diagnostics: discovered ${extAddresses.length} device(s) but every per-node query failed`,
+            );
+        }
+        return results;
+    }
+
+    /**
+     * Zero MAC and MLE counters on a single mesh node via the OTBR REST API. Only available on
+     * camelCase OTBR backends; throws {@link OtbrRestError} `"rest_disabled"` otherwise.
      */
     async resetCounters(
         _target: { rloc16?: number; ip?: string },
@@ -169,4 +295,44 @@ export class OtbrRestDiagnosticSource implements DiagnosticSource {
         }
         await this.#client.resetDiagnosticCounters({ action: "resetNetworkDiagCounterTask" });
     }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/** Drop duplicate nodes (two BRs report overlapping views); keep the first per rloc16. */
+function dedupeByRloc16(nodes: DiagnosticResponse[]): DiagnosticResponse[] {
+    const seen = new Set<number>();
+    const out = new Array<DiagnosticResponse>();
+    for (const node of nodes) {
+        if (node.rloc16 !== undefined) {
+            if (seen.has(node.rloc16)) continue;
+            seen.add(node.rloc16);
+        }
+        out.push(node);
+    }
+    return out;
+}
+
+/**
+ * Run `fn` over `items` with at most `limit` concurrent executions. `fn` must handle its own errors
+ * — a rejection propagates through `Promise.all` while sibling workers keep running detached.
+ */
+async function runBounded<T>(items: readonly T[], limit: number, fn: (item: T) => Promise<void>): Promise<void> {
+    let cursor = 0;
+    const workerCount = Math.max(1, Math.min(limit, items.length));
+    const workers = new Array<Promise<void>>();
+    for (let i = 0; i < workerCount; i++) {
+        workers.push(
+            (async () => {
+                for (;;) {
+                    const index = cursor++;
+                    if (index >= items.length) return;
+                    await fn(items[index]);
+                }
+            })(),
+        );
+    }
+    await Promise.all(workers);
 }

--- a/packages/thread-br-client/src/otbr-rest/OtbrRestDiagnosticSource.ts
+++ b/packages/thread-br-client/src/otbr-rest/OtbrRestDiagnosticSource.ts
@@ -113,6 +113,8 @@ export class OtbrRestDiagnosticSource implements DiagnosticSource {
     readonly #types: readonly string[];
     readonly #deviceCount: number;
     readonly #retries: number;
+    /** Shared in-flight sweep, so concurrent queries don't race on BR-global collection state. */
+    #inFlight?: Promise<DiagnosticResponse[]>;
 
     constructor(client: ClientLike, capability: OtbrRestCapability, options: OtbrRestDiagnosticOptions = {}) {
         this.#client = client;
@@ -198,8 +200,29 @@ export class OtbrRestDiagnosticSource implements DiagnosticSource {
         };
     }
 
+    /**
+     * Fetch the full mesh view, coalescing concurrent callers onto one in-flight sweep.
+     *
+     * The collection flow mutates BR-global state (`DELETE /api/diagnostics` + per-node actions), so
+     * two overlapping sweeps against the same BR would race — one clearing the cache while the other
+     * reads it. Since a sweep always fetches the whole mesh, sharing one in-flight result is both
+     * race-free and cheaper.
+     */
+    #collect(): Promise<DiagnosticResponse[]> {
+        if (this.#inFlight === undefined) {
+            const run = this.#collectOnce();
+            this.#inFlight = run;
+            void run
+                .catch(() => {})
+                .finally(() => {
+                    if (this.#inFlight === run) this.#inFlight = undefined;
+                });
+        }
+        return this.#inFlight;
+    }
+
     /** Fetch and decode the full mesh view via the build-appropriate REST flavor. */
-    async #collect(): Promise<DiagnosticResponse[]> {
+    async #collectOnce(): Promise<DiagnosticResponse[]> {
         if (this.#capability.diagnosticsApi === "none") {
             throw new OtbrRestError(
                 "rest_unsupported",

--- a/packages/thread-br-client/src/otbr-rest/OtbrRestDiagnosticSource.ts
+++ b/packages/thread-br-client/src/otbr-rest/OtbrRestDiagnosticSource.ts
@@ -28,9 +28,10 @@ type ClientLike = Pick<
 >;
 
 /**
- * Network-diagnostic TLV types requested per node on the collection API. This is the authoritative
- * queryable set from ot-br-posix's own REST test suite (`getNetworkDiagnosticTask` AllTLVs) — every
- * key here is a valid request type; a type the build rejects fails the whole action with 400.
+ * Network-diagnostic TLV types requested per node on the collection API. A subset of ot-br-posix's
+ * queryable set (`getNetworkDiagnosticTask`) — only the types {@link translateNodeJson} actually
+ * decodes, so we don't make the BR collect data we discard. Every key is a valid request type; a
+ * type the build rejects fails the whole action with 400.
  */
 const DEFAULT_DIAG_TYPES: readonly string[] = [
     "extAddress",
@@ -46,9 +47,6 @@ const DEFAULT_DIAG_TYPES: readonly string[] = [
     "vendorModel",
     "vendorSwVersion",
     "threadStackVersion",
-    "children",
-    "childIpv6Addresses",
-    "routerNeighbors",
     "mleCounters",
 ];
 
@@ -212,6 +210,8 @@ export class OtbrRestDiagnosticSource implements DiagnosticSource {
         if (this.#inFlight === undefined) {
             const run = this.#collectOnce();
             this.#inFlight = run;
+            // Clear on settle so the next call starts a fresh sweep. The clear is queued before any
+            // awaiter's continuation, so a caller that awaits #collect() then calls again re-sweeps.
             void run
                 .catch(() => {})
                 .finally(() => {
@@ -250,7 +250,13 @@ export class OtbrRestDiagnosticSource implements DiagnosticSource {
      * diagnostic action (bounded concurrency), then read the aggregated collection.
      */
     async #collectViaActions(): Promise<unknown[]> {
-        await this.#client.clearDiagnostics();
+        // Best-effort: a BR that serves the read side but rejects DELETE must not fail every sweep.
+        // Stale entries then merge with fresh ones, which dedupe tolerates.
+        try {
+            await this.#client.clearDiagnostics();
+        } catch (err) {
+            logger.debug(`clearDiagnostics failed (continuing with a possibly stale cache): ${errorOf(err).message}`);
+        }
 
         const discoverId = await this.#client.postAction("updateDeviceCollectionTask", {
             maxAge: DISCOVER_MAX_AGE_S,

--- a/packages/thread-br-client/src/otbr-rest/OtbrRestProbe.ts
+++ b/packages/thread-br-client/src/otbr-rest/OtbrRestProbe.ts
@@ -35,10 +35,11 @@ export class OtbrRestProbe {
 
         try {
             const { keyFormat, networkName, extPanId } = await client.probeNode();
+            const diagnosticsApi = await client.detectDiagnosticsApi();
             logger.debug(
-                `probe OK ${baseUrl} keyFormat=${keyFormat} xp=${Bytes.toHex(extPanId).toUpperCase()} network="${networkName}"`,
+                `probe OK ${baseUrl} keyFormat=${keyFormat} diagnosticsApi=${diagnosticsApi} xp=${Bytes.toHex(extPanId).toUpperCase()} network="${networkName}"`,
             );
-            return { baseUrl, keyFormat, probedAt: Date.now(), networkName, extPanId };
+            return { baseUrl, keyFormat, probedAt: Date.now(), networkName, extPanId, diagnosticsApi };
         } catch (err) {
             if (err instanceof OtbrRestError) {
                 logger.debug(`probe MISS ${baseUrl} /node ${err.code} (${err.message})`);

--- a/packages/thread-br-client/src/otbr-rest/OtbrRestProbe.ts
+++ b/packages/thread-br-client/src/otbr-rest/OtbrRestProbe.ts
@@ -19,10 +19,11 @@ export class OtbrRestProbe {
      * Probe a host:port for OTBR REST. Returns the detected capability or
      * `null` if the endpoint is not OTBR or not reachable within `timeoutMs`.
      *
-     * A single `GET /node` both confirms the endpoint is OTBR and reveals its
-     * key casing: legacy builds emit PascalCase keys, post-2024 builds
-     * camelCase. Anything that is not a JSON object carrying `networkName` and
-     * `extPanId` is treated as "not OTBR".
+     * `GET /node` both confirms the endpoint is OTBR and reveals its key casing:
+     * legacy builds emit PascalCase keys, post-2024 builds camelCase. Anything that
+     * is not a JSON object carrying `networkName` and `extPanId` is treated as "not
+     * OTBR". A status-only probe of the diagnostics endpoints then records which
+     * flavor the BR serves (`diagnosticsApi`: legacy | collection | none).
      */
     static async probe(
         host: string,

--- a/packages/thread-br-client/src/otbr-rest/index.ts
+++ b/packages/thread-br-client/src/otbr-rest/index.ts
@@ -15,6 +15,7 @@ export type {
     OtbrRestClientOptions,
 } from "./OtbrRestClient.js";
 export { OtbrRestDiagnosticSource } from "./OtbrRestDiagnosticSource.js";
+export type { OtbrRestDiagnosticOptions } from "./OtbrRestDiagnosticSource.js";
 export { OtbrRestError } from "./OtbrRestError.js";
 export type { OtbrRestErrorCode, OtbrRestErrorOptions } from "./OtbrRestError.js";
 export { OtbrRestProbe } from "./OtbrRestProbe.js";

--- a/packages/thread-br-client/src/otbr-rest/translation.ts
+++ b/packages/thread-br-client/src/otbr-rest/translation.ts
@@ -307,15 +307,16 @@ export function translateNodeJson(json: unknown): DiagnosticResponse {
     }
 
     // Legacy builds emit `IP6AddressList` (→ `ip6AddressList` after normalization); post-2024
-    // builds emit `ipv6Addresses`. Accept either.
+    // builds emit `ipv6Addresses`. Accept either, and label logs/errors with the key actually seen.
+    const ip6Key = json["ipv6Addresses"] !== undefined ? "ipv6Addresses" : "ip6AddressList";
     const ip6Addresses = asArray(json["ipv6Addresses"] ?? json["ip6AddressList"]);
     if (ip6Addresses !== undefined) {
-        result.ipv6Addresses = optionalField("ipv6Addresses", () => {
+        result.ipv6Addresses = optionalField(ip6Key, () => {
             const list = new Array<Bytes>();
             for (const entry of ip6Addresses) {
                 const text = asString(entry);
                 if (text === undefined) {
-                    throw new OtbrRestError("rest_protocol", "ipv6Addresses: entry is not a string");
+                    throw new OtbrRestError("rest_protocol", `${ip6Key}: entry is not a string`);
                 }
                 list.push(parseIpv6(text));
             }

--- a/packages/thread-br-client/src/otbr-rest/translation.ts
+++ b/packages/thread-br-client/src/otbr-rest/translation.ts
@@ -275,7 +275,7 @@ export function translateNodeJson(json: unknown): DiagnosticResponse {
 
     const extAddress = asString(json["extAddress"]);
     if (extAddress !== undefined) {
-        result.extMacAddress = parseHexBytes(extAddress, "extAddress", 8);
+        result.extMacAddress = optionalField("extAddress", () => parseHexBytes(extAddress, "extAddress", 8));
     }
 
     const rloc16 = parseRloc16(json["rloc16"]);

--- a/packages/thread-br-client/src/otbr-rest/translation.ts
+++ b/packages/thread-br-client/src/otbr-rest/translation.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes } from "@matter/general";
+import { Bytes, errorOf, Logger } from "@matter/general";
 import type { DiagnosticResponse } from "../diagnostic/DiagnosticResponse.js";
 import type { ChildTableEntry } from "../tlv/diag/ChildTable.js";
 import type { Connectivity, ParentPriority } from "../tlv/diag/Connectivity.js";
@@ -17,9 +17,25 @@ import type { Route64, Route64Entry } from "../tlv/diag/Route64.js";
 import { OtbrRestError } from "./OtbrRestError.js";
 import { parseHexBytes, parseRloc16 } from "./parseHexBytes.js";
 
+const logger = Logger.get("OtbrRestTranslation");
+
 const TIMEOUT_EXP_MIN = 4;
 const IPV6_BYTES = 16;
 const IPV6_GROUPS = 8;
+
+/**
+ * Run an optional-field translation, skipping (with a debug log) rather than throwing if the BR's
+ * shape for that field is unexpected. REST returns whatever the BR last collected, so one node's
+ * malformed enrichment TLV must not abort the whole mesh view.
+ */
+function optionalField<T>(field: string, fn: () => T): T | undefined {
+    try {
+        return fn();
+    } catch (e) {
+        logger.debug(`skipping OTBR diagnostic field "${field}": ${errorOf(e).message}`);
+        return undefined;
+    }
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -143,23 +159,26 @@ function requireBigInt(record: Record<string, unknown>, key: string, where: stri
     return n;
 }
 
+// The OTBR REST diagnostics collection names MLE counters differently from the DiagnosticResponse
+// domain fields (verified live against a real BR): e.g. `radioDisabledCount` → `disabledRole`,
+// `totalTrackingTime` → `trackedTime`.
 function translateMleCounters(input: Record<string, unknown>): MleCounters {
     return {
-        disabledRole: requireNumber(input, "disabledRole", "mleCounters"),
-        detachedRole: requireNumber(input, "detachedRole", "mleCounters"),
-        childRole: requireNumber(input, "childRole", "mleCounters"),
-        routerRole: requireNumber(input, "routerRole", "mleCounters"),
-        leaderRole: requireNumber(input, "leaderRole", "mleCounters"),
-        attachAttempts: requireNumber(input, "attachAttempts", "mleCounters"),
-        partitionIdChanges: requireNumber(input, "partitionIdChanges", "mleCounters"),
-        betterPartitionAttachAttempts: requireNumber(input, "betterPartitionAttachAttempts", "mleCounters"),
-        parentChanges: requireNumber(input, "parentChanges", "mleCounters"),
-        trackedTime: requireBigInt(input, "trackedTime", "mleCounters"),
-        disabledTime: requireBigInt(input, "disabledTime", "mleCounters"),
-        detachedTime: requireBigInt(input, "detachedTime", "mleCounters"),
-        childTime: requireBigInt(input, "childTime", "mleCounters"),
-        routerTime: requireBigInt(input, "routerTime", "mleCounters"),
-        leaderTime: requireBigInt(input, "leaderTime", "mleCounters"),
+        disabledRole: requireNumber(input, "radioDisabledCount", "mleCounters"),
+        detachedRole: requireNumber(input, "detachedRoleCount", "mleCounters"),
+        childRole: requireNumber(input, "childRoleCount", "mleCounters"),
+        routerRole: requireNumber(input, "routerRoleCount", "mleCounters"),
+        leaderRole: requireNumber(input, "leaderRoleCount", "mleCounters"),
+        attachAttempts: requireNumber(input, "attachAttemptsCount", "mleCounters"),
+        partitionIdChanges: requireNumber(input, "partIdChangesCount", "mleCounters"),
+        betterPartitionAttachAttempts: requireNumber(input, "betterPartIdAttachAttemptsCount", "mleCounters"),
+        parentChanges: requireNumber(input, "newParentCount", "mleCounters"),
+        trackedTime: requireBigInt(input, "totalTrackingTime", "mleCounters"),
+        disabledTime: requireBigInt(input, "radioDisabledTime", "mleCounters"),
+        detachedTime: requireBigInt(input, "detachedRoleTime", "mleCounters"),
+        childTime: requireBigInt(input, "childRoleTime", "mleCounters"),
+        routerTime: requireBigInt(input, "routerRoleTime", "mleCounters"),
+        leaderTime: requireBigInt(input, "leaderRoleTime", "mleCounters"),
     };
 }
 
@@ -263,58 +282,71 @@ export function translateNodeJson(json: unknown): DiagnosticResponse {
     if (rloc16 !== undefined) result.rloc16 = rloc16;
 
     const mode = asRecord(json["mode"]);
-    if (mode !== undefined) result.mode = translateMode(mode);
+    if (mode !== undefined) result.mode = optionalField("mode", () => translateMode(mode));
 
     const timeout = asNumber(json["timeout"]);
     if (timeout !== undefined) result.timeout = timeout;
 
     const connectivity = asRecord(json["connectivity"]);
-    if (connectivity !== undefined) result.connectivity = translateConnectivity(connectivity);
+    if (connectivity !== undefined) {
+        result.connectivity = optionalField("connectivity", () => translateConnectivity(connectivity));
+    }
 
     const route = asRecord(json["route"]);
-    if (route !== undefined) result.route64 = translateRoute(route);
+    if (route !== undefined) result.route64 = optionalField("route", () => translateRoute(route));
 
     const leaderData = asRecord(json["leaderData"]);
-    if (leaderData !== undefined) result.leaderData = translateLeaderData(leaderData);
+    if (leaderData !== undefined)
+        result.leaderData = optionalField("leaderData", () => translateLeaderData(leaderData));
 
     const networkData = asString(json["networkData"]);
     if (networkData !== undefined) {
-        result.networkData = NetworkData.decode(parseHexBytes(networkData, "networkData"));
+        result.networkData = optionalField("networkData", () =>
+            NetworkData.decode(parseHexBytes(networkData, "networkData")),
+        );
     }
 
-    const ip6Addresses = asArray(json["ip6AddressList"]);
+    // Legacy builds emit `IP6AddressList` (→ `ip6AddressList` after normalization); post-2024
+    // builds emit `ipv6Addresses`. Accept either.
+    const ip6Addresses = asArray(json["ipv6Addresses"] ?? json["ip6AddressList"]);
     if (ip6Addresses !== undefined) {
-        const list = new Array<Bytes>();
-        for (const entry of ip6Addresses) {
-            const text = asString(entry);
-            if (text === undefined) {
-                throw new OtbrRestError("rest_protocol", "ip6AddressList: entry is not a string");
+        result.ipv6Addresses = optionalField("ipv6Addresses", () => {
+            const list = new Array<Bytes>();
+            for (const entry of ip6Addresses) {
+                const text = asString(entry);
+                if (text === undefined) {
+                    throw new OtbrRestError("rest_protocol", "ipv6Addresses: entry is not a string");
+                }
+                list.push(parseIpv6(text));
             }
-            list.push(parseIpv6(text));
-        }
-        result.ipv6Addresses = list;
+            return list;
+        });
     }
 
     const macCounters = asRecord(json["macCounters"]);
-    if (macCounters !== undefined) result.macCounters = translateMacCounters(macCounters);
+    if (macCounters !== undefined)
+        result.macCounters = optionalField("macCounters", () => translateMacCounters(macCounters));
 
     const mleCounters = asRecord(json["mleCounters"]);
-    if (mleCounters !== undefined) result.mleCounters = translateMleCounters(mleCounters);
+    if (mleCounters !== undefined)
+        result.mleCounters = optionalField("mleCounters", () => translateMleCounters(mleCounters));
 
     const childTable = asArray(json["childTable"]);
-    if (childTable !== undefined) result.childTable = translateChildTable(childTable);
+    if (childTable !== undefined)
+        result.childTable = optionalField("childTable", () => translateChildTable(childTable));
 
     const channelPages = asString(json["channelPages"]);
     if (channelPages !== undefined) {
-        const bytes = parseHexBytes(channelPages, "channelPages");
-        result.channelPages = Array.from(Bytes.of(bytes));
+        result.channelPages = optionalField("channelPages", () =>
+            Array.from(Bytes.of(parseHexBytes(channelPages, "channelPages"))),
+        );
     }
 
     const maxChildTimeout = asNumber(json["maxChildTimeout"]);
     if (maxChildTimeout !== undefined) result.maxChildTimeout = maxChildTimeout;
 
     const eui64 = asString(json["eui64"]);
-    if (eui64 !== undefined) result.eui64 = parseHexBytes(eui64, "eui64", 8);
+    if (eui64 !== undefined) result.eui64 = optionalField("eui64", () => parseHexBytes(eui64, "eui64", 8));
 
     const version = asNumber(json["version"]);
     if (version !== undefined) result.version = version;

--- a/packages/thread-br-client/src/selection/selectSource.ts
+++ b/packages/thread-br-client/src/selection/selectSource.ts
@@ -7,7 +7,8 @@
 import { Bytes } from "@matter/general";
 import type { ThreadCredentialsRegistry } from "../credentials/ThreadCredentialsRegistry.js";
 import type { ThreadNetworkCredentials } from "../credentials/ThreadNetworkCredentials.js";
-import type { DiagnosticSource } from "../diagnostic/DiagnosticSource.js";
+import type { DiagnosticDetailTransport, DiagnosticSource } from "../diagnostic/index.js";
+import { HybridDiagnosticSource } from "../diagnostic/index.js";
 import type { BorderRouterEntry } from "../discovery/BorderRouterEntry.js";
 import type { OtbrRestCapability } from "../otbr-rest/OtbrRestCapability.js";
 
@@ -21,16 +22,22 @@ export interface SelectSourceOpts {
     makeRestSource: (cap: OtbrRestCapability) => DiagnosticSource;
     /** Factory for the MeshCoP source (caller injects). */
     makeMeshcopSource: (creds: ThreadNetworkCredentials, br: BorderRouterEntry) => DiagnosticSource;
+    /**
+     * Preferred transport when BOTH REST and MeshCoP are available for this BR. Defaults to `"coap"`
+     * — direct CoAP queries are much faster than the BR-managed REST action model, which is used
+     * only when no credentials exist or `"rest"` is selected.
+     */
+    detailTransport?: DiagnosticDetailTransport;
 }
 
 /**
- * Pick the diagnostic source per spec §4.10 priority:
- *   1. `otbrRestEnabled` AND `restCapabilities` has an entry for this BR's extPanId → REST.
- *   2. Credentials registered for this BR's extPanId → MeshCoP.
- *   3. Neither → undefined (Mode B observation only).
+ * Pick the diagnostic source for a Border Router:
+ *   - REST capability (if `otbrRestEnabled`) AND registered credentials → {@link HybridDiagnosticSource}
+ *     routing per `detailTransport` (default CoAP).
+ *   - Only one available → that source.
+ *   - Neither → undefined (Mode B observation only).
  *
- * Returns undefined when the BR carries no `extendedPanIdHex`, since both lookups
- * key on it.
+ * Returns undefined when the BR carries no `extendedPanIdHex`, since both lookups key on it.
  */
 export function selectSource(opts: SelectSourceOpts): DiagnosticSource | undefined {
     const { br, credentials, restCapabilities, otbrRestEnabled, makeRestSource, makeMeshcopSource } = opts;
@@ -39,13 +46,14 @@ export function selectSource(opts: SelectSourceOpts): DiagnosticSource | undefin
     const extPanId = Bytes.of(Bytes.fromHex(br.extendedPanIdHex));
     const lookupKey = Bytes.toHex(extPanId);
 
-    if (otbrRestEnabled) {
-        const cap = restCapabilities.get(lookupKey);
-        if (cap !== undefined) return makeRestSource(cap);
-    }
+    const cap = otbrRestEnabled ? restCapabilities.get(lookupKey) : undefined;
+    const rest = cap !== undefined ? makeRestSource(cap) : undefined;
 
     const creds = credentials.getCredentials(extPanId);
-    if (creds !== undefined) return makeMeshcopSource(creds, br);
+    const coap = creds !== undefined ? makeMeshcopSource(creds, br) : undefined;
 
-    return undefined;
+    if (rest !== undefined && coap !== undefined) {
+        return new HybridDiagnosticSource({ coap, rest, detailTransport: opts.detailTransport });
+    }
+    return coap ?? rest;
 }

--- a/packages/thread-br-client/src/selection/selectSource.ts
+++ b/packages/thread-br-client/src/selection/selectSource.ts
@@ -47,7 +47,8 @@ export function selectSource(opts: SelectSourceOpts): DiagnosticSource | undefin
     const lookupKey = Bytes.toHex(extPanId);
 
     const cap = otbrRestEnabled ? restCapabilities.get(lookupKey) : undefined;
-    const rest = cap !== undefined ? makeRestSource(cap) : undefined;
+    // A cap with diagnosticsApi "none" serves REST but no diagnostics endpoint — not usable here.
+    const rest = cap !== undefined && cap.diagnosticsApi !== "none" ? makeRestSource(cap) : undefined;
 
     const creds = credentials.getCredentials(extPanId);
     const coap = creds !== undefined ? makeMeshcopSource(creds, br) : undefined;

--- a/packages/thread-br-client/test/DiagnosticResetTest.ts
+++ b/packages/thread-br-client/test/DiagnosticResetTest.ts
@@ -64,10 +64,21 @@ function makeCapability(keyFormat: "camel" | "pascal"): OtbrRestCapability {
         probedAt: 1_700_000_000_000,
         networkName: "TestNet",
         extPanId: Bytes.of(Bytes.fromHex("1122334455667788")),
+        diagnosticsApi: keyFormat === "camel" ? "collection" : "legacy",
     };
 }
 
-type ClientLike = Pick<OtbrRestClient, "getDiagnostics" | "getNode" | "resetDiagnosticCounters">;
+type ClientLike = Pick<
+    OtbrRestClient,
+    | "getDiagnostics"
+    | "getNode"
+    | "resetDiagnosticCounters"
+    | "postAction"
+    | "getAction"
+    | "getDiagnosticsCollection"
+    | "listDevices"
+    | "clearDiagnostics"
+>;
 
 function mockRestClient(onReset?: (body: unknown) => void): ClientLike {
     return {
@@ -78,6 +89,19 @@ function mockRestClient(onReset?: (body: unknown) => void): ClientLike {
         resetDiagnosticCounters: async (body: unknown) => {
             onReset?.(body);
         },
+        postAction: async () => {
+            throw new Error("not used");
+        },
+        getAction: async () => {
+            throw new Error("not used");
+        },
+        getDiagnosticsCollection: async () => {
+            throw new Error("not used");
+        },
+        listDevices: async () => {
+            throw new Error("not used");
+        },
+        clearDiagnostics: async () => {},
     };
 }
 

--- a/packages/thread-br-client/test/HybridDiagnosticSourceTest.ts
+++ b/packages/thread-br-client/test/HybridDiagnosticSourceTest.ts
@@ -93,11 +93,16 @@ describe("HybridDiagnosticSource", () => {
         expect(new HybridDiagnosticSource({ rest }).kind).to.equal("otbr-rest");
     });
 
-    it("canQuery is true when either transport can serve the extPanId", () => {
-        const coap = new FakeSource("meshcop", false);
-        const rest = new FakeSource("otbr-rest", true);
-        const hybrid = new HybridDiagnosticSource({ coap, rest });
-        expect(hybrid.canQuery(EXT_PAN)).to.equal(true);
+    it("canQuery reflects the preferred (query-serving) transport, not the other", () => {
+        // Default prefers CoAP: a CoAP that cannot serve must report false even if REST could,
+        // since every query routes to CoAP.
+        const coapNo = new FakeSource("meshcop", false);
+        const restYes = new FakeSource("otbr-rest", true);
+        expect(new HybridDiagnosticSource({ coap: coapNo, rest: restYes }).canQuery(EXT_PAN)).to.equal(false);
+        // With REST preferred, canQuery reflects REST.
+        expect(
+            new HybridDiagnosticSource({ coap: coapNo, rest: restYes, detailTransport: "rest" }).canQuery(EXT_PAN),
+        ).to.equal(true);
     });
 
     it("throws when constructed with neither transport", () => {

--- a/packages/thread-br-client/test/HybridDiagnosticSourceTest.ts
+++ b/packages/thread-br-client/test/HybridDiagnosticSourceTest.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Bytes, Observable } from "@matter/general";
+import type { DiagnosticResponse } from "../src/diagnostic/DiagnosticResponse.js";
+import type { DiagnosticSource, QueryMulticastHandle } from "../src/diagnostic/DiagnosticSource.js";
+import { HybridDiagnosticSource } from "../src/diagnostic/HybridDiagnosticSource.js";
+
+const EXT_PAN = Bytes.of(Bytes.fromHex("1122334455667788"));
+
+class FakeSource implements DiagnosticSource {
+    unicastCalls = 0;
+    multicastCalls = 0;
+    resetCalls = 0;
+    constructor(
+        readonly kind: "meshcop" | "otbr-rest",
+        private readonly answers = true,
+    ) {}
+    canQuery(extPanId: Bytes): boolean {
+        return this.answers && Bytes.areEqual(extPanId, EXT_PAN);
+    }
+    async queryUnicast(): Promise<DiagnosticResponse> {
+        this.unicastCalls++;
+        return { unknown: [], rloc16: this.kind === "meshcop" ? 0x1000 : 0x2000 };
+    }
+    queryMulticast(): QueryMulticastHandle {
+        this.multicastCalls++;
+        const onNode = new Observable<[DiagnosticResponse]>();
+        const onError = new Observable<[Error]>();
+        return { onNode, onError, done: Promise.resolve(), close: async () => {} };
+    }
+    async resetCounters(): Promise<void> {
+        this.resetCalls++;
+    }
+}
+
+describe("HybridDiagnosticSource", () => {
+    it("routes queryUnicast to CoAP by default", async () => {
+        const coap = new FakeSource("meshcop");
+        const rest = new FakeSource("otbr-rest");
+        const hybrid = new HybridDiagnosticSource({ coap, rest });
+        const res = await hybrid.queryUnicast({ rloc16: 1 }, []);
+        expect(res.rloc16).to.equal(0x1000);
+        expect(coap.unicastCalls).to.equal(1);
+        expect(rest.unicastCalls).to.equal(0);
+    });
+
+    it('routes queryUnicast to REST when detailTransport="rest"', async () => {
+        const coap = new FakeSource("meshcop");
+        const rest = new FakeSource("otbr-rest");
+        const hybrid = new HybridDiagnosticSource({ coap, rest, detailTransport: "rest" });
+        const res = await hybrid.queryUnicast({ rloc16: 1 }, []);
+        expect(res.rloc16).to.equal(0x2000);
+        expect(rest.unicastCalls).to.equal(1);
+        expect(coap.unicastCalls).to.equal(0);
+    });
+
+    it("falls back to REST when no CoAP source is present, even with default transport", async () => {
+        const rest = new FakeSource("otbr-rest");
+        const hybrid = new HybridDiagnosticSource({ rest });
+        const res = await hybrid.queryUnicast({ rloc16: 1 }, []);
+        expect(res.rloc16).to.equal(0x2000);
+        expect(rest.unicastCalls).to.equal(1);
+    });
+
+    it('falls back to CoAP when detailTransport="rest" but no REST source is present', async () => {
+        const coap = new FakeSource("meshcop");
+        const hybrid = new HybridDiagnosticSource({ coap, detailTransport: "rest" });
+        const res = await hybrid.queryUnicast({ rloc16: 1 }, []);
+        expect(res.rloc16).to.equal(0x1000);
+        expect(coap.unicastCalls).to.equal(1);
+    });
+
+    it("routes queryMulticast and resetCounters to the preferred transport", async () => {
+        const coap = new FakeSource("meshcop");
+        const rest = new FakeSource("otbr-rest");
+        const hybrid = new HybridDiagnosticSource({ coap, rest });
+        hybrid.queryMulticast("ff03::2", { tlvTypes: [], windowMs: 0 });
+        await hybrid.resetCounters({ rloc16: 1 });
+        expect(coap.multicastCalls).to.equal(1);
+        expect(coap.resetCalls).to.equal(1);
+        expect(rest.multicastCalls).to.equal(0);
+    });
+
+    it("reports the active transport's kind", () => {
+        const coap = new FakeSource("meshcop");
+        const rest = new FakeSource("otbr-rest");
+        expect(new HybridDiagnosticSource({ coap, rest }).kind).to.equal("meshcop");
+        expect(new HybridDiagnosticSource({ coap, rest, detailTransport: "rest" }).kind).to.equal("otbr-rest");
+        expect(new HybridDiagnosticSource({ rest }).kind).to.equal("otbr-rest");
+    });
+
+    it("canQuery is true when either transport can serve the extPanId", () => {
+        const coap = new FakeSource("meshcop", false);
+        const rest = new FakeSource("otbr-rest", true);
+        const hybrid = new HybridDiagnosticSource({ coap, rest });
+        expect(hybrid.canQuery(EXT_PAN)).to.equal(true);
+    });
+
+    it("throws when constructed with neither transport", () => {
+        expect(() => new HybridDiagnosticSource({})).to.throw(/at least one/i);
+    });
+});

--- a/packages/thread-br-client/test/OtbrRestActionRunnerTest.ts
+++ b/packages/thread-br-client/test/OtbrRestActionRunnerTest.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Millis } from "@matter/general";
+import { runActionToCompletion } from "../src/otbr-rest/OtbrRestActionRunner.js";
+import { OtbrRestError } from "../src/otbr-rest/OtbrRestError.js";
+
+class ScriptedActionClient {
+    calls = 0;
+    constructor(private readonly statuses: Array<{ status: string; resultId?: string }>) {}
+    async getAction(_id: string): Promise<{ status: string; resultId?: string }> {
+        const entry = this.statuses[Math.min(this.calls, this.statuses.length - 1)];
+        this.calls++;
+        return entry;
+    }
+}
+
+describe("runActionToCompletion", () => {
+    before(MockTime.enable);
+
+    it("polls until the action reaches completed and returns the result id", async () => {
+        const client = new ScriptedActionClient([
+            { status: "pending" },
+            { status: "active" },
+            { status: "completed", resultId: "diag-1" },
+        ]);
+        const promise = runActionToCompletion(client, "act-1", { pollInterval: Millis(100), timeout: Millis(5000) });
+        for (let i = 0; i < 3; i++) {
+            await MockTime.yield();
+            await MockTime.advance(100);
+        }
+        const result = await promise;
+        expect(result.status).to.equal("completed");
+        expect(result.resultId).to.equal("diag-1");
+        expect(client.calls).to.equal(3);
+    });
+
+    it("returns immediately on a terminal stopped status without sleeping", async () => {
+        const client = new ScriptedActionClient([{ status: "stopped" }]);
+        const result = await runActionToCompletion(client, "x", { pollInterval: Millis(100), timeout: Millis(5000) });
+        expect(result.status).to.equal("stopped");
+        expect(result.resultId).to.be.undefined;
+        expect(client.calls).to.equal(1);
+    });
+
+    it("throws rest_protocol when the action never reaches a terminal status before timeout", async () => {
+        const client = new ScriptedActionClient([{ status: "pending" }]);
+        const caught = runActionToCompletion(client, "x", { pollInterval: Millis(100), timeout: Millis(250) }).catch(
+            (e: unknown) => e,
+        );
+        for (let i = 0; i < 4; i++) {
+            await MockTime.yield();
+            await MockTime.advance(100);
+        }
+        const err = await caught;
+        expect(err).to.be.instanceOf(OtbrRestError);
+        expect((err as OtbrRestError).code).to.equal("rest_protocol");
+    });
+});

--- a/packages/thread-br-client/test/OtbrRestClientTest.ts
+++ b/packages/thread-br-client/test/OtbrRestClientTest.ts
@@ -665,8 +665,16 @@ describe("OtbrRestClient collection API", () => {
         expect(server.lastRequest().path).to.equal("/api/diagnostics");
     });
 
-    it("getDiagnosticsCollection throws rest_protocol when the body is not an array", async () => {
-        server.on("GET", "/api/diagnostics", () => jsonResponse(JSON.stringify({ data: [] })));
+    it("getDiagnosticsCollection accepts a JSON:API envelope { data: [...] }", async () => {
+        server.on("GET", "/api/diagnostics", () =>
+            jsonResponse(JSON.stringify({ data: [{ rloc16: "0x4800" }], meta: { collection: { total: 1 } } })),
+        );
+        const list = await client.getDiagnosticsCollection();
+        expect(list).to.have.length(1);
+    });
+
+    it("getDiagnosticsCollection throws rest_protocol when the body is neither array nor envelope", async () => {
+        server.on("GET", "/api/diagnostics", () => jsonResponse(JSON.stringify({ foo: 1 })));
         await expectRestError(client.getDiagnosticsCollection(), "rest_protocol");
     });
 

--- a/packages/thread-br-client/test/OtbrRestClientTest.ts
+++ b/packages/thread-br-client/test/OtbrRestClientTest.ts
@@ -577,3 +577,144 @@ describe("OtbrRestClient mutations", () => {
         await expectRestError(client.setState(true), "rest_conflict");
     });
 });
+
+describe("OtbrRestClient collection API", () => {
+    before(MockTime.enable);
+
+    let server: MockOtbrServer;
+    let client: OtbrRestClient;
+
+    beforeEach(() => {
+        server = new MockOtbrServer();
+        server.install();
+        client = new OtbrRestClient({ host: "br.example" });
+    });
+    afterEach(() => server.uninstall());
+
+    it("postAction posts a vnd.api+json task envelope and returns the action id", async () => {
+        server.on("POST", "/api/actions", () =>
+            jsonResponse(
+                JSON.stringify({
+                    data: [{ id: "act-123", type: "getNetworkDiagnosticTask", attributes: { status: "pending" } }],
+                    meta: { collection: { offset: 0, limit: 200, total: 1 } },
+                }),
+            ),
+        );
+        const id = await client.postAction("getNetworkDiagnosticTask", {
+            destination: "0011223344556677",
+            types: ["extAddress", "rloc16"],
+            timeout: 10,
+        });
+        expect(id).to.equal("act-123");
+        const req = server.lastRequest();
+        expect(req.method).to.equal("POST");
+        expect(req.path).to.equal("/api/actions");
+        expect(req.contentType).to.equal("application/vnd.api+json");
+        expect(JSON.parse(req.body!)).to.deep.equal({
+            data: [
+                {
+                    type: "getNetworkDiagnosticTask",
+                    attributes: { destination: "0011223344556677", types: ["extAddress", "rloc16"], timeout: 10 },
+                },
+            ],
+        });
+    });
+
+    it("postAction throws rest_protocol when the response carries no action id", async () => {
+        server.on("POST", "/api/actions", () => jsonResponse(JSON.stringify({ data: [] })));
+        await expectRestError(
+            client.postAction("getNetworkDiagnosticTask", { destination: "0011223344556677", types: [] }),
+            "rest_protocol",
+        );
+    });
+
+    it("getAction returns the status and the completed result id", async () => {
+        server.on("GET", "/api/actions/act-123", () =>
+            jsonResponse(
+                JSON.stringify({
+                    data: {
+                        id: "act-123",
+                        type: "getNetworkDiagnosticTask",
+                        attributes: { status: "completed" },
+                        relationships: { result: { data: { type: "networkDiagnostics", id: "diag-9" } } },
+                    },
+                }),
+            ),
+        );
+        const action = await client.getAction("act-123");
+        expect(action.status).to.equal("completed");
+        expect(action.resultId).to.equal("diag-9");
+        expect(server.lastRequest().path).to.equal("/api/actions/act-123");
+    });
+
+    it("getAction returns status without a result id while pending", async () => {
+        server.on("GET", "/api/actions/act-123", () =>
+            jsonResponse(JSON.stringify({ data: { id: "act-123", attributes: { status: "pending" } } })),
+        );
+        const action = await client.getAction("act-123");
+        expect(action.status).to.equal("pending");
+        expect(action.resultId).to.be.undefined;
+    });
+
+    it("getDiagnosticsCollection requests application/json and returns the bare array", async () => {
+        server.on("GET", "/api/diagnostics", () =>
+            jsonResponse(JSON.stringify([{ rloc16: "0x4800" }, { rloc16: "0x0400" }])),
+        );
+        const list = await client.getDiagnosticsCollection();
+        expect(list).to.have.length(2);
+        expect(server.lastRequest().path).to.equal("/api/diagnostics");
+    });
+
+    it("getDiagnosticsCollection throws rest_protocol when the body is not an array", async () => {
+        server.on("GET", "/api/diagnostics", () => jsonResponse(JSON.stringify({ data: [] })));
+        await expectRestError(client.getDiagnosticsCollection(), "rest_protocol");
+    });
+
+    it("listDevices returns the bare device array", async () => {
+        server.on("GET", "/api/devices", () =>
+            jsonResponse(JSON.stringify([{ extAddress: "0011223344556677" }, { extAddress: "8899aabbccddeeff" }])),
+        );
+        const devices = await client.listDevices();
+        expect(devices).to.have.length(2);
+        expect(server.lastRequest().path).to.equal("/api/devices");
+    });
+
+    it("clearDiagnostics issues DELETE /api/diagnostics", async () => {
+        server.on("DELETE", "/api/diagnostics", () => new Response("", { status: 200 }));
+        await client.clearDiagnostics();
+        const req = server.lastRequest();
+        expect(req.method).to.equal("DELETE");
+        expect(req.path).to.equal("/api/diagnostics");
+    });
+});
+
+describe("OtbrRestClient.detectDiagnosticsApi", () => {
+    before(MockTime.enable);
+
+    let server: MockOtbrServer;
+    let client: OtbrRestClient;
+
+    beforeEach(() => {
+        server = new MockOtbrServer();
+        server.install();
+        client = new OtbrRestClient({ host: "br.example" });
+    });
+    afterEach(() => server.uninstall());
+
+    it('returns "collection" when GET /api/diagnostics is served', async () => {
+        server.on("GET", "/api/diagnostics", () => jsonResponse("[]"));
+        expect(await client.detectDiagnosticsApi()).to.equal("collection");
+    });
+
+    it('returns "legacy" when /api/diagnostics 404s but GET /diagnostics is served', async () => {
+        server.on("GET", "/api/diagnostics", () => new Response("", { status: 404 }));
+        server.on("GET", "/diagnostics", () => jsonResponse("[]"));
+        expect(await client.detectDiagnosticsApi()).to.equal("legacy");
+    });
+
+    it('returns "none" when neither diagnostics endpoint is served', async () => {
+        server.on("GET", "/api/diagnostics", () => new Response("", { status: 404 }));
+        server.on("GET", "/diagnostics", () => new Response("", { status: 404 }));
+        expect(await client.detectDiagnosticsApi()).to.equal("none");
+    });
+});

--- a/packages/thread-br-client/test/OtbrRestCollectionDiagnosticsTest.ts
+++ b/packages/thread-br-client/test/OtbrRestCollectionDiagnosticsTest.ts
@@ -1,0 +1,254 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Bytes, Millis } from "@matter/general";
+import type { DiagnosticResponse } from "../src/diagnostic/DiagnosticResponse.js";
+import type { OtbrRestCapability } from "../src/otbr-rest/OtbrRestCapability.js";
+import { OtbrRestClient } from "../src/otbr-rest/OtbrRestClient.js";
+import { OtbrRestDiagnosticSource } from "../src/otbr-rest/OtbrRestDiagnosticSource.js";
+
+const EXT_PAN_HEX = "1122334455667799";
+
+/**
+ * Stateful fetch-level mock of the post-2024 OTBR collection REST API. Models the real
+ * request→poll→result flow: `POST /api/actions` creates an action that completes on the next poll;
+ * a completed `getNetworkDiagnosticTask` appends a diagnostic entry for its destination, and
+ * `updateDeviceCollectionTask` publishes the device directory. Drives the real
+ * {@link OtbrRestClient} + orchestration over HTTP.
+ */
+class MockCollectionOtbr {
+    #restore?: () => void;
+    #actions = new Map<string, { type: string; destination?: string; polls: number; done: boolean }>();
+    #diagnostics: Array<Record<string, unknown>> = [];
+    #seq = 0;
+    #diagAttempts = new Map<string, number>();
+    // extAddress -> the diagnostic entry a getNetworkDiagnosticTask for it yields. Missing = "stopped".
+    readonly nodes: Map<string, Record<string, unknown>>;
+    // Destinations that stop on their first attempt and only succeed on a retry.
+    readonly flakyFirst: Set<string>;
+
+    constructor(nodes: Map<string, Record<string, unknown>>, flakyFirst: Set<string> = new Set()) {
+        this.nodes = nodes;
+        this.flakyFirst = flakyFirst;
+    }
+
+    install(): void {
+        const original = globalThis.fetch;
+        this.#restore = () => {
+            globalThis.fetch = original;
+        };
+        globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+            const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+            const method = (init?.method ?? "GET").toUpperCase();
+            const path = new URL(url).pathname;
+            return this.#route(method, path, typeof init?.body === "string" ? init.body : undefined);
+        }) as typeof fetch;
+    }
+    uninstall(): void {
+        this.#restore?.();
+    }
+
+    #json(body: unknown, status = 200): Response {
+        return new Response(JSON.stringify(body), {
+            status,
+            headers: { "Content-Type": "application/vnd.api+json" },
+        });
+    }
+
+    #route(method: string, path: string, body?: string): Response {
+        if (method === "POST" && path === "/api/actions") {
+            const parsed = JSON.parse(body ?? "{}");
+            const item = parsed.data?.[0];
+            const id = `act-${this.#seq++}`;
+            const destination = item?.attributes?.destination;
+            if (item?.type === "getNetworkDiagnosticTask" && typeof destination === "string") {
+                this.#diagAttempts.set(destination, (this.#diagAttempts.get(destination) ?? 0) + 1);
+            }
+            this.#actions.set(id, { type: item?.type, destination, polls: 0, done: false });
+            return this.#json({ data: [{ id, type: item?.type, attributes: { status: "pending" } }] });
+        }
+        if (method === "GET" && path.startsWith("/api/actions/")) {
+            const id = path.slice("/api/actions/".length);
+            const action = this.#actions.get(id);
+            if (action === undefined) return this.#json({ title: "Not Found", status: 404 }, 404);
+            action.polls++;
+            if (!action.done && action.polls >= 1) {
+                action.done = true;
+                if (action.type === "getNetworkDiagnosticTask" && action.destination !== undefined) {
+                    const entry = this.nodes.get(action.destination);
+                    const stopsThisAttempt =
+                        this.flakyFirst.has(action.destination) &&
+                        (this.#diagAttempts.get(action.destination) ?? 0) <= 1;
+                    if (entry !== undefined && !stopsThisAttempt) this.#diagnostics.push(entry);
+                    else {
+                        return this.#json({ data: { id, attributes: { status: "stopped" } } });
+                    }
+                }
+            }
+            return this.#json({ data: { id, attributes: { status: action.done ? "completed" : "pending" } } });
+        }
+        if (method === "GET" && path === "/api/devices") {
+            const devices = [...this.nodes.keys()].map(extAddress => ({ extAddress }));
+            return new Response(JSON.stringify(devices), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+            });
+        }
+        if (method === "GET" && path === "/api/diagnostics") {
+            return new Response(JSON.stringify(this.#diagnostics), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+            });
+        }
+        if (method === "DELETE" && path === "/api/diagnostics") {
+            this.#diagnostics = [];
+            return new Response("", { status: 200 });
+        }
+        return new Response(`no route ${method} ${path}`, { status: 501 });
+    }
+}
+
+function capability(): OtbrRestCapability {
+    return {
+        baseUrl: "http://br.example:8081",
+        keyFormat: "camel",
+        probedAt: 0,
+        networkName: "MockThread",
+        extPanId: Bytes.of(Bytes.fromHex(EXT_PAN_HEX)),
+        diagnosticsApi: "collection",
+    };
+}
+
+function diagNode(extAddress: string, rloc16: string): Record<string, unknown> {
+    return { extAddress, rloc16 };
+}
+
+async function collectAll(source: OtbrRestDiagnosticSource): Promise<DiagnosticResponse[]> {
+    const nodes: DiagnosticResponse[] = [];
+    const handle = source.queryMulticast("ff03::2", { tlvTypes: [], windowMs: 0 });
+    handle.onNode.on(n => {
+        nodes.push(n);
+    });
+    await handle.done;
+    return nodes;
+}
+
+describe("OtbrRestDiagnosticSource collection API", () => {
+    before(MockTime.enable);
+
+    let mock: MockCollectionOtbr;
+    afterEach(() => mock?.uninstall());
+
+    function makeSource(
+        nodes: Map<string, Record<string, unknown>>,
+        flakyFirst: Set<string> = new Set(),
+    ): OtbrRestDiagnosticSource {
+        mock = new MockCollectionOtbr(nodes, flakyFirst);
+        mock.install();
+        const client = new OtbrRestClient({ host: "br.example" });
+        return new OtbrRestDiagnosticSource(client, capability(), {
+            pollInterval: Millis(1),
+            actionTimeout: Millis(1000),
+            discoverTimeout: Millis(1000),
+            retries: 2,
+        });
+    }
+
+    it("discovers, per-node queries, and aggregates all mesh nodes", async () => {
+        const nodes = new Map([
+            ["12ac0f37d73aa693", diagNode("12ac0f37d73aa693", "0x4800")],
+            ["dae92dad730ecfd2", diagNode("dae92dad730ecfd2", "0xe000")],
+        ]);
+        const source = makeSource(nodes);
+        const drive = collectAll(source);
+        for (let i = 0; i < 12; i++) {
+            await MockTime.yield();
+            await MockTime.advance(1);
+        }
+        const result = await drive;
+        const rlocs = result.map(n => n.rloc16).sort();
+        expect(rlocs).to.deep.equal([0x4800, 0xe000]);
+    });
+
+    it("skips nodes whose diagnostic action stops without a result", async () => {
+        const nodes = new Map([
+            ["12ac0f37d73aa693", diagNode("12ac0f37d73aa693", "0x4800")],
+            // present in the device directory but yields no diagnostic (action stops)
+            ["deadbeefdeadbeef", undefined as unknown as Record<string, unknown>],
+        ]);
+        const source = makeSource(nodes);
+        const drive = collectAll(source);
+        for (let i = 0; i < 12; i++) {
+            await MockTime.yield();
+            await MockTime.advance(1);
+        }
+        const result = await drive;
+        expect(result.map(n => n.rloc16)).to.deep.equal([0x4800]);
+    });
+
+    it("retries a node that stops on its first attempt and collects it on retry", async () => {
+        const nodes = new Map([["12ac0f37d73aa693", diagNode("12ac0f37d73aa693", "0x4800")]]);
+        const source = makeSource(nodes, new Set(["12ac0f37d73aa693"]));
+        const drive = collectAll(source);
+        for (let i = 0; i < 20; i++) {
+            await MockTime.yield();
+            await MockTime.advance(1);
+        }
+        const result = await drive;
+        expect(result.map(n => n.rloc16)).to.deep.equal([0x4800]);
+    });
+
+    async function driveAndCollect(source: OtbrRestDiagnosticSource): Promise<DiagnosticResponse[]> {
+        const drive = collectAll(source);
+        for (let i = 0; i < 16; i++) {
+            await MockTime.yield();
+            await MockTime.advance(1);
+        }
+        return drive;
+    }
+
+    it("dedupes two BRs reporting the same rloc16 to a single node", async () => {
+        const nodes = new Map([
+            ["aaaaaaaaaaaaaaaa", diagNode("aaaaaaaaaaaaaaaa", "0x4800")],
+            ["bbbbbbbbbbbbbbbb", diagNode("bbbbbbbbbbbbbbbb", "0x4800")],
+        ]);
+        const result = await driveAndCollect(makeSource(nodes));
+        expect(result).to.have.length(1);
+        expect(result[0].rloc16).to.equal(0x4800);
+    });
+
+    it("keeps entries that carry no rloc16 (not collapsed as duplicates)", async () => {
+        const nodes = new Map([
+            ["aaaaaaaaaaaaaaaa", { extAddress: "aaaaaaaaaaaaaaaa" }],
+            ["bbbbbbbbbbbbbbbb", { extAddress: "bbbbbbbbbbbbbbbb" }],
+        ]);
+        const result = await driveAndCollect(makeSource(nodes));
+        expect(result).to.have.length(2);
+        expect(result.every(n => n.rloc16 === undefined)).to.equal(true);
+    });
+
+    it("keeps a node with a malformed ipv6 address, dropping only that field", async () => {
+        const nodes = new Map([
+            [
+                "12ac0f37d73aa693",
+                { extAddress: "12ac0f37d73aa693", rloc16: "0x4800", ipv6Addresses: ["fe80::1%wpan0"] },
+            ],
+        ]);
+        const result = await driveAndCollect(makeSource(nodes));
+        expect(result).to.have.length(1);
+        expect(result[0].rloc16).to.equal(0x4800);
+        expect(result[0].ipv6Addresses).to.be.undefined;
+    });
+
+    it("drops a wholly undecodable entry but keeps the rest of the mesh", async () => {
+        const nodes = new Map([
+            ["badbadbadbadbad0", { extAddress: "NOT-HEX", rloc16: "0x4800" }],
+            ["12ac0f37d73aa693", diagNode("12ac0f37d73aa693", "0xe000")],
+        ]);
+        const result = await driveAndCollect(makeSource(nodes));
+        expect(result.map(n => n.rloc16)).to.deep.equal([0xe000]);
+    });
+});

--- a/packages/thread-br-client/test/OtbrRestCollectionDiagnosticsTest.ts
+++ b/packages/thread-br-client/test/OtbrRestCollectionDiagnosticsTest.ts
@@ -25,6 +25,8 @@ class MockCollectionOtbr {
     #diagnostics: Array<Record<string, unknown>> = [];
     #seq = 0;
     #diagAttempts = new Map<string, number>();
+    clearCount = 0;
+    discoverCount = 0;
     // extAddress -> the diagnostic entry a getNetworkDiagnosticTask for it yields. Missing = "stopped".
     readonly nodes: Map<string, Record<string, unknown>>;
     // Destinations that stop on their first attempt and only succeed on a retry.
@@ -64,6 +66,7 @@ class MockCollectionOtbr {
             const item = parsed.data?.[0];
             const id = `act-${this.#seq++}`;
             const destination = item?.attributes?.destination;
+            if (item?.type === "updateDeviceCollectionTask") this.discoverCount++;
             if (item?.type === "getNetworkDiagnosticTask" && typeof destination === "string") {
                 this.#diagAttempts.set(destination, (this.#diagAttempts.get(destination) ?? 0) + 1);
             }
@@ -104,6 +107,7 @@ class MockCollectionOtbr {
             });
         }
         if (method === "DELETE" && path === "/api/diagnostics") {
+            this.clearCount++;
             this.#diagnostics = [];
             return new Response("", { status: 200 });
         }
@@ -250,5 +254,30 @@ describe("OtbrRestDiagnosticSource collection API", () => {
         ]);
         const result = await driveAndCollect(makeSource(nodes));
         expect(result.map(n => n.rloc16)).to.deep.equal([0xe000]);
+    });
+
+    it("coalesces concurrent sweeps into a single BR-mutating collection run", async () => {
+        const nodes = new Map([["12ac0f37d73aa693", diagNode("12ac0f37d73aa693", "0x4800")]]);
+        const source = makeSource(nodes);
+        // Two overlapping multicast sweeps on the same source instance.
+        const a: DiagnosticResponse[] = [];
+        const b: DiagnosticResponse[] = [];
+        const ha = source.queryMulticast("ff03::2", { tlvTypes: [], windowMs: 0 });
+        const hb = source.queryMulticast("ff03::2", { tlvTypes: [], windowMs: 0 });
+        ha.onNode.on(n => {
+            a.push(n);
+        });
+        hb.onNode.on(n => {
+            b.push(n);
+        });
+        for (let i = 0; i < 16; i++) {
+            await MockTime.yield();
+            await MockTime.advance(1);
+        }
+        await Promise.all([ha.done, hb.done]);
+        expect(mock.clearCount).to.equal(1);
+        expect(mock.discoverCount).to.equal(1);
+        expect(a.map(n => n.rloc16)).to.deep.equal([0x4800]);
+        expect(b.map(n => n.rloc16)).to.deep.equal([0x4800]);
     });
 });

--- a/packages/thread-br-client/test/OtbrRestCollectionDiagnosticsTest.ts
+++ b/packages/thread-br-client/test/OtbrRestCollectionDiagnosticsTest.ts
@@ -247,13 +247,15 @@ describe("OtbrRestDiagnosticSource collection API", () => {
         expect(result[0].ipv6Addresses).to.be.undefined;
     });
 
-    it("drops a wholly undecodable entry but keeps the rest of the mesh", async () => {
+    it("keeps a node with a malformed extAddress, dropping only that field", async () => {
         const nodes = new Map([
-            ["badbadbadbadbad0", { extAddress: "NOT-HEX", rloc16: "0x4800" }],
-            ["12ac0f37d73aa693", diagNode("12ac0f37d73aa693", "0xe000")],
+            // 14 hex chars — wrong length for an 8-byte ext address.
+            ["12ac0f37d73aa693", { extAddress: "12ac0f37d73aa6", rloc16: "0x4800" }],
         ]);
         const result = await driveAndCollect(makeSource(nodes));
-        expect(result.map(n => n.rloc16)).to.deep.equal([0xe000]);
+        expect(result).to.have.length(1);
+        expect(result[0].rloc16).to.equal(0x4800);
+        expect(result[0].extMacAddress).to.be.undefined;
     });
 
     it("coalesces concurrent sweeps into a single BR-mutating collection run", async () => {

--- a/packages/thread-br-client/test/OtbrRestDiagnosticSourceTest.ts
+++ b/packages/thread-br-client/test/OtbrRestDiagnosticSourceTest.ts
@@ -165,4 +165,25 @@ describe("OtbrRestDiagnosticSource", () => {
         const b = await collect("ff03::2", [], 5000);
         expect(a).to.have.length(b.length);
     });
+
+    it('rejects diagnostics when diagnosticsApi is "none" instead of hitting a 404', async () => {
+        const cap = { ...makeCapability("1122334455667788"), diagnosticsApi: "none" as const };
+        let getDiagnosticsCalled = false;
+        const client: ClientLike = {
+            ...mockClient(),
+            getDiagnostics: async () => {
+                getDiagnosticsCalled = true;
+                return [];
+            },
+        };
+        const source = new OtbrRestDiagnosticSource(client, cap);
+        try {
+            await source.queryUnicast({ rloc16: 18432 }, []);
+            expect.fail("expected OtbrRestError");
+        } catch (err) {
+            expect(err).to.be.instanceOf(OtbrRestError);
+            expect((err as OtbrRestError).code).to.equal("rest_unsupported");
+        }
+        expect(getDiagnosticsCalled).to.equal(false);
+    });
 });

--- a/packages/thread-br-client/test/OtbrRestDiagnosticSourceTest.ts
+++ b/packages/thread-br-client/test/OtbrRestDiagnosticSourceTest.ts
@@ -17,7 +17,17 @@ const PACKAGE_ROOT = process.cwd();
 const FIXTURE_DIR = resolve(PACKAGE_ROOT, "test/fixtures/otbr-rest");
 const RAW_DIAGNOSTICS: unknown = JSON.parse(readFileSync(resolve(FIXTURE_DIR, "diagnostics.json"), "utf8"));
 
-type ClientLike = Pick<OtbrRestClient, "getDiagnostics" | "getNode" | "resetDiagnosticCounters">;
+type ClientLike = Pick<
+    OtbrRestClient,
+    | "getDiagnostics"
+    | "getNode"
+    | "resetDiagnosticCounters"
+    | "postAction"
+    | "getAction"
+    | "getDiagnosticsCollection"
+    | "listDevices"
+    | "clearDiagnostics"
+>;
 
 function normalizedDiagnostics(): unknown[] {
     const normalized = normalizeKeys(RAW_DIAGNOSTICS);
@@ -32,6 +42,7 @@ function makeCapability(extPanIdHex: string): OtbrRestCapability {
         probedAt: 1_700_000_000_000,
         networkName: "TestNet",
         extPanId: Bytes.of(Bytes.fromHex(extPanIdHex)),
+        diagnosticsApi: "legacy",
     };
 }
 
@@ -42,6 +53,19 @@ function mockClient(): ClientLike {
             throw new Error("not used in tests");
         },
         resetDiagnosticCounters: async () => {},
+        postAction: async () => {
+            throw new Error("not used in legacy tests");
+        },
+        getAction: async () => {
+            throw new Error("not used in legacy tests");
+        },
+        getDiagnosticsCollection: async () => {
+            throw new Error("not used in legacy tests");
+        },
+        listDevices: async () => {
+            throw new Error("not used in legacy tests");
+        },
+        clearDiagnostics: async () => {},
     };
 }
 

--- a/packages/thread-br-client/test/OtbrRestProbeTest.ts
+++ b/packages/thread-br-client/test/OtbrRestProbeTest.ts
@@ -31,9 +31,11 @@ function installFetch(handler: FetchHandler): () => void {
 describe("OtbrRestProbe", () => {
     before(MockTime.enable);
 
-    it("detects keyFormat=pascal from PascalCase /node keys", async () => {
+    it("detects keyFormat=pascal and diagnosticsApi=legacy for an old build", async () => {
         const restore = installFetch(async url => {
             if (url.endsWith("/node")) return new Response(NODE_PASCAL_FIXTURE, { status: 200 });
+            if (url.endsWith("/api/diagnostics")) return new Response("", { status: 404 });
+            if (url.endsWith("/diagnostics")) return new Response("[]", { status: 200 });
             throw new Error(`unexpected url: ${url}`);
         });
         try {
@@ -41,6 +43,7 @@ describe("OtbrRestProbe", () => {
             expect(cap).to.not.be.null;
             if (cap === null) return;
             expect(cap.keyFormat).to.equal("pascal");
+            expect(cap.diagnosticsApi).to.equal("legacy");
             expect(cap.networkName).to.equal("TestNet");
             expect(Bytes.toHex(cap.extPanId)).to.equal("1122334455667788");
             expect(cap.baseUrl).to.equal("http://br.example:8081");
@@ -50,9 +53,10 @@ describe("OtbrRestProbe", () => {
         }
     });
 
-    it("detects keyFormat=camel from camelCase /node keys", async () => {
+    it("detects keyFormat=camel and diagnosticsApi=collection for a post-2024 build", async () => {
         const restore = installFetch(async url => {
             if (url.endsWith("/node")) return new Response(NODE_CAMEL_FIXTURE, { status: 200 });
+            if (url.endsWith("/api/diagnostics")) return new Response("[]", { status: 200 });
             throw new Error(`unexpected url: ${url}`);
         });
         try {
@@ -60,6 +64,7 @@ describe("OtbrRestProbe", () => {
             expect(cap).to.not.be.null;
             if (cap === null) return;
             expect(cap.keyFormat).to.equal("camel");
+            expect(cap.diagnosticsApi).to.equal("collection");
             expect(cap.networkName).to.equal("MockThread");
             expect(Bytes.toHex(cap.extPanId)).to.equal("1122334455667799");
         } finally {
@@ -67,17 +72,33 @@ describe("OtbrRestProbe", () => {
         }
     });
 
-    it("never fetches /api/actions", async () => {
+    it("reports diagnosticsApi=none when neither diagnostics endpoint is served", async () => {
+        const restore = installFetch(async url => {
+            if (url.endsWith("/node")) return new Response(NODE_CAMEL_FIXTURE, { status: 200 });
+            if (url.endsWith("/diagnostics")) return new Response("", { status: 404 });
+            throw new Error(`unexpected url: ${url}`);
+        });
+        try {
+            const cap = await OtbrRestProbe.probe("br.example", 8081, 500);
+            expect(cap).to.not.be.null;
+            expect(cap?.diagnosticsApi).to.equal("none");
+        } finally {
+            restore();
+        }
+    });
+
+    it("never fetches /api/actions during probe", async () => {
         const seen = new Array<string>();
         const restore = installFetch(async url => {
             seen.push(url);
             if (url.endsWith("/node")) return new Response(NODE_CAMEL_FIXTURE, { status: 200 });
+            if (url.endsWith("/api/diagnostics")) return new Response("[]", { status: 200 });
             throw new Error(`unexpected url: ${url}`);
         });
         try {
             await OtbrRestProbe.probe("br.example", 8081, 500);
             expect(seen.some(u => u.includes("/api/actions"))).to.be.false;
-            expect(seen).to.deep.equal(["http://br.example:8081/node"]);
+            expect(seen).to.deep.equal(["http://br.example:8081/node", "http://br.example:8081/api/diagnostics"]);
         } finally {
             restore();
         }

--- a/packages/thread-br-client/test/SelectSourceTest.ts
+++ b/packages/thread-br-client/test/SelectSourceTest.ts
@@ -110,6 +110,36 @@ describe("selectSource", () => {
         expect(meshcopCalls).to.have.lengthOf(1);
     });
 
+    it('ignores a REST capability whose diagnosticsApi is "none", using CoAP instead', () => {
+        const restCalls = new Array<OtbrRestCapability>();
+        const cap = { ...makeCap(), diagnosticsApi: "none" as const };
+        const result = selectSource({
+            br: makeBr(),
+            credentials: credsRegistryWith(makeCreds()),
+            restCapabilities: new Map([[EXT_PAN_HEX_LOWER, cap]]),
+            otbrRestEnabled: true,
+            makeRestSource: c => {
+                restCalls.push(c);
+                return STUB_REST;
+            },
+            makeMeshcopSource: () => STUB_MESHCOP,
+        });
+        expect(result).to.equal(STUB_MESHCOP);
+        expect(restCalls).to.have.lengthOf(0);
+    });
+
+    it('returns undefined when the only capability has diagnosticsApi "none" and no creds', () => {
+        const result = selectSource({
+            br: makeBr(),
+            credentials: credsRegistryWith(undefined),
+            restCapabilities: new Map([[EXT_PAN_HEX_LOWER, { ...makeCap(), diagnosticsApi: "none" as const }]]),
+            otbrRestEnabled: true,
+            makeRestSource: () => STUB_REST,
+            makeMeshcopSource: () => STUB_MESHCOP,
+        });
+        expect(result).to.equal(undefined);
+    });
+
     it('builds a hybrid preferring REST when detailTransport="rest" and both are available', () => {
         const result = selectSource({
             br: makeBr(),

--- a/packages/thread-br-client/test/SelectSourceTest.ts
+++ b/packages/thread-br-client/test/SelectSourceTest.ts
@@ -45,6 +45,7 @@ function makeCap(): OtbrRestCapability {
         probedAt: 0,
         networkName: "OpenThread",
         extPanId: EXT_PAN_BYTES.slice(),
+        diagnosticsApi: "collection",
     };
 }
 
@@ -82,7 +83,7 @@ const STUB_MESHCOP: DiagnosticSource = {
 };
 
 describe("selectSource", () => {
-    it("picks REST when otbrRestEnabled and a capability exists, even if creds are also registered", () => {
+    it("builds a hybrid preferring CoAP when both a capability and creds are available", () => {
         const br = makeBr();
         const cap = makeCap();
         const restCalls = new Array<OtbrRestCapability>();
@@ -103,10 +104,24 @@ describe("selectSource", () => {
             },
         });
 
-        expect(result).to.equal(STUB_REST);
+        // Hybrid built from both; default detailTransport=coap → active transport is MeshCoP.
+        expect(result?.kind).to.equal("meshcop");
         expect(restCalls).to.have.lengthOf(1);
-        expect(restCalls[0]).to.equal(cap);
-        expect(meshcopCalls).to.have.lengthOf(0);
+        expect(meshcopCalls).to.have.lengthOf(1);
+    });
+
+    it('builds a hybrid preferring REST when detailTransport="rest" and both are available', () => {
+        const result = selectSource({
+            br: makeBr(),
+            credentials: credsRegistryWith(makeCreds()),
+            restCapabilities: new Map([[EXT_PAN_HEX_LOWER, makeCap()]]),
+            otbrRestEnabled: true,
+            detailTransport: "rest",
+            makeRestSource: () => STUB_REST,
+            makeMeshcopSource: () => STUB_MESHCOP,
+        });
+
+        expect(result?.kind).to.equal("otbr-rest");
     });
 
     it("falls back to MeshCoP when REST is enabled but no capability is registered", () => {

--- a/packages/thread-br-client/test/TranslationTest.ts
+++ b/packages/thread-br-client/test/TranslationTest.ts
@@ -103,6 +103,13 @@ describe("translateNodeJson", () => {
         expect(translateNodeJson({ rloc16: "0x4800" }).rloc16).to.equal(18432);
     });
 
+    it("reads the post-2024 `ipv6Addresses` field name (not just legacy `ip6AddressList`)", () => {
+        const decoded = translateNodeJson({ rloc16: 5120, ipv6Addresses: ["fe80::1", "fd00::2"] });
+        expect(decoded.ipv6Addresses).to.not.be.undefined;
+        expect(decoded.ipv6Addresses!).to.have.length(2);
+        expect(Bytes.toHex(decoded.ipv6Addresses![0])).to.equal("fe800000000000000000000000000001");
+    });
+
     it("omits rloc16 when malformed rather than mis-decoding", () => {
         expect(translateNodeJson({ rloc16: "0x10000" }).rloc16).to.be.undefined;
         expect(translateNodeJson({ rloc16: "garbage" }).rloc16).to.be.undefined;
@@ -150,26 +157,30 @@ describe("translateNodeJson", () => {
         expect(() => __testables.parseIpv6("1::2::3")).to.throw();
     });
 
-    it("translates mleCounters object from normalized OTBR JSON", () => {
-        const decoded = translateNodeJson({
-            mleCounters: {
-                disabledRole: 1,
-                detachedRole: 2,
-                childRole: 3,
-                routerRole: 4,
-                leaderRole: 5,
-                attachAttempts: 6,
-                partitionIdChanges: 7,
-                betterPartitionAttachAttempts: 8,
-                parentChanges: 9,
-                trackedTime: 100000,
-                disabledTime: 200000,
-                detachedTime: 300000,
-                childTime: 400000,
-                routerTime: 500000,
-                leaderTime: 600000,
-            },
-        });
+    // Real OTBR REST mleCounters wire names (verified live against a BR).
+    function mle(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+        return {
+            radioDisabledCount: 1,
+            detachedRoleCount: 2,
+            childRoleCount: 3,
+            routerRoleCount: 4,
+            leaderRoleCount: 5,
+            attachAttemptsCount: 6,
+            partIdChangesCount: 7,
+            betterPartIdAttachAttemptsCount: 8,
+            newParentCount: 9,
+            totalTrackingTime: 100000,
+            radioDisabledTime: 200000,
+            detachedRoleTime: 300000,
+            childRoleTime: 400000,
+            routerRoleTime: 500000,
+            leaderRoleTime: 600000,
+            ...overrides,
+        };
+    }
+
+    it("translates mleCounters from the real OTBR wire names", () => {
+        const decoded = translateNodeJson({ mleCounters: mle() });
         expect(decoded.mleCounters).to.not.be.undefined;
         expect(decoded.mleCounters!.disabledRole).to.equal(1);
         expect(decoded.mleCounters!.parentChanges).to.equal(9);
@@ -185,111 +196,36 @@ describe("translateNodeJson", () => {
     it("decodes string-encoded 64-bit MLE time counters without precision loss", () => {
         // 2^53 + 1 = 9007199254740993 — not representable as a JS number.
         const decoded = translateNodeJson({
-            mleCounters: {
-                disabledRole: 1,
-                detachedRole: 2,
-                childRole: 3,
-                routerRole: 4,
-                leaderRole: 5,
-                attachAttempts: 6,
-                partitionIdChanges: 7,
-                betterPartitionAttachAttempts: 8,
-                parentChanges: 9,
-                trackedTime: "9007199254740993",
-                disabledTime: "200000",
-                detachedTime: "300000",
-                childTime: "400000",
-                routerTime: "500000",
-                leaderTime: "600000",
-            },
+            mleCounters: mle({ totalTrackingTime: "9007199254740993", radioDisabledTime: "200000" }),
         });
         expect(decoded.mleCounters!.trackedTime).to.equal(9007199254740993n);
         expect(decoded.mleCounters!.disabledTime).to.equal(200000n);
     });
 
-    it("rejects a string MLE counter beyond the uint64 range", () => {
-        const base = {
-            disabledRole: 1,
-            detachedRole: 2,
-            childRole: 3,
-            routerRole: 4,
-            leaderRole: 5,
-            attachAttempts: 6,
-            partitionIdChanges: 7,
-            betterPartitionAttachAttempts: 8,
-            parentChanges: 9,
-            // 2^64 = 18446744073709551616, one past uint64 max.
-            trackedTime: "18446744073709551616",
-            disabledTime: 0,
-            detachedTime: 0,
-            childTime: 0,
-            routerTime: 0,
-            leaderTime: 0,
-        };
-        expect(() => translateNodeJson({ mleCounters: base })).to.throw(/uint64/);
-    });
-
     it("accepts the uint64 maximum string MLE counter", () => {
-        const base = {
-            disabledRole: 1,
-            detachedRole: 2,
-            childRole: 3,
-            routerRole: 4,
-            leaderRole: 5,
-            attachAttempts: 6,
-            partitionIdChanges: 7,
-            betterPartitionAttachAttempts: 8,
-            parentChanges: 9,
-            trackedTime: "18446744073709551615",
-            disabledTime: 0,
-            detachedTime: 0,
-            childTime: 0,
-            routerTime: 0,
-            leaderTime: 0,
-        };
-        expect(translateNodeJson({ mleCounters: base }).mleCounters!.trackedTime).to.equal(18446744073709551615n);
+        const decoded = translateNodeJson({ mleCounters: mle({ totalTrackingTime: "18446744073709551615" }) });
+        expect(decoded.mleCounters!.trackedTime).to.equal(18446744073709551615n);
     });
 
-    it("rejects a negative numeric MLE counter (uint64 range enforced on all paths)", () => {
-        const base = {
-            disabledRole: 1,
-            detachedRole: 2,
-            childRole: 3,
-            routerRole: 4,
-            leaderRole: 5,
-            attachAttempts: 6,
-            partitionIdChanges: 7,
-            betterPartitionAttachAttempts: 8,
-            parentChanges: 9,
-            trackedTime: -1,
-            disabledTime: 0,
-            detachedTime: 0,
-            childTime: 0,
-            routerTime: 0,
-            leaderTime: 0,
-        };
-        expect(() => translateNodeJson({ mleCounters: base })).to.throw(/uint64/);
+    it("skips mleCounters but keeps the node when a counter exceeds uint64", () => {
+        // 2^64 = 18446744073709551616, one past uint64 max.
+        const decoded = translateNodeJson({
+            rloc16: 5120,
+            mleCounters: mle({ totalTrackingTime: "18446744073709551616" }),
+        });
+        expect(decoded.rloc16).to.equal(5120);
+        expect(decoded.mleCounters).to.be.undefined;
     });
 
-    it("rejects a malformed string MLE counter", () => {
-        const base = {
-            disabledRole: 1,
-            detachedRole: 2,
-            childRole: 3,
-            routerRole: 4,
-            leaderRole: 5,
-            attachAttempts: 6,
-            partitionIdChanges: 7,
-            betterPartitionAttachAttempts: 8,
-            parentChanges: 9,
-            trackedTime: "12.5",
-            disabledTime: 0,
-            detachedTime: 0,
-            childTime: 0,
-            routerTime: 0,
-            leaderTime: 0,
-        };
-        expect(() => translateNodeJson({ mleCounters: base })).to.throw(/trackedTime/);
+    it("skips mleCounters when a numeric counter is negative", () => {
+        const decoded = translateNodeJson({ rloc16: 5120, mleCounters: mle({ totalTrackingTime: -1 }) });
+        expect(decoded.rloc16).to.equal(5120);
+        expect(decoded.mleCounters).to.be.undefined;
+    });
+
+    it("skips mleCounters when a string counter is malformed", () => {
+        const decoded = translateNodeJson({ rloc16: 5120, mleCounters: mle({ totalTrackingTime: "12.5" }) });
+        expect(decoded.mleCounters).to.be.undefined;
     });
 
     it("translates mode with all-zero flags", () => {


### PR DESCRIPTION
## Problem

`@matter/thread-br-client` REST diagnostics returned **zero nodes** on both OTBR build families:
- **Post-2024 builds** (HA addon): `GET /diagnostics` → **404**. Diagnostics moved behind an action-based collection API (`POST /api/actions` → poll `GET /api/actions/:id` → `GET /api/diagnostics`). No code path reached it.
- **Legacy builds**: `GET /diagnostics` serves a **PascalCase** snapshot (`ExtAddress`, `Rloc16`, `IP6AddressList`, `MACCounters`) that the camelCase-only translator never matched.

Verified live against real border routers on both build families.

## What this does

### Collection-API support (post-2024 OTBR)
- `OtbrRestClient` gains action wrappers (`postAction`/`getAction`/`getDiagnosticsCollection`/`listDevices`/`clearDiagnostics`) using the JSON:API `application/vnd.api+json` media type.
- `OtbrRestActionRunner` polls an action to a terminal state (injectable `Time`, MockTime-driven in tests).
- `OtbrRestProbe` records `OtbrRestCapability.diagnosticsApi: "legacy" | "collection" | "none"`.
- `OtbrRestDiagnosticSource` orchestrates the collection flow: clear → discover devices → per-node `getNetworkDiagnosticTask` (bounded concurrency + bounded retry, tolerating transient "stopped" like the OTBR web UI) → aggregate → dedupe by rloc16. Legacy builds keep the fast snapshot path.

### Translation robustness
- Accepts both key casings and the `ipv6Addresses`/`ip6AddressList` field-name difference.
- **mleCounters wire names corrected** against a real BR (the prior names were never emitted by any build).
- `optionalField` + per-entry skip: a malformed enrichment field or one undecodable node no longer zeroes the whole mesh view.

### Hybrid CoAP/REST source
Live measurement: a full-mesh REST collection sweep takes ~1–2 min (one BR-managed action per node, each capped by the BR's timeout), vs seconds over direct CoAP. So:
- `HybridDiagnosticSource` prefers **CoAP** for diagnostic queries and uses the REST action model only when there are no Thread credentials, or when explicitly selected. Configurable via `detailTransport` (default `"coap"`); reports its active transport's `kind`.
- `selectSource` returns the hybrid when a BR offers both transports (no signature break — new opt is optional, default coap).

## Testing
- TDD throughout; a stateful fetch-level REST mock exercises the full action lifecycle end-to-end over HTTP.
- Live-verified against real OTBR BRs (legacy snapshot + post-2024 collection).
- Independent adversarial review over the cumulative diff; findings addressed (per-node decode resilience, discover/outage logging, dedupe + edge-case tests, `runBounded` contract).

## Gates
Full clean monorepo build; `@matter/thread-br-client` esm + cjs **753/753**; format + lint clean.

## Consumer note
matterjs-server needs no required change — the existing `selectSource` call now yields the faster hybrid and fixes the 0-nodes bug automatically. Optional `detailTransport` knob; review any `source.kind` assumptions (a hybrid reports its active transport, `"meshcop"` by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)