### PR TITLE
fix(protocol): resolve group session id collisions by operational key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Single-command invokes no longer sending a commandRef on the wire nor require one echoed in the response
     - Fix: Single commands skip auto-batching when the peer accepts only one path per invoke or the response is suppressed
     - Fix: Closing a client interaction aborts an in-flight command batch instead of awaiting its response
+    - Fix: Ensure group messaging works correctly when multiple key sets share a group session id (matching by operational key instead of session id for ACL, session caching, and outbound reuse)
 
 - @matter/thread-br-client
     - Feature: Added as new package to support communication with Thread Border Routers through CoAP and with OpenThread Border Routers via REST (if exposed)

--- a/packages/protocol/src/groups/FabricGroups.ts
+++ b/packages/protocol/src/groups/FabricGroups.ts
@@ -88,8 +88,8 @@ export class FabricGroups {
         return this.#groups.currentKeyForId(groupId);
     }
 
-    subjectForGroup(id: GroupId, keySetId: number) {
-        return this.#groups.subjectForGroup(id, keySetId);
+    subjectForGroup(id: GroupId, operationalKey: Bytes) {
+        return this.#groups.subjectForGroup(id, operationalKey);
     }
 
     multicastAddressFor(groupId: GroupId): string {

--- a/packages/protocol/src/groups/Groups.ts
+++ b/packages/protocol/src/groups/Groups.ts
@@ -6,7 +6,7 @@
 
 import { Subject } from "#action/server/Subject.js";
 import type { Fabric } from "#fabric/Fabric.js";
-import { BasicMap, DataWriter, ImplementationError, ipv6BytesToString } from "@matter/general";
+import { BasicMap, Bytes, DataWriter, ImplementationError, ipv6BytesToString } from "@matter/general";
 import { EndpointNumber, GroupId } from "@matter/types";
 import { KeySets, OperationalKeySet } from "./KeySets.js";
 
@@ -52,10 +52,12 @@ export class Groups {
         }
     }
 
-    subjectForGroup(id: GroupId, keySetId: number) {
+    subjectForGroup(id: GroupId, operationalKey: Bytes) {
+        const mappedKeySetId = this.idMap.get(id);
         return Subject.Group({
             id,
-            hasValidMapping: this.idMap.get(id) === keySetId,
+            hasValidMapping:
+                mappedKeySetId !== undefined && this.#keySets.containsOperationalKey(mappedKeySetId, operationalKey),
             endpoints: this.endpointMap.get(id) ?? [],
         });
     }

--- a/packages/protocol/src/groups/KeySets.ts
+++ b/packages/protocol/src/groups/KeySets.ts
@@ -45,6 +45,18 @@ export class KeySets<T extends OperationalKeySet> extends BasicSet<T> {
     }
 
     /**
+     * Returns whether the given group key set holds an operational key equal to the provided one. Used to resolve group
+     * session id collisions: two key sets with identical key material derive the same session id, so the decrypting key
+     * set may differ from the one a group is mapped to while still carrying the key that authenticated the message.
+     */
+    containsOperationalKey(keySetId: number, key: Bytes): boolean {
+        if (this.forId(keySetId) === undefined) {
+            return false;
+        }
+        return this.allKeysForId(keySetId).some(({ key: operationalKey }) => Bytes.areEqual(operationalKey, key));
+    }
+
+    /**
      * Return an operative list of operational keys, start time and their session IDs for a specified
      * group key set id. This is mainly used for receiving messages.
      */

--- a/packages/protocol/src/session/GroupSession.ts
+++ b/packages/protocol/src/session/GroupSession.ts
@@ -199,7 +199,20 @@ export class GroupSession extends SecureSession {
         if (message === undefined || message.packetHeader.destGroupId === undefined) {
             throw new ImplementationError("GroupSession requires a message with destGroupId");
         }
-        return this.fabric.groups.subjectForGroup(GroupId(message.packetHeader.destGroupId), this.keySetId);
+        return this.fabric.groups.subjectForGroup(GroupId(message.packetHeader.destGroupId), this.#operationalGroupKey);
+    }
+
+    /**
+     * Whether this cached session was established for the given fabric, group session id and operational key. Session
+     * ids are a 16-bit hash of the operational key, so two key sets can share one; a cached session must therefore be
+     * matched by key (and fabric), never by session id alone, or a later message would be evaluated against a stale key.
+     */
+    matches(fabricIndex: FabricIndex, id: number, operationalKey: Bytes): boolean {
+        return (
+            this.#id === id &&
+            this.#fabric.fabricIndex === fabricIndex &&
+            Bytes.areEqual(this.#operationalGroupKey, operationalKey)
+        );
     }
 
     override notifyActivity(_messageReceived: boolean) {

--- a/packages/protocol/src/session/SessionManager.ts
+++ b/packages/protocol/src/session/SessionManager.ts
@@ -607,7 +607,11 @@ export class SessionManager {
             );
         }
 
-        const session = this.#groupSessions.get(fabric.nodeId)?.get("id", sessionId);
+        // Outbound sessions register under their group node id (see registerGroupSession), so look up the same bucket
+        // and match by key: a session id can be shared by multiple keys, so reuse must verify the operational key.
+        const session = this.#groupSessions
+            .get(address.nodeId)
+            ?.find(s => s.matches(fabric.fabricIndex, sessionId, key));
         if (session) {
             return session;
         }
@@ -658,7 +662,7 @@ export class SessionManager {
         const groupId = GroupId(rawGroupId);
         GroupId.assertGroupId(groupId);
 
-        let session = this.#groupSessions.get(sourceNodeId)?.get("id", sessionId);
+        let session = this.#groupSessions.get(sourceNodeId)?.find(s => s.matches(fabric.fabricIndex, sessionId, key));
         if (session === undefined) {
             session = new GroupSession({
                 manager: this,

--- a/packages/protocol/test/groups/GroupsTest.ts
+++ b/packages/protocol/test/groups/GroupsTest.ts
@@ -4,15 +4,31 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Subject } from "#action/server/Subject.js";
 import type { Fabric } from "#fabric/Fabric.js";
 import { Groups } from "#groups/Groups.js";
-import type { KeySets, OperationalKeySet } from "#groups/KeySets.js";
-import { FabricId, GroupId } from "@matter/types";
+import { KeySets, type OperationalKeySet } from "#groups/KeySets.js";
+import { EndpointNumber, FabricId, GroupId } from "@matter/types";
 
 function groups() {
     const fabric = { fabricId: FabricId(0x1122334455667788n) } as Fabric;
     const keySets = {} as unknown as KeySets<OperationalKeySet>;
     return new Groups(fabric, keySets);
+}
+
+function keySet(groupKeySetId: number, operationalEpochKey0: Uint8Array): OperationalKeySet {
+    return {
+        groupKeySetId,
+        operationalEpochKey0,
+        groupSessionId0: 100,
+        epochStartTime0: 1_000,
+        operationalEpochKey1: null,
+        groupSessionId1: null,
+        epochStartTime1: null,
+        operationalEpochKey2: null,
+        groupSessionId2: null,
+        epochStartTime2: null,
+    } as unknown as OperationalKeySet;
 }
 
 describe("Groups", () => {
@@ -53,6 +69,48 @@ describe("Groups", () => {
 
             expect(g.idMap.get(GroupId(1))).equal(10);
             expect(g.idMap.get(GroupId(2))).undefined;
+        });
+    });
+
+    describe("subjectForGroup", () => {
+        const SHARED = Uint8Array.from({ length: 16 }, (_, i) => i);
+        const OTHER = Uint8Array.from({ length: 16 }, () => 0xaa);
+
+        function mapped() {
+            const fabric = { fabricId: FabricId(0x1122334455667788n) } as Fabric;
+            const keySets = new KeySets<OperationalKeySet>();
+            // 0x01a3 and 0x01a4 carry identical key material, so they derive the same group session id.
+            keySets.add(keySet(0x01a3, SHARED));
+            keySets.add(keySet(0x01a4, Uint8Array.from(SHARED)));
+            keySets.add(keySet(0x0055, OTHER));
+            const g = new Groups(fabric, keySets);
+            g.idMap = new Map([
+                [GroupId(0x0101), 0x01a4],
+                [GroupId(0x0300), 0x0055],
+            ]);
+            g.endpointMap.set(GroupId(0x0101), [EndpointNumber(1)]);
+            return g;
+        }
+
+        it("accepts a session-id collision peer that carries the authenticating key", () => {
+            // Message decrypted under key set 0x01a3, but group 0x0101 maps to its collision peer 0x01a4.
+            const subject = mapped().subjectForGroup(GroupId(0x0101), Uint8Array.from(SHARED));
+
+            expect(Subject.isGroup(subject) && subject.hasValidMapping).equal(true);
+            expect(Subject.isGroup(subject) ? subject.endpoints : undefined).deep.equal([EndpointNumber(1)]);
+        });
+
+        it("rejects when the mapped key set does not carry the authenticating key", () => {
+            const subject = mapped().subjectForGroup(GroupId(0x0300), Uint8Array.from(SHARED));
+
+            expect(Subject.isGroup(subject) && subject.hasValidMapping).equal(false);
+        });
+
+        it("rejects an unmapped group", () => {
+            const subject = mapped().subjectForGroup(GroupId(0x0999), Uint8Array.from(SHARED));
+
+            expect(Subject.isGroup(subject) && subject.hasValidMapping).equal(false);
+            expect(Subject.isGroup(subject) ? subject.endpoints : undefined).deep.equal([]);
         });
     });
 });

--- a/packages/protocol/test/groups/KeySetsTest.ts
+++ b/packages/protocol/test/groups/KeySetsTest.ts
@@ -123,4 +123,48 @@ describe("KeySets", () => {
             expect(sets.currentKeyForId(0).sessionId).equal(101);
         });
     });
+
+    describe("containsOperationalKey", () => {
+        it("returns false for an unknown key set", () => {
+            expect(new KeySets<OperationalKeySet>().containsOperationalKey(5, new Uint8Array(16))).equal(false);
+        });
+
+        it("matches an operational key present in the key set", () => {
+            const key = Uint8Array.from({ length: 16 }, (_, i) => i);
+            const sets = new KeySets<OperationalKeySet>();
+            sets.add(keySet(1, { operationalEpochKey0: key }));
+
+            expect(sets.containsOperationalKey(1, Uint8Array.from(key))).equal(true);
+        });
+
+        it("does not match a key absent from the key set", () => {
+            const sets = new KeySets<OperationalKeySet>();
+            sets.add(keySet(1, { operationalEpochKey0: Uint8Array.from({ length: 16 }, () => 1) }));
+
+            expect(
+                sets.containsOperationalKey(
+                    1,
+                    Uint8Array.from({ length: 16 }, () => 2),
+                ),
+            ).equal(false);
+        });
+
+        it("matches keys stored in a secondary slot", () => {
+            const key = Uint8Array.from({ length: 16 }, () => 7);
+            const sets = new KeySets<OperationalKeySet>();
+            sets.add(keySet(1, { operationalEpochKey1: key, groupSessionId1: 101, epochStartTime1: 1_000 }));
+
+            expect(sets.containsOperationalKey(1, Uint8Array.from(key))).equal(true);
+        });
+
+        it("matches across key sets that share identical key material (session id collision)", () => {
+            const key = Uint8Array.from({ length: 16 }, (_, i) => i);
+            const sets = new KeySets<OperationalKeySet>();
+            sets.add(keySet(0x01a3, { operationalEpochKey0: key }));
+            sets.add(keySet(0x01a4, { operationalEpochKey0: Uint8Array.from(key) }));
+
+            expect(sets.containsOperationalKey(0x01a3, Uint8Array.from(key))).equal(true);
+            expect(sets.containsOperationalKey(0x01a4, Uint8Array.from(key))).equal(true);
+        });
+    });
 });

--- a/packages/protocol/test/session/SecureSessionTest.ts
+++ b/packages/protocol/test/session/SecureSessionTest.ts
@@ -181,5 +181,30 @@ describe("SecureSession", () => {
             expect(result.message.packetHeader.destGroupId).equals(groupId);
             expect(result.message.packetHeader.messageId).equals(0x12345679);
         });
+
+        it("matches a cached session by fabric, session id and operational key, not by id alone", async () => {
+            const { fabric } = await groupFabric();
+            const current = fabric.groups.keySets.currentKeyForId(1);
+            const session = new GroupSession({
+                id: current.sessionId!,
+                fabric,
+                keySetId: 1,
+                operationalGroupKey: current.key,
+                operationalPrivacyKey: current.privacyKey,
+                peerNodeId: NodeId(0xffffffffffff0002n),
+                multicastAddress: fabric.groups.multicastAddressFor(GroupId(2)),
+                messageCounter: new MessageCounter(fabric.crypto),
+            });
+
+            expect(session.matches(fabric.fabricIndex, current.sessionId!, Bytes.of(current.key))).equals(true);
+
+            // Same session id but a different operational key (a hash collision) must not match — this is the stale-key
+            // guard: reusing this session would evaluate the message against the wrong key for ACL.
+            expect(
+                session.matches(fabric.fabricIndex, current.sessionId!, b$`ffffffffffffffffffffffffffffffff`),
+            ).equals(false);
+            expect(session.matches(FabricIndex(99), current.sessionId!, Bytes.of(current.key))).equals(false);
+            expect(session.matches(fabric.fabricIndex, current.sessionId! ^ 0x1, Bytes.of(current.key))).equals(false);
+        });
     });
 });


