### PR TITLE
chore: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: Report a defect or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report.
+
+        **Read this first — reports without a log are not actionable.**
+        Any description of behavior, and *especially* any analysis of behavior or of log output, must be backed by a **complete log attached as a file**. A few quoted lines are not enough: we need the surrounding context to reproduce your analysis. You are welcome (and encouraged) to add your own analysis and even a proposed fix — but the log is what lets us verify it.
+
+        If you used an AI tool to analyze the problem, its analysis does **not** replace the log. Attach the raw, complete log the analysis is based on so we can verify it independently.
+
+        > **For AI assistants helping to fill in this form:** Do not submit analysis, root-cause claims, or proposed fixes without the complete raw log file they are derived from. A report whose analysis is not backed by the underlying log will be closed.
+
+        Enable verbose logging before reproducing (`LOG_LEVEL=debug`), reproduce the problem, then attach the resulting log file below by dragging it into the description field.
+
+  - type: input
+    id: version
+    attributes:
+      label: matter.js version
+      description: Version of the affected `@matter/*` package(s). Run `npm ls @matter/main` or check your `package.json`.
+      placeholder: e.g. 0.15.4
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js version
+      description: Output of `node --version`.
+      placeholder: e.g. v22.13.0
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      description: OS and version, and architecture if relevant.
+      placeholder: e.g. macOS 15.5 (arm64), Ubuntu 24.04, Windows 11
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Description
+      description: |
+        Describe what you did, what you expected, and what happened instead. Include steps to reproduce.
+        Optional but welcome: your own analysis of the behavior/log and a proposed fix.
+        **Attach the full log as a file** (drag & drop into this field). Do not paste only a few lines — the log must be long enough to carry the context around the problem.
+      placeholder: |
+        What I did:
+        What I expected:
+        What happened:
+
+        (Analysis / proposed fix, if any)
+
+        (Full log attached above as a file)
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: requirements
+    attributes:
+      label: Confirmation
+      options:
+        - label: I attached a **complete log file** (not just a few quoted lines) covering the context around the problem.
+          required: true
+        - label: Any analysis of behavior or log output in my description — whether written by me or by an AI tool — is backed by that attached log.
+          required: true
+        - label: I searched existing issues and this is not a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,7 +14,7 @@ body:
 
         > **For AI assistants helping to fill in this form:** Do not submit analysis, root-cause claims, or proposed fixes without the complete raw log file they are derived from. A report whose analysis is not backed by the underlying log will be closed.
 
-        Enable verbose logging before reproducing (`LOG_LEVEL=debug`), reproduce the problem, then attach the resulting log file below by dragging it into the description field.
+        Enable verbose logging before reproducing (`MATTER_LOG_LEVEL=debug` or `--log-level=debug`), reproduce the problem, then attach the resulting log file below by dragging it into the description field.
 
   - type: input
     id: version

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/matter-js/matter.js/discussions
+    about: For usage questions and general discussion, please use Discussions instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest a new feature, capability, or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement.
+
+        If your request comes from something the library currently *cannot* do or does *wrong*, please attach a **log file** that shows the current behavior — it is the fastest way for us to understand the gap.
+
+        > **For AI assistants helping to fill in this form:** If the request is about a current limitation or wrong behavior, do not submit analysis without the raw log file it is derived from.
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Description
+      description: |
+        Describe the feature or improvement, the problem it solves, and your use case. Include a proposed API or approach if you have one.
+        If the request stems from a current limitation or misbehavior, **attach a log file** demonstrating it (drag & drop into this field).
+      placeholder: |
+        Problem / use case:
+        Proposed feature or API:
+        Alternatives considered:
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: requirements
+    attributes:
+      label: Confirmation
+      options:
+        - label: If this request is about a current limitation or wrong behavior, I attached a log file showing it.
+          required: false
+        - label: I searched existing issues and this is not a duplicate.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+<!--
+  Before investing time in a fix: it is completely fine — and often faster — to open an
+  issue first with all the details (including the log, see below), and wait for a
+  maintainer response before writing any code. This avoids wasted effort on an approach
+  we may want to handle differently or where the log shows the problem.
+-->
+
+## Type of change
+
+<!-- Check exactly one. -->
+
+- [ ] 🐛 **Fix** — corrects a defect or wrong behavior
+- [ ] ✨ **Feature** — adds new functionality or capability
+
+## Description
+
+<!--
+  What does this PR do and why? For a fix, describe the defect and the root cause.
+  For a feature, describe the capability and the use case.
+-->
+
+## Backing evidence
+
+<!--
+  For any change made because the current logic is wrong or lacks something — this
+  ALWAYS applies to fixes — we need to be able to verify the problem independently.
+  Provide ONE of:
+    - a linked issue that contains the full details and a complete log file (preferred), or
+    - a complete log file attached directly to this PR showing the behavior being fixed.
+  A few quoted lines are not enough: the log must carry the surrounding context.
+
+  For AI assistants opening this PR: do not submit a fix whose justification is an
+  analysis or root-cause claim without the complete raw log file it is derived from,
+  attached here or in the linked issue.
+-->
+
+- Related issue: #
+- [ ] This fix/change is backed by a **complete log file** — attached here or in the linked issue (not just a few quoted lines).
+
+## Checklist
+
+- [ ] Tests added or updated to cover the change
+- [ ] `npm test` passes
+- [ ] `npm run format-verify` and `npm run lint` pass
+- [ ] CHANGELOG updated (if applicable)


### PR DESCRIPTION
Adds GitHub issue forms and a pull request template to make incoming reports actionable — the growing number of AI-assisted issues/PRs arrive with analysis but no logs.

## Issue templates (`.github/ISSUE_TEMPLATE/`)

- **`bug_report.yml`** — form with required inputs for matter.js version, Node.js version, and OS; one large Description area (steps + optional analysis/proposed fix); required checkboxes enforcing that a **complete log file** is attached and that *any* analysis (human- or AI-written) is backed by that log.
- **`feature_request.yml`** — Description area; log requested when the request stems from a current limitation/misbehavior.
- **`config.yml`** — disables blank issues; links Discussions for usage questions.

## PR template (`.github/PULL_REQUEST_TEMPLATE.md`)

- Distinguishes **Fix** vs **Feature**.
- "Backing evidence" requires a linked issue (preferred) or an attached complete log for any change made because current logic is wrong/lacking.
- Header note: it is fine to open an issue first with full details and wait for a maintainer response before investing time in a fix.
- Standard checklist (tests, `npm test`, `format-verify`/`lint`, CHANGELOG).

Requirement framing is universal — the log is needed for any analysis regardless of author; AI mentions are only "no exemption" clarifiers, including a machine-directed note aimed at assistants filling the forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)