### PR TITLE
fix(thread-br-client): reject queryMulticast().done on a fatal MeshCoP session failure

### DIFF
--- a/packages/thread-br-client/src/diagnostic/MeshCopDiagnosticSource.ts
+++ b/packages/thread-br-client/src/diagnostic/MeshCopDiagnosticSource.ts
@@ -363,9 +363,18 @@ export class MeshCopDiagnosticSource implements DiagnosticSource {
                 await teardownPromise;
             })
             .catch(err => {
-                onError.emit(errorOf(err));
+                // A terminal session failure (petition rejected, session couldn't establish) yields
+                // zero data — surface it on onError for observers AND reject `done`, so a total
+                // failure isn't mistaken for a clean empty window. (Per-node onError.emit inside the
+                // query loop stay non-fatal; done still resolves for partial success.)
+                const e = errorOf(err);
+                onError.emit(e);
                 teardown();
+                throw e;
             });
+        // Floor handler: keep a fatal session failure from becoming an unhandled rejection when the
+        // caller only calls close() (or ignores done). Real awaiters of `done` still see the rejection.
+        void sessionPromise.catch(() => {});
 
         return {
             onNode,
@@ -373,7 +382,8 @@ export class MeshCopDiagnosticSource implements DiagnosticSource {
             done: sessionPromise,
             close: async () => {
                 teardown();
-                await sessionPromise;
+                // close() is idempotent cleanup and must not throw; the failure surfaces via done.
+                await sessionPromise.catch(() => {});
             },
         };
     }

--- a/packages/thread-br-client/src/diagnostic/MeshCopDiagnosticSource.ts
+++ b/packages/thread-br-client/src/diagnostic/MeshCopDiagnosticSource.ts
@@ -263,12 +263,19 @@ export class MeshCopDiagnosticSource implements DiagnosticSource {
             resolveTeardown();
         };
 
-        // sessionPromise resolves AFTER Commissioner.release() (or the catch
-        // branch) so callers awaiting handle.done / handle.close() see the
-        // commissioner cleanly released before they tear down DTLS. Without
-        // this, COMM_REL would race against socket close and BR would never
-        // see the release ACK (manifested as petition-rejected on retry).
-        const sessionPromise = this.#commissioner
+        let resolveDone!: () => void;
+        let rejectDone!: (error: Error) => void;
+        const done = new Promise<void>((resolve, reject) => {
+            resolveDone = resolve;
+            rejectDone = reject;
+        });
+
+        // `released` settles once the commissioner session has fully torn down — AFTER
+        // Commissioner.release() — so close() can await a clean release before tearing down DTLS.
+        // (Without that ordering COMM_REL races socket close and the BR never sees the release ACK,
+        // manifesting as petition-rejected on the next attempt.) It always resolves; the outcome is
+        // reported through `done`, so close() never observes the error and never has to swallow one.
+        const released = this.#commissioner
             .withSession(async () => {
                 if (closed) return;
                 logger.debug(`queryMulticast START tlvs=${opts.tlvTypes.length} window=${windowMs}ms`);
@@ -362,28 +369,27 @@ export class MeshCopDiagnosticSource implements DiagnosticSource {
 
                 await teardownPromise;
             })
-            .catch(err => {
-                // A terminal session failure (petition rejected, session couldn't establish) yields
-                // zero data — surface it on onError for observers AND reject `done`, so a total
-                // failure isn't mistaken for a clean empty window. (Per-node onError.emit inside the
-                // query loop stay non-fatal; done still resolves for partial success.)
-                const e = errorOf(err);
-                onError.emit(e);
-                teardown();
-                throw e;
-            });
-        // Floor handler: keep a fatal session failure from becoming an unhandled rejection when the
-        // caller only calls close() (or ignores done). Real awaiters of `done` still see the rejection.
-        void sessionPromise.catch(() => {});
+            .then(
+                () => resolveDone(),
+                err => {
+                    // A terminal session failure (petition rejected, session couldn't establish)
+                    // yields zero data — surface it on onError for observers and reject `done`, so a
+                    // total failure isn't mistaken for a clean empty window. (Per-node onError.emit
+                    // inside the query loop stay non-fatal; done still resolves for partial success.)
+                    const e = errorOf(err);
+                    onError.emit(e);
+                    teardown();
+                    rejectDone(e);
+                },
+            );
 
         return {
             onNode,
             onError,
-            done: sessionPromise,
+            done,
             close: async () => {
                 teardown();
-                // close() is idempotent cleanup and must not throw; the failure surfaces via done.
-                await sessionPromise.catch(() => {});
+                await released;
             },
         };
     }

