### PR TITLE
fix(protocol): clamp commissioning failsafe to device max cumulative failsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/node
     - Fix: Optimize Cluster data updates when structures change for ClientNodes
 
+- @matter/protocol
+    - Fix: Ensure the commissioning failsafe timer stays within the device's maximum cumulative failsafe
+
 ## 0.17.6 (2026-07-16)
 
 - @matter/general

--- a/packages/protocol/src/peer/ControllerCommissioningFlow.ts
+++ b/packages/protocol/src/peer/ControllerCommissioningFlow.ts
@@ -294,6 +294,12 @@ const BTP_IDLE_ALIVE_INTERVAL = Seconds(25);
 /** Expected maximum time for CASE session establishment over the operational network. */
 const CASE_RECONNECT_TIMEOUT = Minutes(5);
 
+/**
+ * Send/retry slack added on top of the operation's own max wait when sizing the failsafe. Bounds the MRP worst-case
+ * round-trip, which for an idle ICD peer (huge advertised idle interval) can otherwise exceed the uint16 armFailSafe field.
+ */
+const FAILSAFE_PROCESSING_MARGIN = Seconds(10);
+
 /** Devices may report very low scan/connect timeouts that are not enough in practice */
 const MIN_NETWORK_SCAN_TIMEOUT_SECONDS = 60;
 const MIN_NETWORK_CONNECT_TIMEOUT_SECONDS = 60;
@@ -854,7 +860,12 @@ export class ControllerCommissioningFlow {
                 this.#commissioningStartedTime + Seconds(basicCommissioningInfo.maxCumulativeFailsafeSeconds),
             );
         }
-        const expiryLength = time ?? this.#defaultFailSafeTime;
+        // armFailSafe.expiryLengthSeconds must not exceed the device's mandatory (uint16) maximum cumulative failsafe.
+        const { basicCommissioningInfo } = this.collectedCommissioningData;
+        const maxExpiry = basicCommissioningInfo
+            ? Seconds(basicCommissioningInfo.maxCumulativeFailsafeSeconds)
+            : this.#defaultFailSafeTime;
+        const expiryLength = Duration.min(time ?? this.#defaultFailSafeTime, maxExpiry);
         this.#ensureGeneralCommissioningSuccess(
             "armFailSafe",
             await this.#invokeCommand({
@@ -882,7 +893,12 @@ export class ControllerCommissioningFlow {
     }
 
     async #ensureFailsafeTimerFor(maxProcessingTime: Duration) {
-        const minFailsafeTime = this.interaction.maximumPeerResponseTime(maxProcessingTime, true);
+        // We never wait longer than maxProcessingTime for the operation, so the failsafe only needs to outlive that
+        // plus send slack. The raw MRP worst-case can be far larger for an idle ICD peer and would overflow uint16.
+        const minFailsafeTime = Duration.min(
+            this.interaction.maximumPeerResponseTime(maxProcessingTime, true),
+            Millis(maxProcessingTime + FAILSAFE_PROCESSING_MARGIN),
+        );
 
         if (this.interaction.channelType === ChannelType.BLE) {
             this.#armFailsafeInterval?.stop();


### PR DESCRIPTION
## Problem

Commissioning an ICD device that advertises a very long idle interval (SII ~12h) failed with:

```
Failed to re-arm failsafe before operational reconnect, proceeding anyway
[validation-out-of-bounds] (ValidationOutOfBoundsError/135) Invalid value: 550146 is above the maximum, 65535.
```

`#reconnectWithDevice` calls `#ensureFailsafeTimerFor(CASE_RECONNECT_TIMEOUT)` on the UDP PASE session. `maximumPeerResponseTime` sums the MRP worst-case retransmission backoff over the peer's idle interval — for a 12h idle interval that reaches ~550146 s, which is then passed straight into `armFailSafe.expiryLengthSeconds` (uint16, max 65535) and overflows.

## Fix

Two bounds, both defensive:

- **`#ensureFailsafeTimerFor`** — cap `minFailsafeTime` at `maxProcessingTime + FAILSAFE_PROCESSING_MARGIN` (10s send slack). We never actually wait longer than `maxProcessingTime` for the operation, so the failsafe never needs the pathological MRP worst-case.
- **`#armFailsafe`** — clamp the armed expiry to the device's mandatory `maxCumulativeFailsafeSeconds` (itself a uint16), so no path can overflow the field.

`#currentFailSafeEndTime` inherits the clamped value, keeping controller and device in sync.

## Testing

- `@matter/protocol` build + type check green
- MRP + CommissioningConnection suites: 37/37 (ESM/CJS/Web)
- format-verify + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)