### PR TITLE
fix(chip-testing): run ICDB/2.5 factory-fresh

### DIFF
--- a/support/chip-testing/test/icd/ICDB.test.ts
+++ b/support/chip-testing/test/icd/ICDB.test.ts
@@ -9,7 +9,7 @@ import { LitIcdApp } from "../support.js";
 describe("ICDB", () => {
     // The 2.x state-machine cases self-commission in setup_class (get_setup_payload_info_config), so they must run
     // factory-fresh rather than against the pre-commissioned subject. 1.x/3.x use the default (pre-commissioned) flow.
-    const selfCommissioned = ["ICDB/2.1", "ICDB/2.2", "ICDB/2.3", "ICDB/2.4"];
+    const selfCommissioned = ["ICDB/2.1", "ICDB/2.2", "ICDB/2.3", "ICDB/2.4", "ICDB/2.5"];
 
     chip("ICDB/*")
         .subject(LitIcdApp)


### PR DESCRIPTION
## Problem

The nightly chip image build went red on `test-icd` (both `chiptool` and `matterjs` controllers):

```
File "/src/python_testing/TC_ICDB_2_5.py", line 101, in setup_class
    info = setup_payload_info[0]
IndexError: list index out of range
```

`TC_ICDB_2_5` landed upstream in project-chip/connectedhomeip#43656 (2026-07-25) and our `chip("ICDB/*")` glob picked it up automatically from the freshly built image.

## Cause

Like ICDB 2.1–2.4, the new test commissions the DUT itself in `setup_class` — `get_setup_payload_info_config(self.matter_test_config)`, then `CommissionOnNetwork` for TH1 and a second fabric for TH2. It therefore needs a factory-fresh subject and a setup code on the command line.

The descriptor generator strips `--discriminator`/`--passcode`/`--commissioning-method` from python test headers (`PYTHON_IGNORE_ARGS`), and `createCommand` only injects `--qr-code` for tests declared `.uncommissioned()`. ICDB/2.5 was not on that list, so the payload list was empty.

Confirmed from the run's config dump: no `qr_code_content`, no `discriminators`.

## Fix

Add `ICDB/2.5` to the self-commissioned set in `support/chip-testing/test/icd/ICDB.test.ts`, so it runs factory-fresh and receives the subject's QR pairing code.

## Follow-up (separate PR)

Two related items surfaced while diagnosing this, both needing a chip image rebuild so they are kept out of this fix:

- `generate-test-descriptor` calls `get_defined_test_steps(name)` with the `TC_`-stripped name, which upstream cannot resolve — it raises `AttributeError` into a swallowing `except`, so python tests never get step members and `startUncommissioned` is never emitted.
- With that repaired, `uncommissioned` can be derived from the descriptor instead of hardcoded per-suite lists, which is what let this upstream addition break the nightly in the first place.

## Verification

`npm run format-verify` and `npm run lint` clean. The test itself only runs inside the chip docker image, so the nightly (or a manual chip image run) is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)