### PR TITLE
fix: subscription liveness on empty keepalives + maxInterval unit fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Closing a client interaction aborts an in-flight command batch instead of awaiting its response
     - Fix: Ensure group messaging works correctly when multiple key sets share a group session id
     - Fix: Cap a peer-negotiated BDX block size to the transport payload size, so OTA blocks no longer exceed the UDP message limit
+    - Fix: Report a sustained subscription's fallback `maxInterval` in seconds instead of a millisecond value while no subscription is established
 
 - @matter/thread-br-client
     - Feature: Added as new package to support communication with Thread Border Routers through CoAP and with OpenThread Border Routers via REST (if exposed)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Tag manufacturer-extension (MEI) attributes with `WildcardSkipCustomElements` so wildcard reads skip them
     - Fix: Manufacturer-specific attributes in standard clusters are now filtered by the `WildcardSkipCustomElements` flag instead of `WildcardSkipGlobalAttributes` during wildcard path expansion
     - Fix: Signal subscription "alive" when a sustained subscription (re)establishes so peer structure changes are surfaced immediately instead of at the next periodic report
+    - Fix: Also signal subscription "alive" on empty max-interval keepalive reports, so a quiet peer keeps refreshing its liveness signal
     - Fix: Bound node shutdown so an interaction parked awaiting an MRP ack from an unresponsive peer (e.g. a restarted ICD) can no longer hang close
     - Fix: Also respect local (imported/stored) OTA images when checking for available updates, not only the DCL
 

--- a/packages/node/src/behavior/system/network/NetworkClient.ts
+++ b/packages/node/src/behavior/system/network/NetworkClient.ts
@@ -150,6 +150,12 @@ export class NetworkClient extends NetworkBehavior {
                         this.events.subscriptionAlive.emit(); // Inform that subscription is alive
                     }
                 },
+                keepaliveReceived: () => {
+                    // Empty keepalives invoke keepaliveReceived, not updated(), so mirror the liveness emit here.
+                    if (this.internal.activeSubscription?.subscriptionId !== ClientSubscription.NO_SUBSCRIPTION) {
+                        this.events.subscriptionAlive.emit();
+                    }
+                },
                 closed: () => {
                     if (!(this.internal.activeSubscription instanceof SustainedSubscription)) {
                         this.events.subscriptionStatusChanged.emit(false);

--- a/packages/protocol/src/action/client/subscription/SustainedSubscription.ts
+++ b/packages/protocol/src/action/client/subscription/SustainedSubscription.ts
@@ -438,7 +438,7 @@ export class SustainedSubscription extends ClientSubscription {
     }
 
     get maxInterval() {
-        return this.#subscription?.maxInterval ?? Hours.one;
+        return this.#subscription?.maxInterval ?? Seconds.of(Hours.one);
     }
 }
 

--- a/packages/protocol/test/action/client/subscription/SustainedSubscriptionTest.ts
+++ b/packages/protocol/test/action/client/subscription/SustainedSubscriptionTest.ts
@@ -240,6 +240,46 @@ describe("SustainedSubscription", () => {
             subscription.close();
             await MockTime.resolve(subscription.done!, { macrotasks: true });
         });
+
+        it("reports maxInterval in seconds, using a seconds fallback before a subscription is established", async () => {
+            const subscription = build();
+
+            // Hours.one in seconds, not its 3_600_000 ms Duration value.
+            expect(subscription.maxInterval).equal(3600);
+
+            await flush();
+            expect(subscription.maxInterval).equal(60);
+
+            subscription.close();
+            await MockTime.resolve(subscription.done!, { macrotasks: true });
+        });
+
+        it("forwards a caller-provided keepaliveReceived when no wakefulness is registered", async () => {
+            let callerCalls = 0;
+            let capturedKeepalive: SustainedClientSubscribe["keepaliveReceived"];
+            const subscription = build({
+                request: {
+                    sustain: true,
+                    updated: async () => {},
+                    keepaliveReceived: () => {
+                        callerCalls++;
+                    },
+                } as unknown as SustainedClientSubscribe,
+                subscribe: async (request: Subscribe) => {
+                    capturedKeepalive = (request as SustainedClientSubscribe).keepaliveReceived;
+                    return fakePeerSub();
+                },
+            });
+
+            await flush();
+            expect(subscription.active.value).equal(true);
+
+            capturedKeepalive?.();
+            expect(callerCalls).equal(1);
+
+            subscription.close();
+            await MockTime.resolve(subscription.done!, { macrotasks: true });
+        });
     });
 
     describe("ICD await-mode behavior", () => {


### PR DESCRIPTION
Fixes #4057 and #4058.

## #4057 — subscription liveness gap on empty keepalives

`NetworkClient` wired only `updated` + `closed` on its sustained-subscribe request. Empty max-interval keepalive reports go through `ClientSubscriptionHandler`'s empty-report branch, which invokes `keepaliveReceived` — never `updated`. So a quiet peer sending only keepalives never refreshed `subscriptionAlive`/`connectionAlive` after establishment, and watchdogs monitoring `connectionAlive` as a liveness timestamp flagged healthy devices as disconnected.

Fix: add a `keepaliveReceived` callback on `NetworkClient` that emits `subscriptionAlive` under the same `NO_SUBSCRIPTION` guard as `updated`. `SustainedSubscription.#run` already propagates the caller's `keepaliveReceived` (via the per-iteration request spread), so no further wiring is needed.

## #4058 — maxInterval unit mismatch in fallback

`SustainedSubscription.maxInterval` returns `#subscription.maxInterval` (seconds, per the `ClientSubscription.maxInterval: number` contract and matching every consumer: `Seconds(this.maxInterval)` etc.), but fell back to `Hours.one` — a **millisecond** `Duration` = `3_600_000` — while no subscription was established. Second-based consumers (e.g. `PairedNode.currentSubscriptionIntervalSeconds`) then reported a ~42-day interval during resubscribe gaps.

Fix: fall back to `Seconds.of(Hours.one)` (= 3600). Kept the return type `number` — returning `undefined` would break the abstract `maxInterval: number` contract and the `SustainedSubscription.assert` structural type predicate against `SubscribeResponse`.

## Tests
Two new tests in `SustainedSubscriptionTest`:
- caller-provided `keepaliveReceived` is forwarded when no wakefulness is registered (the non-ICD path #4057 hits)
- `maxInterval` reports seconds, using a seconds fallback (3600) before a subscription is established

Full protocol (1442) + node (1447) suites, format-verify, and lint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)