### PR TITLE
fix(node): consider stored/imported OTA images in auto-update check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Tag manufacturer-extension (MEI) attributes with `WildcardSkipCustomElements` so wildcard reads skip them
     - Fix: Manufacturer-specific attributes in standard clusters are now filtered by the `WildcardSkipCustomElements` flag instead of `WildcardSkipGlobalAttributes` during wildcard path expansion
     - Fix: Signal subscription "alive" when a sustained subscription (re)establishes so peer structure changes are surfaced immediately instead of at the next periodic report
+    - Fix: Also respect local (imported/stored) OTA images when checking for available updates, not only the DCL
 
 - @matter/nodejs-shell
     - Feature: Added `icd` shell commands to register/unregister/stay-active ICD clients and inspect/watch node wakefulness and availability

--- a/packages/node/src/behavior/system/software-update/SoftwareUpdateManager.ts
+++ b/packages/node/src/behavior/system/software-update/SoftwareUpdateManager.ts
@@ -371,7 +371,7 @@ export class SoftwareUpdateManager extends Behavior {
 
     /** Triggered by a Timer to call the update with different parameters */
     async #checkAvailableUpdates() {
-        await this.queryUpdates();
+        await this.queryUpdates({ includeStoredUpdates: true });
         await this.#cleanupObsoleteUpdates();
     }
 
