### PR TITLE
fix(chip-testing): derive factory-fresh subjects from the test descriptor

### DIFF
--- a/packages/testing/src/chip/chip.ts
+++ b/packages/testing/src/chip/chip.ts
@@ -129,7 +129,7 @@ function createBuilder(initial: {
 }): chip.Builder {
     const implementations = new Map<TestDescriptor, Mocha.Test>();
     let subject: undefined | Subject.Factory;
-    let startCommissioned = true;
+    let startCommissioned: undefined | boolean;
     let only = false;
     const beforeStartHooks = Array<chip.BeforeHook>();
     const beforeTestHooks = Array<chip.BeforeHook>();
@@ -216,6 +216,11 @@ function createBuilder(initial: {
 
         uncommissioned() {
             startCommissioned = false;
+            return this;
+        },
+
+        commissioned() {
+            startCommissioned = true;
             return this;
         },
 
@@ -327,7 +332,7 @@ function createBuilder(initial: {
 
             await State.activateSubject(
                 factory,
-                startCommissioned,
+                startCommissioned ?? !descriptor.startUncommissioned,
                 test,
                 (subject, test) => runBeforeHooks(beforeStartHooks, subject, test),
                 appArgs,
@@ -489,6 +494,11 @@ export namespace chip {
          * Start subject as new-from-factory rather than commissioned.
          */
         uncommissioned(): Builder;
+
+        /**
+         * Start subject commissioned even if the test descriptor asks for new-from-factory.
+         */
+        commissioned(): Builder;
 
         /**
          * Run following tests defined by this builder only.

--- a/support/chip-testing/test/icd/ICDB.test.ts
+++ b/support/chip-testing/test/icd/ICDB.test.ts
@@ -7,14 +7,5 @@
 import { LitIcdApp } from "../support.js";
 
 describe("ICDB", () => {
-    // The 2.x state-machine cases self-commission in setup_class (get_setup_payload_info_config), so they must run
-    // factory-fresh rather than against the pre-commissioned subject. 1.x/3.x use the default (pre-commissioned) flow.
-    const selfCommissioned = ["ICDB/2.1", "ICDB/2.2", "ICDB/2.3", "ICDB/2.4", "ICDB/2.5"];
-
-    chip("ICDB/*")
-        .subject(LitIcdApp)
-        .exclude(...selfCommissioned);
-    chip(...selfCommissioned)
-        .subject(LitIcdApp)
-        .uncommissioned();
+    chip("ICDB/*").subject(LitIcdApp);
 });

--- a/support/chip/support/generate-test-descriptor
+++ b/support/chip/support/generate-test-descriptor
@@ -374,7 +374,8 @@ def load_python():
                 steps = instance.get_defined_test_steps(test_method_name)
                 if steps:
                     props["members"] = list(map(lambda step: {
-                        "name": step.test_plan_number,
+                        # Numbered steps (self.step(1)) arrive as ints but descriptor names index a virtual filesystem
+                        "name": str(step.test_plan_number),
                         "kind": "step",
                         "description": step.description,
                     }, steps))

--- a/support/chip/support/generate-test-descriptor
+++ b/support/chip/support/generate-test-descriptor
@@ -13,6 +13,7 @@ During build, the Dockerfile stores this as /lib/test-descriptor.json.  The @mat
 runtime.
 """
 
+import ast
 import os
 import json
 import yaml
@@ -22,6 +23,7 @@ import inspect
 import importlib
 import re
 import shutil
+import textwrap
 from matter.testing.matter_testing import MatterBaseTest, MatterTestConfig
 from matter.testing.runner import generate_mobly_test_config
 
@@ -38,6 +40,18 @@ PYTHON_IGNORE_ARGS = [
     "--PICS",
     "--app-pipe",
 ]
+
+# CHIP APIs that commission a device.  We commission the subject ourselves and strip commissioning arguments from python
+# tests (see PYTHON_IGNORE_ARGS), so a test that commissions the DUT in setup_class instead needs a factory-fresh subject
+# and a setup code on the command line
+COMMISSIONING_APIS = [
+    "commission_device",
+    "CommissionOnNetwork",
+]
+
+# Commissioning calls that do not name this are for a helper device on another fabric (a bridged ICD, a
+# commissioner-control server) and say nothing about the state the DUT must start in
+DUT_ARGUMENT = "dut_node_id"
 
 # Somewhere in the code we run for test reflection CHIP decides to create a directory for the test name.  So execute in
 # /tmp/metadata-garbage and clean up when we're done
@@ -147,6 +161,38 @@ def parse_command_line(str: str):
 
     return args
 
+def commissions_dut_itself(test_class):
+    """Detect whether a python test commissions the DUT in setup_class.
+
+    Such tests must run against a factory-fresh subject rather than the pre-commissioned subject we share between tests.
+    We walk the MRO up to MatterBaseTest because the override may live in an intermediate base class.
+    """
+    for klass in test_class.__mro__:
+        if klass is MatterBaseTest:
+            break
+
+        setup_class = klass.__dict__.get("setup_class")
+        if setup_class is None:
+            continue
+
+        try:
+            source = textwrap.dedent(inspect.getsource(setup_class))
+            tree = ast.parse(source)
+        except (OSError, SyntaxError) as e:
+            sys.stderr.write(f"Error reading setup_class of {klass.__name__}: {e}\n")
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+
+            callee = node.func
+            name = callee.attr if isinstance(callee, ast.Attribute) else getattr(callee, "id", None)
+            if name in COMMISSIONING_APIS and DUT_ARGUMENT in ast.unparse(node):
+                return True
+
+    return False
+
 def load_python():
     """ Load metadata from Python tests.  This requires a bit more fiddling because:
 
@@ -229,6 +275,8 @@ def load_python():
         # Instantiate the test for introspection purposes
         instance = test_class(mobly_test_config)
         all_test_methods = instance.get_existing_test_names()
+
+        self_commissioning = commissions_dut_itself(test_class)
 
         # Extract run information from the YAML header.  Much of this is encoded as command line arguments
         parsed_header = yaml.full_load("".join(header))
@@ -317,14 +365,14 @@ def load_python():
             except Exception as e:
                 sys.stderr.write(f"Error extracting PICS for {path}: {e}\n")
 
-            # Extract steps if present
+            if self_commissioning:
+                props["startUncommissioned"] = True
+
+            # Extract steps if present.  As with the description this needs the full method name
             steps = None
             try:
-                steps = instance.get_defined_test_steps(name)
+                steps = instance.get_defined_test_steps(test_method_name)
                 if steps:
-                    if not steps[0].is_commissioning:
-                        props["startUncommissioned"] = True
-
                     props["members"] = list(map(lambda step: {
                         "name": step.test_plan_number,
                         "kind": "step",


### PR DESCRIPTION
Follow-up to #4170, which fixed a red nightly by hand-adding `ICDB/2.5` to a list of tests that must run against an uncommissioned subject. This removes the need for that list.

## Background

We commission the test subject ourselves and cache it between tests, so the descriptor generator strips `--commissioning-method`, `--discriminator` and `--passcode` from python test headers (`PYTHON_IGNORE_ARGS`). A test that commissions the DUT itself in `setup_class` therefore finds no setup payload and fails before its first step:

```
File "/src/python_testing/TC_ICDB_2_5.py", line 101, in setup_class
    info = setup_payload_info[0]
IndexError: list index out of range
```

Which tests behave that way was tracked by hand in `ICDB.test.ts`, so every upstream addition of one breaks the nightly until someone notices.

## Detection

`generate-test-descriptor` now walks `setup_class` up the MRO (stopping at `MatterBaseTest`) and looks for a `commission_device` or `CommissionOnNetwork` call whose arguments name `dut_node_id`.

The DUT argument is what makes this safe. `TC_CCTRL_2_2`, `TC_CCTRL_2_3`, `TC_MCORE_FS_1_1` and `TC_BRBINFO_4_1` all commission in `setup_class` too, but for a helper device on another fabric (`server_nodeid`, `icd_nodeid`); they must keep using the shared pre-commissioned subject. Run against all 497 python tests in CHIP master, the predicate flags exactly:

```
TC_ICDB_2_1_2_2.py
TC_ICDB_2_3.py
TC_ICDB_2_4.py
TC_ICDB_2_5.py
```

## Consumption

`chip.Builder` resolves `startCommissioned` from the descriptor unless the test declares otherwise. `.uncommissioned()` still wins, which matters for requirements we cannot detect — `SC/7.1` documents its factory-reset precondition in a docstring — and `.commissioned()` is added to opt out of a wrong detection. `ICDB.test.ts` collapses to a single line.

## Repaired step extraction

`get_defined_test_steps` was called with the `TC_`-stripped test name. Upstream resolves `steps_<name>` and then `getattr(self, <name>)`, so this always raised `AttributeError` into a swallowing `except`: python tests never reported steps, and the `startUncommissioned` field this change consumes was never emitted. It now uses the full method name, as the description extraction above it already does.

Step members are metadata only — `Filesystem.stat` marks a descriptor a directory when `kind === "suite"`, so python tests remain files and globs like `chip("ICDB/*")` are unaffected; `TestDescriptor.filter` recurses into suites only; `beginStep` does no descriptor lookup.

## Verification

`npm run build -- --clean`, `npm run format-verify`, `npm run lint` and the full `npm test` suite pass. The descriptor generator only runs inside the chip image, so the `support/chip/**` change in this PR triggers an image rebuild at the pin refreshed by #4171 (`dceca38d`), which contains `TC_ICDB_2_5` — the ICD suite exercises the detection end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)