### PR TITLE
fix(types): guard nested-struct recursion in ObjectSchema inject/removeField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 ## __WORK IN PROGRESS__
 
+- @matter/types
+    - Fix: `ObjectSchema.injectField`/`removeField` no longer crash on fabric-scoped commands that omit an optional nested struct field
+
 - @matter/thread-br-client
     - Fix: Use the correct MeshCoP commissioner keep-alive URI (`c/ca`) and resign the session with a rejecting keep-alive instead of a nonexistent `c/cr` release URI that Border Routers answered with 4.04
 

--- a/packages/types/src/tlv/TlvObject.ts
+++ b/packages/types/src/tlv/TlvObject.ts
@@ -307,7 +307,7 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
                     field.schema.validate(fieldValue); // Make sure type matches
                     (value as any)[k] = fieldValue;
                 }
-            } else {
+            } else if ((value as any)[k] !== undefined && (value as any)[k] !== null) {
                 (value as any)[k] = field.schema.injectField((value as any)[k], fieldId, fieldValue, injectChecker);
             }
         }
@@ -326,7 +326,7 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
                 if ((value as any)[k] !== undefined && removeChecker((value as any)[k])) {
                     delete (value as any)[k];
                 }
-            } else {
+            } else if ((value as any)[k] !== undefined && (value as any)[k] !== null) {
                 (value as any)[k] = field.schema.removeField((value as any)[k], fieldId, removeChecker);
             }
         }

--- a/packages/types/src/tlv/TlvObject.ts
+++ b/packages/types/src/tlv/TlvObject.ts
@@ -301,14 +301,15 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
     ): TypeFromFields<F> {
         for (const k in this.fieldDefinitions) {
             const field = this.fieldDefinitions[k] as FieldType<any>;
+            const fieldValueOfK = (value as any)[k];
 
             if (field.id === fieldId) {
-                if (injectChecker((value as any)[k])) {
+                if (injectChecker(fieldValueOfK)) {
                     field.schema.validate(fieldValue); // Make sure type matches
                     (value as any)[k] = fieldValue;
                 }
-            } else if ((value as any)[k] !== undefined && (value as any)[k] !== null) {
-                (value as any)[k] = field.schema.injectField((value as any)[k], fieldId, fieldValue, injectChecker);
+            } else if (fieldValueOfK !== undefined && fieldValueOfK !== null) {
+                (value as any)[k] = field.schema.injectField(fieldValueOfK, fieldId, fieldValue, injectChecker);
             }
         }
         return value;
@@ -321,13 +322,14 @@ export class ObjectSchema<F extends TlvFields> extends TlvSchema<TypeFromFields<
     ): TypeFromFields<F> {
         for (const k in this.fieldDefinitions) {
             const field = this.fieldDefinitions[k] as FieldType<any>;
+            const fieldValueOfK = (value as any)[k];
 
             if (field.id === fieldId) {
-                if ((value as any)[k] !== undefined && removeChecker((value as any)[k])) {
+                if (fieldValueOfK !== undefined && removeChecker(fieldValueOfK)) {
                     delete (value as any)[k];
                 }
-            } else if ((value as any)[k] !== undefined && (value as any)[k] !== null) {
-                (value as any)[k] = field.schema.removeField((value as any)[k], fieldId, removeChecker);
+            } else if (fieldValueOfK !== undefined && fieldValueOfK !== null) {
+                (value as any)[k] = field.schema.removeField(fieldValueOfK, fieldId, removeChecker);
             }
         }
         return value;

--- a/packages/types/test/tlv/TlvObjectTest.ts
+++ b/packages/types/test/tlv/TlvObjectTest.ts
@@ -262,6 +262,16 @@ describe("TlvObject tests", () => {
                     { mandatoryField: 2, optionalField: "test" },
                 ]);
             });
+
+            it("injects field value when an optional nested struct field is omitted", () => {
+                const schema = TlvObject({
+                    nested: TlvOptionalField(2, TlvObject({ cipherSuite: TlvField(0, TlvUInt8) })),
+                    fabricIndex: TlvField(254, TlvFabricIndex),
+                });
+
+                const result = schema.injectField({ fabricIndex: FabricIndex(0) }, 254, FabricIndex(1), () => true);
+                expect(result).deep.equal({ fabricIndex: FabricIndex(1) });
+            });
         });
 
         describe("ValidationError", () => {
@@ -322,6 +332,16 @@ describe("TlvObject tests", () => {
                     () => true,
                 );
                 expect(result).deep.equal([{ mandatoryField: 1 }, { mandatoryField: 2 }]);
+            });
+
+            it("removes field value when an optional nested struct field is omitted", () => {
+                const schema = TlvObject({
+                    nested: TlvOptionalField(2, TlvObject({ cipherSuite: TlvField(0, TlvUInt8) })),
+                    fabricIndex: TlvField(254, TlvFabricIndex),
+                });
+
+                const result = schema.removeField({ fabricIndex: FabricIndex(1) }, 254, () => true);
+                expect(result).deep.equal({});
             });
         });
     });


### PR DESCRIPTION
## Problem

`ObjectSchema.injectField` (and its sibling `removeField`) recursed into optional nested struct fields even when the field value was `undefined`, throwing `Cannot read properties of undefined (reading 'cipherSuite')` while decoding fabric-scoped commands that omit an optional struct field.

Reproduces for any fabric-scoped command with an omitted optional struct-typed field — surfaced with `WebRtcTransportProvider.ProvideOffer` invoked without the optional `SFrameConfig`.

```
[InteractionMessenger] Cannot read properties of undefined (reading 'cipherSuite')
  at ObjectSchema.injectField (@matter/types/.../TlvObject.js)
  at #decodeWithSchema (@matter/protocol/.../CommandInvokeResponse.js)
```

`CommandInvokeResponse#decodeWithSchema` always injects the accessing `fabricIndex` via `tlv.injectField(...)`; the recursion then descended into the omitted nested struct whose value was `undefined`.

## Fix

Guard the else-branch recursion in both `injectField` and `removeField` so it only descends into present (`!== undefined && !== null`) values. This mirrors the existing `value[k] !== undefined` guard already present in `removeField`'s `field.id === fieldId` branch — the else-branch was missing the equivalent in both methods.

## Tests

Added inject + remove cases covering an omitted optional nested struct field. Both reproduced the exact crash before the fix and pass after.

Fixes #4083

🤖 Generated with [Claude Code](https://claude.com/claude-code)