### PR TITLE
feat(node): configurable session intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: `Heap` now stores each item at most once and maintains its position index eagerly, so deleting an item added after an earlier deletion works reliably
 
 - @matter/node
+    - Enhancement: Custom server session intervals (idle/active interval, active threshold) are now configurable via `sessions.intervals`
     - Fix: Optimize Cluster data updates when structures change for ClientNodes
     - Fix: Prevent subscriptions from being activated on a closing session
 

--- a/packages/node/src/behavior/system/network/ServerNetworkRuntime.ts
+++ b/packages/node/src/behavior/system/network/ServerNetworkRuntime.ts
@@ -347,6 +347,7 @@ export class ServerNetworkRuntime extends NetworkRuntime {
         // mDNS) so peers learn it during PASE/CASE and can select TCP for sessions they initiate to us.
         env.get(SessionManager).sessionParameters = {
             maxPathsPerInvoke: this.owner.state.basicInformation.maxPathsPerInvoke,
+            ...this.owner.state.sessions.intervals,
             ...(tcpConfig.incoming || tcpConfig.outgoing
                 ? { supportedTransports: { tcpClient: tcpConfig.outgoing, tcpServer: tcpConfig.incoming } }
                 : {}),

--- a/packages/node/src/behavior/system/sessions/SessionsBehavior.ts
+++ b/packages/node/src/behavior/system/sessions/SessionsBehavior.ts
@@ -6,7 +6,13 @@
 
 import type { ServerNode } from "#node/ServerNode.js";
 import { EventEmitter, Observable } from "@matter/general";
-import { ExposedFabricInformation, NodeSession, SessionManager, Subscription } from "@matter/protocol";
+import {
+    ExposedFabricInformation,
+    NodeSession,
+    SessionIntervals,
+    SessionManager,
+    Subscription,
+} from "@matter/protocol";
 import { NodeId } from "@matter/types";
 import { NodeLifecycle } from "../../../node/NodeLifecycle.js";
 import { Behavior } from "../../Behavior.js";
@@ -106,6 +112,13 @@ export namespace SessionsBehavior {
 
     export class State {
         sessions: Record<number, Session> = {};
+
+        /**
+         * Session intervals this node uses and advertises.  Applied when the node starts; values you omit fall back to
+         * the Matter defaults.  Non-default values are also carried in the operational DNS-SD advertisement
+         * (SII/SAI/SAT).
+         */
+        intervals?: Partial<SessionIntervals>;
     }
 
     export class Events extends EventEmitter {

--- a/packages/node/test/behavior/system/sessions/SessionsBehaviorTest.ts
+++ b/packages/node/test/behavior/system/sessions/SessionsBehaviorTest.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Millis, Seconds } from "@matter/general";
+import { SessionIntervals, SessionManager } from "@matter/protocol";
+import { MockServerNode } from "../../../node/mock-server-node.js";
+
+describe("SessionsBehavior", () => {
+    describe("intervals configuration", () => {
+        it("applies configured intervals to the SessionManager", async () => {
+            const node = await MockServerNode.createOnline(undefined, {
+                sessions: { intervals: { idleInterval: Millis(1000), activeThreshold: Seconds(6) } },
+            });
+
+            const parameters = node.env.get(SessionManager).sessionParameters;
+            expect(parameters.idleInterval).equals(Millis(1000));
+            expect(parameters.activeThreshold).equals(Seconds(6));
+
+            await node.close();
+        });
+
+        it("retains defaults for intervals left unset", async () => {
+            const node = await MockServerNode.createOnline(undefined, {
+                sessions: { intervals: { idleInterval: Millis(1000) } },
+            });
+
+            const parameters = node.env.get(SessionManager).sessionParameters;
+            expect(parameters.activeInterval).equals(SessionIntervals.defaults.activeInterval);
+            expect(parameters.activeThreshold).equals(SessionIntervals.defaults.activeThreshold);
+
+            await node.close();
+        });
+    });
+});

--- a/packages/protocol/src/protocol/DeviceAdvertiser.ts
+++ b/packages/protocol/src/protocol/DeviceAdvertiser.ts
@@ -358,7 +358,10 @@ export class DeviceAdvertiser {
             return;
         }
 
-        const icd = this.#icdAdvertisementProvider?.(fabric);
+        // An ICD-managed fabric governs its own advertised intervals (a LIT ICD deliberately omits SII); only otherwise
+        // do the node's session intervals apply.
+        const { idleInterval, activeInterval, activeThreshold } = this.#context.sessions.sessionParameters;
+        const intervals = this.#icdAdvertisementProvider?.(fabric) ?? { idleInterval, activeInterval, activeThreshold };
 
         for (const advertiser of this.#advertisers) {
             if (event === "startup") {
@@ -370,7 +373,7 @@ export class DeviceAdvertiser {
             }
 
             advertiser.advertise(
-                ServiceDescription.Operational({ fabric, tcp: this.#context.supportedTransports, ...icd }),
+                ServiceDescription.Operational({ fabric, tcp: this.#context.supportedTransports, ...intervals }),
                 event,
             );
         }

--- a/packages/protocol/src/session/SessionManager.ts
+++ b/packages/protocol/src/session/SessionManager.ts
@@ -315,10 +315,11 @@ export class SessionManager {
         if (parameters.activeThreshold !== undefined) {
             assertActiveThreshold(parameters.activeThreshold);
         }
-        this.#sessionParameters = {
-            ...this.#sessionParameters,
-            ...parameters,
-        };
+        for (const [key, value] of Object.entries(parameters)) {
+            if (value !== undefined) {
+                (this.#sessionParameters as Record<string, unknown>)[key] = value;
+            }
+        }
     }
 
     /**

--- a/packages/protocol/test/protocol/DeviceAdvertiserTest.ts
+++ b/packages/protocol/test/protocol/DeviceAdvertiserTest.ts
@@ -8,7 +8,8 @@ import { Advertiser } from "#advertisement/Advertiser.js";
 import { CommissioningMode } from "#advertisement/CommissioningMode.js";
 import { ServiceDescription } from "#advertisement/ServiceDescription.js";
 import { DeviceAdvertiser, DeviceAdvertiserContext, IcdAdvertisement } from "#protocol/DeviceAdvertiser.js";
-import { Observable, Seconds } from "@matter/general";
+import { SessionIntervals } from "#session/SessionIntervals.js";
+import { Millis, Observable, Seconds } from "@matter/general";
 import { FabricIndex, NodeId, VendorId } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
 
@@ -63,6 +64,7 @@ function createMockContext() {
         retry,
         subscriptionsChanged,
         forFabric: () => [] as any[],
+        sessionParameters: { ...SessionIntervals.defaults },
     } as unknown as DeviceAdvertiserContext["sessions"];
 
     return {
@@ -315,6 +317,75 @@ describe("DeviceAdvertiser", () => {
 
             const desc = opAds[0].description as ServiceDescription.Operational;
             expect(desc.icd).to.be.undefined;
+        });
+    });
+
+    describe("session intervals in operational advertisements", () => {
+        function createFabric() {
+            return {
+                fabricIndex: FabricIndex(1),
+                globalId: 1n,
+                nodeId: NodeId(1n),
+            } as any;
+        }
+
+        it("feeds the node's session intervals into a non-ICD operational advertisement", () => {
+            const { fabrics, sessions } = createMockContext();
+            (sessions as any).sessionParameters = {
+                idleInterval: Millis(1000),
+                activeInterval: Millis(700),
+                activeThreshold: Seconds(6),
+            };
+            const advertiser = new MockAdvertiser();
+            const deviceAdvertiser = new DeviceAdvertiser({ fabrics, sessions });
+            deviceAdvertiser.addAdvertiser(advertiser);
+            deviceAdvertiser.enterOperationalMode();
+
+            const fabric = createFabric();
+            (fabrics as any)[Symbol.iterator] = () => [fabric].values();
+            (fabrics.events.added as Observable<[any]>).emit(fabric);
+
+            const opAds = advertiser.advertiseCalls.filter(c => c.description.kind === "operational");
+            expect(opAds.length).greaterThan(0);
+
+            const desc = opAds[0].description as ServiceDescription.Operational;
+            expect(desc.idleInterval).equals(Millis(1000));
+            expect(desc.activeInterval).equals(Millis(700));
+            expect(desc.activeThreshold).equals(Seconds(6));
+            expect(desc.icd).to.be.undefined;
+        });
+
+        it("lets the ICD provider override the node's session intervals", () => {
+            const { fabrics, sessions } = createMockContext();
+            (sessions as any).sessionParameters = {
+                idleInterval: Millis(1000),
+                activeInterval: Millis(700),
+                activeThreshold: Seconds(6),
+            };
+            const advertiser = new MockAdvertiser();
+            const deviceAdvertiser = new DeviceAdvertiser({ fabrics, sessions });
+            deviceAdvertiser.addAdvertiser(advertiser);
+
+            deviceAdvertiser.setIcdAdvertisementProvider(() => ({
+                icd: IcdManagement.OperatingMode.Lit,
+                // idleInterval omitted — LIT SHOULD NOT advertise SII
+                activeInterval: Seconds(3),
+                activeThreshold: Seconds(5),
+            }));
+            deviceAdvertiser.enterOperationalMode();
+
+            const fabric = createFabric();
+            (fabrics as any)[Symbol.iterator] = () => [fabric].values();
+            (fabrics.events.added as Observable<[any]>).emit(fabric);
+
+            const opAds = advertiser.advertiseCalls.filter(c => c.description.kind === "operational");
+            expect(opAds.length).greaterThan(0);
+
+            const desc = opAds[0].description as ServiceDescription.Operational;
+            expect(desc.idleInterval).to.be.undefined;
+            expect(desc.activeInterval).equals(Seconds(3));
+            expect(desc.activeThreshold).equals(Seconds(5));
+            expect(desc.icd).equals(IcdManagement.OperatingMode.Lit);
         });
     });
 });

--- a/packages/protocol/test/session/SessionManagerTest.ts
+++ b/packages/protocol/test/session/SessionManagerTest.ts
@@ -333,4 +333,26 @@ describe("SessionManager", () => {
             expect(sessionManager.sessionParameters.activeThreshold).equal(Millis(65535));
         });
     });
+
+    describe("session parameter setter", () => {
+        function newManager(parameters: Partial<SessionParameters>) {
+            const storage = new MemoryStorageDriver();
+            storage.initialize();
+            return new SessionManager({
+                parameters: parameters as SessionParameters,
+                fabrics: new FabricManager(new StandardCrypto()),
+                storage: new StorageContext(storage, ["context"]),
+            });
+        }
+
+        it("ignores undefined values and retains current values", async () => {
+            const sessionManager = newManager({ idleInterval: Millis(1000), activeInterval: Millis(700) });
+            await sessionManager.construction.ready;
+
+            sessionManager.sessionParameters = { idleInterval: undefined, activeInterval: Millis(600) };
+
+            expect(sessionManager.sessionParameters.idleInterval).equal(Millis(1000));
+            expect(sessionManager.sessionParameters.activeInterval).equal(Millis(600));
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Adds a config surface for the session intervals a node uses and advertises (idle interval / active interval / active threshold — SII / SAI / SAT), and closes a gap where non-ICD nodes could never advertise them.

- **`SessionsBehavior.State.intervals`** — new optional `Partial<SessionIntervals>`. Applied when the node starts; omitted values fall back to the Matter defaults. Survives offline/online.
- **`ServerNetworkRuntime`** — feeds the configured intervals into `SessionManager.sessionParameters` (alongside the existing `maxPathsPerInvoke` / TCP transports).
- **`SessionManager.sessionParameters` setter** — now ignores `undefined` values instead of overwriting current parameters. (Also removes a latent crash: the getter unconditionally reads `supportedTransports.tcpClient`, so a `{ supportedTransports: undefined }` would previously have thrown.)
- **`DeviceAdvertiser`** — for a non-ICD fabric the operational advertisement now carries the node's intervals; an ICD-managed fabric still governs its own advertised intervals (a LIT ICD deliberately omits SII). Non-default values only: the wire-level gate suppresses intervals equal to the spec defaults.

## Testing

- New unit tests: setter undefined-retention; `DeviceAdvertiser` non-ICD fallback and ICD-override-with-omitted-SII paths; node-level propagation of `sessions.intervals` to `SessionManager`.
- Full suites green: `@matter/protocol` 1476/1476, `@matter/node` 1471/1471. Clean build, format, lint all pass.

## Note (out of scope)

Pre-existing: an ICD SIT node re-seeds its advertised intervals from `sessionParameters` at online; combining ICD + custom intervals is worth a live check that the custom SII/SAI actually advertise. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)