### PR TITLE
fix(protocol): start unsecured message reception window empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/protocol
     - Fix: Peer session selection now prefers the session the peer was last heard from and skips peer-lost sessions, so a dead session still retransmitting no longer outranks a freshly established one
     - Fix: `BleScanner.close()` no longer orphans a timeout-less continuous discovery, which previously blocked shutdown when a BLE commission was in flight
+    - Fix: Do not drop reordered unsecured/PASE messages with a counter just below the first one seen as duplicates
 
 - @matter/thread-br-client
     - Fix: Use the correct MeshCoP commissioner keep-alive URI (`c/ca`) and resign the session with a rejecting keep-alive instead of a nonexistent `c/cr` release URI that Border Routers answered with 4.04

--- a/packages/protocol/src/protocol/MessageReceptionState.ts
+++ b/packages/protocol/src/protocol/MessageReceptionState.ts
@@ -28,7 +28,7 @@ export abstract class MessageReceptionState {
  */
 export class MessageReceptionStateEncryptedWithoutRollover extends MessageReceptionState {
     protected maximumMessageCounter: number | undefined;
-    private messageCounterBitmap = 0xffffffff; // All bits set to 1
+    private messageCounterBitmap = this.initialBitmap;
 
     constructor(messageCounter?: number) {
         super();
@@ -37,10 +37,18 @@ export class MessageReceptionStateEncryptedWithoutRollover extends MessageRecept
         }
     }
 
+    /**
+     * Bitmap seeded when the window is first anchored to a counter. All-1s for encrypted messages marks every
+     * sub-max counter as already-received (replay protection).
+     */
+    protected get initialBitmap(): number {
+        return 0xffffffff;
+    }
+
     /** Initialize the message counter state. */
     private initialize(messageCounter: number) {
         this.maximumMessageCounter = messageCounter;
-        this.messageCounterBitmap = 0xffffffff; // All bits set to 1
+        this.messageCounterBitmap = this.initialBitmap;
     }
 
     /**
@@ -173,6 +181,15 @@ export class MessageReceptionStateEncryptedWithRollover extends MessageReception
  * back the window to the current location.
  */
 export class MessageReceptionStateUnencryptedWithRollover extends MessageReceptionStateEncryptedWithoutRollover {
+    /**
+     * Empty window: no sub-max counters have been received yet, so legitimately reordered messages below the first
+     * observed counter stay acceptable. Unencrypted duplicate detection is not a security control, so this loses
+     * nothing; matches the CHIP reference implementation, which has never seeded a full window.
+     */
+    protected override get initialBitmap(): number {
+        return 0;
+    }
+
     protected override calculateDiff(messageCounter: number) {
         if (this.maximumMessageCounter === undefined) {
             return 0;

--- a/packages/protocol/test/protocol/MessageReceptionStateTest.ts
+++ b/packages/protocol/test/protocol/MessageReceptionStateTest.ts
@@ -581,7 +581,7 @@ describe("MessageReceptionState", () => {
                 );
                 state.updateMessageCounter(0x1234);
                 expect(updateCalled).equal(true);
-                assertMessageWindowUpdate(prototype, state, 0x1235, 0b11111111111111111111111111111111, false, 1);
+                assertMessageWindowUpdate(prototype, state, 0x1235, 0b1, false, 1);
             });
 
             it("correct difference gets calculated and state gets updated after being initialized", () => {
@@ -786,6 +786,17 @@ describe("MessageReceptionState", () => {
                 assertMessageWindowUpdate(prototype, state, 94, 0b100000, false, -6);
                 assertMessageWindowUpdate(prototype, state, 132, 0b10000000000000000000000000000000, false, 32);
                 assertMessageWindowUpdate(prototype, state, 126, 0b10000000000000000000000000100000, false, -6);
+            });
+
+            it("accepts an in-window sub-max counter delivered right after the first counter", () => {
+                // Reproduces issue #4095: a StandaloneAck (af) arrives before the earlier-numbered
+                // PbkdfParamResponse (af-1). With an empty starting window the response is new, not a duplicate.
+                const state = new MessageReceptionStateUnencryptedWithRollover();
+                const af = 0x0e8288af;
+
+                state.updateMessageCounter(af); // first observed counter anchors max
+                expect(() => state.updateMessageCounter(af - 1)).not.throws(); // reordered response accepted
+                expect(() => state.updateMessageCounter(af - 1)).throws(DuplicateMessageError); // genuine replay rejected
             });
         });
     });


### PR DESCRIPTION
## Problem

Fixes matter-js/matterjs-server#886. PASE commissioning to some Thread devices stalls (~11s timeout). Root cause is receiver-side: the unsecured/PASE `MessageReceptionState` inherited the **encrypted** all-1s bitmap initialization, which marks every counter below the first one seen as already-received.

Real trigger: with redundant Border Routers, the controller's single `PbkdfParamRequest` is injected into the Thread mesh twice, so the device emits both a `PbkdfParamResponse` (counter `ae`) and a forced `StandaloneAck` (counter `af = ae+1`). The tiny ack is delivered first; the fragmented response arrives ~2s later. With an all-1s window the response (`af-1`, in-window, bit set) is flagged `dup` and dropped, so the handshake never advances.

The device is spec/CHIP-conformant; the break is entirely the receiver's window init.

## Fix

Move the seed bitmap into an overridable `initialBitmap` getter:
- Encrypted (`WithoutRollover`, group `WithRollover`) keep `0xffffffff` — replay protection.
- Unencrypted (`UnencryptedWithRollover`) overrides to `0` (empty window), matching the CHIP reference implementation (`PeerMessageCounter::SetCounter` → `mWindow.reset()`, empty since 2021).

After that, existing `UnencryptedWithRollover` logic is correct: in-window + bit-clear → new; in-window + bit-set → duplicate; below-window → new (rollback).

Encrypted unicast is unaffected — it is seeded `max=0`, and with monotone (no-rollover) diffs the all-1s bits only ever cover nonexistent `≤0` counters, so the window behaves as empty in practice.

## Spec note

matter.js's prior all-1s init was spec-compliant (§4.6.5.4 says all-1s for all encryption levels). This is a deliberate deviation to match CHIP and tolerate real-world reorder/duplication; a paired spec-enhancement (scope the empty init to unencrypted) is tracked to be raised upstream so matter.js becomes compliant again once the spec is corrected.

## Tests

- New regression: `af`-then-`af-1` reorder accepted, replay of `af-1` still rejected.
- Corrected the stale unencrypted "gets initialized" expectation (`0xffffffff` → `0b1`).
- Full protocol suite green (ESM/CJS/Web), `format-verify` + `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)