### PR TITLE
feat(node): resolve peer custom cluster elements by real name via a controller Matter model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/general
     - Fix: `Heap` now stores each item at most once and maintains its position index eagerly, so deleting an item added after an earlier deletion works reliably
 
+- @matter/model
+    - Enhancement: `MatterModel.withClusters()` returns a copy of a model with clusters added or replaced by ID
+
 - @matter/node
+    - Enhancement: Controllers accept a custom Matter model via the `matter` option so a commissioned peer's custom or extended cluster elements resolve to real names instead of synthetic `attr$…`/`command$…` identifiers
     - Enhancement: `SoftwareUpdateManager.checkForUpdates()` forces an immediate OTA update check and cleanup of obsolete stored updates
     - Enhancement: Custom server session intervals (idle/active interval, active threshold) are now configurable via `sessions.intervals`
     - Fix: Optimize Cluster data updates when structures change for ClientNodes

--- a/packages/model/src/models/MatterModel.ts
+++ b/packages/model/src/models/MatterModel.ts
@@ -47,6 +47,28 @@ export class MatterModel extends ScopeModel<MatterElement, MatterModel.Child> im
     }
 
     /**
+     * Create a copy of this model with clusters added or replaced.
+     *
+     * A supplied cluster replaces the standard cluster with the same ID (a plain addition loses to the standard entry
+     * during lookup) and clusters with new IDs are appended.  Use this to teach a {@link ClientNode} about custom or
+     * extended clusters so a controller resolves their elements to real names instead of synthetic `attr$…`/`command$…`.
+     */
+    withClusters(...clusters: ClusterModel[]): MatterModel {
+        const model = this.clone();
+        for (const cluster of clusters) {
+            const child = cluster.clone();
+            const existing = model.clusters(cluster.id);
+            const index = existing ? model.children.indexOf(existing) : -1;
+            if (index >= 0) {
+                model.children.splice(index, 1, child);
+            } else {
+                model.children.push(child);
+            }
+        }
+        return model;
+    }
+
+    /**
      * Device types.
      */
     get deviceTypes() {

--- a/packages/model/test/models/MatterModelTest.ts
+++ b/packages/model/test/models/MatterModelTest.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AttributeElement, AttributeModel, ClusterModel, Matter } from "@matter/model";
+
+const ACCESS_CONTROL_ID = 0x1f;
+
+describe("MatterModel", () => {
+    describe("withClusters", () => {
+        it("appends a cluster with a new ID", () => {
+            const custom = new ClusterModel({ id: 0xfff4_fc00, name: "MyCustomCluster" });
+
+            const model = Matter.withClusters(custom);
+
+            expect(model.clusters(0xfff4_fc00)?.name).equals("MyCustomCluster");
+            expect([...model.clusters].length).equals([...Matter.clusters].length + 1);
+        });
+
+        it("replaces a cluster with an existing ID rather than adding a duplicate", () => {
+            const extendedAccessControl = Matter.clusters(ACCESS_CONTROL_ID)!.extend(
+                {},
+                AttributeElement({ id: 0xfff4_0000, name: "MyCounter", type: "uint32", conformance: "O" }),
+            );
+
+            const model = Matter.withClusters(extendedAccessControl);
+
+            const resolved = model.clusters(ACCESS_CONTROL_ID);
+            expect(resolved?.get(AttributeModel, "MyCounter")).not.undefined;
+            expect([...model.clusters].length).equals([...Matter.clusters].length);
+        });
+
+        it("does not mutate the source model", () => {
+            const custom = new ClusterModel({ id: 0xfff4_fc01, name: "Ephemeral" });
+
+            Matter.withClusters(custom);
+
+            expect(Matter.clusters(0xfff4_fc01)).undefined;
+            expect(Matter.clusters(ACCESS_CONTROL_ID)?.get(AttributeModel, "MyCounter")).undefined;
+        });
+    });
+});

--- a/packages/node/src/behavior/system/controller/ControllerBehavior.ts
+++ b/packages/node/src/behavior/system/controller/ControllerBehavior.ts
@@ -16,6 +16,7 @@ import {
     SharedEnvironmentServices,
     TransportSet,
 } from "@matter/general";
