### PR TITLE
fix(node): correct BDX transfer option resolution and registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,10 +52,10 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/protocol
     - Enhancement: A BDX exchange retransmits its pending message early when a duplicate proves the peer is awake and still waiting for it
+    - Enhancement: Network profiles accept a separate `bdxAdditionalMrpDelay` for bulk transfer, defaulting to the profile's messaging margin
     - Fix: The peer's medium-specific MRP retransmission margin now applies to peer-initiated exchanges (e.g. subscription data reports) and to exchanges created without peer context
     - Fix: BDX retransmission intervals are capped so the whole MRP schedule fits inside the peer's BDX response budget, which acknowledgements do not extend; the peer's idle cadence does not raise the cap, since a peer holding an open exchange is in active mode
     - Fix: A retransmission timer is no longer armed for a message that was acknowledged while an earlier transmission of it was still in flight, which left the timer running unreferenced
-    - Enhancement: Network profiles accept a separate `bdxAdditionalMrpDelay` for bulk transfer, defaulting to the profile's messaging margin
     - Fix: Grouped `PeerTimingParameters` (`kickRestartCooldown`, `addressChangeProbeCooldown`) merge field-wise, so overriding one member keeps its siblings
     - Fix: Ensure that an unsecured session created for an inbound message is discarded when no protocol handler adopts it
     - Fix: Ensure that closed exchanges are removed from their session for all session types

