### PR TITLE
fix(thread-br-client): correct MeshCoP commissioner keep-alive and release URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The main work (all changes without a GitHub username in brackets in the below li
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+
+- @matter/thread-br-client
+    - Fix: Use the correct MeshCoP commissioner keep-alive URI (`c/ca`) and resign the session with a rejecting keep-alive instead of a nonexistent `c/cr` release URI that Border Routers answered with 4.04
+
 ## 0.17.5 (2026-07-13)
 
 - @matter/\*:

--- a/packages/thread-br-client/src/commissioner/Commissioner.ts
+++ b/packages/thread-br-client/src/commissioner/Commissioner.ts
@@ -5,7 +5,6 @@
  */
 
 import { type Duration, Logger, MatterError, Millis, Seconds, Time, TimeoutError, type Timer } from "@matter/general";
-import { BasicTlv, MeshCopTlvType } from "@matter/protocol";
 import type { CoapClient } from "../coap/CoapClient.js";
 import { LeadKa } from "./LeadKa.js";
 import { LeadPet } from "./LeadPet.js";
@@ -134,7 +133,7 @@ export class Commissioner {
         const response = await this.#coap.request({
             type: "CON",
             code: "0.02",
-            uriPath: ["c", "ka"],
+            uriPath: ["c", "ca"],
             payload: LeadKa.buildRequest(sessionId),
         });
 
@@ -145,33 +144,29 @@ export class Commissioner {
     }
 
     /**
-     * Send a MeshCoP `COMM_REL` (commissioner release) request.
+     * Resign the commissioner session via a MeshCoP `COMM_KA` (keep-alive) with a
+     * rejecting State TLV. Thread has no dedicated release URI on the Border Agent
+     * channel; a keep-alive carrying `State=reject` is how a commissioner relinquishes.
      *
      * Best-effort — CoAP errors are logged at `warn` level and swallowed so a
-     * failed release does not block teardown. The BR will expire the session on
-     * its own if the release is lost.
+     * failed resign does not block teardown. Dropping the DTLS session also makes
+     * the Border Agent revoke the role, so a lost resign is harmless.
      *
      * @param sessionId - Session ID returned by {@link petition}.
      */
     async release(sessionId: number): Promise<void> {
         try {
-            // COMM_REL requires both COMMISSIONER_SESSION_ID and COMMISSIONER_ID (Thread spec Table 8-16).
-            const sessionBytes = new Uint8Array(2);
-            sessionBytes[0] = (sessionId >> 8) & 0xff;
-            sessionBytes[1] = sessionId & 0xff;
-            const releasePayload = BasicTlv.encode([
-                { type: MeshCopTlvType.COMMISSIONER_SESSION_ID, value: sessionBytes },
-                {
-                    type: MeshCopTlvType.COMMISSIONER_ID,
-                    value: new TextEncoder().encode(Commissioner.COMMISSIONER_ID),
-                },
-            ]);
-            await this.#coap.request({
+            const response = await this.#coap.request({
                 type: "CON",
                 code: "0.02",
-                uriPath: ["c", "cr"],
-                payload: releasePayload,
+                uriPath: ["c", "ca"],
+                payload: LeadKa.buildRequest(sessionId, "reject"),
             });
+            // CoapClient resolves 4.xx/5.xx responses rather than throwing, so a rejected
+            // resign is only visible by inspecting the response code.
+            if (!response.code.startsWith("2.")) {
+                logger.warn(`Commissioner release got non-success CoAP response ${response.code} (best-effort)`);
+            }
         } catch (err) {
             logger.warn("Commissioner release failed (best-effort):", err);
         }

--- a/packages/thread-br-client/src/commissioner/LeadKa.ts
+++ b/packages/thread-br-client/src/commissioner/LeadKa.ts
@@ -14,19 +14,26 @@ export interface LeadKaResponse {
     state: "accept" | "reject" | "pending";
 }
 
-/** MeshCoP State TLV value for an "alive" keep-alive (Thread spec Table 8-11). */
+/** MeshCoP State TLV values (Thread spec Table 8-11). */
 const STATE_ACCEPT = 0x01;
