### PR TITLE
fix(node): tolerate non-compliant peers omitting mandatory Descriptor lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/types
     - Enhancement: Added the NFC Transport Layer (NTL, bit 4) capability to the onboarding payload Discovery Capabilities bitmap
 
+- @project-chip/matter.js
+    - Fix: Harden endpoint structure processing against non-compliant peers that omit mandatory Descriptor list attributes; treat an absent list as empty and warn-and-ignore missing device types instead of crashing
+
 ## 0.17.4 (2026-07-01)
 
 - @matter/general

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Also signal subscription "alive" on empty max-interval keepalive reports, so a quiet peer keeps refreshing its liveness signal
     - Fix: Bound node shutdown so an interaction parked awaiting an MRP ack from an unresponsive peer (e.g. a restarted ICD) can no longer hang close
     - Fix: Also respect local (imported/stored) OTA images when checking for available updates, not only the DCL
+    - Fix: Harden endpoint structure processing against non-compliant peers that omit mandatory Descriptor list attributes, treating an absent list as empty instead of crashing
 
 - @matter/nodejs-shell
     - Feature: Added `icd` shell commands to register/unregister/stay-active ICD clients and inspect/watch node wakefulness and availability

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -960,10 +960,8 @@ export class PairedNode {
             return;
         }
         collectedData.set(endpointId, endpoint);
-        if (descriptorData.partsList.length) {
-            for (const partEndpointId of descriptorData.partsList) {
-                this.#collectEndpoints(partEndpointId, collectedData);
-            }
+        for (const partEndpointId of descriptorData.partsList ?? []) {
+            this.#collectEndpoints(partEndpointId, collectedData);
         }
     }
 
@@ -976,12 +974,12 @@ export class PairedNode {
         return !(
             areNumberListsSame(
                 device.getDeviceTypes().map(({ code }) => code),
-                descriptorData.deviceTypeList.map(({ deviceType }) => deviceType),
+                (descriptorData.deviceTypeList ?? []).map(({ deviceType }) => deviceType),
             ) &&
             // Check if the cluster clients are the same - they map to the serverList attribute
             areNumberListsSame(
                 device.getAllClusterClients().map(({ id }) => id),
-                descriptorData.serverList,
+                descriptorData.serverList ?? [],
             )
         );
     }
