### PR TITLE
feat(ble): log noble disconnect reasons with HCI status text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The main work (all changes without a GitHub username in brackets in the below li
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+
+- @matter/nodejs-ble
+    - Enhancement: BLE disconnect logs now include the noble disconnect reason with its HCI status text
+
 ## 0.17.7 (2026-07-27)
 
 - @matter/general

--- a/package-lock.json
+++ b/package-lock.json
@@ -2025,9 +2025,9 @@
             ]
         },
         "node_modules/@oxlint/binding-android-arm-eabi": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.75.0.tgz",
-            "integrity": "sha512-lutovtFzJqlRaqpZrCqSSGaHZzl9nIxxpjLzhSRLunN6dCLylj0uzlCyQGaQDIys7rrv8kVXiFO+R4Zpn0bX7g==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.76.0.tgz",
+            "integrity": "sha512-ZHIE5Zt9AsPDcY4nOlofXt0YfneEeo+QrKMPcPzLf2Z6Q8VtV2W73d7SFJ920WUwyik783u/doKCs3KXdwG+7w==",
             "cpu": [
                 "arm"
             ],
@@ -2042,9 +2042,9 @@
             }
         },
         "node_modules/@oxlint/binding-android-arm64": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.75.0.tgz",
-            "integrity": "sha512-hXI0hDgHkw4w5nfru72aG7y+2iQJmC4waH/KV6H/hbgA6yAP5jYNx0P9yug15Hs0tWl/+mda3Jjn/2gmDT48tw==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.76.0.tgz",
+            "integrity": "sha512-shm/ngQilHK6bs+ElJWa4oHfNj5vL1Gl/iVEJldTQjpr0/67oSgr0KUpbmcnLig5Fo0v/l6j2567A7TOL89ONA==",
             "cpu": [
                 "arm64"
             ],
@@ -2059,9 +2059,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-arm64": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.75.0.tgz",
-            "integrity": "sha512-D91BWbK/dMYfCcrghspPIuKs2D9LF4Z/OabVSQjw1AO6PWxArD7teDA48bm0ySFqWDaPVqmQRl5GMWNglTXyrQ==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.76.0.tgz",
+            "integrity": "sha512-rvJmrAPKSQ9aWJ6wIS6CK2tJjwzfW0ApQH9qokq6sfDvmHwoyIHxHFMq7z7i7GiV6fdE6s8qvBqWKPTu8RmT6Q==",
             "cpu": [
                 "arm64"
             ],
@@ -2076,9 +2076,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-x64": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.75.0.tgz",
-            "integrity": "sha512-02mpwzf12BonZ6PT0TuQoomvEh2kVl2WGBIKWezCyToIS+rYkQZ6GXnARBAl9A4Ovm2V+Xe7M4KretyqmmcnJQ==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.76.0.tgz",
+            "integrity": "sha512-U/zYdb7VYKGY6pA9Vd2rYl9O/HlCylcOlb5PGPvVLtg+oLGsk6H3XGKEMHKyqD3nmmtmlmwb/8SwU2vfSAtvMw==",
             "cpu": [
                 "x64"
             ],
@@ -2093,9 +2093,9 @@
             }
         },
         "node_modules/@oxlint/binding-freebsd-x64": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.75.0.tgz",
-            "integrity": "sha512-qZJgLnDaBsiL5YESx2t/TZ8eXkL9fEkKoXEdzegROhlz9A0lgyGnZ0dAzJrh7LJAHQl2K9RdRueN2s/9N7+odg==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.76.0.tgz",
+            "integrity": "sha512-WvKG9CAriuo0XNiFzpXjDngUZcRGFNpaK2kLyMUsnJlShxkT96u+BpJQ3KqdQwGOrvI14L6V8bAwXwAYNNY6Jg==",
             "cpu": [
                 "x64"
             ],
@@ -2110,9 +2110,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.75.0.tgz",
-            "integrity": "sha512-7XlaWA5BJD3XpCfrEqjEe6Zseeb14S7QGa304XfwKignRaKQ+eIj775BQ7nIslggWickl4IsPUFqJ+/gAyNHVg==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.76.0.tgz",
+            "integrity": "sha512-qJ5+RH99TqFRq3UCDxkW0zJJu9c+OAHFY72vGlxZLEpuO+MpKo3POgqb8sYipL9KYm8XY6ofb0HsOuvY6hQNqQ==",
             "cpu": [
                 "arm"
             ],
@@ -2127,9 +2127,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.75.0.tgz",
-            "integrity": "sha512-av6Tpv8yrcMMMOadOqENBhlsLRcGFXXwoQ0hzHhsmS9FJ4Wioy8we427GbcMe2XTxmL2e60T67H1Dyr3up+tAA==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.76.0.tgz",
+            "integrity": "sha512-PvPCVptkgVARsucgIqFQQcSmJ6xc6GtnVB5bRBekRahTc9eObMtjHfMjy5M+C2tHt5UCMttWM9RuSk/H9NqYeg==",
             "cpu": [
                 "arm"
             ],
