### PR TITLE
Task layer Increment 2b: capacity admission + RemoveNodeFromGroup

### DIFF
--- a/packages/node-manager/src/reconcile/GroupMembershipItemKind.ts
+++ b/packages/node-manager/src/reconcile/GroupMembershipItemKind.ts
@@ -32,6 +32,9 @@ export class GroupMembershipItemKind implements ItemKind<GroupMembershipGrant> {
     readonly kind = "endpointGroupMembership";
     readonly priority = PRIORITY_BANDS.membership;
 
+    // capacity is per-group (groupTable) but the key is per-endpoint; the group slot is gated by groupKeyMap.
+    readonly excludeFromAdmission = true;
+
     #commands(node: ClientNode, localEndpoint: number) {
         return node.endpoints.for(localEndpoint).commandsOf(GroupsClient);
     }

--- a/packages/node-manager/src/task/Task.ts
+++ b/packages/node-manager/src/task/Task.ts
@@ -5,7 +5,7 @@
  */
 
 import { ImplementationError } from "@matter/general";
-import { ChangeEntry, TaskPhase, TaskState, TaskStatus } from "./types.js";
+import { ChangeEntry, PlannedChange, TaskPhase, TaskState, TaskStatus } from "./types.js";
 
 export interface TaskPersistence {
     type: string;
@@ -53,6 +53,11 @@ export abstract class Task<P = unknown> {
             revertTaskId: this.revertTaskId,
             revertOf: this.revertOf,
         };
+    }
+
+    /** Intents this task will create, derived from params, for pre-flight capacity admission. Removals omit. */
+    plannedChanges(): PlannedChange[] {
+        return new Array<PlannedChange>();
     }
 
     /** Deterministic internal id from type + params. Subclasses override with their own key. */

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -10,6 +10,7 @@ import { DatatypeModel, FieldElement } from "@matter/model";
 import { Agent, Behavior, ClientNode, DesiredStateBehavior, itemMapKey, Node, ServerNode } from "@matter/node";
 import { TaskCancelledSignal, TaskCapacityExceededError, TaskSuspendedSignal } from "./errors.js";
 import { ADD_NODE_TO_GROUP_TYPE, AddNodeToGroup } from "./groups/AddNodeToGroup.js";
+import { REMOVE_NODE_FROM_GROUP_TYPE, RemoveNodeFromGroup } from "./groups/RemoveNodeFromGroup.js";
 import { Revert, REVERT_TYPE } from "./Revert.js";
 import { GateControl, RunningTaskContext } from "./RunningTaskContext.js";
 import { Task, TaskPersistence } from "./Task.js";
