### PR TITLE
fix(node): infer network medium from root endpoint diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Support the `!=` (not-equal) operator in value conformance expressions
     - Fix: Ensure `FabricAuthority` is fully constructed before it is used in the WebRTC Transport Requestor, OTA Software Update Provider and Software Update clusters
     - Fix: Consider existing node IDs when determining the next node ID to commission
+    - Fix: Determine the network medium of nodes without a Network Commissioning cluster from the WiFi or Thread Network Diagnostics cluster on their root endpoint
 
 - @matter/nodejs
     - Fix: Ensure the namespace directory exists before the `sqlite` storage driver opens the database

--- a/packages/node/src/node/NodePhysicalProperties.ts
+++ b/packages/node/src/node/NodePhysicalProperties.ts
@@ -12,6 +12,7 @@ import { IcdManagementClient } from "#behaviors/icd-management";
 import { NetworkCommissioningClient } from "#behaviors/network-commissioning";
 import { PowerSourceClient } from "#behaviors/power-source";
 import { ThreadNetworkDiagnosticsClient } from "#behaviors/thread-network-diagnostics";
+import { WiFiNetworkDiagnosticsClient } from "#behaviors/wi-fi-network-diagnostics";
 import { Endpoint } from "#endpoint/Endpoint.js";
 import { AggregatorEndpoint } from "#endpoints/aggregator";
 import { Node } from "#node/Node.js";
@@ -50,7 +51,55 @@ export function NodePhysicalProperties(node: Node) {
 
     inspectEndpoint(node, properties);
 
+    if (!properties.supportsWifi && !properties.supportsThread && !properties.supportsEthernet) {
+        inferNetworkMediumFromDiagnostics(node, properties);
+    }
+
     return properties;
+}
+
+/**
+ * Determine the operational medium of a node that reports no network interfaces via Network Commissioning ("commissioned
+ * by other means") from the network diagnostics cluster of the medium it operates on.
+ *
+ * The mandatory diagnostics attributes are all nullable and null while the interface is not associated, so a populated
+ * one distinguishes an operational interface from a cluster that merely exists.
+ *
+ * Diagnostics describe the node itself, so only the root endpoint is considered.
+ */
+function inferNetworkMediumFromDiagnostics(node: Node, properties: PhysicalDeviceProperties) {
+    const wifiDiagnosticsType = node.behaviors.typeFor(WiFiNetworkDiagnosticsClient);
+    const wifi = wifiDiagnosticsType ? node.maybeStateOf(wifiDiagnosticsType) : undefined;
+    if (wifi?.bssid !== undefined && wifi.bssid !== null) {
+        properties.supportsWifi = true;
+    }
+
+    const threadDiagnosticsType = node.behaviors.typeFor(ThreadNetworkDiagnosticsClient);
+    const thread = threadDiagnosticsType ? node.maybeStateOf(threadDiagnosticsType) : undefined;
+    if (
+        thread !== undefined &&
+        (isPresent(thread.extendedPanId) ||
+            isPresent(thread.panId) ||
+            isPresent(thread.channel) ||
+            isPresent(thread.networkName))
+    ) {
+        properties.supportsThread = true;
+
+        // A null extended PAN ID leaves threadActive false.  When Thread is the only medium the node reports we trust
+        // the remaining details instead, otherwise the node stays unclassified despite being reachable.
+        if (
+            !properties.supportsWifi &&
+            properties.wifiActive === undefined &&
+            properties.ethernetActive === undefined
+        ) {
+            properties.threadActive = true;
+            properties.threadChannel ??= thread.channel ?? undefined;
+        }
+    }
+}
+
+function isPresent(value: unknown) {
+    return value !== undefined && value !== null;
 }
 
 // Device types are collected node-wide (including bridged endpoints behind an aggregator) so consumers such as the

--- a/packages/node/test/node/NodePhysicalPropertiesTest.ts
+++ b/packages/node/test/node/NodePhysicalPropertiesTest.ts
@@ -6,6 +6,7 @@
 
 import { ClusterBehavior } from "#behavior/cluster/ClusterBehavior.js";
 import { IcdManagementServer } from "#behaviors/icd-management";
+import { NetworkCommissioningServer } from "#behaviors/network-commissioning";
 import { PowerSourceServer } from "#behaviors/power-source";
 import { SwitchServer } from "#behaviors/switch";
 import { ThreadNetworkDiagnosticsServer } from "#behaviors/thread-network-diagnostics";
@@ -19,12 +20,20 @@ import { SecondaryNetworkInterfaceEndpoint } from "#endpoints/secondary-network-
 import { Node } from "#node/Node.js";
 import { NodePhysicalProperties } from "#node/NodePhysicalProperties.js";
 import { ServerNode } from "#node/ServerNode.js";
-import { Instant, Minutes, Seconds } from "@matter/general";
+import { Bytes, Instant, Minutes, Seconds } from "@matter/general";
 import { PhysicalDeviceProperties, Subscribe } from "@matter/protocol";
 import { PowerSource } from "@matter/types/clusters/power-source";
 import { Switch } from "@matter/types/clusters/switch";
 import { ThreadNetworkDiagnostics } from "@matter/types/clusters/thread-network-diagnostics";
 import { MockServerNode } from "./mock-server-node.js";