@@ -2144,9 +2144,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-gnu": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.75.0.tgz",
-            "integrity": "sha512-WcUhd8fHT5plrA14lANevl+hOl815mVI5t2hU21oFWrZKFXIVV/Sr4rWQV0NzSvzBupbMLNc5ErEA6Ehxh5jMg==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.76.0.tgz",
+            "integrity": "sha512-3KeFDx8Bu4HPAXbuHZOr/oHvN+QT+JQhMw/NYPz7Z071xLSsG27Jfh9PIQVEY7hk1I+jr43ExqRIeJ6VKk2yLw==",
             "cpu": [
                 "arm64"
             ],
@@ -2164,9 +2164,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-musl": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.75.0.tgz",
-            "integrity": "sha512-UWzp5wRHFe/ESO3+eEaxXsTkYTGLYjnTsi/I5neEacXSItQ6WNleapfOAeA4x2b8nyhJ4uQxqvtv9pHv8kWJtQ==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.76.0.tgz",
+            "integrity": "sha512-oPFkkKTgl0K/EIg9fQ8oA3IGcI05/Mq1en04iFa41mmNPT+6KEiByVazTOZZJiHMBBrbsns1YJ2e1Scqwzesjw==",
             "cpu": [
                 "arm64"
             ],
@@ -2184,9 +2184,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.75.0.tgz",
-            "integrity": "sha512-XEVRwGMLKCUKrvhLAz4F6AIh8MJrQVdSZtAmPpRZt9tGPsUnamPOcl3dS/ZQzJnar/Ymgc//+xho0L60Emzuxg==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.76.0.tgz",
+            "integrity": "sha512-gN7yZ0eqflA5Fhf1wvHxGUltIV3FsvmB1zhNMDEK9vSHhc7E6qg9CuPeBgPZab66Tjzq6w6kHAtNEvnTHf4cyw==",
             "cpu": [
                 "ppc64"
             ],
@@ -2204,9 +2204,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.75.0.tgz",
-            "integrity": "sha512-mAG4DUXqfLC8cTjMD2kt3jDmVzFREYtDyeLNdLdsCcBc4Zbl2EMuiFektGBilQwkNjYnMvCqJs55U+Hyb+b+jw==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.76.0.tgz",
+            "integrity": "sha512-S/HqMbn22mQrjtErUxEoS/a55u8kIeXvreIxiJu5G7Le3UecEd6SQZxrDIpuhtgaFnsY/nVra3ytP+pRljDilA==",
             "cpu": [
                 "riscv64"
             ],
@@ -2224,9 +2224,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-musl": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.75.0.tgz",
-            "integrity": "sha512-95hrAvriAlI+pekSomTFIn0+bawMDlDwTNVmdjsFusTHyL2JWh7TWvRNG/Lkim72uN8OiCcO9wcaC6omLP5E3w==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.76.0.tgz",
+            "integrity": "sha512-ZIga3097VJZolGZk6SrIAUokIGfRkxRlhiHDUznZptGBfwrhD7pNfD1rzEzsCwvk/1DX0A1bLz+liuNh5QKIVQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -2244,9 +2244,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-s390x-gnu": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.75.0.tgz",
-            "integrity": "sha512-4b6f2+FrtruAESrCqIKcrarzfrSx+wk2QNcp+RT91/Prc+pMQMAfyZ1rG1c3tFQNl8Bc616tx40uNXyxNBRPbQ==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.76.0.tgz",
+            "integrity": "sha512-ZGiiA7pFzMJSyMWYZTVlPgbTsx+Vl8ihLGMIujPwaslUF7kIPPWAbVmAlTc+9lWDV+DCiB8Ikixu+lSHeOIIWQ==",
             "cpu": [
                 "s390x"
             ],
@@ -2264,9 +2264,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-gnu": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.75.0.tgz",
-            "integrity": "sha512-nshAhrUvXFUWOvqQ2soIw7HFNWvpvEV4o0cYSqPtzLiPF5gKyYTDOOTJ6Rn8g8K/iGvPIrbDA4v8+5MvnjJrrg==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.76.0.tgz",
+            "integrity": "sha512-JLiy5WuvEBFTT6ErIFV35SLzi0R7Iri6MKU6dZbTxfIx8pndbbPs3Mj780nMipBFcPkti+okAPOJ9POKkHFEgg==",
             "cpu": [
                 "x64"
             ],
@@ -2284,9 +2284,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-musl": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.75.0.tgz",
-            "integrity": "sha512-e4jNxLKnxLC6sYBQRxrI2pgIIxnmMtF8U/VwNYcjTT/CLS+spH624cYVnj07bTKwaEWT37/e025isOs6j/0xqA==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.76.0.tgz",
+            "integrity": "sha512-z7lgKQtbo/I1NIe8G5NHLesxJDv0tRSUWTpXKb9Pm3E9nKFKfO4IOSDtFroKgXtOYb0jQbcdH+0wzTyMXVes+A==",
             "cpu": [
                 "x64"
             ],
