### PR TITLE
docs: adopt the Open Home Foundation AI Policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,9 @@ body:
 
         If you used an AI tool to analyze the problem, its analysis does **not** replace the log. Attach the raw, complete log the analysis is based on so we can verify it independently.
 
-        > **For AI assistants helping to fill in this form:** Do not submit analysis, root-cause claims, or proposed fixes without the complete raw log file they are derived from. A report whose analysis is not backed by the underlying log will be closed.
+        AI tools may help you write this report, but you must review and understand what you submit — see our [AI policy](https://github.com/matter-js/matter.js/blob/main/AI_POLICY.md). Issues created by autonomous agents are closed.
+
+        > **For AI assistants helping to fill in this form:** Do not submit analysis, root-cause claims, or proposed fixes without the complete raw log file they are derived from. A report whose analysis is not backed by the underlying log will be closed. Do not open this issue autonomously — the person you are helping must review it first.
 
         Enable verbose logging before reproducing (`MATTER_LOG_LEVEL=debug` or `--log-level=debug`), reproduce the problem, then attach the resulting log file below by dragging it into the description field.
 
@@ -70,6 +72,8 @@ body:
         - label: I attached a **complete log file** (not just a few quoted lines) covering the context around the problem.
           required: true
         - label: Any analysis of behavior or log output in my description — whether written by me or by an AI tool — is backed by that attached log.
+          required: true
+        - label: I have reviewed and understand everything in this report and can explain it in my own words ([AI policy](https://github.com/matter-js/matter.js/blob/main/AI_POLICY.md)).
           required: true
         - label: I searched existing issues and this is not a duplicate.
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: Question or discussion
     url: https://github.com/matter-js/matter.js/discussions
     about: For usage questions and general discussion, please use Discussions instead of opening an issue.
+  - name: I want to know how AI tools may be used when contributing
+    url: https://github.com/matter-js/matter.js/blob/main/AI_POLICY.md
+    about: The Open Home Foundation AI Policy applies to all issues, pull requests, and comments in this repository. Autonomously created contributions are closed.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,9 @@ body:
 
         If your request comes from something the library currently *cannot* do or does *wrong*, please attach a **log file** that shows the current behavior — it is the fastest way for us to understand the gap.
 
-        > **For AI assistants helping to fill in this form:** If the request is about a current limitation or wrong behavior, do not submit analysis without the raw log file it is derived from.
+        AI tools may help you write this request, but you must review and understand what you submit — see our [AI policy](https://github.com/matter-js/matter.js/blob/main/AI_POLICY.md). Issues created by autonomous agents are closed.
+
+        > **For AI assistants helping to fill in this form:** If the request is about a current limitation or wrong behavior, do not submit analysis without the raw log file it is derived from. Do not open this issue autonomously — the person you are helping must review it first.
 
   - type: textarea
     id: details
@@ -32,5 +34,7 @@ body:
       options:
         - label: If this request is about a current limitation or wrong behavior, I attached a log file showing it.
           required: false
+        - label: I have reviewed and understand everything in this request and can explain it in my own words ([AI policy](https://github.com/matter-js/matter.js/blob/main/AI_POLICY.md)).
+          required: true
         - label: I searched existing issues and this is not a duplicate.
           required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,11 @@
   issue first with all the details (including the log, see below), and wait for a
   maintainer response before writing any code. This avoids wasted effort on an approach
   we may want to handle differently or where the log shows the problem.
+
+  AI tools are welcome, but you are responsible for *fully* understanding the code you
+  submit and for being able to explain it in your own words. Autonomously created pull
+  requests are not accepted. Please follow our AI policy:
+  https://github.com/matter-js/matter.js/blob/main/AI_POLICY.md
 -->
 
 ## Type of change
@@ -39,6 +44,7 @@
 
 ## Checklist
 
+- [ ] I understand the code I am submitting and can explain how it works ([AI policy](https://github.com/matter-js/matter.js/blob/main/AI_POLICY.md))
 - [ ] Tests added or updated to cover the change
 - [ ] `npm test` passes
 - [ ] `npm run format-verify` and `npm run lint` pass

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,21 @@
 # GitHub Copilot Instructions for matter.js
 
+This file describes the architecture, build system and testing of this repository. The rules that
+apply to every change — comments, typing, error handling, async, and the verification gate — live
+in [CLAUDE.md](../CLAUDE.md) (`AGENTS.md` is a symlink to it). Read both.
+
+## AI policy
+
+This project follows the [Open Home Foundation AI Policy](../AI_POLICY.md).
+Autonomous contributions are not accepted: a human must review, understand,
+and be able to explain every change before it is submitted. Do not open
+issues or pull requests autonomously, and do not post comments on behalf of
+a user without their review.
+
+Additionally in this repository: never submit a bug report, root-cause claim,
+or fix whose justification is an analysis without the complete raw log file it
+is derived from.
+
 ## Project Overview
 
 matter.js is a comprehensive TypeScript implementation of the Matter/Thread smart home protocol. This is a monorepo containing multiple packages that work together to provide Matter protocol support for JavaScript/TypeScript applications.
@@ -18,20 +34,29 @@ matter.js is a comprehensive TypeScript implementation of the Matter/Thread smar
 
 - `@matter/nodejs` - Node.js platform implementation
 - `@matter/nodejs-ble` - Bluetooth Low Energy support for Node.js
+- `@matter/nodejs-ws` - WebSocket network transport for Node.js
 - `@matter/nodejs-shell` - Interactive shell for Matter operations
+- `@matter/react-native` - React Native platform implementation
 
 ### Application Packages
 
 - `@matter/main` - Main entry point package
-- `@matter/examples` - Example applications and devices
+- `@matter/examples-*` - Example applications and devices, one package per example in `examples/`
 - `@matter/create` - Project scaffolding tool
+- `@matter/cli-tool` - Scriptable command line interface
+- `@matter/mqtt` - MQTT bridge
+- `@matter/thread-br-client` - Thread border router client
 - `@project-chip/matter.js` - Legacy compatibility package
 
 ### Development Tools
 
-- `packages/tools` - Build system, documentation generation, project management
+- `@matter/testing` - Test runner (`matter-test`) and test infrastructure
 - `support/codegen` - Code generation from Matter specifications
 - `support/chip-testing` - Integration with Project CHIP/connectedhomeip for testing
+- `support/models` - Pre-parsed Matter models and local model overrides
+
+Build tooling lives outside this repository in the `@nacho-iot/js-tools` dependency, which
+provides the `nacho-build` and `nacho-run` commands.
 
 ## Code Generation System
 
@@ -62,8 +87,8 @@ This project heavily uses code generation:
 
 - Core abstraction for endpoint functionality in `@matter/node`
 - Extend `Behavior` class for cluster implementations
-- Use `@behavior` decorator for registration
-- File pattern: `src/behaviors/[cluster-name]/[ClusterName]Behavior.ts`
+- File pattern: `src/behaviors/[cluster-name]/[ClusterName]{Behavior,Server,Client}.ts`
+- `loader.behavior(name)` / `loader.server(name)` load them dynamically in either module format
 
 ### Environment and ServerNode
 
@@ -93,31 +118,33 @@ This project heavily uses code generation:
 
 - Extensive use of TypeScript generics and conditional types
 - **IMPORTANT**: Requires at least `"strictNullChecks": true` or preferably `"strict": true`
-- Base TypeScript configuration in `packages/tools/tsc/tsconfig.base.json` uses `"strict": true`
+- Base TypeScript configuration in `tsc/tsconfig.base.json` (repository root) uses `"strict": true`
 - Schema validation with `Schema` classes
 
 ## CLI Tools and Examples
 
 ### Available CLI Tools
 
-- `nacho-build` - Build packages and documentation
-- `nacho-run` - Execute TypeScript files with automatic transpilation and source maps
-- `matter-test` - Run tests across workspace packages
-- `matter-create` - Scaffolding tool for new Matter.js projects
-- `matter-version` - Version management tool
+- `nacho-build` - Build packages and documentation (from `@nacho-iot/js-tools`)
+- `nacho-run` - Execute TypeScript files with automatic transpilation and source maps (from `@nacho-iot/js-tools`)
+- `matter-test` - Run tests across workspace packages (from `@matter/testing`)
+- `matter-create` - Scaffolding tool for new Matter.js projects (from `@matter/create`)
+- `nacho-build version` - Version management (exposed as `npm run version`)
 
 ### Example Applications
 
 The repository includes ready-to-run example applications:
 
 ```bash
-npm run matter-device       # Simple on/off device
-npm run matter-bridge       # Bridge with multiple devices
-npm run matter-composeddevice # Composed device example
-npm run matter-multidevice  # Multiple device example
-npm run matter-controller   # Controller example
-npm run shell              # Interactive Matter shell
+npm run matter-device            # Simple on/off device (alias of device-onoff)
+npm run matter-bridge            # Bridge with multiple devices
+npm run device-composed-wc-light # Composed device example
+npm run device-multiple-onoff    # Multiple device example
+npm run matter-controller        # Controller example
+npm run shell                    # Interactive Matter shell
 ```
+
+`package.json` in the repository root holds the full list of example scripts.
 
 ### Running Examples
 
@@ -156,7 +183,8 @@ nacho-run examples/controller/src/ControllerNode.ts
 ### Project References
 
 - All packages use TypeScript project references
-- Managed automatically by build tools in `packages/tools/src/building/tsconfig.ts`
+- `nacho-build` maintains the `references` in each `tsconfig.json` automatically and otherwise
+  preserves manual edits; `nacho-build configure` rewrites them with defaults
 - Incremental compilation via `"composite": true`
 - Separate configs for lib, app, and test builds
 
@@ -164,10 +192,10 @@ nacho-run examples/controller/src/ControllerNode.ts
 
 ### Project Structure
 
-- Monorepo managed with custom build tools in `packages/tools`
-- Use `nacho-build` command for building packages (via node_modules/.bin/)
-- Custom `nacho-run` for executing TypeScript files with source maps
-- Custom `matter-test` for running tests across packages
+- Monorepo managed with the `nacho-build` tooling from the `@nacho-iot/js-tools` dependency
+- Use `nacho-build` for building packages (via node_modules/.bin/)
+- `nacho-run` executes TypeScript files with source maps
+- `matter-test` from `@matter/testing` runs tests across packages
 - Support for ESM and CommonJS outputs
 - TypeScript project references for incremental builds
 
@@ -185,14 +213,16 @@ nacho-build           # Direct build tool (via node_modules/.bin/nacho-build)
 
 Code generation is handled through TypeScript files in `support/codegen/src/`:
 
+Use the root npm scripts — they pass the flags each generator needs:
+
 ```bash
-# Run code generation scripts with nacho-run
-nacho-run support/codegen/src/generate-spec.ts        # Generate from Matter spec
-nacho-run support/codegen/src/generate-clusters.ts    # Generate cluster definitions
-nacho-run support/codegen/src/generate-endpoints.ts   # Generate endpoint definitions
-nacho-run support/codegen/src/generate-forwards.ts    # Generate forward exports
-nacho-run support/codegen/src/generate-model.ts       # Generate data models
-nacho-run support/codegen/src/generate-vscode.ts      # Generate VS Code configuration
+npm run generate-spec        # Generate from Matter spec
+npm run generate-chip        # Generate from connectedhomeip definitions
+npm run generate-model       # Generate data models
+npm run generate-clusters    # Generate cluster definitions
+npm run generate-endpoints   # Generate endpoint definitions
+npm run generate-forwards    # Generate forward exports
+npm run generate-vscode      # Generate VS Code configuration
 ```
 
 ## Testing Patterns
@@ -200,7 +230,8 @@ nacho-run support/codegen/src/generate-vscode.ts      # Generate VS Code configu
 ### Unit Tests
 
 - Use custom `matter-test` framework (not Jest directly)
-- Test files: `*.test.ts` alongside source files
+- Test files live in each package's `test/` directory, mirroring `src/`, and match
+  `test/**/*{.test,Test}.ts`
 - Run tests with `npm run test` or `matter-test -w`
 - Mock external dependencies, especially platform-specific code
 - Tests are run for ESM, CJS, and web (when Playwright is installed) module formats
@@ -239,16 +270,17 @@ Options:
 ### Integration Tests
 
 - Device commissioning and interaction tests in `support/tests`
-- Use `@matter/examples` for test scenarios
+- The example packages in `examples/` serve as test scenarios
 - CHIP tool integration for interoperability testing
 - Located in `support/chip-testing` package
 
 ### Running Tests
 
 ```bash
-npm run test           # Run all tests in workspace
-matter-test -w         # Run tests with workspace scanning
-matter-test <package>  # Run tests for specific package
+npm run test                      # Run all tests in workspace (matter-test -w)
+matter-test -w                    # Same: run ESM, CJS and web tests
+npm test -- -p packages/<name>    # Run tests for one package only
+matter-test cjs -p packages/node  # One module format for one package
 ```
 
 ## Coding Guidelines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,45 @@
+# Open Home Foundation - AI Policy
+
+We support using AI (i.e., LLMs) as tools when contributing to Open Home Foundation projects. However, you are responsible for any contributions you submit, and we are responsible for any contributions we merge and release. We hold a high bar for all contributions to our projects.
+
+Our maintainers dedicate their time and expertise to reviewing contributions. Submitting AI-generated content that you have not personally reviewed and understood wastes that time and will not be accepted.
+
+## Autonomous agents
+
+**We do not allow autonomous agents to be used for contributing to our projects.** We will close any pull requests or issues that we believe were created autonomously, and may mark automated comments as spam. This includes contributions that bypass the provided issue or pull request templates.
+
+## Communication on issues, pull requests, and code reviews
+
+We don't mind if you use AI tools to help you write. However, do not have tools post unreviewed content on your behalf. Keep responses to the minimum needed to communicate your intent. We may hide any comments that we believe are unreviewed AI output.
+
+If you are opening a pull request, we expect you to be able to explain the proposed changes in your own words. This includes the pull request description and responses to questions. If you use AI to help generate the pull request summary, you must review it for technical accuracy.
+
+**Do not use AI to generate answers to questions from maintainers.** You should understand and be able to explain your own work. Using AI to improve grammar or clarity is fine, but the substance of your responses must be your own.
+
+If you wish to include context from an interaction with AI in your comments, it must be in a quote block (e.g., using `>`) and disclosed as such. It must be accompanied by your own commentary explaining the relevance and implications of the context. Do not share long snippets.
+
+## Non-native English speakers
+
+We understand that AI is useful when communicating as a non-native English speaker. Using AI to improve the grammar or clarity of text you have written yourself is fine. If you are using AI to translate your comments, please ensure the translation accurately reflects your intent. Including your original text in a details block shows the effort behind your contribution, helps maintainers verify the translation if needed, and keeps the conversation readable.
+
+## Code and documentation contributions
+
+AI can be a helpful tool for writing code and documentation. However, due to the foundational open source nature of our projects, we require a human in the loop who understands the work produced by AI.
+
+All contributions must be reviewed and understood by the contributor before submission. You should be able to explain every change in a pull request you submit. Pull requests that appear to be unreviewed AI output will be closed without review.
+
+## Our use of AI
+
+Some of our projects use AI tools to assist with code reviews, issue triaging, reporting, and other project management tasks. These tools may leave comments on pull requests or issues. As with any automated tooling, these comments are not always correct.
+
+If an AI tool leaves a comment on your contribution, treat it as you would any other review comment. If you believe it is incorrect, say so; a brief explanation is sufficient. Maintainers always have the final say. If in doubt, ask a maintainer.
+
+## Enforcement
+
+Contributions that do not follow this policy will be closed. Repeated violations may result in being blocked from contributing to OHF projects. If you believe your contribution was closed in error, you are welcome to reach out to a maintainer to discuss.
+
+---
+
+The canonical version of this policy is published at
+<https://developers.home-assistant.io/docs/ai_policy>. In case of differences,
+the published version applies.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,115 @@
+# CLAUDE.md
+
+Guidance for AI coding agents working with code in this repository. `AGENTS.md` is a symlink to
+this file, so agents reading either name get the same instructions.
+
+Architecture, package layout, code generation, build and test reference:
+[.github/copilot-instructions.md](.github/copilot-instructions.md). This file carries the rules
+that apply to every change.
+
+## AI policy
+
+This project follows the [Open Home Foundation AI Policy](AI_POLICY.md). Autonomous
+contributions are not accepted: a human must review, understand, and be able to explain every
+change before it is submitted. Do not open issues or pull requests autonomously, and do not post
+comments on behalf of a user without their review.
+
+Additionally in this repository: never submit a bug report, root-cause claim, or fix whose
+justification is an analysis without the complete raw log file it is derived from.
+
+## Before declaring work done
+
+Run from the repository root, in this order:
+
+```bash
+npm run build        # `npm run build-clean` before opening a PR — incremental caches mask errors in dependent packages
+npm run format       # rewrites files in place; `npm run format-verify` only checks
+npm run lint
+npm test             # `npm test -- -p packages/<name>` while iterating on one package
+```
+
+Use the project scripts, never invoke prettier, oxlint or the test runner directly — the scripts
+pick up project configuration a direct call misses. Single tests are fine for fast iteration, but
+the full suite gates completion.
+
+If a test fails after your change, assume the change broke it. Do not fix unrelated failures
+along the way; report them.
+
+Claims of "done", "fixed" or "passing" need the command output behind them.
+
+## Code comments
+
+WHY, not WHAT. Add a WHAT comment only when the logic is genuinely non-obvious. Before writing
+any comment, ask: would a reader who sees only the final code — not the diff — need it? If the
+identifiers and JSDoc already say it, delete the comment.
+
+Acceptable, and rare:
+
+- An invariant a future refactor could innocently break (one line, forward-looking)
+- A non-obvious specification constraint the code depends on
+- A documented tradeoff ("we accept X because Y is worse")
+- Cross-file coupling the type system cannot express
+
+Always wrong:
+
+- Narrating the change ("moved from A to B because…", "this used to do Y") — that belongs in the
+  commit message
+- Restating an `if` condition or an identifier in prose
+- Pointing at structure the reader can see ("cleanup lives in the outer `finally`")
+- Trivia about standard APIs
+- Justifying the code by walking through rejected alternatives — state the invariant instead
+
+Never put GitHub issue or pull request numbers or URLs in code or test comments. Describe the
+case; references belong in the commit message or pull request body.
+
+Public APIs get JSDoc, including `@see` references to the relevant Matter specification section.
+
+## TypeScript
+
+- Avoid type casts (`as any`, `as SomeType`). Use generics, type narrowing, overloads or proper
+  interfaces. If a cast is genuinely unavoidable, say so in the pull request.
+- No `ts-ignore` or comparable escapes — find and fix the real typing issue.
+- `new Array<T>()` for empty typed arrays, not `const x: T[] = []`.
+- The base configuration is `"strict": true`; consumers need at least `strictNullChecks`.
+
+## Errors
+
+Never throw a plain `Error`. Throw a typed `MatterError` subclass from `@matter/general`, chosen
+for what actually went wrong:
+
+- `InternalError` — cannot happen; an invariant of our own code was violated
+- `ImplementationError` — the caller used the API wrongly
+- `NotImplementedError`, `ConstraintError`, `CommissioningError`, … — see
+  `packages/general/src/MatterError.ts` and the protocol packages for the full set
+
+Error messages carry context, not just a symptom.
+
+## Async
+
+- Prefer `async`/`await` over raw promise chains.
+- Never void or swallow a promise. For event-driven asynchronous work in behaviors use
+  `reactTo`/`stopReacting`. If catching is genuinely unavoidable, log the error.
+- Handle cancellation with `AbortSignal` where the operation can be abandoned.
+- Use `using` for resource management where applicable.
+
+## Values and formatting
+
+- Format durations with `Duration.format()`. Never hand-roll `/ 1000` arithmetic for display.
+- Encode Matter payloads through the TLV schemas; validate all external input against a schema.
+
+## Monorepo
+
+- Always run `npm install` from the repository root, never from a package directory — installing
+  inside a workspace breaks hoisting and produces a wrong `node_modules` layout, even when the
+  `package.json` you edited lives in `packages/foo/`.
+- Packages use TypeScript project references. A new cross-package dependency must be added to the
+  relevant `tsconfig.json`, not only to `package.json`.
+- Generated files (`/*** THIS FILE IS GENERATED, DO NOT EDIT ***/`) are never edited by hand.
+  Change the generator in `support/codegen` or the model overrides in `support/models/src/local`.
+
+## Changelog and working documents
+
+- User-visible changes get a `CHANGELOG.md` entry under the `## __WORK IN PROGRESS__` heading:
+  state the change, keep it short, skip the rationale. That heading is matched literally by the
+  release workflow — do not reformat it.
+- Plans, analyses and other working documents stay uncommitted.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,287 +1,148 @@
-# Contributing to Matter (formerly Project CHIP)
+# Contributing to matter.js
 
-Want to contribute? Great! First, read this page (including the small print at
-the end). By submitting a pull request, you represent that you have the right to
-license your contribution to the Connectivity Standards Alliance and the
-community, and agree by submitting the patch that your contributions are
-licensed under the [Apache 2.0 license](./LICENSE). Before submitting the pull
-request, please make sure you have tested your changes and that they follow the
-project guidelines for contributing code.
+Want to help out? Great. matter.js is part of the [Open Home Foundation](https://www.openhomefoundation.org/).
 
-# Contributing as an Open Source Contributor
+By submitting a pull request you represent that you have the right to license your
+contribution under the [Apache 2.0 license](./LICENSE) of this repository.
 
-As an open source contributor you can report bugs and request features in the
-[Issue Tracker](https://github.com/project-chip/connectedhomeip/issues), as well
-as contribute bug fixes and features that do not impact Matter specification as
-a pull request. For example: ports of Matter to add APIs to alternative
-programming languages (e.g. Java, JS), hardware ports, or an optimized
-implementation of existing functionality. For features that impact the
-specification, please join Matter work group within the Connectivity Standards
-Alliance. The requirements to become an open source contributor of the
-[Matter Repository](https://github.com/project-chip/connectedhomeip) are:
+matter.js implements the Matter specification; it does not define it. Changes that would
+require a change to the specification itself belong in the Matter working group of the
+[Connectivity Standards Alliance](https://csa-iot.org/), not here.
 
--   Agree to the [Code of Conduct](./CODE_OF_CONDUCT.md)
--   Agree to the [License](./LICENSE)
--   Have signed the
-    [Matter Working Group CLA](https://gist.github.com/clapre/65aa9fc63981da765039e0bb7e8701be)
+# AI policy
 
-# Contributing as a Connectivity Standards Alliance Matter Working Group Member
+This project follows the
+[Open Home Foundation AI Policy](./AI_POLICY.md). In short: AI tools are
+welcome as an aid, but you must fully understand and be able to explain every
+change you submit. Contributions made by autonomous agents — issues, pull
+requests, or comments posted without human review — are not accepted.
 
-As a participant of the Connectivity Standards Alliance Matter Working Group,
-you can attend Working Group meetings, propose changes to the Matter
-specification, and contribute code for approved updates to the specification.
-The requirements to become a member of the
-[Matter Repository](https://github.com/project-chip/connectedhomeip) are:
+In particular, for this repository: an AI-produced root-cause analysis is not a
+substitute for the raw log it was derived from. Attach the log.
 
--   Must be a [Participant member](http://www.zigbeealliance.org/join) or higher
-    of the Connectivity Standards Alliance
--   Must be a Matter Working Group member
--   Have signed the Alliance Matter Working Group CLA
--   Have approval from your company's official approver
+If you work with an AI coding agent, point it at [CLAUDE.md](./CLAUDE.md)
+(`AGENTS.md` is a symlink to the same file) — it carries the rules that apply to
+every change, and [.github/copilot-instructions.md](./.github/copilot-instructions.md)
+describes the repository layout and build system.
 
-# Bugs
+# Questions and discussion
 
-If you find a bug in the source code, you can help us by
-[submitting a GitHub Issue](https://github.com/matter-js/matter.js/issues/new).
-The best bug reports provide a detailed description of the issue and
-step-by-step instructions for predictably reproducing the issue. Even better,
-you can
-[submit a Pull Request](https://github.com/matter-js/matter.js/blob/master/CONTRIBUTING.md#submitting-a-pull-request)
-with a fix.
+For usage questions, ideas and general discussion use the
+[Discussions](https://github.com/matter-js/matter.js/discussions) in this repository, or the
+"Matter Integrators" [Discord server](https://discord.gg/ujmRNrhDuW). Please do not open an
+issue for a question.
 
-# New Features
+# Reporting bugs
 
-You can request a new feature by
-[submitting an Idea in Discussions](https://github.com/matter-js/matter.js/discussions/categories/ideas).
-If you would like to implement a new feature, please consider the scope of the
-new feature:
+Report defects through the
+[issue templates](https://github.com/matter-js/matter.js/issues/new/choose).
 
--   _Large feature_: first
-    [submit an Idea in Discussions](https://github.com/matter-js/matter.js/discussions/categories/ideas)
-    and communicate your proposal so that the community can review and provide
-    feedback. Getting early feedback will help ensure your implementation work
-    is accepted by the community. This will also allow us to better coordinate
-    our efforts and minimize duplicated effort.
--   _Small feature_: can be implemented and directly
-    [submitted as a Pull Request](https://github.com/matter-js/matter.js/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
+**A report without a complete log file is not actionable.** Any description of behavior — and
+especially any analysis of behavior or of log output, whether written by you or by an AI tool —
+must be backed by a complete log attached as a file. Enable verbose logging
+(`MATTER_LOG_LEVEL=debug` or `--log-level=debug`), reproduce the problem, then attach the
+resulting log. A few quoted lines are not enough; we need the surrounding context to reproduce
+your analysis.
 
-# Contributing Code
+Your own analysis and a proposed fix are welcome on top of that — the log is what lets us verify
+them.
 
-Matter follows the "Fork-and-Pull" model for accepting contributions.
+# Requesting features
 
-### Initial Setup
+Request a feature through the
+[issue templates](https://github.com/matter-js/matter.js/issues/new/choose), or start with an
+[Idea in Discussions](https://github.com/matter-js/matter.js/discussions/categories/ideas) if the
+scope is large. Early feedback on a large feature avoids wasted work and duplicated effort. Small,
+self-contained features can go straight to a pull request.
 
-Setup your GitHub fork and continuous-integration services:
+If the request comes from something matter.js currently cannot do or does wrong, attach a log
+showing the current behavior.
 
-1. Fork the [Matter.js repository](https://github.com/matter-js/matter.js)
-   by clicking "Fork" on the web UI.
+# Development setup
 
-2. All contributions must pass all checks and reviews to be accepted.
-
-Setup your local development environment:
+matter.js uses the "fork and pull request" model. Fork the repository on GitHub, then:
 
 ```bash
 # Clone your fork
-git clone git@github.com:<username>/matter.git
+git clone git@github.com:<username>/matter.js.git
+cd matter.js
 
 # Configure upstream alias
 git remote add upstream git@github.com:matter-js/matter.js.git
+
+# Install dependencies and build — always from the repository root
+npm install
 ```
 
-### Submitting a Pull Request
+This is an npm workspaces monorepo. Never run `npm install` inside a package directory: it breaks
+workspace hoisting and produces a wrong `node_modules` layout, even when the `package.json` you
+changed lives in `packages/`.
 
-#### Branch
+See the [README](./README.md#extending-and-contributing-to-matterjs) for platform prerequisites,
+and [.github/copilot-instructions.md](./.github/copilot-instructions.md) for the repository
+layout, code generation and build system.
 
-For each new feature, create a working branch:
+# Making a change
+
+Create a working branch off `main`:
 
 ```bash
-# Create a working branch for your new feature
-git branch --track <branch-name> origin/master
-
-# Checkout the branch
+git branch --track <branch-name> origin/main
 git checkout <branch-name>
 ```
 
-#### Create Commits
+Keep it current with upstream so that merging stays a fast-forward:
 
 ```bash
-# Add each modified file you'd like to include in the commit
-git add <file1> <file2>
+git checkout main
+git pull upstream main
 
-# Create a commit
-git commit
-```
-
-This will open up a text editor where you can craft your commit message.
-
-#### Upstream Sync and Clean Up
-
-Prior to submitting your pull request, you might want to do a few things to
-clean up your branch and make it as simple as possible for the original
-repository's maintainer to test, accept, and merge your work.
-
-If any commits have been made to the upstream master branch, you should rebase
-your development branch so that merging it will be a simple fast-forward that
-won't require any conflict resolution work.
-
-```bash
-# Fetch upstream master and merge with your repository's master branch
-git checkout master
-git pull upstream master
-
-# If there were any new commits, rebase your development branch
 git checkout <branch-name>
-git rebase master
+git rebase main
 ```
 
-Now, it may be desirable to squash some of your smaller commits down into a
-small number of larger more cohesive commits. You can do this with an
-interactive rebase:
+Code conventions — comments, typing, error handling, async, logging — are documented in
+[CLAUDE.md](./CLAUDE.md). They apply to human and AI-assisted contributions alike.
+
+Add a `CHANGELOG.md` entry under the `## __WORK IN PROGRESS__` heading for anything user-visible.
+Keep it short: state the change.
+
+# Before opening a pull request
+
+Run the full gate from the repository root, in this order:
 
 ```bash
-# Rebase all commits on your development branch
-git checkout <branch-name>
-git rebase -i master
-```
-
-This will open up a text editor where you can specify which commits to squash.
-
-#### Run local Tests, Linting and Formatting
-
-Ideally you should run the continuous-integration tests locally before pushing:
-
-```bash
+npm run build-clean   # incremental caches can mask errors in dependent packages
+npm run format        # rewrites files in place
+npm run lint
 npm run test
 ```
 
-Same also for the linter and formatter:
+CI enforces build, formatting, linting and tests. Use these scripts rather than calling prettier,
+oxlint or the test runner directly.
+
+Tests are expected for behavior changes. If a change genuinely cannot be covered automatically,
+say so in the pull request and describe how you verified it manually.
+
+# Pull request and review
+
+Push your branch to your fork and open the pull request against `main`:
 
 ```bash
-npm run lint
-npm run format
-```
-
-#### Push and Test
-
-```bash
-# Checkout your branch
-git checkout <branch-name>
-
-# Push to your GitHub fork:
 git push origin <branch-name>
 ```
 
-This will trigger the continuous-integration checks. You can view the results in
-the respective services. Note that the integration checks will report failures
-on occasion.
+Fill in the pull request template completely — type of change, what it does and why, the backing
+log or linked issue for a fix, and the checklist.
 
-### Review Requirements
+A maintainer (see [CODEOWNERS](./CODEOWNERS)) reviews and merges once CI is green. Note that CI
+occasionally reports unrelated failures; if a job looks unrelated to your change, say so in the
+pull request rather than pushing speculative fixes.
 
-#### Documentation Best Practices
+Expect to answer questions about your change in your own words.
 
-matter.js right now do not use any documentation generator. We are working on it!
+# Documentation
 
-Matter uses Doxygen to markup (or markdown) all C, C++, Objective C, Objective
-C++, Perl, Python, and Java code. Read our
-[Doxygen Best Practices, Conventions, and Style](https://github.com/project-chip/connectedhomeip/blob/master/docs/style/DOXYGEN.adoc)
-
-#### Submit Pull Request
-
-Once you've validated the CI results, go to the page for your fork on GitHub,
-select your development branch, and click the pull request button. If you need
-to make any adjustments to your pull request, just push the updates to GitHub.
-Your pull request will automatically track the changes on your development
-branch and update.
-
-#### Merge Requirements
-
--   Github Workflows pass
--   Builds pass
--   Tests pass
--   Linting passes
--   Code style passes
-
-When can I merge? After these have been satisfied, a reviewer will merge the PR
-into master
-
-#### Documentation
-
-Documentation undergoes the same review process as code See the
-[Documentation Style Guide](https://github.com/project-chip/connectedhomeip/blob/master/docs/STYLE_GUIDE.md)
-for more information on how to author and format documentation for contribution.
-
-## Merge Processes
-
-Merges require at least 1 approvals from unique require-reviewers lists, and all
-CI tests passing.
-
-### Shorter Reviews
-
-Development Lead & Vice Leads can merge a change with fewer then the required
-approvals have been submitted.
-
-A separate "fast track" label will be created that will only require a single
-checkbox to be set, this label shall only be set by the Development Lead, and/or
-Vice Lead (unless they’re both unavailable, in which case a replacement can be
-temporarily appointed)
-
-"Day" here means "business day" (i.e. PRs on friday do not get fast-tracked
-faster).
-
-### Fast track types
-
-### Trivial changes
-
-Small changes or changes that do not affect the main functionality of the code
-can be fast tracked immediately. Examples:
-
--   Adding/removing documentation (.md files)
--   Adding tests (may include small reorganization/method adding/changes to
-    enable testability):
-    -   certification tests
-    -   stability tests
-    -   integration tests
-    -   functional tests
-    -   Test scripts
-    -   Additional tests following a pattern (e.g. YAML tests)
--   Adding/updating/fixing tooling to aid in development
--   Re-running code generation
--   Code readability refactors:
-    -   renaming enum/classes/structure members
-    -   moving constant header location
-    -   Obviously trivial build rule changes (e.g. adding missing files to build
-        rules)
-    -   Changing comments
-    -   Adding/removing includes (include what you need and only what you need
-        rules)
--   Pulling new third-party repo files
--   Platform vendors/maintainers adding platform features/logic/bug fixes to
-    their own platforms
--   Most changes to existing docker files (pulling new versions, reorganizing)
--   Most changes to new dockerfile version in workflows
-
-#### Fast track changes
-
-Larger functionality changes are allowed to be fast tracked with these
-requirements/restrictions:
-
--   Require at least 1 day to have passed since the creation of the PR
--   Require at least 1 checkmark from someone familiar with the code or problem
-    space
-    -   This requirement shall be dropped after a PR is 3 days old with stale or
-        no feedback.
--   Code is sufficiently covered by automated tests (or impossible to
-    automatically test with a very solid reason for this - e.g. changes to BLE
-    parameters cannot be automatically tested, but should have been manually
-    verified)
-
-Fast tracking these changes will involve resolving any obviously 'resolved'
-comments (judgment call here: were they replied to or addressed) and merging the
-change.
-
-Any "request for changes" marker will always be respected unless obviously
-resolved (i.e. author marked "requesting changes because of X and X was done in
-the PR")
-
--   This requirement shall be dropped after a PR is 3 days old with stale or no
-    feedback.
+Public APIs are documented with JSDoc, including `@see` references to the relevant Matter
+specification sections. The API documentation is generated from it with `npm run build-doc` and
+published for each release. Documentation changes go through the same review as code.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JavaScript/TypeScript based Matter Implementation
 
-[![license](https://img.shields.io/badge/license-Apache2-green.svg)](https://raw.githubusercontent.com/matter-js/matter.js/master/LICENSE)
+[![license](https://img.shields.io/badge/license-Apache2-green.svg)](https://raw.githubusercontent.com/matter-js/matter.js/main/LICENSE)
 
 ## What is Matter?
 
@@ -84,14 +84,18 @@ If your project is not based on Node.js you need to implement the platform speci
 
 ### Run the examples
 
-The templates we use when you bootstrap a new application are available as examples you can run directly.  You can
-install them in Node.js as follows:
+The templates we use when you bootstrap a new application are available as examples you can run directly. Bootstrap one
+with the project creator:
 
 ```bash
-npm install @matter/examples
+npm init @matter
 ```
 
-Please refer to the Examples readme for information regarding their usage: [examples](examples/README.md)
+The examples also live in this repository and can be run from a clone with `npm run <example-name>` — see the root
+`package.json` for the available scripts. Please refer to the Examples readme for information regarding their usage:
+[examples](examples/README.md)
+
+> The examples were published as a single `@matter/examples` package up to version 0.15.x only.
 
 ### Extending and contributing to matter.js
 
@@ -107,6 +111,16 @@ This will install all dependencies and create symlinks between the packages, so 
 
 On Windows, in order to successfully build all the packages (tested on Windows 11 Pro) make sure to have installed Node.js 20+, the windows-build-tools and node-gyp version 10.
 On Non-Windows platforms and having Python 3.12+ installed, please also make sure to use npm 10.2.3+.
+
+Please read the [contributing guide](./CONTRIBUTING.md) before opening an issue or pull request.
+
+## AI policy
+
+This project follows the [Open Home Foundation AI Policy](./AI_POLICY.md).
+
+AI tools are welcome as an aid, but you must fully understand and be able to explain every
+change you submit. Contributions created by autonomous agents — issues, pull requests, or
+comments posted without human review — are not accepted and will be closed.
 
 ## Connecting with the community
 
@@ -201,7 +215,7 @@ You can use `npm run build-clean` on the root level to build all packages from s
 
 You can use `npm run test` on the root level to run all tests for all packages.
 
-Special testing using the Chip-Tool-Certification tests is available in the package chip-testing. Please refer to the [README.md](chip-testing/README.md) in the package for more details.
+Special testing using the Chip-Tool-Certification tests is available in the package chip-testing. Please refer to the [README.md](./support/chip-testing/README.md) in the package for more details.
 
 ## API documentation
 


### PR DESCRIPTION
## Type of change

- [x] ✨ **Feature** — adds new functionality or capability (documentation and policy only, no code)

## Description

Adopts the [Open Home Foundation AI Policy](https://github.com/matter-js/matter.js/blob/main/AI_POLICY.md) in this repository, mirroring matter-js/matterjs-server#956 and home-assistant/core#176917. This is part of the rollout across the `home-assistant` and `home-assistant-libs` organizations, announced in [this blog post](https://developers.home-assistant.io/blog/2026/07/20/ai-policy/).

- Adds `AI_POLICY.md` to the repository root (verbatim policy text; its footer points at the canonical version at developers.home-assistant.io).
- Every other file links to our own `AI_POLICY.md` rather than to the upstream page — single hop, one place to update.
- Adds `CLAUDE.md` carrying the rules that apply to every change: verification gate, comment policy, typing, typed `MatterError` subclasses, promise handling, monorepo install rules, changelog. `AGENTS.md` is a symlink to it, so agents reading either name get the same instructions. `.github/copilot-instructions.md` keeps the architecture and build reference and cross-references both.
- Adds AI policy sections to `README.md`, `CONTRIBUTING.md` and `.github/copilot-instructions.md`, including the repository-specific rule that an AI-produced analysis never replaces the raw log it is derived from.
- Issue and pull request templates: policy note, a "do not open this autonomously" directive for AI assistants filling in the form, and an understand-what-you-submit confirmation.

### CONTRIBUTING.md rewrite

`CONTRIBUTING.md` was inherited boilerplate from `project-chip/connectedhomeip`: it routed bug reports to the CHIP issue tracker, required the CSA Matter Working Group CLA, linked CHIP style guides, and documented CHIP merge governance. It now describes this repository — support routing, the complete-log requirement, development setup, the four-command gate, our review flow — and states a plain Apache 2.0 license grant.

Two points for reviewers, since these replace inherited text rather than facts:

- **Licensing:** the old text licensed contributions "to the Connectivity Standards Alliance and the community" and required the CSA Matter Working Group CLA. Replaced with a plain Apache 2.0 grant per `LICENSE` (copyright holder is "Matter.js Authors"), no CLA. If matter.js does require a CLA, it needs to go back in.
- **Merge governance:** the CHIP fast-track rules and approval counts were replaced with "a maintainer (see `CODEOWNERS`) reviews and merges once CI is green."

### Stale facts corrected in the documentation touched here

- `packages/tools` no longer exists — build tooling comes from the external `@nacho-iot/js-tools` dependency. Fixes the base tsconfig path (`tsc/tsconfig.base.json`), the tsconfig-reference management claim, and the package lists (adding `nodejs-ws`, `react-native`, `cli-tool`, `mqtt`, `thread-br-client`, `@matter/testing`, `support/models`).
- `matter-version` does not exist; version management is `nacho-build version` (`npm run version`).
- There is no `@behavior` decorator; behaviors load via `loader.behavior()` / `loader.server()`.
- Tests live in each package's `test/` directory matching `test/**/*{.test,Test}.ts`, not alongside sources.
- Example and codegen commands corrected to the scripts that actually exist, and `matter-test <package>` to the real invocation forms.
- `@matter/examples` was published up to 0.15.x only — points at the per-example `@matter/examples-*` packages and `npm init @matter` instead.
- matter.js `master` links and the documented git workflow retargeted to `main`; fork clone URL and the `support/chip-testing` README link fixed.

## Backing evidence

Policy rollout and documentation accuracy, no behavior change. Every corrected claim was verified against the working tree (`package.json` scripts, `node_modules/.bin` targets, file paths, npm registry for `@matter/examples`).

- Related issue: —
- [ ] This fix/change is backed by a **complete log file** — n/a, no defect involved

## Checklist

- [x] I understand the code I am submitting and can explain how it works ([AI policy](https://github.com/matter-js/matter.js/blob/main/AI_POLICY.md))
- [ ] Tests added or updated to cover the change — n/a, documentation only
- [ ] `npm test` passes — not run, no code changed
- [x] `npm run format-verify` and `npm run lint` pass
- [ ] CHANGELOG updated (if applicable) — n/a, no user-visible library change
