### PR TITLE
fix(protocol): clear group message reception state when a key set is removed or rewritten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Parallel PASE commissioning now uses the won session immediately instead of blocking on losing attempts' cleanup, which could let the won session expire at the device failsafe before use
     - Fix: A device dropped during parallel PASE for invalid credentials no longer accepts a slower successful attempt on another of its addresses
     - Fix: Extend the handling of non-compliant devices that drop the commissioning connection when network details are added (`AddOrUpdateWiFi`/`AddOrUpdateThread`), not only on `ConnectNetwork`, treating them as non-concurrent and proceeding directly to operational discovery
+    - Fix: Clear group message reception (replay) state when a group key set is removed or rewritten, so valid messages are not rejected as replays after a key set is re-provisioned with a reused epoch key
 
 ## 0.17.6 (2026-07-16)
 

--- a/packages/protocol/src/groups/FabricGroups.ts
+++ b/packages/protocol/src/groups/FabricGroups.ts
@@ -124,6 +124,7 @@ export class FabricGroups {
      */
     async setFromGroupKeySet(groupKeySet: GroupKeySet) {
         const { epochKey0, epochKey1, epochKey2 } = groupKeySet;
+        const previousEntry = this.#keySets.get("groupKeySetId", groupKeySet.groupKeySetId);
 
         if (epochKey0 === null) {
             throw new MatterFlowError("EpochKey0 must be set"); // checked before, but to make typing happy
@@ -169,6 +170,11 @@ export class FabricGroups {
                     ? await this.#keySets.sessionIdFromKey(this.#fabric.crypto, operationalEpochKey2)
                     : null,
         });
+        // An in-place rewrite that changes epoch keys drops the previous operational keys; forget their reception state
+        // (unless still referenced) so a later key set reusing a dropped epoch key re-synchronizes on its first message.
+        if (previousEntry !== undefined) {
+            this.#forgetUnreferencedReceptionState(previousEntry);
+        }
     }
 
     /** Removes a group key set by its id. */
@@ -176,6 +182,36 @@ export class FabricGroups {
         if (groupKeySetId === 0) {
             throw new InternalError("Cannot remove the group key set 0.");
         }
-        return this.#keySets.delete("groupKeySetId", groupKeySetId);
+        const removedEntry = this.#keySets.get("groupKeySetId", groupKeySetId);
+        const deleted = this.#keySets.delete("groupKeySetId", groupKeySetId);
+        if (removedEntry !== undefined) {
+            this.#forgetUnreferencedReceptionState(removedEntry);
+        }
+        return deleted;
+    }
+
+    /**
+     * Forget the group message replay-protection state for a departing key set's operational keys, unless a remaining
+     * key set still derives the same key — duplicate epoch keys share one reception window, so it must survive until the
+     * last referencing key set is gone.
+     */
+    #forgetUnreferencedReceptionState(formerEntry: OperationalKeySet) {
+        const stillReferenced = new Set<string>();
+        for (const keySet of this.#keySets) {
+            for (const key of [keySet.operationalEpochKey0, keySet.operationalEpochKey1, keySet.operationalEpochKey2]) {
+                if (key !== null) {
+                    stillReferenced.add(Bytes.toHex(key));
+                }
+            }
+        }
+        for (const key of [
+            formerEntry.operationalEpochKey0,
+            formerEntry.operationalEpochKey1,
+            formerEntry.operationalEpochKey2,
+        ]) {
+            if (key !== null && !stillReferenced.has(Bytes.toHex(key))) {
+                this.#messagingState.forgetReceptionState(key);
+            }
+        }
     }
 }

--- a/packages/protocol/src/groups/MessagingState.ts
+++ b/packages/protocol/src/groups/MessagingState.ts
@@ -87,4 +87,13 @@ export class MessagingState {
         }
         return receptionState;
     }