@@ -1130,7 +1128,7 @@ export class PairedNode {
             throw new InternalError("Endpoints not initialized yet! Should never happen");
         }
         const partLists = Array.from(descriptors.entries()).map(
-            ([epNo, ep]) => [epNo, ep.stateOf(DescriptorClient).partsList] as [EndpointNumber, EndpointNumber[]], // else Typescript gets confused
+            ([epNo, ep]) => [epNo, ep.stateOf(DescriptorClient).partsList ?? []] as [EndpointNumber, EndpointNumber[]], // else Typescript gets confused
         );
         logger.debug(() => [this.#peerAddress, `Endpoints from PartsLists`, Diagnostic.json(partLists)]);
 
@@ -1198,7 +1196,7 @@ export class PairedNode {
     #createDevice(endpointId: EndpointNumber, endpoint: ClientEndpoint, interactionClient: InteractionClient) {
         const descriptorData = endpoint.stateOf(DescriptorClient);
 
-        const deviceTypes = descriptorData.deviceTypeList.flatMap(({ deviceType, revision }) => {
+        const deviceTypes = (descriptorData.deviceTypeList ?? []).flatMap(({ deviceType, revision }) => {
             const deviceTypeDefinition = getDeviceTypeDefinitionFromModelByCode(deviceType);
             if (deviceTypeDefinition === undefined) {
                 logger.info(
@@ -1223,7 +1221,7 @@ export class PairedNode {
         const endpointClusters = Array<ClusterClientObj>();
 
         // Add ClusterClients for all server clusters of the device
-        for (const clusterId of descriptorData.serverList) {
+        for (const clusterId of descriptorData.serverList ?? []) {
             const clusterModel = Matter.clusters(clusterId);
             const cluster = (
                 clusterModel !== undefined
@@ -1248,7 +1246,7 @@ export class PairedNode {
             return aggregator;
         } else {
             // It seems to be device but has a partsList, so it is a composed device
-            if (descriptorData.partsList.length > 0) {
+            if ((descriptorData.partsList ?? []).length > 0) {
                 const composedDevice = new ComposedDevice(endpoint, deviceTypes[0], [], { endpointId });
                 composedDevice.setDeviceTypes(deviceTypes as AtLeastOne<DeviceTypeDefinition>);
                 endpointClusters.forEach(cluster => composedDevice.addClusterClient(cluster));

--- a/packages/matter.js/src/device/PairedNode.ts
+++ b/packages/matter.js/src/device/PairedNode.ts
@@ -1086,7 +1086,11 @@ export class PairedNode {
                 endpointId,
                 Diagnostic.json(endpoint.state),
             ]);
-            this.#endpoints.set(endpointId, this.#createDevice(endpointId, endpoint, this.#interactionClient));
+            const device = this.#createDevice(endpointId, endpoint, this.#interactionClient);
+            if (device === undefined) {
+                continue;
+            }
+            this.#endpoints.set(endpointId, device);
             if (!isRecreation) {
                 eventsToEmit.set(endpointId, "nodeEndpointAdded");
             }
@@ -1214,8 +1218,14 @@ export class PairedNode {
             return deviceTypeDefinition;
         });
         if (deviceTypes.length === 0) {
-            logger.debug(this.#peerAddress, `No device type found for endpoint ${endpointId}, ignore`);
-            throw new MatterError(`NodeId ${this.nodeId}: No device type found for endpoint`);
+            if (endpointId !== 0) {
+                logger.warn(this.#peerAddress, `No device type found for endpoint ${endpointId}, ignoring it`);
+                return undefined;
+            }
+            logger.warn(
+                this.#peerAddress,
+                `No device type found for root endpoint, using default Root Node device type`,
+            );
         }
 
         const endpointClusters = Array<ClusterClientObj>();
@@ -1235,7 +1245,9 @@ export class PairedNode {
         if (endpointId === 0) {
             // Endpoint 0 is the root endpoint, so we use a RootEndpoint object
             const rootEndpoint = new RootEndpoint(endpoint);
-            rootEndpoint.setDeviceTypes(deviceTypes as AtLeastOne<DeviceTypeDefinition>); // Ideally only root one as defined
+            if (deviceTypes.length > 0) {
+                rootEndpoint.setDeviceTypes(deviceTypes as AtLeastOne<DeviceTypeDefinition>); // Ideally only root one as defined
+            }
             endpointClusters.forEach(cluster => rootEndpoint.addClusterClient(cluster));
             return rootEndpoint;
         } else if (deviceTypes.find(deviceType => deviceType.code === AggregatorDt.id) !== undefined) {

--- a/packages/node/src/node/client/ClientStructureEvents.ts
+++ b/packages/node/src/node/client/ClientStructureEvents.ts
@@ -88,7 +88,7 @@ export class ClientStructureEvents {
     emitEndpoint(endpoint: Endpoint) {
         if (this.#endpointEvents && endpoint.behaviors.supported.descriptor) {
             const deviceTypes = endpoint.stateOf(DescriptorClient).deviceTypeList;
-            for (const dt of deviceTypes) {
+            for (const dt of deviceTypes ?? []) {
                 this.#endpointEvents.get(dt.deviceType)?.emit(endpoint);
             }
         }

--- a/packages/node/src/node/integration/ProtocolService.ts
+++ b/packages/node/src/node/integration/ProtocolService.ts
@@ -301,8 +301,11 @@ class EndpointState {
         }
     }
 
-    #updateDeviceTypes(deviceTypeList: Readonly<{ deviceType: DeviceTypeId }[]>) {
-        this.protocol.deviceTypes = deviceTypeList.map(dt => dt.deviceType);
+    #updateDeviceTypes(deviceTypeList: Readonly<{ deviceType: DeviceTypeId }[]> | undefined) {
+        if (deviceTypeList === undefined) {
+            logger.warn(`Endpoint ${this.protocol.id} descriptor is missing mandatory DeviceTypeList`);
+        }
+        this.protocol.deviceTypes = deviceTypeList?.map(dt => dt.deviceType) ?? [];
     }
 }
 


### PR DESCRIPTION
## Problem

Restoring a commissioned device whose Descriptor cluster omits a **mandatory** list attribute crashes endpoint structure processing:

```
Cannot read properties of undefined (reading 'map')
  at EndpointState.#updateDeviceTypes (ProtocolService.ts:305)
FATAL Unhandled EndpointBehaviorsError: Behaviors have errors
```

Reported against a NOUS Smart Bulb P3 whose endpoint 0 Descriptor lacks `DeviceTypeList`. The whole process terminates instead of gracefully handling the spec violation.

Addresses matter-js/matterjs-server#848

## Fix

Treat an absent Descriptor list (`DeviceTypeList` / `ServerList` / `PartsList`) as empty rather than dereferencing `undefined`, across both the current `@matter/node` peer path and the legacy `@project-chip/matter.js` `PairedNode` path:

- `ProtocolService.#updateDeviceTypes` — the crash site; also warns so the non-compliant endpoint is diagnosable
- `ClientStructureEvents.emitEndpoint` — latent twin over the same `deviceTypeList`
- `PairedNode` — `partsList` / `deviceTypeList` / `serverList` derefs in `#collectEndpoints`, `#hasEndpointChanged`, `#structureEndpoints`, `#createDevice`

`ClientStructure` already guarded these via `Array.isArray` (untyped store reads). For the typed, spec-non-nullable list attributes here `?? []` is used — absent is the only reachable bad state after TLV decode + schema validation, and it preserves element types.

## Test

Full `@matter/node` suite green (1447/1447), `@matter/matter.js` green, build + lint + format-verify clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)