@@ -454,8 +454,9 @@ export class SoftwareUpdateManager extends Behavior {
      *
      * Returns a list of peers for which updates are available along with the collected update info.
      *
-     * If `includeStoredUpdates` is set to true available and known local update will be returned without checking the
-     * DCL again.
+     * If `includeStoredUpdates` is set to true, locally stored/imported OTA images are considered as update candidates
+     * alongside the DCL. The DCL is always queried regardless; across all candidates the highest applicable and allowed
+     * version wins.
      */
     async queryUpdates(options: { peerToCheck?: ClientNode; includeStoredUpdates?: boolean } = {}) {
         const { peerToCheck, includeStoredUpdates = false } = options;
@@ -526,14 +527,6 @@ export class SoftwareUpdateManager extends Behavior {
     async #checkProductForUpdates(infos: CollectedNodesUpdateInfo, includeStoredUpdates: boolean) {
         const { vendorId, productId, softwareVersion, otaEndpoints } = infos;
 
-        // No need to query again if we already did and know that updates are available
-        if (
-            includeStoredUpdates &&
-            [...otaEndpoints.values()].every(({ peerAddress }) => this.internal.knownUpdates.has(peerAddress))
-        ) {
-            return [...otaEndpoints.values()].map(({ peerAddress }) => peerAddress);
-        }
-
         const updateDetails = await this.internal.otaService.checkForUpdate({
             vendorId,
             productId,
@@ -552,7 +545,7 @@ export class SoftwareUpdateManager extends Behavior {
                 vendorId,
                 productId,
                 softwareVersion,
-                file: `ota/${fd.text}`,
+                file: fd.text,
                 peers: [...otaEndpoints.values()].map(({ peerAddress }) => peerAddress.toString()),
             }),
         );
@@ -1086,10 +1079,19 @@ export class SoftwareUpdateManager extends Behavior {
         const entry = this.internal.updateQueue[entryIndex];
         if (status === OtaUpdateStatus.Done) {
             logger.info(`OTA update completed for node`, peerAddress.toString());
+            const completedVersion = toVersion ?? entry.targetSoftwareVersion;
             this.internal.updateQueue.splice(entryIndex, 1);
             this.internal.knownUpdates.delete(peerAddress);
             this.internal.pendingStartUpSuppress.delete(peerAddress);
             this.events.updateDone.emit(peerAddress);
+
+            // Also clean up consents (mirrors the software-version-change path, which is not reached when the Done
+            // status arrives directly instead of via a subsequent version-change event)
+            this.internal.consents = this.internal.consents.filter(
+                ({ peerAddress: consentAddress, targetSoftwareVersion }) =>
+                    !PeerAddress.is(peerAddress, consentAddress) || targetSoftwareVersion > completedVersion,
+            );
+
             this.#triggerQueuedUpdate();
         } else if (status === OtaUpdateStatus.Cancelled) {
             // BDX transport interruption: reset the entry so it can be retried.

--- a/packages/node/test/behaviors/ota/OtaTest.ts
+++ b/packages/node/test/behaviors/ota/OtaTest.ts
@@ -457,6 +457,40 @@ describe("Ota", () => {
         expect(updateFailedEvents).length(0);
     }).timeout(10_000);
 
+    it("Done status clears the consent for the completed version", async () => {
+        const { TestOtaProviderServer } = InstrumentedOtaProviderServer({
+            requestUserConsentForUpdate: false,
+        });
+        const { TestOtaRequestorServer } = InstrumentedOtaRequestorServer({ requestUserConsent: false });
+
+        const { site, device, controller, otaProvider } = await initOtaSite(
+            TestOtaProviderServer,
+            TestOtaRequestorServer,
+        );
+        await using _localSite = site;
+
+        const { vendorId, productId, targetSoftwareVersion } = await addTestOtaImage(device, controller);
+
+        const peer1 = controller.peers.get("peer1")!;
+        const peerAddress = peer1.state.commissioning.peerAddress!;
+
+        await otaProvider.act(agent =>
+            agent
+                .get(SoftwareUpdateManager)
+                .addUpdateConsent(peerAddress, VendorId(vendorId), productId, targetSoftwareVersion),
+        );
+        expect(await otaProvider.act(agent => agent.get(SoftwareUpdateManager).hasConsent(peerAddress))).equals(true);
+
+        await otaProvider.act(agent => {
+            agent
+                .get(SoftwareUpdateManager)
+                .onOtaStatusChange(peerAddress, OtaUpdateStatus.Done, targetSoftwareVersion);
+        });
+
+        expect(await otaProvider.act(agent => agent.get(SoftwareUpdateManager).hasConsent(peerAddress))).equals(false);
+        expect(await otaProvider.act(agent => agent.get(SoftwareUpdateManager).queuedUpdates)).length(0);
+    }).timeout(10_000);
+
     it("Apply failure detected when startUp fires after Applying state", async () => {
         // This test verifies the status ordering fix: previousProgressStatus is saved BEFORE the
         // clearing block in #onSoftwareVersionChanged, so the Applying check on startUp works correctly.
@@ -1089,16 +1123,21 @@ describe("Ota", () => {
     }).timeout(10_000);
 
     it("Cleanup purges stored test-mode OTA when allowTestOtaImages is disabled, preserves prod/local", async () => {
-        const { TestOtaProviderServer } = InstrumentedOtaProviderServer({
-            requestUserConsentForUpdate: false,
+        // Device intentionally has no OTA requestor, so it is not an update target: the periodic check offers
+        // nothing and #cleanupObsoleteUpdates is exercised in isolation.
+        const site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair({
+            controller: {
+                type: ServerNode.RootEndpoint,
+                parts: [{ id: "ota-provider", type: OtaProviderEndpoint }],
+            },
         });
-        const { TestOtaRequestorServer } = InstrumentedOtaRequestorServer({ requestUserConsent: false });
-
-        const { site, device, controller, otaProvider } = await initOtaSite(
-            TestOtaProviderServer,
-            TestOtaRequestorServer,
-        );
         await using _localSite = site;
+
+        const otaProvider = controller.parts.get("ota-provider")!;
+        await otaProvider.act(agent => {
+            agent.get(SoftwareUpdateManager).state.allowTestOtaImages = true;
+        });
 
         // Store a test-mode OTA image via the helper (matches device vid/pid, version = peer + 1).
         const { otaImage } = await addTestOtaImage(device, controller);


### PR DESCRIPTION
## Problem

The periodic/auto OTA update check (`SoftwareUpdateManager.#checkAvailableUpdates`) called `queryUpdates()` with `includeStoredUpdates` defaulting to `false`. As a result, locally imported/stored OTA images were never scanned and only the DCL was consulted — so an imported firmware higher than any DCL version was silently ignored, and the DCL version was offered instead.

## Fix

- Auto-check now passes `includeStoredUpdates: true`, so stored/imported local images are considered as update candidates.
- Removed a short-circuit in `#checkProductForUpdates` that returned cached known-updates **without** querying the DCL. Every check now queries the DCL, and the highest applicable + allowed version across `{ local, dcl-prod, dcl-test }` wins (existing selection/applicability logic decides "allowed").
- Cleaned up lingering consent on the `onOtaStatusChange` `Done` path — it previously did not clear `internal.consents` (unlike the version-change path), leaving a stale consent for the completed version for the process lifetime.
- Fixed a doubled `ota/ota/` prefix in the "OTA update available" log line (`fd.text` already carries the `ota/` scope).

Consent re-notification cadence is intentionally unchanged (still re-emitted per interval) to preserve lost-event recovery.

## Tests

- New regression test: `Done status clears the consent for the completed version`.
- Isolated the cleanup test (device without an OTA requestor → not an update target) so it exercises `#cleanupObsoleteUpdates` alone rather than conflating it with the now-active offer path.

## Verification

Independent adversarial review over the cumulative diff (no new bugs). Full gate green: clean build, `@matter/node` 1446/1446, `format-verify`, `lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)