### PR TITLE
fix(node): rebuild client behavior when peer cluster structure changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 ## __WORK IN PROGRESS__
 
+- @matter/node
+    - Fix: Attributes added when a peer cluster gains features at runtime are now readable
+
 - @matter/thread-br-client
     - Fix: Use the correct MeshCoP commissioner keep-alive URI (`c/ca`) and resign the session with a rejecting keep-alive instead of a nonexistent `c/cr` release URI that Border Routers answered with 4.04
 

--- a/packages/node/src/behavior/internal/BehaviorBacking.ts
+++ b/packages/node/src/behavior/internal/BehaviorBacking.ts
@@ -178,12 +178,41 @@ export abstract class BehaviorBacking {
     }
 
     set type(type: Behavior.Type) {
-        if (!type.supports(this.#type)) {
-            // Peer-only: a changed data version already forced a full re-read, so the new type and its values are
-            // current and the change reaches consumers via ServersChanged.  Informational, not a compatibility fault.
-            logger.info(`Updated behavior ${this} to match changed peer cluster structure`);
+        if (type.supports(this.#type)) {
+            this.#type = type;
+            return;
         }
+
+        // Peer-only: a changed data version already forced a full re-read, so the new type and its values are
+        // current and the change reaches consumers via ServersChanged.  Informational, not a compatibility fault.
+        logger.info(`Updated behavior ${this} to match changed peer cluster structure`);
         this.#type = type;
+
+        this.refreshForChangedType();
+    }
+
+    /**
+     * Rebuild state derived from {@link type} after the backed cluster structure changes.  Derivatives that cache
+     * additional type-derived data override to refresh it.
+     */
+    protected refreshForChangedType() {
+        const datasource = this.#datasource;
+        if (datasource === undefined) {
+            return;
+        }
+
+        // Server stores can't reseed a rebuilt datasource, so recreating would reset their state to defaults; only
+        // externally-mutable (peer) stores reclaim their live values.
+        const store = this.store;
+        if (!("reclaimValues" in store) || typeof store.reclaimValues !== "function") {
+            return;
+        }
+
+        // Move live values back to the store so the rebuilt datasource re-seeds from current data, not defaults.
+        store.reclaimValues();
+
+        datasource.close();
+        this.#datasource = Datasource(this.datasourceOptions);
     }
 
     /**

--- a/packages/node/src/behavior/internal/ClientBehaviorBacking.ts
+++ b/packages/node/src/behavior/internal/ClientBehaviorBacking.ts
@@ -56,6 +56,13 @@ export class ClientBehaviorBacking extends BehaviorBacking {
         return options;
     }
 
+    protected override refreshForChangedType() {
+        // Elements are cached from the old schema; drop so they rebuild from the new type.  Base rebuilds the datasource.
+        this.#elements = undefined;
+
+        super.refreshForChangedType();
+    }
+
     /**
      * Map attribute ID keys back to property names before broadcasting.
      *

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -29,6 +29,7 @@ import { AggregatorEndpoint } from "#endpoints/aggregator";
 import type { ClientEndpointInitializer } from "#node/client/ClientEndpointInitializer.js";
 import { ClientNodeFactory } from "#node/client/ClientNodeFactory.js";
 import { ClientStructureEvents } from "#node/client/ClientStructureEvents.js";
+import { ChangeNotificationService } from "#node/integration/ChangeNotificationService.js";
 import { ServerNode } from "#node/ServerNode.js";
 import { ClientCacheBuffer } from "#storage/client/ClientCacheBuffer.js";
 import {
@@ -1496,6 +1497,140 @@ describe("ClientNode", () => {
 
         newValue = await MockTime.resolve(sawChange);
         expect(newValue).equals(1200);
+    });
+
+    it("exposes attributes added by a behavior replace", async () => {
+        // *** SETUP ***
+
+        const LiftWc = WindowCoveringServer.with("Lift", "PositionAwareLift").set({
+            currentPositionLiftPercent100ths: 0,
+        });
+
+        await using site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair({
+            device: {
+                type: ServerNode.RootEndpoint,
+                device: WindowCoveringDevice.with(LiftWc),
+            },
+        });
+
+        const peer1 = controller.peers.get("peer1")!;
+        const clientEp1 = peer1.parts.get("ep1")!;
+        expect(clientEp1).not.undefined;
+
+        const serverEp1 = device.parts.get("part0")!;
+        expect(serverEp1).not.undefined;
+
+        // Tilt attribute is not part of the Lift-only schema, so reading it must fail before the replace
+        await expect(
+            MockTime.resolve(clientEp1.getStateOf(WindowCoveringClient, ["currentPositionTiltPercent100ths"])),
+        ).rejectedWith(/currentPositionTiltPercent100ths/);
+
+        // *** REPLACE CLUSTER ADDING TILT ***
+
+        await MockTime.resolve(device.stop());
+        await serverEp1.erase();
+
+        const LiftTiltWc = WindowCoveringServer.with("Lift", "PositionAwareLift", "Tilt", "PositionAwareTilt").set({
+            type: WindowCovering.WindowCoveringType.Unknown,
+            currentPositionLiftPercent100ths: 0,
+            currentPositionTiltPercent100ths: 0,
+        });
+
+        // Nudge so version number changes, otherwise new endpoint won't sync
+        device.env.set(Entropy, MockCrypto(0x20));
+
+        await device.add({
+            type: WindowCoveringDevice.with(LiftTiltWc),
+            number: 1,
+            id: "part0b",
+        });
+
+        const replaced = new Promise(resolve => peer1.env.get(ClientStructureEvents).clusterReplaced.on(resolve));
+
+        await MockTime.resolve(device.start());
+        await MockTime.resolve(replaced);
+
+        // *** VALIDATE ***
+
+        // The attribute added by the Tilt feature must now be readable rather than reported absent
+        const tilt = await MockTime.resolve(
+            clientEp1.getStateOf(WindowCoveringClient, ["currentPositionTiltPercent100ths"]),
+        );
+        expect(tilt).deep.equals({ currentPositionTiltPercent100ths: 0 });
+
+        // The local featureMap view must reflect the new feature set, not the stale Lift-only one
+        expect((clientEp1.stateOf(WindowCoveringClient) as unknown as GlobalAttributeState).featureMap).deep.equals({
+            lift: true,
+            positionAwareLift: true,
+            tilt: true,
+            positionAwareTilt: true,
+        });
+
+        // The local state view must include the attribute added by the Tilt feature
+        expect(clientEp1.stateOf(WindowCoveringClient).currentPositionTiltPercent100ths).equals(0);
+    });
+
+    it("propagates global attribute changes to the change notification service", async () => {
+        // *** SETUP ***
+
+        const LiftWc = WindowCoveringServer.with("Lift", "PositionAwareLift").set({
+            currentPositionLiftPercent100ths: 0,
+        });
+
+        await using site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair({
+            device: {
+                type: ServerNode.RootEndpoint,
+                device: WindowCoveringDevice.with(LiftWc),
+            },
+        });
+
+        const peer1 = controller.peers.get("peer1")!;
+        const serverEp1 = device.parts.get("part0")!;
+
+        const globalUpdates = new Array<{ properties?: string[] }>();
+        const changeService = controller.env.get(ChangeNotificationService);
+        changeService.change.on(change => {
+            if (
+                change.kind === "update" &&
+                (change.behavior as ClusterBehavior.Type).cluster?.id === WindowCoveringClient.cluster.id &&
+                change.properties?.some(p => p === "featureMap" || p === "attributeList")
+            ) {
+                globalUpdates.push({ properties: change.properties });
+            }
+        });
+
+        // *** REPLACE CLUSTER ADDING TILT ***
+
+        await MockTime.resolve(device.stop());
+        await serverEp1.erase();
+
+        const LiftTiltWc = WindowCoveringServer.with("Lift", "PositionAwareLift", "Tilt", "PositionAwareTilt").set({
+            type: WindowCovering.WindowCoveringType.Unknown,
+            currentPositionLiftPercent100ths: 0,
+            currentPositionTiltPercent100ths: 0,
+        });
+
+        device.env.set(Entropy, MockCrypto(0x20));
+
+        await device.add({
+            type: WindowCoveringDevice.with(LiftTiltWc),
+            number: 1,
+            id: "part0b",
+        });
+
+        const replaced = new Promise(resolve => peer1.env.get(ClientStructureEvents).clusterReplaced.on(resolve));
+
+        await MockTime.resolve(device.start());
+        await MockTime.resolve(replaced);
+
+        // *** VALIDATE ***
+
+        expect(
+            globalUpdates.length,
+            "featureMap/attributeList change must reach the change notification service",
+        ).not.equals(0);
     });
 
     it("correctly removes behavior", async () => {

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -5,7 +5,6 @@
  */
 
 import { ClusterBehavior } from "#behavior/cluster/ClusterBehavior.js";
-import { GlobalAttributeState } from "#behavior/cluster/ClusterState.js";
 import { CommissioningClient } from "#behavior/system/commissioning/CommissioningClient.js";
 import { RemoteDescriptor } from "#behavior/system/commissioning/RemoteDescriptor.js";
 import { ControllerBehavior } from "#behavior/system/controller/ControllerBehavior.js";
@@ -1477,7 +1476,7 @@ describe("ClientNode", () => {
 
         await MockTime.resolve(replaced);
 
-        expect((clientEp1.stateOf(WindowCoveringClient) as unknown as GlobalAttributeState).featureMap).deep.equals({
+        expect(clientEp1.globalsOf(WindowCoveringClient).featureMap).deep.equals({
             lift: true,
             positionAwareLift: true,
             tilt: true,
@@ -1560,7 +1559,7 @@ describe("ClientNode", () => {
         expect(tilt).deep.equals({ currentPositionTiltPercent100ths: 0 });
 
         // The local featureMap view must reflect the new feature set, not the stale Lift-only one
-        expect((clientEp1.stateOf(WindowCoveringClient) as unknown as GlobalAttributeState).featureMap).deep.equals({
+        expect(clientEp1.globalsOf(WindowCoveringClient).featureMap).deep.equals({
             lift: true,
             positionAwareLift: true,
             tilt: true,
@@ -1594,7 +1593,8 @@ describe("ClientNode", () => {
         changeService.change.on(change => {
             if (
                 change.kind === "update" &&
-                (change.behavior as ClusterBehavior.Type).cluster?.id === WindowCoveringClient.cluster.id &&
+                ClusterBehavior.is(change.behavior) &&
+                change.behavior.cluster.id === WindowCoveringClient.cluster.id &&
                 change.properties?.some(p => p === "featureMap" || p === "attributeList")
             ) {
                 globalUpdates.push({ properties: change.properties });


### PR DESCRIPTION
## Problem

When a peer's cluster structure changes at runtime (e.g. a firmware upgrade adds features and their attributes), `inject()` swaps the backing's `#type` in place via `set type`. Two type-derived caches were never rebuilt:

- **`ClientBehaviorBacking.#elements`** — the supported attribute/command set. `#performRead` validates against it, so a newly-added attribute (e.g. ICD `operatingMode`) threw `AttributeNotPresentError` until the controller was reinitialized.
- **base `#datasource`** — built once with the old supervisor/schema, so new attributes were absent from the local view and `featureMap` decoded against stale feature bits (read back as `0`).

The "add new behavior" path always worked because it builds a fresh backing; only the in-place "replace existing" path swapped the type without refreshing derived state. `featuresOf` reads `type.features` directly, so it was never broken — which masked the gap in existing tests.

## Fix

On a structural type change (`!type.supports(old)`), `set type` now calls `refreshForChangedType()`:

- base `BehaviorBacking` rebuilds the datasource against the new supervisor, preserving current values (reclaim → re-seed; version re-read from the store). Guarded so only externally-mutable (peer) stores rebuild — server datasources are left untouched.
- `ClientBehaviorBacking` additionally clears its `#elements` cache.

## Tests

`packages/node/test/node/ClientNodeTest.ts`:
- reproduces the attribute-not-present failure + stale local view + stale featureMap after a feature-adding replace (fails before the fix);
- a guard asserting global-attribute (featureMap/attributeList) changes reach the change-notification service.

Full `@matter/node` suite green (1458 ESM/CJS, 1449 Web), format + lint clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)