@@ -68,6 +69,7 @@ export class TaskManagerBehavior extends Behavior {
     /** Built-in task types registered before the resume pass. */
     protected registerBuiltins(): void {
         this.internal.registry.register(ADD_NODE_TO_GROUP_TYPE, AddNodeToGroup);
+        this.internal.registry.register(REMOVE_NODE_FROM_GROUP_TYPE, RemoveNodeFromGroup);
         this.internal.registry.register(REVERT_TYPE, Revert);
     }
 

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -241,6 +241,9 @@ export class TaskManagerBehavior extends Behavior {
                 continue; // unresolvable peer: the phase gate will park; capacity is re-checked on device write
             }
             const itemKind = await this.endpoint.act(agent => this.taskReconciler(agent).itemKind(kind));
+            if (itemKind?.excludeFromAdmission) {
+                continue; // capacity counts a coarser resource another kind already gates (e.g. membership vs group)
+            }
             const capacity = await itemKind?.capacity?.(peer);
             if (capacity === undefined) {
                 continue; // kind reports no capacity limit (e.g. groupKey) — the device write is the gate

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -7,14 +7,14 @@
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
 import { Logger, Mutex, Observable } from "@matter/general";
 import { DatatypeModel, FieldElement } from "@matter/model";
-import { Agent, Behavior, ClientNode, Node, ServerNode } from "@matter/node";
-import { TaskCancelledSignal, TaskSuspendedSignal } from "./errors.js";
+import { Agent, Behavior, ClientNode, DesiredStateBehavior, itemMapKey, Node, ServerNode } from "@matter/node";
+import { TaskCancelledSignal, TaskCapacityExceededError, TaskSuspendedSignal } from "./errors.js";
 import { ADD_NODE_TO_GROUP_TYPE, AddNodeToGroup } from "./groups/AddNodeToGroup.js";
 import { Revert, REVERT_TYPE } from "./Revert.js";
 import { GateControl, RunningTaskContext } from "./RunningTaskContext.js";
 import { Task, TaskPersistence } from "./Task.js";
 import { TaskCtor, TaskRegistry } from "./TaskRegistry.js";
-import { TaskState, TaskStatus } from "./types.js";
+import { PlannedChange, TaskState, TaskStatus } from "./types.js";
 
 const TERMINAL_STATES: ReadonlySet<TaskState> = new Set<TaskState>(["completed", "failed", "cancelled"]);
 
@@ -213,8 +213,49 @@ export class TaskManagerBehavior extends Behavior {
         gate.wake.emit();
     }
 
+    /**
+     * Reject a task before any node mutation if its planned changes would overflow a target's device capacity.
+     * Runs before the first persist/phase; the thrown error ends the task `failed` with an empty changeSet.
+     */
+    async #admit(task: Task): Promise<void> {
+        const planned = task.plannedChanges();
+        if (planned.length === 0) {
+            return;
+        }
+        const byNodeKind = new Map<string, PlannedChange[]>();
+        for (const pc of planned) {
+            const k = `${pc.peerId}\0${pc.kind}`;
+            let group = byNodeKind.get(k);
+            if (group === undefined) {
+                group = new Array<PlannedChange>();
+                byNodeKind.set(k, group);
+            }
+            group.push(pc);
+        }
+        for (const group of byNodeKind.values()) {
+            const { peerId, kind } = group[0];
+            const peer = this.resolvePeerNode(peerId);
+            if (peer === undefined) {
+                continue; // unresolvable peer: the phase gate will park; capacity is re-checked on device write
+            }
+            const itemKind = await this.endpoint.act(agent => this.taskReconciler(agent).itemKind(kind));
+            const capacity = await itemKind?.capacity?.(peer);
+            if (capacity === undefined) {
+                continue; // kind reports no capacity limit (e.g. groupKey) — the device write is the gate
+            }
+            const items = peer.stateOf(DesiredStateBehavior).items;
+            const added = group.filter(pc => items[itemMapKey(pc.kind, pc.key)] === undefined).length;
+            if (capacity.used + added > capacity.limit) {
+                throw new TaskCapacityExceededError(
+                    `Task ${task.id}: ${kind} on ${peerId} exceeds capacity — needs ${added} slot(s) but only ${capacity.limit - capacity.used} free`,
+                );
+            }
+        }
+    }
+
     async #drive(task: Task): Promise<void> {
         try {
+            await this.#admit(task); // fail-fast before any node is touched
             // Persist before first phase so a crash-resume sees the task.
             await this.#persist(task);
             while (task.progress.phaseIndex < task.phases.length && task.progress.state === "running") {

--- a/packages/node-manager/src/task/errors.ts
+++ b/packages/node-manager/src/task/errors.ts
@@ -14,6 +14,9 @@ export class TaskPeerUnavailableError extends TaskError {}
 /** A task's forward work failed terminally; the manager spawns a revert task to roll back its changeSet. */
 export class TaskFailedError extends TaskError {}
 
+/** A task's planned changes would exceed a node's device capacity for some item kind. */
+export class TaskCapacityExceededError extends TaskError {}
+
 /** Internal signal a running gate throws when cancel is requested, so #drive stops cleanly (not "failed"). */
 export class TaskCancelledSignal extends TaskError {}
 

--- a/packages/node-manager/src/task/groups/AddNodeToGroup.ts
+++ b/packages/node-manager/src/task/groups/AddNodeToGroup.ts
@@ -8,6 +8,7 @@ import { GroupId } from "@matter/types";
 import { GroupKeyManagement } from "@matter/types/clusters/group-key-management";
 import { Task } from "../Task.js";
 import { TaskContext, TaskPhase } from "../types.js";
+import { membershipKey } from "./keys.js";
 
 export const ADD_NODE_TO_GROUP_TYPE = "addNodeToGroup";
 
@@ -31,7 +32,7 @@ export class AddNodeToGroup extends Task<AddNodeToGroupParams> {
     readonly type = ADD_NODE_TO_GROUP_TYPE;
 
     static override idFor(params: AddNodeToGroupParams): string {
-        return `${ADD_NODE_TO_GROUP_TYPE}:${params.peerId}:${params.groupId}`;
+        return `${ADD_NODE_TO_GROUP_TYPE}:${params.peerId}:${params.groupId}:${params.endpoint}`;
     }
 
     get phases(): TaskPhase[] {
@@ -65,7 +66,7 @@ export class AddNodeToGroup extends Task<AddNodeToGroupParams> {
         await ctx.setIntent(
             peer,
             "endpointGroupMembership",
-            String(p.groupId),
+            membershipKey(p.groupId, p.endpoint),
             { localEndpoint: p.endpoint, groupId, groupName: p.groupName },
             "converge",
         );
@@ -73,7 +74,7 @@ export class AddNodeToGroup extends Task<AddNodeToGroupParams> {
         await ctx.awaitCommitted([
             { peer, kind: "groupKey", key: String(p.groupKeySetId) },
             { peer, kind: "groupKeyMap", key: String(p.groupId) },
-            { peer, kind: "endpointGroupMembership", key: String(p.groupId) },
+            { peer, kind: "endpointGroupMembership", key: membershipKey(p.groupId, p.endpoint) },
         ]);
     }
 }

--- a/packages/node-manager/src/task/groups/AddNodeToGroup.ts
+++ b/packages/node-manager/src/task/groups/AddNodeToGroup.ts
@@ -7,7 +7,7 @@
 import { GroupId } from "@matter/types";
 import { GroupKeyManagement } from "@matter/types/clusters/group-key-management";
 import { Task } from "../Task.js";
-import { TaskContext, TaskPhase } from "../types.js";
+import { PlannedChange, TaskContext, TaskPhase } from "../types.js";
 import { membershipKey } from "./keys.js";
 
 export const ADD_NODE_TO_GROUP_TYPE = "addNodeToGroup";
@@ -39,12 +39,28 @@ export class AddNodeToGroup extends Task<AddNodeToGroupParams> {
         return [{ name: "provision", run: ctx => this.#provision(ctx) }];
     }
 
-    async #provision(ctx: TaskContext): Promise<void> {
+    override plannedChanges(): PlannedChange[] {
         const p = this.params;
-        const peer = ctx.resolvePeer(p.peerId);
-        const groupId = GroupId(p.groupId);
+        return [
+            { peerId: p.peerId, kind: "groupKey", key: String(p.groupKeySetId), intent: this.#keySet() },
+            {
+                peerId: p.peerId,
+                kind: "groupKeyMap",
+                key: String(p.groupId),
+                intent: { groupId: GroupId(p.groupId), groupKeySetId: p.groupKeySetId },
+            },
+            {
+                peerId: p.peerId,
+                kind: "endpointGroupMembership",
+                key: membershipKey(p.groupId, p.endpoint),
+                intent: { localEndpoint: p.endpoint, groupId: GroupId(p.groupId), groupName: p.groupName },
+            },
+        ];
+    }
 
-        const keySet = {
+    #keySet() {
+        const p = this.params;
+        return {
             groupKeySetId: p.groupKeySetId,
             groupKeySecurityPolicy: p.groupKeySecurityPolicy,
             epochKey0: p.epochKey0,
@@ -54,8 +70,14 @@ export class AddNodeToGroup extends Task<AddNodeToGroupParams> {
             epochKey2: null,
             epochStartTime2: null,
         };
+    }
 
-        await ctx.setIntent(peer, "groupKey", String(p.groupKeySetId), keySet, "converge");
+    async #provision(ctx: TaskContext): Promise<void> {
+        const p = this.params;
+        const peer = ctx.resolvePeer(p.peerId);
+        const groupId = GroupId(p.groupId);
+
+        await ctx.setIntent(peer, "groupKey", String(p.groupKeySetId), this.#keySet(), "converge");
         await ctx.setIntent(
             peer,
             "groupKeyMap",

--- a/packages/node-manager/src/task/groups/RemoveNodeFromGroup.ts
+++ b/packages/node-manager/src/task/groups/RemoveNodeFromGroup.ts
@@ -40,7 +40,7 @@ export class RemoveNodeFromGroup extends Task<RemoveNodeFromGroupParams> {
             return; // decommissioned: intent is GC'd with the node
         }
 
-        // Read the key-set id from the live map intent before removing the map.
+        // The keyset id is unreadable once the map intent is gone, so capture it before removal.
         const keySetId = this.#mappedKeySetId(peer, p.groupId);
 
         const removed = new Array<{ kind: string; key: string }>();

--- a/packages/node-manager/src/task/groups/RemoveNodeFromGroup.ts
+++ b/packages/node-manager/src/task/groups/RemoveNodeFromGroup.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ClientNode, DesiredStateBehavior, itemMapKey } from "@matter/node";
+import { Task } from "../Task.js";
+import { TaskContext, TaskPhase } from "../types.js";
+import { membershipKey } from "./keys.js";
+
+export const REMOVE_NODE_FROM_GROUP_TYPE = "removeNodeFromGroup";
+
+export interface RemoveNodeFromGroupParams {
+    peerId: string;
+    endpoint: number;
+    groupId: number;
+}
+
+/**
+ * Removes a peer endpoint from a group: drops the membership, then the group-to-key-set map and the key set
+ * itself — but only while no other group still references them ({@link TaskContext.removeIntentIfUnreferenced}).
+ * Dependents-first (membership, then map, then key set) so each reference check sees the prior removal.
+ */
+export class RemoveNodeFromGroup extends Task<RemoveNodeFromGroupParams> {
+    readonly type = REMOVE_NODE_FROM_GROUP_TYPE;
+
+    static override idFor(p: RemoveNodeFromGroupParams): string {
+        return `${REMOVE_NODE_FROM_GROUP_TYPE}:${p.peerId}:${p.groupId}:${p.endpoint}`;
+    }
+
+    get phases(): TaskPhase[] {
+        return [{ name: "remove", run: ctx => this.#remove(ctx) }];
+    }
+
+    async #remove(ctx: TaskContext): Promise<void> {
+        const p = this.params;
+        const peer = ctx.tryResolvePeer(p.peerId);
+        if (peer === undefined) {
+            return; // decommissioned: intent is GC'd with the node
+        }
+
+        // Read the key-set id from the live map intent before removing the map.
+        const keySetId = this.#mappedKeySetId(peer, p.groupId);
+
+        const removed = new Array<{ kind: string; key: string }>();
+        if (
+            await ctx.removeIntentIfUnreferenced(peer, "endpointGroupMembership", membershipKey(p.groupId, p.endpoint))
+        ) {
+            removed.push({ kind: "endpointGroupMembership", key: membershipKey(p.groupId, p.endpoint) });
+        }
+        if (await ctx.removeIntentIfUnreferenced(peer, "groupKeyMap", String(p.groupId))) {
+            removed.push({ kind: "groupKeyMap", key: String(p.groupId) });
+        }
+        if (keySetId !== undefined && (await ctx.removeIntentIfUnreferenced(peer, "groupKey", String(keySetId)))) {
+            removed.push({ kind: "groupKey", key: String(keySetId) });
+        }
+
+        if (removed.length > 0) {
+            await ctx.awaitGate([peer], () => removed.every(r => ctx.itemAbsent(peer, r.kind, r.key)));
+        }
+    }
+
+    #mappedKeySetId(peer: ClientNode, groupId: number): number | undefined {
+        const item = peer.stateOf(DesiredStateBehavior).items[itemMapKey("groupKeyMap", String(groupId))];
+        return (item?.intent as { groupKeySetId?: number } | undefined)?.groupKeySetId;
+    }
+}

--- a/packages/node-manager/src/task/groups/keys.ts
+++ b/packages/node-manager/src/task/groups/keys.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** Membership intent key: per (group, endpoint) so one peer can join a group on several endpoints. */
+export function membershipKey(groupId: number, endpoint: number): string {
+    return `${groupId}:${endpoint}`;
+}

--- a/packages/node-manager/src/task/types.ts
+++ b/packages/node-manager/src/task/types.ts
@@ -25,6 +25,14 @@ export interface ChangeEntry {
     prior?: { intent: unknown; mode: ItemMode };
 }
 
+/** An intent a task will create, derived from its params, for pre-flight capacity admission. */
+export interface PlannedChange {
+    peerId: string;
+    kind: string;
+    key: string;
+    intent: unknown;
+}
+
 export interface TaskPhase {
     name: string;
     run(ctx: TaskContext): Promise<void>;

--- a/packages/node-manager/test/task/AdmissionTest.ts
+++ b/packages/node-manager/test/task/AdmissionTest.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
+import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
+import { Environment } from "@matter/general";
+import { CapacityInfo, ClientNode, ServerNode } from "@matter/node";
+import { MockServerNode } from "@matter/node/testing";
+import { FakePeer, SyntheticTask } from "./helpers.js";
+
+class TestTaskManager extends TaskManagerBehavior {
+    static override readonly schema = TaskManagerBehavior.schema;
+    static peers = new Map<string, FakePeer>();
+    static reconcilerPeer?: FakePeer;
+    protected override resolvePeerNode(peerId: string): ClientNode | undefined {
+        return TestTaskManager.peers.get(peerId)?.asNode();
+    }
+    protected override taskReconciler(): ReconcilerBehavior {
+        return TestTaskManager.reconcilerPeer as unknown as ReconcilerBehavior;
+    }
+}
+
+const RootEndpoint = MockServerNode.RootEndpoint.with(TestTaskManager);
+
+async function awaitState(node: ServerNode, id: string, ...states: string[]): Promise<void> {
+    for (let i = 0; i < 10_000; i++) {
+        const state = await node.act(a => a.get(TestTaskManager).state.tasks[id]?.state);
+        if (state !== undefined && states.includes(state)) return;
+        await MockTime.advance(1);
+    }
+    throw new Error(`Task ${id} did not reach state ${states.join("|")}`);
+}
+
+/** A peer whose "cap" kind reports a fixed capacity, for admission tests. */
+function capPeer(id: string, capacity: CapacityInfo): FakePeer {
+    const peer = new FakePeer(id);
+    peer.itemKind = (kind: string) =>
+        kind === "cap"
+            ? {
+                  async capacity() {
+                      return capacity;
+                  },
+              }
+            : undefined;
+    return peer;
+}
+
+describe("capacity admission", () => {
+    before(() => MockTime.init());
+
+    it("rejects a task whose planned changes exceed capacity, before touching the node", async () => {
+        const environment = new Environment("test");
+        const peer = capPeer("p", { limit: 1, used: 1 });
+        TestTaskManager.peers.set("p", peer);
+        TestTaskManager.reconcilerPeer = peer;
+
+        let ran = false;
+        SyntheticTask.plannedChangesByTag["over"] = [{ peerId: "p", kind: "cap", key: "x", intent: {} }];
+        SyntheticTask.phasesByTag["over"] = [{ name: "should-not-run", run: async () => void (ran = true) }];
+
+        const node = await MockServerNode.create(RootEndpoint, { environment, id: "adm-over" });
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+        await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "over" }));
+
+        await awaitState(node, "synthetic:over", "failed");
+        const rec = node.stateOf(TestTaskManager).tasks["synthetic:over"];
+        expect(rec.error).contains("capacity");
+        expect(rec.changeSet.length).equals(0);
+        expect(rec.revertTaskId).equals(undefined);
+        expect(ran).equals(false);
+        await node.close();
+    });
+
+    it("admits a task that fits", async () => {
+        const environment = new Environment("test");
+        const peer = capPeer("p", { limit: 4, used: 1 });
+        TestTaskManager.peers.set("p", peer);
+        TestTaskManager.reconcilerPeer = peer;
+
+        let ran = false;
+        SyntheticTask.plannedChangesByTag["fits"] = [{ peerId: "p", kind: "cap", key: "x", intent: {} }];
+        SyntheticTask.phasesByTag["fits"] = [{ name: "runs", run: async () => void (ran = true) }];
+
+        const node = await MockServerNode.create(RootEndpoint, { environment, id: "adm-fits" });
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+        await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "fits" }));
+
+        await awaitState(node, "synthetic:fits", "completed");
+        expect(ran).equals(true);
+        await node.close();
+    });
+});

--- a/packages/node-manager/test/task/AdmissionTest.ts
+++ b/packages/node-manager/test/task/AdmissionTest.ts
@@ -74,6 +74,35 @@ describe("capacity admission", () => {
         await node.close();
     });
 
+    it("does not reject an excludeFromAdmission kind even at its capacity limit", async () => {
+        const environment = new Environment("test");
+        const peer = new FakePeer("p");
+        // Mirrors membership: capacity is exhausted, but the kind opts out of admission (a coarser kind gates it).
+        peer.itemKind = (kind: string) =>
+            kind === "member"
+                ? {
+                      excludeFromAdmission: true,
+                      async capacity() {
+                          return { limit: 4, used: 4 };
+                      },
+                  }
+                : undefined;
+        TestTaskManager.peers.set("p", peer);
+        TestTaskManager.reconcilerPeer = peer;
+
+        let ran = false;
+        SyntheticTask.plannedChangesByTag["member"] = [{ peerId: "p", kind: "member", key: "1:2", intent: {} }];
+        SyntheticTask.phasesByTag["member"] = [{ name: "runs", run: async () => void (ran = true) }];
+
+        const node = await MockServerNode.create(RootEndpoint, { environment, id: "adm-member" });
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+        await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "member" }));
+
+        await awaitState(node, "synthetic:member", "completed");
+        expect(ran).equals(true);
+        await node.close();
+    });
+
     it("admits a task that fits", async () => {
         const environment = new Environment("test");
         const peer = capPeer("p", { limit: 4, used: 1 });

--- a/packages/node-manager/test/task/groups/AddNodeToGroupIntegrationTest.ts
+++ b/packages/node-manager/test/task/groups/AddNodeToGroupIntegrationTest.ts
@@ -9,6 +9,8 @@ import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { DesiredStateBehavior, itemMapKey, NetworkClient, ServerNode } from "@matter/node";
 import { GroupKeyManagementServer } from "@matter/node/behaviors/group-key-management";
 import { GroupsServer } from "@matter/node/behaviors/groups";
+import { DimmableLightDevice } from "@matter/node/devices/dimmable-light";
+import { OnOffLightDevice } from "@matter/node/devices/on-off-light";
 import { OnOffLightSwitchDevice } from "@matter/node/devices/on-off-light-switch";
 import { MockServerNode, MockSite, subscribedPeer } from "@matter/node/testing";
 import { SustainedSubscription } from "@matter/protocol";
@@ -32,13 +34,14 @@ const PARAMS: AddNodeToGroupParams = {
     epochStartTime0: 946684800000001n, // must be > IPK_DEFAULT_EPOCH_START_TIME
 };
 
-const TASK_ID = `${ADD_NODE_TO_GROUP_TYPE}:peer1:${0x101}`;
+const TASK_ID = `${ADD_NODE_TO_GROUP_TYPE}:peer1:${0x101}:1`;
+const MEMBERSHIP_KEY = `${0x101}:${PARAMS.endpoint}`;
 
 const ControllerRoot = MockServerNode.RootEndpoint.with(TaskManagerBehavior);
 
-function isMember(device: ServerNode): boolean {
+function isMember(device: ServerNode, endpoint: EndpointNumber = LOCAL_EP): boolean {
     const { groupTable } = device.stateOf(GroupKeyManagementServer);
-    return groupTable.some(e => e.groupId === GROUP && e.endpoints.includes(LOCAL_EP));
+    return groupTable.some(e => e.groupId === GROUP && e.endpoints.includes(endpoint));
 }
 
 function itemState(
@@ -80,7 +83,7 @@ describe("AddNodeToGroup task integration (single peer)", () => {
 
         expect(itemState(peer, "groupKey", String(GROUP_KEY_SET_ID))).equals("committed");
         expect(itemState(peer, "groupKeyMap", String(GROUP))).equals("committed");
-        expect(itemState(peer, "endpointGroupMembership", String(GROUP))).equals("committed");
+        expect(itemState(peer, "endpointGroupMembership", MEMBERSHIP_KEY)).equals("committed");
         expect(isMember(device)).equals(true);
     });
 
@@ -131,7 +134,7 @@ describe("AddNodeToGroup task integration (single peer)", () => {
 
         expect(itemState(peer, "groupKey", String(GROUP_KEY_SET_ID))).equals(undefined);
         expect(itemState(peer, "groupKeyMap", String(GROUP))).equals(undefined);
-        expect(itemState(peer, "endpointGroupMembership", String(GROUP))).equals(undefined);
+        expect(itemState(peer, "endpointGroupMembership", MEMBERSHIP_KEY)).equals(undefined);
         expect(isMember(device)).equals(false);
         // Cancelling an already-completed task spawns the revert but leaves the original's truthful state.
         const status = await controller.act(agent => agent.get(TaskManagerBehavior).get(TASK_ID)?.status);
@@ -165,5 +168,34 @@ describe("AddNodeToGroup task integration (single peer)", () => {
         await subscribedPeer(controller2, "peer1");
         await awaitState(controller2, TASK_ID, "completed");
         expect(isMember(device)).equals(true);
+    });
+
+    it("provisions the same group on two endpoints of one peer", async () => {
+        await using site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair({
+            controller: { type: ControllerRoot },
+            device: {
+                type: MockServerNode.RootEndpoint,
+                parts: [
+                    { type: OnOffLightDevice.with(GroupsServer), number: 1 },
+                    { type: DimmableLightDevice.with(GroupsServer), number: 2 },
+                ],
+            },
+        });
+        const peer = await subscribedPeer(controller, "peer1");
+
+        const idEp1 = `${ADD_NODE_TO_GROUP_TYPE}:peer1:${0x101}:1`;
+        const idEp2 = `${ADD_NODE_TO_GROUP_TYPE}:peer1:${0x101}:2`;
+
+        await controller.act(a => a.get(TaskManagerBehavior).run("addNodeToGroup", { ...PARAMS, endpoint: 1 }));
+        await awaitState(controller, idEp1, "completed");
+
+        await controller.act(a => a.get(TaskManagerBehavior).run("addNodeToGroup", { ...PARAMS, endpoint: 2 }));
+        await awaitState(controller, idEp2, "completed");
+
+        expect(itemState(peer, "endpointGroupMembership", `${0x101}:1`)).equals("committed");
+        expect(itemState(peer, "endpointGroupMembership", `${0x101}:2`)).equals("committed");
+        expect(isMember(device, EndpointNumber(1))).equals(true);
+        expect(isMember(device, EndpointNumber(2))).equals(true);
     });
 });

--- a/packages/node-manager/test/task/groups/RemoveNodeFromGroupIntegrationTest.ts
+++ b/packages/node-manager/test/task/groups/RemoveNodeFromGroupIntegrationTest.ts
@@ -136,7 +136,9 @@ describe("RemoveNodeFromGroup task integration (single peer)", () => {
         });
         const peer = await subscribedPeer(controller, "peer1");
 
-        const limit = peer.stateOf(GroupKeyManagementClient).maxGroupsPerFabric ?? 4;
+        // Read the limit from the peer's cached state, not a constant: a broken cache read must fail loudly.
+        const limit = peer.stateOf(GroupKeyManagementClient).maxGroupsPerFabric;
+        expect(limit).equals(4);
         for (let i = 0; i < limit; i++) {
             const groupId = 0x201 + i;
             await controller.act(a => a.get(TaskManagerBehavior).run("addNodeToGroup", addParams(groupId, 50 + i)));

--- a/packages/node-manager/test/task/groups/RemoveNodeFromGroupIntegrationTest.ts
+++ b/packages/node-manager/test/task/groups/RemoveNodeFromGroupIntegrationTest.ts
@@ -1,0 +1,158 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ADD_NODE_TO_GROUP_TYPE, AddNodeToGroupParams } from "#task/groups/AddNodeToGroup.js";
+import { membershipKey } from "#task/groups/keys.js";
+import { REMOVE_NODE_FROM_GROUP_TYPE } from "#task/groups/RemoveNodeFromGroup.js";
+import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
+import { DesiredStateBehavior, itemMapKey, ServerNode } from "@matter/node";
+import { GroupKeyManagementClient, GroupKeyManagementServer } from "@matter/node/behaviors/group-key-management";
+import { GroupsServer } from "@matter/node/behaviors/groups";
+import { OnOffLightSwitchDevice } from "@matter/node/devices/on-off-light-switch";
+import { MockServerNode, MockSite, subscribedPeer } from "@matter/node/testing";
+import { EndpointNumber, GroupId } from "@matter/types";
+import { GroupKeyManagement } from "@matter/types/clusters/group-key-management";
+
+const { TrustFirst } = GroupKeyManagement.GroupKeySecurityPolicy;
+
+const LOCAL_EP = EndpointNumber(1);
+const GROUP_A = 0x101;
+const GROUP_B = 0x102;
+const SHARED_KEY_SET = 42;
+
+const ControllerRoot = MockServerNode.RootEndpoint.with(TaskManagerBehavior);
+
+function addParams(groupId: number, groupKeySetId: number, endpoint = 1): AddNodeToGroupParams {
+    return {
+        peerId: "peer1",
+        endpoint,
+        groupId,
+        groupName: `g${groupId}`,
+        groupKeySetId,
+        groupKeySecurityPolicy: TrustFirst,
+        epochKey0: new Uint8Array(16).fill(0xab),
+        epochStartTime0: 946684800000001n, // must be > IPK_DEFAULT_EPOCH_START_TIME
+    };
+}
+
+const addTaskId = (groupId: number, endpoint = 1) => `${ADD_NODE_TO_GROUP_TYPE}:peer1:${groupId}:${endpoint}`;
+const removeTaskId = (groupId: number, endpoint = 1) => `${REMOVE_NODE_FROM_GROUP_TYPE}:peer1:${groupId}:${endpoint}`;
+
+function isMember(device: ServerNode, groupId: number, endpoint: EndpointNumber = LOCAL_EP): boolean {
+    const { groupTable } = device.stateOf(GroupKeyManagementServer);
+    return groupTable.some(e => e.groupId === GroupId(groupId) && e.endpoints.includes(endpoint));
+}
+
+function itemState(
+    peer: { stateOf(type: unknown): { items: Record<string, { status: { state: string } }> } },
+    kind: string,
+    key: string,
+) {
+    return peer.stateOf(DesiredStateBehavior).items[itemMapKey(kind, key)]?.status.state;
+}
+
+/** Pump virtual time + macrotasks until the persisted task state is one of `states` (else throw). */
+async function awaitState(node: ServerNode, id: string, ...states: string[]): Promise<void> {
+    for (let i = 0; i < 2_000; i++) {
+        const state = await node.act(a => a.get(TaskManagerBehavior).state.tasks[id]?.state);
+        if (state !== undefined && states.includes(state)) {
+            return;
+        }
+        await MockTime.advance(100);
+        await MockTime.macrotask;
+    }
+    throw new Error(`Task ${id} did not reach state ${states.join("|")}`);
+}
+
+describe("RemoveNodeFromGroup task integration (single peer)", () => {
+    before(() => {
+        MockTime.init();
+    });
+
+    it("round-trips: add provisions the three items, remove drops them all", async () => {
+        await using site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair({
+            controller: { type: ControllerRoot },
+            device: { type: MockServerNode.RootEndpoint, device: OnOffLightSwitchDevice.with(GroupsServer) },
+        });
+        const peer = await subscribedPeer(controller, "peer1");
+
+        await controller.act(a => a.get(TaskManagerBehavior).run("addNodeToGroup", addParams(GROUP_A, SHARED_KEY_SET)));
+        await awaitState(controller, addTaskId(GROUP_A), "completed");
+        expect(isMember(device, GROUP_A)).equals(true);
+
+        await controller.act(a =>
+            a.get(TaskManagerBehavior).run("removeNodeFromGroup", { peerId: "peer1", endpoint: 1, groupId: GROUP_A }),
+        );
+        await awaitState(controller, removeTaskId(GROUP_A), "completed");
+
+        expect(itemState(peer, "endpointGroupMembership", membershipKey(GROUP_A, 1))).equals(undefined);
+        expect(itemState(peer, "groupKeyMap", String(GROUP_A))).equals(undefined);
+        expect(itemState(peer, "groupKey", String(SHARED_KEY_SET))).equals(undefined);
+        expect(isMember(device, GROUP_A)).equals(false);
+    });
+
+    it("keeps a shared key set while another group still maps it", async () => {
+        await using site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair({
+            controller: { type: ControllerRoot },
+            device: { type: MockServerNode.RootEndpoint, device: OnOffLightSwitchDevice.with(GroupsServer) },
+        });
+        const peer = await subscribedPeer(controller, "peer1");
+
+        await controller.act(a => a.get(TaskManagerBehavior).run("addNodeToGroup", addParams(GROUP_A, SHARED_KEY_SET)));
+        await awaitState(controller, addTaskId(GROUP_A), "completed");
+        await controller.act(a => a.get(TaskManagerBehavior).run("addNodeToGroup", addParams(GROUP_B, SHARED_KEY_SET)));
+        await awaitState(controller, addTaskId(GROUP_B), "completed");
+
+        await controller.act(a =>
+            a.get(TaskManagerBehavior).run("removeNodeFromGroup", { peerId: "peer1", endpoint: 1, groupId: GROUP_A }),
+        );
+        await awaitState(controller, removeTaskId(GROUP_A), "completed");
+
+        expect(itemState(peer, "endpointGroupMembership", membershipKey(GROUP_A, 1))).equals(undefined);
+        expect(itemState(peer, "groupKeyMap", String(GROUP_A))).equals(undefined);
+        expect(isMember(device, GROUP_A)).equals(false);
+
+        // Group B still maps key set 42, so the shared key-set intent and B's membership survive.
+        expect(itemState(peer, "groupKey", String(SHARED_KEY_SET))).equals("committed");
+        expect(itemState(peer, "groupKeyMap", String(GROUP_B))).equals("committed");
+        expect(itemState(peer, "endpointGroupMembership", membershipKey(GROUP_B, 1))).equals("committed");
+        expect(isMember(device, GROUP_B)).equals(true);
+    });
+
+    it("rejects an add that would exceed the device group capacity", async () => {
+        await using site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair({
+            controller: { type: ControllerRoot },
+            device: {
+                type: MockServerNode.RootEndpoint,
+                device: OnOffLightSwitchDevice.with(GroupsServer),
+                groupKeyManagement: { maxGroupsPerFabric: 4 }, // spec minimum, saturates in four provisions
+            },
+        });
+        const peer = await subscribedPeer(controller, "peer1");
+
+        const limit = peer.stateOf(GroupKeyManagementClient).maxGroupsPerFabric ?? 4;
+        for (let i = 0; i < limit; i++) {
+            const groupId = 0x201 + i;
+            await controller.act(a => a.get(TaskManagerBehavior).run("addNodeToGroup", addParams(groupId, 50 + i)));
+            await awaitState(controller, addTaskId(groupId), "completed");
+        }
+
+        const overGroup = 0x201 + limit;
+        await controller.act(a => a.get(TaskManagerBehavior).run("addNodeToGroup", addParams(overGroup, 50 + limit)));
+        await awaitState(controller, addTaskId(overGroup), "failed");
+
+        const error = await controller.act(a => a.get(TaskManagerBehavior).state.tasks[addTaskId(overGroup)]?.error);
+        expect(error).contains("capacity");
+
+        // Admission rejects before any node mutation: no new group, no leftover intent.
+        expect(isMember(device, overGroup)).equals(false);
+        expect(itemState(peer, "groupKeyMap", String(overGroup))).equals(undefined);
+        expect(itemState(peer, "endpointGroupMembership", membershipKey(overGroup, 1))).equals(undefined);
+    });
+});

--- a/packages/node-manager/test/task/groups/RemoveNodeFromGroupTest.ts
+++ b/packages/node-manager/test/task/groups/RemoveNodeFromGroupTest.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
+import { RemoveNodeFromGroup, RemoveNodeFromGroupParams } from "#task/groups/RemoveNodeFromGroup.js";
+import { RunningTaskContext } from "#task/RunningTaskContext.js";
+import { TaskState } from "#task/types.js";
+import { itemMapKey } from "@matter/node";
+import { FakePeer } from "../helpers.js";
+
+/** Mirror the real ItemKind.isReferenced: live (non-deletePending) dependents keep an entry referenced. */
+function wireItemKind(peer: FakePeer) {
+    (peer as unknown as { itemKind(kind: string): unknown }).itemKind = (kind: string) => {
+        if (kind === "groupKeyMap") {
+            return {
+                isReferenced: (_n: unknown, key: string) =>
+                    Object.values(peer.items).some(
+                        item =>
+                            item.kind === "endpointGroupMembership" &&
+                            item.status.state !== "deletePending" &&
+                            Number((item.intent as { groupId: number }).groupId) === Number(key),
+                    ),
+            };
+        }
+        if (kind === "groupKey") {
+            return {
+                isReferenced: (_n: unknown, key: string) =>
+                    Object.values(peer.items).some(
+                        item =>
+                            item.kind === "groupKeyMap" &&
+                            item.status.state !== "deletePending" &&
+                            (item.intent as { groupKeySetId: number }).groupKeySetId === Number(key),
+                    ),
+            };
+        }
+        return undefined;
+    };
+}
+
+function runRemove(peer: FakePeer, params: RemoveNodeFromGroupParams) {
+    const task = new RemoveNodeFromGroup(RemoveNodeFromGroup.idFor(params), params);
+    const setState = (s: TaskState) => {
+        task.progress.state = s;
+    };
+    wireItemKind(peer);
+    const ctx = new RunningTaskContext(task, () => peer.asNode(), peer as unknown as ReconcilerBehavior, setState);
+    return task.phases[0].run(ctx);
+}
+
+function seedGroup(peer: FakePeer) {
+    peer.setIntent("groupKey", "42", { groupKeySetId: 42 });
+    peer.setState("groupKey", "42", "committed");
+    peer.setIntent("groupKeyMap", "257", { groupId: 257, groupKeySetId: 42 });
+    peer.setState("groupKeyMap", "257", "committed");
+    peer.setIntent("endpointGroupMembership", "257:1", { groupId: 257, localEndpoint: 1 });
+    peer.setState("endpointGroupMembership", "257:1", "committed");
+}
+
+describe("RemoveNodeFromGroup task", () => {
+    before(() => MockTime.init());
+
+    it("removes membership, then unshared map and key set", async () => {
+        const peer = new FakePeer("p1");
+        seedGroup(peer);
+        await MockTime.resolve(runRemove(peer, { peerId: "p1", endpoint: 1, groupId: 0x101 }));
+        expect(peer.items[itemMapKey("endpointGroupMembership", "257:1")]).equals(undefined);
+        expect(peer.items[itemMapKey("groupKeyMap", "257")]).equals(undefined);
+        expect(peer.items[itemMapKey("groupKey", "42")]).equals(undefined);
+    });
+
+    it("keeps a key set still referenced by another group's map", async () => {
+        const peer = new FakePeer("p1");
+        seedGroup(peer);
+        peer.setIntent("groupKeyMap", "258", { groupId: 258, groupKeySetId: 42 });
+        peer.setState("groupKeyMap", "258", "committed");
+        await MockTime.resolve(runRemove(peer, { peerId: "p1", endpoint: 1, groupId: 0x101 }));
+        expect(peer.items[itemMapKey("endpointGroupMembership", "257:1")]).equals(undefined);
+        expect(peer.items[itemMapKey("groupKeyMap", "257")]).equals(undefined);
+        expect(peer.items[itemMapKey("groupKey", "42")]).not.equals(undefined);
+    });
+});

--- a/packages/node-manager/test/task/groups/RollbackIntegrationTest.ts
+++ b/packages/node-manager/test/task/groups/RollbackIntegrationTest.ts
@@ -35,7 +35,7 @@ const PARAMS: AddNodeToGroupParams = {
     epochStartTime0: 946684800000001n, // must be > IPK_DEFAULT_EPOCH_START_TIME
 };
 
-const TASK_ID = `${ADD_NODE_TO_GROUP_TYPE}:peer1:${0x101}`;
+const TASK_ID = `${ADD_NODE_TO_GROUP_TYPE}:peer1:${0x101}:1`;
 
 const FAILING_TYPE = "failingProvision";
 const FAILING_ID = `${FAILING_TYPE}:peer1:${0x101}`;
@@ -97,9 +97,9 @@ class FailingProvision extends Task<AddNodeToGroupParams> {
 
 const ControllerRoot = MockServerNode.RootEndpoint.with(TaskManagerBehavior);
 
-function isMember(device: ServerNode): boolean {
+function isMember(device: ServerNode, endpoint: EndpointNumber = LOCAL_EP): boolean {
     const { groupTable } = device.stateOf(GroupKeyManagementServer);
-    return groupTable.some(e => e.groupId === GROUP && e.endpoints.includes(LOCAL_EP));
+    return groupTable.some(e => e.groupId === GROUP && e.endpoints.includes(endpoint));
 }
 
 function keySetCount(device: ServerNode, id: number): number {
@@ -179,7 +179,7 @@ describe("Rollback task integration (single peer)", () => {
 
         expect(itemState(peer, "groupKey", String(GROUP_KEY_SET_ID))).equals(undefined);
         expect(itemState(peer, "groupKeyMap", String(GROUP))).equals(undefined);
-        expect(itemState(peer, "endpointGroupMembership", String(GROUP))).equals(undefined);
+        expect(itemState(peer, "endpointGroupMembership", `${GROUP}:${PARAMS.endpoint}`)).equals(undefined);
         expect(isMember(device)).equals(false);
 
         const status = await controller.act(agent => agent.get(TaskManagerBehavior).get(TASK_ID)?.status);
@@ -258,5 +258,47 @@ describe("Rollback task integration (single peer)", () => {
         expect(itemState(peer2, "groupKeyMap", String(GROUP))).equals(undefined);
         expect(itemState(peer2, "endpointGroupMembership", String(GROUP))).equals(undefined);
         expect(isMember(device)).equals(false);
+    });
+
+    it("cancelling one endpoint's membership leaves the other endpoint and the shared items intact", async () => {
+        await using site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair({
+            controller: { type: ControllerRoot },
+            device: {
+                type: MockServerNode.RootEndpoint,
+                parts: [
+                    { type: OnOffLightSwitchDevice.with(GroupsServer), number: 1 },
+                    { type: OnOffLightSwitchDevice.with(GroupsServer), number: 2 },
+                ],
+            },
+        });
+        const peer = await subscribedPeer(controller, "peer1");
+
+        const idEp1 = `${ADD_NODE_TO_GROUP_TYPE}:peer1:${0x101}:1`;
+        const idEp2 = `${ADD_NODE_TO_GROUP_TYPE}:peer1:${0x101}:2`;
+
+        await controller.act(agent =>
+            agent.get(TaskManagerBehavior).run(ADD_NODE_TO_GROUP_TYPE, { ...PARAMS, endpoint: 1 }),
+        );
+        await awaitState(controller, idEp1, "completed");
+        await controller.act(agent =>
+            agent.get(TaskManagerBehavior).run(ADD_NODE_TO_GROUP_TYPE, { ...PARAMS, endpoint: 2 }),
+        );
+        await awaitState(controller, idEp2, "completed");
+
+        await MockTime.resolve(
+            controller.act(agent => agent.get(TaskManagerBehavior).cancel(idEp1)),
+            {
+                macrotasks: true,
+            },
+        );
+        await awaitState(controller, `revert:${idEp1}`, "completed");
+
+        expect(itemState(peer, "endpointGroupMembership", `${GROUP}:1`)).equals(undefined);
+        expect(itemState(peer, "endpointGroupMembership", `${GROUP}:2`)).equals("committed");
+        expect(itemState(peer, "groupKey", String(GROUP_KEY_SET_ID))).equals("committed");
+        expect(itemState(peer, "groupKeyMap", String(GROUP))).equals("committed");
+        expect(isMember(device, EndpointNumber(1))).equals(false);
+        expect(isMember(device, EndpointNumber(2))).equals(true);
     });
 });

--- a/packages/node-manager/test/task/helpers.ts
+++ b/packages/node-manager/test/task/helpers.ts
@@ -5,16 +5,20 @@
  */
 
 import { Task } from "#task/Task.js";
-import { TaskPhase } from "#task/types.js";
+import { PlannedChange, TaskPhase } from "#task/types.js";
 import { Observable } from "@matter/general";
 import { ClientNode, DesiredStateBehavior, ItemMode, ItemState, ManagedItem, itemMapKey } from "@matter/node";
 
 /** A synthetic task whose phases are supplied inline; for unit-testing the manager/driver. */
 export class SyntheticTask extends Task<{ tag: string }> {
     static phasesByTag: Record<string, TaskPhase[]> = {};
+    static plannedChangesByTag: Record<string, PlannedChange[]> = {};
     override readonly type = "synthetic";
     override get phases() {
         return SyntheticTask.phasesByTag[this.params.tag] ?? new Array<TaskPhase>();
+    }
+    override plannedChanges(): PlannedChange[] {
+        return SyntheticTask.plannedChangesByTag[this.params.tag] ?? new Array<PlannedChange>();
     }
     static override idFor(params: { tag: string }) {
         return `synthetic:${params.tag}`;

--- a/packages/node/src/behavior/system/desired-state/ItemKind.ts
+++ b/packages/node/src/behavior/system/desired-state/ItemKind.ts
@@ -35,6 +35,13 @@ export interface ItemKind<I = unknown> {
     capacity?(node: ClientNode): Promise<CapacityInfo>;
 
     /**
+     * Exclude this kind from pre-flight task admission. Set when `capacity` counts a coarser resource than
+     * this kind's per-item key (e.g. per-endpoint membership sharing a per-group limit), so admitting it
+     * would double-count a slot another kind already gates. `capacity` still serves the reconciler.
+     */
+    readonly excludeFromAdmission?: boolean;
+
+    /**
      * Report whether another live desired-state intent still depends on the `(kind, key)` entry, so a
      * shared entry is not deleted while referenced. Unimplemented ⇒ no dependents ⇒ always removable.
      */

--- a/packages/node/test/behaviors/basic-information/ConfigurationVersionTest.ts
+++ b/packages/node/test/behaviors/basic-information/ConfigurationVersionTest.ts
@@ -8,8 +8,8 @@ import { BasicInformationServer } from "#behaviors/basic-information";
 import { BridgedDeviceBasicInformationServer } from "#behaviors/bridged-device-basic-information";
 import { OnOffLightDevice } from "#devices/on-off-light";
 import { AggregatorEndpoint } from "#endpoints/aggregator";
-import { BridgedLightDevice, createBridge } from "../../endpoints/bridge-helpers.js";
 import { MockServerNode } from "@matter/node/testing";
+import { BridgedLightDevice, createBridge } from "../../endpoints/bridge-helpers.js";
 
 // A bridged device that enables the optional ConfigurationVersion attribute by seeding an initial value.
 const VersionedBridgedLightDevice = OnOffLightDevice.with(

--- a/packages/node/test/behaviors/occupancy-sensing/OccupancySensingServerTest.ts
+++ b/packages/node/test/behaviors/occupancy-sensing/OccupancySensingServerTest.ts
@@ -6,10 +6,10 @@
 
 import { OccupancySensingServer } from "#behaviors/occupancy-sensing";
 import { OccupancySensorDevice } from "#devices/occupancy-sensor";
+import { MockServerNode } from "@matter/node/testing";
 import { Val } from "@matter/protocol";
 import { OccupancySensing } from "@matter/types/clusters/occupancy-sensing";
 import { MockEndpoint } from "../../endpoint/mock-endpoint.js";
-import { MockServerNode } from "@matter/node/testing";
 
 // Detector-type and OccupancyEvent features are selected explicitly.
 const PirOccupancySensing = OccupancySensingServer.with("PassiveInfrared", "OccupancyEvent");

--- a/packages/node/test/node/ClientStructureOffloadTest.ts
+++ b/packages/node/test/node/ClientStructureOffloadTest.ts
@@ -9,8 +9,8 @@ import { OnOffClient } from "#behaviors/on-off";
 import { SwitchClient, SwitchServer } from "#behaviors/switch";
 import { OnOffLightDevice } from "#devices/on-off-light";
 import { ServerNode } from "#node/ServerNode.js";
-import { Switch } from "@matter/types/clusters/switch";
 import { MockSite, subscribedPeer } from "@matter/node/testing";
+import { Switch } from "@matter/types/clusters/switch";
 
 describe("ClientStructureOffload", () => {
     before(() => {


### PR DESCRIPTION
Sub-PR into `node-manager` (umbrella PR #3948 carries CI). Increment 2b of the imperative Task layer — **capacity admission + removal**. Completes Increment 2 (2a = rollback-safety core, merged via #3997).

Spec: `docs/superpowers/specs/2026-06-26-node-manager-task-layer-2-design.md` (sections C, D, membership key).

## What lands
- **Per-endpoint membership key** — the `endpointGroupMembership` intent key becomes `groupId:endpoint` (via a shared `membershipKey()` helper), and `AddNodeToGroup.idFor` gains `:endpoint`, so one peer can join a group on multiple endpoints. `GroupMembershipItemKind` and `groupKeyMap.isReferenced` read the intent body (not the key), so the shared-entry refcount cascade is unaffected.
- **Pre-flight capacity admission** — `Task.plannedChanges()` declares the intents a task will create; `TaskManagerBehavior.#admit` runs before any node is touched and rejects the whole task with `TaskCapacityExceededError` if any `(node, kind)` would overflow. A rejected task ends `failed` with an empty changeset (no revert).
- **`RemoveNodeFromGroup`** — the inverse task: removes membership, then the group→key-set map, then the key set, each only while no other group still references it (`removeIntentIfUnreferenced`, dependents-first). Records its own changeset so a cancel restores the group.
- **`ItemKind.excludeFromAdmission`** — a kind whose `capacity` counts a coarser resource than its per-item key (per-endpoint membership vs per-group limit) opts out of admission so it is not double-counted; the group slot is gated by `groupKeyMap`. `capacity` still serves the reconciler.
- **Merge fix** — prettier import-order on harness test files repointed to `@matter/node/testing` during the main→node-manager merge (fixes the `check-and-lint` failure on #3948).

## Tests / gate
- Unit: membership two-endpoint + cross-endpoint revert isolation; admission accept/reject + exclude-from-admission; RemoveNodeFromGroup unshared-teardown + shared-key-set-kept.
- Integration (commissioned peer): round-trip removal, shared key set kept across a group removal, admission rejection end-to-end (device `maxGroupsPerFabric: 4`, saturated, extra add rejected).
- `build --clean` ✓ · `format-verify` ✓ · `lint` ✓ · node-manager 126/126 · node 1329/1329.

## Follow-ups (non-blocking)
- Extract the shared commissioned-peer test helpers (`isMember`/`itemState`/`awaitState`) into one module (currently duplicated across Add/Remove integration files).
- `PlannedChange.intent` is unused at branch scope (kept for forward use); dedupe the intent literals between `plannedChanges()` and the provision phase.
- Carried from 2a → Inc3: pass `revertOf` into the task at creation; narrow a `ReconcilerSurface` interface to drop test casts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)