### PR TITLE
fix(node): don't enforce choice conformance for members gated by an inapplicable condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Optimize Cluster data updates when structures change for ClientNodes
     - Fix: Prevent subscriptions from being activated on a closing session
     - Fix: Thermostat adjusts the coupled setpoint limit to preserve the AutoMode deadband instead of rejecting the write
+    - Fix: Choice conformance no longer requires a member gated by an inapplicable condition (e.g. `[ICTL].b+` when the feature is unsupported)
 
 - @matter/protocol
     - Enhancement: Connect to a newly discovered address as soon as it supersedes the previously cached address instead of waiting out the connection retry delay

--- a/packages/node/src/behavior/state/validation/conformance-compiler.ts
+++ b/packages/node/src/behavior/state/validation/conformance-compiler.ts
@@ -272,11 +272,23 @@ export function astToFunction(schema: ValueModel, supervisor: RootSupervisor): V
      *
      * Choice conformance is only relevant when validating multiple properties on the same cluster or struct.
      *
-     * Compiling a choice always results in a RuntimeNode that updates the count in options.choice.  If a property is
-     * validated individually then choice is irrelevant and the node does not affect conformance.
+     * A choice whose gating expression is applicable compiles to a RuntimeNode that updates the count in
+     * options.choices.  If a property is validated individually then choice is irrelevant and the node does not affect
+     * conformance.  When the gating expression is statically non-applicable the wrapped static node is returned as-is
+     * so the member neither joins nor constrains the group.
      */
     function createChoice(param: Conformance.Ast.Choice): DynamicNode {
         const compiled = compile(param.expr);
+
+        // A member whose gating expression is non-applicable must neither join nor constrain the choice group, else
+        // the group's cardinality is enforced against a field that cannot exist here.  Static gate: defer to the
+        // field's own conformance, which disallows the value.
+        if (isStatic(compiled)) {
+            const { code } = asConformance(compiled);
+            if (code === Code.Nonconformant || code === Code.Disallowed) {
+                return compiled;
+            }
+        }
 
         const name = param.name;
         const template: ValidationLocation.Choice = {
@@ -290,23 +302,25 @@ export function astToFunction(schema: ValueModel, supervisor: RootSupervisor): V
             code: Code.Evaluate,
 
             evaluate: (value, options) => {
+                const result = evaluateNode(compiled, value, options);
+
+                // Same invariant for a gate only resolvable at runtime: skip the group when the condition is false.
+                const { code } = asConformance(result);
+                if (code === Code.Nonconformant || code === Code.Disallowed) {
+                    return result;
+                }
+
                 // Update choice definitions.  This is supplied by the struct validator.  If we're only validating a
                 // single field then choices aren't available so the choice is ignored
                 const choices = options?.choices;
-                let choice;
                 if (choices) {
-                    choice = choices[name];
-                    if (!choice) {
-                        choice = choices[name] = { ...template };
-                    }
+                    const choice = (choices[name] ??= { ...template });
                     if (value !== undefined) {
                         choice.count++;
                     }
                 }
 
-                // The status of the subexpression is not relevant for the choice.  If conformance fails then it doesn't
-                // matter if we count the choice or not
-                return evaluateNode(compiled, value, options);
+                return result;
             },
         };
     }

--- a/packages/node/test/behavior/state/validation/conformanceTest.ts
+++ b/packages/node/test/behavior/state/validation/conformanceTest.ts
@@ -449,6 +449,34 @@ const AllTests = Tests({
                     },
                 },
             ),
+
+            // A choice group whose members are all gated by an unsupported feature must not apply: omission is
+            // allowed, a set value is still disallowed, and the "at least one" rule only holds once enabled
+            "feature-gated group": Tests(
+                Features({ F: "Foo" }),
+                Fields({ name: "Test1", conformance: "[F].a+" }, { name: "Test2", conformance: "[F].a+" }),
+                {
+                    "allows omission if feature disabled": {},
+
+                    "disallows field if feature disabled": {
+                        record: { test1: 1234 },
+                        error: disallowed("[F].a+", "test1"),
+                    },
+
+                    "allows one field if feature enabled": {
+                        supports: ["foo"],
+                        record: { test1: 1234 },
+                    },
+
+                    "requires one field if feature enabled": {
+                        supports: ["foo"],
+                        error: {
+                            type: ConformanceError,
+                            message: 'Validating Test: Conformance choice "a": Too few fields present (0 of min 1)',
+                        },
+                    },
+                },
+            ),
         }),
 
         "enum values": Tests(


### PR DESCRIPTION
## Problem

Fixes #4126.

A `CameraAvStreamManagement` cluster server with only the `Audio` feature (no `Video`/`Snapshot`/`ImageControl`) — a legal combination per Matter 1.6.0 §16.5 (Audio Doorbell) — fails to construct:

```
Validating …cameraAvStreamManagement.state: Conformance choice "b": Too few fields present (0 of min 1)
```

`ImageRotation`/`ImageFlipHorizontal`/`ImageFlipVertical` are `[ICTL].b+` — they only exist, and the choice-group constraint only applies, when the `ICTL` feature is enabled. With `ICTL` off they are non-applicable, yet the runtime validator still enforced the group's min-count against them.

## Root cause

`createChoice()` in `conformance-compiler.ts` registered **every** member field into `options.choices[name]` unconditionally, ignoring that the member's gating expression (`[ICTL]`) resolved to statically non-applicable. `validateStruct` then enforced `count >= target` on that phantom group.

## Fix

`createChoice()` now skips choice-group registration when the member is non-applicable for the instance:
- **statically** (gate resolves to `Nonconformant`/`Disallowed`, e.g. feature off) — returns the wrapped static node, mirroring `createOptionalIf`;
- **at runtime** (gate condition evaluates false).

Applicable members count exactly as before; a set-but-disallowed field is still rejected by the field-level validator.

## Tests

Added `conformance ➡ choice ➡ feature-gated group` (`[F].a+`, structural twin of `[ICTL].b+`): allows omission when the feature is off, still disallows a set value when off, and preserves the "at least one" requirement when the feature is on.

## Verification

- `npx matter-test esm -p packages/node` — 1482/1482 pass
- `npm run format-verify` — clean
- `npm run lint` — clean

## Note

Independently authored alongside #4127 (thanks @lboue for the report and parallel fix); this variant additionally covers the set-value-disallowed path and refreshes the now-stale `createChoice` JSDoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)