### PR TITLE
fix(protocol): stop ICD wakefulness timers on fabric/node shutdown

### DIFF
--- a/packages/protocol/src/fabric/Fabric.ts
+++ b/packages/protocol/src/fabric/Fabric.ts
@@ -278,6 +278,15 @@ export class Fabric {
     }
 
     /**
+     * Release in-memory resources that must not outlive the fabric — currently the ICD wakefulness timers, which would
+     * otherwise keep firing and delay node shutdown.  Does not delete or unpersist the fabric.
+     */
+    [Symbol.dispose](): void {
+        this.#icd?.close();
+        this.#icd = undefined;
+    }
+
+    /**
      * True when this fabric has controller-role ICD peers whose Check-Ins we receive. Lets inbound Check-In processing
      * skip fabrics with no receive path — in particular a pure ICD device, which holds only device-role registrations
      * (it sends Check-Ins, never receives them) and must not trial-decrypt inbound Check-In messages.
@@ -440,6 +449,7 @@ export class Fabric {
     async #delete(currentExchange?: MessageExchange) {
         await this.#deleting.emit();
         await this.#closeSessions(currentExchange);
+        this[Symbol.dispose]();
         await this.#deleted.emit();
     }
 

--- a/packages/protocol/src/fabric/FabricManager.ts
+++ b/packages/protocol/src/fabric/FabricManager.ts
@@ -91,6 +91,10 @@ export class FabricManager {
 
     async close() {
         await this.#construction.close();
+        // Release fabric-scoped in-memory resources (ICD wakefulness timers) so they do not delay shutdown.
+        for (const fabric of this.#fabrics) {
+            fabric[Symbol.dispose]();
+        }
     }
 
     static [Environmental.create](env: Environment) {

--- a/packages/protocol/src/icd/FabricIcd.ts
+++ b/packages/protocol/src/icd/FabricIcd.ts
@@ -100,6 +100,22 @@ export class FabricIcd {
     }
 
     /**
+     * In-memory teardown for shutdown: cancel every peer's wakefulness timers so they do not outlive the fabric (e.g.
+     * delaying node shutdown).  Does not unpersist registrations.
+     */
+    close(): void {
+        for (const { wakefulness } of this.#peers.values()) {
+            wakefulness.close();
+        }
+        this.#peers.clear();
+        this.#registrations.clear();
+    }
+
+    [Symbol.dispose](): void {
+        this.close();
+    }
+
+    /**
      * Trial-decrypts a Check-In payload against all registered peer keys.
      *
      * Returns true if a key matched (even when the counter was a replay), false when no key decrypted the payload.

--- a/packages/protocol/test/icd/FabricIcdTest.ts
+++ b/packages/protocol/test/icd/FabricIcdTest.ts
@@ -139,6 +139,7 @@ describe("FabricIcd", () => {
 
     describe("controller role — wakefulness", () => {
         before(MockTime.enable);
+        after(MockTime.disable);
 
         it("wakefulnessFor returns an IcdPeerWakefulness after addPeer", () => {
             const icd = fabricIcd();

--- a/packages/protocol/test/icd/FabricIcdTest.ts
+++ b/packages/protocol/test/icd/FabricIcdTest.ts
@@ -7,7 +7,7 @@
 import { CheckInMessage } from "#icd/CheckInMessage.js";
 import { FabricIcd } from "#icd/FabricIcd.js";
 import { IcdPeerWakefulness } from "#icd/IcdPeerWakefulness.js";
-import { Bytes, StandardCrypto } from "@matter/general";
+import { Bytes, Seconds, StandardCrypto } from "@matter/general";
 import { NodeId } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
 
@@ -138,6 +138,8 @@ describe("FabricIcd", () => {
     });
 
     describe("controller role — wakefulness", () => {
+        before(MockTime.enable);
+
         it("wakefulnessFor returns an IcdPeerWakefulness after addPeer", () => {
             const icd = fabricIcd();
             icd.addPeer({ peerNodeId: NodeId(11), key: KEY_A, counterStart: 10, lastOffset: 0 }, () => {});
@@ -171,6 +173,25 @@ describe("FabricIcd", () => {
         it("wakefulnessFor returns undefined for unknown peer", () => {
             const icd = fabricIcd();
             expect(icd.wakefulnessFor(NodeId(99))).undefined;
+        });
+
+        it("close cancels peer wakefulness timers and clears peers", async () => {
+            const icd = fabricIcd();
+            icd.addPeer({ peerNodeId: NodeId(11), key: KEY_A, counterStart: 10, lastOffset: 0 }, () => {});
+            const wakefulness = icd.wakefulnessFor(NodeId(11))!;
+            wakefulness.requiresAwait = true;
+            wakefulness.noteSignal(); // arms the availability-expiry timer
+            expect(wakefulness.available.value).true;
+
+            icd.close();
+
+            expect(icd.hasPeers).false;
+            expect(icd.wakefulnessFor(NodeId(11))).undefined;
+
+            // The expiry timer was cancelled: advancing well past the window fires no leaked callback, so the value
+            // is frozen rather than flipping to false.
+            await MockTime.advance(Seconds(600));
+            expect(wakefulness.available.value).true;
         });
 
         it("peerFed emits the peer node ID on addPeer", () => {


### PR DESCRIPTION
## Problem

A registered LIT ICD peer left an `icd-peer-available` timer running after node shutdown, delaying process exit by up to a full idle interval (observed ~1m38s in a diagnostic timer dump).

ICD registrations and their `IcdPeerWakefulness` live on the `Fabric` (fabric-scoped, and deliberately outlive `IcdClient` behavior teardown so they survive restarts). Their availability/awake timers were never cancelled on shutdown: `FabricIcd` had no teardown, and nothing disposed `Fabric.#icd`.

## Fix

- `FabricIcd.close()` (+ `[Symbol.dispose]`) — cancels every peer's `IcdPeerWakefulness` timers and clears the peer/registration maps.
- `Fabric[Symbol.dispose]()` — closes `#icd`; also invoked on the fabric-deletion path.
- `FabricManager.close()` — disposes each fabric. This runs on node shutdown via `ServerEnvironment` → `env.close(FabricManager)`.

In-memory teardown only; persisted registrations are untouched.

## Test

`FabricIcd` › `close cancels peer wakefulness timers and clears peers`: arms an availability window, closes, advances 600s and asserts the value is frozen (no leaked timer fired) and peers are cleared.

Only two ICD timers exist, both in `IcdPeerWakefulness`; no `IcdClient` timers.

## Verification (local)
- `npm run build` ✅
- `npm run format-verify` ✅
- `npm run lint` ✅
- `npm run test -- -p packages/protocol` ✅ 1437/1437
- `npm run test -- -p packages/node` ✅ 1443/1443

No CHANGELOG entry — controller-side ICD is still unreleased (WIP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)