### PR TITLE
fix(node): don't enforce choice conformance for members gated by an inapplicable condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Optimize Cluster data updates when structures change for ClientNodes
     - Fix: Prevent subscriptions from being activated on a closing session
     - Fix: Thermostat adjusts the coupled setpoint limit to preserve the AutoMode deadband instead of rejecting the write
+    - Fix: A choice conformance group (e.g. `[ICTL].b+`) no longer requires a member whose own gating condition (e.g. an unsupported feature) makes it inapplicable, which previously blocked constructing clusters such as an Audio-only `CameraAvStreamManagement` server
 
 - @matter/protocol
     - Enhancement: Connect to a newly discovered address as soon as it supersedes the previously cached address instead of waiting out the connection retry delay

--- a/packages/node/src/behavior/state/validation/conformance-compiler.ts
+++ b/packages/node/src/behavior/state/validation/conformance-compiler.ts
@@ -278,6 +278,18 @@ export function astToFunction(schema: ValueModel, supervisor: RootSupervisor): V
     function createChoice(param: Conformance.Ast.Choice): DynamicNode {
         const compiled = compile(param.expr);
 
+        // If the wrapped expression is statically disallowed or nonconformant (e.g. "[FEATURE].x+" where
+        // FEATURE is not supported), this member is never actually part of choice group "name" for this
+        // instance.  The outer gate excludes it entirely, so it must not contribute to, or be constrained
+        // by, the group's cardinality requirement.  Without this, a choice group whose gating condition is
+        // never met still demands "at least one of these fields" from fields that aren't even legal to set.
+        if (isStatic(compiled)) {
+            const staticCompiled = asConformance(compiled);
+            if (staticCompiled.code === Code.Nonconformant || staticCompiled.code === Code.Disallowed) {
+                return compiled;
+            }
+        }
+
         const name = param.name;
         const template: ValidationLocation.Choice = {
             count: 0,
@@ -290,23 +302,30 @@ export function astToFunction(schema: ValueModel, supervisor: RootSupervisor): V
             code: Code.Evaluate,
 
             evaluate: (value, options) => {
-                // Update choice definitions.  This is supplied by the struct validator.  If we're only validating a
-                // single field then choices aren't available so the choice is ignored
-                const choices = options?.choices;
-                let choice;
-                if (choices) {
-                    choice = choices[name];
-                    if (!choice) {
-                        choice = choices[name] = { ...template };
-                    }
-                    if (value !== undefined) {
-                        choice.count++;
+                const result = evaluateNode(compiled, value, options);
+
+                // Only register/count this member if its own gating condition actually resolves to
+                // something applicable for this instance.  A member whose condition is not met at runtime
+                // (e.g. "[FEATURE]" evaluates false) is not part of the choice group's cardinality
+                // requirement either -- mirrors the static check above for conditions only resolvable at
+                // runtime.
+                const resolved = asConformance(result);
+                if (resolved.code !== Code.Nonconformant && resolved.code !== Code.Disallowed) {
+                    // Update choice definitions.  This is supplied by the struct validator.  If we're only
+                    // validating a single field then choices aren't available so the choice is ignored
+                    const choices = options?.choices;
+                    if (choices) {
+                        let choice = choices[name];
+                        if (!choice) {
+                            choice = choices[name] = { ...template };
+                        }
+                        if (value !== undefined) {
+                            choice.count++;
+                        }
                     }
                 }
 
-                // The status of the subexpression is not relevant for the choice.  If conformance fails then it doesn't
-                // matter if we count the choice or not
-                return evaluateNode(compiled, value, options);
+                return result;
             },
         };
     }

--- a/packages/node/test/behavior/state/validation/conformanceTest.ts
+++ b/packages/node/test/behavior/state/validation/conformanceTest.ts
@@ -449,6 +449,27 @@ const AllTests = Tests({
                     },
                 },
             ),
+
+            "gated by disabled feature": Tests(
+                Features({ F: "Foo" }),
+                Fields({ name: "Test1", conformance: "[F].a+" }, { name: "Test2", conformance: "[F].a+" }),
+                {
+                    "allows omission if feature disabled": {},
+
+                    "requires one field if feature enabled": {
+                        supports: ["foo"],
+                        error: {
+                            type: ConformanceError,
+                            message: 'Validating Test: Conformance choice "a": Too few fields present (0 of min 1)',
+                        },
+                    },
+
+                    "allows one field if feature enabled": {
+                        supports: ["foo"],
+                        record: { test1: 1234 },
+                    },
+                },
+            ),
         }),
 
         "enum values": Tests(


### PR DESCRIPTION
## Summary

Fixes #4126.

`createChoice()` in `packages/node/src/behavior/state/validation/conformance-compiler.ts` registered every `X.a+`-style choice member into the group's cardinality tracking unconditionally, even when the member's own gating condition (e.g. `[FEATURE].a+`) was statically or dynamically not applicable. This made the group's "at least one of these fields" constraint fire even when none of the fields were legal to set in the first place.

Concretely, `CameraAvStreamManagement`'s `ImageRotation`/`ImageFlipHorizontal`/`ImageFlipVertical` (conformance `[ICTL].b+`) could never construct an Audio-only (or Video/Snapshot-only) cluster server, because the choice group was enforced even though `ICTL` was disabled and none of the three attributes were applicable at all. See #4126 for the full analysis, minimal repro, and debug log.

`createChoice()` now only registers a member into the choice group when its own resolved conformance (checked statically at compile time, and again at each runtime evaluation) is not `Nonconformant`/`Disallowed` — mirroring how `createOptionalIf()` already treats a purely gated field one level up. No change was needed in `ValueValidator`, since a choice group that never receives a registration is naturally skipped by its enforcement loop.

## Test plan

- [x] Added 3 new cases under `choice > gated by disabled feature` in `packages/node/test/behavior/state/validation/conformanceTest.ts`, mirroring the `[ICTL].b+` shape with a disableable feature.
- [x] Verified the new "allows omission if feature disabled" case fails with `Too few fields present (0 of min 1)` on the pre-fix code (`git stash` of the source change), and passes after.
- [x] `packages/node`: full `behavior/state/validation` suite green (305/305).
- [x] `packages/node`: full test suite 1459/1464 green; the 5 failures are unrelated peer/TCP commissioning timeouts (`Operation aborted` / session timeouts in this sandbox), not touched by this change.
- [x] Full monorepo `npm install` type-check + transpile green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