@@ -2304,9 +2304,9 @@
             }
         },
         "node_modules/@oxlint/binding-openharmony-arm64": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.75.0.tgz",
-            "integrity": "sha512-hZ2lH+1qLf/DiEP9UWuQTK2JWj/BgvMB4jhIV4SmNU1wfEiYYX4TynQyAZXx0j9X4qRYizAL042SKaV+8ynh4w==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.76.0.tgz",
+            "integrity": "sha512-JOjKymIpb9QcYfEhZsN6h4V9Ivd474W38cNIBRv6bg2TbIvogbMTH0Mg6YWW9TiRDqfcX+/Hyfsbo5vcSE5guQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2321,9 +2321,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-arm64-msvc": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.75.0.tgz",
-            "integrity": "sha512-Ilj6PNzGDS3bCU0MSJH7Msh0NhH+T/mRp2shwg+q+GHeVlPwP5LEboW96aW+3kVKFk6zYZy1Xi5pZkqZh6X8KQ==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.76.0.tgz",
+            "integrity": "sha512-pqDWZiwcmByWUEm1NFUBNiT6aentCcaoMWJv0HbXEmuYermJ4sg8ppVrshubYP2MZ6SHccJJcpr6x469PuDFIw==",
             "cpu": [
                 "arm64"
             ],
@@ -2338,9 +2338,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-ia32-msvc": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.75.0.tgz",
-            "integrity": "sha512-QVit2nOEOiPhkmsrksPSkoGCdnZRNkspt8fwoYyP09te1VEbnSj4LAxua4rc8FKTmWkySVe05j8iz9GXYfF1AQ==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.76.0.tgz",
+            "integrity": "sha512-Ba0O659kgMv6pwO3z9PdO+K3aMxQRaw9HnG+e6AtOfgwcKFvYilciQYBoUBmxfQvOCKZe1SwjMkuB542NkuDMQ==",
             "cpu": [
                 "ia32"
             ],
@@ -2355,9 +2355,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-x64-msvc": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.75.0.tgz",
-            "integrity": "sha512-DSxnNkBUAYARPwJtR12Ig3deWr8w0H997xP6jy33i+e0SyYJw8FKuz4+cZtpmPEhQmvlPJE3X/2vNxDmLkd/rA==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.76.0.tgz",
+            "integrity": "sha512-5qcirPHO8nKfkoowEVWtpAoVTcYDy6g0UT0NGic450Qv8J2NrOqg4uQ8QppRP4MDTC7Xx47lbZnmadTH03CGGA==",
             "cpu": [
                 "x64"
             ],
