### PR TITLE
fix(node): await FabricAuthority construction before reading fabrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Thermostat adjusts the coupled setpoint limit to preserve the AutoMode deadband instead of rejecting the write
     - Fix: Choice conformance no longer requires a member gated by an inapplicable condition (e.g. `[ICTL].b+` when the feature is unsupported)
     - Fix: Support the `!=` (not-equal) operator in value conformance expressions
+    - Fix: Ensure `FabricAuthority` is fully constructed before it is used in the WebRTC Transport Requestor, OTA Software Update Provider and Software Update clusters
 
 - @matter/protocol
     - Enhancement: Connect to a newly discovered address as soon as it supersedes the previously cached address instead of waiting out the connection retry delay

--- a/packages/node/src/behavior/system/software-update/SoftwareUpdateManager.ts
+++ b/packages/node/src/behavior/system/software-update/SoftwareUpdateManager.ts
@@ -182,7 +182,7 @@ export class SoftwareUpdateManager extends Behavior {
         // For now let's just provide update functionality when we are the fabric owner
         // In theory we could also claim that for any other fabric but could conflict with the main controller of
         // the fabric that then also claims being "the one provider".
-        const fabricAuthority = this.env.get(FabricAuthority);
+        const fabricAuthority = await this.env.load(FabricAuthority);
         const ownFabric = fabricAuthority.fabrics[0];
         if (!ownFabric) {
             // Can only happen if the SoftwareUpdateManager is used without any commissioned nodes

--- a/packages/node/src/behaviors/ota-software-update-provider/OtaSoftwareUpdateProviderServer.ts
+++ b/packages/node/src/behaviors/ota-software-update-provider/OtaSoftwareUpdateProviderServer.ts
@@ -105,7 +105,7 @@ export class OtaSoftwareUpdateProviderServer extends OtaSoftwareUpdateProviderBe
     }
 
     async #nodeOnline() {
-        const fabricAuthority = this.env.get(FabricAuthority);
+        const fabricAuthority = await this.env.load(FabricAuthority);
         const ownFabric = fabricAuthority.fabrics[0];
         if (!ownFabric) {
             // Can only happen if the SoftwareUpdateManager is used without any commissioned nodes

--- a/packages/node/src/behaviors/web-rtc-transport-requestor/WebRtcTransportRequestorServer.ts
+++ b/packages/node/src/behaviors/web-rtc-transport-requestor/WebRtcTransportRequestorServer.ts
@@ -53,7 +53,7 @@ export class WebRtcTransportRequestorServer extends WebRtcTransportRequestorBeha
     }
 
     async #nodeOnline() {
-        const fabricAuthority = this.env.get(FabricAuthority);
+        const fabricAuthority = await this.env.load(FabricAuthority);
         const ownFabric = fabricAuthority.fabrics[0];
         if (!ownFabric) {
             this.reactTo(fabricAuthority.fabricAdded, this.#nodeOnline, { once: true });


### PR DESCRIPTION
## Problem

Fixes #4130.

`WebRtcTransportRequestorServer`, `OtaSoftwareUpdateProviderServer` and `SoftwareUpdateManager` read `fabricAuthority.fabrics[0]` in their `#nodeOnline()` handlers via `env.get(FabricAuthority)`, which returns the instance without awaiting its construction.

The `.fabrics` getter calls `hasControlOf()` → `CertificateAuthority.rootCert`, which asserts the CA construction is `Active`. On nodes where behavior initialization wins the race against CA construction (reliably reproducible on large aggregator bridges with many endpoints), this throws `uninitialized-dependency: root cert is still initializing`. The throw is unhandled and takes the whole node offline right after it comes online.

## Fix

Use `await this.env.load(FabricAuthority)` (which awaits the `FabricAuthority` construction, in turn awaiting the `CertificateAuthority` and `FabricManager`) before reading `fabrics`. This matches the existing idiom in `ControllerBehavior.initialize()`.

Applied to all three affected behaviors. Controller-side consumers (`ControllerBehavior`, `CommissioningClient`) already await `env.load(FabricAuthority)` and are unaffected.

## Verification

- `npm run build -w @matter/node` ✓
- `npm run format-verify` ✓
- `npm run lint` ✓
- node package tests 1540/1540 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)