### PR TITLE
test(node): cover Matter §7.3 conformance grammar; fix != operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Optimize Cluster data updates when structures change for ClientNodes
     - Fix: Prevent subscriptions from being activated on a closing session
     - Fix: Thermostat adjusts the coupled setpoint limit to preserve the AutoMode deadband instead of rejecting the write
+    - Fix: Support the `!=` (not-equal) operator in value conformance expressions
 
 - @matter/protocol
     - Enhancement: Connect to a newly discovered address as soon as it supersedes the previously cached address instead of waiting out the connection retry delay

--- a/packages/node/src/behavior/state/validation/conformance-util.ts
+++ b/packages/node/src/behavior/state/validation/conformance-util.ts
@@ -173,6 +173,7 @@ export function createLogicalBinaryEvaluator(
 
 const ComparisonOperators: Record<string, BinaryOperator<{}>> = {
     [Conformance.Operator.EQ]: (a, b) => a === b,
+    [Conformance.Operator.NE]: (a, b) => a !== b,
     [Conformance.Operator.GT]: (a, b) => a > b,
     [Conformance.Operator.GTE]: (a, b) => a >= b,
     [Conformance.Operator.LT]: (a, b) => a < b,

--- a/packages/node/test/behavior/state/validation/conformanceTest.ts
+++ b/packages/node/test/behavior/state/validation/conformanceTest.ts
@@ -6,7 +6,15 @@
 
 import { LocalActorContext } from "#behavior/context/server/LocalActorContext.js";
 import { RootSupervisor } from "#behavior/supervision/RootSupervisor.js";
-import { ClusterModel, CommandModel, DataModelPath, FeatureMap, FieldElement, FieldModel } from "@matter/model";
+import {
+    AttributeModel,
+    ClusterModel,
+    CommandModel,
+    DataModelPath,
+    FeatureMap,
+    FieldElement,
+    FieldModel,
+} from "@matter/model";
 import { ConformanceError, EnumValueConformanceError, UnknownEnumValueError } from "@matter/protocol";
 import { Features, Fields, Tests, testValidation } from "./validation-test-utils.js";
 
@@ -449,6 +457,80 @@ const AllTests = Tests({
                     },
                 },
             ),
+
+            "two or more": Tests(
+                Fields(
+                    { name: "Test1", conformance: "O.a2+" },
+                    { name: "Test2", conformance: "O.a2+" },
+                    { name: "Test3", conformance: "O.a2+" },
+                ),
+                {
+                    "allows two fields": {
+                        record: { test1: 1234, test2: 4321 },
+                    },
+
+                    "allows three fields": {
+                        record: { test1: 1234, test2: 4321, test3: 1111 },
+                    },
+
+                    "disallows no fields": {
+                        error: {
+                            type: ConformanceError,
+                            message: 'Validating Test: Conformance choice "a": Too few fields present (0 of min 2)',
+                        },
+                    },
+
+                    "disallows one field": {
+                        record: { test1: 1234 },
+                        error: {
+                            type: ConformanceError,
+                            message: 'Validating Test: Conformance choice "a": Too few fields present (1 of min 2)',
+                        },
+                    },
+                },
+            ),
+
+            "at most one": Tests(
+                Fields({ name: "Test1", conformance: "O.a-" }, { name: "Test2", conformance: "O.a-" }),
+                {
+                    "allows one field": {
+                        record: { test1: 1234 },
+                    },
+
+                    "allows omission": {},
+
+                    "disallows multiple fields": {
+                        record: { test1: 1234, test2: 4321 },
+                        error: {
+                            type: ConformanceError,
+                            message: 'Validating Test: Conformance choice "a": Too many fields present (2 of max 1)',
+                        },
+                    },
+                },
+            ),
+
+            "at most two": Tests(
+                Fields(
+                    { name: "Test1", conformance: "O.a2-" },
+                    { name: "Test2", conformance: "O.a2-" },
+                    { name: "Test3", conformance: "O.a2-" },
+                ),
+                {
+                    "allows two fields": {
+                        record: { test1: 1234, test2: 4321 },
+                    },
+
+                    "allows omission": {},
+
+                    "disallows three fields": {
+                        record: { test1: 1234, test2: 4321, test3: 1111 },
+                        error: {
+                            type: ConformanceError,
+                            message: 'Validating Test: Conformance choice "a": Too many fields present (3 of max 2)',
+                        },
+                    },
+                },
+            ),
         }),
 
         "enum values": Tests(
@@ -542,6 +624,260 @@ const AllTests = Tests({
                 },
             },
         ),