@@ -2536,9 +2536,9 @@
             }
         },
         "node_modules/@react-native/assets-registry": {
-            "version": "0.86.0",
-            "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.86.0.tgz",
-            "integrity": "sha512-nIaXbm2jX1OTYp0qbviJ3O6KZivoE8z3BnhUQ2LsqfZSWRoOK/n1qsiAr6oALiNKWnXY3j2KPwtYORnZzp8xew==",
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.86.2.tgz",
+            "integrity": "sha512-vcX/mBjWAVnWofu7KecotquI2unZ/tITwA7OGdq/mdY/zmGXIEvYhfEYyOQij/LRqi9WAL+iizInTBWnxDhK/Q==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -2546,9 +2546,9 @@
             }
         },
         "node_modules/@react-native/codegen": {
-            "version": "0.86.0",
-            "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.86.0.tgz",
-            "integrity": "sha512-uTs9DBo3+/lUqinsGZK0FKJRBVClrwMXoZToaDxE1Q2SL2e55vs2GwyZfIKzPl5uJnbu4PfFMIp0/mLXLWUMuA==",
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.86.2.tgz",
+            "integrity": "sha512-xKkudsahUJ1n//55g4fXk5BStVqqmZlz8HQveL45ZxcfDnwvhuYe2GymksQANFsSN+slvrarjrfq8kIxJzbceA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -2620,13 +2620,13 @@
             }
         },
         "node_modules/@react-native/community-cli-plugin": {
-            "version": "0.86.0",
-            "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.86.0.tgz",
-            "integrity": "sha512-Jv8p1ebEPfTzs8gmrjsdT2XMXFfeAg45Pman+XPLFGaSeGAZkutRFRyX9Cs9aGTSOyIA9YPJ6vDNb1ayTf1FKQ==",
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.86.2.tgz",
+            "integrity": "sha512-YHXNKoM6Y/HjREySZ5arET2xgiHgg67r1MdwJB//MPJAJ0Xc5g0u6UHxY9VzsHO3Y07dre6s0BinYwjt1SEWvQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@react-native/dev-middleware": "0.86.0",
+                "@react-native/dev-middleware": "0.86.2",
                 "debug": "^4.4.0",
                 "invariant": "^2.2.4",
                 "metro": "^0.84.3",
@@ -2639,7 +2639,7 @@
             },
             "peerDependencies": {
                 "@react-native-community/cli": "*",
-                "@react-native/metro-config": "0.86.0"
+                "@react-native/metro-config": "0.86.2"
             },
             "peerDependenciesMeta": {
                 "@react-native-community/cli": {
@@ -2651,9 +2651,9 @@
             }
         },
         "node_modules/@react-native/debugger-frontend": {
-            "version": "0.86.0",
-            "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.86.0.tgz",
-            "integrity": "sha512-7Mb3nDfyJeys+ELF75Ageu7VKERlnIMoO+aNPoXqTXvz+b41L6l2CqMyLpDHxkBSlenij6gEepPNgaIyWHbJZw==",
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.86.2.tgz",
+            "integrity": "sha512-KGS1aV5F6cIqpnoIUhLBXyVzy1oAj8jBFGau6vX4Vy0HXRJN7p+68RU7x6NuyraHvQcR14ccMGT5TkFuNjQ4gA==",
             "license": "BSD-3-Clause",
             "peer": true,
             "engines": {
@@ -2661,9 +2661,9 @@
             }
         },
         "node_modules/@react-native/debugger-shell": {
-            "version": "0.86.0",
-            "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.86.0.tgz",
-            "integrity": "sha512-Y0zEkZzLz8ou6o/VLml1A31X/rMgc6DRjwxwzPMa94qRTMY070WeBCNTITQo4kKTBAUgbxh07oXPQqp0Tpja8w==",
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.86.2.tgz",
+            "integrity": "sha512-/TaVJ2+gGajZPJGrFaObUQmHmlaxAlfmOPZicl6pNKDUjzSgFMpcLkdTOExvb+USYTVdGX1XwxXyvjQdUO2bvg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -2676,15 +2676,15 @@
             }
         },
         "node_modules/@react-native/dev-middleware": {
-            "version": "0.86.0",
-            "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.86.0.tgz",
-            "integrity": "sha512-20pTO6yTybmvXvro520H6C7jydIQnLKOl5qFtVEcHSdFrY63r3OGei+Rx9bILgSRmH6jgnfEcijcMx7pwWuQtw==",
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.86.2.tgz",
+            "integrity": "sha512-B7L0vKvg+IcEElT7Vpqh1xj5yJAqWUegjbP+bQRaorJMAYnv11GkliTnZV2AdTDfZQJWgOEx8i8LGkHkUg7bnA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@isaacs/ttlcache": "^1.4.1",
-                "@react-native/debugger-frontend": "0.86.0",
-                "@react-native/debugger-shell": "0.86.0",
+                "@react-native/debugger-frontend": "0.86.2",
+                "@react-native/debugger-shell": "0.86.2",
                 "chrome-launcher": "^0.15.2",
                 "chromium-edge-launcher": "^0.3.0",
                 "connect": "^3.6.5",
@@ -2800,9 +2800,9 @@
             }
         },
         "node_modules/@react-native/gradle-plugin": {
-            "version": "0.86.0",
-            "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.86.0.tgz",
-            "integrity": "sha512-a1RcfaEDqWExCGfCwadIxt4l8FvKYgFqeMf2uzeKyAOnb+vTGNIeCvifFL2MqvgaeYxlER437HbMIajGcuJ1pQ==",
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.86.2.tgz",
+            "integrity": "sha512-2F6x14NcHMpVmfTTFKfMkpV5dZedZrLiv6PE+c3vgnesV2bjleUBydr4U+NI8VkI7OwW71L0A5qQ76I9LCrfoQ==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -2810,9 +2810,9 @@
             }
         },
         "node_modules/@react-native/js-polyfills": {
-            "version": "0.86.0",
-            "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.86.0.tgz",
-            "integrity": "sha512-zYy/Cjd1VTnZ2iCNaG9bDF9C3l2ntESiPRscjIlI5FKugu6aeTwsDSv1aI8Bc4Kp3vEdoVg+UQhLAhE4svREaQ==",
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.86.2.tgz",
+            "integrity": "sha512-bIwNcGBaQ74shB5z1mRkxOpjikimuwsnOCEkZSzL67Z1FTyK1ObpENfyd2QvcvVW9Cjl+tHuw9ynpBnb2jPoJQ==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -2820,16 +2820,16 @@
             }
         },
         "node_modules/@react-native/normalize-colors": {
-            "version": "0.86.0",
-            "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.86.0.tgz",
-            "integrity": "sha512-kG0wfCGghUKlfxkJyyHCDVutWVYWK7/DG58ojA/4v9EfulgF+osuSQmlbNb3rcKX58qutm7JcldSeVLgGFha9g==",
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.86.2.tgz",
+            "integrity": "sha512-EzPFc9Y6lzYOWeso2almwXI7f8+qReHxWvT+algsOczb2UhWXIWXDoSvkdwoSfiwwmGt/ijJgKJoeHlzPkLwRg==",
             "license": "MIT",
             "peer": true
         },
         "node_modules/@react-native/virtualized-lists": {
-            "version": "0.86.0",
-            "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.86.0.tgz",
-            "integrity": "sha512-4/ZLXdf/OSpPDVO0AsQ1SJdRIzt5t9BNQ46QwGgxvX7/cirYR5k8KXctNGGgW8lQo2gZChEfY2zFCZg9nM/jiw==",
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.86.2.tgz",
+            "integrity": "sha512-uO0J72gh3EvE+1/GHRk18QRyBDTRHRB0AraAfojsRjbT7VMuJwKrZYaKGshavoaEud6aw00ZB9/8mTMIKjjcAw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -2842,7 +2842,7 @@
             "peerDependencies": {
                 "@types/react": "^19.2.0",
                 "react": "*",
-                "react-native": "0.86.0"
+                "react-native": "0.86.2"
             },
             "peerDependenciesMeta": {
                 "@types/react": {
@@ -3219,9 +3219,9 @@
             }
         },
         "node_modules/@stoprocent/bluetooth-hci-socket": {
-            "version": "2.2.8",
-            "resolved": "https://registry.npmjs.org/@stoprocent/bluetooth-hci-socket/-/bluetooth-hci-socket-2.2.8.tgz",
-            "integrity": "sha512-Nbnj3ZoDMHCGU9p4t+tZbPJp7tbyCaPF4o1qcpegUZKauQi12wqLjYv3GPZmNSpgM/5kmtEq9PpfxCM3w6AT7g==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@stoprocent/bluetooth-hci-socket/-/bluetooth-hci-socket-2.3.0.tgz",
+            "integrity": "sha512-xTigfmWCBqNJyPibOCS8F4dTt0LdE5zHAlpOc919ladh1Q+PjQgSGMQZoXxpK9CzZgZCmPF5f90jC0IkogwQEg==",
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -3470,9 +3470,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "26.1.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-            "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+            "version": "26.1.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+            "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~8.3.0"
@@ -3886,9 +3886,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+            "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -4244,9 +4244,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.11.4",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.4.tgz",
-            "integrity": "sha512-s4+sLr9mZ/CyqeRritFeYV/Zx73OAtmaHn6kkBS1XRoJn1hrg3xIDUcpicAEX68tkcIN0iBCgti31C8zxtkhsQ==",
+            "version": "2.11.5",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.5.tgz",
+            "integrity": "sha512-xJo6a6YZnwZfnyGmQKWMbVOcii7XRibjOskRh+WJ9UHQoX16xrQrcIgAMQOzfvs8XiLMx6ih/fsLPF73iY2D1A==",
             "license": "Apache-2.0",
             "peer": true,
             "bin": {
@@ -5451,9 +5451,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.396",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
-            "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
+            "version": "1.5.397",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.397.tgz",
+            "integrity": "sha512-khGTy9U9x02KEtsKM8vx5A62BsRmcOsIgDpWr1ImE32Ax8GxHGPHZf+Eu9H8zOOyHJnB0jTbseyTHbq2XCT8yw==",
             "license": "ISC",
             "peer": true
         },
@@ -6518,9 +6518,9 @@
             "license": "MIT"
         },
         "node_modules/hermes-compiler": {
-            "version": "250829098.0.14",
-            "resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-250829098.0.14.tgz",
-            "integrity": "sha512-5meXwsZxgiqFaJjNzwjzI9IyUkuGGBisu+z9BvQWmGVpjH6nz11hgqkyxe4dl8UAdyIV4lTbz91+Dlnjz0VxqA==",
+            "version": "250829098.0.16",
+            "resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-250829098.0.16.tgz",
+            "integrity": "sha512-xsgzk+mUyvt9t1nUbF8USBlYxajTUtPJhVZ86q85s/SEoMKCF+52YZcudb0ENSnV3T3lV9mgB3s6R7+pH90zgw==",
             "license": "MIT",
             "peer": true
         },
@@ -8326,12 +8326,12 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "version": "10.2.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+            "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.5"
+                "brace-expansion": "^5.0.8"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -8851,9 +8851,9 @@
             }
         },
         "node_modules/oxlint": {
-            "version": "1.75.0",
-            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.75.0.tgz",
-            "integrity": "sha512-m9WzjRcRYA/uqIZDa9tclrieoPJ/ln1QYTKdFx6NUOs8uY5DiHlIwRQoCrHT6OM6O3ww3l2skY5gO7G7ZphE7g==",
+            "version": "1.76.0",
+            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.76.0.tgz",
+            "integrity": "sha512-6QoFioEU4fNdiUx/2Eo6TRd6NG7H7njnRCz8rhB66cZmMHDTqcm1Rjvl8Wry+ZTQMBAmyb4Mlf62Mk5X+eHSOw==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -8866,25 +8866,25 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxlint/binding-android-arm-eabi": "1.75.0",
-                "@oxlint/binding-android-arm64": "1.75.0",
-                "@oxlint/binding-darwin-arm64": "1.75.0",
-                "@oxlint/binding-darwin-x64": "1.75.0",
-                "@oxlint/binding-freebsd-x64": "1.75.0",
-                "@oxlint/binding-linux-arm-gnueabihf": "1.75.0",
-                "@oxlint/binding-linux-arm-musleabihf": "1.75.0",
-                "@oxlint/binding-linux-arm64-gnu": "1.75.0",
-                "@oxlint/binding-linux-arm64-musl": "1.75.0",
-                "@oxlint/binding-linux-ppc64-gnu": "1.75.0",
-                "@oxlint/binding-linux-riscv64-gnu": "1.75.0",
-                "@oxlint/binding-linux-riscv64-musl": "1.75.0",
-                "@oxlint/binding-linux-s390x-gnu": "1.75.0",
-                "@oxlint/binding-linux-x64-gnu": "1.75.0",
-                "@oxlint/binding-linux-x64-musl": "1.75.0",
-                "@oxlint/binding-openharmony-arm64": "1.75.0",
-                "@oxlint/binding-win32-arm64-msvc": "1.75.0",
-                "@oxlint/binding-win32-ia32-msvc": "1.75.0",
-                "@oxlint/binding-win32-x64-msvc": "1.75.0"
+                "@oxlint/binding-android-arm-eabi": "1.76.0",
+                "@oxlint/binding-android-arm64": "1.76.0",
+                "@oxlint/binding-darwin-arm64": "1.76.0",
+                "@oxlint/binding-darwin-x64": "1.76.0",
+                "@oxlint/binding-freebsd-x64": "1.76.0",
+                "@oxlint/binding-linux-arm-gnueabihf": "1.76.0",
+                "@oxlint/binding-linux-arm-musleabihf": "1.76.0",
+                "@oxlint/binding-linux-arm64-gnu": "1.76.0",
+                "@oxlint/binding-linux-arm64-musl": "1.76.0",
+                "@oxlint/binding-linux-ppc64-gnu": "1.76.0",
+                "@oxlint/binding-linux-riscv64-gnu": "1.76.0",
+                "@oxlint/binding-linux-riscv64-musl": "1.76.0",
+                "@oxlint/binding-linux-s390x-gnu": "1.76.0",
+                "@oxlint/binding-linux-x64-gnu": "1.76.0",
+                "@oxlint/binding-linux-x64-musl": "1.76.0",
+                "@oxlint/binding-openharmony-arm64": "1.76.0",
+                "@oxlint/binding-win32-arm64-msvc": "1.76.0",
+                "@oxlint/binding-win32-ia32-msvc": "1.76.0",
+                "@oxlint/binding-win32-x64-msvc": "1.76.0"
             },
             "peerDependencies": {
                 "oxlint-tsgolint": ">=7.0.2001",
@@ -9593,19 +9593,19 @@
             "peer": true
         },
         "node_modules/react-native": {
-            "version": "0.86.0",
-            "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.86.0.tgz",
-            "integrity": "sha512-17ALh/dd6AO4pgOVmOO5Axll5PbErEo3XFyLokyzW6usyi+OShIEPwUW26wLPlhVifgSOIfECCH0WN+0IqtJ1w==",
+            "version": "0.86.2",
+            "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.86.2.tgz",
+            "integrity": "sha512-zbJXGZpwfZGA79Z9ob6Atvfx4nAQL8yJBa35s58E4Oo+khPykfQP2sTeumkKbjwajFYfVayg8pj7Il9nIfTk7A==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@react-native/assets-registry": "0.86.0",
-                "@react-native/codegen": "0.86.0",
-                "@react-native/community-cli-plugin": "0.86.0",
-                "@react-native/gradle-plugin": "0.86.0",
-                "@react-native/js-polyfills": "0.86.0",
-                "@react-native/normalize-colors": "0.86.0",
-                "@react-native/virtualized-lists": "0.86.0",
+                "@react-native/assets-registry": "0.86.2",
+                "@react-native/codegen": "0.86.2",
+                "@react-native/community-cli-plugin": "0.86.2",
+                "@react-native/gradle-plugin": "0.86.2",
+                "@react-native/js-polyfills": "0.86.2",
+                "@react-native/normalize-colors": "0.86.2",
+                "@react-native/virtualized-lists": "0.86.2",
                 "abort-controller": "^3.0.0",
                 "anser": "^1.4.9",
                 "ansi-regex": "^5.0.0",
@@ -9613,7 +9613,7 @@
                 "base64-js": "^1.5.1",
                 "commander": "^12.0.0",
                 "flow-enums-runtime": "^0.0.6",
-                "hermes-compiler": "250829098.0.14",
+                "hermes-compiler": "250829098.0.16",
                 "invariant": "^2.2.4",
                 "memoize-one": "^5.0.0",
                 "metro-runtime": "^0.84.3",
@@ -9639,7 +9639,7 @@
                 "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             },
             "peerDependencies": {
-                "@react-native/jest-preset": "0.86.0",
+                "@react-native/jest-preset": "0.86.2",
                 "@types/react": "^19.1.1",
                 "react": "^19.2.3"
             },
@@ -9689,9 +9689,9 @@
             }
         },
         "node_modules/react-native-nitro-modules": {
-            "version": "0.36.1",
-            "resolved": "https://registry.npmjs.org/react-native-nitro-modules/-/react-native-nitro-modules-0.36.1.tgz",
-            "integrity": "sha512-kBv/VvKqAmkXAvP1DxJMC9b/fRhh7JdSO4EUnPP46hJjrIFeFR8AwKm8mYaKZEuF014M/TVdv2vomVUW0umsQQ==",
+            "version": "0.36.3",
+            "resolved": "https://registry.npmjs.org/react-native-nitro-modules/-/react-native-nitro-modules-0.36.3.tgz",
+            "integrity": "sha512-8nVnqxN2ZJdKw8u6HnUXBStd/ERRMzvN93g+A48EhWWeYQVx4idKYRMuNGXXsPUNIWOreNKs2hky2PBfnCif/g==",
             "license": "MIT",
             "peer": true,
             "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3219,9 +3219,9 @@
             }
         },
         "node_modules/@stoprocent/bluetooth-hci-socket": {
-            "version": "2.2.6",
-            "resolved": "https://registry.npmjs.org/@stoprocent/bluetooth-hci-socket/-/bluetooth-hci-socket-2.2.6.tgz",
-            "integrity": "sha512-elKIsQe78EnxXzxfA/iuqGufD02d6t3S95eNhFaPvTJs7S3IHq2CdIHwTg3BLwae7Jw14mwK0VhWVtNtzrLyoA==",
+            "version": "2.2.8",
+            "resolved": "https://registry.npmjs.org/@stoprocent/bluetooth-hci-socket/-/bluetooth-hci-socket-2.2.8.tgz",
+            "integrity": "sha512-Nbnj3ZoDMHCGU9p4t+tZbPJp7tbyCaPF4o1qcpegUZKauQi12wqLjYv3GPZmNSpgM/5kmtEq9PpfxCM3w6AT7g==",
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -3245,9 +3245,9 @@
             }
         },
         "node_modules/@stoprocent/noble": {
-            "version": "2.5.9",
-            "resolved": "https://registry.npmjs.org/@stoprocent/noble/-/noble-2.5.9.tgz",
-            "integrity": "sha512-w0arOJHuyorlrPwll43Va2vDmW6jJiWWwjXysvp8NR4y9hjGADaMHN/v2mKkM7Nr/lmcjwphXik5P/IkUXJ8uw==",
+            "version": "2.5.10",
+            "resolved": "https://registry.npmjs.org/@stoprocent/noble/-/noble-2.5.10.tgz",
+            "integrity": "sha512-350BwxEE45x1jL9GkIeFTWeZe4EAUx5FZN9SVzEZce3g7FaVDdfyDhCmLC4cnqqAo6wSdigWRkbQk/xa54cvOw==",
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -3261,7 +3261,7 @@
                 "node": ">=14"
             },
             "optionalDependencies": {
-                "@stoprocent/bluetooth-hci-socket": "^2.2.6"
+                "@stoprocent/bluetooth-hci-socket": "^2.2.8"
             },
             "peerDependencies": {
                 "dbus-next": "^0.10.0"
@@ -12324,7 +12324,7 @@
             },
             "optionalDependencies": {
                 "@stoprocent/bleno": "^0.12.5",
-                "@stoprocent/noble": "^2.5.9"
+                "@stoprocent/noble": "^2.5.10"
             }
         },
         "packages/nodejs-shell": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
         "@memlab/cli@2.0.4": true,
         "@serialport/bindings-cpp@12.0.1": true,
         "@stoprocent/bleno@0.12.5": true,
