### PR TITLE
fix(node): bound shutdown wait so an unresponsive peer can't hang node close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Tag manufacturer-extension (MEI) attributes with `WildcardSkipCustomElements` so wildcard reads skip them
     - Fix: Manufacturer-specific attributes in standard clusters are now filtered by the `WildcardSkipCustomElements` flag instead of `WildcardSkipGlobalAttributes` during wildcard path expansion
     - Fix: Signal subscription "alive" when a sustained subscription (re)establishes so peer structure changes are surfaced immediately instead of at the next periodic report
+    - Fix: Bound node shutdown so an interaction parked awaiting an MRP ack from an unresponsive peer (e.g. a restarted ICD) can no longer hang close
 
 - @matter/nodejs-shell
     - Feature: Added `icd` shell commands to register/unregister/stay-active ICD clients and inspect/watch node wakefulness and availability

--- a/packages/general/src/log/LogFormat.ts
+++ b/packages/general/src/log/LogFormat.ts
@@ -562,15 +562,17 @@ function renderDictionary(value: object, formatter: Formatter) {
 }
 
 function valueFor(value: unknown) {
-    if (typeof value !== "object" || value === null) {
-        return value;
-    }
-    if (Diagnostic.value in value) {
+    // Walk the proxy chain in lockstep with presentationFor: unwrap presentation-less proxies, but stop at the level
+    // that declares a presentation and return its value, so the value matches the presentation the switch acts on.
+    while (typeof value === "object" && value !== null && Diagnostic.value in value) {
         const proxied = Diagnostic.valueOf(value);
         if (proxied === value) {
             throw new InternalError("Diagnostic value proxies to itself");
         }
-        return proxied;
+        if (Diagnostic.presentation in value) {
+            return proxied;
+        }
+        value = proxied;
     }
     return value;
 }

--- a/packages/general/test/log/LoggerTest.ts
+++ b/packages/general/test/log/LoggerTest.ts
@@ -326,6 +326,20 @@ describe("Logger", () => {
             expect(result.message).equal("xxxx-xx-xx xx:xx:xx.xxx ERROR UnitTest Uh oh");
         });
 
+        it("resolves a value that proxies to a presented value", () => {
+            // An object whose [Diagnostic.value] returns a Diagnostic wrapper (e.g. NodeActivity → Diagnostic.list)
+            // must render the wrapper's value, not treat the wrapper itself as the list.
+            const proxied = {
+                get [Diagnostic.value]() {
+                    return Diagnostic.list(["one", "two"]);
+                },
+            };
+            const result = captureOne(() => {
+                logger.debug("pending", proxied);
+            });
+            expect(result.message).equals("xxxx-xx-xx xx:xx:xx.xxx DEBUG UnitTest pending\n  one\n  two");
+        });
+
         it("emphasizes", () => {
             const result = captureOne(() => {
                 logger.error("THIS IS", Diagnostic.strong("VERY"), "IMPORTANT");

--- a/packages/node/src/behavior/system/network/NetworkRuntime.ts
+++ b/packages/node/src/behavior/system/network/NetworkRuntime.ts
@@ -5,9 +5,18 @@
  */
 
 import type { Node } from "#node/Node.js";
-import { Abort, Construction, ImplementationError } from "@matter/general";
+import { Abort, Construction, Duration, ImplementationError, Logger, Seconds, Time } from "@matter/general";
 import { NodeActivity } from "../../context/NodeActivity.js";
 import { NetworkBehavior } from "./NetworkBehavior.js";
+
+const logger = Logger.get("NetworkRuntime");
+
+/**
+ * Upper bound on how long shutdown waits for node activity to settle before force-closing sessions and exchanges.
+ * Guards against an interaction parked on MRP retransmission to an unresponsive peer (e.g. a restarted ICD, whose
+ * backoff spans the idle interval) holding activity open for hours.
+ */
+const ACTIVITY_DRAIN_TIMEOUT = Seconds(5);
 
 /**
  * Base class for networking implementation.
@@ -44,7 +53,18 @@ export abstract class NetworkRuntime {
     async [Construction.destruct]() {
         this.#abort();
         const activity = this.#owner.env.get(NodeActivity);
-        await activity.inactive;
+        if (!activity.inactive.value) {
+            const drainTimeout = Time.sleep("shutdown activity drain", ACTIVITY_DRAIN_TIMEOUT);
+            await Promise.race([activity.inactive, drainTimeout]);
+            if (activity.inactive.value) {
+                drainTimeout.cancel("activity drained");
+            } else {
+                logger.warn(
+                    `Node activity did not settle within ${Duration.format(ACTIVITY_DRAIN_TIMEOUT)}; forcing shutdown`,
+                    activity,
+                );
+            }
+        }
 
         try {
             await this.stop();

--- a/packages/node/test/node/ShutdownActivityTest.ts
+++ b/packages/node/test/node/ShutdownActivityTest.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NodeActivity } from "#behavior/context/NodeActivity.js";
+import { MockServerNode } from "./mock-server-node.js";
+
+describe("shutdown activity draining", () => {
+    it("shuts down even if node activity never settles", async () => {
+        const node = await MockServerNode.createOnline();
+
+        // Model an interaction parked on an MRP ack from an unresponsive peer (e.g. a restarted ICD, whose
+        // retransmission backoff spans the idle interval): an activity that never closes.  Without the drain bound,
+        // close() awaits NodeActivity.inactive forever (MockTime aborts after one virtual hour).
+        const stuck = node.env.get(NodeActivity).begin("stuck interaction");
+        expect(node.env.get(NodeActivity).inactive.value).equals(false);
+
+        try {
+            await node.close();
+        } finally {
+            stuck.close();
+        }
+    });
+});


### PR DESCRIPTION
## Problem

A controller hung on `node.close()` after `going offline`. Diagnostics showed an old session with exchanges stuck "waiting for ack" for ~48m, and MRP retransmission backoffs blown out to `1h 57m` — because the peer was a **restarted ICD** whose MRP backoff is capped at the ~1h `SleepyIdleInterval`.

Root cause is in `NetworkRuntime[Construction.destruct]`:

```
this.#abort();              // only blocks NEW activity
await activity.inactive;    // ← unbounded: waits for in-flight interactions to drain
await this.stop();          // force-closes sessions/exchanges — never reached
```

An `InteractionServer` handler parked at `MessageExchange` `await abort.race(ackPromise)` holds a `NodeActivity` actor open (`InteractionServer` even documents *"prevents the server from shutting down whilst the exchange is active"*). `#abort()` does **not** cancel that parked send, and the force-close paths that would (`SessionManager.closeAllSessions` / `ExchangeManager.close`, both with a `ShutdownError` cause) live inside `stop()`, after the gate. So `activity.inactive` never resolves and shutdown hangs until MRP finally exhausts — hours later for an ICD.

This is **generic**: any unresponsive peer mid-interaction at shutdown triggers it; an ICD's hour-scale backoff just makes it near-permanent.

## Fix

Bound the drain to 5s, then proceed to `stop()` (which force-closes everything). Graceful when work drains fast, bounded when a peer is dead. Covers invoke/read/write/subscribe and server-initiated reports uniformly.

Second commit fixes a **latent log-renderer bug** surfaced by the shutdown warn: `valueFor` unwrapped only one proxy level while `presentationFor` walked the whole chain, so logging any object whose `[Diagnostic.value]` returns a `Diagnostic` wrapper (e.g. `NodeActivity → Diagnostic.list`) threw `"Diagnostic list is not iterable"`. `valueFor` now walks the chain in lockstep.

## Tests

- `ShutdownActivityTest` — node closes even when activity never settles (hangs without the fix; MockTime aborts after one virtual hour).
- `LoggerTest` — an object whose `[Diagnostic.value]` proxies to a presented value renders instead of crashing.
- Full suites green: `@matter/general` 1227/1227, `@matter/node` 1446/1446. format-verify + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)