+
+    /**
+     * Discards the replay-protection reception state for an operational key.  Called when the key's key set is removed
+     * so that a later key set reusing the same epoch key starts a fresh counter window and its first message
+     * re-synchronizes instead of being rejected as a replay against the removed key's high-water counter.
+     */
+    forgetReceptionState(operationalKey: Bytes) {
+        this.#messageDataReceptionState.delete(Bytes.toHex(operationalKey));
+    }
 }

--- a/packages/protocol/test/session/SessionManagerTest.ts
+++ b/packages/protocol/test/session/SessionManagerTest.ts
@@ -7,6 +7,7 @@
 import { Fabric } from "#fabric/Fabric.js";
 import { FabricManager } from "#fabric/FabricManager.js";
 import { SessionParameters } from "#index.js";
+import { DuplicateMessageError } from "#protocol/MessageReceptionState.js";
 import { SessionManager } from "#session/SessionManager.js";
 import {
     b$,
@@ -295,6 +296,106 @@ describe("SessionManager", () => {
             fabric.groups.removeGroupKeySet(1);
             const after = await sessionManager.groupDataMessageCounter.getIncrementedCounter();
             expect(after).greaterThan(before);
+        });
+
+        const keySet = (groupKeySetId: number, epochKey0: Bytes) => ({
+            groupKeySetId,
+            groupKeySecurityPolicy: 0,
+            epochKey0,
+            epochStartTime0: 1,
+            epochKey1: null,
+            epochStartTime1: null,
+            epochKey2: null,
+            epochStartTime2: null,
+            groupKeyMulticastPolicy: 0,
+        });
+
+        it("forgets group message reception state when its key set is removed so a reused key re-syncs", async () => {
+            const crypto = new StandardCrypto();
+            const storage = new MemoryStorageDriver();
+            storage.initialize();
+            const fabricManager = new FabricManager(crypto);
+            await fabricManager.construction.ready;
+            const fabric = groupFabric(crypto, new StorageContext(storage, ["fabric"]));
+            fabricManager.addFabric(fabric);
+
+            const epochKey = b$`000102030405060708090a0b0c0d0e0f`;
+            await fabric.groups.setFromGroupKeySet(keySet(1, epochKey));
+
+            const source = NodeId(2);
+            const operationalKey = fabric.groups.keySets.get("groupKeySetId", 1)!.operationalEpochKey0;
+
+            // Advance the replay window; a lower counter on the retained state is then a replay.
+            fabric.groups.messaging.receptionStateFor(source, operationalKey).updateMessageCounter(1000);
+            expect(() =>
+                fabric.groups.messaging.receptionStateFor(source, operationalKey).updateMessageCounter(500),
+            ).throws(DuplicateMessageError);
+
+            // Remove and re-provision the identical epoch key (same derived operational key).
+            fabric.groups.removeGroupKeySet(1);
+            await fabric.groups.setFromGroupKeySet(keySet(1, epochKey));
+            const reusedKey = fabric.groups.keySets.get("groupKeySetId", 1)!.operationalEpochKey0;
+            expect(Bytes.toHex(reusedKey)).equals(Bytes.toHex(operationalKey));
+
+            // The fresh window syncs on the first (lower) counter instead of rejecting it as a replay.
+            expect(() =>
+                fabric.groups.messaging.receptionStateFor(source, reusedKey).updateMessageCounter(500),
+            ).not.throws();
+        });
+
+        it("keeps reception state until the last key set sharing an operational key is removed", async () => {
+            const crypto = new StandardCrypto();
+            const storage = new MemoryStorageDriver();
+            storage.initialize();
+            const fabricManager = new FabricManager(crypto);
+            await fabricManager.construction.ready;
+            const fabric = groupFabric(crypto, new StorageContext(storage, ["fabric"]));
+            fabricManager.addFabric(fabric);
+
+            const epochKey = b$`000102030405060708090a0b0c0d0e0f`;
+            await fabric.groups.setFromGroupKeySet(keySet(1, epochKey));
+            await fabric.groups.setFromGroupKeySet(keySet(2, epochKey));
+
+            const source = NodeId(2);
+            const operationalKey = fabric.groups.keySets.get("groupKeySetId", 1)!.operationalEpochKey0;
+            fabric.groups.messaging.receptionStateFor(source, operationalKey).updateMessageCounter(1000);
+
+            // One of two key sets shares the derived key, so its reception window must survive this removal.
+            fabric.groups.removeGroupKeySet(1);
+            expect(() =>
+                fabric.groups.messaging.receptionStateFor(source, operationalKey).updateMessageCounter(500),
+            ).throws(DuplicateMessageError);
+
+            // Removing the last referencing key set forgets it.
+            fabric.groups.removeGroupKeySet(2);
+            expect(() =>
+                fabric.groups.messaging.receptionStateFor(source, operationalKey).updateMessageCounter(500),
+            ).not.throws();
+        });
+
+        it("forgets the previous operational key when a key set is rewritten with a new epoch key", async () => {
+            const crypto = new StandardCrypto();
+            const storage = new MemoryStorageDriver();
+            storage.initialize();
+            const fabricManager = new FabricManager(crypto);
+            await fabricManager.construction.ready;
+            const fabric = groupFabric(crypto, new StorageContext(storage, ["fabric"]));
+            fabricManager.addFabric(fabric);
+
+            const epochA = b$`000102030405060708090a0b0c0d0e0f`;
+            const epochB = b$`0f0e0d0c0b0a09080706050403020100`;
+            await fabric.groups.setFromGroupKeySet(keySet(1, epochA));
+
+            const source = NodeId(2);
+            const operationalA = fabric.groups.keySets.get("groupKeySetId", 1)!.operationalEpochKey0;
+            fabric.groups.messaging.receptionStateFor(source, operationalA).updateMessageCounter(1000);
+
+            // In-place rewrite with a different epoch key drops key A, so its window must be forgotten.
+            await fabric.groups.setFromGroupKeySet(keySet(1, epochB));
+
+            expect(() =>
+                fabric.groups.messaging.receptionStateFor(source, operationalA).updateMessageCounter(500),
+            ).not.throws();
         });
     });
 