+
+        "value operators": Tests({
+            "not equal": Tests(
+                Fields(
+                    { name: "Value", type: "uint8" },
+                    { name: "Dependent", type: "bool", conformance: "Value != 4" },
+                ),
+                {
+                    "requires if unequal": {
+                        record: { value: 5 },
+                        error: missing("Value != 4", "dependent"),
+                    },
+
+                    "allows if unequal": {
+                        record: { value: 5, dependent: true },
+                    },
+
+                    "disallows if equal": {
+                        record: { value: 4, dependent: true },
+                        error: disallowed("Value != 4", "dependent"),
+                    },
+
+                    "allows omission if equal": {
+                        record: { value: 4 },
+                    },
+                },
+            ),
+
+            "at least": Tests(
+                Fields(
+                    { name: "Value", type: "uint8" },
+                    { name: "Dependent", type: "bool", conformance: "Value >= 4" },
+                ),
+                {
+                    "requires if equal": {
+                        record: { value: 4 },
+                        error: missing("Value >= 4", "dependent"),
+                    },
+
+                    "requires if greater": {
+                        record: { value: 5 },
+                        error: missing("Value >= 4", "dependent"),
+                    },
+
+                    "disallows if less": {
+                        record: { value: 3, dependent: true },
+                        error: disallowed("Value >= 4", "dependent"),
+                    },
+                },
+            ),
+
+            "at most": Tests(
+                Fields(
+                    { name: "Value", type: "uint8" },
+                    { name: "Dependent", type: "bool", conformance: "Value <= 4" },
+                ),
+                {
+                    "requires if equal": {
+                        record: { value: 4 },
+                        error: missing("Value <= 4", "dependent"),
+                    },
+
+                    "requires if less": {
+                        record: { value: 3 },
+                        error: missing("Value <= 4", "dependent"),
+                    },
+
+                    "disallows if greater": {
+                        record: { value: 5, dependent: true },
+                        error: disallowed("Value <= 4", "dependent"),
+                    },
+                },
+            ),
+
+            range: Tests(
+                Fields(
+                    { name: "Value", type: "uint8" },
+                    { name: "Dependent", type: "bool", conformance: "Value >= 2 & Value <= 8" },
+                ),
+                {
+                    "requires within range": {
+                        record: { value: 5 },
+                        error: missing("Value >= 2 & Value <= 8", "dependent"),
+                    },
+
+                    "allows within range": {
+                        record: { value: 5, dependent: true },
+                    },
+
+                    "disallows below range": {
+                        record: { value: 1, dependent: true },
+                        error: disallowed("Value >= 2 & Value <= 8", "dependent"),
+                    },
+
+                    "disallows above range": {
+                        record: { value: 9, dependent: true },
+                        error: disallowed("Value >= 2 & Value <= 8", "dependent"),
+                    },
+                },
+            ),
+        }),
+
+        "exclusive or": Tests(Features({ F: "Foo", B: "Bar" }), {
+            mandatory: Tests(Fields({ conformance: "F ^ B" }), {
+                "allows if one enabled (LHS)": {
+                    supports: ["foo"],
+                    record: { test: 1234 },
+                },
+
+                "requires if one enabled": {
+                    supports: ["bar"],
+                    error: missing("F ^ B"),
+                },
+
+                "disallows if both enabled": {
+                    supports: ["foo", "bar"],
+                    record: { test: 1234 },
+                    error: disallowed("F ^ B"),
+                },
+
+                "disallows if neither enabled": {
+                    record: { test: 1234 },
+                    error: disallowed("F ^ B"),
+                },
+
+                "allows omission if both enabled": {
+                    supports: ["foo", "bar"],
+                },
+            }),
+
+            optional: Tests(Fields({ conformance: "[F ^ B]" }), {
+                "allows if one enabled": {
+                    supports: ["foo"],
+                    record: { test: 1234 },
+                },
+
+                "allows omission if one enabled": {
+                    supports: ["foo"],
+                },
+
+                "disallows if both enabled": {
+                    supports: ["foo", "bar"],
+                    record: { test: 1234 },
+                    error: disallowed("[F ^ B]"),
+                },
+            }),
+        }),
+
+        otherwise: Tests(Features({ F: "Foo", B: "Bar" }), {
+            "mandatory otherwise optional": Tests(Fields({ conformance: "F, O" }), {
+                "requires if enabled": {
+                    supports: ["foo"],
+                    error: missing("F, O"),
+                },
+
+                "allows if enabled": {
+                    supports: ["foo"],
+                    record: { test: 1234 },
+                },
+
+                "allows if disabled": {
+                    record: { test: 1234 },
+                },
+
+                "allows omission if disabled": {},
+            }),
+
+            "optional otherwise mandatory": Tests(Fields({ conformance: "[F], M" }), {
+                "allows if enabled": {
+                    supports: ["foo"],
+                    record: { test: 1234 },
+                },
+
+                "allows omission if enabled": {
+                    supports: ["foo"],
+                },
+
+                "requires if disabled": {
+                    error: missing("[F], M"),
+                },
+            }),
+
+            "negated mandatory otherwise optional": Tests(Fields({ conformance: "!F, O" }), {
+                "requires if disabled": {
+                    error: missing("!F, O"),
+                },
+
+                "allows if enabled": {
+                    supports: ["foo"],
+                    record: { test: 1234 },
+                },
+
+                "allows omission if enabled": {
+                    supports: ["foo"],
+                },
+            }),
+
+            "mandatory otherwise optional-if": Tests(Fields({ conformance: "F, [B]" }), {
+                "requires if first enabled": {
+                    supports: ["foo"],
+                    error: missing("F, [B]"),
+                },
+
+                "allows if second enabled": {
+                    supports: ["bar"],
+                    record: { test: 1234 },
+                },
+
+                "allows omission if second enabled": {
+                    supports: ["bar"],
+                },
+
+                "disallows if neither enabled": {
+                    record: { test: 1234 },
+                    error: disallowed("F, [B]"),
+                },
+            }),
+
+            "optional list equals disjunction": Tests(Fields({ conformance: "[F], [B]" }), {
+                "allows if enabled (LHS)": {
+                    supports: ["foo"],
+                    record: { test: 1234 },
+                },
+
+                "allows if enabled (RHS)": {
+                    supports: ["bar"],
+                    record: { test: 1234 },
+                },
+
+                "disallows if disabled": {
+                    record: { test: 1234 },
+                    error: disallowed("[F], [B]"),
+                },
+
+                "allows omission if disabled": {},
+            }),
+        }),
+
+        disallowed: Tests(Fields({ conformance: "X" }), {
+            "disallows the field": {
+                record: { test: 1234 },
+                error: disallowed("X"),
+            },
+
+            "allows omission": {},
+        }),
+
+        provisional: Tests(Fields({ conformance: "P" }), {
+            "allows the field": {
+                record: { test: 1234 },
+            },
+
+            "allows omission": {},
+        }),
 
         "enum equality": Tests(
             Fields(
@@ -790,6 +1126,48 @@ describe("conformance", () => {
 
         it("requires field when conformance references cluster element", () => {
             expect(() => validate({})).throw(ConformanceError);
+        });
+    });
+
+    describe("revision", () => {
+        function managerFor(revision: number, conformance: string) {
+            const cluster = new ClusterModel({
+                name: "Test",
+                children: [
+                    FeatureMap.clone(),
+                    new AttributeModel({ name: "ClusterRevision", id: 0xfffd, type: "uint16", default: revision }),
+                    new FieldModel({ name: "Dependent", type: "uint8", conformance }),
+                ],
+            });
+            return RootSupervisor.for(cluster).get(cluster);
+        }
+
+        function validate(manager: ReturnType<typeof managerFor>, record: Record<string, unknown>) {
+            manager.validate?.(record, LocalActorContext.ReadOnly, { path: new DataModelPath("Test") });
+        }
+
+        it("requires field when revision satisfies mandatory condition", () => {
+            const manager = managerFor(2, "Rev >= v2");
+            expect(() => validate(manager, {})).throw(ConformanceError);
+            expect(() => validate(manager, { dependent: 42 })).not.throw();
+        });
+
+        it("disallows field when revision below mandatory condition", () => {
+            const manager = managerFor(1, "Rev >= v2");
+            expect(() => validate(manager, { dependent: 42 })).throw(ConformanceError);
+            expect(() => validate(manager, {})).not.throw();
+        });
+
+        it("allows field when revision satisfies optional condition", () => {
+            const manager = managerFor(2, "[Rev >= v2]");
+            expect(() => validate(manager, { dependent: 42 })).not.throw();
+            expect(() => validate(manager, {})).not.throw();
+        });
+
+        it("disallows field when revision below optional condition", () => {
+            const manager = managerFor(1, "[Rev >= v2]");
+            expect(() => validate(manager, { dependent: 42 })).throw(ConformanceError);
+            expect(() => validate(manager, {})).not.throw();
         });
     });
 });