+const STATE_REJECT = 0xff;
 
 export namespace LeadKa {
-    export function buildRequest(sessionId: number): Bytes {
+    /**
+     * Build a MGMT_COMMISSIONER_KA.req payload.
+     *
+     * @param sessionId - Commissioner session ID assigned by the Border Router.
+     * @param state - `"accept"` to keep the session alive; `"reject"` to resign it.
+     */
+    export function buildRequest(sessionId: number, state: "accept" | "reject" = "accept"): Bytes {
         const sessionBytes = new Uint8Array(2);
         sessionBytes[0] = (sessionId >> 8) & 0xff;
         sessionBytes[1] = sessionId & 0xff;
-        // MGMT_COMMISSIONER_KA.req carries a State TLV (accept) ahead of the
-        // session id; without it the Border Agent treats the keep-alive as
-        // malformed and lets the commissioner session expire.
+        // MGMT_COMMISSIONER_KA.req carries a State TLV ahead of the session id;
+        // without it the Border Agent treats the keep-alive as malformed and lets
+        // the commissioner session expire.
         return BasicTlv.encode([
-            { type: MeshCopTlvType.STATE, value: new Uint8Array([STATE_ACCEPT]) },
+            { type: MeshCopTlvType.STATE, value: new Uint8Array([state === "reject" ? STATE_REJECT : STATE_ACCEPT]) },
             { type: MeshCopTlvType.COMMISSIONER_SESSION_ID, value: sessionBytes },
         ]);
     }

--- a/packages/thread-br-client/src/diagnostic/MeshCopDiagnosticSource.ts
+++ b/packages/thread-br-client/src/diagnostic/MeshCopDiagnosticSource.ts
@@ -264,8 +264,8 @@ export class MeshCopDiagnosticSource implements DiagnosticSource {
         };
 
         // `done` settles AFTER Commissioner.release() so callers awaiting handle.done / handle.close()
-        // see a clean release before tearing down DTLS. (Without that ordering COMM_REL races socket
-        // close and the BR never sees the release ACK, manifesting as petition-rejected on retry.)
+        // see a clean resign before tearing down DTLS. (Without that ordering the reject keep-alive
+        // races socket close and the BR never sees the ACK, manifesting as petition-rejected on retry.)
         const done = this.#commissioner
             .withSession(async () => {
                 if (closed) return;

--- a/packages/thread-br-client/test/CommissionerTest.ts
+++ b/packages/thread-br-client/test/CommissionerTest.ts
@@ -223,11 +223,13 @@ describe("Commissioner", () => {
     });
 
     describe("keepAlive", () => {
-        it("passes session ID as COMMISSIONER_SESSION_ID TLV", async () => {
+        it("posts to c/ca with the session ID as COMMISSIONER_SESSION_ID TLV", async () => {
+            let capturedUriPath: string[] | undefined;
             let capturedPayload: Uint8Array | undefined;
 
             const mockCoap = {
                 request: async (opts: { uriPath: string[]; payload?: Uint8Array }) => {
+                    capturedUriPath = opts.uriPath;
                     capturedPayload = opts.payload;
                     return ackMessage(buildKaResponse(STATE_ACCEPT));
                 },
@@ -236,8 +238,12 @@ describe("Commissioner", () => {
 
             await new Commissioner(mockCoap).keepAlive(42);
 
+            expect(capturedUriPath).to.deep.equal(["c", "ca"]);
             expect(capturedPayload).to.not.be.undefined;
             const entries = BasicTlv.walk(capturedPayload!);
+            const stateEntry = entries.find(e => e.type === MeshCopTlvType.STATE);
+            expect(stateEntry).to.not.be.undefined;
+            expect(Bytes.of(stateEntry!.value)[0]).to.equal(STATE_ACCEPT);
             const sidEntry = entries.find(e => e.type === MeshCopTlvType.COMMISSIONER_SESSION_ID);
             expect(sidEntry).to.not.be.undefined;
             const sidValue = Bytes.of(sidEntry!.value);
@@ -260,11 +266,13 @@ describe("Commissioner", () => {
     });
 
     describe("release", () => {
-        it("includes both COMMISSIONER_SESSION_ID and COMMISSIONER_ID in payload", async () => {
+        it("resigns via c/ca keep-alive carrying State(reject) and the session ID", async () => {
+            let capturedUriPath: string[] | undefined;
             let capturedPayload: Uint8Array | undefined;
 
             const mockCoap = {
                 request: async (opts: { uriPath: string[]; payload?: Uint8Array }) => {
+                    capturedUriPath = opts.uriPath;
                     capturedPayload = opts.payload;
                     return ackMessage(new Uint8Array());
                 },
@@ -273,15 +281,43 @@ describe("Commissioner", () => {
 
             await new Commissioner(mockCoap).release(42);
 
+            expect(capturedUriPath).to.deep.equal(["c", "ca"]);
             expect(capturedPayload).to.not.be.undefined;
             const entries = BasicTlv.walk(capturedPayload!);
+            const stateEntry = entries.find(e => e.type === MeshCopTlvType.STATE);
             const sidEntry = entries.find(e => e.type === MeshCopTlvType.COMMISSIONER_SESSION_ID);
-            const idEntry = entries.find(e => e.type === MeshCopTlvType.COMMISSIONER_ID);
+            expect(stateEntry).to.not.be.undefined;
+            expect(Bytes.of(stateEntry!.value)[0]).to.equal(STATE_REJECT);
             expect(sidEntry).to.not.be.undefined;
-            expect(idEntry).to.not.be.undefined;
             const sidValue = Bytes.of(sidEntry!.value);
             expect((sidValue[0] << 8) | sidValue[1]).to.equal(42);
-            expect(new TextDecoder().decode(idEntry!.value)).to.equal(Commissioner.COMMISSIONER_ID);
+        });
+
+        it("swallows CoAP errors (best-effort)", async () => {
+            const mockCoap = {
+                request: async () => {
+                    throw new Error("coap boom");
+                },
+                close: async () => {},
+            } as unknown as CoapClient;
+
+            await new Commissioner(mockCoap).release(42);
+        });
+
+        it("tolerates a non-success CoAP response without throwing (best-effort)", async () => {
+            const mockCoap = {
+                request: async () =>
+                    ({
+                        type: "ACK",
+                        code: "4.04",
+                        messageId: 0,
+                        token: new Uint8Array(4),
+                        payload: new Uint8Array(),
+                    }) as CoapMessage,
+                close: async () => {},
+            } as unknown as CoapClient;
+
+            await new Commissioner(mockCoap).release(42);
         });
     });
 

--- a/packages/thread-br-client/test/LeadKaTest.ts
+++ b/packages/thread-br-client/test/LeadKaTest.ts
@@ -35,6 +35,16 @@ describe("LeadKa", () => {
             const entries = BasicTlv.walk(payload);
             expect(entries[1].value).to.deep.equal(new Uint8Array([0x00, 0x00]));
         });
+
+        it("encodes State(reject) when resigning", () => {
+            const payload = LeadKa.buildRequest(0x0007, "reject");
+            const entries = BasicTlv.walk(payload);
+            expect(entries).to.have.lengthOf(2);
+            expect(entries[0].type).to.equal(MeshCopTlvType.STATE);
+            expect(entries[0].value).to.deep.equal(new Uint8Array([0xff]));
+            expect(entries[1].type).to.equal(MeshCopTlvType.COMMISSIONER_SESSION_ID);
+            expect(entries[1].value).to.deep.equal(new Uint8Array([0x00, 0x07]));
+        });
     });
 
     describe("parseResponse", () => {


### PR DESCRIPTION
## Problem

Reported via a user gathering Thread topology from Home Assistant: reloading the OTBR node in the matter-server dashboard triggers warnings in the OTBR log on **every** diagnostics gather.

Root cause — two wrong Thread MeshCoP CoAP URIs in `Commissioner.ts`:

| operation | before | correct (OpenThread `uri_paths`) |
|---|---|---|
| keep-alive | `c/ka` | `c/ca` |
| release | `c/cr` (does not exist) | — no dedicated release URI |

The `c/cr` release POST returns `4.04 NotFound` from the Border Agent, producing the log noise (`Coap: Failed to process request - NotFound` + the mbedtls close-notify spam). Thread has no dedicated release URI on the Border Agent channel — a commissioner relinquishes by sending a keep-alive with `State=reject` (matches OpenThread's own `Commissioner::SendKeepAlive` resign path).

The keep-alive URI bug was latent: matter-server's gather ops finish under the 40s keep-alive interval by default (topology 20s, scans 30s), so no keep-alive ever fired.

## Fix

- keep-alive → `c/ca`
- release → resign via `c/ca` keep-alive carrying `State=reject` (also frees the commissioner slot immediately, so a fast re-reload no longer risks petition-rejected)
- `LeadKa.buildRequest` gains a `state` param (`accept` default / `reject`)
- `release()` now inspects the CoAP response code and warns on non-2.xx — `CoapClient` resolves 4.xx/5.xx rather than throwing, which is exactly why the original 404 went unnoticed

## Tests

Unit tests assert the `c/ca` URI and reject state for both keep-alive and release (a future URI regression now fails at the unit level). Package: ESM 763/763, CJS 763/763.

🤖 Generated with [Claude Code](https://claude.com/claude-code)