### PR TITLE
feat(shell): close phase-2 ClientNode migration gaps

### DIFF
--- a/docs/MIGRATION_CONTROLLER_018.md
+++ b/docs/MIGRATION_CONTROLLER_018.md
@@ -171,13 +171,30 @@ await node.commission({ passcode: 20202021 /* ...same CommissioningOptions... */
 ```
 
 `peers.commission` runs discovery then commissions in one call; `peers.forDescriptor(...)` finds/creates the
-peer node for a known address, which you then `node.commission(options)`. Await `node.lifecycle.seeded`
-before reading the peer's structure.
+peer node for a known address, which you then `node.commission(options)`. Wait for the peer's structure
+before reading it, bounding the wait so an offline peer does not hang (see "Is the node ready?").
 
 `onAttestationFailure(findings)` replaces the legacy attestation callback — return `true`/`false` to accept
 or reject; each finding carries `level` (`"error"` / `"warn"` / `"info"`), `type` and `message`. To
 decommission, use `node.decommission()` (contacts the device) or `node.delete()` (force-drop locally when
 the peer is unreachable).
+
+### Delegated / split commissioning (legacy `PaseCommissioner`)
+
+Legacy `PaseCommissioner` performed the PASE phase to admit a device into an existing fabric, then handed
+off via a callback to complete the flow elsewhere. On the new API:
+
+- **Adding a device that is already commissioned by another admin into your fabric** (the common
+  "delegated" case) is the standard Matter multi-admin flow: the current admin opens a commissioning window
+  on the device (`node.openEnhancedCommissioningWindow(...)` → pairing code), then your controller
+  `serverNode.peers.commission({ /* the enhanced pairing code's passcode + discriminator */ })`. No
+  `PaseCommissioner` object is involved — each admin drives an ordinary commission against its own fabric
+  (the controller `ServerNode` is multi-fabric via `FabricAuthority`).
+- **Deciding whether to proceed after PASE** (e.g. a parallel-candidate race where only one PASE winner
+  should continue) is `CommissioningClient.CommissioningOptions.continueCommissioningAfterPase?: () => boolean`
+  — called immediately after PASE, before the main flow; return `false` to close the PASE session and stop.
+- A true **PASE-establish-here, complete-CASE-in-a-separate-process** handoff has no public convenience; it
+  is a lower-level composition over the protocol commissioning flow rather than a shipped API.
 
 ---
 
@@ -387,31 +404,29 @@ For a single specific value you can instead `reactTo` that behavior's `<attr>$Ch
 own event) directly — fault-isolated and torn down with the behavior. That is the exception, not the
 common case; reach for `ChangeNotificationService` when you need the whole node/peer change feed.
 
-### Verified shell idiom: watch one node's changes (`subscribe` command)
+### Verified shell idiom: node-wide diagnostic logging (all peers)
 
-The aggregate stream covers the controller node **and every peer**, so a per-node watcher filters to the
-target node's endpoint subtree. This is the proven replacement for the legacy per-`PairedNode` event bus
-(shell `cmd_subscribe.ts`):
+The legacy per-connect diagnostic callbacks (`attributeChangedCallback` / `eventTriggeredCallback` /
+`stateInformationCallback`, passed into every `PairedNode.connect`) map onto **one** node-wide listener,
+registered once, rather than a callback bundle per connect. The shell wires this in
+`MatterNode` (`installDiagnosticLogging`, `util/diagnosticLogging.ts`):
 
 ```ts
-import { ChangeNotificationService, ClusterBehavior, NetworkClient } from "@matter/node";
+import { ChangeNotificationService, ClusterBehavior, NodeConnectionState } from "@matter/node";
 
-// `node` is the target ClientNode; the node is its own root endpoint, so an endpoint belongs to it when
-// the node appears on the endpoint's owner chain.
-function ownedBy(endpoint, node) {
-    for (let e = endpoint; e !== undefined; e = e.owner) if (e === node) return true;
-    return false;
-}
+const observers = new ObserverGroup();
 
-const observers = new ObserverGroup(); // one group per watcher; close it to unsubscribe
+// attributeChangedCallback / eventTriggeredCallback: one aggregate stream for every peer. Map each change
+// back to its peer via the owner chain (a peer node is its own root endpoint).
 observers.on(serverNode.env.get(ChangeNotificationService).change, change => {
-    if (!ownedBy(change.endpoint, node)) return; // ignore other peers / the controller node
+    const peer = serverNode.peers.commissioned.find(p => ownedBy(change.endpoint, p));
+    if (peer === undefined) return; // a change on the controller node itself, not a peer
     switch (change.kind) {
         case "update": {
             if (!ClusterBehavior.is(change.behavior)) break;
             const state = change.endpoint.stateOf(change.behavior.id);
             const changed = change.properties?.reduce((o, n) => ((o[n] = state[n]), o), {}) ?? state;
-            // change.version carries the data version
+            // peer.peerAddress.nodeId, change.endpoint.number, change.behavior.cluster.id, change.version
             break;
         }
         case "event":  /* change.behavior/event/number/timestamp/priority/payload */ break;
@@ -419,19 +434,20 @@ observers.on(serverNode.env.get(ChangeNotificationService).change, change => {
     }
 });
 
-// Liveness (subscription established / dropped / re-established), replacing PairedNode connection events:
-observers.on(node.eventsOf(NetworkClient).subscriptionStatusChanged, isActive => { /* ... */ });
-
-// Establishing the sustained subscription is just a state write; changes then flow to the listener above:
-await node.set({ network: { autoSubscribe: true } });
-
-// Tear down when the node goes away, and when re-subscribing the same node:
-observers.on(node.lifecycle.destroyed, () => observers.close());
+// stateInformationCallback: each peer's connection-state transitions, for existing and future peers.
+const watch = peer =>
+    observers.on(peer.lifecycle.connectionStateChanged, state => {
+        /* NodeConnectionState.Connected / Disconnected / Reconnecting / WaitingForDeviceDiscovery */
+    });
+for (const peer of serverNode.peers.commissioned) watch(peer);
+observers.on(serverNode.peers.added, watch);
 ```
 
-The legacy per-connect diagnostic callbacks (`attributeChangedCallback` / `eventTriggeredCallback` /
-`stateInformationCallback`) map onto exactly this: register **one** `ChangeNotificationService` listener
-covering all peers rather than a callback bundle per connect.
+To watch a **single** node instead (e.g. the shell `subscribe` command establishing an on-demand
+subscription), filter the same aggregate stream to that node's endpoint subtree with `ownedBy`, and use
+`node.eventsOf(NetworkClient).subscriptionStatusChanged` for its subscription liveness. Establishing the
+sustained subscription is just a state write — `await node.set({ network: { autoSubscribe: true } })` — after
+which changes flow to the node-wide listener above.
 
 ---
 
@@ -453,6 +469,23 @@ discriminator/passcode/salt/iterations and PAKE verifier and returns the pairing
 Legacy `initialized` / `localInitializationDone` / `remoteInitializationDone` → `clientNode.lifecycle.isSeeded`
 (the peer's structure has been read: BasicInformation present and more than just the root endpoint), with
 `lifecycle.seeded` emitting once on the false→true transition.
+
+`await lifecycle.seeded` never resolves for a peer that is offline, so bound the wait — legacy
+`await node.events.initialized` had the same hang. Race it against a timeout and abort the command on
+expiry (the shell's `awaitSeeded` helper, `util/awaitSeeded.ts`):
+
+```ts
+if (clientNode.lifecycle.isSeeded) return true;
+const observers = new ObserverGroup();
+const sleep = Time.sleep("awaitSeeded", Seconds(60));
+try {
+    const seeded = new Promise(resolve => observers.on(clientNode.lifecycle.seeded, () => resolve()));
+    return await Promise.race([seeded.then(() => true), sleep.then(() => false)]);
+} finally {
+    sleep.cancel();
+    observers.close();
+}
+```
 
 ---
 
@@ -536,10 +569,19 @@ needed (bulk connect happens automatically on controller start unless `autoStart
 verified shell idiom above), then `await clientNode.set({ network: { autoSubscribe: true } })`. Do **not** look
 for a `subscribeAllAttributesAndEvents` — the sustained subscription is state-driven.
 
-**Where did the per-connect diagnostic callbacks go?** There is no per-connect callback bundle. Wire a single
-node-wide `ChangeNotificationService` listener (plus `NetworkClient.subscriptionStatusChanged` for liveness) that
-covers every peer — one registration instead of callbacks threaded through each connect call.
+**Where did the per-connect diagnostic callbacks go?** There is no per-connect callback bundle. Wire it once,
+node-wide: a single `ChangeNotificationService.change` listener (attribute/event/structure changes for every
+peer) plus, per peer, `lifecycle.connectionStateChanged` (attach to `serverNode.peers.commissioned` now and to
+`serverNode.peers.added` for future peers) — one registration set instead of callbacks threaded through each
+connect call. See the node-wide diagnostic-logging idiom above.
 
 **How do I wait until a node's structure is usable?** `if (!clientNode.lifecycle.isSeeded) await clientNode.lifecycle.seeded;`
 before reading its endpoints/behaviors. For an offline peer this can wait indefinitely, so bound it (timeout /
 abort on `WaitingForDeviceDiscovery`) if the caller must not hang.
+
+**I'm upgrading directly from a pre-0.13 (pre-`ServerNode`) install — is my controller storage migrated?**
+The legacy `CommissioningController` carried a one-time migration of the old on-disk layout
+(`credentials` → `certificates`/`fabrics`, plus per-node data) into the `ServerNode` stores. The new API has
+no equivalent hook. Anyone who has already run a 0.13+ (`ServerNode`-based) build is unaffected — that storage
+is already in the new format and is reused as-is via `FabricAuthority.defaultFabric`. Only a *direct* jump from
+a pre-0.13 layout to 0.18 needs a manual re-commission (or an interim run on a 0.13–0.17 build to migrate).

--- a/packages/nodejs-shell/src/MatterNode.ts
+++ b/packages/nodejs-shell/src/MatterNode.ts
@@ -31,6 +31,7 @@ import { OtaProviderEndpoint } from "@matter/node/endpoints/ota-provider";
 import { Ble, Fabric, FabricAuthority } from "@matter/protocol";
 import { NodeId } from "@matter/types";
 import { join } from "node:path";
+import { installDiagnosticLogging } from "./util/diagnosticLogging.js";
 
 const logger = Logger.get("Node");
 
@@ -285,6 +286,8 @@ export class MatterNode {
                 logger.info(`Update failed for peer`, peer);
             });
 
+            installDiagnosticLogging(node, this.#observers);
+
             this.#started = true;
         })();
 
@@ -297,8 +300,7 @@ export class MatterNode {
 
     /**
      * Returns the {@link ClientNode}s for the commissioned peers, connecting them (unless `autoConnect: false`).
-     * Nodes connect asynchronously; await `node.lifecycle.seeded` (guarded by `node.lifecycle.isSeeded`) before
-     * relying on the endpoint structure.
+     * Nodes connect asynchronously; use {@link awaitSeeded} before relying on the endpoint structure.
      */
     async connectAndGetNodes(nodeIdStr?: string, connectOptions?: ConnectClientNodeOptions): Promise<ClientNode[]> {
         await this.start();

--- a/packages/nodejs-shell/src/shell/cmd_cluster-attributes.ts
+++ b/packages/nodejs-shell/src/shell/cmd_cluster-attributes.ts
@@ -9,7 +9,12 @@ import { AttributeModel, ClusterModel, Matter } from "@matter/model";
 import { AttributeId, ClusterId, ClusterLookup, EndpointNumber, ValidationError } from "@matter/types";
 import type { Argv } from "yargs";
 import { MatterNode } from "../MatterNode.js";
-import { readAttributesRemote, resolveClusterEndpoint, ResolvedClusterEndpoint } from "../util/ClusterEndpoint.js";
+import {
+    elementKnownUnsupported,
+    readAttributesRemote,
+    resolveClusterEndpoint,
+    ResolvedClusterEndpoint,
+} from "../util/ClusterEndpoint.js";
 import { convertJsonDataWithModel } from "../util/Json.js";
 
 function generateAllAttributeHandlersForCluster(yargs: Argv, theNode: MatterNode) {
@@ -147,7 +152,7 @@ function generateClusterAttributeHandlers(yargs: Argv, cluster: ClusterModel, th
                                 const attributeName = attribute.propertyName;
                                 if (
                                     !remote &&
-                                    !endpoint.behaviors.elementsOf(behaviorType).attributes.has(attributeName)
+                                    elementKnownUnsupported(endpoint, behaviorType, "attributes", attributeName)
                                 ) {
                                     continue;
                                 }
@@ -274,7 +279,7 @@ function generateAttributeReadHandler(
             }
             const { node, endpoint, behaviorType } = resolved;
 
-            if (!remote && !endpoint.behaviors.elementsOf(behaviorType).attributes.has(attributeName)) {
+            if (!remote && elementKnownUnsupported(endpoint, behaviorType, "attributes", attributeName)) {
                 console.log(
                     `ERROR: Attribute ${node.peerAddress?.nodeId}/${endpointId}/${clusterId}/${attribute.id} not supported by the device.`,
                 );
@@ -348,7 +353,7 @@ function generateAttributeWriteHandler(
             }
             const { node, endpoint, behaviorType } = resolved;
 
-            if (!force && !endpoint.behaviors.elementsOf(behaviorType).attributes.has(attributeName)) {
+            if (!force && elementKnownUnsupported(endpoint, behaviorType, "attributes", attributeName)) {
                 console.log(
                     `ERROR: Attribute ${node.peerAddress?.nodeId}/${endpointId}/${clusterId}/${attribute.id} not supported by the device.`,
                 );

--- a/packages/nodejs-shell/src/shell/cmd_cluster-commands.ts
+++ b/packages/nodejs-shell/src/shell/cmd_cluster-commands.ts
@@ -9,7 +9,7 @@ import { ClusterModel, CommandModel, Matter } from "@matter/model";
 import { ValidationError } from "@matter/types";
 import type { Argv } from "yargs";
 import { MatterNode } from "../MatterNode.js";
-import { resolveClusterEndpoint } from "../util/ClusterEndpoint.js";
+import { elementKnownUnsupported, resolveClusterEndpoint } from "../util/ClusterEndpoint.js";
 import { convertJsonDataWithModel } from "../util/Json.js";
 
 function generateAllCommandHandlersForCluster(yargs: Argv, theNode: MatterNode) {
@@ -130,7 +130,7 @@ async function executeCommand(
     }
     const { node, endpoint, behaviorType } = resolved;
 
-    if (!endpoint.behaviors.elementsOf(behaviorType).commands.has(commandName)) {
+    if (elementKnownUnsupported(endpoint, behaviorType, "commands", commandName)) {
         console.log(
             `ERROR: Command ${node.peerAddress?.nodeId}/${endpointId}/${clusterId}/${command.id} not supported.`,
         );

--- a/packages/nodejs-shell/src/shell/cmd_commission.ts
+++ b/packages/nodejs-shell/src/shell/cmd_commission.ts
@@ -12,6 +12,7 @@ import { DiscoveryCapabilitiesSchema, ManualPairingCodeCodec, NodeId, QrCode, Qr
 import { GeneralCommissioning } from "@matter/types/clusters";
 import type { Argv } from "yargs";
 import { MatterNode } from "../MatterNode.js";
+import { awaitSeeded } from "../util/awaitSeeded.js";
 
 const logger = Logger.get("Commission");
 
@@ -197,12 +198,6 @@ export default function commands(theNode: MatterNode) {
                                         };
                                     }
 
-                                    // MIGRATION-GAP: shell-diagnostic-callbacks — the legacy per-connect attribute/event/state
-                                    // diagnostic logging has no equivalent for the new commission options; a
-                                    // ChangeNotificationService-backed replacement is filed at
-                                    // ~/.todos/matter.js/decease-legacy-controller/shell-diagnostic-callbacks.md (same gap as
-                                    // cmd_nodes.ts `connect`/`add`).
-
                                     let node: ClientNode;
                                     if (ip !== undefined && port !== undefined) {
                                         // Known address: locate/create the peer node directly instead of running mDNS
@@ -227,8 +222,8 @@ export default function commands(theNode: MatterNode) {
 
                                     console.log("Commissioned Node:", node.peerAddress?.nodeId.toString());
 
-                                    if (!node.lifecycle.isSeeded) {
-                                        await node.lifecycle.seeded;
+                                    if (!(await awaitSeeded(node))) {
+                                        return;
                                     }
 
                                     // Example to read cluster state directly instead of via a ClusterClient
@@ -270,8 +265,8 @@ export default function commands(theNode: MatterNode) {
                         const { nodeId, timeout } = argv;
                         await theNode.start();
                         const node = (await theNode.connectAndGetNodes(nodeId, { autoSubscribe: false }))[0];
-                        if (!node.lifecycle.isSeeded) {
-                            await node.lifecycle.seeded;
+                        if (!(await awaitSeeded(node))) {
+                            return;
                         }
 
                         await node.openBasicCommissioningWindow(Seconds(timeout));
@@ -299,8 +294,8 @@ export default function commands(theNode: MatterNode) {
                         await theNode.start();
                         const { nodeId, timeout } = argv;
                         const node = (await theNode.connectAndGetNodes(nodeId, { autoSubscribe: false }))[0];
-                        if (!node.lifecycle.isSeeded) {
-                            await node.lifecycle.seeded;
+                        if (!(await awaitSeeded(node))) {
+                            return;
                         }
                         const { qrPairingCode, manualPairingCode } = await node.openEnhancedCommissioningWindow(
                             Seconds(timeout),
@@ -345,8 +340,8 @@ export default function commands(theNode: MatterNode) {
                             await node.delete();
                         } else {
                             const node = (await theNode.connectAndGetNodes(nodeIdStr, { autoSubscribe: false }))[0];
-                            if (!node.lifecycle.isSeeded) {
-                                await node.lifecycle.seeded;
+                            if (!(await awaitSeeded(node))) {
+                                return;
                             }
                             await node.decommission();
                         }

--- a/packages/nodejs-shell/src/shell/cmd_icd.ts
+++ b/packages/nodejs-shell/src/shell/cmd_icd.ts
@@ -11,6 +11,7 @@ import { NodeId, SubjectId, VendorId } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
 import type { Argv } from "yargs";
 import { MatterNode } from "../MatterNode.js";
+import { awaitSeeded } from "../util/awaitSeeded.js";
 
 const watchers = new Map<string, ObserverGroup>();
 
@@ -99,8 +100,8 @@ async function connectedIcdNode(theNode: MatterNode, nodeId: NodeId): Promise<Cl
         throw new ImplementationError(`Node ${nodeId} not found / not connected`);
     }
     // Behaviors populate as part of seeding; await it so a not-yet-seeded peer isn't misread as non-ICD.
-    if (!clientNode.lifecycle.isSeeded) {
-        await clientNode.lifecycle.seeded;
+    if (!(await awaitSeeded(clientNode, { quiet: true }))) {
+        throw new ImplementationError(`Node ${nodeId} did not become ready (offline?)`);
     }
     if (!clientNode.behaviors.has(IcdClient)) {
         throw new ImplementationError(`Node ${nodeId} is not an ICD device (no IcdManagement cluster)`);

--- a/packages/nodejs-shell/src/shell/cmd_identify.ts
+++ b/packages/nodejs-shell/src/shell/cmd_identify.ts
@@ -7,6 +7,7 @@
 import { IdentifyClient } from "@matter/node/behaviors/identify";
 import type { Argv } from "yargs";
 import { MatterNode } from "../MatterNode.js";
+import { awaitSeeded } from "../util/awaitSeeded.js";
 
 export default function commands(theNode: MatterNode) {
     return {
@@ -36,9 +37,7 @@ export default function commands(theNode: MatterNode) {
             const { nodeId, time = 10, endpointId } = argv;
             const nodes = await theNode.connectAndGetNodes(nodeId);
             for (const node of nodes) {
-                if (!node.lifecycle.isSeeded) {
-                    await node.lifecycle.seeded;
-                }
+                await awaitSeeded(node);
             }
             await theNode.iterateNodeDevices(
                 nodes,

--- a/packages/nodejs-shell/src/shell/cmd_nodes.ts
+++ b/packages/nodejs-shell/src/shell/cmd_nodes.ts
@@ -26,6 +26,7 @@ import { FabricAuthority, PeerSet } from "@matter/protocol";
 import { NodeId } from "@matter/types";
 import type { Argv } from "yargs";
 import { MatterNode } from "../MatterNode.js";
+import { awaitSeeded } from "../util/awaitSeeded.js";
 
 const logger = Logger.get("cmd_nodes");
 
@@ -132,8 +133,8 @@ export default function commands(theNode: MatterNode) {
                     async argv => {
                         const { nodeId } = argv;
                         const node = (await theNode.connectAndGetNodes(nodeId))[0];
-                        if (!node.lifecycle.isSeeded) {
-                            await node.lifecycle.seeded;
+                        if (!(await awaitSeeded(node))) {
+                            return;
                         }
 
                         console.log("Logging structure of Node ", node.peerAddress?.nodeId.toString());
@@ -240,10 +241,6 @@ export default function commands(theNode: MatterNode) {
                         const { nodeId: nodeIdStr, maxSubscriptionInterval, minSubscriptionInterval } = argv;
                         const autoSubscribe = minSubscriptionInterval !== undefined;
 
-                        // MIGRATION-GAP: shell-diagnostic-callbacks — the legacy per-connect attribute/event/state
-                        // diagnostic logging has no equivalent on ConnectClientNodeOptions; a
-                        // ChangeNotificationService-backed replacement is filed at
-                        // ~/.todos/matter.js/decease-legacy-controller/shell-diagnostic-callbacks.md
                         await theNode.connectAndGetNodes(nodeIdStr !== "all" ? nodeIdStr : undefined, {
                             autoSubscribe,
                             subscribeMinIntervalFloorSeconds: autoSubscribe ? minSubscriptionInterval : undefined,
@@ -484,8 +481,6 @@ export default function commands(theNode: MatterNode) {
 
                         const autoSubscribe = minSubscriptionInterval !== undefined;
 
-                        // MIGRATION-GAP: shell-diagnostic-callbacks — see the `connect` command above; same dropped
-                        // per-connect diagnostic logging, same filed todo.
                         await theNode.connectAndGetNodes(nodeIdStr, {
                             autoSubscribe,
                             subscribeMinIntervalFloorSeconds: autoSubscribe ? minSubscriptionInterval : undefined,

--- a/packages/nodejs-shell/src/shell/cmd_subscribe.ts
+++ b/packages/nodejs-shell/src/shell/cmd_subscribe.ts
@@ -4,22 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Diagnostic, ImplementationError, ObserverGroup } from "@matter/general";
-import { ChangeNotificationService, ClusterBehavior, Endpoint, NetworkClient } from "@matter/node";
+import { ImplementationError, ObserverGroup } from "@matter/general";
+import { NetworkClient } from "@matter/node";
 import type { Argv } from "yargs";
 import { MatterNode } from "../MatterNode.js";
 
 const watchers = new Map<string, ObserverGroup>();
-
-/** True if `endpoint` belongs to `node`'s endpoint tree (the node itself is its own root endpoint). */
-function ownedBy(endpoint: Endpoint, node: Endpoint) {
-    for (let e: Endpoint | undefined = endpoint; e !== undefined; e = e.owner) {
-        if (e === node) {
-            return true;
-        }
-    }
-    return false;
-}
 
 export default function commands(theNode: MatterNode) {
     return {
@@ -55,46 +45,8 @@ export default function commands(theNode: MatterNode) {
                 watchers.delete(key);
             });
 
-            // ChangeNotificationService is one aggregate stream for the controller node and *all* its peers, so
-            // restrict to the endpoint tree of the node this command targets.
-            observers.on(theNode.node.env.get(ChangeNotificationService).change, change => {
-                const { endpoint } = change;
-                if (!ownedBy(endpoint, node)) {
-                    return;
-                }
-
-                switch (change.kind) {
-                    case "update": {
-                        const { behavior, properties, version } = change;
-                        if (!ClusterBehavior.is(behavior)) {
-                            break;
-                        }
-                        const state = endpoint.stateOf(behavior.id);
-                        const changed =
-                            properties === undefined
-                                ? state
-                                : Object.fromEntries(properties.map(name => [name, state[name]]));
-                        console.log(
-                            `${nodeId}: Attribute ${endpoint.number}/${behavior.cluster.id} changed to ${Diagnostic.json(changed)} (version ${version})`,
-                        );
-                        break;
-                    }
-                    case "event": {
-                        const { behavior, event, number, timestamp, priority, payload } = change;
-                        if (!ClusterBehavior.is(behavior)) {
-                            break;
-                        }
-                        console.log(
-                            `${nodeId}: Event ${endpoint.number}/${behavior.cluster.id}/${event.propertyName} (#${number}, priority ${priority}, at ${timestamp}) triggered with ${Diagnostic.json(payload)}`,
-                        );
-                        break;
-                    }
-                    case "delete": {
-                        console.log(`${nodeId}: Endpoint ${endpoint.number} removed`);
-                        break;
-                    }
-                }
-            });
+            // Attribute/event/structure changes for every peer are logged node-wide by installDiagnosticLogging
+            // (MatterNode.start); this command only establishes the subscription and reports its liveness.
 
             // Surface subscription liveness transitions (establishment, drop, re-establishment).
             observers.on(node.eventsOf(NetworkClient).subscriptionStatusChanged, isActive => {

--- a/packages/nodejs-shell/src/util/ClusterEndpoint.ts
+++ b/packages/nodejs-shell/src/util/ClusterEndpoint.ts
@@ -6,8 +6,9 @@
 
 import { ClientNode, ClusterBehavior, Endpoint } from "@matter/node";
 import { Read, ReadResult } from "@matter/protocol";
-import { AttributePath, ClusterId, EventPath } from "@matter/types";
+import { AttributePath, ClusterId, EventPath, Status } from "@matter/types";
 import { MatterNode } from "../MatterNode.js";
+import { awaitSeeded } from "./awaitSeeded.js";
 
 export interface ResolvedClusterEndpoint {
     node: ClientNode;
@@ -27,8 +28,8 @@ export async function resolveClusterEndpoint(
     clusterId: number,
 ): Promise<ResolvedClusterEndpoint | undefined> {
     const node = (await theNode.connectAndGetNodes(nodeIdStr))[0];
-    if (!node.lifecycle.isSeeded) {
-        await node.lifecycle.seeded;
+    if (!(await awaitSeeded(node))) {
+        return undefined;
     }
 
     const behaviorType = node.endpoints.has(endpointId)
@@ -39,6 +40,24 @@ export async function resolveClusterEndpoint(
         return undefined;
     }
     return { node, endpoint: node.endpoints.for(endpointId), behaviorType };
+}
+
+/**
+ * True only when `name` is a *known-absent* attribute/command of `behaviorType` on `endpoint`.
+ *
+ * The supported set derives from the behavior's global attribute/command list, which is EMPTY until that list has
+ * been read (a narrow window right after connect). An empty set is treated as "not yet known" — the caller proceeds
+ * to the live read/invoke rather than false-rejecting a genuinely supported element. Only a populated set that omits
+ * `name` is a real "unsupported" answer.
+ */
+export function elementKnownUnsupported(
+    endpoint: Endpoint,
+    behaviorType: ClusterBehavior.Type,
+    kind: "attributes" | "commands",
+    name: string,
+): boolean {
+    const elements = endpoint.behaviors.elementsOf(behaviorType)[kind];
+    return elements.size > 0 && !elements.has(name);
 }
 
 /**
@@ -55,6 +74,12 @@ export async function readAttributesRemote(
         for await (const report of chunk) {
             if (report.kind === "attr-value") {
                 values.push(report);
+            } else if (report.kind === "attr-status") {
+                // A device-declined read (e.g. UnsupportedAttribute/UnsupportedAccess) otherwise reads as empty.
+                const { path, status } = report;
+                console.log(
+                    `ERROR: ${path.endpointId}/${path.clusterId}/${path.attributeId}: ${Status[status] ?? status}`,
+                );
             }
         }
     }
@@ -72,6 +97,9 @@ export async function readEventsRemote(
         for await (const report of chunk) {
             if (report.kind === "event-value") {
                 values.push(report);
+            } else if (report.kind === "event-status") {
+                const { path, status } = report;
+                console.log(`ERROR: ${path.endpointId}/${path.clusterId}/${path.eventId}: ${Status[status] ?? status}`);
             }
         }
     }

--- a/packages/nodejs-shell/src/util/awaitSeeded.ts
+++ b/packages/nodejs-shell/src/util/awaitSeeded.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Duration, ObserverGroup, Seconds, Time } from "@matter/general";
+import { ClientNode } from "@matter/node";
+
+const DEFAULT_SEEDED_TIMEOUT = Seconds(60);
+
+/**
+ * Wait (bounded) for a peer's endpoint structure to seed before reading it.
+ *
+ * Legacy `await node.events.initialized` blocked forever for an offline peer; the direct replacement
+ * `await node.lifecycle.seeded` inherits that hang. This bounds the wait: it returns `true` once the node is seeded
+ * and, on timeout, prints an "offline?" notice and returns `false` so the caller can abort the command instead of
+ * hanging.
+ */
+export async function awaitSeeded(
+    node: ClientNode,
+    { timeout = DEFAULT_SEEDED_TIMEOUT, quiet = false }: { timeout?: Duration; quiet?: boolean } = {},
+): Promise<boolean> {
+    if (node.lifecycle.isSeeded) {
+        return true;
+    }
+
+    const observers = new ObserverGroup();
+    const sleep = Time.sleep("awaitSeeded", timeout);
+    try {
+        const seeded = new Promise<void>(resolve => observers.on(node.lifecycle.seeded, () => resolve()));
+        const isSeeded = await Promise.race([seeded.then(() => true), sleep.then(() => false)]);
+        if (!isSeeded && !quiet) {
+            console.log(
+                `Node ${node.peerAddress?.nodeId} did not become ready within ${Number(timeout) / 1000}s (offline?); giving up.`,
+            );
+        }
+        return isSeeded;
+    } finally {
+        sleep.cancel();
+        observers.close();
+    }
+}

--- a/packages/nodejs-shell/src/util/awaitSeeded.ts
+++ b/packages/nodejs-shell/src/util/awaitSeeded.ts
@@ -32,7 +32,7 @@ export async function awaitSeeded(
         const isSeeded = await Promise.race([seeded.then(() => true), sleep.then(() => false)]);
         if (!isSeeded && !quiet) {
             console.log(
-                `Node ${node.peerAddress?.nodeId} did not become ready within ${Number(timeout) / 1000}s (offline?); giving up.`,
+                `Node ${node.peerAddress?.nodeId} did not become ready within ${Duration.format(timeout)} (offline?); giving up.`,
             );
         }
         return isSeeded;

--- a/packages/nodejs-shell/src/util/diagnosticLogging.ts
+++ b/packages/nodejs-shell/src/util/diagnosticLogging.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Diagnostic, ObserverGroup } from "@matter/general";
+import {
+    ChangeNotificationService,
+    ClientNode,
+    ClusterBehavior,
+    Endpoint,
+    NodeConnectionState,
+    ServerNode,
+} from "@matter/node";
+
+/** True if `endpoint` belongs to `node`'s endpoint tree (the node itself is its own root endpoint). */
+function ownedBy(endpoint: Endpoint, node: Endpoint) {
+    for (let e: Endpoint | undefined = endpoint; e !== undefined; e = e.owner) {
+        if (e === node) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function connectionStateLabel(state: NodeConnectionState) {
+    switch (state) {
+        case NodeConnectionState.Connected:
+            return "connected";
+        case NodeConnectionState.Disconnected:
+            return "disconnected";
+        case NodeConnectionState.Reconnecting:
+            return "reconnecting";
+        case NodeConnectionState.WaitingForDeviceDiscovery:
+            return "waiting for device to be discovered again";
+    }
+}
+
+/**
+ * Wire node-wide diagnostic logging once for the controller and all its peers.
+ *
+ * Replaces the legacy per-connect `createDiagnosticCallbacks` (attribute/event/state callbacks passed into each
+ * `PairedNode.connect`), which the ClientNode API dropped. A single aggregate {@link ChangeNotificationService} stream
+ * covers attribute/event changes for every peer, and each peer's connection-state transitions are logged from its
+ * lifecycle. Registered handlers are owned by `observers` and torn down when it closes.
+ */
+export function installDiagnosticLogging(node: ServerNode, observers: ObserverGroup): void {
+    observers.on(node.env.get(ChangeNotificationService).change, change => {
+        const { endpoint } = change;
+        const peer = node.peers.commissioned.find(peer => ownedBy(endpoint, peer));
+        if (peer === undefined) {
+            return; // A change on the controller's own node, not a peer.
+        }
+        const nodeId = peer.peerAddress?.nodeId;
+
+        switch (change.kind) {
+            case "update": {
+                const { behavior, properties, version } = change;
+                if (!ClusterBehavior.is(behavior)) {
+                    break;
+                }
+                const state = endpoint.stateOf(behavior.id);
+                const changed =
+                    properties === undefined ? state : Object.fromEntries(properties.map(name => [name, state[name]]));
+                console.log(
+                    `Node ${nodeId}: Attribute ${endpoint.number}/${behavior.cluster.id} changed to ${Diagnostic.json(changed)} (version ${version})`,
+                );
+                break;
+            }
+            case "event": {
+                const { behavior, event, number, timestamp, priority, payload } = change;
+                if (!ClusterBehavior.is(behavior)) {
+                    break;
+                }
+                console.log(
+                    `Node ${nodeId}: Event ${endpoint.number}/${behavior.cluster.id}/${event.propertyName} (#${number}, priority ${priority}, at ${timestamp}) triggered with ${Diagnostic.json(payload)}`,
+                );
+                break;
+            }
+            case "delete": {
+                console.log(`Node ${nodeId}: Endpoint ${endpoint.number} removed`);
+                break;
+            }
+        }
+    });
+
+    // Log each commissioned peer's connection-state transitions, torn down when the peer is removed.
+    // peers.added/deleted fire for every node in the container (including transient discovery and group nodes),
+    // so key the handlers by node to remove them on cull and skip nodes without a peer address.
+    const connectionHandlers = new Map<ClientNode, (state: NodeConnectionState) => void>();
+    const watchConnection = (peer: ClientNode) => {
+        if (connectionHandlers.has(peer)) {
+            return;
+        }
+        const handler = (state: NodeConnectionState) => {
+            const nodeId = peer.peerAddress?.nodeId;
+            if (nodeId !== undefined) {
+                console.log(`Node ${nodeId} ${connectionStateLabel(state)}`);
+            }
+        };
+        connectionHandlers.set(peer, handler);
+        peer.lifecycle.connectionStateChanged.on(handler);
+    };
+    const unwatchConnection = (peer: ClientNode) => {
+        const handler = connectionHandlers.get(peer);
+        if (handler !== undefined) {
+            peer.lifecycle.connectionStateChanged.off(handler);
+            connectionHandlers.delete(peer);
+        }
+    };
+    for (const peer of node.peers.commissioned) {
+        watchConnection(peer);
+    }
+    observers.on(node.peers.added, watchConnection);
+    observers.on(node.peers.deleted, unwatchConnection);
+}


### PR DESCRIPTION
Phase-2 of the PairedNode/CommissioningController → ClientNode controller migration: fixes the gaps the nodejs-shell reskin (#4091) surfaced. Stacked on `feat/clientnode-controller-api` (#4091); shell-only + migration-guide, no library changes.

## What

- **Bounded seeded wait** — new `util/awaitSeeded.ts`. Legacy `await node.events.initialized` (and its direct successor `await lifecycle.seeded`) hangs forever for an offline peer. The helper races `seeded` against a 60s timeout, prints an "offline?" notice, and returns `false` so the command aborts instead of hanging. Replaces the 8 raw `await lifecycle.seeded` sites (each bails cleanly).
- **Node-wide diagnostic logging** — new `util/diagnosticLogging.ts`, wired once in `MatterNode.start`. Replaces the dropped per-connect `createDiagnosticCallbacks`: one aggregate `ChangeNotificationService.change` listener (attribute/event/structure for every peer) + per-peer `connectionStateChanged` (attached to current + future peers, torn down on `peers.deleted`). `cmd_subscribe` drops its now-redundant per-node change listener (keeps subscription establishment + liveness feedback).
- **Remote-read status reports** — `readAttributesRemote`/`readEventsRemote` now surface `attr-status`/`event-status` as `ERROR: <path>: <status>` lines, so a device-declined `--remote`/by-id read is visible instead of empty.
- **Element gate tolerance** — `elementKnownUnsupported`: the supported attribute/command set is empty until a behavior's global lists are read (a narrow post-connect window). Treat empty as "not yet known" and proceed to the live read/invoke rather than false-rejecting a genuinely supported element (4 call sites).
- **Migration guide** — `PaseCommissioner` new-world recipe (multi-admin window + commission; `continueCommissioningAfterPase` post-PASE gate; no split-completer convenience), pre-0.13 legacy-storage-migration note, and the node-wide diagnostic-logging / bounded-wait idioms.

## Verification

Shell type-check ✓, `format-verify` ✓, `oxlint` ✓. No library files changed (library tests unaffected; shell has no unit suite). One independent adversarial review pass — 0 Critical, 1 Important (diagnostic listener leak under discovery/decommission churn) fixed before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)