### PR DESCRIPTION
## What

Audited the runtime conformance validator (`conformance-compiler.ts`, `conformance-util.ts`, `ValueValidator.ts`) against the Matter 1.6.0 conformance grammar (`§7.3`) and filled the test-coverage gaps. Every construct the validator implements now has direct coverage.

## Coverage added

| Construct | Status before |
| --- | --- |
| Choice `O.a2+` (at least two) | untested (live in models) |
| Choice `O.a-` / `O.a2-` (at most — `orLess`) | never exercised (live: water-heater `[!TP], [TP].a-`) |
| Value `!=` | broken — see fix below |
| Value `<=`, `>=` | untested (only `<`, `>`, `==`) |
| Range `x <= EF & EF <= y` | untested |
| XOR `^` | untested |
| Otherwise `F, O` / `[F], M` / `!F, O` / `F, [B]` / `[F], [B]` | only one complex case |
| Revision `Rev >= vN` / `[Rev >= vN]` | untested |
| Disallowed `X` (field level) | only enum-member level |
| Provisional `P` | untested |

## Fix included

Adding `!=` coverage surfaced a real gap: the runtime comparison-operator map (`conformance-util.ts`) had entries for `==`, `<`, `<=`, `>`, `>=` but **not `!=`**, so a `Value != 4` conformance threw `Unknown binary operator !=` at runtime even though the parser and AST support it and the spec (§7.3.9) defines it. Added the operator (`a !== b`). No shipped 1.6.0 model uses `!=` yet, so this was latent, but it affects any custom cluster using it.

## Known limitation (not addressed here)

The choice **range form** `O.a2-4` (§7.3.14) is deliberately rejected by the parser (`INVALID_CHOICE`) — the Choice AST has no range field. No 1.6.0 model uses it, so there is no live impact; supporting it would require AST + parser + validator work and belongs in a separate change.

## Verification

- `npx matter-test esm -p packages/node` — 1535/1535 pass
- `npm run format-verify` — clean
- `npm run lint` — clean

Test expectations independently reviewed against the spec grammar (not against implementation behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)