-        "@stoprocent/bluetooth-hci-socket@2.2.8": true,
+        "@stoprocent/bluetooth-hci-socket@2.3.0": true,
         "@stoprocent/noble@2.5.10": true,
         "usb@2.18.0": true,
         "fsevents@2.3.2": true

--- a/package.json
+++ b/package.json
@@ -114,8 +114,8 @@
         "@memlab/cli@2.0.4": true,
         "@serialport/bindings-cpp@12.0.1": true,
         "@stoprocent/bleno@0.12.5": true,
-        "@stoprocent/bluetooth-hci-socket@2.2.6": true,
-        "@stoprocent/noble@2.5.7": true,
+        "@stoprocent/bluetooth-hci-socket@2.2.8": true,
+        "@stoprocent/noble@2.5.10": true,
         "usb@2.18.0": true,
         "fsevents@2.3.2": true
     }

--- a/packages/nodejs-ble/package.json
+++ b/packages/nodejs-ble/package.json
@@ -34,7 +34,7 @@
     },
     "optionalDependencies": {
         "@stoprocent/bleno": "^0.12.5",
-        "@stoprocent/noble": "^2.5.9"
+        "@stoprocent/noble": "^2.5.10"
     },
     "engines": {
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"

--- a/packages/nodejs-ble/src/NobleBleChannel.ts
+++ b/packages/nodejs-ble/src/NobleBleChannel.ts
@@ -31,6 +31,7 @@ import {
 } from "@matter/protocol";
 import type { Characteristic, Peripheral } from "@stoprocent/noble";
 import { BleScanner } from "./BleScanner.js";
+import { nobleDisconnectReason } from "./NobleBleClient.js";
 
 const logger = Logger.get("BleChannel");
 
@@ -219,21 +220,23 @@ export class NobleBleCentralInterface implements Transport {
                 this.#connectionGuards.delete(connectionGuard);
             };
 
-            // Handler to retry the connection. Called on disconnections and errors.
-            const reTryHandler = (error?: any) => {
+            // Handler to retry the connection. Called on disconnections (with a noble disconnect reason) and errors.
+            const reTryHandler = (errorOrReason?: unknown) => {
                 // Cancel tracking states because we are done in this context
                 clearConnectionGuard();
                 this.#connectionsInProgress.delete(peripheralAddress);
                 peripheral.removeListener("connect", connectListener);
                 peripheral.removeListener("disconnect", reTryHandler);
 
-                if (error) {
+                if (errorOrReason instanceof Error) {
                     logger.info(
                         `Peripheral ${peripheralAddress} disconnected while trying to connect, try again`,
-                        error,
+                        errorOrReason,
                     );
                 } else {
-                    logger.info(`Peripheral ${peripheralAddress} disconnected while trying to connect, try again`);
+                    logger.info(
+                        `Peripheral ${peripheralAddress} disconnected while trying to connect (reason ${nobleDisconnectReason(errorOrReason)}), try again`,
+                    );
                 }
 
                 // Try again and chain promises
@@ -628,8 +631,10 @@ export class NobleBleChannel extends BleChannel<Bytes> {
     ) {
         super();
         this.#cleanupDataListener = cleanupDataListener;
-        peripheral.once("disconnect", () => {
-            logger.debug(`Disconnected from peripheral ${peripheral.address}. Closing BTP session`);
+        peripheral.once("disconnect", reason => {
+            logger.debug(
+                `Disconnected from peripheral ${peripheral.address} (reason ${nobleDisconnectReason(reason)}). Closing BTP session`,
+            );
             this.#connected = false;
             this.#cleanupDataListener();
             this.#terminateIterator();

--- a/packages/nodejs-ble/src/NobleBleClient.ts
+++ b/packages/nodejs-ble/src/NobleBleClient.ts
@@ -13,18 +13,32 @@ import { BleOptions } from "./NodeJsBle.js";
 
 const logger = Logger.get("NobleBleClient");
 let noble: Noble;
+let hciStatusMessage: (reason: number) => string;
 
 function loadNoble(hciId?: number) {
     // load noble driver with the correct device selected
     if (hciId !== undefined) {
         process.env.NOBLE_HCI_DEVICE_ID = hciId.toString();
     }
-    noble = require("@stoprocent/noble");
+    const nobleExports = require("@stoprocent/noble");
+    hciStatusMessage = nobleExports.hciStatusMessage;
+    noble = nobleExports;
     if (typeof noble.on !== "function") {
         // The following commit broke the default exported instance of noble:
         // https://github.com/abandonware/noble/commit/b67eea246f719947fc45b1b52b856e61637a8a8e
-        noble = (noble as any)({ extended: false });
+        noble = nobleExports({ extended: false });
     }
+}
+
+/**
+ * Render a noble disconnect reason. Linux HCI bindings report a numeric controller status, other bindings a
+ * descriptive string.
+ */
+export function nobleDisconnectReason(reason: unknown) {
+    if (typeof reason === "number") {
+        return `0x${reason.toString(16).padStart(2, "0")} (${hciStatusMessage(reason)})`;
+    }
+    return reason === undefined ? "unknown" : String(reason);
 }
 
 export class NobleBleClient {


### PR DESCRIPTION
noble 2.5.10 exports `hciStatusMessage()` ([stoprocent/noble#103](https://github.com/stoprocent/noble/pull/103)), so BLE disconnect reasons can be logged as `0x08 (Connection Timeout)` instead of being dropped.

- New `nobleDisconnectReason()` in `NobleBleClient.ts`. Numeric HCI status renders as hex + spec text; string reasons (macOS/Windows bindings, library-initiated cleanup) pass through; missing reason renders as `unknown`. `loadNoble()` captures `hciStatusMessage` from the module exports it already requires — no second `require`, and it works on the factory-fallback path where the Noble instance itself would not carry the function.
- The disconnect reason argument was previously ignored at both `disconnect` listeners (connection retry and channel teardown); both now log it.
- `reTryHandler` doubles as the `disconnect` listener and as an error callback, so it now branches on `instanceof Error` — real errors keep their error payload, reasons get rendered text. The former truthiness check also mistook HCI status `0` for "no reason at all".

Bumps `@stoprocent/noble` to `^2.5.10`.

Drops one pre-existing `as any` cast in `loadNoble()`.

Verified: `npm run build`, `npm run format-verify`, `npm run lint`, full `npm test` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)