### PR TITLE
fix(bdx): cap negotiated block size to transport payload size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Single commands skip auto-batching when the peer accepts only one path per invoke or the response is suppressed
     - Fix: Closing a client interaction aborts an in-flight command batch instead of awaiting its response
     - Fix: Ensure group messaging works correctly when multiple key sets share a group session id
+    - Fix: Cap a peer-negotiated BDX block size to the transport payload size, so OTA blocks no longer exceed the UDP message limit
 
 - @matter/thread-br-client
     - Feature: Added as new package to support communication with Thread Border Routers through CoAP and with OpenThread Border Routers via REST (if exposed)

--- a/packages/protocol/src/bdx/bdx-session-initiator.ts
+++ b/packages/protocol/src/bdx/bdx-session-initiator.ts
@@ -16,6 +16,16 @@ import { BDX_VERSION, BdxInit, BdxTransferControlBitmap } from "./schema/BdxInit
 
 const logger = Logger.get("bdxSessionInitiator");
 
+/** Cap a negotiated block size to what the transport can carry (payload size minus the 4-byte block counter). */
+function capBlockSizeToTransport(messenger: BdxMessenger, maxBlockSize: number): number {
+    const transportMaxBlockSize = messenger.maxPayloadSize - 4;
+    if (maxBlockSize > transportMaxBlockSize) {
+        logger.info(`Capping maxBlockSize ${maxBlockSize} to transport max payload size ${transportMaxBlockSize}bytes`);
+        return transportMaxBlockSize;
+    }
+    return maxBlockSize;
+}
+
 /**
  * Handles the initiation of a BDX session by exchanging *Init and *Accept messages and negotiating the transfer
  * parameters.
@@ -185,6 +195,8 @@ export async function bdxSessionInitiator(messenger: BdxMessenger, config: BdxSe
             throw new BdxError("Can not determine a valid transfer mode", BdxStatusCode.TransferMethodNotSupported);
         }
 
+        maxBlockSize = capBlockSizeToTransport(messenger, maxBlockSize);
+
         const requestedMaxBlockSize = config.transferConfig.maxBlockSize;
         if (requestedMaxBlockSize !== undefined && maxBlockSize > requestedMaxBlockSize) {
             maxBlockSize = requestedMaxBlockSize;
@@ -216,8 +228,8 @@ export async function bdxSessionInitiator(messenger: BdxMessenger, config: BdxSe
     ): Flow.TransferOptions {
         const {
             transferControl: { senderDrive, asynchronousTransfer },
-            maxBlockSize,
         } = acceptMessage;
+        let { maxBlockSize } = acceptMessage;
         if (asynchronousTransfer) {
             // Async is not supported by matter SDK and such, so always decline this for now
             throw new BdxError(
@@ -225,6 +237,8 @@ export async function bdxSessionInitiator(messenger: BdxMessenger, config: BdxSe
                 BdxStatusCode.TransferMethodNotSupported,
             );
         }
+
+        maxBlockSize = capBlockSizeToTransport(messenger, maxBlockSize);
 
         const dataLength =
             "length" in acceptMessage && acceptMessage.length !== undefined

--- a/packages/protocol/src/bdx/bdx-session-initiator.ts
+++ b/packages/protocol/src/bdx/bdx-session-initiator.ts
@@ -20,7 +20,7 @@ const logger = Logger.get("bdxSessionInitiator");
 function capBlockSizeToTransport(messenger: BdxMessenger, maxBlockSize: number): number {
     const transportMaxBlockSize = messenger.maxPayloadSize - 4;
     if (maxBlockSize > transportMaxBlockSize) {
-        logger.info(`Capping maxBlockSize ${maxBlockSize} to transport max payload size ${transportMaxBlockSize}bytes`);
+        logger.info(`Capping maxBlockSize ${maxBlockSize} to transport max block size ${transportMaxBlockSize} bytes`);
         return transportMaxBlockSize;
     }
     return maxBlockSize;

--- a/packages/protocol/test/bdx/BdxTest.ts
+++ b/packages/protocol/test/bdx/BdxTest.ts
@@ -5,6 +5,7 @@ import {
     BdxBlockQueryWithSkipMessage,
     BdxClient,
     BdxError,
+    BdxMessage,
     BdxReceiveInitMessage,
     BdxStatusResponseError,
     Flow,
@@ -314,6 +315,85 @@ describe("BdxTest", () => {
                         expect(clientExchangeData[3].data.blockCounter).equals(2);
 
                         const receivedData = readBlob(clientStorage, fd.blobName);
+                        expect(receivedData).to.deep.equal(data);
+                    },
+                });
+            });
+
+            it("Caps a peer-proposed maxBlockSize larger than the transport payload size", async () => {
+                const data = crypto.randomBytes(2048);
+
+                let fd: PersistedFileDesignator;
+                await bdxTransfer({
+                    prepare: async (clientStorage, serverStorage, messenger) => {
+                        fd = new PersistedFileDesignator("data", clientStorage);
+                        writeBlob(serverStorage, "data", data);
+
+                        return {
+                            bdxClient: BdxClient.asReceiver(messenger, { fileDesignator: fd }),
+                            expectedInitialMessageType: BdxMessageType.ReceiveInit,
+                        };
+                    },
+                    // Simulate a non-compliant peer that proposes a 4096 byte block on a transport whose negotiated
+                    // block size caps at 966 bytes. The recorded clientExchangeData still shows the original message
+                    // because it is captured before this manipulator runs.
+                    clientExchangeManipulator: message => {
+                        if (message.payloadHeader.messageType === BdxMessageType.ReceiveInit) {
+                            const { message: init } = BdxMessage.decode(BdxMessageType.ReceiveInit, message.payload);
+                            message.payload = BdxMessage.encode({
+                                kind: BdxMessageType.ReceiveInit,
+                                message: { ...init, maxBlockSize: 4096 },
+                            });
+                        }
+                        return message;
+                    },
+                    validate: async (clientStorage, _serverStorage, { clientExchangeData, serverExchangeData }) => {
+                        expect(serverExchangeData[0].type).equals(BdxMessageType.ReceiveAccept);
+                        expect(serverExchangeData[0].data.maxBlockSize).equals(966);
+
+                        expect(serverExchangeData[1].type).equals(BdxMessageType.Block);
+                        expect(serverExchangeData[1].data.data.length).equals(966);
+
+                        const receivedData = readBlob(clientStorage, fd.blobName);
+                        expect(receivedData).to.deep.equal(data);
+                        expect(clientExchangeData[clientExchangeData.length - 1].type).equals(
+                            BdxMessageType.BlockAckEof,
+                        );
+                    },
+                });
+            });
+
+            it("Caps a peer-accepted maxBlockSize larger than the transport payload size", async () => {
+                const data = crypto.randomBytes(2048);
+
+                let fd: PersistedFileDesignator;
+                await bdxTransfer({
+                    prepare: async (clientStorage, _serverStorage, messenger) => {
+                        fd = new PersistedFileDesignator("data", clientStorage);
+                        writeBlob(clientStorage, "data", data);
+
+                        return {
+                            bdxClient: BdxClient.asSender(messenger, { fileDesignator: fd }),
+                            expectedInitialMessageType: BdxMessageType.SendInit,
+                        };
+                    },
+                    // Simulate a non-compliant peer whose SendAccept echoes a 4096 byte block on a transport whose
+                    // negotiated block size caps at 966 bytes. The sender-initiator must not send blocks that large.
+                    serverExchangeManipulator: message => {
+                        if (message.payloadHeader.messageType === BdxMessageType.SendAccept) {
+                            const { message: accept } = BdxMessage.decode(BdxMessageType.SendAccept, message.payload);
+                            message.payload = BdxMessage.encode({
+                                kind: BdxMessageType.SendAccept,
+                                message: { ...accept, maxBlockSize: 4096 },
+                            });
+                        }
+                        return message;
+                    },
+                    validate: async (_clientStorage, serverStorage, { clientExchangeData }) => {
+                        expect(clientExchangeData[1].type).equals(BdxMessageType.Block);
+                        expect(clientExchangeData[1].data.data.length).equals(966);
+
+                        const receivedData = readBlob(serverStorage, fd.blobName);
                         expect(receivedData).to.deep.equal(data);
                     },
                 });


### PR DESCRIPTION
## Problem

Reported in [home-assistant/core#176136](https://github.com/home-assistant/core/issues/176136): an OTA update to an Eberle UTE-3500 loops on `downloadError`. The device (BDX receiver/driver) proposes a 4096-byte block size in its `ReceiveInit`, and matter.js (the sender) accepts it verbatim — then emits ~4134-byte Block messages over UDP, exceeding the 1232-byte Matter message limit, so the transfer never completes.

## Root cause

BDX block-size negotiation clamped the requested size to our own config but never to the transport MTU. Two code paths were affected in `bdx-session-initiator.ts`:

- `determineAcceptParameters` — we respond to an incoming `*Init` as **sender-responder** (the OTA case). Peer-proposed `maxBlockSize` was taken as-is.
- `collectAcceptParameters` — we are the **initiator** and consume a peer's `*Accept`. A non-compliant peer echoing an oversized block would make us send oversized Blocks (symmetric gap).

The initiator's own outgoing proposal (`buildInitMessage`) already started from `maxPayloadSize - 4`, so only these two consumption paths were wrong.

## Fix

Cap the negotiated block size to `messenger.maxPayloadSize - 4` (payload minus the 4-byte block counter) on both paths, via a shared `capBlockSizeToTransport` helper. `maxPayloadSize` reflects the actual channel, so UDP stays bounded while TCP/large-MTU peers still get large blocks. We only cap *down*, consistent with the BDX rule that the sender's Accept block size must be ≤ the receiver-proposed value.

## Tests

Two regression tests in `BdxTest.ts` simulating a non-compliant peer proposing 4096 on a 966-byte-cap transport:
- responder path (peer's `ReceiveInit`)
- initiator path (peer's `SendAccept`)

Both verified to fail without the fix (`blockSize: 4096`) and pass with it. Full protocol suite green (1440/1440), format + lint clean.

## Note

The device firmware is also non-compliant (proposing a block it cannot route over its own UDP). This change makes matter.js robust against such peers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)