### PR TITLE
fix(node): restore group endpoint mappings at startup

### DIFF
--- a/packages/node/src/behaviors/group-key-management/GroupKeyManagementServer.ts
+++ b/packages/node/src/behaviors/group-key-management/GroupKeyManagementServer.ts
@@ -138,6 +138,14 @@ export class GroupKeyManagementServer extends GroupKeyManagementBase {
         if (this.state.groupKeyMap.length) {
             this.#updateGroupKeyMap(this.state.groupKeyMap);
         }
+        if (this.state.groupTable.length) {
+            // Restore the runtime endpoint map, which group command dispatch expands over
+            for (const { fabricIndex, groupId, endpoints } of this.state.groupTable) {
+                if (fabrics.has(fabricIndex)) {
+                    fabrics.for(fabricIndex).groups.endpoints.set(groupId, [...endpoints]);
+                }
+            }
+        }
     }
 
     /** Handle the recreation (update) of a fabric, so we need to reinitialize the group key sets */


### PR DESCRIPTION
## Problem

`GroupKeyManagementServer#online()` restores the group key sets and the group key map from persisted state, but not the runtime endpoint map derived from the persisted `groupTable` — that only happens in the fabric-*replace* handler. After a node restart:

- group multicast messages are still received and decrypted (the key map is restored),
- but group command dispatch expands over `session.subject.endpoints` → `fabric.groups.endpoints`, which is **empty** — commands to previously configured groups are silently not dispatched,
- `BindingManager` group-member lookups come up empty as well,

until a fresh `AddGroup` repopulates the map. CI never restarts a configured node mid-test, so this went unnoticed.

## Fix

Rebuild `fabric.groups.endpoints` from the persisted `groupTable` for every loaded fabric at startup, mirroring the existing key-map restore.

Found during the Groupcast branch (#3298) final review; this part is legacy-relevant independent of Groupcast and applies to the Matter 1.6.0 line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)