### PR DESCRIPTION
## Problem

Group message replay protection keeps a per-fabric reception (counter) window keyed by the **operational group key** (`MessagingState`, keyed by `(operationalKeyHex, sourceNodeId)`). A message whose counter is ≤ the window is rejected as a replay.

Removing a group key set (`KeySetRemove`) or rewriting one in place with a new epoch key (`KeySetWrite`) left the old key's reception window behind. A later key set that reuses the same epoch key derives the **same** operational key, hits the stale high-water counter, and rejects legitimate lower-counter messages as replays (`GroupcastTestResult = MessageReplay`).

Real-world symptom: running **TC_ACE_1_6 twice against the same node without a restart** — the test tears down (RemoveAllGroups, clear GroupKeyMap, KeySetRemove) and re-provisions the same keys; the second run's group message is dropped as a replay against the first run's counter. (CI passes because each run gets a fresh node; the bug only bites repeat-runs on a live device or key-rotation-with-reuse.)

## Fix

Forget the reception state for a departing key set's operational keys, on both removal and in-place rewrite — but only when **no remaining key set still derives the same operational key** (duplicate epoch keys share one window, so it survives until the last referencing key set is gone).

Reception state is in-memory only and already resets on restart, so this does not weaken replay protection (re-provisioning the same epoch key after a reboot already starts fresh).

## Tests

Three unit tests in `SessionManagerTest.ts`:
- remove + re-provision the same epoch key → fresh window re-syncs on the first message
- two key sets sharing an operational key → window survives removing one, forgotten on the last
- in-place rewrite with a new epoch key → old key's window forgotten

All toggle-verified (fail without the fix). `build --clean`, protocol suite, format-verify, lint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)