### PR TITLE
fix(node): suppress OTA activity while the node is offline

### DIFF
--- a/packages/node/src/behavior/system/software-update/SoftwareUpdateManager.ts
+++ b/packages/node/src/behavior/system/software-update/SoftwareUpdateManager.ts
@@ -1089,6 +1089,8 @@ export class SoftwareUpdateManager extends Behavior {
      */
     onOtaStatusChange(peerAddress: PeerAddress, status: OtaUpdateStatus, toVersion?: number) {
         if (this.internal.suppressUpdates) {
+            // A post-dispose Applying would otherwise re-arm the already-disposed armer whose observers are
+            // closed, leaving an entry that never gets a grace timer nor self-cleans.
             return;
         }
         peerAddress = PeerAddress(peerAddress);

--- a/packages/node/src/behavior/system/software-update/SoftwareUpdateManager.ts
+++ b/packages/node/src/behavior/system/software-update/SoftwareUpdateManager.ts
@@ -165,6 +165,7 @@ export class SoftwareUpdateManager extends Behavior {
         await this.internal.otaService.construction;
 
         this.reactTo(rootNode.lifecycle.online, this.#nodeOnline);
+        this.reactTo(rootNode.lifecycle.goingOffline, this.#nodeGoingOffline);
         if (rootNode.lifecycle.isOnline) {
             await this.#nodeOnline();
         }
@@ -174,6 +175,7 @@ export class SoftwareUpdateManager extends Behavior {
     }
 
     async #nodeOnline() {
+        this.internal.suppressUpdates = false;
         if (this.internal.announcements !== undefined) {
             await this.internal.announcements.close();
             this.internal.announcements = undefined;
@@ -202,6 +204,10 @@ export class SoftwareUpdateManager extends Behavior {
             delay,
             this.callback(this.#initializeUpdateCheck),
         ).start();
+    }
+
+    #nodeGoingOffline() {
+        this.internal.suppressUpdates = true;
     }
 
     #updateAnnouncementSettings() {
@@ -481,7 +487,7 @@ export class SoftwareUpdateManager extends Behavior {
         // Collect all client nodes and their versions, so we only need to check each version once
         const updateDetails = new Map<string, CollectedNodesUpdateInfo>();
         for (const peer of rootNode.peers) {
-            if (this.internal.closed) {
+            if (this.internal.suppressUpdates) {
                 return [];
             }
             if (peerToCheck !== undefined && peerToCheck !== peer) {
@@ -512,7 +518,7 @@ export class SoftwareUpdateManager extends Behavior {
 
         const peersWithUpdates = new Array<{ peerAddress: PeerAddress; info: SoftwareUpdateInfo }>();
         for (const infos of updateDetails.values()) {
-            if (this.internal.closed) {
+            if (this.internal.suppressUpdates) {
                 return [];
             }
             try {
@@ -550,7 +556,7 @@ export class SoftwareUpdateManager extends Behavior {
             includeStoredUpdates,
             isProduction: this.state.allowTestOtaImages ? undefined : true,
         });
-        if (!updateDetails || this.internal.closed) {
+        if (!updateDetails || this.internal.suppressUpdates) {
             return [];
         }
         const fd = await this.internal.otaService.downloadUpdate(updateDetails);
@@ -589,7 +595,7 @@ export class SoftwareUpdateManager extends Behavior {
                     consent.peerAddress.fabricIndex === peerAddress.fabricIndex &&
                     consent.peerAddress.nodeId === peerAddress.nodeId,
             );
-            if (this.internal.closed) {
+            if (this.internal.suppressUpdates) {
                 break;
             }
             if (hasConsent) {
@@ -791,7 +797,7 @@ export class SoftwareUpdateManager extends Behavior {
      * monitor for stalled updates.
      */
     #triggerQueuedUpdate() {
-        if (this.internal.closed) {
+        if (this.internal.suppressUpdates) {
             return;
         }
         const now = Time.nowMs;
@@ -850,7 +856,7 @@ export class SoftwareUpdateManager extends Behavior {
      * The node usually calls queryImage as a result of this when it processes the announcement.
      */
     async #triggerUpdateOnNode(entry: UpdateQueueEntry) {
-        if (this.internal.announcements == undefined) {
+        if (this.internal.announcements === undefined) {
             logger.info(`Not yet initialized with peers, can not trigger update on node`, entry.peerAddress);
             return;
         }
@@ -1082,9 +1088,7 @@ export class SoftwareUpdateManager extends Behavior {
      * messages, and triggers the necessary events.
      */
     onOtaStatusChange(peerAddress: PeerAddress, status: OtaUpdateStatus, toVersion?: number) {
-        if (this.internal.closed) {
-            // A post-dispose Applying would otherwise re-arm the already-disposed armer whose observers are
-            // closed, leaving an entry that never gets a grace timer nor self-cleans.
+        if (this.internal.suppressUpdates) {
             return;
         }
         peerAddress = PeerAddress(peerAddress);
@@ -1145,7 +1149,7 @@ export class SoftwareUpdateManager extends Behavior {
     }
 
     override async [Symbol.asyncDispose]() {
-        this.internal.closed = true;
+        this.internal.suppressUpdates = true;
         this.internal.checkForUpdateTimer?.stop();
         this.internal.updateQueueTimer?.stop();
         await this.internal.announcements?.close();
@@ -1200,7 +1204,7 @@ export namespace SoftwareUpdateManager {
 
         rebootResubscribeArmer?: RebootResubscribeArmer;
 
-        closed = false;
+        suppressUpdates = false;
     }
 
     export class Events extends EventEmitter {

--- a/packages/node/src/behavior/system/software-update/SoftwareUpdateManager.ts
+++ b/packages/node/src/behavior/system/software-update/SoftwareUpdateManager.ts
@@ -206,8 +206,14 @@ export class SoftwareUpdateManager extends Behavior {
         ).start();
     }
 
-    #nodeGoingOffline() {
+    async #nodeGoingOffline() {
         this.internal.suppressUpdates = true;
+        this.internal.checkForUpdateTimer?.stop();
+
+        // Announcements run on their own timers and write to peers, so the suppression flag alone does not stop them.
+        // #nodeOnline installs a fresh instance.
+        await this.internal.announcements?.close();
+        this.internal.announcements = undefined;
     }
 
     #updateAnnouncementSettings() {
@@ -1206,7 +1212,8 @@ export namespace SoftwareUpdateManager {
 
         rebootResubscribeArmer?: RebootResubscribeArmer;
 
-        suppressUpdates = false;
+        /** Raised whenever the node is not online, so update work cannot start before the first online transition. */
+        suppressUpdates = true;
     }
 
     export class Events extends EventEmitter {


### PR DESCRIPTION
Minor hardening in `SoftwareUpdateManager`.

The update paths guarded only against disposal (`internal.closed`), so a node that had gone offline but was not yet disposed kept doing update work: collecting per-peer update info, downloading images, walking the consent list, firing queued updates, and reacting to OTA status changes.

The guard now covers both states — raised on `lifecycle.goingOffline`, lowered again on `lifecycle.online` so a node that comes back resumes normally. `internal.closed` is renamed to `internal.suppressUpdates` since it no longer means "disposed"; `[Symbol.asyncDispose]` still raises it, so the previous behavior is a subset.

Two gaps found in review and fixed on top:

- The flag started out lowered, so update work could still run between `initialize()` and the first online transition — the very window it exists to cover. It now starts raised.
- Going offline left the `OtaAnnouncements` instance alive. It runs its own timers and writes to peers, so it kept announcing while offline regardless of the flag. It is now closed on `goingOffline` along with the update-check timer; `#nodeOnline` already installs a fresh instance.

The queue timer is deliberately left running: `#triggerQueuedUpdate` returns immediately while suppressed and re-arms itself only when there is queue work, so stopping it would gain nothing and could delay a resumed queue.

Also tightens one `== undefined` to `=== undefined`.

## Checklist

- [x] `npm test` passes (full suite, all packages)
- [x] `npm run format-verify` and `npm run lint` pass
- [x] `npm run build -- --clean` passes
- [ ] Tests added or updated — none; no new externally observable behavior beyond the lifecycle guard, and `SoftwareUpdateManager` has no existing unit-test harness for lifecycle transitions
- [ ] CHANGELOG updated — not applicable, internal hardening with no API change

No log file attached: this is not an issue-driven fix but a proactive hardening of the offline path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)