### PR TITLE
fix: repair behavior events observer transplant on drop/re-inject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,12 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 ## __WORK IN PROGRESS__
 
+- @matter/general
+    - Fix: `Observable.detachObservers()` now disarms the source observable and `attachObservers()` preserves once-semantics of the transferred observers
+
 - @matter/node
     - Fix: Attributes added when a peer cluster gains features at runtime are now readable
+    - Fix: Event listeners now survive a behavior drop/re-inject cycle (observer transplant was silently dropping them) and the rebuilt events surface is correctly wired for event reporting
 
 - @matter/protocol
     - Fix: `BleScanner.close()` no longer orphans a timeout-less continuous discovery, which previously blocked shutdown when a BLE commission was in flight

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ The main work (all changes without a GitHub username in brackets in the below li
 ## __WORK IN PROGRESS__
 
 - @matter/general
-    - Fix: `Observable.detachObservers()` now disarms the source observable and `attachObservers()` preserves once-semantics of the transferred observers
+    - Fix: `Observable.detachObservers()` now disarms the source observable (including active async iteration) and `attachObservers()` preserves once-semantics of the transferred observers
+    - Fix: Async iteration over an `Observable` now delivers emitted values (previously it ended immediately) and terminates cleanly on dispose instead of spinning
 
 - @matter/node
     - Fix: Attributes added when a peer cluster gains features at runtime are now readable

--- a/packages/general/src/util/Observable.ts
+++ b/packages/general/src/util/Observable.ts
@@ -427,10 +427,14 @@ export class BasicObservable<T extends any[] = any[], R = void> implements Obser
             return;
         }
 
