### PR TITLE
fix(model): initialize class metadata via Object.defineProperty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/model
     - Enhancement: Added cluster-variance rules for the Matter 1.6 conformance idioms
+    - Fix: Initialize class metadata via `Object.defineProperty` so importing matter.js no longer throws when `Function.prototype[Symbol.metadata]` is non-writable (TC39 decorator-metadata / core-js polyfill, reported by Sylvan86)
 
 - @matter/node
     - Feature: Server-side Intermittently Connected Device (ICD) support via the IcdManagement cluster: client registration/unregistration, StayActiveRequest, SIT/LIT operating modes with DSLS, and Check-In delivery to registered clients

--- a/packages/model/src/decoration/semantics/ClassSemantics.ts
+++ b/packages/model/src/decoration/semantics/ClassSemantics.ts
@@ -239,7 +239,11 @@ export class ClassSemantics extends Semantics {
         // Source is a constructor
         let metadata: MatterMetadata;
         if (!Object.hasOwn(source, Symbol.metadata)) {
-            metadata = source[Symbol.metadata] = {};
+            // Define the own property directly rather than assigning through [[Set]]; the TC39 decorator-metadata
+            // proposal (and core-js) makes Function.prototype[Symbol.metadata] a non-writable property, which would
+            // otherwise cause the assignment to throw in strict mode
+            metadata = {};
+            Object.defineProperty(source, Symbol.metadata, { value: metadata, writable: true, configurable: true });
         } else {
             metadata = source[Symbol.metadata] as MatterMetadata;
         }

--- a/packages/model/src/decoration/semantics/ClassSemantics.ts
+++ b/packages/model/src/decoration/semantics/ClassSemantics.ts
@@ -239,11 +239,15 @@ export class ClassSemantics extends Semantics {
         // Source is a constructor
         let metadata: MatterMetadata;
         if (!Object.hasOwn(source, Symbol.metadata)) {
-            // Define the own property directly rather than assigning through [[Set]]; the TC39 decorator-metadata
-            // proposal (and core-js) makes Function.prototype[Symbol.metadata] a non-writable property, which would
-            // otherwise cause the assignment to throw in strict mode
+            // Must not assign through [[Set]]: Function.prototype[Symbol.metadata] is non-writable per the TC39
+            // decorator-metadata proposal (and core-js), which makes such an assignment throw in strict mode
             metadata = {};
-            Object.defineProperty(source, Symbol.metadata, { value: metadata, writable: true, configurable: true });
+            Object.defineProperty(source, Symbol.metadata, {
+                value: metadata,
+                writable: true,
+                enumerable: true,
+                configurable: true,
+            });
         } else {
             metadata = source[Symbol.metadata] as MatterMetadata;
         }

--- a/packages/model/test/decoration/semantics/ClassSemanticsTest.ts
+++ b/packages/model/test/decoration/semantics/ClassSemanticsTest.ts
@@ -166,6 +166,30 @@ describe("ClassSemantics", () => {
         });
     });
 
+    it("initializes metadata when Function.prototype[Symbol.metadata] is non-writable", () => {
+        // The TC39 decorator-metadata proposal (and core-js) install Function.prototype[Symbol.metadata] as a
+        // non-writable property; initializing metadata via a plain assignment through [[Set]] would then throw in
+        // strict mode.  An undecorated class reaches ClassSemantics.of without its own Symbol.metadata, exercising
+        // the initialization path.
+        Object.defineProperty(Function.prototype, Symbol.metadata, {
+            value: null,
+            writable: false,
+            enumerable: false,
+            configurable: true,
+        });
+
+        try {
+            class Foo {}
+
+            expect(Object.hasOwn(Foo, Symbol.metadata)).false;
+            const semantics = ClassSemantics.of(Foo);
+            expect(semantics.new).equals(Foo);
+            expect(Object.hasOwn(Foo, Symbol.metadata)).true;
+        } finally {
+            delete (Function.prototype as { [Symbol.metadata]?: unknown })[Symbol.metadata];
+        }
+    });
+
     describe("new field", () => {
         it("is possible when not final", () => {
             @datatype()

--- a/packages/model/test/decoration/semantics/ClassSemanticsTest.ts
+++ b/packages/model/test/decoration/semantics/ClassSemanticsTest.ts
@@ -167,10 +167,7 @@ describe("ClassSemantics", () => {
     });
 
     it("initializes metadata when Function.prototype[Symbol.metadata] is non-writable", () => {
-        // The TC39 decorator-metadata proposal (and core-js) install Function.prototype[Symbol.metadata] as a
-        // non-writable property; initializing metadata via a plain assignment through [[Set]] would then throw in
-        // strict mode.  An undecorated class reaches ClassSemantics.of without its own Symbol.metadata, exercising
-        // the initialization path.
+        const original = Object.getOwnPropertyDescriptor(Function.prototype, Symbol.metadata);
         Object.defineProperty(Function.prototype, Symbol.metadata, {
             value: null,
             writable: false,
@@ -186,7 +183,11 @@ describe("ClassSemantics", () => {
             expect(semantics.new).equals(Foo);
             expect(Object.hasOwn(Foo, Symbol.metadata)).true;
         } finally {
-            delete (Function.prototype as { [Symbol.metadata]?: unknown })[Symbol.metadata];
+            if (original === undefined) {
+                delete (Function.prototype as { [Symbol.metadata]?: unknown })[Symbol.metadata];
+            } else {
+                Object.defineProperty(Function.prototype, Symbol.metadata, original);
+            }
         }
     });
 


### PR DESCRIPTION
## Problem

`ClassSemantics.of()` initialized class metadata with a plain assignment:

```ts
metadata = source[Symbol.metadata] = {};
```

That assignment triggers `[[Set]]`, which walks the prototype chain of `source`. When `Function.prototype[Symbol.metadata]` is a **non-writable** property, the assignment throws in strict mode:

```
TypeError: Cannot assign to read only property 'Symbol(Symbol.metadata)' of function 'class ClusterBehavior ...'
```

A non-writable `Function.prototype[Symbol.metadata]` is the expected environment:

- The [TC39 decorator-metadata proposal](https://github.com/tc39/proposal-decorator-metadata) specifies it as an initially-`null`, non-writable property.
- `core-js` polyfills it that way (pulled in transitively via `@babel/runtime-corejs3` → `core-js-pure`, e.g. `swagger-client`).
- Native engine support will have the same attributes without any polyfill.

Because the property is process-global, any dependency loading the polyfill makes `import "@matter/main"` crash during module evaluation. Real-world report: a Node-RED install combining `node-red-contrib-knx-ultimate` (bundles matter.js) with `node-red-contrib-homeconnect` (→ `swagger-client` → `core-js-pure`).

## Fix

Create the own property directly with `Object.defineProperty`, which is unaffected by read-only properties higher in the prototype chain. Descriptor flags (`writable: true, configurable: true`) match what the assignment would have produced.

## Testing

Added a regression test that installs a non-writable `Function.prototype[Symbol.metadata]` and exercises the initialization path via an undecorated class (mirrors the real stack trace, where an undecorated class reaches `ClassSemantics.of` without its own metadata). Verified it fails without the fix and passes with it. Full `@matter/model` suite (484/484), format-verify, and lint all pass.

Fixes #4050

🤖 Generated with [Claude Code](https://claude.com/claude-code)