--- a/packages/thread-br-client/src/diagnostic/MeshCopDiagnosticSource.ts
+++ b/packages/thread-br-client/src/diagnostic/MeshCopDiagnosticSource.ts
@@ -263,19 +263,10 @@ export class MeshCopDiagnosticSource implements DiagnosticSource {
             resolveTeardown();
         };
 
-        let resolveDone!: () => void;
-        let rejectDone!: (error: Error) => void;
-        const done = new Promise<void>((resolve, reject) => {
-            resolveDone = resolve;
-            rejectDone = reject;
-        });
-
-        // `released` settles once the commissioner session has fully torn down — AFTER
-        // Commissioner.release() — so close() can await a clean release before tearing down DTLS.
-        // (Without that ordering COMM_REL races socket close and the BR never sees the release ACK,
-        // manifesting as petition-rejected on the next attempt.) It always resolves; the outcome is
-        // reported through `done`, so close() never observes the error and never has to swallow one.
-        const released = this.#commissioner
+        // `done` settles AFTER Commissioner.release() so callers awaiting handle.done / handle.close()
+        // see a clean release before tearing down DTLS. (Without that ordering COMM_REL races socket
+        // close and the BR never sees the release ACK, manifesting as petition-rejected on retry.)
+        const done = this.#commissioner
             .withSession(async () => {
                 if (closed) return;
                 logger.debug(`queryMulticast START tlvs=${opts.tlvTypes.length} window=${windowMs}ms`);
@@ -369,19 +360,16 @@ export class MeshCopDiagnosticSource implements DiagnosticSource {
 
                 await teardownPromise;
             })
-            .then(
-                () => resolveDone(),
-                err => {
-                    // A terminal session failure (petition rejected, session couldn't establish)
-                    // yields zero data — surface it on onError for observers and reject `done`, so a
-                    // total failure isn't mistaken for a clean empty window. (Per-node onError.emit
-                    // inside the query loop stay non-fatal; done still resolves for partial success.)
-                    const e = errorOf(err);
-                    onError.emit(e);
-                    teardown();
-                    rejectDone(e);
-                },
-            );
+            .catch(err => {
+                // A terminal session failure (petition rejected, session couldn't establish) yields
+                // zero data — surface it on onError for observers and reject `done`, so a total
+                // failure isn't mistaken for a clean empty window. (Per-node onError.emit inside the
+                // query loop stay non-fatal; done still resolves for partial success.)
+                const e = errorOf(err);
+                onError.emit(e);
+                teardown();
+                throw e;
+            });
 
         return {
             onNode,
@@ -389,7 +377,13 @@ export class MeshCopDiagnosticSource implements DiagnosticSource {
             done,
             close: async () => {
                 teardown();
-                await released;
+                // Await the clean commissioner release. A terminal failure is the caller's to observe
+                // via `done`; here it is only logged, both because close() is cleanup that must not
+                // throw and so the rejection is handled (never an unhandled rejection when a caller
+                // uses close() without awaiting done).
+                await done.catch(error =>
+                    logger.debug(`queryMulticast released after failure: ${errorOf(error).message}`),
+                );
             },
         };
     }

--- a/packages/thread-br-client/src/diagnostic/MeshCopDiagnosticSource.ts
+++ b/packages/thread-br-client/src/diagnostic/MeshCopDiagnosticSource.ts
@@ -361,10 +361,8 @@ export class MeshCopDiagnosticSource implements DiagnosticSource {
                 await teardownPromise;
             })
             .catch(err => {
-                // A terminal session failure (petition rejected, session couldn't establish) yields
-                // zero data — surface it on onError for observers and reject `done`, so a total
-                // failure isn't mistaken for a clean empty window. (Per-node onError.emit inside the
-                // query loop stay non-fatal; done still resolves for partial success.)
+                // Reject `done` on a fatal session failure so a total failure isn't mistaken for a
+                // clean empty window; the per-node onError.emit above stay non-fatal.
                 const e = errorOf(err);
                 onError.emit(e);
                 teardown();
@@ -377,10 +375,8 @@ export class MeshCopDiagnosticSource implements DiagnosticSource {
             done,
             close: async () => {
                 teardown();
-                // Await the clean commissioner release. A terminal failure is the caller's to observe
-                // via `done`; here it is only logged, both because close() is cleanup that must not
-                // throw and so the rejection is handled (never an unhandled rejection when a caller
-                // uses close() without awaiting done).
+                // close() is cleanup and must not throw; the failure surfaces via `done`. Logging it
+                // also handles the rejection, so an only-close() caller never hits an unhandled one.
                 await done.catch(error =>
                     logger.debug(`queryMulticast released after failure: ${errorOf(error).message}`),
                 );

--- a/packages/thread-br-client/test/DiagnosticSourceTest.ts
+++ b/packages/thread-br-client/test/DiagnosticSourceTest.ts
@@ -582,6 +582,49 @@ describe("MeshCopDiagnosticSource", () => {
         const want = Bytes.of(deriveMeshLocalAddress(ML_PREFIX, (29 << 10) & 0xffff));
         expect(proxyTxTargets.some(t => t.length === want.length && t.every((b, i) => b === want[i]))).to.equal(true);
     });
+
+    it("queryMulticast: done rejects when the commissioner session fails fatally (petition rejected)", async () => {
+        const failing: CommissionerLike = {
+            withSession: async <T>(_fn: (sessionId: number) => Promise<T>): Promise<T> => {
+                throw new Error("petition rejected");
+            },
+        };
+        const source = new MeshCopDiagnosticSource(
+            failing,
+            { request: async () => ackMessage(), listen: () => () => {} },
+            environment,
+            ML_PREFIX,
+        );
+        const handle = source.queryMulticast("ff03::2", { tlvTypes: [], windowMs: 100 });
+        let errored: Error | undefined;
+        handle.onError.on(e => {
+            errored = e;
+        });
+        let rejected = false;
+        await handle.done.catch(() => {
+            rejected = true;
+        });
+        expect(rejected).to.equal(true);
+        expect(errored?.message).to.equal("petition rejected");
+    });
+
+    it("queryMulticast: close() does not throw even when the session failed fatally", async () => {
+        const failing: CommissionerLike = {
+            withSession: async <T>(_fn: (sessionId: number) => Promise<T>): Promise<T> => {
+                throw new Error("boom");
+            },
+        };
+        const source = new MeshCopDiagnosticSource(
+            failing,
+            { request: async () => ackMessage(), listen: () => () => {} },
+            environment,
+            ML_PREFIX,
+        );
+        const handle = source.queryMulticast("ff03::2", { tlvTypes: [], windowMs: 100 });
+        handle.onError.on(() => {});
+        await handle.close(); // must resolve, not throw
+        await handle.done.catch(() => {}); // consume the fatal rejection
+    });
 });
 
 describe("missingRouterIds", () => {


### PR DESCRIPTION
## Bug

`MeshCopDiagnosticSource.queryMulticast()` returned `done = commissioner.withSession(...).catch(err => onError.emit(errorOf(err)))`. That outer catch **resolves** after emitting `onError`, so `done` **never rejected** — even on a terminal failure that yields zero data:
- commissioner **petition rejected** (another commissioner active on the OTBR), or
- the DTLS/CoAP session couldn't establish after acquire.

Per the `DiagnosticSource` contract, `done` "resolves when the window elapsed or `close()` completed", and `onError` is for errors that did **not** abort the handle. Collapsing a total failure into `onError` + resolve makes it indistinguishable from a clean empty result.

**Consumer impact:** matterjs-server's `#driveStream` does `await handle.done` then publishes a complete (no `partialReason`) snapshot → the cache holds a healthy-but-empty network for the full 1-hour TTL, and a normal refresh can't recover it.

## Fix

- A terminal `withSession` failure now emits `onError` (for observers) **and re-throws**, so `done` rejects. The consumer's existing catch maps it (→ `petition_rejected`) and publishes a re-fetchable partial — no consumer change required.
- Per-node `onError.emit` inside the query loop remain **non-fatal**; `done` still resolves on partial success (contract preserved).
- `close()` swallows the rejection (idempotent cleanup must not throw), and a floor handler prevents an unhandled rejection when a caller uses only `close()`.

Checked `OtbrRestDiagnosticSource` (the todo asked): it already rejects `done` on failure — no swallow there. Only the MeshCoP path had this.

## Tests
+2: a fatal session failure rejects `done` (and fires `onError`); `close()` does not throw on a fatal failure.

## Gates
Clean build; `@matter/thread-br-client` esm + cjs 760/760; format + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)