### PR TITLE
fix(protocol): only log invoke commandRef when encoded on the wire

### DIFF
--- a/packages/protocol/src/action/client/ClientInteraction.ts
+++ b/packages/protocol/src/action/client/ClientInteraction.ts
@@ -608,7 +608,7 @@ export class ClientInteraction<
                                 Diagnostic.strong(Invoke.isLegacy(cmd) ? "(legacy)" : resolvePathForSpecifier(cmd)),
                                 "with",
                                 isObject(fields) ? Diagnostic.dict(fields) : "(no payload)",
-                                commandRef !== undefined ? `(ref ${commandRef})` : "",
+                                commandRef !== undefined && batchCommands.size > 1 ? `(ref ${commandRef})` : "",
                             ];
                         }),
                     ),

--- a/packages/protocol/src/action/request/Invoke.ts
+++ b/packages/protocol/src/action/request/Invoke.ts
@@ -152,7 +152,7 @@ export function Invoke(
                         Diagnostic.strong(Invoke.isLegacy(cmd) ? "(legacy)" : resolvePathForSpecifier(cmd)),
                         "with",
                         isObject(fields) ? Diagnostic.dict(fields) : "(no payload)",
-                        commandRef !== undefined ? `(ref ${commandRef})` : "",
+                        commandRef !== undefined && commands.length > 1 ? `(ref ${commandRef})` : "",
                     ];
                 }),
             ),


### PR DESCRIPTION
## Problem

`ClientInteraction` logs `(ref N)` on outbound invokes even when no commandRef is encoded on the wire, e.g.:

```
Invoke » ... 2.cameraAvStreamManagement.videoStreamAllocate with ... (ref 1)
```

Since #4023, single-command invokes intentionally omit `commandRef` from the wire (per spec — servers without batch-invoke support don't echo it, so single commands are correlated by position). But the two diagnostic renderers still printed the *client-local* `commandRef`, so a phantom `(ref N)` showed up for any invoke that took the auto-batch path even when the batch collapsed to a single command. Confusing when reading traces against the actual TLV payload (which carries no ref).

## Fix

Gate the `(ref N)` render on the same multi-command condition that puts the ref on the wire (`invokeRequests.length > 1`):

- `Invoke.ts` default renderer → `commands.length > 1`
- `ClientInteraction.ts` batch renderer → `batchCommands.size > 1`

The splitting path already builds the batch renderer, so split sub-batches of size 1 also correctly hide the ref. Multi-command invokes (where the ref *is* encoded) still log it.

Log-only change, no wire/behavior impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)