### PR TITLE
fix(testing): implement Timer.interval in MockTimer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A device dropped during parallel PASE for invalid credentials no longer accepts a slower successful attempt on another of its addresses
     - Fix: Extend the handling of non-compliant devices that drop the commissioning connection when network details are added (`AddOrUpdateWiFi`/`AddOrUpdateThread`), not only on `ConnectNetwork`, treating them as non-concurrent and proceeding directly to operational discovery
     - Fix: Clear group message reception (replay) state when a group key set is removed or rewritten, so valid messages are not rejected as replays after a key set is re-provisioned with a reused epoch key
+    - Fix: A subscription reaching its timeout at the current instant now expires instead of rescheduling a zero-length timeout repeatedly
+
+- @matter/testing
+    - Fix: Mock timers implement the `Timer.interval` accessor, so assignments take effect on the next start, reads no longer return `undefined` and out-of-range intervals are rejected as in production
+    - Fix: Mock timers report `isPeriodic` correctly and restart instead of double-arming when started while running
+    - Fix: `MockTime.advance()` fails with a diagnostic instead of spinning when a timer rearms without letting mock time advance
 
 ## 0.17.6 (2026-07-16)
 

--- a/packages/protocol/src/action/client/subscription/ClientSubscriptions.ts
+++ b/packages/protocol/src/action/client/subscription/ClientSubscriptions.ts
@@ -245,7 +245,7 @@ export class ClientSubscriptions implements Lifetime.Owner {
                 if (timeoutAt === undefined) {
                     // Set timeout time
                     timeoutAt = subscription.timeoutAt = Timestamp(now + subscription.timeout);
-                } else if (timeoutAt < now) {
+                } else if (timeoutAt <= now) {
                     // Timeout
                     subscription.timedOut();
                     continue;

--- a/packages/protocol/test/action/client/subscription/ClientSubscriptionsTest.ts
+++ b/packages/protocol/test/action/client/subscription/ClientSubscriptionsTest.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ClientSubscriptions } from "#action/client/subscription/ClientSubscriptions.js";
+import { PeerSubscription } from "#action/client/subscription/PeerSubscription.js";
+import { PeerAddress } from "#peer/PeerAddress.js";
+import { Duration, Lifetime, Seconds, Time, Timestamp } from "@matter/general";
+import { FabricIndex, NodeId } from "@matter/types";
+
+const PEER = PeerAddress({ fabricIndex: FabricIndex(1), nodeId: NodeId(1) });
+
+function fakePeerSub(timeout: Duration, timedOut: () => void): PeerSubscription {
+    return {
+        peer: PEER,
+        subscriptionId: 1,
+        isReading: false,
+        timeout,
+        timedOut,
+    } as unknown as PeerSubscription;
+}
+
+describe("ClientSubscriptions", () => {
+    beforeEach(() => MockTime.reset());
+
+    describe("resetTimer", () => {
+        it("expires a subscription that times out at the current instant", async () => {
+            const subscriptions = new ClientSubscriptions(Lifetime("test client subscriptions"));
+            let timedOutCount = 0;
+            const subscription = fakePeerSub(Seconds(10), () => timedOutCount++);
+
+            subscriptions.addPeer(subscription);
+            expect(subscription.timeoutAt).equal(Timestamp(Time.nowMs + Seconds(10)));
+
+            await MockTime.advance(Seconds(10));
+
+            expect(timedOutCount).equal(1);
+        });
+    });
+});

--- a/packages/protocol/test/dcl/DclCertificateServiceTest.ts
+++ b/packages/protocol/test/dcl/DclCertificateServiceTest.ts
@@ -11,7 +11,6 @@ import { DclCertificateService } from "#dcl/DclCertificateService.js";
 import {
     Bytes,
     Crypto,
-    Days,
     Diagnostic,
     Environment,
     LogFormat,
@@ -759,7 +758,7 @@ describe("DclCertificateService", () => {
             );
             fetchMock.install();
 
-            const service = new DclCertificateService(environment, { updateInterval: Days(365) }); // Disable auto-updates
+            const service = new DclCertificateService(environment, { updateInterval: null });
             await service.construction;
 
             // Clear the index to simulate the certificate not being present
@@ -799,7 +798,7 @@ describe("DclCertificateService", () => {
             });
             fetchMock.install();
 
-            const service = new DclCertificateService(environment, { updateInterval: Days(365) });
+            const service = new DclCertificateService(environment, { updateInterval: null });
             await service.construction;
 
             const cert = await service.getOrFetchCertificate("NONEXISTENTCERTIFICATE");
@@ -813,7 +812,7 @@ describe("DclCertificateService", () => {
             fetchMock.addResponse("/dcl/pki/root-certificates", { error: "Server error" }, { status: 500 });
             fetchMock.install();
 
-            const service = new DclCertificateService(environment, { updateInterval: Days(365) });
+            const service = new DclCertificateService(environment, { updateInterval: null });
             await service.construction;
 
             const cert = await service.getOrFetchCertificate("785CE705B86B8F4E6FC793AA60CB43EA696882D5");

--- a/packages/testing/src/mocks/time.ts
+++ b/packages/testing/src/mocks/time.ts
@@ -31,6 +31,8 @@ export interface MockTime extends MockTimeLike {}
 
 const macrotaskDependents = new Set<Promise<unknown>>();
 
+const timerNames = new WeakMap<TimerCallback, string>();
+
 const registry = {
     timers: new Set<MockTimer>(),
     register(_timer: MockTimer) {},
@@ -41,23 +43,28 @@ const registry = {
 class MockTimer {
     name = "Test";
     systemId = 0;
-    intervalMs = 0;
-    isPeriodic = false;
+    utility = false;
+    readonly isPeriodic: boolean;
 
     #mockTime: MockTime;
-    #duration: number;
+    #interval = 0;
+    #armedInterval = 0;
 
     isRunning = false;
     readonly #callback: TimerCallback;
 
-    constructor(mockTime: MockTime, name: string, duration: number, callback: TimerCallback) {
+    constructor(mockTime: MockTime, name: string, duration: number, callback: TimerCallback, isPeriodic = false) {
         this.name = name;
+        this.isPeriodic = isPeriodic;
 
         this.#mockTime = mockTime;
-        this.#duration = duration;
+        this.interval = duration;
 
-        if (this instanceof MockInterval) {
-            this.#callback = callback;
+        if (isPeriodic) {
+            this.#callback = async () => {
+                this.#mockTime.callbackAtTime(this.#mockTime.nowMs + this.#armedInterval, this.#callback);
+                await callback();
+            };
         } else {
             this.#callback = () => {
                 this.#close();
@@ -66,9 +73,32 @@ class MockTimer {
         }
     }
 
+    /**
+     * The timer's interval.
+     *
+     * As with the production implementation, changes have no effect until the timer restarts.
+     */
+    set interval(interval: number) {
+        if (interval < 0 || interval > 2147483647) {
+            throw new Error(
+                `Invalid intervalMs: ${interval}. The value must be between 0 and 32-bit maximum value (2147483647)`,
+            );
+        }
+        this.#interval = interval;
+    }
+
+    get interval() {
+        return this.#interval;
+    }
+
     start() {
+        if (this.isRunning) {
+            this.stop();
+        }
         registry.register(this);
-        this.#mockTime.callbackAtTime(this.#mockTime.nowMs + this.#duration, this.#callback);
+        timerNames.set(this.#callback, `${this.name}(${this.#interval}${this.isPeriodic ? ",periodic" : ""})`);
+        this.#armedInterval = this.#interval;
+        this.#mockTime.callbackAtTime(this.#mockTime.nowMs + this.#armedInterval, this.#callback);
         this.isRunning = true;
         return this;
     }
@@ -82,16 +112,6 @@ class MockTimer {
         registry.unregister(this);
         this.#mockTime.removeCallback(this.#callback);
         this.isRunning = false;
-    }
-}
-
-class MockInterval extends MockTimer {
-    constructor(mockTime: MockTime, name: string, duration: number, callback: TimerCallback) {
-        const intervalCallback = async () => {
-            mockTime.callbackAtTime(mockTime.nowMs + duration, intervalCallback);
-            await callback();
-        };
-        super(mockTime, name, duration, intervalCallback);
     }
 }
 
@@ -233,7 +253,7 @@ export const MockTime = {
     },
 
     getPeriodicTimer(name: string, interval: number, callback: TimerCallback): MockTimer {
-        return new MockInterval(this, name, interval, callback);
+        return new MockTimer(this, name, interval, callback, true);
     },
 
     /**
@@ -357,11 +377,24 @@ export const MockTime = {
     async advance(ms: number) {
         const newTimeMs = nowMs + ms;
 
+        let previousAtMs: number | undefined;
+        let iterationsAtSameTime = 0;
         while (callbacks.length) {
             const { atMs, callback } = callbacks[0];
             if (atMs > newTimeMs) break;
             callbacks.shift();
             nowMs = atMs;
+
+            // A timer that rearms at the current time never lets the mock clock advance, so without this guard the
+            // loop spins indefinitely
+            iterationsAtSameTime = atMs === previousAtMs ? iterationsAtSameTime + 1 : 0;
+            previousAtMs = atMs;
+            if (iterationsAtSameTime > 10000) {
+                throw new TestTimeoutError(
+                    `Timer ${timerNames.get(callback) ?? "(unknown)"} rearms without advancing mock time`,
+                );
+            }
+
             await callback();
         }
 

--- a/packages/testing/test/mocks/MockTimeTest.ts
+++ b/packages/testing/test/mocks/MockTimeTest.ts
@@ -75,7 +75,106 @@ describe("MockTime", () => {
         });
     });
 
+    describe("interval", () => {
+        it("reports the construction duration", () => {
+            expect(MockTime.getTimer("Test", 30, () => {}).interval).equal(30);
+            expect(MockTime.getPeriodicTimer("Test periodic", 30, () => {}).interval).equal(30);
+        });
+
+        it("controls the fire time of a subsequent start", async () => {
+            let firedTime;
+
+            const timer = MockTime.getTimer("Test", 30, () => (firedTime = MockTime.nowMs));
+            timer.start();
+            timer.stop();
+
+            timer.interval = 100;
+            timer.start();
+
+            await MockTime.advance(50);
+            expect(firedTime).equal(undefined);
+
+            await MockTime.advance(50);
+            expect(firedTime).equal(FAKE_TIME + 100);
+        });
+
+        it("does not affect a running timer until it restarts", async () => {
+            const firedTimes = new Array<number>();
+
+            const timer = MockTime.getTimer("Test", 30, () => firedTimes.push(MockTime.nowMs));
+            timer.start();
+            timer.interval = 100;
+
+            await MockTime.advance(30);
+            expect(firedTimes).deep.equal([FAKE_TIME + 30]);
+
+            timer.start();
+
+            await MockTime.advance(100);
+            expect(firedTimes).deep.equal([FAKE_TIME + 30, FAKE_TIME + 130]);
+        });
+
+        it("controls the period of a periodic timer from the next start", async () => {
+            const firedTimes = new Array<number>();
+
+            const timer = MockTime.getPeriodicTimer("Test periodic", 30, () => firedTimes.push(MockTime.nowMs));
+            timer.start();
+            timer.interval = 50;
+
+            // The armed period continues to apply while running
+            await MockTime.advance(60);
+            expect(firedTimes).deep.equal([FAKE_TIME + 30, FAKE_TIME + 60]);
+
+            timer.stop();
+            timer.start();
+
+            await MockTime.advance(100);
+            expect(firedTimes).deep.equal([FAKE_TIME + 30, FAKE_TIME + 60, FAKE_TIME + 110, FAKE_TIME + 160]);
+
+            timer.stop();
+        });
+
+        it("rejects out-of-range values", () => {
+            const timer = MockTime.getTimer("Test", 30, () => {});
+
+            expect(() => (timer.interval = -1)).throws("must be between");
+            expect(() => (timer.interval = 2_147_483_648)).throws("must be between");
+            expect(() => MockTime.getTimer("Test", -1, () => {})).throws("must be between");
+            expect(() => MockTime.getPeriodicTimer("Test periodic", 2_147_483_648, () => {})).throws("must be between");
+
+            expect(timer.interval).equal(30);
+        });
+    });
+
+    describe("advance", () => {
+        it("rejects a timer that rearms without advancing time", async () => {
+            MockTime.getPeriodicTimer("Spinner", 0, () => {}).start();
+
+            await expect(MockTime.advance(1)).rejectedWith("Spinner");
+        });
+    });
+
+    describe("isPeriodic", () => {
+        it("distinguishes one-shot from periodic timers", () => {
+            expect(MockTime.getTimer("Test", 30, () => {}).isPeriodic).equal(false);
+            expect(MockTime.getPeriodicTimer("Test periodic", 30, () => {}).isPeriodic).equal(true);
+        });
+    });
+
     describe("getTimer", () => {
+        it("restarts rather than double-arming when started while running", async () => {
+            const firedTimes = new Array<number>();
+
+            const timer = MockTime.getTimer("Test", 30, () => firedTimes.push(MockTime.nowMs));
+            timer.start();
+
+            await MockTime.advance(10);
+            timer.start();
+
+            await MockTime.advance(100);
+            expect(firedTimes).deep.equal([FAKE_TIME + 40]);
+        });
+
         it("returns a timer that will call a callback in the future", async () => {
             let firedTime;
 


### PR DESCRIPTION
## Problem

`Timer` declares a mutable `interval` and `StandardTimer` honors it. `MockTimer` did not: it captured the duration as a private `#duration` at construction and exposed no `interval` accessor at all.

Consequences under `MockTime`:

- `timer.interval = x` wrote a stray own property and changed nothing about when the timer fires — no error, no warning. Tests that appear to verify a cadence change silently measure the *constructor* duration.
- Reads returned `undefined`: `ClientInteraction`'s batch shortening computed `undefined - elapsed` = `NaN` (so it never shortened), `MessageExchange.retransmissionRestartSaving` always returned `Instant` (so the restart kick was always suppressed), and timer diagnostics rendered `Duration.format(undefined)`.
- `isPeriodic` was hardcoded `false` even for periodic timers, `utility` was absent, and `start()` on a running timer queued a *second* callback where production restarts.

## Change

`MockTimer` now mirrors `StandardTimer`:

- `interval` getter/setter with the same range validation and message (`0 … 2147483647`)
- an armed-interval snapshot taken in `start()`, so assignment while running takes effect only on the next `start()` — matching `setTimeout`/`setInterval` arming
- `start()` restarts instead of double-arming when already running
- `MockInterval` folded into `MockTimer` behind an `isPeriodic` flag, so periodic repeats reschedule against the armed interval instead of a constructor closure
- `utility` added, dead `intervalMs` removed

`MockTime.advance()` gained a guard: a timer that rearms at the current mock instant now fails with a `TestTimeoutError` naming the timer instead of spinning at 100% CPU indefinitely.

## Latent bugs this exposed

Honoring the assignment surfaced two real defects that the silent no-op had been hiding:

1. **`ClientSubscriptions.resetTimer()`** used `timeoutAt < now`, so a subscription whose deadline fell exactly on the current instant was neither expired nor rescheduled sanely — it armed a 0 ms timeout that re-armed itself at the same instant. Production self-heals on the next wall-clock millisecond, but the subscription does not expire at that instant; under mock time it spins forever (this hung the `@matter/node` suite). Now `timeoutAt <= now`.
2. **`DclCertificateServiceTest`** disabled auto-updates via `updateInterval: Days(365)` — 31536000000 ms, past the 32-bit `setTimeout` limit, which `StandardTimer` rejects. Switched to `updateInterval: null`, the actual disable knob.

## Tests

- `MockTimeTest`: interval reported, applied on restart, no effect while running (one-shot and periodic), out-of-range rejection at construction and on assignment, `isPeriodic` split, no double-arm, spin guard
- `ClientSubscriptionsTest` (new): a subscription timing out at the current instant expires — verified to fail with `<` restored

Full suite green across all 10 packages (ESM/CJS/Web) after a clean build; `format-verify` and `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)