### PR TITLE
fix(node): log peer cluster structure changes at info, not warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,6 @@ The main work (all changes without a GitHub username in brackets in the below li
 	## __WORK IN PROGRESS__
 -->
 
-## __WORK IN PROGRESS__
-
-- @matter/node
-    - Fix: Log peer cluster structure changes (e.g. after a device firmware upgrade) at info level instead of warn
-
 ## 0.17.5 (2026-07-13)
 
 - @matter/\*:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The main work (all changes without a GitHub username in brackets in the below li
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+
+- @matter/node
+    - Fix: Log peer cluster structure changes (e.g. after a device firmware upgrade) at info level instead of warn
+
 ## 0.17.5 (2026-07-13)
 
 - @matter/\*:

--- a/packages/node/src/behavior/internal/BehaviorBacking.ts
+++ b/packages/node/src/behavior/internal/BehaviorBacking.ts
@@ -179,13 +179,9 @@ export abstract class BehaviorBacking {
 
     set type(type: Behavior.Type) {
         if (!type.supports(this.#type)) {
-            // This is unlikely to cause issues because we limit to peer contexts.  In that case we implement elements
-            // fairly expansively regardless of reported support.  So worst case scenario the metadata reported earlier
-            // may be out of sync with the device.  There is a small possibility this causes problems, though, so log a
-            // warning
-            logger.warn(
-                `The cluster for active behavior ${this} may no longer be strictly compatible with local implementation`,
-            );
+            // Peer-only: a changed data version already forced a full re-read, so the new type and its values are
+            // current and the change reaches consumers via ServersChanged.  Informational, not a compatibility fault.
+            logger.info(`Updated behavior ${this} to match changed peer cluster structure`);
         }
         this.#type = type;
     }


### PR DESCRIPTION
## Problem

When a paired peer changes its cluster structure — e.g. after a device firmware upgrade (Matter 1.2 → 1.4 in the reported case) — matter.js logs one `WARN` per affected cluster:

```
WARN BehaviorBacking The cluster for active behavior server-1-fff1.@1:44c.basicInformation may no longer be strictly compatible with local implementation
WARN BehaviorBacking The cluster for active behavior server-1-fff1.@1:44c.networkCommissioning ...
...
```

This is misleading. The `!type.supports(this.#type)` check is a coarse JS-identity/prototype check, so it fires on *any* regenerated peer type, including fully-compatible additive changes.

## Why it's not a warning

- **Peer-only.** Only reached from the client/peer context type swap.
- **Data is current.** The changed data version already forced a full wildcard re-read, so both the regenerated behavior type (schema) and its values are up to date after the swap — there is no genuine staleness.
- **Consumers are notified.** The change is signalled to upper layers via `EndpointLifecycle.Change.ServersChanged` (→ `node_updated`), so they can react.
- **Non-actionable & expected.** Nothing for the operator to fix; routine on firmware upgrades. One `WARN` per cluster is pure noise.

## Change

- `logger.warn` → `logger.info` in the `BehaviorBacking` `type` setter.
- Clearer message: `Updated behavior <path> to match changed peer cluster structure`.
- Comment rewritten to state the invariant (re-read makes it current; reaches consumers via `ServersChanged`).

## Verification

`build`, `format-verify`, `lint`, and `packages/node` tests (1447/1447) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)