+import { MatterModel } from "@matter/model";
 import {
     Ble,
     ClientSubscriptions,
@@ -58,6 +59,11 @@ export class ControllerBehavior extends Behavior {
         }
 
         const node = Node.forEndpoint(this.endpoint);
+
+        // Publish the controller's model so auto-created peer nodes inherit it via the environment
+        if (this.state.matter !== undefined) {
+            node.env.set(MatterModel, this.state.matter);
+        }
 
         // Configure discovery transports
         if (this.state.ip === undefined) {
@@ -297,5 +303,13 @@ export namespace ControllerBehavior {
          * Case Authenticated Tags to be used to commission and connect to devices.
          */
         caseAuthenticatedTags?: CaseAuthenticatedTag[] = undefined;
+
+        /**
+         * Model of Matter semantics used for peers commissioned or discovered by this controller.
+         *
+         * Supply a model extended with custom or manufacturer-specific clusters (see {@link MatterModel.extended}) so
+         * their attributes and commands resolve to real names instead of synthetic `attr$…`/`command$…` identifiers.
+         */
+        matter?: MatterModel = undefined;
     }
 }

--- a/packages/node/src/behavior/system/controller/ControllerBehavior.ts
+++ b/packages/node/src/behavior/system/controller/ControllerBehavior.ts
@@ -307,7 +307,7 @@ export namespace ControllerBehavior {
         /**
          * Model of Matter semantics used for peers commissioned or discovered by this controller.
          *
-         * Supply a model extended with custom or manufacturer-specific clusters (see {@link MatterModel.extended}) so
+         * Supply a model extended with custom or manufacturer-specific clusters (see {@link MatterModel.withClusters}) so
          * their attributes and commands resolve to real names instead of synthetic `attr$…`/`command$…` identifiers.
          */
         matter?: MatterModel = undefined;

--- a/packages/node/src/node/ClientNode.ts
+++ b/packages/node/src/node/ClientNode.ts
@@ -45,7 +45,7 @@ const logger = Logger.get("ClientNode");
  * you invoke {@link commissioned}.
  */
 export class ClientNode extends Node<ClientNode.RootEndpoint> {
-    #matter: MatterModel;
+    #matter?: MatterModel;
     #interaction?: ClientNodeInteraction;
     #blockInteractions = false;
     #cachedPeerAddress?: PeerAddress;
@@ -67,7 +67,7 @@ export class ClientNode extends Node<ClientNode.RootEndpoint> {
         this.env.set(Node, this);
         this.env.set(ClientNode, this);
 
-        this.#matter = options.matter ?? Matter;
+        this.#matter = options.matter;
     }
 
     override readonly nodeType: "client" | "group" = "client";
@@ -77,8 +77,8 @@ export class ClientNode extends Node<ClientNode.RootEndpoint> {
      *
      * Matter elements missing from this model will not support all functionality.
      */
-    get matter() {
-        return this.#matter;
+    override get matter(): MatterModel {
+        return this.#matter ?? this.env.maybeGet(MatterModel) ?? Matter;
     }
 
     override get endpoints(): ClientNodeEndpoints {

--- a/packages/node/src/node/Node.ts
+++ b/packages/node/src/node/Node.ts
@@ -25,6 +25,7 @@ import {
     ImplementationError,
     Logger,
 } from "@matter/general";
+import { Matter, MatterModel } from "@matter/model";
 import { Interactable } from "@matter/protocol";
 import type { EndpointNumber } from "@matter/types";
 import { RootEndpoint } from "../endpoints/root.js";
@@ -85,6 +86,14 @@ export abstract class Node<T extends Node.CommonRootEndpoint = Node.CommonRootEn
 
     override get env() {
         return this.#environment;
+    }
+
+    /**
+     * Model of Matter semantics understood by this node.  Defaults to the standard model; client nodes may narrow or
+     * extend it so remote clusters resolve to real element names.
+     */
+    get matter(): MatterModel {
+        return Matter;
     }
 
     /**

--- a/packages/node/src/node/client/ClientStructure.ts
+++ b/packages/node/src/node/client/ClientStructure.ts
@@ -32,7 +32,6 @@ import {
     DeviceClassification,
     FeatureMap,
     GeneratedCommandList,
-    Matter,
     type FeatureBitmap,
 } from "@matter/model";
 import { ReadScope, Val, type Read, type ReadResult } from "@matter/protocol";
@@ -689,6 +688,7 @@ export class ClientStructure {
                 if (this.#commandFactory) {
                     shape.commandFactory = this.#commandFactory;
                 }
+                shape.matter = this.#node.matter;
                 const behaviorType = PeerBehavior(shape);
 
                 if (endpoint.lifecycle.isInstalled) {
@@ -730,7 +730,7 @@ export class ClientStructure {
                 }
 
                 let isApp = false;
-                const model = Matter.deviceTypes(dt.deviceType);
+                const model = this.#node.matter.deviceTypes(dt.deviceType);
                 if (model !== undefined) {
                     isApp = DeviceClassification.isApplication(model.classification);
                 }
@@ -917,7 +917,7 @@ export class ClientStructure {
         }
 
         // Try to resolve by looking up the cluster model by capitalized behavior name (e.g. "onOff" → "OnOff")
-        const clusterModel = Matter.clusters(capitalize(behaviorId));
+        const clusterModel = this.#node.matter.clusters(capitalize(behaviorId));
         if (clusterModel) {
             return this.#clusterFor(endpoint, clusterModel.id as ClusterId);
         }

--- a/packages/node/src/node/client/PeerBehavior.ts
+++ b/packages/node/src/node/client/PeerBehavior.ts
@@ -18,6 +18,7 @@ import {
     FeatureBitmap,
     FeatureSet,
     Matter,
+    MatterModel,
     type ValueModel,
 } from "@matter/model";
 import { AttributeId, ClusterId, CommandId } from "@matter/types";
@@ -25,7 +26,10 @@ import { ClientCommandMethod } from "./ClientCommandMethod.js";
 
 const BIT_BLOCK_SIZE = Math.log2(Number.MAX_SAFE_INTEGER);
 
-const discoveredCaches = new Map<ClusterBehaviorType.CommandFactory, Record<string, ClusterBehavior.Type>>();
+const discoveredCaches = new Map<
+    ClusterBehaviorType.CommandFactory,
+    WeakMap<MatterModel, Record<string, ClusterBehavior.Type>>
+>();
 const knownCaches = new Map<ClusterBehaviorType.CommandFactory, WeakMap<ClusterBehavior.Type, ClusterBehavior.Type>>();
 
 const isPeer = Symbol("is-peer");
@@ -73,6 +77,12 @@ export namespace PeerBehavior {
         commands?: CommandId[];
         generatedCommands?: CommandId[];
         commandFactory?: ClusterBehaviorType.CommandFactory;
+
+        /**
+         * Model used to resolve standard element names/shapes.  Defaults to the global {@link Matter} model; a client
+         * node supplies its own so custom or extended clusters resolve to real names.
+         */
+        matter?: MatterModel;
     }
 
     /**
@@ -86,12 +96,17 @@ export namespace PeerBehavior {
 }
 
 function instrumentDiscoveredShape(shape: PeerBehavior.DiscoveredClusterShape) {
-    const analysis = DiscoveredShapeAnalysis(shape);
+    const matter = shape.matter ?? Matter;
+    const analysis = DiscoveredShapeAnalysis(shape, matter);
     const factory = shape.commandFactory ?? ClientCommandMethod;
 
-    let cache = discoveredCaches.get(factory);
+    let byModel = discoveredCaches.get(factory);
+    if (!byModel) {
+        discoveredCaches.set(factory, (byModel = new WeakMap()));
+    }
+    let cache = byModel.get(matter);
     if (!cache) {
-        discoveredCaches.set(factory, (cache = {}));
+        byModel.set(matter, (cache = {}));
     }
 
     const fingerprint = createFingerprint(analysis);
@@ -102,7 +117,7 @@ function instrumentDiscoveredShape(shape: PeerBehavior.DiscoveredClusterShape) {
 
     // Find a base behavior for the standard cluster, if available
     let baseType: Behavior.Type | undefined;
-    const standardSchema = Matter.get(ClusterModel, shape.id);
+    const standardSchema = matter.get(ClusterModel, shape.id);
     if (standardSchema) {
         // Create a base behavior from the standard schema
         baseType = ClusterBehaviorType({
@@ -360,8 +375,11 @@ interface DiscoveredShapeAnalysis {
 /**
  * Analyze a discovered cluster shape to determine how we should override the behavior and schema.
  */
-function DiscoveredShapeAnalysis(shape: PeerBehavior.DiscoveredClusterShape): DiscoveredShapeAnalysis {
-    const standardCluster = Matter.clusters(shape.id);
+function DiscoveredShapeAnalysis(
+    shape: PeerBehavior.DiscoveredClusterShape,
+    matter: MatterModel = Matter,
+): DiscoveredShapeAnalysis {
+    const standardCluster = matter.clusters(shape.id);
     const schema =
         standardCluster ??
         new ClusterModel({ id: shape.id, name: createUnknownName("Cluster", shape.id), revision: shape.revision });

--- a/packages/node/test/behaviors/access-control/AccessControlCustomExtensionTest.ts
+++ b/packages/node/test/behaviors/access-control/AccessControlCustomExtensionTest.ts
@@ -1,0 +1,233 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ControllerBehavior } from "#behavior/system/controller/ControllerBehavior.js";
+import { AccessControlClient, AccessControlServer } from "#behaviors/access-control";
+import { MaybePromise } from "@matter/general";
+import {
+    attribute,
+    AttributeElement,
+    AttributeModel,
+    command,
+    CommandElement,
+    CommandModel,
+    field,
+    FieldElement,
+    Matter,
+    MatterModel,
+    response,
+    string,
+    uint32,
+} from "@matter/model";
+import {
+    ClusterId,
+    CommandId,
+    EndpointNumber,
+    TlvField,
+    TlvInvokeResponseData,
+    TlvObject,
+    TlvString,
+    TlvUInt32,
+    TypeFromSchema,
+} from "@matter/types";
+import { AccessControl } from "@matter/types/clusters/access-control";
+import { MockServerNode } from "../../node/mock-server-node.js";
+import { MockSite } from "../../node/mock-site.js";
+import { interaction } from "../../node/node-helpers.js";
+
+/**
+ * Modern replacement for hand-writing a custom ClusterType: extend an existing generated server behavior with a
+ * manufacturer-specific attribute and command using the decorator API.  The base AccessControl model is merged with the
+ * new elements and TLV is generated automatically.
+ */
+class DoThingRequest {
+    @field(string)
+    note!: string;
+}
+
+class DoThingResponse {
+    @field(uint32)
+    count!: number;
+}
+
+const MY_ATTR_ID = 0xfff4_0000;
+const MY_CMD_ID = 0xfff4_0001;
+
+class CustomAccessControlServer extends AccessControlServer {
+    declare state: CustomAccessControlServer.State;
+
+    @command(MY_CMD_ID, DoThingRequest)
+    @response(DoThingResponse)
+    doThing(request: DoThingRequest): MaybePromise<DoThingResponse> {
+        this.state.myCounter += request.note.length;
+        return { count: this.state.myCounter };
+    }
+}
+
+namespace CustomAccessControlServer {
+    export class State extends AccessControlServer.State {
+        @attribute(MY_ATTR_ID, uint32)
+        myCounter: number = 0;
+    }
+}
+
+const CustomRoot = MockServerNode.RootEndpoint.with(CustomAccessControlServer);
+
+// TLV of the custom command request/response.  On the controller (generic path) the field layout is not discoverable
+// from the wire, so the caller encodes it explicitly.
+const TlvDoThingRequest = TlvObject({ note: TlvField(0, TlvString) });
+const TlvDoThingResponse = TlvObject({ count: TlvField(0, TlvUInt32) });
+
+const ATTR_NAME = `attr$${MY_ATTR_ID.toString(16)}`;
+const CMD_NAME = `command$${MY_CMD_ID.toString(16)}`;
+
+// Controller-side view of the same extension: a schema-only model with real element names.  A controller resolves peer
+// clusters against its model, so registering this teaches it to expose the extras by name instead of attr$…/command$….
+const ExtendedAccessControl = Matter.clusters(AccessControl.id)!.extend(
+    {},
+    AttributeElement({ id: MY_ATTR_ID, name: "MyCounter", type: "uint32", conformance: "O", access: "R V" }),
+    CommandElement(
+        { id: MY_CMD_ID, name: "DoThing", response: "DoThingResponse", conformance: "O", direction: "request" },
+        FieldElement({ id: 0, name: "Note", type: "string" }),
+    ),
+    CommandElement(
+        { id: MY_CMD_ID, name: "DoThingResponse", conformance: "O", direction: "response" },
+        FieldElement({ id: 0, name: "Count", type: "uint32" }),
+    ),
+);
+const ControllerModel = Matter.withClusters(ExtendedAccessControl);
+
+describe("AccessControl custom extension", () => {
+    describe("server", () => {
+        it("adds the custom attribute and command to the cluster schema", () => {
+            const schema = CustomAccessControlServer.schema;
+
+            const attr = schema.get(AttributeModel, "myCounter");
+            expect(attr).not.undefined;
+            expect(attr!.id).equals(MY_ATTR_ID);
+
+            const cmd = schema.get(CommandModel, "doThing");
+            expect(cmd).not.undefined;
+            expect(cmd!.id).equals(MY_CMD_ID);
+        });
+
+        it("keeps base elements and reads the custom attribute default", async () => {
+            const node = await MockServerNode.createOnline(CustomRoot);
+            try {
+                await node.act(agent => {
+                    const acl = agent.get(CustomAccessControlServer);
+                    expect(acl.state.acl).deep.equals([]);
+                    expect(acl.state.myCounter).equals(0);
+                });
+            } finally {
+                await node.close();
+            }
+        });
+
+        it("advertises and round-trips the custom command over the wire", async () => {
+            const node = await MockServerNode.createOnline(CustomRoot);
+            try {
+                const fabric = await node.addFabric();
+                let response: undefined | TypeFromSchema<typeof TlvInvokeResponseData>;
+                await interaction.invoke(
+                    node,
+                    fabric,
+                    {
+                        commandPath: {
+                            endpointId: EndpointNumber(0),
+                            clusterId: ClusterId(AccessControl.id),
+                            commandId: CommandId(MY_CMD_ID),
+                        },
+                        commandFields: TlvDoThingRequest.encodeTlv({ note: "hello" }),
+                    },
+                    r => {
+                        response = r;
+                    },
+                );
+
+                expect(response?.command).not.undefined;
+                expect(TlvDoThingResponse.decodeTlv(response!.command!.commandFields!)).deep.equals({ count: 5 });
+                expect(node.stateOf(CustomAccessControlServer).myCounter).equals(5);
+            } finally {
+                await node.close();
+            }
+        });
+    });
+
+    describe("controller", () => {
+        it("reads the custom attribute and invokes the custom command on a commissioned peer", async () => {
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                device: { type: CustomRoot, accessControl: { myCounter: 7 } },
+            });
+
+            const peer = controller.peers.get("peer1")!;
+            expect(peer).not.undefined;
+
+            // Discovered manufacturer elements have no compile-time type: reads use the string-keyed cluster overload,
+            // and the synthetic command takes a pre-encoded TLV stream (its field layout is not advertised on the wire).
+            const before = await peer.getStateOf("accessControl", [ATTR_NAME]);
+            expect(before[ATTR_NAME]).equals(7);
+
+            await peer.act(agent => {
+                const client = agent.get(AccessControlClient) as unknown as Record<
+                    string,
+                    (fields: unknown) => unknown
+                >;
+                return client[CMD_NAME](TlvDoThingRequest.encodeTlv({ note: "hello" }));
+            });
+
+            expect(device.stateOf(CustomAccessControlServer).myCounter).equals(12);
+
+            const after = await peer.getStateOf("accessControl", [ATTR_NAME]);
+            expect(after[ATTR_NAME]).equals(12);
+        });
+    });
+
+    describe("controller with custom model", () => {
+        it("publishes the controller model to the node environment", async () => {
+            const node = await MockServerNode.createOnline(MockServerNode.RootEndpoint, {
+                controller: { matter: ControllerModel },
+            });
+            try {
+                expect(node.stateOf(ControllerBehavior).matter).equals(ControllerModel);
+                expect(node.env.maybeGet(MatterModel)).equals(ControllerModel);
+            } finally {
+                await node.close();
+            }
+        });
+
+        it("exposes custom peer elements by real name", async () => {
+            await using site = new MockSite();
+            const { controller, device } = await site.addCommissionedPair({
+                // MockSite types controller config as Configuration<any>, which rejects behavior-state keys; the
+                // ControllerBehavior.matter option itself is properly typed (see the test above).
+                controller: { controller: { matter: ControllerModel } } as any,
+                device: { type: CustomRoot, accessControl: { myCounter: 7 } },
+            });
+
+            const peer = controller.peers.get("peer1")!;
+
+            // Real names now, via the stock AccessControlClient.  The extra elements still lack a compile-time type, so
+            // access is by string key / cast — but no synthetic attr$…/command$… identifiers.
+            const before = await peer.getStateOf("accessControl", ["myCounter"]);
+            expect(before.myCounter).equals(7);
+
+            await peer.act(agent => {
+                const client = agent.get(AccessControlClient) as unknown as Record<
+                    string,
+                    (fields: unknown) => unknown
+                >;
+                return client.doThing({ note: "hello" });
+            });
+
+            expect(device.stateOf(CustomAccessControlServer).myCounter).equals(12);
+
+            const after = await peer.getStateOf("accessControl", ["myCounter"]);
+            expect(after.myCounter).equals(12);
+        });
+    });
+});

--- a/packages/node/test/behaviors/groups/GroupsServerSchemaTest.ts
+++ b/packages/node/test/behaviors/groups/GroupsServerSchemaTest.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GroupsServer } from "#behaviors/groups";
+import { CommandModel } from "@matter/model";
+import {
+    ClusterId,
+    CommandId,
+    EndpointNumber,
+    Status,
+    TlvField,
+    TlvInvokeResponseData,
+    TlvObject,
+    TlvString,
+    TlvUInt16,
+    TypeFromSchema,
+} from "@matter/types";
+import { Groups } from "@matter/types/clusters/groups";
+import { MockServerNode } from "../../node/mock-server-node.js";
+import { interaction } from "../../node/node-helpers.js";
+
+const TlvAddGroupRequest = TlvObject({
+    groupId: TlvField(0, TlvUInt16),
+    groupName: TlvField(1, TlvString),
+});
+
+const TlvAddGroupResponse = TlvObject({
+    status: TlvField(0, TlvUInt16),
+    groupId: TlvField(1, TlvUInt16),
+});
+
+const AN_OVERLONG_NAME = "X".repeat(17); // base GroupName constraint is "max 16"
+
+// Invoke AddGroup on the default device (OnOffLightDevice on endpoint 1 includes GroupsServer).
+async function invokeAddGroup(fields: { groupId: number; groupName: string }) {
+    const node = await MockServerNode.createOnline();
+    try {
+        const fabric = await node.addFabric();
+        let response: undefined | TypeFromSchema<typeof TlvInvokeResponseData>;
+        await interaction.invoke(
+            node,
+            fabric,
+            {
+                commandPath: {
+                    endpointId: EndpointNumber(1),
+                    clusterId: ClusterId(Groups.id),
+                    commandId: CommandId(Groups.schema.commands.require("AddGroup").id!),
+                },
+                commandFields: TlvAddGroupRequest.encodeTlv(fields),
+            },
+            r => {
+                response = r;
+            },
+        );
+        return response;
+    } finally {
+        await node.close();
+    }
+}
+
+describe("GroupsServer schema relaxation", () => {
+    it("relaxes AddGroup GroupId/GroupName constraints relative to the base cluster", () => {
+        const baseAddGroup = Groups.schema.commands.require("AddGroup");
+        expect(baseAddGroup.fields.require("GroupId").constraint.min).equals(1);
+        expect(baseAddGroup.fields.require("GroupName").constraint.max).equals(16);
+
+        const serverAddGroup = GroupsServer.schema.get(CommandModel, "AddGroup");
+        expect(serverAddGroup).not.undefined;
+        expect(serverAddGroup!.fields.require("GroupId").constraint.min).undefined;
+        expect(serverAddGroup!.fields.require("GroupName").constraint.max).undefined;
+    });
+
+    // A relaxed field lets an out-of-constraint value reach the handler (which returns a ConstraintError command
+    // payload) instead of the interaction layer rejecting it with a bare ConstraintError status.
+
+    it("accepts an over-long GroupName and returns a command response from the handler", async () => {
+        const response = await invokeAddGroup({ groupId: 1, groupName: AN_OVERLONG_NAME });
+
+        expect(response?.command).not.undefined;
+        expect(response?.status).undefined;
+
+        const { status, groupId } = TlvAddGroupResponse.decodeTlv(response!.command!.commandFields!);
+        expect(status).equals(Status.ConstraintError);
+        expect(groupId).equals(1);
+    });
+
+    it("accepts an out-of-range GroupId and returns a command response from the handler", async () => {
+        const response = await invokeAddGroup({ groupId: 0, groupName: "grp" });
+
+        expect(response?.command).not.undefined;
+        expect(response?.status).undefined;
+
+        const { status, groupId } = TlvAddGroupResponse.decodeTlv(response!.command!.commandFields!);
+        expect(status).equals(Status.ConstraintError);
+        expect(groupId).equals(0);
+    });
+});

--- a/packages/node/test/behaviors/groups/GroupsServerSchemaTest.ts
+++ b/packages/node/test/behaviors/groups/GroupsServerSchemaTest.ts
@@ -11,6 +11,7 @@ import {
     CommandId,
     EndpointNumber,
     Status,
+    TlvEnum,
     TlvField,
     TlvInvokeResponseData,
     TlvObject,
@@ -28,7 +29,7 @@ const TlvAddGroupRequest = TlvObject({
 });
 
 const TlvAddGroupResponse = TlvObject({
-    status: TlvField(0, TlvUInt16),
+    status: TlvField(0, TlvEnum<Status>()),
     groupId: TlvField(1, TlvUInt16),
 });
 


### PR DESCRIPTION
## Problem

When a controller commissions a peer that exposes **custom or extended cluster elements** (manufacturer-specific attributes/commands), discovery resolved element names against the global `Matter` model. Anything not in that canonical model surfaced under synthetic `attr$<hex>` / `command$<hex>` names — the controller couldn't address those elements by their real names.

## Change

A controller can now supply its own Matter model; discovery resolves peer elements against it, so custom/extended elements appear by real name (and get working command senders). The model flows from the controller down to every auto-created peer node — no per-peer wiring.

- `MatterModel.withClusters(...clusters)` — returns a model copy with clusters added or replaced by ID (base preserved; source model never mutated)
- `Node.matter` getter (defaults to the global model); `ClientNode.matter` resolves explicit option → node environment → global
- `PeerBehavior` / `ClientStructure` resolve discovery against the node model; the discovered-behavior cache is keyed per model (no cross-model collision)
- `ControllerBehavior` gains a `matter` option, published to the node environment on init so auto-created peers inherit it via the env chain (node-scoped, no global singleton)

### Usage

```ts
const controller = await ServerNode.create(RootEndpoint, {
    controller: { matter: Matter.withClusters(extendedAccessControl) },
});
// every auto-created peer, no per-peer setup:
peer.stateOf(AccessControlClient).myCounter          // real name
peer.commandsOf(AccessControlClient).doThing({ ... }) // real name
```

Runtime access is by real name. Compile-time typing of the extras on the stock `*Client` behavior is a separate, deferred concern (would need a typings augmentation) — out of scope here.

## Tests

- `MatterModelTest` — `withClusters()` append / replace-by-ID / source-immutability
- `AccessControlCustomExtensionTest` — decorator-based extension of an existing cluster on the **server** (schema merge + wire round-trip) and the **controller** (generic `attr$…` path, and real-name path via a controller model)
- `GroupsServerSchemaTest` — coverage for `GroupsServer`'s command-constraint relaxation (previously untested)

Full suites green (node, model), format + lint clean. Adversarial and greg (lauckhart) reviews passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)