### PR TITLE
fix(node): re-install client clusters the peer drops and re-adds

### DIFF
--- a/packages/node/src/node/client/ClientStructure.ts
+++ b/packages/node/src/node/client/ClientStructure.ts
@@ -566,7 +566,6 @@ export class ClientStructure {
         }
 
         if (attributeSetChanged) {
-            // Rebuilding on any difference honors both added and removed attributes.
             cluster.behavior = undefined;
         }
 
@@ -591,9 +590,8 @@ export class ClientStructure {
      * Mark values for attributes dropped by a new attribute list for deletion.
      *
      * The client store keys attribute values by both numeric attribute ID (protocol updates) and property name (seed
-     * data), so we clear both forms.  Names come from the outgoing behavior's schema, which still describes the dropped
-     * attributes.  Entries are added to {@link values} so the pending {@link Datasource.ExternallyMutableStore.externalSet}
-     * removes them; a value of `undefined` deletes a key.
+     * data), so we clear both forms.  Entries added to {@link values} are removed by the pending
+     * {@link Datasource.ExternallyMutableStore.externalSet}; a value of `undefined` deletes a key.
      */
     #pruneDroppedAttributes(cluster: ClusterStructure, newAttributeList: readonly unknown[], values: Val.StructMap) {
         if (!cluster.attributes) {

--- a/packages/node/src/node/client/ClientStructure.ts
+++ b/packages/node/src/node/client/ClientStructure.ts
@@ -542,26 +542,32 @@ export class ClientStructure {
         this.#clustersWithDataThisInteraction.add(cluster);
         this.#preserveAbsentCluster(endpoint.endpoint, cluster);
 
+        // A non-empty AttributeList is authoritative for the attribute set.  An empty list is ignored so it doesn't
+        // churn against the received-attribute fallback.  Detect the change up front, before any feature comparison
+        // clears the behavior, so the outgoing behavior's schema is still available to prune dropped attributes.
+        const attributeList = attrs.values.get(AttributeList.id);
+        const newAttributes = Array.isArray(attributeList) && attributeList.length ? attributeList : undefined;
+        const attributeSetChanged =
+            !!cluster.behavior &&
+            newAttributes !== undefined &&
+            !isDeepEqual(
+                cluster.attributes,
+                [...newAttributes].sort((a, b) => a - b),
+            );
+
+        if (attributeSetChanged) {
+            this.#pruneDroppedAttributes(cluster, newAttributes, attrs.values);
+        }
+
         if (cluster.behavior && attrs.values.has(FeatureMap.id)) {
             if (!isDeepEqual(cluster.features, attrs.values.get(FeatureMap.id))) {
                 cluster.behavior = undefined;
             }
         }
 
-        if (cluster.behavior && attrs.values.has(AttributeList.id)) {
-            const attributeList = attrs.values.get(AttributeList.id);
-            // A non-empty AttributeList is authoritative: rebuilding on any difference honors both added and removed
-            // attributes.  An empty list is ignored here so it doesn't churn against the received-attribute fallback.
-            if (
-                Array.isArray(attributeList) &&
-                attributeList.length &&
-                !isDeepEqual(
-                    cluster.attributes,
-                    [...attributeList].sort((a, b) => a - b),
-                )
-            ) {
-                cluster.behavior = undefined;
-            }
+        if (attributeSetChanged) {
+            // Rebuilding on any difference honors both added and removed attributes.
+            cluster.behavior = undefined;
         }
 
         if (cluster.behavior && attrs.values.has(AcceptedCommandList.id)) {
@@ -579,6 +585,40 @@ export class ClientStructure {
 
         await cluster.store.externalSet(attrs.values);
         this.#synchronizeCluster(endpoint, cluster);
+    }
+
+    /**
+     * Mark values for attributes dropped by a new attribute list for deletion.
+     *
+     * The client store keys attribute values by both numeric attribute ID (protocol updates) and property name (seed
+     * data), so we clear both forms.  Names come from the outgoing behavior's schema, which still describes the dropped
+     * attributes.  Entries are added to {@link values} so the pending {@link Datasource.ExternallyMutableStore.externalSet}
+     * removes them; a value of `undefined` deletes a key.
+     */
+    #pruneDroppedAttributes(cluster: ClusterStructure, newAttributeList: readonly unknown[], values: Val.StructMap) {
+        if (!cluster.attributes) {
+            return;
+        }
+
+        const retained = new Set(newAttributeList);
+        const oldAttributes = cluster.behavior?.cluster?.attributes;
+
+        for (const id of cluster.attributes) {
+            if (retained.has(id)) {
+                continue;
+            }
+
+            values.set(id, undefined);
+
+            if (oldAttributes) {
+                for (const [name, def] of Object.entries(oldAttributes)) {
+                    if (def.id === id) {
+                        values.set(name, undefined);
+                        break;
+                    }
+                }
+            }
+        }
     }
 
     /**
@@ -957,10 +997,15 @@ export class ClientStructure {
     async #rebuild(structure: EndpointStructure) {
         const { endpoint, clusters } = structure;
 
-        for (const cluster of clusters.values()) {
+        for (const [key, cluster] of clusters.entries()) {
             const { behavior, pendingBehavior, pendingDelete } = cluster;
 
             if (pendingDelete) {
+                // Discard the structure entirely so a later re-appearance rebuilds it from scratch with a fresh store
+                // and a fresh behavior.  Keeping a dropped cluster's structure around leaves a stale behavior reference
+                // that suppresses regeneration in #synchronizeCluster, so the cluster never re-installs.
+                clusters.delete(key);
+
                 if (!behavior) {
                     continue;
                 }

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -1725,6 +1725,125 @@ describe("ClientNode", () => {
         ]);
     });
 
+    it("removes attributes when a behavior replace drops a feature", async () => {
+        // *** SETUP ***
+
+        const LiftTiltWc = WindowCoveringServer.with("Lift", "PositionAwareLift", "Tilt", "PositionAwareTilt").set({
+            type: WindowCovering.WindowCoveringType.Unknown,
+            currentPositionLiftPercent100ths: 0,
+            currentPositionTiltPercent100ths: 0,
+        });
+
+        await using site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair({
+            device: {
+                type: ServerNode.RootEndpoint,
+                device: WindowCoveringDevice.with(LiftTiltWc),
+            },
+        });
+
+        const peer1 = controller.peers.get("peer1")!;
+        const clientEp1 = peer1.parts.get("ep1")!;
+        const serverEp1 = device.parts.get("part0")!;
+
+        // Tilt is present initially
+        expect(clientEp1.globalsOf(WindowCoveringClient).featureMap.tilt).equals(true);
+        expect(clientEp1.stateOf(WindowCoveringClient).currentPositionTiltPercent100ths).equals(0);
+
+        // *** REPLACE CLUSTER DROPPING TILT ***
+
+        await MockTime.resolve(device.stop());
+        await serverEp1.erase();
+
+        const LiftWc = WindowCoveringServer.with("Lift", "PositionAwareLift").set({
+            currentPositionLiftPercent100ths: 0,
+        });
+
+        // Nudge so version number changes, otherwise new endpoint won't sync
+        device.env.set(Entropy, MockCrypto(0x20));
+
+        await device.add({
+            type: WindowCoveringDevice.with(LiftWc),
+            number: 1,
+            id: "part0b",
+        });
+
+        const replaced = new Promise(resolve => peer1.env.get(ClientStructureEvents).clusterReplaced.on(resolve));
+
+        await MockTime.resolve(device.start());
+        await MockTime.resolve(replaced);
+
+        // *** VALIDATE ***
+
+        // featureMap and feature view reflect the shrunk feature set
+        expect(clientEp1.globalsOf(WindowCoveringClient).featureMap.tilt).equals(false);
+        expect(clientEp1.featuresOf(WindowCoveringClient).tilt).equals(false);
+
+        // The schema-validated read path correctly rejects the dropped attribute
+        await expect(
+            MockTime.resolve(clientEp1.getStateOf(WindowCoveringClient, ["currentPositionTiltPercent100ths"])),
+        ).rejectedWith(/not present on behavior/);
+
+        // The raw state view must not retain the dropped attribute's stale value
+        expect(clientEp1.stateOf(WindowCoveringClient).currentPositionTiltPercent100ths).equals(undefined);
+
+        // Lift attribute survives the replace
+        expect(clientEp1.stateOf(WindowCoveringClient).currentPositionLiftPercent100ths).equals(0);
+    });
+
+    it("re-installs a cluster the device drops and later restores", async () => {
+        // *** SETUP ***
+
+        const LiftWc = WindowCoveringServer.with("Lift", "PositionAwareLift").set({
+            currentPositionLiftPercent100ths: 0,
+        });
+
+        await using site = new MockSite();
+        const { controller, device } = await site.addCommissionedPair({
+            device: {
+                type: ServerNode.RootEndpoint,
+                device: OnOffLightDevice.with(LiftWc),
+            },
+        });
+
+        const peer1 = controller.peers.get("peer1")!;
+        const clientEp1 = peer1.parts.get("ep1")!;
+
+        expect(clientEp1.behaviors.supported["windowCovering"]).to.be.ok;
+
+        // *** REMOVE THE CLUSTER ***
+
+        await MockTime.resolve(device.stop());
+        await device.parts.get("part0")!.erase();
+        device.env.set(Entropy, MockCrypto(0x20));
+        await device.add({ type: OnOffLightDevice, number: 1, id: "part0b" });
+
+        const deleted = new Promise(resolve => peer1.env.get(ClientStructureEvents).clusterDeleted.on(resolve));
+        await MockTime.resolve(device.start());
+        await MockTime.resolve(deleted);
+
+        expect(clientEp1.behaviors.supported["windowCovering"]).to.be.undefined;
+
+        // *** RESTORE THE CLUSTER ***
+
+        await MockTime.resolve(device.stop());
+        await device.parts.get("part0b")!.erase();
+        device.env.set(Entropy, MockCrypto(0x40));
+        await device.add({ type: OnOffLightDevice.with(LiftWc), number: 1, id: "part0c" });
+
+        const added = new Promise(resolve =>
+            peer1.env.get(ClientStructureEvents).clusterInstalled(WindowCoveringClient).on(resolve),
+        );
+        await MockTime.resolve(device.start());
+        await MockTime.resolve(added);
+
+        // *** VALIDATE ***
+
+        expect(clientEp1.behaviors.supported["windowCovering"]).to.be.ok;
+        expect(clientEp1.stateOf(WindowCoveringClient).currentPositionLiftPercent100ths).equals(0);
+        expect(clientEp1.globalsOf(WindowCoveringClient).featureMap.lift).equals(true);
+    });
+
     it("handles shutdown event and reestablishes connection", () => {
         // TODO
     });
@@ -2130,6 +2249,60 @@ describe("ClientNode", () => {
             return [attr(Descriptor.id, Descriptor.attributes.serverList.id, EP1_SERVER_LIST, version)];
         }
 
+        function descriptorServerListWithNeoReport(version: number): ReadResult.Report[] {
+            return [attr(Descriptor.id, Descriptor.attributes.serverList.id, [...EP1_SERVER_LIST, NEO], version)];
+        }
+
+        // Like neoReports but with attribute 2 present in both the attribute list and the data — same featureMap.
+        function neoReportsWithExtraAttr(version: number): ReadResult.Report[] {
+            return [
+                attr(NEO, ClusterRevision.id, 1, version),
+                attr(NEO, FeatureMap.id, {}, version),
+                attr(
+                    NEO,
+                    AttributeList.id,
+                    [
+                        0,
+                        2,
+                        GeneratedCommandList.id,
+                        AcceptedCommandList.id,
+                        AttributeList.id,
+                        FeatureMap.id,
+                        ClusterRevision.id,
+                    ],
+                    version,
+                ),
+                attr(NEO, AcceptedCommandList.id, [], version),
+                attr(NEO, GeneratedCommandList.id, [], version),
+                attr(NEO, 0, 1234, version),
+                attr(NEO, 2, 5678, version),
+            ];
+        }
+
+        // Like neoReports but with an accepted command (1) added — same featureMap and attribute list.
+        function neoReportsWithExtraCommand(version: number): ReadResult.Report[] {
+            return [
+                attr(NEO, ClusterRevision.id, 1, version),
+                attr(NEO, FeatureMap.id, {}, version),
+                attr(
+                    NEO,
+                    AttributeList.id,
+                    [
+                        0,
+                        GeneratedCommandList.id,
+                        AcceptedCommandList.id,
+                        AttributeList.id,
+                        FeatureMap.id,
+                        ClusterRevision.id,
+                    ],
+                    version,
+                ),
+                attr(NEO, AcceptedCommandList.id, [1], version),
+                attr(NEO, GeneratedCommandList.id, [], version),
+                attr(NEO, 0, 1234, version),
+            ];
+        }
+
         async function* readResult(...chunks: ReadResult.Report[][]): ReadResult {
             for (const chunk of chunks) {
                 yield chunk;
@@ -2217,6 +2390,102 @@ describe("ClientNode", () => {
 
             expect(neoActive(), "NEO behavior should be dropped").false;
             expect(neoStorageKeys(), "NEO storage should be erased").empty;
+        });
+
+        it("re-installs a cluster the peer drops and later serves again", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair();
+            const peer1 = await subscribedPeer(controller, "peer1");
+
+            const initializer = peer1.env.get(EndpointInitializer) as ClientEndpointInitializer;
+            const structure = initializer.structure;
+            const request = Read({ attributes: [{}], fabricFilter: structure.subscribedFabricFiltered });
+
+            const neoActive = () => {
+                const endpoint = structure.endpointFor(EP1);
+                return (
+                    endpoint !== undefined &&
+                    Object.values(endpoint.behaviors.supported).some(
+                        type => (type as ClusterBehavior.Type).cluster?.id === NEO,
+                    )
+                );
+            };
+
+            // NEO present in serverList and serving data.
+            await drain(structure.mutate(request, readResult(descriptorServerListWithNeoReport(10), neoReports(10))));
+            expect(neoActive(), "NEO should be active initially").true;
+
+            // Peer drops NEO: descriptor omits it and no data is served.
+            await drain(structure.mutate(request, readResult(descriptorServerListReport(11))));
+            expect(neoActive(), "NEO should be dropped").false;
+
+            // Peer serves NEO again and lists it in the descriptor.  It must come back.
+            await drain(structure.mutate(request, readResult(descriptorServerListWithNeoReport(12), neoReports(12))));
+            expect(neoActive(), "NEO must be re-installed after the peer serves it again").true;
+        });
+
+        it("rebuilds a cluster when the peer changes its attribute list without a feature change", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair();
+            const peer1 = await subscribedPeer(controller, "peer1");
+            const structure = (peer1.env.get(EndpointInitializer) as ClientEndpointInitializer).structure;
+            const request = Read({ attributes: [{}], fabricFilter: structure.subscribedFabricFiltered });
+
+            const neoType = () => {
+                const endpoint = structure.endpointFor(EP1);
+                return endpoint === undefined
+                    ? undefined
+                    : Object.values(endpoint.behaviors.supported).find(
+                          type => (type as ClusterBehavior.Type).cluster?.id === NEO,
+                      );
+            };
+
+            await drain(structure.mutate(request, readResult(descriptorServerListWithNeoReport(10), neoReports(10))));
+            const before = neoType();
+            expect(before, "NEO should be active initially").not.undefined;
+
+            // Same featureMap, but the attribute list (and data) now include attribute 2.
+            await drain(
+                structure.mutate(
+                    request,
+                    readResult(descriptorServerListWithNeoReport(11), neoReportsWithExtraAttr(11)),
+                ),
+            );
+            const after = neoType();
+            expect(after, "NEO should remain active").not.undefined;
+            expect(after, "behavior must be rebuilt to reflect the new attribute set").not.equals(before);
+        });
+
+        it("rebuilds a cluster when the peer changes its accepted command list without a feature change", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair();
+            const peer1 = await subscribedPeer(controller, "peer1");
+            const structure = (peer1.env.get(EndpointInitializer) as ClientEndpointInitializer).structure;
+            const request = Read({ attributes: [{}], fabricFilter: structure.subscribedFabricFiltered });
+
+            const neoType = () => {
+                const endpoint = structure.endpointFor(EP1);
+                return endpoint === undefined
+                    ? undefined
+                    : Object.values(endpoint.behaviors.supported).find(
+                          type => (type as ClusterBehavior.Type).cluster?.id === NEO,
+                      );
+            };
+
+            await drain(structure.mutate(request, readResult(descriptorServerListWithNeoReport(10), neoReports(10))));
+            const before = neoType();
+            expect(before, "NEO should be active initially").not.undefined;
+
+            // Same featureMap and attribute list, but a new accepted command appears.
+            await drain(
+                structure.mutate(
+                    request,
+                    readResult(descriptorServerListWithNeoReport(11), neoReportsWithExtraCommand(11)),
+                ),
+            );
+            const after = neoType();
+            expect(after, "NEO should remain active").not.undefined;
+            expect(after, "behavior must be rebuilt to reflect the new command set").not.equals(before);
         });
     });
 });


### PR DESCRIPTION
## Problem

Reported in matterjs-server#882: an occupancy-sensing cluster vanished permanently after a device reflash. A device dropped the cluster from its descriptor `serverList`, matter.js removed it, then the device restored it — but the cluster never came back. Every subsequent `occupancyChanged` event landed as `Received event … for unsupported cluster`.

Root cause: when `#rebuild` drops a cluster, it dropped the endpoint behavior but left the `ClusterStructure` in the endpoint's `clusters` map with `cluster.behavior` still referencing the dropped behavior. On re-appearance, `#synchronizeCluster`'s regeneration guard (`if (cluster.behavior === undefined)`) was false, so the cluster was never regenerated or re-installed. It stayed "known" with no backing forever.

## Fix

1. **`#rebuild`** deletes the `ClusterStructure` from the map on drop, so re-appearance rebuilds it from scratch (fresh store, `behavior === undefined` → generate + install). This also removes a latent bug where `injectVersionFilters` kept emitting a `dataVersionFilter` for the dropped-but-mapped cluster, which could suppress full re-delivery.

2. **`#updateCluster` / `#pruneDroppedAttributes`** — a secondary staleness issue found while testing feature changes: after a feature-shrink rebuild (e.g. a WindowCovering that drops Tilt), the schema-validated paths (`getStateOf`/`featuresOf`/`featureMap`) were correct, but the raw `stateOf` proxy still exposed the dropped attributes' stale values because the reused store retained them. The attribute-set change is now detected before the behavior is cleared, and dropped attributes are pruned from the store (by both numeric-ID and property-name key forms, since the client store holds both).

## Tests

New `ClientNode` tests, device-driven where a real matter.js device can express the scenario, synthetic (buggy-peer `ReadResult` injection) where it can't:

- cluster drop → re-add (synthetic + device-driven) — the reported regression
- feature-shrink drops attributes (device-driven) — schema paths + no stale `stateOf` leak
- attribute-list-only rebuild (synthetic)
- accepted-command-list-only rebuild (synthetic)

Full `@matter/node` suite green (1469/1469), format + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)