--- a/packages/node/src/behavior/system/network/NetworkServer.ts
+++ b/packages/node/src/behavior/system/network/NetworkServer.ts
@@ -146,12 +146,12 @@ export namespace NetworkServer {
 
         @field(duration)
         additionalMrpDelay?: Duration;
-
-        @field(duration)
-        bdxAdditionalMrpDelay?: Duration;
     }
 
     export class LimitsConfig extends ConcreteLimitsConfig {
+        @field(duration)
+        bdxAdditionalMrpDelay?: Duration;
+
         @field(ConcreteLimitsConfig)
         connect?: ConcreteLimitsConfig;
 

--- a/packages/node/src/behavior/system/software-update/SoftwareUpdateManager.ts
+++ b/packages/node/src/behavior/system/software-update/SoftwareUpdateManager.ts
@@ -55,6 +55,18 @@ import { OtaSoftwareUpdateRequestor } from "@matter/types/clusters/ota-software-
 
 const logger = Logger.get("SoftwareUpdateManager");
 
+/** Rejects transfer options a BDX session could not honour, before any state changes on their behalf. */
+function assertTransferOptions({ maxBdxBlockSize, bdxAdditionalMrpDelay }: SoftwareUpdateManager.UpdateTarget) {
+    if (maxBdxBlockSize !== undefined && (!Number.isInteger(maxBdxBlockSize) || maxBdxBlockSize <= 0)) {
+        throw new ImplementationError(`maxBdxBlockSize must be a positive integer, got ${maxBdxBlockSize}`);
+    }
+    if (bdxAdditionalMrpDelay !== undefined && (!Number.isFinite(bdxAdditionalMrpDelay) || bdxAdditionalMrpDelay < 0)) {
+        throw new ImplementationError(
+            `bdxAdditionalMrpDelay must be a finite, non-negative duration, got ${bdxAdditionalMrpDelay}`,
+        );
+    }
+}
+
 interface UpdateConsent extends SoftwareUpdateManager.UpdateTarget {
     peerAddress: PeerAddress;
 }
@@ -836,6 +848,8 @@ export class SoftwareUpdateManager extends Behavior {
             existing.productId = entry.productId;
             existing.targetSoftwareVersion = entry.targetSoftwareVersion;
             existing.endpoint = entry.endpoint;
+            existing.maxBdxBlockSize = entry.maxBdxBlockSize;
+            existing.bdxAdditionalMrpDelay = entry.bdxAdditionalMrpDelay;
             logger.info(`Updated existing queued update for node ${entry.peerAddress.toString()}`);
         } else {
             logger.info(`Queuing update consent for node ${entry.peerAddress.toString()}`);
@@ -955,6 +969,7 @@ export class SoftwareUpdateManager extends Behavior {
      */
     async forceUpdate(peerAddress: PeerAddress, target: SoftwareUpdateManager.UpdateTarget) {
         const { vendorId, productId, targetSoftwareVersion } = target;
+        assertTransferOptions(target);
         peerAddress = PeerAddress(peerAddress);
         const existingEntry = this.internal.updateQueue.find(
             e =>
@@ -1049,34 +1064,21 @@ export class SoftwareUpdateManager extends Behavior {
     }
 
     /**
-     * The BDX block size cap that applies to this peer's pending update: its own override if one was given with the
-     * consent, otherwise {@link State.maxBdxBlockSize}.  Undefined accepts whatever the peer requests.
+     * How BDX should carry this peer's pending update: the options given with its consent, else the general defaults
+     * in {@link State}.  An absent value leaves the decision to the peer and its medium.
+     *
+     * A consent may exist before the update is queued, so both are consulted.
      */
-    maxBdxBlockSizeFor(peerAddress: PeerAddress) {
-        const { queued, consent } = this.#pendingUpdateFor(peerAddress);
-        return queued?.maxBdxBlockSize ?? consent?.maxBdxBlockSize ?? this.state.maxBdxBlockSize;
-    }
-
-    /**
-     * The additive MRP retransmission margin that applies to this peer's pending update, resolved like
-     * {@link maxBdxBlockSizeFor}.  Undefined leaves the peer's medium to imply it.
-     */
-    bdxAdditionalMrpDelayFor(peerAddress: PeerAddress) {
-        const { queued, consent } = this.#pendingUpdateFor(peerAddress);
-        return queued?.bdxAdditionalMrpDelay ?? consent?.bdxAdditionalMrpDelay ?? this.state.bdxAdditionalMrpDelay;
-    }
-
-    /**
-     * The queue entry and consent for a peer.  Both are consulted because a queue entry created from an existing
-     * consent may not carry that consent's options.
-     */
-    #pendingUpdateFor(peerAddress: PeerAddress) {
+    bdxTransferOptionsFor(peerAddress: PeerAddress) {
         peerAddress = PeerAddress(peerAddress);
         const matches = (candidate: PeerAddress) =>
             candidate.fabricIndex === peerAddress.fabricIndex && candidate.nodeId === peerAddress.nodeId;
+        const pending =
+            this.internal.updateQueue.find(entry => matches(entry.peerAddress)) ??
+            this.internal.consents.find(consent => matches(consent.peerAddress));
         return {
-            queued: this.internal.updateQueue.find(entry => matches(entry.peerAddress)),
-            consent: this.internal.consents.find(consent => matches(consent.peerAddress)),
+            maxBlockSize: pending?.maxBdxBlockSize ?? this.state.maxBdxBlockSize,
+            additionalMrpDelay: pending?.bdxAdditionalMrpDelay ?? this.state.bdxAdditionalMrpDelay,
         };
     }
 
@@ -1089,15 +1091,7 @@ export class SoftwareUpdateManager extends Behavior {
      */
     async addUpdateConsent(peerAddress: PeerAddress, target: SoftwareUpdateManager.UpdateTarget) {
         const { vendorId, productId, targetSoftwareVersion, maxBdxBlockSize, bdxAdditionalMrpDelay } = target;
-        if (maxBdxBlockSize !== undefined && (!Number.isInteger(maxBdxBlockSize) || maxBdxBlockSize <= 0)) {
-            throw new ImplementationError(`maxBdxBlockSize must be a positive integer, got ${maxBdxBlockSize}`);
-        }
-        if (
-            bdxAdditionalMrpDelay !== undefined &&
-            (!Number.isFinite(bdxAdditionalMrpDelay) || bdxAdditionalMrpDelay < 0)
-        ) {
-            throw new ImplementationError(`bdxAdditionalMrpDelay must not be negative, got ${bdxAdditionalMrpDelay}`);
-        }
+        assertTransferOptions(target);
         peerAddress = PeerAddress(peerAddress);
         // Filter out all existing consents for this peer, they are replaced by the new one
         const consents = this.internal.consents.filter(
@@ -1291,8 +1285,8 @@ export namespace SoftwareUpdateManager {
         /**
          * Additive MRP retransmission margin for OTA transfers, overriding the margin the peer's medium implies.
          *
-         * The margin is amplified by the backoff multiplier and the whole schedule has to fit the peer's BDX response
-         * budget, so a large value costs the transfer rather than protecting it.
+         * A BDX retransmission interval is capped so the whole schedule fits the peer's response budget, so values
+         * above roughly 7s are inert.
          */
         bdxAdditionalMrpDelay?: Duration = undefined;
     }

--- a/packages/node/src/behaviors/ota-software-update-provider/OtaSoftwareUpdateProviderServer.ts
+++ b/packages/node/src/behaviors/ota-software-update-provider/OtaSoftwareUpdateProviderServer.ts
@@ -286,8 +286,7 @@ export class OtaSoftwareUpdateProviderServer extends OtaSoftwareUpdateProviderBe
                     preferredDriverModes: [Flow.DriverMode.ReceiverDrive],
                     // That's also the default but especially stated for OTA, but let's set it explicitly
                     messageTimeout: Minutes(5),
-                    maxBlockSize: this.agent.get(SoftwareUpdateManager).maxBdxBlockSizeFor(peerAddress),
-                    additionalMrpDelay: this.agent.get(SoftwareUpdateManager).bdxAdditionalMrpDelayFor(peerAddress),
+                    ...this.agent.get(SoftwareUpdateManager).bdxTransferOptionsFor(peerAddress),
                 })
             ) {
                 // We could not enable BDX for this scope because another process is registered with different details

--- a/packages/node/test/behaviors/ota/OtaTest.ts
+++ b/packages/node/test/behaviors/ota/OtaTest.ts
@@ -17,7 +17,6 @@ import { ServerNode } from "#node/ServerNode.js";
 import {
     Bytes,
     createPromise,
-    type Duration,
     ImplementationError,
     Millis,
     Minutes,
@@ -635,13 +634,11 @@ describe("Ota", () => {
             },
         ]);
     }).timeout(10_000); // locally needs 1s, but CI might be slower
-
-    it("resolves the BDX block size cap from the consent, then from state", async () => {
+    /** A commissioned pair with an OTA image staged, for tests that only exercise transfer-option resolution. */
+    async function otaSiteWithImage() {
         const { TestOtaRequestorServer } = InstrumentedOtaRequestorServer(
             { requestUserConsent: false },
-            {
-                expectedOtaImage: Bytes.fromHex(""),
-            },
+            { expectedOtaImage: Bytes.fromHex("") },
         );
         const { TestOtaProviderServer } = InstrumentedOtaProviderServer({ requestUserConsentForUpdate: false });
 
@@ -649,169 +646,82 @@ describe("Ota", () => {
             TestOtaProviderServer,
             TestOtaRequestorServer,
         );
-        await using _localSite = site;
-
         const { vendorId, productId, targetSoftwareVersion } = await addTestOtaImage(device, controller);
         const peerAddress = controller.peers.get("peer1")!.state.commissioning.peerAddress!;
 
-        // Nothing configured: accept whatever the peer requests
-        expect(await otaProvider.act(agent => agent.get(SoftwareUpdateManager).maxBdxBlockSizeFor(peerAddress))).equals(
-            undefined,
-        );
+        const optionsFor = () =>
+            otaProvider.act(agent => agent.get(SoftwareUpdateManager).bdxTransferOptionsFor(peerAddress));
+        const consentTo = (target: Partial<SoftwareUpdateManager.UpdateTarget>) =>
+            otaProvider.act(agent =>
+                agent.get(SoftwareUpdateManager).addUpdateConsent(peerAddress, {
+                    vendorId: VendorId(vendorId),
+                    productId,
+                    targetSoftwareVersion,
+                    ...target,
+                }),
+            );
+
+        return { site, otaProvider, peerAddress, optionsFor, consentTo };
+    }
+
+    it("resolves transfer options from the consent, then from state", async () => {
+        const { site, otaProvider, optionsFor, consentTo } = await otaSiteWithImage();
+        await using _localSite = site;
+
+        // Nothing configured: the peer and its medium decide
+        expect(await optionsFor()).deep.equals({ maxBlockSize: undefined, additionalMrpDelay: undefined });
 
         await otaProvider.act(agent => {
-            agent.get(SoftwareUpdateManager).state.maxBdxBlockSize = 512;
+            const { state } = agent.get(SoftwareUpdateManager);
+            state.maxBdxBlockSize = 512;
+            state.bdxAdditionalMrpDelay = Seconds(2);
         });
-        expect(await otaProvider.act(agent => agent.get(SoftwareUpdateManager).maxBdxBlockSizeFor(peerAddress))).equals(
-            512,
-        );
+        expect(await optionsFor()).deep.equals({ maxBlockSize: 512, additionalMrpDelay: Seconds(2) });
 
-        // A consent-level override outranks the general default
-        await otaProvider.act(agent =>
-            agent.get(SoftwareUpdateManager).addUpdateConsent(peerAddress, {
-                vendorId: VendorId(vendorId),
-                productId,
-                targetSoftwareVersion,
-                maxBdxBlockSize: 256,
-            }),
-        );
-        expect(await otaProvider.act(agent => agent.get(SoftwareUpdateManager).maxBdxBlockSizeFor(peerAddress))).equals(
-            256,
-        );
-    }).timeout(10_000);
+        // Consent-level overrides outrank the general defaults
+        await consentTo({ maxBdxBlockSize: 256, bdxAdditionalMrpDelay: Millis(500) });
+        expect(await optionsFor()).deep.equals({ maxBlockSize: 256, additionalMrpDelay: Millis(500) });
+    });
 
-    it("keeps a consent's BDX options when the update is queued later", async () => {
-        const { TestOtaRequestorServer } = InstrumentedOtaRequestorServer(
-            { requestUserConsent: false },
-            {
-                expectedOtaImage: Bytes.fromHex(""),
-            },
-        );
-        const { TestOtaProviderServer } = InstrumentedOtaProviderServer({ requestUserConsentForUpdate: false });
-
-        const { site, device, controller, otaProvider } = await initOtaSite(
-            TestOtaProviderServer,
-            TestOtaRequestorServer,
-        );
+    it("lets a later consent change and clear the options of a queued update", async () => {
+        const { site, optionsFor, consentTo } = await otaSiteWithImage();
         await using _localSite = site;
 
-        const { vendorId, productId, targetSoftwareVersion } = await addTestOtaImage(device, controller);
-        const peerAddress = controller.peers.get("peer1")!.state.commissioning.peerAddress!;
+        await consentTo({ maxBdxBlockSize: 256, bdxAdditionalMrpDelay: Millis(500) });
+        expect(await optionsFor()).deep.equals({ maxBlockSize: 256, additionalMrpDelay: Millis(500) });
 
-        await otaProvider.act(agent =>
-            agent.get(SoftwareUpdateManager).addUpdateConsent(peerAddress, {
-                vendorId: VendorId(vendorId),
-                productId,
-                targetSoftwareVersion,
-                maxBdxBlockSize: 256,
-                bdxAdditionalMrpDelay: Millis(500),
-            }),
-        );
+        await consentTo({ maxBdxBlockSize: 128 });
+        expect(await optionsFor()).deep.equals({ maxBlockSize: 128, additionalMrpDelay: undefined });
 
-        // A queue entry that carries no override of its own must not mask the consent's
-        await otaProvider.act(agent => {
-            const manager = agent.get(SoftwareUpdateManager);
-            for (const entry of manager.internal.updateQueue) {
-                entry.maxBdxBlockSize = undefined;
-                entry.bdxAdditionalMrpDelay = undefined;
-            }
-        });
+        await consentTo({});
+        expect(await optionsFor()).deep.equals({ maxBlockSize: undefined, additionalMrpDelay: undefined });
+    });
 
-        expect(await otaProvider.act(agent => agent.get(SoftwareUpdateManager).maxBdxBlockSizeFor(peerAddress))).equals(
-            256,
-        );
-        expect(
-            await otaProvider.act(agent => agent.get(SoftwareUpdateManager).bdxAdditionalMrpDelayFor(peerAddress)),
-        ).equals(Millis(500));
-    }).timeout(10_000);
-
-    it("resolves the BDX MRP margin from the consent, then from state", async () => {
-        const { TestOtaRequestorServer } = InstrumentedOtaRequestorServer(
-            { requestUserConsent: false },
-            {
-                expectedOtaImage: Bytes.fromHex(""),
-            },
-        );
-        const { TestOtaProviderServer } = InstrumentedOtaProviderServer({ requestUserConsentForUpdate: false });
-
-        const { site, device, controller, otaProvider } = await initOtaSite(
-            TestOtaProviderServer,
-            TestOtaRequestorServer,
-        );
+    it("rejects invalid transfer options before touching any state", async () => {
+        const { site, otaProvider, peerAddress, consentTo } = await otaSiteWithImage();
         await using _localSite = site;
-
-        const { vendorId, productId, targetSoftwareVersion } = await addTestOtaImage(device, controller);
-        const peerAddress = controller.peers.get("peer1")!.state.commissioning.peerAddress!;
-
-        // Nothing configured: the peer's medium implies the margin
-        expect(
-            await otaProvider.act(agent => agent.get(SoftwareUpdateManager).bdxAdditionalMrpDelayFor(peerAddress)),
-        ).equals(undefined);
-
-        await otaProvider.act(agent => {
-            agent.get(SoftwareUpdateManager).state.bdxAdditionalMrpDelay = Seconds(2);
-        });
-        expect(
-            await otaProvider.act(agent => agent.get(SoftwareUpdateManager).bdxAdditionalMrpDelayFor(peerAddress)),
-        ).equals(Seconds(2));
-
-        await otaProvider.act(agent =>
-            agent.get(SoftwareUpdateManager).addUpdateConsent(peerAddress, {
-                vendorId: VendorId(vendorId),
-                productId,
-                targetSoftwareVersion,
-                bdxAdditionalMrpDelay: Millis(500),
-            }),
-        );
-        expect(
-            await otaProvider.act(agent => agent.get(SoftwareUpdateManager).bdxAdditionalMrpDelayFor(peerAddress)),
-        ).equals(Millis(500));
-    }).timeout(10_000);
-
-    it("rejects an invalid BDX block size at the call site", async () => {
-        const { TestOtaRequestorServer } = InstrumentedOtaRequestorServer(
-            { requestUserConsent: false },
-            {
-                expectedOtaImage: Bytes.fromHex(""),
-            },
-        );
-        const { TestOtaProviderServer } = InstrumentedOtaProviderServer({ requestUserConsentForUpdate: false });
-
-        const { site, device, controller, otaProvider } = await initOtaSite(
-            TestOtaProviderServer,
-            TestOtaRequestorServer,
-        );
-        await using _localSite = site;
-
-        const { vendorId, productId, targetSoftwareVersion } = await addTestOtaImage(device, controller);
-        const peerAddress = controller.peers.get("peer1")!.state.commissioning.peerAddress!;
-
-        for (const bdxAdditionalMrpDelay of [Millis(-1), Number.NaN as Duration]) {
-            await expect(
-                otaProvider.act(agent =>
-                    agent.get(SoftwareUpdateManager).addUpdateConsent(peerAddress, {
-                        vendorId: VendorId(vendorId),
-                        productId,
-                        targetSoftwareVersion,
-                        bdxAdditionalMrpDelay,
-                    }),
-                ),
-            ).to.be.rejectedWith(ImplementationError);
-        }
 
         for (const maxBdxBlockSize of [0, -1, 1.5, Number.NaN]) {
-            await expect(
-                otaProvider.act(agent =>
-                    agent.get(SoftwareUpdateManager).addUpdateConsent(peerAddress, {
-                        vendorId: VendorId(vendorId),
-                        productId,
-                        targetSoftwareVersion,
-                        maxBdxBlockSize,
-                    }),
-                ),
-            ).to.be.rejectedWith(ImplementationError);
+            await expect(consentTo({ maxBdxBlockSize })).to.be.rejectedWith(ImplementationError);
         }
-    }).timeout(10_000);
+        for (const bdxAdditionalMrpDelay of [Millis(-1), Millis(Number.NaN)]) {
+            await expect(consentTo({ bdxAdditionalMrpDelay })).to.be.rejectedWith(ImplementationError);
+        }
+
+        // forceUpdate tears down BDX registration and queue state on its way, so it must reject first too
+        await expect(
+            otaProvider.act(agent =>
+                agent.get(SoftwareUpdateManager).forceUpdate(peerAddress, {
+                    vendorId: VendorId(0),
+                    productId: 0,
+                    targetSoftwareVersion: 1,
+                    maxBdxBlockSize: 0,
+                }),
+            ),
+        ).to.be.rejectedWith(ImplementationError);
+
+        expect(await otaProvider.act(agent => agent.get(SoftwareUpdateManager).queuedUpdates)).length(0);
+    });
 
     it("Queue processes a single update via addUpdateConsent", async () => {
         const data = { expectedOtaImage: Bytes.fromHex("") };

--- a/packages/node/test/node/ClientTuningTest.ts
+++ b/packages/node/test/node/ClientTuningTest.ts
@@ -186,7 +186,7 @@ describe("ClientTuningTest", () => {
         const controller = await site.addController({
             network: {
                 profiles: {
-                    thread: { bdxAdditionalMrpDelay: Seconds(8) },
+                    thread: { bdxAdditionalMrpDelay: Seconds(3) },
                     wifi: { bdxAdditionalMrpDelay: Seconds(2) },
                 },
             },
@@ -197,14 +197,14 @@ describe("ClientTuningTest", () => {
         const profiles = controller.env.get(NetworkProfiles);
 
         const thread = profiles.get("thread");
-        expect(thread.bdxAdditionalMrpDelay).equals(Seconds(8));
+        expect(thread.mrpMargins.bdx).equals(Seconds(3));
         expect(thread.additionalMrpDelay).equals(Seconds(1.5));
 
         const wifi = profiles.get("wifi");
-        expect(wifi.bdxAdditionalMrpDelay).equals(Seconds(2));
+        expect(wifi.mrpMargins.bdx).equals(Seconds(2));
         expect(wifi.additionalMrpDelay).equals(Seconds(1));
 
-        expect(profiles.get("conservative").bdxAdditionalMrpDelay).equals(Seconds(1.5));
+        expect(profiles.get("conservative").mrpMargins.bdx).equals(Seconds(1.5));
     });
 
     it("ownNetworkProfileId sets the sender-side MRP margin", async () => {

--- a/packages/nodejs-shell/src/shell/cmd_nodes.ts
+++ b/packages/nodejs-shell/src/shell/cmd_nodes.ts
@@ -761,6 +761,20 @@ export default function commands(theNode: MatterNode) {
                                             describe:
                                                 "Additive MRP retransmission margin for this transfer, in milliseconds (default: derived from the device's medium)",
                                             type: "number",
+                                        })
+                                        .check(argv => {
+                                            const blockSize = argv.maxBlockSize as number | undefined;
+                                            const margin = argv.mrpMargin as number | undefined;
+                                            if (
+                                                blockSize !== undefined &&
+                                                (!Number.isInteger(blockSize) || blockSize <= 0)
+                                            ) {
+                                                throw new Error("--max-block-size must be a positive integer");
+                                            }
+                                            if (margin !== undefined && (!Number.isFinite(margin) || margin < 0)) {
+                                                throw new Error("--mrp-margin must be a non-negative number of ms");
+                                            }
+                                            return true;
                                         });
                                 },
                                 async argv => {

--- a/packages/protocol/src/bdx/BdxProtocol.ts
+++ b/packages/protocol/src/bdx/BdxProtocol.ts
@@ -60,20 +60,34 @@ export class BdxProtocol implements ProtocolHandler {
         if (peerDetails !== undefined) {
             const { storage: existingStorage, config: existingConfig } = peerDetails;
             if (existingStorage !== storage || !isDeepEqual(config, existingConfig)) {
-                logger.warn(
-                    "Cannot enable BDX for peer",
-                    peer,
-                    "with different storage or config:",
-                    config,
-                    "vs",
-                    existingConfig,
-                );
-                return false;
+                // A caller that derives its config from mutable state legitimately arrives with different values
+                // between transfers.  Only a transfer already under way is entitled to the config it started with.
+                if (this.#hasActiveSessionFor(peer, storage.scope)) {
+                    logger.warn(
+                        "Cannot enable BDX for peer",
+                        peer,
+                        "with different storage or config while a transfer is active:",
+                        config,
+                        "vs",
+                        existingConfig,
+                    );
+                    return false;
+                }
+                this.#peerScopes.set(peerScopeStr, { peer, storage, config });
             }
         } else {
             this.#peerScopes.set(peerScopeStr, { peer, storage, config });
         }
         return true;
+    }
+
+    #hasActiveSessionFor(peer: PeerAddress, scope: string) {
+        for (const { session, scope: sessionScope } of this.#activeBdxSessions.values()) {
+            if (sessionScope === scope && PeerAddress.is(peer, session.peerAddress)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     async disablePeerForScope(peer: PeerAddress, storage: ScopedStorage, force = false) {
@@ -122,17 +136,18 @@ export class BdxProtocol implements ProtocolHandler {
                         );
                     }
 
-                    if (config?.additionalMrpDelay !== undefined) {
-                        exchange.peerAdditionalMrpDelay = config.additionalMrpDelay;
+                    const { messageTimeout, additionalMrpDelay, ...sessionConfig } = config ?? {};
+                    if (additionalMrpDelay !== undefined) {
+                        exchange.peerAdditionalMrpDelay = additionalMrpDelay;
                     }
 
-                    messenger = new BdxMessenger(exchange, config?.messageTimeout);
+                    messenger = new BdxMessenger(exchange, messageTimeout);
 
                     const bdxSession = BdxSession.fromMessage(messenger, {
                         initMessageType,
                         initMessage,
                         fileDesignator: new PersistedFileDesignator(fileDesignator, storage),
-                        ...config,
+                        ...sessionConfig,
                     });
                     await this.#registerSession(messenger, bdxSession, storageScope);
 

--- a/packages/protocol/src/peer/NetworkProfile.ts
+++ b/packages/protocol/src/peer/NetworkProfile.ts
@@ -47,12 +47,12 @@ export interface ConcreteNetworkProfile {
     additionalMrpDelay: Duration;
 
     /**
-     * {@link additionalMrpDelay} for bulk transfer (BDX) exchanges, which sustain many round trips over one path.
+     * The additive MRP margins for this profile, by traffic class.
      *
-     * Defaults to {@link additionalMrpDelay}; set it only for a medium that needs bulk transfer paced differently from
-     * normal messaging.
+     * Precomputed because it is read on the send path; {@link MRP.Margins.bdx} is {@link additionalMrpDelay} unless
+     * the medium needs bulk transfer paced differently from normal messaging.
      */
-    bdxAdditionalMrpDelay: Duration;
+    mrpMargins: MRP.Margins;
 }
 
 /**
@@ -147,28 +147,29 @@ export class NetworkProfiles {
         return this.configure(id, this.#defaults[id as keyof NetworkProfiles.Templates]);
     }
 
-    configure(id: string, limits: NetworkProfiles.Limits, parent?: MRP.Margins) {
-        const additionalMrpDelay = limits.additionalMrpDelay ?? parent?.messaging ?? Millis(0);
-        const bdxAdditionalMrpDelay = limits.bdxAdditionalMrpDelay ?? parent?.bdx ?? additionalMrpDelay;
+    configure(id: string, limits: NetworkProfiles.Limits, parentDelay?: Duration) {
+        const additionalMrpDelay = limits.additionalMrpDelay ?? parentDelay ?? Millis(0);
         const network: NetworkProfile = {
             id,
             semaphore: new Semaphore(`network semaphore ${id}`, limits.exchanges, limits.delay, limits.timeout),
             additionalMrpDelay,
-            bdxAdditionalMrpDelay,
+            mrpMargins: {
+                messaging: additionalMrpDelay,
+                bdx: limits.bdxAdditionalMrpDelay ?? additionalMrpDelay,
+            },
         };
-        const inherited = { messaging: additionalMrpDelay, bdx: bdxAdditionalMrpDelay };
         if (limits.connect) {
             network.connect = this.configure(
                 `${id}:connect`,
                 { ...limits.connect, connect: undefined, probeAddress: undefined },
-                inherited,
+                additionalMrpDelay,
             );
         }
         if (limits.probeAddress) {
             network.probeAddress = this.configure(
                 `${id}:probe`,
                 { ...limits.probeAddress, connect: undefined, probeAddress: undefined },
-                inherited,
+                additionalMrpDelay,
             );
         }
         logger.info(
@@ -253,18 +254,20 @@ export namespace NetworkProfiles {
          * Additive MRP retransmission margin for this medium.  Defaults to 0 unless the template sets one.
          */
         additionalMrpDelay?: Duration;
-
-        /**
-         * {@link additionalMrpDelay} for bulk transfer (BDX) exchanges.  Unset inherits the parent profile's value for
-         * a sub-profile, and otherwise falls back to this profile's {@link additionalMrpDelay}.
-         */
-        bdxAdditionalMrpDelay?: Duration;
     }
 
     /**
      * Parameters that control exchange throttling for a specific medium.
      */
     export interface Limits extends ConcreteLimits {
+        /**
+         * {@link additionalMrpDelay} for bulk transfer (BDX) exchanges, which sustain many round trips over one path.
+         *
+         * Defaults to {@link additionalMrpDelay}.  Values above roughly 7s are inert: a BDX retransmission interval is
+         * capped so the whole schedule fits the peer's response budget.
+         */
+        bdxAdditionalMrpDelay?: Duration;
+
         /**
          * Overrides specifically for establishing new sessions.
          *

--- a/packages/protocol/src/peer/Peer.ts
+++ b/packages/protocol/src/peer/Peer.ts
@@ -169,13 +169,8 @@ export class Peer {
 
             // Only pad when we actually know the peer's medium; the "unknown" fallback is deliberately not applied
             // here because it would inflate responder timing for every peer of a node that never characterizes them.
-            session.peerMrpMarginsResolver = () => {
-                if (this.#physicalProperties === undefined) {
-                    return undefined;
-                }
-                const { additionalMrpDelay, bdxAdditionalMrpDelay } = this.network;
-                return { messaging: additionalMrpDelay, bdx: bdxAdditionalMrpDelay };
-            };
+            session.peerMrpMarginsResolver = () =>
+                this.#physicalProperties === undefined ? undefined : this.network.mrpMargins;
         });
     }
 

--- a/packages/protocol/src/peer/PeerExchangeProvider.ts
+++ b/packages/protocol/src/peer/PeerExchangeProvider.ts
@@ -85,13 +85,10 @@ export class PeerExchangeProvider extends ExchangeProvider {
             }
 
             const network = this.#context.networks.select(this.#peer, options?.network);
-            const medium = this.#context.networks.forPeer(this.#peer);
+            const protocol = options?.protocol ?? INTERACTION_PROTOCOL_ID;
             const peerAdditionalMrpDelay =
                 options?.additionalMrpDelay ??
-                MRP.marginFor(
-                    { messaging: medium.additionalMrpDelay, bdx: medium.bdxAdditionalMrpDelay },
-                    options?.protocol ?? INTERACTION_PROTOCOL_ID,
-                );
+                MRP.marginFor(this.#context.networks.forPeer(this.#peer).mrpMargins, protocol);
             const slot = await network.semaphore.obtainSlot(abort);
 
             try {
@@ -133,7 +130,7 @@ export class PeerExchangeProvider extends ExchangeProvider {
                     session,
                     network,
                     peerAdditionalMrpDelay,
-                    options?.protocol ?? INTERACTION_PROTOCOL_ID,
+                    protocol,
                     options?.addressOverride,
                 );
 

--- a/packages/protocol/test/peer/NetworkProfileTest.ts
+++ b/packages/protocol/test/peer/NetworkProfileTest.ts
@@ -42,9 +42,9 @@ describe("NetworkProfiles", () => {
 
         it("bdx defaults to the messaging margin", () => {
             const profiles = new NetworkProfiles();
-            expect(profiles.get("wifi").bdxAdditionalMrpDelay).equals(Seconds(1));
-            expect(profiles.get("fast").bdxAdditionalMrpDelay).equals(Millis(0));
-            expect(profiles.get("conservative").bdxAdditionalMrpDelay).equals(Seconds(1.5));
+            expect(profiles.get("wifi").mrpMargins.bdx).equals(Seconds(1));
+            expect(profiles.get("fast").mrpMargins.bdx).equals(Millis(0));
+            expect(profiles.get("conservative").mrpMargins.bdx).equals(Seconds(1.5));
         });
 
         it("a configured bdx margin overrides the default and reaches the sub-profiles", () => {
@@ -52,9 +52,7 @@ describe("NetworkProfiles", () => {
             profiles.defaults = { conservative: { bdxAdditionalMrpDelay: Seconds(3) } };
             const conservative = profiles.get("conservative");
             expect(conservative.additionalMrpDelay).equals(Seconds(1.5));
-            expect(conservative.bdxAdditionalMrpDelay).equals(Seconds(3));
-            expect(conservative.connect?.bdxAdditionalMrpDelay).equals(Seconds(3));
-            expect(conservative.probeAddress?.bdxAdditionalMrpDelay).equals(Seconds(3));
+            expect(conservative.mrpMargins.bdx).equals(Seconds(3));
         });
 
         it("connect and probe sub-profiles inherit the parent additive delay", () => {

--- a/packages/protocol/test/protocol/MessageExchangeTest.ts
+++ b/packages/protocol/test/protocol/MessageExchangeTest.ts
@@ -659,7 +659,7 @@ describe("MessageExchange", () => {
                 id: "unlimited",
                 semaphore: new Semaphore("test", Infinity),
                 additionalMrpDelay: Seconds(5),
-                bdxAdditionalMrpDelay: Seconds(5),
+                mrpMargins: { messaging: Seconds(5), bdx: Seconds(5) },
             };
         }
 


### PR DESCRIPTION
Follow-up to #4200, which merged before these review findings were addressed.

## Two defects

**A re-consent could not change or clear a queued update's transfer options.** `#queueUpdate` copies the identity fields onto an existing not-yet-started entry but did not copy `maxBdxBlockSize` / `bdxAdditionalMrpDelay`, and resolution reads the queue entry before the consent. So consenting again with different options — or with none — left the original values in force silently. Both fields are now assigned.

**`BdxProtocol.enablePeerForScope` could wedge a peer at `Busy` indefinitely.** It rejects a re-registration whose config is not deep-equal to the stored one, and the OTA provider answers `Busy` for 5 minutes when it does. That was safe while the config was a constant literal; #4200 made it derive from mutable state, so any drift between two `queryImage` calls for the same peer and scope — the queue entry or consent being removed, the application changing a state default, or the first defect above flipping a value — made every subsequent `queryImage` return `Busy` forever, because nothing clears the registration short of `applyUpdateRequest` or an explicit cancel. It now replaces the stored config when no transfer is active for that peer and scope, and refuses only mid-transfer.

## Correctness

- Validation moved into a shared guard invoked at the top of both `addUpdateConsent()` and `forceUpdate()`. `forceUpdate` previously validated only via its delegation, by which point it had already spliced a stale queue entry, cleared `pendingStartUpSuppress` and force-disabled the BDX registration.
- A non-finite margin no longer reports `"must not be negative"`.
- The shell validates both options in the yargs `check` step, so a bad value is a usage error rather than something announced and then thrown.

## Simplification

- `mrpMargins` is precomputed once per profile in `configure()`. It was assembled as a fresh object inside `Peer`'s resolver, which `MessageExchange.#sendAdditionalDelay` reads several times per transmission.
- `bdxAdditionalMrpDelay` moves from `ConcreteLimits` to `Limits` (and `ConcreteLimitsConfig` to `LimitsConfig`). Only the medium profile ever read it — `connect` and `probeAddress` sub-profiles never did. `configure()`'s recursion parameter reverts to a `Duration`.
- `maxBdxBlockSizeFor()` and `bdxAdditionalMrpDelayFor()` collapse into one `bdxTransferOptionsFor()` that the provider spreads, so a `queryImage` performs one lookup instead of four array scans.
- Transport-tuning fields no longer leak into `BdxSessionConfiguration` through the config spread.

## Documentation

The state and profile JSDoc claimed a large BDX margin "costs the transfer". It does not — `BDX_MAX_RETRANSMISSION_INTERVAL` caps the interval at `30s/4 − 100ms`, so anything beyond roughly 7s is inert. Corrected in both places, and `ClientTuningTest` now configures a value the cap can honour instead of `Seconds(8)`.

## Tests

Net −240/+165: the four resolution tests collapse behind one fixture, and the test that hand-mutated `internal.updateQueue` is replaced by one that drives the real re-consent path — which is what the first defect actually needed. The `Number.NaN as Duration` cast is gone.

Mutation-verified: removing the `#queueUpdate` assignments fails the re-consent test.

**Not covered:** the `forceUpdate`-validates-before-mutating guard. Distinguishing it requires a seeded stale queue entry plus an active BDX registration, which means hand-mutating internals — the same pattern this PR removes elsewhere. The guard is in place; the ordering is not asserted.

## Deferred review findings

- State-level defaults (`state.maxBdxBlockSize`, `state.bdxAdditionalMrpDelay`) are unvalidated, so a bad value there still surfaces late inside the protocol dispatch path. Validating behavior state on write needs a decision on mechanism.
- `MRP.marginFor` hard-codes `BDX_PROTOCOL_ID` in the generic MRP namespace.
- `MessageExchange.peerAdditionalMrpDelay` is a write-only setter that overwrites unconditionally, unlike the adjacent `onSend`/`onReceive` setters.
- `OtaSoftwareUpdateProviderServer.#hasUpdateConsent` returns `MaybePromise<boolean>` consumed as a boolean — pre-existing and unverified.

## Checklist

- [x] Tests added or updated to cover the change
- [x] `npm test` passes (full suite, all packages)
- [x] `npm run format-verify` and `npm run lint` pass
- [ ] `npm run build -- --clean` — fails on `packages/testing/src/chai.ts` (`Config.deepEqual`, `ChaiUtils.eql`), reproduced on unmodified `main`; unrelated to this change
- [x] CHANGELOG — no entry; #4200's entries already describe the feature and this corrects it before release

🤖 Generated with [Claude Code](https://claude.com/claude-code)