-        return {
+        const detached = {
             observers: this.#observers,
             once: this.#once,
         };
+
+        this.#observers = this.#once = undefined;
+
+        return detached;
     }
 
     attachObservers(detached: DetachedObservers<T, R>) {
@@ -438,7 +442,7 @@ export class BasicObservable<T extends any[] = any[], R = void> implements Obser
             return;
         }
         for (const observer of detached.observers) {
-            if (this.#once?.has(observer)) {
+            if (detached.once?.has(observer)) {
                 this.once(observer);
             } else {
                 this.on(observer);

--- a/packages/general/src/util/Observable.ts
+++ b/packages/general/src/util/Observable.ts
@@ -412,10 +412,11 @@ export class BasicObservable<T extends any[] = any[], R = void> implements Obser
         try {
             while (promise) {
                 const next = await promise;
-                if (next) {
-                    promise = next.promise;
-                    yield next.value[0];
+                if (!next) {
+                    break;
                 }
+                promise = next.promise;
+                yield next.value[0];
             }
         } finally {
             this.#removeIterator?.();
@@ -423,7 +424,9 @@ export class BasicObservable<T extends any[] = any[], R = void> implements Obser
     }
 
     detachObservers(): DetachedObservers<T, R> | undefined {
-        if (!this.#observers) {
+        this.#stopIteration?.();
+
+        if (!this.#observers?.size) {
             return;
         }
 
@@ -467,7 +470,7 @@ export class BasicObservable<T extends any[] = any[], R = void> implements Obser
         function observer(...args: T): undefined {
             const oldResolve = resolve;
             promise = newPromise();
-            oldResolve({ value: args[0], promise });
+            oldResolve({ value: args, promise });
         }
 
         this.on(observer);
@@ -478,7 +481,7 @@ export class BasicObservable<T extends any[] = any[], R = void> implements Obser
         };
 
         this.#removeIterator = () => {
-            if (!iteratorCount--) {
+            if (!--iteratorCount) {
                 this.#stopIteration?.();
             }
         };
@@ -486,9 +489,12 @@ export class BasicObservable<T extends any[] = any[], R = void> implements Obser
         this.#stopIteration = () => {
             this.off(observer);
             resolve(undefined);
+            this.#joinIteration = undefined;
             this.#stopIteration = undefined;
             this.#removeIterator = undefined;
         };
+
+        return promise;
     }
 }
 

--- a/packages/general/test/util/ObservableTest.ts
+++ b/packages/general/test/util/ObservableTest.ts
@@ -78,6 +78,74 @@ describe("Observable", () => {
         expect(persistentValues).deep.equals([1, 2]);
     });
 
+    it("ends active iteration on dispose", async () => {
+        const source = new BasicObservable<[value: number]>();
+
+        const iterator = source[Symbol.asyncIterator]();
+        const first = iterator.next();
+        await Promise.resolve();
+
+        source[Symbol.dispose]();
+
+        expect((await first).done).true;
+    });
+
+    it("disarms source when last iterator exits", async () => {
+        const source = new BasicObservable<[value: number]>();
+
+        const iterator = source[Symbol.asyncIterator]();
+        const first = iterator.next();
+        await Promise.resolve();
+
+        expect(source.isObserved).true;
+        source.emit(1);
+        expect((await first).value).equals(1);
+
+        await iterator.return?.(undefined);
+
+        expect(source.isObserved).false;
+    });
+
+    it("supports new iteration after previous iteration stopped", async () => {
+        const source = new BasicObservable<[value: number]>();
+
+        const iterator1 = source[Symbol.asyncIterator]();
+        const first = iterator1.next();
+        await Promise.resolve();
+        source[Symbol.dispose]();
+        await first;
+
+        const iterator2 = source[Symbol.asyncIterator]();
+        const second = iterator2.next();
+        await Promise.resolve();
+        source.emit(3);
+
+        expect((await second).value).equals(3);
+    });
+
+    it("ends active iteration on detach and transfers only explicit observers", async () => {
+        const source = new BasicObservable<[value: number]>();
+
+        const values = new Array<number>();
+        source.on(value => {
+            values.push(value);
+        });
+
+        const iterator = source[Symbol.asyncIterator]();
+        const first = iterator.next();
+        await Promise.resolve();
+
+        const detached = source.detachObservers();
+        expect(detached).not.undefined;
+        expect((await first).done).true;
+        expect(detached!.observers?.size).equals(1);
+
+        const target = new BasicObservable<[value: number]>();
+        target.attachObservers(detached!);
+        target.emit(2);
+        expect(values).deep.equals([2]);
+    });
+
     it("disarms the source on detach", () => {
         const source = new BasicObservable<[value: number]>();
 

--- a/packages/general/test/util/ObservableTest.ts
+++ b/packages/general/test/util/ObservableTest.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AsyncObservable, Observable, ObservableValue, ObserverGroup } from "#util/Observable.js";
+import { AsyncObservable, BasicObservable, Observable, ObservableValue, ObserverGroup } from "#util/Observable.js";
 
 // Observable deserves proper unit tests but is tested heavily via other modules.  Currently this file just tests a
 // few spot cases
@@ -50,6 +50,47 @@ describe("ObservableGroup", () => {
         observers.close();
 
         expect(observable.isObserved).false;
+    });
+});
+
+describe("Observable", () => {
+    it("preserves once semantics across detach/attach", () => {
+        const source = new BasicObservable<[value: number]>();
+        const target = new BasicObservable<[value: number]>();
+
+        const onceValues = new Array<number>();
+        const persistentValues = new Array<number>();
+        source.once(value => {
+            onceValues.push(value);
+        });
+        source.on(value => {
+            persistentValues.push(value);
+        });
+
+        const detached = source.detachObservers();
+        expect(detached).not.undefined;
+        target.attachObservers(detached!);
+
+        target.emit(1);
+        target.emit(2);
+
+        expect(onceValues).deep.equals([1]);
+        expect(persistentValues).deep.equals([1, 2]);
+    });
+
+    it("disarms the source on detach", () => {
+        const source = new BasicObservable<[value: number]>();
+
+        const values = new Array<number>();
+        source.on(value => {
+            values.push(value);
+        });
+
+        source.detachObservers();
+
+        expect(source.isObserved).false;
+        source.emit(1);
+        expect(values).deep.equals([]);
     });
 });
 

--- a/packages/node/src/endpoint/properties/Behaviors.ts
+++ b/packages/node/src/endpoint/properties/Behaviors.ts
@@ -58,7 +58,7 @@ export class Behaviors {
     #events: Record<string, EventEmitter> = {};
     #options: Record<string, object | undefined>;
     #protocol?: ProtocolService;
-    #detachedObservers?: Record<string, DetachedObservers>;
+    #detachedObservers?: Record<string, Record<string, DetachedObservers>>;
 
     /**
      * The {@link SupportedBehaviors} of the {@link Endpoint}.
@@ -847,7 +847,7 @@ export class Behaviors {
      * Updates endpoint "state" and "events" properties to include properties for a supported behavior.
      */
     #augmentEndpoint(type: Behavior.Type) {
-        const { id, Events } = type;
+        const { id } = type;
 
         // Descriptors persist across the lifetime of the Behaviors instance (constructor + inject install them and
         // close does not remove them so reuse paths like factory-reset can re-activate the same getter).  Returning
@@ -869,11 +869,15 @@ export class Behaviors {
         const detachedObservers = this.#detachedObservers?.[type.id];
         if (detachedObservers) {
             delete this.#detachedObservers![type.id];
-            const newEvents = new Events();
+            const newEvents = this.#createEventsFor(type);
             for (const key in detachedObservers) {
                 const newEvent = (newEvents as unknown as Record<string, BasicObservable | undefined>)[key];
                 if (newEvent && "attachObservers" in newEvent) {
-                    newEvent.attachObservers(detachedObservers);
+                    newEvent.attachObservers(detachedObservers[key]);
+                } else {
+                    logger.warn(
+                        `Discarding observers of ${this.#endpoint}.${id}.${key} because the replacement behavior does not support the event`,
+                    );
                 }
             }
             this.#events[id] = newEvents;
@@ -883,11 +887,7 @@ export class Behaviors {
             get: () => {
                 let events = this.#events[id];
                 if (!events) {
-                    events = this.#events[id] = new Events();
-
-                    if (typeof (events as Events).setContext === "function") {
-                        (events as Events).setContext(this.#endpoint, type);
-                    }
+                    events = this.#events[id] = this.#createEventsFor(type);
                 }
                 return events;
             },
@@ -895,6 +895,14 @@ export class Behaviors {
             enumerable: true,
             configurable: true,
         });
+    }
+
+    #createEventsFor(type: Behavior.Type) {
+        const events = new type.Events();
+        if (typeof (events as Events).setContext === "function") {
+            (events as Events).setContext(this.#endpoint, type);
+        }
+        return events;
     }
 }
 

--- a/packages/node/test/endpoint/properties/BehaviorsTest.ts
+++ b/packages/node/test/endpoint/properties/BehaviorsTest.ts
@@ -8,8 +8,42 @@ import { Behavior } from "#behavior/Behavior.js";
 import { OnOffServer } from "#behaviors/on-off";
 import { OnOffLightDevice } from "#devices/on-off-light";
 import { Endpoint } from "#endpoint/Endpoint.js";
+import { MockEndpoint } from "../mock-endpoint.js";
 
 describe("Behaviors", () => {
+    it("transplants observers when a behavior is dropped and re-injected", async () => {
+        const light = await MockEndpoint.create(OnOffLightDevice);
+
+        const changes = new Array<boolean>();
+        light.eventsOf(OnOffServer).onOff$Changed.on(value => {
+            changes.push(value);
+        });
+
+        const installedType = light.behaviors.supported[OnOffServer.id];
+        await light.behaviors.drop(OnOffServer.id);
+        light.behaviors.inject(installedType);
+
+        await light.set({ onOff: { onOff: true } });
+
+        expect(changes).deep.equals([true]);
+
+        await light.close();
+    });
+
+    it("sets context on transplanted events", async () => {
+        const light = await MockEndpoint.create(OnOffLightDevice);
+
+        light.eventsOf(OnOffServer).onOff$Changed.on(() => {});
+
+        const installedType = light.behaviors.supported[OnOffServer.id];
+        await light.behaviors.drop(OnOffServer.id);
+        light.behaviors.inject(installedType);
+
+        expect(light.eventsOf(OnOffServer).endpoint).equals(light);
+
+        await light.close();
+    });
+
     it("accepts different base class for cluster requirements", () => {
         class MyOnOffServer extends OnOffServer {}
 


### PR DESCRIPTION
## Summary

The observer-transplant machinery introduced in #2837 ("Transplant observers on behavior replace") was dead code at runtime — a behavior drop/re-inject cycle silently lost every registered event listener. Found while investigating a (disproven) hypothesis that `clusterReplaced` strands `Peers` instrumentation listeners; the plain replace path is fine (same `Events` instance survives), but the drop→re-add path was broken in three ways:

- **Transplant never ran:** `Behaviors.#augmentEndpoint` passed the whole per-behavior record (keyed by event name) to `Observable.attachObservers()` instead of `detachedObservers[key]`, so the `!detached.observers` guard returned immediately and all detached listeners were dropped. The `#detachedObservers` field annotation missed one record level, which made the wrong call typecheck.
- **Once-semantics lost:** `attachObservers()` checked the target observable's own (empty) once-set instead of `detached.once`, so once-observers would have re-attached as persistent.
- **Missing `setContext`:** the transplant path populated the events cache directly, permanently bypassing the lazy getter's only `Events.setContext()` call — leaving `endpoint`/`behavior` undefined on the rebuilt instance and skipping `OccurrenceManager` wiring for real cluster events (event reporting would silently stop after a drop/re-inject).

Also hardened per review:

- `detachObservers()` now disarms the source observable (ownership transfer, matching `Symbol.dispose` behavior), removing double-emission risk from stale references.
- Observers detached for events the replacement type does not support are logged instead of silently discarded.
- Shared `#createEventsFor` helper so transplant branch and lazy getter cannot diverge again.

## Follow-up: Observable async iteration was entirely non-functional

Validating the Copilot review comment (detach stranding active `for await` consumers) surfaced that async iteration over `BasicObservable` never worked, masked by a missing `return` that made every `for await` complete instantly. Fixed in `12f36a4d6`:

- `#addIterator()` did not return the promise chain — `for await` over any observable ended immediately without delivering values.
- Termination livelock: `resolve(undefined)` left the same settled promise in the loop — an infinite microtask spin that starves the event loop.
- `#removeIterator` off-by-one (postfix decrement): the last exiting iterator never disarmed the source, leaking the internal observer.
- `#stopIteration` did not clear `#joinIteration`, so a later iteration joined the dead chain.
- Yielded values were double-unwrapped (`args[0]` stored, `[0]` indexed again) — every value came out `undefined`.
- Per review suggestion: `detachObservers()` now stops active iteration before snapshotting, so consumers terminate cleanly and the internal iteration observer is not transplanted.

## Testing

- New regression tests: once-semantics across detach/attach + source disarm (`ObservableTest`), listener transplant and `setContext` on drop/re-inject (`BehaviorsTest`); all verified red on `main` before the fix.
- Full clean build, complete repo test suite, format-verify, and lint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