+
+class EthernetCommissioningServer extends NetworkCommissioningServer.with("EthernetNetworkInterface") {
+    override initialize() {
+        this.state.maxNetworks = 1;
+        this.state.interfaceEnabled = true;
+        this.state.networks = [{ networkId: Bytes.fromHex("00"), connected: true }];
+    }
+}
 
 describe("NodePhysicalProperties", () => {
     it("chooses correct default intervals", async () => {
@@ -115,6 +124,65 @@ describe("NodePhysicalProperties", () => {
             maxIntervalCeiling: Minutes(1),
             minIntervalFloor: Instant,
         });
+    });
+
+    it("infers wifi from root endpoint diagnostics when Network Commissioning is absent", async () => {
+        const WifiServer = WiFiNetworkDiagnosticsServer.set({ bssid: Bytes.fromHex("847848cc0bde") });
+        const node = await MockServerNode.create(ServerNode.RootEndpoint.with(WifiServer));
+        const props = NodePhysicalProperties(node);
+
+        expect(props.supportsWifi).true;
+        expect(props.supportsThread).false;
+        expect(props.supportsEthernet).false;
+    });
+
+    it("does not infer wifi from an unassociated interface", async () => {
+        const node = await MockServerNode.create(ServerNode.RootEndpoint.with(WiFiNetworkDiagnosticsServer));
+        const props = NodePhysicalProperties(node);
+
+        expect(props.supportsWifi).false;
+    });
+
+    it("infers thread from root endpoint diagnostics when Network Commissioning is absent", async () => {
+        const ThreadServer = ThreadNetworkDiagnosticsServer.set({ channel: 15, panId: 0x1234 });
+        const node = await MockServerNode.create(ServerNode.RootEndpoint.with(ThreadServer));
+        const props = NodePhysicalProperties(node);
+
+        expect(props.supportsThread).true;
+        expect(props.supportsWifi).false;
+        expect(props.threadActive).true;
+        expect(props.threadChannel).equals(15);
+    });
+
+    it("does not infer thread from an unjoined interface", async () => {
+        const node = await MockServerNode.create(ServerNode.RootEndpoint.with(ThreadNetworkDiagnosticsServer));
+        const props = NodePhysicalProperties(node);
+
+        expect(props.supportsThread).false;
+        expect(props.threadActive).false;
+    });
+
+    it("does not infer a medium from diagnostics on a non-root endpoint", async () => {
+        const WifiServer = WiFiNetworkDiagnosticsServer.set({ bssid: Bytes.fromHex("847848cc0bde") });
+        const node = await MockServerNode.create({
+            parts: [new Endpoint(SecondaryNetworkInterfaceEndpoint.with(WifiServer))],
+        });
+        const props = NodePhysicalProperties(node);
+
+        expect(props.supportsWifi).false;
+    });
+
+    it("does not infer a medium when Network Commissioning reports one", async () => {
+        const WifiServer = WiFiNetworkDiagnosticsServer.set({ bssid: Bytes.fromHex("847848cc0bde") });
+        const ThreadServer = ThreadNetworkDiagnosticsServer.set({ channel: 15, panId: 0x1234 });
+        const node = await MockServerNode.create(
+            ServerNode.RootEndpoint.with(EthernetCommissioningServer, WifiServer, ThreadServer),
+        );
+        const props = NodePhysicalProperties(node);
+
+        expect(props.supportsEthernet).true;
+        expect(props.supportsWifi).false;
+        expect(props.supportsThread).false;
     });
 
     it("reports the specification version and no Generic Switch by default", async () => {


### PR DESCRIPTION
## Problem

Devices commissioned by other means expose no Network Commissioning cluster, so `NodePhysicalProperties` left `supportsWifi`/`supportsThread`/`supportsEthernet` all false and the node could only be handled by the generic "other means" branch in `NetworkProfile`.

A real example (Dyson Purifier Humidify+Cool, reported via ioBroker.matter) has root endpoint server list `29 31 40 45 48 51 52 54 60 62 63` — no `0x31` NetworkCommissioning, but `0x36` WiFiNetworkDiagnostics with `bssid: 847848cc0bde`, `securityType`, `channelNumber` and `rssi` all populated. The medium is plainly WiFi; we just did not look.

## Change

When Network Commissioning yields no medium at all, infer it from the network diagnostics cluster on the **root endpoint only** (diagnostics describe the node itself):

- `WiFiNetworkDiagnostics.bssid` non-null → `supportsWifi`
- `ThreadNetworkDiagnostics` with any of `extendedPanId` / `panId` / `channel` / `networkName` non-null → `supportsThread`

The mandatory diagnostics attributes are all nullable and null while the interface is not associated, so requiring a populated one keeps a stub cluster from being read as an operational interface.

Thread inference additionally sets `threadActive` (and `threadChannel`) when Thread is the only medium the node reports at all (`wifiActive`/`ethernetActive` both undefined and no inferred WiFi). Without that, a node with a null extended PAN ID keeps `threadActive === false` from the existing check, and `supportsThread === true` then makes it fall past the thread branch, past WiFi, and past the "other means" branch in `NetworkProfile.forPeer` (which requires all three supports flags false) into `unknown` — worse than the current `fast`.

## Tests

6 new cases in `NodePhysicalPropertiesTest`: inferred WiFi, inferred Thread (including `threadActive`/`threadChannel`), unassociated WiFi and unjoined Thread rejected, diagnostics on a non-root endpoint ignored, and no inference when Network Commissioning reports a medium.

Full suite (all packages, ESM + CJS + Web), clean build, `format-verify` and `lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)