### PR DESCRIPTION
## Problem

Scheduled CHIP CI (`test_TC_SC_5_2`) started failing after the test image bump pulled the new "Group Session ID Collision" steps (CSA connectedhomeip #72759). Step 6a sends a group `AddGroup(0x0201)` over group `0x0101` using two key sets (`0x01a3`/`0x01a4`) with **identical key material**; step 6b's `ViewGroup(0x0201)` then returned `139` (NOT_FOUND) instead of Success.

## Root cause

A Matter group session id is a 16-bit hash of the operational group key, so two key sets with identical material derive the **same** session id (a collision). The implementation selected and reused group sessions by session id alone:

- **ACL** (`Groups.subjectForGroup`) computed `hasValidMapping = idMap.get(groupId) === keySetId`, but `GroupSession.decode` picks the first colliding key set that decrypts, which may differ from the one the group is mapped to → `FabricAccessControl` set authMode `None` → the group command was **silently denied** (group commands send no response) → the group was never added.
- **Inbound cache** reused a cached session by `(sourceNodeId, sessionId)`, keeping a **stale operational key/fabric** for a colliding session.
- **Outbound cache** (`groupSessionForAddress`) looked up under `fabric.nodeId` while sessions register under their group node id → the lookup **always missed**, leaking a `GroupSession` (+channel) per group send.

## Fix

Match by the operational key (and fabric) that actually authenticated/encrypts the message, instead of by session id:

- `KeySets.containsOperationalKey(keySetId, key)` — does a key set carry a given operational key (any epoch slot).
- `Groups.subjectForGroup(id, operationalKey)` — `hasValidMapping` when the group's mapped key set carries the authenticating key (accepts collision peers, rejects unrelated keys → fails closed).
- `GroupSession.matches(fabricIndex, id, operationalKey)` + `SessionManager` inbound/outbound lookups use `.find(matches)` (also closes a latent cross-fabric same-NodeId gap and the outbound leak).

## Tests

- `KeySetsTest`: `containsOperationalKey` incl. identical-key collision across key sets.
- `GroupsTest`: `subjectForGroup` collision-peer accept, wrong-key reject, unmapped reject.
- `SecureSessionTest`: `GroupSession.matches` discriminates by key/fabric/id.

All regress the old code. Full gate green: protocol 1434, node 1441, format, lint, clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)