### PR TITLE
fix(protocol): unblock BleScanner.close() from orphaning timeout-less continuous discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/node
     - Fix: Attributes added when a peer cluster gains features at runtime are now readable
 
+- @matter/protocol
+    - Fix: `BleScanner.close()` no longer orphans a timeout-less continuous discovery, which previously blocked shutdown when a BLE commission was in flight
+
 - @matter/thread-br-client
     - Fix: Use the correct MeshCoP commissioner keep-alive URI (`c/ca`) and resign the session with a rejecting keep-alive instead of a nonexistent `c/cr` release URI that Border Routers answered with 4.04
 

--- a/packages/protocol/src/common/BleScanner.ts
+++ b/packages/protocol/src/common/BleScanner.ts
@@ -67,6 +67,7 @@ export class BleScanner implements Scanner {
         }
     >();
     readonly #discoveredMatterDevices = new Map<string, StoredDiscoveredBleDevice>();
+    #closed = false;
 
     constructor(client: BleScannerClient) {
         this.#client = client;
@@ -363,7 +364,7 @@ export class BleScanner implements Scanner {
             },
         );
 
-        while (!canceled) {
+        while (!canceled && !this.#closed) {
             this.#getCommissionableDevices(identifier).forEach(({ deviceData }) => {
                 const { deviceIdentifier } = deviceData;
                 if (!discoveredDevices.has(deviceIdentifier)) {
@@ -395,9 +396,12 @@ export class BleScanner implements Scanner {
     }
 
     async close() {
+        // A continuous-discovery loop is driven by an external cancelSignal, so it has no cancelResolver we can
+        // trigger here; #closed makes the loop exit instead of re-registering after we resolve its awaiter.
+        this.#closed = true;
         await this.closeClient();
-        [...this.#recordWaiters.keys()].forEach(queryId =>
-            this.#finishWaiter(queryId, !!this.#recordWaiters.get(queryId)?.timer),
-        );
+        for (const queryId of [...this.#recordWaiters.keys()]) {
+            this.#finishWaiter(queryId, true);
+        }
     }
 }

--- a/packages/protocol/src/common/BleScanner.ts
+++ b/packages/protocol/src/common/BleScanner.ts
@@ -399,9 +399,12 @@ export class BleScanner implements Scanner {
         // A continuous-discovery loop is driven by an external cancelSignal, so it has no cancelResolver we can
         // trigger here; #closed makes the loop exit instead of re-registering after we resolve its awaiter.
         this.#closed = true;
-        await this.closeClient();
-        for (const queryId of [...this.#recordWaiters.keys()]) {
-            this.#finishWaiter(queryId, true);
+        try {
+            await this.closeClient();
+        } finally {
+            for (const queryId of [...this.#recordWaiters.keys()]) {
+                this.#finishWaiter(queryId, true);
+            }
         }
     }
 }

--- a/packages/protocol/test/common/BleScannerTest.ts
+++ b/packages/protocol/test/common/BleScannerTest.ts
@@ -96,4 +96,45 @@ describe("BleScanner", () => {
             expect(scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 1000 })).to.have.lengthOf(1);
         });
     });
+
+    describe("close", () => {
+        it("settles a timeout-less continuous discovery driven by an external cancel signal", async () => {
+            const client = new MockBleScannerClient();
+            const scanner = new BleScanner(client);
+
+            // Mirrors Discovery.ts: no timeout, external cancelSignal that never resolves during shutdown.
+            const cancelSignal = new Promise<void>(() => {});
+
+            let settled = false;
+            const discovery = scanner
+                .findCommissionableDevicesContinuously({ longDiscriminator: 1737 }, () => {}, undefined, cancelSignal)
+                .then(() => (settled = true));
+
+            await Promise.resolve();
+            expect(settled).to.equal(false);
+
+            await scanner.close();
+            await discovery;
+
+            expect(settled).to.equal(true);
+        });
+
+        it("settles a timeout-less continuous discovery with an internal cancel signal", async () => {
+            const client = new MockBleScannerClient();
+            const scanner = new BleScanner(client);
+
+            let settled = false;
+            const discovery = scanner
+                .findCommissionableDevicesContinuously({ longDiscriminator: 1737 }, () => {})
+                .then(() => (settled = true));
+
+            await Promise.resolve();
+            expect(settled).to.equal(false);
+
+            await scanner.close();
+            await discovery;
+
+            expect(settled).to.equal(true);
+        });
+    });
 });

--- a/packages/protocol/test/common/BleScannerTest.ts
+++ b/packages/protocol/test/common/BleScannerTest.ts
@@ -15,8 +15,11 @@ class MockBleScannerClient implements BleScannerClient {
     setDiscoveryCallback(callback: (peripheral: BlePeripheral, data: Bytes) => void) {
         this.callback = callback;
     }
+    stopScanningError?: Error;
     async startScanning() {}
-    async stopScanning() {}
+    async stopScanning() {
+        if (this.stopScanningError) throw this.stopScanningError;
+    }
 
     discover(address: string, data: Bytes) {
         this.callback!({ address }, data);
@@ -135,6 +138,20 @@ describe("BleScanner", () => {
             await discovery;
 
             expect(settled).to.equal(true);
+        });
+
+        it("releases waiters and rethrows when the client fails to stop scanning", async () => {
+            const client = new MockBleScannerClient();
+            client.stopScanningError = new Error("stop failed");
+            const scanner = new BleScanner(client);
+
+            // Would hang (mocha timeout) if close() left the waiter orphaned on the closeClient() throw.
+            const discovery = scanner.findCommissionableDevicesContinuously({ longDiscriminator: 1737 }, () => {});
+
+            await Promise.resolve();
+
+            await expect(scanner.close()).to.be.rejectedWith("stop failed");
+            await expect(discovery).to.be.rejectedWith("stop failed");
         });
     });
 });


### PR DESCRIPTION
## Problem

Ctrl-C on a BLE-proxy commissioning app **never exits** when a BLE commission is in flight on the error path. Process hangs right after:

```
BleScanner  Finishing waiter for query SD:14, resolving: false
```

`RuntimeService.close()` does `cancel(); await this.inactive;`. `inactive` resolves only when all runtime workers finish. The in-flight commission is a worker stuck inside `BleScanner.findCommissionableDevicesContinuously`, sitting on a timeout-less waiter.

At shutdown `BleScanner.close()` ran `#finishWaiter(id, !!timer)`. For a continuous discovery started **without a timeout** there is no timer, so it passed `false` — `#finishWaiter` then **deletes the waiter without resolving it**. The `await promise` inside `#registerWaiterPromise` is orphaned forever, the `while` loop never returns, the worker never completes, and `await inactive` hangs.

Only reproduces on the error path (BLE connect fail, or a later commission step failing) — on success PASE wins, the discovery's cancelSignal fires, and the loop exits cleanly before shutdown.

## Fix

The sole production caller (`Discovery.ts`) drives the loop with an **external `cancelSignal`**, so the waiter has no `cancelResolver` that `close()` can trigger — just resolving the awaiter would leave `canceled === false` and the loop would re-register and hang again.

- Add a `#closed` flag the discovery loop checks (`while (!canceled && !this.#closed)`) so it exits instead of re-registering.
- `close()` sets `#closed = true`, then resolves all waiters unconditionally.

## Tests

Regression tests for both the external-cancelSignal path (mirrors production, the actual failure) and the internal-signal path — assert the discovery promise settles after `close()`. Verified both hang (mocha timeout, exact `resolving: false` symptom) against the unfixed source.

Full `@matter/protocol` suite green (1444/1444 ESM/CJS/Web), format-verify and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)