### PR TITLE
fix(protocol): don't hold won PASE session for losing attempts' cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/protocol
     - Enhancement: Connect to a newly discovered address as soon as it supersedes the previously cached address instead of waiting out the connection retry delay
     - Fix: Ensure the commissioning failsafe timer stays within the device's maximum cumulative failsafe
+    - Fix: Parallel PASE commissioning now uses the won session immediately instead of blocking on losing attempts' cleanup, which could let the won session expire at the device failsafe before use
+    - Fix: A device dropped during parallel PASE for invalid credentials no longer accepts a slower successful attempt on another of its addresses
 
 ## 0.17.6 (2026-07-16)
 

--- a/packages/protocol/src/peer/CommissioningConnection.ts
+++ b/packages/protocol/src/peer/CommissioningConnection.ts
@@ -119,10 +119,14 @@ export async function CommissioningConnection(
                 if (session === null) {
                     return null;
                 }
-                if (winner !== undefined || abort.aborted) {
-                    // We lost the overall race — close this session to avoid leaking a PASE channel.
+                // deviceAc fired ⇒ this device was dropped for invalid credentials, so a late success on
+                // another of its addresses must not win.
+                if (winner !== undefined || abort.aborted || deviceAc.signal.aborted) {
+                    // Close this session so we don't leak a PASE channel.  A credential drop fires only
+                    // deviceAc (not the outer abort), so use the composed signal's reason — abort.reason
+                    // would be empty and lose the real cause.
                     session
-                        .initiateForceClose({ cause: asError(abort.reason ?? new Error("commissioning race lost")) })
+                        .initiateForceClose({ cause: asError(signal.reason ?? new Error("commissioning race lost")) })
                         .catch(e => {
                             logger.warn("Error closing losing PASE session:", asError(e));
                         });
@@ -141,7 +145,7 @@ export async function CommissioningConnection(
                         // Wrong passcode — all addresses of this device will fail identically; cancel them now.
                         logger.info(`Dropping device ${candidate.device.deviceIdentifier} due to invalid credentials`);
                         lastNonRetryableError = asErr;
-                        deviceAc.abort();
+                        deviceAc.abort(asErr);
                         pool.markInvalidCredentials(candidate.deviceKey);
                     } else if (causedBy(asErr, NoResponseTimeoutError, TransientPeerCommunicationError, NetworkError)) {
                         lastError = asErr;
@@ -150,7 +154,7 @@ export async function CommissioningConnection(
                         );
                     } else {
                         // Non-retryable error — preserve original type for caller.
-                        abort.abort();
+                        abort.abort(asErr);
                         lastNonRetryableError = asErr;
                     }
                 }
@@ -176,14 +180,17 @@ export async function CommissioningConnection(
             await abort.race(...pending);
         }
 
-        // Wait for losers to run their cleanup (send InvalidParam, close any orphan session).  Every attempt
-        // resolves to null by construction (see launchAttempt's .catch → return null), so allSettled never
-        // rejects here and needs no guard.
-        await MatterAggregateError.allSettled([...pending]);
-
         if (winner !== undefined) {
+            // Do NOT await loser cleanup: a loser stuck in an abort-unresponsive MRP wait would age the won
+            // session past the device pairing failsafe, killing it before commissioning uses it.
+            MatterAggregateError.allSettled([...pending]).catch(error =>
+                logger.warn("Error during losing PASE attempt cleanup:", asError(error)),
+            );
             return winner;
         }
+
+        // No winner — wait for every attempt to settle so we report the most specific failure below.
+        await MatterAggregateError.allSettled([...pending]);
         if (lastNonRetryableError !== undefined) {
             throw lastNonRetryableError;
         }

--- a/packages/protocol/test/peer/CommissioningConnectionTest.ts
+++ b/packages/protocol/test/peer/CommissioningConnectionTest.ts
@@ -52,6 +52,41 @@ describe("CommissioningConnection", () => {
         expect(attempts).deep.equals(["a:fd00::1", "b:fd00::2"]);
     });
 
+    it("does not accept a late success on a device already dropped for invalid credentials", async () => {
+        // One device, two addresses sharing a device abort: the first address fails the credential check
+        // (dropping the whole device), so a slower success on the second address must NOT be accepted as
+        // the winner — the device has been permanently dropped.
+        let releaseLate!: () => void;
+        const lateGate = new Promise<void>(r => (releaseLate = r));
+        let closeCause: unknown;
+
+        const p = CommissioningConnection({
+            devices: [device("a", [udp("fd00::1"), udp("fd00::2")])],
+            timeout: Seconds(2),
+            staggerDelay: 0,
+            establishSession: async address => {
+                if ((address as ServerAddressUdp).ip === "fd00::1") {
+                    throw new UnexpectedDataError("invalid credentials");
+                }
+                await lateGate;
+                return {
+                    initiateForceClose: async (options?: { cause?: unknown }) => {
+                        closeCause = options?.cause;
+                    },
+                } as any;
+            },
+        });
+
+        // Let fd00::1 fail and mark the device invalid, then let fd00::2 complete.
+        await new Promise(r => setTimeout(r, 0));
+        releaseLate();
+
+        await expect(p).rejectedWith(UnexpectedDataError);
+        await new Promise(r => setTimeout(r, 0));
+        // The late session is closed with the real credential error, not the generic race fallback.
+        expect(closeCause).instanceof(UnexpectedDataError);
+    });
+
     it("keeps device in play for network errors while addresses remain", async () => {
         const attempts = new Array<string>();
 
@@ -121,7 +156,60 @@ describe("CommissioningConnection", () => {
         resolveSecond();
 
         await p;
+        // The won session is returned without blocking on loser cleanup, so the loser closes its
+        // orphan session in the background — yield to let that finish before asserting.
+        await new Promise(r => setTimeout(r, 0));
         expect(sessionClosed).equals(true);
+    });
+
+    it("returns the won session without waiting for an abort-unresponsive loser to settle", async () => {
+        // Regression for the parallel-PASE commissioning flake: once one address wins PASE the won
+        // session must be returned immediately.  A loser wedged in an abort-unresponsive wait (device
+        // PASE responder locked until its ~60s pairing failsafe) must NOT delay the winner, or the won
+        // session ages past the failsafe and is already dead by the time commissioning uses it.
+        let releaseLoser!: () => void;
+        const loserGate = new Promise<void>(r => (releaseLoser = r));
+        let winnerResolved = false;
+        let winnerSessionClosed = false;
+
+        const p = CommissioningConnection({
+            devices: [device("winner", [udp("abcd::2")]), device("loser", [udp("10.10.10.2")])],
+            timeout: Seconds(90),
+            staggerDelay: 0,
+            establishSession: async address => {
+                if ((address as ServerAddressUdp).ip === "abcd::2") {
+                    return {
+                        initiateForceClose: async () => {
+                            winnerSessionClosed = true;
+                        },
+                    } as any;
+                }
+                // Loser deliberately ignores the abort signal — models a PASE attempt wedged in an MRP
+                // wait against a device whose responder stays locked until its pairing failsafe expires.
+                await loserGate;
+                return { initiateForceClose: async () => {} } as any;
+            },
+        });
+        const settled = p.then(result => {
+            winnerResolved = true;
+            return result;
+        });
+
+        try {
+            // Give the winner every chance to establish and the race to settle, WITHOUT releasing the loser.
+            for (let i = 0; i < 5; i++) {
+                await new Promise(r => setTimeout(r, 0));
+            }
+
+            expect(winnerResolved).equals(true);
+            const result = await settled;
+            expect(result.discoveryData.deviceIdentifier).equals("winner");
+            expect(winnerSessionClosed).equals(false);
+        } finally {
+            // Release the loser so its cleanup runs and nothing dangles into the next test.
+            releaseLoser();
+            await new Promise(r => setTimeout(r, 0));
+        }
     });
 
     it("closes session if timeout fires while establishment is pending", async () => {


### PR DESCRIPTION
## Problem

Rare CI flake (~1/60 of a full CJS `packages/node` run): commissioning hangs with `Peer is no longer responding to active session` → MRP ack exhaustion. Any commissioned-pair test, position-independent.

## Root cause

Address-level parallel PASE in `CommissioningConnection`. A mock host exposes two addresses (`abcd::<i>` IPv6 + `10.10.10.<i>` IPv4), and `MockTime.resolve({macrotasks})` fast-forwards the 15s per-address stagger, so both race.

`ControllerCommissioner.commission` awaits `CommissioningConnection` **before** claiming the node ID and running the commissioning flow. `CommissioningConnection` set `winner` at t≈0 (won PASE, `abort.abort()` fired) but then did `await allSettled([...pending])` — **holding the won session until every losing attempt settled**. The losing attempt reached the device, got wedged in an abort-unresponsive MRP wait (the device PASE responder stays locked until its ~60s pairing failsafe), and settled only ~60s later. So the won session was returned/commissioned past the failsafe, by which point the device had already killed it → every operational message ignored → MRP hang.

## Fix

- Return the won session immediately; run losing-attempt cleanup as a detached, handled-and-logged promise. Only the no-winner path still awaits (for accurate error reporting).
- Also reject a late PASE success on a device already dropped for invalid credentials — the winning-race guard now consults the per-device abort (`deviceAc`), matching the error path.

## Tests

Two deterministic, revert-sensitive regression tests in `CommissioningConnectionTest.ts`:
- `returns the won session without waiting for an abort-unresponsive loser to settle` — a loser that ignores the abort signal must not delay the winner (fails in ~14ms on the old code).
- `does not accept a late success on a device already dropped for invalid credentials`.

Full suites green: `@matter/protocol` 1475/1475, `@matter/node` 1469/1469; format + lint clean.

## Not changed (investigated)

A losing attempt can still run PASE to completion in a rare neck-and-neck interleaving (mock-only; the 15s stagger prevents it on real hardware) and its session is then force-closed. The only uncancellable window is post-Pake3 (`PaseClient.ts:171-176`), which is intentional — aborting there leaves the *device* in a 60s PASE limbo. The primary fix already removes the harm (the winner no longer waits on any loser), so no change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)