### PR TITLE
fix(chip): add SPECIFICATION_VERSION marker so chiptest resolves CHIP_ROOT

### DIFF
--- a/support/chip/Dockerfile
+++ b/support/chip/Dockerfile
@@ -168,6 +168,9 @@ WORKDIR /
 # Some scripts expect pigweed root
 ENV PW_PROJECT_ROOT=/
 
+# chiptest derives CHIP_ROOT by walking parents of its own file for this marker (upstream #72527)
+COPY --from=source /connectedhomeip/SPECIFICATION_VERSION /SPECIFICATION_VERSION
+
 # YAML tests of course use a different data model
 COPY --from=source /connectedhomeip/src/app/zap-templates/zcl/data-model/chip \
     /src/app/zap-templates/zcl/data-model/chip


### PR DESCRIPTION
## Problem

Since CHIP master commit `99faff8945` (#72527), the chip image build's tests abort with:

\`\`\`
File ".../chiptest/test_definition.py", line 36, in <module>
    CHIP_ROOT = next(filter(lambda p: (p / 'SPECIFICATION_VERSION').is_file(), Path(__file__).parents))
StopIteration
\`\`\`

That commit added an import-time `CHIP_ROOT` computation to `chiptest`: it walks the parents of its own file looking for a `SPECIFICATION_VERSION` marker (to load the moved `matter.testing.commissioning_types`). Our image copies `chiptest` flat into `/usr/local/lib/python3.12/dist-packages/chiptest`, so no parent dir carries the marker — `next()` raises `StopIteration`, the import dies, and every `chiptool.py` test fails.

## Fix

Drop `SPECIFICATION_VERSION` at container root `/`, which already serves as the pseudo CHIP root (`PW_PROJECT_ROOT=/`, `/src/python_testing`, `/scripts/tests`). `CHIP_ROOT` then resolves to `/`, and `CHIP_ROOT/src/python_testing/matter_testing_infrastructure` maps to the already-copied `/src/python_testing/matter_testing_infrastructure`.

`[rebuild-chip]` marker included so CI refreshes the CHIP SHA to current master and rebuilds the image against the state that broke us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)