### PR TITLE
fix(protocol): discard unsecured sessions created for unadopted inbound messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: BDX retransmission intervals are capped so the whole MRP schedule fits inside the peer's BDX response budget, which acknowledgements do not extend; the peer's idle cadence does not raise the cap, since a peer holding an open exchange is in active mode
     - Fix: A retransmission timer is no longer armed for a message that was acknowledged while an earlier transmission of it was still in flight, which left the timer running unreferenced
     - Fix: Grouped `PeerTimingParameters` (`kickRestartCooldown`, `addressChangeProbeCooldown`) merge field-wise, so overriding one member keeps its siblings
+    - Fix: Ensure that an unsecured session created for an inbound message is discarded when no protocol handler adopts it
+    - Fix: Ensure that closed exchanges are removed from their session for all session types
+    - Fix: Ensure that a session releases its message channel when the transport owns the underlying channel, so the channel address observer of PASE, CASE and discarded inbound sessions is removed
+    - Fix: Ensure that the end of a session is logged also when its channel was detached before; channel detach is now logged as debug
 
 - @matter/node
     - Enhancement: `network.timing` accepts the kick and address-change parameters

--- a/packages/protocol/src/bdx/BdxSession.ts
+++ b/packages/protocol/src/bdx/BdxSession.ts
@@ -81,7 +81,7 @@ export class BdxSession {
         if (!exchange.session.isSecure) {
             throw new BdxError("Bdx Protocol requires a secure session.");
         }
-        exchange.closed.on(async () => {
+        exchange.closed.once(async () => {
             if (this.#isClosed) {
                 return;
             }

--- a/packages/protocol/src/peer/ControllerCommissioner.ts
+++ b/packages/protocol/src/peer/ControllerCommissioner.ts
@@ -392,7 +392,7 @@ export class ControllerCommissioner {
                 passcode,
                 { abort: signal },
             );
-            unsecuredSession.detachChannel();
+            await unsecuredSession.detachChannel()?.release();
             return caseSession;
         } catch (e) {
             // Close the exchange and rethrow

--- a/packages/protocol/src/peer/PeerConnection.ts
+++ b/packages/protocol/src/peer/PeerConnection.ts
@@ -631,6 +631,13 @@ export async function PeerConnection(
                 throw e;
             } finally {
                 kick?.[Symbol.dispose]();
+
+                if (!socketOwned) {
+                    // Destroy the exchange while its channel is still attached so a pending ack of the final CASE
+                    // message goes out
+                    await exchange.destroy();
+                    await unsecuredSession.detachChannel()?.release();
+                }
             }
         } finally {
             if (socketOwned) {

--- a/packages/protocol/src/protocol/ExchangeManager.ts
+++ b/packages/protocol/src/protocol/ExchangeManager.ts
@@ -193,6 +193,26 @@ export class ExchangeManager implements Transport.Provider {
     async #onMessage(channel: Channel<Bytes>, messageBytes: Bytes) {
         using _lifetime = this.#lifetime.join("receiving from", Diagnostic.strong(channel.name));
 
+        // An unsecured session created for an inbound message must not outlive that message unless a protocol handler
+        // adopts it (PASE and CASE do), otherwise any peer can grow the session table without authenticating
+        const inbound: { unsecuredSession?: UnsecuredSession } = {};
+        try {
+            await this.#receiveMessage(channel, messageBytes, inbound);
+        } finally {
+            const session = inbound.unsecuredSession;
+            if (session !== undefined && !session.isClosed && !session.isClosing && !session.hasActiveExchanges) {
+                // The transport owns the channel of an inbound message, so release it instead of closing it
+                await session.detachChannel()?.release();
+                await session.initiateClose();
+            }
+        }
+    }
+
+    async #receiveMessage(
+        channel: Channel<Bytes>,
+        messageBytes: Bytes,
+        inbound: { unsecuredSession?: UnsecuredSession },
+    ) {
         const packet = MessageCodec.decodePacket(messageBytes);
         const bytes = Bytes.of(messageBytes);
         const aad = bytes.slice(0, bytes.length - packet.applicationPayload.byteLength); // Header+Extensions
@@ -228,7 +248,7 @@ export class ExchangeManager implements Transport.Provider {
                         );
                         return;
                     }
-                    session = this.#sessions.createUnsecuredSession({
+                    session = inbound.unsecuredSession = this.#sessions.createUnsecuredSession({
                         channel,
                         initiatorNodeId,
                     });

--- a/packages/protocol/src/protocol/ExchangeManager.ts
+++ b/packages/protocol/src/protocol/ExchangeManager.ts
@@ -466,7 +466,12 @@ export class ExchangeManager implements Transport.Provider {
     }
 
     #addExchange(exchangeIndex: number, exchange: MessageExchange) {
-        exchange.closed.on(() => this.deleteExchange(exchangeIndex));
+        // A peer reuses exchange IDs, so only drop the index while it still maps to this exchange
+        exchange.closed.once(() => {
+            if (this.#exchanges.get(exchangeIndex) === exchange) {
+                this.deleteExchange(exchangeIndex);
+            }
+        });
         this.#exchanges.set(exchangeIndex, exchange);
 
         // The spec recommends a maximum of 5 concurrent exchanges over a unicast session to avoid exhausting the

--- a/packages/protocol/src/protocol/MessageChannel.ts
+++ b/packages/protocol/src/protocol/MessageChannel.ts
@@ -177,11 +177,7 @@ export class MessageChannel implements Channel<Message> {
         const wasAlreadyClosed = this.closed;
         this.closed = true;
 
-        // Detach address observer before closing
-        if (this.#channelAddressObserver && this.#isIpNetworkChannel) {
-            (this.#channel as IpNetworkChannel<Bytes>).networkAddressChanged.off(this.#channelAddressObserver);
-            this.#channelAddressObserver = undefined;
-        }
+        this.#unobserveChannelAddress();
 
         // TCP connections are 1:1 with sessions — lifecycle managed by ExchangeManager
         // (session eviction on disconnect, channel close on session close). UDP/BLE
@@ -191,6 +187,29 @@ export class MessageChannel implements Channel<Message> {
         }
         if (!wasAlreadyClosed) {
             await this.#onClose?.();
+        }
+    }
+
+    /**
+     * Release the channel without closing the underlying transport channel, for use when the transport rather than the
+     * session owns it.  Closing a BLE channel disconnects the peripheral and closing a connected transport channel
+     * drops messages of other sessions using it.
+     */
+    async release() {
+        const wasAlreadyClosed = this.closed;
+        this.closed = true;
+
+        this.#unobserveChannelAddress();
+
+        if (!wasAlreadyClosed) {
+            await this.#onClose?.();
+        }
+    }
+
+    #unobserveChannelAddress() {
+        if (this.#channelAddressObserver && this.#isIpNetworkChannel) {
+            (this.#channel as IpNetworkChannel<Bytes>).networkAddressChanged.off(this.#channelAddressObserver);
+            this.#channelAddressObserver = undefined;
         }
     }
 

--- a/packages/protocol/src/session/NodeSession.ts
+++ b/packages/protocol/src/session/NodeSession.ts
@@ -328,7 +328,7 @@ export class NodeSession extends SecureSession {
 
     override addExchange(exchange: MessageExchange) {
         super.addExchange(exchange);
-        exchange.closed.on(async () => {
+        exchange.closed.once(async () => {
             if (this.deferredClose && !this.hasActiveExchanges) {
                 this.deferredClose = false;
                 await this.close();

--- a/packages/protocol/src/session/NodeSession.ts
+++ b/packages/protocol/src/session/NodeSession.ts
@@ -329,7 +329,6 @@ export class NodeSession extends SecureSession {
     override addExchange(exchange: MessageExchange) {
         super.addExchange(exchange);
         exchange.closed.on(async () => {
-            this.exchanges.delete(exchange);
             if (this.deferredClose && !this.hasActiveExchanges) {
                 this.deferredClose = false;
                 await this.close();

--- a/packages/protocol/src/session/Session.ts
+++ b/packages/protocol/src/session/Session.ts
@@ -57,6 +57,7 @@ export abstract class Session {
 
     #peerAdditionalMrpDelay?: () => Duration | undefined;
     #closing = ObservableValue();
+    #ended = false;
     #gracefulClose = AsyncObservable<[]>();
     readonly #exchanges = new Set<MessageExchange>();
     protected deferredClose = false;
@@ -115,6 +116,7 @@ export abstract class Session {
 
     addExchange(exchange: MessageExchange) {
         this.#exchanges.add(exchange);
+        exchange.closed.on(() => this.deleteExchange(exchange));
     }
 
     deleteExchange(exchange: MessageExchange) {
@@ -294,7 +296,7 @@ export abstract class Session {
             if (!context.keepSubscriptions) {
                 await this.closeSubscriptions(false, context.currentExchange);
             }
-            for (const exchange of this.#exchanges) {
+            for (const exchange of [...this.#exchanges]) {
                 if (exchange === context.currentExchange) {
                     this.deferredClose = true;
                     continue;
@@ -342,7 +344,7 @@ export abstract class Session {
     detachChannel() {
         const channel = this.#channel;
         this.#channel = undefined;
-        logger.info(this.via, "Channel detached");
+        logger.debug(this.via, "Channel detached");
         return channel;
     }
 
@@ -352,6 +354,10 @@ export abstract class Session {
         if (this.#channel) {
             await this.#channel.close();
             this.#channel = undefined;
+        }
+
+        if (!this.#ended) {
+            this.#ended = true;
             logger.info(this.via, "Session ended");
         }
     }

--- a/packages/protocol/src/session/Session.ts
+++ b/packages/protocol/src/session/Session.ts
@@ -116,7 +116,7 @@ export abstract class Session {
 
     addExchange(exchange: MessageExchange) {
         this.#exchanges.add(exchange);
-        exchange.closed.on(() => this.deleteExchange(exchange));
+        exchange.closed.once(() => this.deleteExchange(exchange));
     }
 
     deleteExchange(exchange: MessageExchange) {

--- a/packages/protocol/src/session/case/CaseServer.ts
+++ b/packages/protocol/src/session/case/CaseServer.ts
@@ -94,6 +94,7 @@ export class CaseServer implements ProtocolHandler {
             }
         } finally {
             // Destroy the unsecure session used to establish the secure Case session
+            await exchange.session.detachChannel()?.release();
             await exchange.session.initiateClose();
         }
     }

--- a/packages/protocol/src/session/pase/PaseServer.ts
+++ b/packages/protocol/src/session/pase/PaseServer.ts
@@ -113,7 +113,7 @@ export class PaseServer implements ProtocolHandler {
                 this.#pairingTimer = undefined;
                 this.#pairingMessenger = undefined;
                 // Detach and Destroy the unsecure session used to establish the Pase session
-                exchange.session.detachChannel();
+                await exchange.session.detachChannel()?.release();
                 await exchange.session.initiateClose();
             }
         }

--- a/packages/protocol/test/protocol/ExchangeManagerTest.ts
+++ b/packages/protocol/test/protocol/ExchangeManagerTest.ts
@@ -4,23 +4,67 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Message } from "#codec/MessageCodec.js";
+import { Message, MessageCodec, SessionType } from "#codec/MessageCodec.js";
 import { FabricManager } from "#fabric/FabricManager.js";
 import { SessionParameters } from "#index.js";
 import { ExchangeManager } from "#protocol/ExchangeManager.js";
 import type { MessageExchange } from "#protocol/MessageExchange.js";
+import type { ProtocolHandler } from "#protocol/ProtocolHandler.js";
 import { ProtocolMocks } from "#protocol/ProtocolMocks.js";
 import { SessionManager } from "#session/SessionManager.js";
+import { UNICAST_UNSECURE_SESSION_ID } from "#session/UnsecuredSession.js";
 import {
     Bytes,
+    Channel,
+    ChannelType,
     Environment,
     MemoryStorageDriver,
     NetworkError,
     StandardCrypto,
     StorageContext,
+    Transport,
     TransportSet,
 } from "@matter/general";
-import { SECURE_CHANNEL_PROTOCOL_ID } from "@matter/types";
+import { NodeId, SECURE_CHANNEL_PROTOCOL_ID, SecureMessageType } from "@matter/types";
+
+/** A UDP-like transport that delivers datagrams on demand. */
+class MockTransport implements Transport {
+    readonly #listeners = new Set<(socket: Channel<Bytes>, data: Bytes) => void>();
+    readonly channel: Channel<Bytes> = {
+        maxPayloadSize: 1280,
+        isReliable: false,
+        supportsLargeMessages: false,
+        name: "mock-udp",
+        type: ChannelType.UDP,
+        async send() {},
+        async close() {},
+    };
+
+    onData(listener: (socket: Channel<Bytes>, data: Bytes) => void): Transport.Listener {
+        this.#listeners.add(listener);
+        return {
+            close: async () => {
+                this.#listeners.delete(listener);
+            },
+        };
+    }
+
+    supports(type: ChannelType) {
+        return type === ChannelType.UDP;
+    }
+
+    async openChannel(): Promise<Channel<Bytes>> {
+        return this.channel;
+    }
+
+    async close() {}
+
+    receive(data: Bytes) {
+        for (const listener of this.#listeners) {
+            listener(this.channel, data);
+        }
+    }
+}
 
 describe("ExchangeManager", () => {
     before(() => MockTime.init());
@@ -96,6 +140,109 @@ describe("ExchangeManager", () => {
             expect(peer.closedWith).is.empty;
             expect(peer.session.isClosing).is.false;
             expect(peer.session.isPeerLost).is.false;
+        });
+    });
+
+    describe("inbound unsecured sessions", () => {
+        /** A manager receiving on a transport we can feed datagrams into. */
+        async function receiver() {
+            const environment = new Environment("test");
+            const storage = new MemoryStorageDriver();
+            storage.initialize();
+
+            const crypto = new StandardCrypto();
+            const sessions = new SessionManager({
+                parameters: {} as SessionParameters,
+                fabrics: new FabricManager(crypto),
+                storage: new StorageContext(storage, ["context"]),
+            });
+            await sessions.construction.ready;
+
+            const transports = new TransportSet();
+            const exchanges = new ExchangeManager({
+                lifetime: environment,
+                entropy: crypto,
+                transports,
+                sessions,
+            });
+
+            const transport = new MockTransport();
+            transports.add(transport);
+
+            return {
+                sessions,
+                exchanges,
+                transport,
+                async [Symbol.asyncDispose]() {
+                    await exchanges.close();
+                    await sessions.close();
+                },
+            };
+        }
+
+        /** Handles the first message like an ICD check-in: no response, exchange closed. */
+        function silentHandler(): ProtocolHandler {
+            return {
+                id: SECURE_CHANNEL_PROTOCOL_ID,
+                requiresSecureSession: false,
+                async onNewExchange(exchange: MessageExchange) {
+                    await exchange.close();
+                },
+                async close() {},
+            };
+        }
+
+        function unsecuredMessage(sourceNodeId: NodeId, messageId: number, requiresAck = false) {
+            return MessageCodec.encodePacket(
+                MessageCodec.encodePayload({
+                    packetHeader: {
+                        sessionId: UNICAST_UNSECURE_SESSION_ID,
+                        sessionType: SessionType.Unicast,
+                        hasPrivacyEnhancements: false,
+                        isControlMessage: false,
+                        hasMessageExtensions: false,
+                        messageId,
+                        sourceNodeId,
+                    },
+                    payloadHeader: {
+                        exchangeId: 1,
+                        protocolId: SECURE_CHANNEL_PROTOCOL_ID,
+                        messageType: SecureMessageType.IcdCheckInMessage,
+                        isInitiatorMessage: true,
+                        requiresAck,
+                        hasSecuredExtension: false,
+                    },
+                    payload: Bytes.empty,
+                }),
+            );
+        }
+
+        /** Message processing runs as a background worker with more await hops than a single yield covers */
+        async function settle() {
+            for (let i = 0; i < 20; i++) {
+                await MockTime.yield();
+            }
+        }
+
+        it("discards the session when the handler does not adopt it", async () => {
+            await using peer = await receiver();
+            peer.exchanges.addProtocolHandler(silentHandler());
+
+            for (let i = 0; i < 3; i++) {
+                peer.transport.receive(unsecuredMessage(NodeId(BigInt(i + 1)), i + 1));
+                await settle();
+            }
+
+            expect(peer.sessions.unsecuredSessions.size).equals(0);
+        });
+
+        it("discards the session when no handler is registered", async () => {
+            await using peer = await receiver();
+
+            peer.transport.receive(unsecuredMessage(NodeId(1n), 1, true));
+            await settle();
+
+            expect(peer.sessions.unsecuredSessions.size).equals(0);
         });
     });
 });

--- a/packages/protocol/test/protocol/MessageChannelTest.ts
+++ b/packages/protocol/test/protocol/MessageChannelTest.ts
@@ -46,3 +46,36 @@ describe("MessageChannel socket swap", () => {
         expect(channel.networkAddress?.ip).equal("::1");
     });
 });
+
+describe("MessageChannel release", () => {
+    function transportChannel() {
+        const channel = new ProtocolMocks.NetworkChannel({ index: 1 });
+        let closed = false;
+        channel.close = async () => {
+            closed = true;
+        };
+        return { channel, wasClosed: () => closed };
+    }
+
+    it("stops observing the transport channel address without closing the channel", async () => {
+        const { channel, wasClosed } = transportChannel();
+        const messageChannel = new ProtocolMocks.MessageChannel({ channel });
+        expect(channel.networkAddressChanged.isObserved).true;
+
+        await messageChannel.release();
+
+        expect(channel.networkAddressChanged.isObserved).false;
+        expect(wasClosed()).false;
+        expect(messageChannel.closed).true;
+    });
+
+    it("closes the transport channel of an unreliable transport on close", async () => {
+        const { channel, wasClosed } = transportChannel();
+        const messageChannel = new ProtocolMocks.MessageChannel({ channel });
+
+        await messageChannel.close();
+
+        expect(channel.networkAddressChanged.isObserved).false;
+        expect(wasClosed()).true;
+    });
+});


### PR DESCRIPTION
## Problem

A controller that receives ICD check-ins from a peer it does not know accumulates one unsecured session per check-in. They all survive until shutdown, where they end at once:

```
2026-08-04 14:50:17.319 DEBUG MessageExchange New exchange « •unsecured#4d6063114b0157c2⇵b0f7 protocol: 0 …
2026-08-04 14:50:17.321 DEBUG SecureChan~lProtocol Ignoring ICD check-in matching no registered peer
…
2026-08-04 14:54:57.933 INFO  Session •unsecured#4d6063114b0157c2 Session ended
2026-08-04 14:54:57.933 INFO  Session •unsecured#a5ed48a75fa7f37e Session ended
2026-08-04 14:54:57.933 INFO  Session •unsecured#35ca375248f8621e Session ended
…
```

`ExchangeManager` creates an unsecured session for any inbound unicast message on session ID 0 whose source node ID is unknown. PASE and CASE keep that session for the duration of session establishment and end it themselves. Nothing ended it for a message no protocol handler adopts — an ICD check-in matching no registered peer, an unsolicited message, or one that fails to decode. Since a check-in sender uses a fresh random ephemeral node ID per check-in, every check-in produced a new map entry, so any peer could grow the session table without authenticating.

## Changes

**Discard unadopted inbound sessions.** `ExchangeManager` tracks a session it creates for an inbound message and discards it once dispatch completes, unless a handler adopted it or exchanges remain open.

**Remove closed exchanges from their session.** `Session.deleteExchange` had no caller; only `NodeSession` removed exchanges, inline on its own set. Unsecured and group sessions therefore retained every exchange ever created, `hasActiveExchanges` stayed true forever, and a deferred close on such a session could never complete. Removal moves to the base class, which the discard above also depends on.

**Release rather than close a channel the transport owns.** `MessageChannel.close()` closes the underlying transport channel for anything that is not TCP. For an inbound message that channel came from `transport.onData`:

- UDP — `UdpTransport.onData` builds a throwaway `UdpChannel` per datagram and its `close()` is a documented no-op.
- BLE — the channel is the live BTP link, and `NobleBleChannel.close()` closes the BTP session and disconnects the peripheral. This is the reachable case: after PASE completes over BLE the unsecured session is detached and dropped, so a late MRP retransmission of `PbkdfParamRequest` creates a fresh throwaway session on that same BTP channel.
- TCP — already skipped by `close()`.

`MessageChannel.release()` performs the same bookkeeping as `close()` — drop the channel address observer, run `onClose` — without closing the transport channel. The shared teardown moved into a private helper so the two paths cannot drift.

The PASE responder, CASE responder and both commissioning handover paths now use it too. They detached (or, in `CaseServer`, closed) without removing the address observer their wrapper had registered on a channel that outlives the session — one leaked observer per commissioning on TCP and BLE. In `PeerConnection` the exchange is destroyed explicitly before the detach, so a pending acknowledgement of the final CASE message still goes out; detaching first would make that send throw `SessionClosedError`, which `destroy()` catches and warns, silently dropping the ack.

**Logging.** `Session ended` is now logged once whether or not the channel was detached first. Previously the log lived inside the `if (this.#channel)` branch, so a detached session ended silently — which is what made this class of leak invisible. `Channel detached` drops to debug.

## Testing

`npm run build`, `npm run format-verify`, `npm run lint` and the full `npm test` suite pass.

New tests:

- `ExchangeManagerTest` — a mock UDP transport feeds real encoded unsecured check-in packets through the manager; asserts `unsecuredSessions` is empty afterwards, both when a handler closes the exchange and when no handler is registered.
- `MessageChannelTest` — `release()` stops observing the transport channel address and leaves the channel open; `close()` stops observing and closes it.

Mutation-verified per hunk: inverting the discard condition fails both `ExchangeManager` tests (`expected 3 to equal 0`, `expected 1 to equal 0`); removing the base-class exchange removal fails the same two, since a stale `hasActiveExchanges` blocks the discard; removing the observer teardown from `release()` fails the release test while the close test still passes.

Not covered by a test: the `PeerConnection` call site. On UDP the previous `close()` was a no-op, so no assertion distinguishes old from new behaviour there, and `CommissioningConnectionTest` mocks `establishSession` and never reaches real CASE. The green suite does show the early `destroy()` and detach do not break CASE handover, since the node package commissioning tests exercise that path. The fix itself rests on the code reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
