### PR TITLE
fix(node-manager): task cancel liveness and lifecycle hardening

### DIFF
--- a/packages/node-manager/src/task/RunningTaskContext.ts
+++ b/packages/node-manager/src/task/RunningTaskContext.ts
@@ -9,7 +9,7 @@ import { asError, Logger, ObserverGroup } from "@matter/general";
 import { ClientNode, DesiredStateBehavior, itemMapKey, ItemMode, ManagedItem, NetworkClient } from "@matter/node";
 import { SustainedSubscription } from "@matter/protocol";
 import { Task } from "./Task.js";
-import { TaskPeerUnavailableError } from "./errors.js";
+import { TaskFailedError, TaskPeerUnavailableError } from "./errors.js";
 import { TaskContext, TaskState } from "./types.js";
 
 const logger = Logger.get("TaskContext");
@@ -85,12 +85,29 @@ export class RunningTaskContext implements TaskContext {
 
     async awaitCommitted(items: Array<{ peer: ClientNode; kind: string; key: string }>): Promise<void> {
         const peers = [...new Set(items.map(i => i.peer))];
-        await this.awaitGate(peers, () => items.every(i => this.#itemState(i.peer, i.kind, i.key) === "committed"));
+        await this.awaitGate(peers, () => {
+            this.#requireAwaited(items);
+            return items.every(i => this.#itemState(i.peer, i.kind, i.key) === "committed");
+        });
+    }
+
+    /**
+     * A commit gate only ever observes success, so an intent the reconciler gave up on — dropped after an
+     * unrecoverable device rejection — would park the task forever. Fail it into the driver's rollback path.
+     */
+    #requireAwaited(items: Array<{ peer: ClientNode; kind: string; key: string }>): void {
+        const gone = items.find(i => this.#itemState(i.peer, i.kind, i.key) === undefined);
+        if (gone !== undefined) {
+            throw new TaskFailedError(
+                `Task ${this.task.id}: awaited intent ${gone.kind}:${gone.key} on ${gone.peer.id} is gone — ` +
+                    `the reconciler dropped it, so it can no longer commit`,
+            );
+        }
     }
 
     /**
      * Suspend until `until` holds over the peers' desired-state items, re-evaluated by verify-reconcile.
-     * Watches each peer's `itemChanged` + subscription status via a per-gate {@link ObserverGroup} (NOT
+     * Watches each peer's item events + subscription status via a per-gate {@link ObserverGroup} (NOT
      * `reactTo`, which is same-node only). While any peer is unreachable the task parks; it runs otherwise.
      */
     async awaitGate(nodes: ClientNode[], until: (items: ManagedItem[]) => boolean): Promise<void> {
@@ -98,10 +115,6 @@ export class RunningTaskContext implements TaskContext {
         if (aborted !== undefined) {
             throw asError(aborted);
         }
-        if (await this.#evaluate(nodes, until)) {
-            return;
-        }
-
         await new Promise<void>((resolve, reject) => {
             const observers = new ObserverGroup();
             let unregisterAbort: (() => void) | undefined;
@@ -143,6 +156,11 @@ export class RunningTaskContext implements TaskContext {
                 evaluating = true;
                 const drain = (): void => {
                     this.#evaluate(nodes, until).then(done => {
+                        // An abort can settle the gate while an evaluation is in flight: a follow-up reconcile
+                        // would race the rollback a cancel spawns next, and nothing awaits it any more.
+                        if (settled) {
+                            return;
+                        }
                         if (done) {
                             finish();
                             return;
@@ -159,20 +177,24 @@ export class RunningTaskContext implements TaskContext {
             };
 
             for (const node of nodes) {
-                observers.on(node.eventsOf(DesiredStateBehavior).itemChanged, recheck);
+                const items = node.eventsOf(DesiredStateBehavior);
+                observers.on(items.itemChanged, recheck);
+                // A dropped item announces itself on `itemRemoved`, not `itemChanged`: without this a gate
+                // waiting on an item the reconciler gives up on parks with nothing left to wake it.
+                observers.on(items.itemRemoved, recheck);
                 observers.on(node.eventsOf(NetworkClient).subscriptionStatusChanged, recheck);
             }
             unregisterAbort = this.gate?.onAbort(recheck);
 
-            // An abort raised during the initial #evaluate await fired its wake before onAbort registered;
-            // re-check so that abort is not lost while the gate parks on (possibly silent) peer observers.
-            const lateAbort = this.gate?.aborted();
-            if (lateAbort !== undefined) {
-                finish(lateAbort);
-                return;
+            // The first evaluation must run with every wakeup source already registered, so that a change,
+            // removal, reachability flip or abort arriving while it is in flight coalesces into a follow-up
+            // evaluation instead of being announced before anything listens.
+            try {
+                recheck();
+            } catch (e) {
+                // Observers outliving the gate keep reconciling the peer on behalf of a task that is gone.
+                finish(e);
             }
-
-            this.#classify(nodes);
         });
 
         this.setState("running");

--- a/packages/node-manager/src/task/Task.ts
+++ b/packages/node-manager/src/task/Task.ts
@@ -12,7 +12,7 @@ export interface TaskPersistence {
     params: unknown;
     phaseIndex: number;
     state: TaskState;
-    externalIds?: string[];
+    externalId?: string;
     changeSet: ChangeEntry[];
     error?: string;
     revertTaskId?: string;
@@ -26,11 +26,8 @@ export abstract class Task<P = unknown> {
     readonly id: string;
     readonly params: P;
 
-    /**
-     * Ids callers use to find this task instead of its internal id. Every request that dedups onto the task
-     * contributes its own, so each caller can observe and cancel the work it asked for.
-     */
-    readonly externalIds: Set<string>;
+    /** Id the caller of `run` asked for this task under, so it can observe and cancel the work it asked for. */
+    readonly externalId?: string;
 
     progress: { phaseIndex: number; state: TaskState };
     changeSet: ChangeEntry[];
@@ -41,7 +38,7 @@ export abstract class Task<P = unknown> {
     constructor(id: string, params: P, persisted?: Partial<TaskPersistence>) {
         this.id = id;
         this.params = params;
-        this.externalIds = new Set(persisted?.externalIds);
+        this.externalId = persisted?.externalId;
         this.progress = { phaseIndex: persisted?.phaseIndex ?? 0, state: persisted?.state ?? "running" };
         this.changeSet = persisted?.changeSet ?? new Array<ChangeEntry>();
         this.error = persisted?.error;
@@ -54,7 +51,7 @@ export abstract class Task<P = unknown> {
             type: this.type,
             state: this.progress.state,
             phaseIndex: this.progress.phaseIndex,
-            externalIds: [...this.externalIds],
+            externalId: this.externalId,
             error: this.error,
             revertTaskId: this.revertTaskId,
             revertOf: this.revertOf,
@@ -100,7 +97,7 @@ export abstract class Task<P = unknown> {
             params: this.params,
             phaseIndex: this.progress.phaseIndex,
             state: this.progress.state,
-            externalIds: this.externalIds.size === 0 ? undefined : [...this.externalIds],
+            externalId: this.externalId,
             changeSet: this.changeSet,
             error: this.error,
             revertTaskId: this.revertTaskId,

--- a/packages/node-manager/src/task/Task.ts
+++ b/packages/node-manager/src/task/Task.ts
@@ -12,7 +12,7 @@ export interface TaskPersistence {
     params: unknown;
     phaseIndex: number;
     state: TaskState;
-    externalId?: string;
+    externalIds?: string[];
     changeSet: ChangeEntry[];
     error?: string;
     revertTaskId?: string;
@@ -25,7 +25,13 @@ export abstract class Task<P = unknown> {
 
     readonly id: string;
     readonly params: P;
-    readonly externalId?: string;
+
+    /**
+     * Ids callers use to find this task instead of its internal id. Every request that dedups onto the task
+     * contributes its own, so each caller can observe and cancel the work it asked for.
+     */
+    readonly externalIds: Set<string>;
+
     progress: { phaseIndex: number; state: TaskState };
     changeSet: ChangeEntry[];
     error?: string;
@@ -35,7 +41,7 @@ export abstract class Task<P = unknown> {
     constructor(id: string, params: P, persisted?: Partial<TaskPersistence>) {
         this.id = id;
         this.params = params;
-        this.externalId = persisted?.externalId;
+        this.externalIds = new Set(persisted?.externalIds);
         this.progress = { phaseIndex: persisted?.phaseIndex ?? 0, state: persisted?.state ?? "running" };
         this.changeSet = persisted?.changeSet ?? new Array<ChangeEntry>();
         this.error = persisted?.error;
@@ -48,7 +54,7 @@ export abstract class Task<P = unknown> {
             type: this.type,
             state: this.progress.state,
             phaseIndex: this.progress.phaseIndex,
-            externalId: this.externalId,
+            externalIds: [...this.externalIds],
             error: this.error,
             revertTaskId: this.revertTaskId,
             revertOf: this.revertOf,
@@ -94,7 +100,7 @@ export abstract class Task<P = unknown> {
             params: this.params,
             phaseIndex: this.progress.phaseIndex,
             state: this.progress.state,
-            externalId: this.externalId,
+            externalIds: this.externalIds.size === 0 ? undefined : [...this.externalIds],
             changeSet: this.changeSet,
             error: this.error,
             revertTaskId: this.revertTaskId,

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -5,13 +5,15 @@
  */
 
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
-import { Logger, Mutex, Observable } from "@matter/general";
+import { asError, Bytes, isDeepEqual, Lifecycle, Logger, Mutex, Observable } from "@matter/general";
 import { DatatypeModel, FieldElement } from "@matter/model";
 import { Agent, Behavior, ClientNode, DesiredStateBehavior, itemMapKey, Node, ServerNode } from "@matter/node";
 import {
     TaskCancelledSignal,
     TaskCapacityExceededError,
     TaskConflictError,
+    TaskManagerClosingError,
+    TaskNotFoundError,
     TaskNotRevertibleError,
     TaskSuspendedSignal,
 } from "./errors.js";
@@ -28,9 +30,48 @@ const TERMINAL_STATES: ReadonlySet<TaskState> = new Set<TaskState>(["completed",
 
 const logger = Logger.get("TaskManager");
 
+/**
+ * A value as a storage round-trip returns it: serialization drops properties whose value is undefined at every
+ * depth, and leaves an array element that is undefined as a hole. Comparing raw values instead rejects an
+ * idempotent re-issue of a request with a nested optional.
+ *
+ * A `Map` becomes its entries because a structural comparison sees no properties on one, and would therefore
+ * accept any map in place of any other.
+ */
+function asStored(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        const stored = new Array<unknown>(value.length);
+        value.forEach((element, index) => {
+            if (element !== undefined) {
+                stored[index] = asStored(element);
+            }
+        });
+        return stored;
+    }
+    if (value instanceof Map) {
+        return [...value.entries()].map(asStored);
+    }
+    if (typeof value !== "object" || value === null || Bytes.isBytes(value)) {
+        return value;
+    }
+    const stored: Record<string, unknown> = {};
+    for (const [key, property] of Object.entries(value)) {
+        if (property !== undefined) {
+            stored[key] = asStored(property);
+        }
+    }
+    return stored;
+}
+
 export interface TaskHandle {
     readonly id: string;
     readonly status: TaskStatus;
+}
+
+/** The retention effect of one persist: ids joining the queue and ids leaving it with their records. */
+interface RetentionPlan {
+    retired: string[];
+    forgotten: string[];
 }
 
 export class TaskManagerBehavior extends Behavior {
@@ -58,12 +99,35 @@ export class TaskManagerBehavior extends Behavior {
         this.internal.registry = new TaskRegistry();
         this.internal.live = new Map();
         this.internal.gates = new Map();
+        this.#adoptInheritedTerminals();
         this.#registerBuiltins();
         // Driving acts on the node, so the resume pass must wait until the node is online.
         if (this.#rootNode.lifecycle.isOnline) {
             this.#resumePersisted();
         } else {
             this.reactTo(this.#rootNode.lifecycle.online, this.#resumePersisted);
+        }
+    }
+
+    /**
+     * Adopt terminal records from a previous start into the retention queue, dropping those beyond
+     * {@link terminalRetention} so a controller that restarts often does not accumulate finished tasks in storage
+     * forever. Their relative age is unknown, hence storage order.
+     */
+    #adoptInheritedTerminals(): void {
+        const inherited = Object.entries(this.state.tasks)
+            .filter(([, p]) => TERMINAL_STATES.has(p.state))
+            .map(([id]) => id);
+        const excess = inherited.length - this.terminalRetention;
+        if (excess > 0) {
+            const tasks = { ...this.state.tasks };
+            for (const id of inherited.splice(0, excess)) {
+                delete tasks[id];
+            }
+            this.state.tasks = tasks;
+        }
+        for (const id of inherited) {
+            this.internal.terminated.add(id);
         }
     }
 
@@ -97,21 +161,31 @@ export class TaskManagerBehavior extends Behavior {
     }
 
     register(type: string, ctor: TaskCtor): void {
+        // Resuming drives a phase, which the dispose drain may already have passed and no persist can record.
+        this.#refuseIfClosing(`Task type "${type}" cannot be registered`);
         this.internal.registry.register(type, ctor);
         // Apps register custom task types after construction; resume their persisted, non-terminal tasks now.
         this.#resumeType(type);
     }
 
-    /** Resume persisted, non-terminal, not-yet-live tasks of a registered type. */
+    /**
+     * Load the persisted tasks of a registered type. A non-terminal task resumes driving; a terminal one becomes
+     * observable history — visible to {@link get} and {@link tasks} and still cancellable through its recorded
+     * changeSet — but is never driven again.
+     */
     #resumeType(type: string): void {
         if (!this.internal.registry.has(type)) {
             return;
         }
         for (const [id, p] of Object.entries(this.state.tasks)) {
-            if (p.type !== type || TERMINAL_STATES.has(p.state) || this.internal.live.has(id)) {
+            if (p.type !== type || this.internal.live.has(id)) {
                 continue;
             }
             const task = this.internal.registry.create(type, id, p.params, p);
+            if (TERMINAL_STATES.has(p.state)) {
+                this.internal.live.set(id, task);
+                continue;
+            }
             // A persisted `parked` task must re-drive; #drive only advances `running` tasks, and the phase's
             // gate re-parks from live reachability if the peer is still offline.
             if (task.progress.state === "parked") {
@@ -122,8 +196,17 @@ export class TaskManagerBehavior extends Behavior {
         }
     }
 
+    // The gate must exist before driving starts — it is the only home for an abort reason, so a cancel or shutdown
+    // arriving before the first phase builds its gate would otherwise be discarded. It is created fresh so an abort
+    // recorded for an earlier run of this id cannot carry over.
     #track(task: Task): void {
-        const drivePromise = this.#drive(task).finally(() => {
+        this.internal.gates.set(task.id, { wake: new Observable() });
+        const drivePromise: Promise<void> = this.#drive(task).finally(() => {
+            // A task turns terminal before its drive promise settles, so a re-run may already own this id's
+            // bookkeeping; only its current owner may clear it.
+            if (this.internal.driving.get(task.id) !== drivePromise) {
+                return;
+            }
             this.internal.driving.delete(task.id);
             this.internal.gates.delete(task.id);
             this.internal.cancelling.delete(task.id);
@@ -131,18 +214,56 @@ export class TaskManagerBehavior extends Behavior {
         this.internal.driving.set(task.id, drivePromise);
     }
 
+    /**
+     * Start `type` with `params`, or join the live task an identical request already started. An `externalId`
+     * becomes an id this task answers to, whether the request started it or joined it, so every caller can
+     * observe and {@link cancel} the work it asked for. Ids are exclusive among unfinished work: one that
+     * already names another live task is refused rather than silently resolving elsewhere.
+     */
     run(type: string, params: unknown, opts?: { externalId?: string }): TaskHandle {
-        return this.#spawn(type, params, { externalId: opts?.externalId });
+        return this.#handle(this.#spawn(type, params, {}, opts?.externalId));
     }
 
     /** Shared creation path so callers (e.g. #spawnRevert) can seed persisted fields before the first persist. */
-    #spawn(type: string, params: unknown, seed: Partial<TaskPersistence>): TaskHandle {
+    #spawn(type: string, params: unknown, seed: Partial<TaskPersistence>, externalId?: string): Task {
         const id = this.internal.registry.idFor(type, params);
+        // Driving started now would outlive the dispose drain and write to peers after close, with no way to
+        // record what it did.
+        this.#refuseIfClosing(`Task ${id} cannot start`);
+        // A cancel of this id is mid-flight: deduping would hand the caller a task that is being torn down, and
+        // replacing it would take over bookkeeping the cancel is still waiting on.
+        if (this.internal.cancelling.has(id)) {
+            throw new TaskConflictError(`Task ${id} rejected: a cancel of this task is still in flight`);
+        }
+        if (externalId !== undefined) {
+            this.#requireClaimableExternalId(externalId, id);
+        }
         const existing = this.internal.live.get(id);
-        if (existing !== undefined) {
-            return this.#handle(existing);
+        if (existing !== undefined && !TERMINAL_STATES.has(existing.progress.state)) {
+            // Only an identical request is idempotent; reusing the id with other values would apply neither the
+            // running task's parameters nor the new ones the caller asked for.
+            if (!this.#sameParams(existing.params, params)) {
+                throw new TaskConflictError(
+                    `Task ${id} rejected: a live task with this id is running with different parameters`,
+                );
+            }
+            if (externalId !== undefined && !existing.externalIds.has(externalId)) {
+                existing.externalIds.add(externalId);
+                // The joining caller's id must outlive this process, or a restart hands it a handle onto nothing.
+                this.#mutex.run(() => this.#writeRecord(existing));
+            }
+            return existing;
+        }
+        const pendingRevert = this.#pendingRevertFor(id);
+        if (pendingRevert !== undefined) {
+            throw new TaskConflictError(
+                `Task ${id} rejected: rollback ${pendingRevert.id} is still in flight and would undo it again`,
+            );
         }
         const task = this.internal.registry.create(type, id, params, seed);
+        if (externalId !== undefined) {
+            task.externalIds.add(externalId);
+        }
         // Synchronous exclusivity check: no await between reading `live` and live.set below, so there is no TOCTOU
         // window. The just-created task is discarded on throw (never tracked or persisted).
         const rk = task.resourceKey();
@@ -155,9 +276,53 @@ export class TaskManagerBehavior extends Behavior {
                 }
             }
         }
+        // A replaced terminal task must leave the retention queue with it, or its eviction would later drop the
+        // fresh task that now holds the id.
+        this.internal.terminated.delete(id);
         this.internal.live.set(id, task);
         this.#track(task);
-        return this.#handle(task);
+        return task;
+    }
+
+    /**
+     * An external id must resolve to the task the caller asked for and to nothing else, so it may not name any
+     * retained task's own id, nor already belong to other unfinished work. A finished task keeps the ids it ran
+     * under, and {@link #find} prefers the live holder, so history does not block reuse of an id.
+     */
+    #requireClaimableExternalId(externalId: string, id: string): void {
+        const conflict = this.internal.live.get(externalId) ?? this.#liveHolderOf(externalId);
+        if (conflict !== undefined && conflict.id !== id) {
+            throw new TaskConflictError(
+                `Task ${id} rejected: external id "${externalId}" already refers to task ${conflict.id}`,
+            );
+        }
+    }
+
+    #liveHolderOf(externalId: string): Task | undefined {
+        for (const t of this.internal.live.values()) {
+            if (t.externalIds.has(externalId) && !TERMINAL_STATES.has(t.progress.state)) {
+                return t;
+            }
+        }
+        return undefined;
+    }
+
+    /** A rollback rewrites exactly the intents a re-run would re-apply, so the two must never overlap. */
+    #pendingRevertFor(id: string): Task | undefined {
+        for (const t of this.internal.live.values()) {
+            if (t.revertOf === id && !TERMINAL_STATES.has(t.progress.state)) {
+                return t;
+            }
+        }
+        return undefined;
+    }
+
+    /**
+     * Whether two parameter sets describe the same request, compared as storage would hand them back: a resumed
+     * task's parameters would otherwise never match the request that started it.
+     */
+    #sameParams(a: unknown, b: unknown): boolean {
+        return isDeepEqual(asStored(a), asStored(b));
     }
 
     // A revert has no resourceKey of its own (so it is never rejected), but it rewrites the intents in its
@@ -184,12 +349,19 @@ export class TaskManagerBehavior extends Behavior {
         if (byId !== undefined) {
             return byId;
         }
+        // Finished work keeps the ids it ran under, so an id can have several holders: the live one is the one
+        // meant by it, and among finished ones the most recent.
+        let retained: Task | undefined;
         for (const t of this.internal.live.values()) {
-            if (t.externalId === idOrExternalId) {
+            if (!t.externalIds.has(idOrExternalId)) {
+                continue;
+            }
+            if (!TERMINAL_STATES.has(t.progress.state)) {
                 return t;
             }
+            retained = t;
         }
-        return undefined;
+        return retained;
     }
 
     #handle(task: Task): TaskHandle {
@@ -198,13 +370,24 @@ export class TaskManagerBehavior extends Behavior {
 
     /**
      * Cancel a task: stop forward driving, then spawn a revert task that rolls back the changeSet as an ordinary
-     * task (parks on offline peers, resumes after restart). Returns the revert handle, or `undefined` if there
-     * was nothing to revert. Does not await the revert — the caller observes it via the returned handle.
+     * task (parks on offline peers, resumes after restart). Does not await the revert — the caller observes it
+     * via the returned handle.
+     *
+     * Each outcome has exactly one meaning: a handle is the rollback, `undefined` is a task with nothing to roll
+     * back, and {@link TaskNotFoundError} is an id no retained task answers to (including a task whose recorded
+     * rollback retention has since forgotten).
+     *
+     * Throws {@link TaskManagerClosingError} if shutdown intervenes before the cancel can be recorded; the task
+     * then keeps its non-terminal state and the cancel must be re-issued after the next start.
      */
     async cancel(idOrExternalId: string): Promise<TaskHandle | undefined> {
         const task = this.#find(idOrExternalId);
-        if (task === undefined || task.progress.state === "cancelled") {
-            return task?.revertTaskId === undefined ? undefined : this.get(task.revertTaskId);
+        if (task === undefined) {
+            throw new TaskNotFoundError(`Cannot cancel "${idOrExternalId}": no task is retained under that id`);
+        }
+        if (task.progress.state === "cancelled") {
+            const revert = this.#revertOf(task);
+            return revert === undefined ? undefined : this.#handle(revert);
         }
 
         // A task past its point of no return declines cancel with zero side effects (gate untouched, state kept).
@@ -216,21 +399,45 @@ export class TaskManagerBehavior extends Behavior {
         // between-phase gap the gate cannot: the driver checks it synchronously before advancing a phase.
         this.internal.cancelling.add(task.id);
         this.#abortGate(task.id, new TaskCancelledSignal(`Task ${task.id} cancelled`));
-        await this.internal.driving.get(task.id);
-        this.internal.gates.delete(task.id);
-        this.internal.cancelling.delete(task.id);
+        try {
+            await this.internal.driving.get(task.id);
+        } finally {
+            // A `cancelling` entry left behind refuses every future run of this id for the process lifetime.
+            this.internal.gates.delete(task.id);
+            this.internal.cancelling.delete(task.id);
+        }
 
+        // Shutdown took over the unwind: state can no longer be persisted, so leave the task non-terminal and
+        // unreverted rather than claiming a cancel that storage would contradict on the next start.
+        this.#refuseIfClosing(`Task ${task.id} cannot be cancelled`);
+
+        // Spawned before the state changes: a refused rollback must leave the task as it was, not cancelled in
+        // memory and unchanged in storage.
+        const revert = this.#spawnRevert(task);
         // running/parked → cancelled; an already-terminal (completed/failed) task keeps its truthful state.
         if (task.progress.state === "running" || task.progress.state === "parked") {
             task.progress.state = "cancelled";
         }
-        const handle = this.#spawnRevert(task);
-        await this.#persist(task);
-        return handle;
+        await this.#persist(task, revert);
+        return revert === undefined ? undefined : this.#handle(revert);
+    }
+
+    // Teardown starts at the node, not at this behavior: `Construction.close` applies `Destroying` before it runs
+    // the destructor that closes behaviors, so this reads true for the whole of our own teardown — from which point
+    // `endpoint.act` refuses and no state write can land.
+    get #isClosing(): boolean {
+        const { status } = this.endpoint.construction;
+        return status === Lifecycle.Status.Destroying || status === Lifecycle.Status.Destroyed;
+    }
+
+    #refuseIfClosing(subject: string): void {
+        if (this.#isClosing) {
+            throw new TaskManagerClosingError(`${subject}: the task manager is shutting down`);
+        }
     }
 
     /** Spawn (or reuse) the revert task for `task`, linking both directions. Returns undefined if no changeSet. */
-    #spawnRevert(task: Task): TaskHandle | undefined {
+    #spawnRevert(task: Task): Task | undefined {
         // A failed revert surfaces as `failed` for operator attention; reverting a revert would recurse unbounded.
         if (task.type === REVERT_TYPE) {
             return undefined;
@@ -240,18 +447,32 @@ export class TaskManagerBehavior extends Behavior {
             return undefined;
         }
         if (task.revertTaskId !== undefined) {
-            return this.get(task.revertTaskId);
+            return this.#revertOf(task);
         }
         if (task.changeSet.length === 0) {
             return undefined;
         }
-        const handle = this.#spawn(
+        const revert = this.#spawn(
             REVERT_TYPE,
             { originalId: task.id, entries: task.changeSet },
             { revertOf: task.id },
         );
-        task.revertTaskId = handle.id;
-        return handle;
+        task.revertTaskId = revert.id;
+        return revert;
+    }
+
+    /** The rollback a task recorded, or undefined if it never had one. A record retention forgot is not "none". */
+    #revertOf(task: Task): Task | undefined {
+        if (task.revertTaskId === undefined) {
+            return undefined;
+        }
+        const revert = this.#find(task.revertTaskId);
+        if (revert === undefined) {
+            throw new TaskNotFoundError(
+                `Task ${task.id} names rollback ${task.revertTaskId}, which is no longer retained`,
+            );
+        }
+        return revert;
     }
 
     #abortGate(id: string, reason: unknown): void {
@@ -261,6 +482,14 @@ export class TaskManagerBehavior extends Behavior {
         }
         gate.aborted = reason;
         gate.wake.emit();
+    }
+
+    /** Throw a recorded abort (cancel or shutdown) so the driver stops before persisting or mutating a peer. */
+    #throwIfAborted(task: Task): void {
+        const aborted = this.internal.gates.get(task.id)?.aborted;
+        if (aborted !== undefined) {
+            throw asError(aborted);
+        }
     }
 
     /**
@@ -309,14 +538,18 @@ export class TaskManagerBehavior extends Behavior {
     async #drive(task: Task): Promise<void> {
         try {
             await this.#admit(task); // fail-fast before any node is touched
+            this.#throwIfAborted(task);
             // Persist before first phase so a crash-resume sees the task.
             await this.#persist(task);
             while (task.progress.phaseIndex < task.phases.length && task.progress.state === "running") {
                 const phase = task.phases[task.progress.phaseIndex];
                 const ctx = await this.endpoint.act(agent => this.#contextFor(task, this.taskReconciler(agent)));
+                // A phase mutates the peer before it reaches its gate, so this is the last point at which an
+                // abort accepted meanwhile can still prevent the write.
+                this.#throwIfAborted(task);
                 await phase.run(ctx);
-                // No gate exists in the gap between phases, so a cancel raced here is caught synchronously
-                // (no await before the increment below) — leaving phaseIndex at the still-revertible phase.
+                // A cancel accepted while the phase ran must leave phaseIndex on that phase: revertibility is
+                // phase-based, so advancing it can cross a task's point of no return and suppress the rollback.
                 if (this.internal.cancelling.has(task.id)) {
                     throw new TaskCancelledSignal(`Task ${task.id} cancelled`);
                 }
@@ -332,13 +565,28 @@ export class TaskManagerBehavior extends Behavior {
             if (e instanceof TaskSuspendedSignal || e instanceof TaskCancelledSignal) {
                 return;
             }
+            // Teardown: neither the failure nor a rollback of it can be recorded, and the rollback's driving would
+            // outlive the dispose drain. Leave the task as the next start can resume it.
+            if (this.#isClosing) {
+                logger.warn(
+                    `Task ${task.id} interrupted by shutdown; its persisted state is left for the next start`,
+                    e,
+                );
+                return;
+            }
             task.progress.state = "failed";
             task.error = e instanceof Error ? e.message : String(e);
             logger.error(`Task ${task.id} failed`, e);
-            this.#spawnRevert(task);
-            // A failing persist here must not re-reject the (otherwise handled) drive promise.
+            // Neither a rollback this manager refuses nor a failing persist may re-reject the (otherwise handled)
+            // drive promise: that turns into an unhandled rejection and a cancel awaiting this task throws.
+            let revert: Task | undefined;
             try {
-                await this.#persist(task);
+                revert = this.#spawnRevert(task);
+            } catch (revertError) {
+                logger.error(`Task ${task.id}: cannot roll back`, revertError);
+            }
+            try {
+                await this.#persist(task, revert);
             } catch (persistError) {
                 logger.error(`Task ${task.id}: failed to persist failure state`, persistError);
             }
@@ -367,13 +615,18 @@ export class TaskManagerBehavior extends Behavior {
         );
     }
 
-    /** Per-task gate control: cancel/shutdown set `aborted`; `onAbort` wakes a parked gate to observe it. */
-    #gateFor(id: string): GateControl {
+    #gateStateFor(id: string): TaskManagerBehavior.GateState {
         let gate = this.internal.gates.get(id);
         if (gate === undefined) {
             gate = { wake: new Observable() };
             this.internal.gates.set(id, gate);
         }
+        return gate;
+    }
+
+    /** Per-task gate control: cancel/shutdown set `aborted`; `onAbort` wakes a parked gate to observe it. */
+    #gateFor(id: string): GateControl {
+        const gate = this.#gateStateFor(id);
         return {
             aborted: () => gate.aborted,
             onAbort: wake => {
@@ -395,16 +648,76 @@ export class TaskManagerBehavior extends Behavior {
 
     // Serialized through the mutex: a spawned revert drives (and persists) concurrently with the original's
     // own persist, so direct concurrent state writes would conflict on the synchronous transaction lock.
-    async #persist(task: Task): Promise<void> {
-        await this.#mutex.produce(() => this.#writeRecord(task));
+    async #persist(task: Task, paired?: Task): Promise<void> {
+        await this.#mutex.produce(() => this.#writeRecord(task, paired));
     }
 
-    async #writeRecord(task: Task): Promise<void> {
-        const record = task.toPersistence();
+    // A task that names a revert and the revert itself go into one transaction: written separately, a crash
+    // between the two loses the rollback while the forward record still promises it.
+    async #writeRecord(task: Task, paired?: Task): Promise<void> {
+        const written = paired === undefined ? [task] : [task, paired];
         await this.endpoint.act(agent => {
+            // Records, retention decision and its bookkeeping belong to one transaction: a task re-run between them
+            // would leave the queue disagreeing with the records, and a write that never gets here must touch
+            // neither.
+            const records = written.map(t => [t.id, t.toPersistence()] as const);
+            const retention = this.#planRetention(written);
             const self = agent.get(TaskManagerBehavior);
-            self.state.tasks = { ...self.state.tasks, [task.id]: record };
+            const tasks = { ...self.state.tasks };
+            for (const id of retention.forgotten) {
+                delete tasks[id];
+            }
+            for (const [id, record] of records) {
+                tasks[id] = record;
+            }
+            self.state.tasks = tasks;
+            this.#applyRetention(retention);
         });
+    }
+
+    /**
+     * Number of terminal tasks kept for observation through {@link get} and {@link tasks} before the oldest are
+     * forgotten. The bound covers retained records, which a restart makes observable again as soon as their type
+     * is registered. Override to tune how much finished history a controller retains.
+     */
+    protected get terminalRetention(): number {
+        return 50;
+    }
+
+    /**
+     * Choose the retention effect of one transaction: the tasks it retires and the oldest ids to forget beyond
+     * {@link terminalRetention}, so finished work stays observable for a while without growing without bound.
+     * The forgotten ids leave persisted state in the same write; {@link #applyRetention} commits the rest.
+     */
+    #planRetention(written: Task[]): RetentionPlan {
+        const retired = written.filter(
+            // A re-run may already own this id: retiring the previous run would expose the live task to eviction.
+            task => TERMINAL_STATES.has(task.progress.state) && this.internal.live.get(task.id) === task,
+        );
+        const queued = new Set([...this.internal.terminated, ...retired.map(task => task.id)]);
+        const writing = new Set(written.map(task => task.id));
+        const forgotten = new Array<string>();
+        for (const id of queued) {
+            if (queued.size - forgotten.length <= this.terminalRetention) {
+                break;
+            }
+            // An id this transaction writes may not be forgotten by it: the record would survive in storage while
+            // leaving both `live` and the queue, so nothing could observe or ever prune it again.
+            if (!writing.has(id)) {
+                forgotten.push(id);
+            }
+        }
+        return { retired: retired.map(task => task.id), forgotten };
+    }
+
+    #applyRetention({ retired, forgotten }: RetentionPlan): void {
+        for (const id of retired) {
+            this.internal.terminated.add(id);
+        }
+        for (const id of forgotten) {
+            this.internal.terminated.delete(id);
+            this.internal.live.delete(id);
+        }
     }
 
     override async [Symbol.asyncDispose]() {
@@ -434,6 +747,7 @@ export namespace TaskManagerBehavior {
         gates!: Map<string, GateState>;
         driving = new Map<string, Promise<void>>();
         cancelling = new Set<string>();
+        terminated = new Set<string>();
         persistMutex?: Mutex;
     }
 

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -35,6 +35,25 @@ export interface TaskHandle {
     readonly status: TaskStatus;
 }
 
+/**
+ * A task's rollback with the two operations that keep it consistent with its record: {@link discard} forgets a
+ * rollback whose record was refused, {@link start} begins driving one whose record is durable.
+ */
+interface PreparedRevert {
+    readonly task?: Task;
+    discard(): void;
+    start(): void;
+}
+
+/** The rollback of a task that has nothing to roll back: nothing to write, start or forget. */
+const NO_REVERT: PreparedRevert = { discard() {}, start() {} };
+
+/** A task registered as live, and whether the caller joined a live task that is already being driven. */
+interface SpawnedTask {
+    task: Task;
+    joined: boolean;
+}
+
 export class TaskManagerBehavior extends Behavior {
     static override readonly id = "taskManager";
     static override readonly early = true;
@@ -151,11 +170,19 @@ export class TaskManagerBehavior extends Behavior {
      * The `externalId` is also the id the caller can {@link get} and {@link cancel} its task under.
      */
     run(type: string, params: unknown, opts?: { externalId?: string }): TaskHandle {
-        return this.#handle(this.#spawn(type, params, { externalId: opts?.externalId }));
+        const { task, joined } = this.#spawn(type, params, { externalId: opts?.externalId });
+        if (!joined) {
+            this.#track(task);
+        }
+        return this.#handle(task);
     }
 
-    /** Shared creation path so callers (e.g. #spawnRevert) can seed persisted fields before the first persist. */
-    #spawn(type: string, params: unknown, seed: Partial<TaskPersistence>): Task {
+    /**
+     * Shared creation path so callers (e.g. #prepareRevert) can seed persisted fields before the first persist.
+     * Registers a new task as live but does not drive it: a task whose record must be durable before it touches a
+     * peer starts with {@link #track} once the write lands.
+     */
+    #spawn(type: string, params: unknown, seed: Partial<TaskPersistence>): SpawnedTask {
         const id = this.internal.registry.idFor(type, params);
         // Driving started now would outlive the dispose drain and write to peers after close, with no way to
         // record what it did.
@@ -172,7 +199,7 @@ export class TaskManagerBehavior extends Behavior {
                     `Task ${id} rejected: this id is held by a live task (${existing.progress.state})`,
                 );
             }
-            return existing;
+            return { task: existing, joined: true };
         }
         const pendingRevert = this.#pendingRevertFor(id);
         if (pendingRevert !== undefined) {
@@ -194,8 +221,7 @@ export class TaskManagerBehavior extends Behavior {
             }
         }
         this.internal.live.set(id, task);
-        this.#track(task);
-        return task;
+        return { task, joined: false };
     }
 
     /** A rollback rewrites exactly the intents a re-run would re-apply, so the two must never overlap. */
@@ -292,15 +318,24 @@ export class TaskManagerBehavior extends Behavior {
         // unreverted rather than claiming a cancel that storage would contradict on the next start.
         this.#refuseIfClosing(`Task ${task.id} cannot be cancelled`);
 
-        // Spawned before the state changes: a refused rollback must leave the task as it was, not cancelled in
+        // Prepared before the state changes: a refused rollback must leave the task as it was, not cancelled in
         // memory and unchanged in storage.
-        const revert = this.#spawnRevert(task);
+        const revert = this.#prepareRevert(task);
+        const stateBeforeCancel = task.progress.state;
         // running/parked → cancelled; an already-terminal (completed/failed) task keeps its truthful state.
-        if (task.progress.state === "running" || task.progress.state === "parked") {
+        if (stateBeforeCancel === "running" || stateBeforeCancel === "parked") {
             task.progress.state = "cancelled";
         }
-        await this.#persist(task, revert);
-        return revert === undefined ? undefined : this.#handle(revert);
+        try {
+            await this.#persist(task, revert.task);
+        } catch (e) {
+            task.progress.state = stateBeforeCancel;
+            revert.discard();
+            throw e;
+        }
+        // The rollback mutates peers, so it may not drive before the record that names it is durable.
+        revert.start();
+        return revert.task === undefined ? undefined : this.#handle(revert.task);
     }
 
     // Teardown starts at the node, not at this behavior: `Construction.close` applies `Destroying` before it runs
@@ -317,29 +352,40 @@ export class TaskManagerBehavior extends Behavior {
         }
     }
 
-    /** Spawn (or reuse) the revert task for `task`, linking both directions. Returns undefined if no changeSet. */
-    #spawnRevert(task: Task): Task | undefined {
+    /** Create (or reuse) the revert task for `task`, linking both directions, without driving it. */
+    #prepareRevert(task: Task): PreparedRevert {
         // A failed revert surfaces as `failed` for operator attention; reverting a revert would recurse unbounded.
         if (task.type === REVERT_TYPE) {
-            return undefined;
+            return NO_REVERT;
         }
         // Past a task's point of no return there is nothing to roll back to; suppress auto-rollback too.
         if (!task.revertible) {
-            return undefined;
+            return NO_REVERT;
         }
         if (task.revertTaskId !== undefined) {
-            return this.#revertOf(task);
+            return { task: this.#revertOf(task), discard() {}, start() {} };
         }
         if (task.changeSet.length === 0) {
-            return undefined;
+            return NO_REVERT;
         }
-        const revert = this.#spawn(
+        const { task: revert, joined } = this.#spawn(
             REVERT_TYPE,
             { originalId: task.id, entries: task.changeSet },
             { revertOf: task.id },
         );
         task.revertTaskId = revert.id;
-        return revert;
+        // A joined rollback is already live and driving, so it is not ours to start or to forget.
+        if (joined) {
+            return { task: revert, discard() {}, start() {} };
+        }
+        return {
+            task: revert,
+            discard: () => {
+                task.revertTaskId = undefined;
+                this.internal.live.delete(revert.id);
+            },
+            start: () => this.#track(revert),
+        };
     }
 
     /** The rollback a task recorded, or undefined if it never had one. */
@@ -459,17 +505,21 @@ export class TaskManagerBehavior extends Behavior {
             logger.error(`Task ${task.id} failed`, e);
             // Neither a rollback this manager refuses nor a failing persist may re-reject the (otherwise handled)
             // drive promise: that turns into an unhandled rejection and a cancel awaiting this task throws.
-            let revert: Task | undefined;
+            let revert = NO_REVERT;
             try {
-                revert = this.#spawnRevert(task);
+                revert = this.#prepareRevert(task);
             } catch (revertError) {
                 logger.error(`Task ${task.id}: cannot roll back`, revertError);
             }
             try {
-                await this.#persist(task, revert);
+                await this.#persist(task, revert.task);
             } catch (persistError) {
+                revert.discard();
                 logger.error(`Task ${task.id}: failed to persist failure state`, persistError);
+                return;
             }
+            // The rollback mutates peers, so it may not drive before the record that names it is durable.
+            revert.start();
         }
     }
 
@@ -535,6 +585,8 @@ export class TaskManagerBehavior extends Behavior {
     // A task that names a revert and the revert itself go into one transaction: written separately, a crash
     // between the two loses the rollback while the forward record still promises it.
     async #writeRecord(task: Task, paired?: Task): Promise<void> {
+        // Serialized with the write, so a shutdown that began while this queued behind the mutex cannot slip past.
+        this.#refuseIfClosing(`Task ${task.id} state cannot be recorded`);
         const records = (paired === undefined ? [task] : [task, paired]).map(t => [t.id, t.toPersistence()] as const);
         await this.endpoint.act(agent => {
             const self = agent.get(TaskManagerBehavior);

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -135,14 +135,20 @@ export class TaskManagerBehavior extends Behavior {
                 continue;
             }
             const task = this.internal.registry.create(type, id, p.params, p);
-            // A persisted `parked` task must re-drive; #drive only advances `running` tasks, and the phase's
-            // gate re-parks from live reachability if the peer is still offline.
-            if (task.progress.state === "parked") {
-                task.progress.state = "running";
-            }
             this.internal.live.set(id, task);
-            this.#track(task);
+            this.#redrive(task);
         }
+    }
+
+    /**
+     * Begin (or resume) driving a live non-terminal task. A `parked` task becomes `running` first: {@link #drive}
+     * only advances a running task, and the phase's gate re-parks from live reachability if the peer is still gone.
+     */
+    #redrive(task: Task): void {
+        if (task.progress.state === "parked") {
+            task.progress.state = "running";
+        }
+        this.#track(task);
     }
 
     // The gate must exist before driving starts — it is the only home for an abort reason, so a cancel or shutdown
@@ -320,7 +326,15 @@ export class TaskManagerBehavior extends Behavior {
 
         // Prepared before the state changes: a refused rollback must leave the task as it was, not cancelled in
         // memory and unchanged in storage.
-        const revert = this.#prepareRevert(task);
+        let revert: PreparedRevert;
+        try {
+            revert = this.#prepareRevert(task);
+        } catch (e) {
+            // The abort above stopped the driver and dropped its gate. A task the manager declines to cancel keeps
+            // its state, so it must keep its driver too, or it sits non-terminal with nothing left to advance it.
+            this.#redrive(task);
+            throw e;
+        }
         const stateBeforeCancel = task.progress.state;
         // running/parked → cancelled; an already-terminal (completed/failed) task keeps its truthful state.
         if (stateBeforeCancel === "running" || stateBeforeCancel === "parked") {

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -365,7 +365,13 @@ export class TaskManagerBehavior extends Behavior {
     }
 
     #handle(task: Task): TaskHandle {
-        return { id: task.id, status: task.status };
+        // A held handle must keep answering for the task it names; a snapshot would freeze at creation time.
+        return {
+            id: task.id,
+            get status() {
+                return task.status;
+            },
+        };
     }
 
     /**

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -5,7 +5,7 @@
  */
 
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
-import { asError, Bytes, isDeepEqual, Lifecycle, Logger, Mutex, Observable } from "@matter/general";
+import { asError, Lifecycle, Logger, Mutex, Observable } from "@matter/general";
 import { DatatypeModel, FieldElement } from "@matter/model";
 import { Agent, Behavior, ClientNode, DesiredStateBehavior, itemMapKey, Node, ServerNode } from "@matter/node";
 import {
@@ -30,48 +30,9 @@ const TERMINAL_STATES: ReadonlySet<TaskState> = new Set<TaskState>(["completed",
 
 const logger = Logger.get("TaskManager");
 
-/**
- * A value as a storage round-trip returns it: serialization drops properties whose value is undefined at every
- * depth, and leaves an array element that is undefined as a hole. Comparing raw values instead rejects an
- * idempotent re-issue of a request with a nested optional.
- *
- * A `Map` becomes its entries because a structural comparison sees no properties on one, and would therefore
- * accept any map in place of any other.
- */
-function asStored(value: unknown): unknown {
-    if (Array.isArray(value)) {
-        const stored = new Array<unknown>(value.length);
-        value.forEach((element, index) => {
-            if (element !== undefined) {
-                stored[index] = asStored(element);
-            }
-        });
-        return stored;
-    }
-    if (value instanceof Map) {
-        return [...value.entries()].map(asStored);
-    }
-    if (typeof value !== "object" || value === null || Bytes.isBytes(value)) {
-        return value;
-    }
-    const stored: Record<string, unknown> = {};
-    for (const [key, property] of Object.entries(value)) {
-        if (property !== undefined) {
-            stored[key] = asStored(property);
-        }
-    }
-    return stored;
-}
-
 export interface TaskHandle {
     readonly id: string;
     readonly status: TaskStatus;
-}
-
-/** The retention effect of one persist: ids joining the queue and ids leaving it with their records. */
-interface RetentionPlan {
-    retired: string[];
-    forgotten: string[];
 }
 
 export class TaskManagerBehavior extends Behavior {
@@ -99,35 +60,12 @@ export class TaskManagerBehavior extends Behavior {
         this.internal.registry = new TaskRegistry();
         this.internal.live = new Map();
         this.internal.gates = new Map();
-        this.#adoptInheritedTerminals();
         this.#registerBuiltins();
         // Driving acts on the node, so the resume pass must wait until the node is online.
         if (this.#rootNode.lifecycle.isOnline) {
             this.#resumePersisted();
         } else {
             this.reactTo(this.#rootNode.lifecycle.online, this.#resumePersisted);
-        }
-    }
-
-    /**
-     * Adopt terminal records from a previous start into the retention queue, dropping those beyond
-     * {@link terminalRetention} so a controller that restarts often does not accumulate finished tasks in storage
-     * forever. Their relative age is unknown, hence storage order.
-     */
-    #adoptInheritedTerminals(): void {
-        const inherited = Object.entries(this.state.tasks)
-            .filter(([, p]) => TERMINAL_STATES.has(p.state))
-            .map(([id]) => id);
-        const excess = inherited.length - this.terminalRetention;
-        if (excess > 0) {
-            const tasks = { ...this.state.tasks };
-            for (const id of inherited.splice(0, excess)) {
-                delete tasks[id];
-            }
-            this.state.tasks = tasks;
-        }
-        for (const id of inherited) {
-            this.internal.terminated.add(id);
         }
     }
 
@@ -168,24 +106,16 @@ export class TaskManagerBehavior extends Behavior {
         this.#resumeType(type);
     }
 
-    /**
-     * Load the persisted tasks of a registered type. A non-terminal task resumes driving; a terminal one becomes
-     * observable history — visible to {@link get} and {@link tasks} and still cancellable through its recorded
-     * changeSet — but is never driven again.
-     */
+    /** Resume persisted, non-terminal, not-yet-live tasks of a registered type. */
     #resumeType(type: string): void {
         if (!this.internal.registry.has(type)) {
             return;
         }
         for (const [id, p] of Object.entries(this.state.tasks)) {
-            if (p.type !== type || this.internal.live.has(id)) {
+            if (p.type !== type || TERMINAL_STATES.has(p.state) || this.internal.live.has(id)) {
                 continue;
             }
             const task = this.internal.registry.create(type, id, p.params, p);
-            if (TERMINAL_STATES.has(p.state)) {
-                this.internal.live.set(id, task);
-                continue;
-            }
             // A persisted `parked` task must re-drive; #drive only advances `running` tasks, and the phase's
             // gate re-parks from live reachability if the peer is still offline.
             if (task.progress.state === "parked") {
@@ -215,42 +145,32 @@ export class TaskManagerBehavior extends Behavior {
     }
 
     /**
-     * Start `type` with `params`, or join the live task an identical request already started. An `externalId`
-     * becomes an id this task answers to, whether the request started it or joined it, so every caller can
-     * observe and {@link cancel} the work it asked for. Ids are exclusive among unfinished work: one that
-     * already names another live task is refused rather than silently resolving elsewhere.
+     * Start `type` with `params`. The task's id is derived from type and params, and only one live task may hold
+     * it: a caller that passes an `externalId` re-issues its own request idempotently, and any other request for
+     * an id a live task already holds is refused rather than silently resolving onto work it did not ask for.
+     * The `externalId` is also the id the caller can {@link get} and {@link cancel} its task under.
      */
     run(type: string, params: unknown, opts?: { externalId?: string }): TaskHandle {
-        return this.#handle(this.#spawn(type, params, {}, opts?.externalId));
+        return this.#handle(this.#spawn(type, params, { externalId: opts?.externalId }));
     }
 
     /** Shared creation path so callers (e.g. #spawnRevert) can seed persisted fields before the first persist. */
-    #spawn(type: string, params: unknown, seed: Partial<TaskPersistence>, externalId?: string): Task {
+    #spawn(type: string, params: unknown, seed: Partial<TaskPersistence>): Task {
         const id = this.internal.registry.idFor(type, params);
         // Driving started now would outlive the dispose drain and write to peers after close, with no way to
         // record what it did.
         this.#refuseIfClosing(`Task ${id} cannot start`);
-        // A cancel of this id is mid-flight: deduping would hand the caller a task that is being torn down, and
+        // A cancel of this id is mid-flight: joining would hand the caller a task that is being torn down, and
         // replacing it would take over bookkeeping the cancel is still waiting on.
         if (this.internal.cancelling.has(id)) {
             throw new TaskConflictError(`Task ${id} rejected: a cancel of this task is still in flight`);
         }
-        if (externalId !== undefined) {
-            this.#requireClaimableExternalId(externalId, id);
-        }
         const existing = this.internal.live.get(id);
         if (existing !== undefined && !TERMINAL_STATES.has(existing.progress.state)) {
-            // Only an identical request is idempotent; reusing the id with other values would apply neither the
-            // running task's parameters nor the new ones the caller asked for.
-            if (!this.#sameParams(existing.params, params)) {
+            if (seed.externalId === undefined || seed.externalId !== existing.externalId) {
                 throw new TaskConflictError(
-                    `Task ${id} rejected: a live task with this id is running with different parameters`,
+                    `Task ${id} rejected: this id is held by a live task (${existing.progress.state})`,
                 );
-            }
-            if (externalId !== undefined && !existing.externalIds.has(externalId)) {
-                existing.externalIds.add(externalId);
-                // The joining caller's id must outlive this process, or a restart hands it a handle onto nothing.
-                this.#mutex.run(() => this.#writeRecord(existing));
             }
             return existing;
         }
@@ -261,9 +181,6 @@ export class TaskManagerBehavior extends Behavior {
             );
         }
         const task = this.internal.registry.create(type, id, params, seed);
-        if (externalId !== undefined) {
-            task.externalIds.add(externalId);
-        }
         // Synchronous exclusivity check: no await between reading `live` and live.set below, so there is no TOCTOU
         // window. The just-created task is discarded on throw (never tracked or persisted).
         const rk = task.resourceKey();
@@ -276,35 +193,9 @@ export class TaskManagerBehavior extends Behavior {
                 }
             }
         }
-        // A replaced terminal task must leave the retention queue with it, or its eviction would later drop the
-        // fresh task that now holds the id.
-        this.internal.terminated.delete(id);
         this.internal.live.set(id, task);
         this.#track(task);
         return task;
-    }
-
-    /**
-     * An external id must resolve to the task the caller asked for and to nothing else, so it may not name any
-     * retained task's own id, nor already belong to other unfinished work. A finished task keeps the ids it ran
-     * under, and {@link #find} prefers the live holder, so history does not block reuse of an id.
-     */
-    #requireClaimableExternalId(externalId: string, id: string): void {
-        const conflict = this.internal.live.get(externalId) ?? this.#liveHolderOf(externalId);
-        if (conflict !== undefined && conflict.id !== id) {
-            throw new TaskConflictError(
-                `Task ${id} rejected: external id "${externalId}" already refers to task ${conflict.id}`,
-            );
-        }
-    }
-
-    #liveHolderOf(externalId: string): Task | undefined {
-        for (const t of this.internal.live.values()) {
-            if (t.externalIds.has(externalId) && !TERMINAL_STATES.has(t.progress.state)) {
-                return t;
-            }
-        }
-        return undefined;
     }
 
     /** A rollback rewrites exactly the intents a re-run would re-apply, so the two must never overlap. */
@@ -315,14 +206,6 @@ export class TaskManagerBehavior extends Behavior {
             }
         }
         return undefined;
-    }
-
-    /**
-     * Whether two parameter sets describe the same request, compared as storage would hand them back: a resumed
-     * task's parameters would otherwise never match the request that started it.
-     */
-    #sameParams(a: unknown, b: unknown): boolean {
-        return isDeepEqual(asStored(a), asStored(b));
     }
 
     // A revert has no resourceKey of its own (so it is never rejected), but it rewrites the intents in its
@@ -349,19 +232,12 @@ export class TaskManagerBehavior extends Behavior {
         if (byId !== undefined) {
             return byId;
         }
-        // Finished work keeps the ids it ran under, so an id can have several holders: the live one is the one
-        // meant by it, and among finished ones the most recent.
-        let retained: Task | undefined;
         for (const t of this.internal.live.values()) {
-            if (!t.externalIds.has(idOrExternalId)) {
-                continue;
-            }
-            if (!TERMINAL_STATES.has(t.progress.state)) {
+            if (t.externalId === idOrExternalId) {
                 return t;
             }
-            retained = t;
         }
-        return retained;
+        return undefined;
     }
 
     #handle(task: Task): TaskHandle {
@@ -380,8 +256,7 @@ export class TaskManagerBehavior extends Behavior {
      * via the returned handle.
      *
      * Each outcome has exactly one meaning: a handle is the rollback, `undefined` is a task with nothing to roll
-     * back, and {@link TaskNotFoundError} is an id no retained task answers to (including a task whose recorded
-     * rollback retention has since forgotten).
+     * back, and {@link TaskNotFoundError} is an id no live task answers to.
      *
      * Throws {@link TaskManagerClosingError} if shutdown intervenes before the cancel can be recorded; the task
      * then keeps its non-terminal state and the cancel must be re-issued after the next start.
@@ -389,7 +264,7 @@ export class TaskManagerBehavior extends Behavior {
     async cancel(idOrExternalId: string): Promise<TaskHandle | undefined> {
         const task = this.#find(idOrExternalId);
         if (task === undefined) {
-            throw new TaskNotFoundError(`Cannot cancel "${idOrExternalId}": no task is retained under that id`);
+            throw new TaskNotFoundError(`Cannot cancel "${idOrExternalId}": no live task answers to that id`);
         }
         if (task.progress.state === "cancelled") {
             const revert = this.#revertOf(task);
@@ -467,16 +342,15 @@ export class TaskManagerBehavior extends Behavior {
         return revert;
     }
 
-    /** The rollback a task recorded, or undefined if it never had one. A record retention forgot is not "none". */
+    /** The rollback a task recorded, or undefined if it never had one. */
     #revertOf(task: Task): Task | undefined {
         if (task.revertTaskId === undefined) {
             return undefined;
         }
         const revert = this.#find(task.revertTaskId);
+        // `undefined` means "nothing to roll back", so a rollback that cannot be resolved must not read as that.
         if (revert === undefined) {
-            throw new TaskNotFoundError(
-                `Task ${task.id} names rollback ${task.revertTaskId}, which is no longer retained`,
-            );
+            throw new TaskNotFoundError(`Task ${task.id} names rollback ${task.revertTaskId}, which is not live`);
         }
         return revert;
     }
@@ -661,69 +535,15 @@ export class TaskManagerBehavior extends Behavior {
     // A task that names a revert and the revert itself go into one transaction: written separately, a crash
     // between the two loses the rollback while the forward record still promises it.
     async #writeRecord(task: Task, paired?: Task): Promise<void> {
-        const written = paired === undefined ? [task] : [task, paired];
+        const records = (paired === undefined ? [task] : [task, paired]).map(t => [t.id, t.toPersistence()] as const);
         await this.endpoint.act(agent => {
-            // Records, retention decision and its bookkeeping belong to one transaction: a task re-run between them
-            // would leave the queue disagreeing with the records, and a write that never gets here must touch
-            // neither.
-            const records = written.map(t => [t.id, t.toPersistence()] as const);
-            const retention = this.#planRetention(written);
             const self = agent.get(TaskManagerBehavior);
             const tasks = { ...self.state.tasks };
-            for (const id of retention.forgotten) {
-                delete tasks[id];
-            }
             for (const [id, record] of records) {
                 tasks[id] = record;
             }
             self.state.tasks = tasks;
-            this.#applyRetention(retention);
         });
-    }
-
-    /**
-     * Number of terminal tasks kept for observation through {@link get} and {@link tasks} before the oldest are
-     * forgotten. The bound covers retained records, which a restart makes observable again as soon as their type
-     * is registered. Override to tune how much finished history a controller retains.
-     */
-    protected get terminalRetention(): number {
-        return 50;
-    }
-
-    /**
-     * Choose the retention effect of one transaction: the tasks it retires and the oldest ids to forget beyond
-     * {@link terminalRetention}, so finished work stays observable for a while without growing without bound.
-     * The forgotten ids leave persisted state in the same write; {@link #applyRetention} commits the rest.
-     */
-    #planRetention(written: Task[]): RetentionPlan {
-        const retired = written.filter(
-            // A re-run may already own this id: retiring the previous run would expose the live task to eviction.
-            task => TERMINAL_STATES.has(task.progress.state) && this.internal.live.get(task.id) === task,
-        );
-        const queued = new Set([...this.internal.terminated, ...retired.map(task => task.id)]);
-        const writing = new Set(written.map(task => task.id));
-        const forgotten = new Array<string>();
-        for (const id of queued) {
-            if (queued.size - forgotten.length <= this.terminalRetention) {
-                break;
-            }
-            // An id this transaction writes may not be forgotten by it: the record would survive in storage while
-            // leaving both `live` and the queue, so nothing could observe or ever prune it again.
-            if (!writing.has(id)) {
-                forgotten.push(id);
-            }
-        }
-        return { retired: retired.map(task => task.id), forgotten };
-    }
-
-    #applyRetention({ retired, forgotten }: RetentionPlan): void {
-        for (const id of retired) {
-            this.internal.terminated.add(id);
-        }
-        for (const id of forgotten) {
-            this.internal.terminated.delete(id);
-            this.internal.live.delete(id);
-        }
     }
 
     override async [Symbol.asyncDispose]() {
@@ -753,7 +573,6 @@ export namespace TaskManagerBehavior {
         gates!: Map<string, GateState>;
         driving = new Map<string, Promise<void>>();
         cancelling = new Set<string>();
-        terminated = new Set<string>();
         persistMutex?: Mutex;
     }
 

--- a/packages/node-manager/src/task/errors.ts
+++ b/packages/node-manager/src/task/errors.ts
@@ -20,10 +20,10 @@ export class TaskCapacityExceededError extends TaskError {}
 /** cancel() was refused: the task passed its point of no return (e.g. a realized group-key rotation). */
 export class TaskNotRevertibleError extends TaskError {}
 
-/** A new task was rejected because a live non-terminal task already holds its exclusive resource. */
+/** A new task was rejected because live work already holds its id, its rollback or an exclusive resource. */
 export class TaskConflictError extends TaskError {}
 
-/** No task is retained under the given id or external id, so there is nothing to observe or act on. */
+/** No live task answers to the given id or external id, so there is nothing to observe or act on. */
 export class TaskNotFoundError extends TaskError {}
 
 /** A task refused to run because a member's current intent violates a required precondition. */

--- a/packages/node-manager/src/task/errors.ts
+++ b/packages/node-manager/src/task/errors.ts
@@ -23,8 +23,17 @@ export class TaskNotRevertibleError extends TaskError {}
 /** A new task was rejected because a live non-terminal task already holds its exclusive resource. */
 export class TaskConflictError extends TaskError {}
 
+/** No task is retained under the given id or external id, so there is nothing to observe or act on. */
+export class TaskNotFoundError extends TaskError {}
+
 /** A task refused to run because a member's current intent violates a required precondition. */
 export class RotationPreconditionError extends TaskError {}
+
+/**
+ * A request was refused because the manager is shutting down and could not record its outcome. A cancelled task
+ * keeps the non-terminal state it had, so the request must be re-issued after the next start.
+ */
+export class TaskManagerClosingError extends TaskError {}
 
 /** Internal signal a running gate throws when cancel is requested, so #drive stops cleanly (not "failed"). */
 export class TaskCancelledSignal extends TaskError {}

--- a/packages/node-manager/src/task/groups/RotateGroupKey.ts
+++ b/packages/node-manager/src/task/groups/RotateGroupKey.ts
@@ -90,6 +90,21 @@ export class RotateGroupKey extends Task<RotateGroupKeyParams> {
                 }
             }
         }
+        // A member is re-derived per phase, so one whose intent appeared after distribute would activate without
+        // holding the new key and could not decrypt traffic from members that already flipped to it.
+        if (phase === "activate") {
+            for (const peer of members) {
+                const current = this.#currentIntent(peer);
+                if (current === undefined || !this.#holdsNewKey(current)) {
+                    throw new RotationPreconditionError(
+                        `Cannot activate group key set ${this.params.groupKeySetId}: peer ${peer.id} does not hold ` +
+                            `this rotation's new key, so it joined the key set after the distribute phase. The ` +
+                            `distributed keys remain dormant; rotate again with a new rotation id so every member ` +
+                            `receives the key before activation.`,
+                    );
+                }
+            }
+        }
         for (const peer of members) {
             await ctx.setIntent(peer, "groupKey", key, this.#struct(peer, phase), "converge");
         }
@@ -104,9 +119,11 @@ export class RotateGroupKey extends Task<RotateGroupKeyParams> {
     // A single-key steady state is the required starting point; a member already carrying THIS rotation's new key in
     // slot 1 is our own distribute output on a park/resume re-drive, not a foreign multi-epoch keyset, so accept it.
     #isRotatable(current: GroupKeyGrant): boolean {
-        if (isSingleKeySteadyState(current)) {
-            return true;
-        }
+        return isSingleKeySteadyState(current) || this.#holdsNewKey(current);
+    }
+
+    /** Whether the member carries this rotation's new key in slot 1 — the output of distribute or of activate. */
+    #holdsNewKey(current: GroupKeyGrant): boolean {
         const slot1 = current.epochKey1;
         return slot1 !== null && slot1 !== undefined && Bytes.areEqual(slot1, this.params.newEpochKey);
     }

--- a/packages/node-manager/src/task/groups/RotateGroupKey.ts
+++ b/packages/node-manager/src/task/groups/RotateGroupKey.ts
@@ -93,22 +93,45 @@ export class RotateGroupKey extends Task<RotateGroupKeyParams> {
         // A member is re-derived per phase, so one whose intent appeared after distribute would activate without
         // holding the new key and could not decrypt traffic from members that already flipped to it.
         if (phase === "activate") {
-            for (const peer of members) {
-                const current = this.#currentIntent(peer);
-                if (current === undefined || !this.#holdsNewKey(current)) {
-                    throw new RotationPreconditionError(
-                        `Cannot activate group key set ${this.params.groupKeySetId}: peer ${peer.id} does not hold ` +
-                            `this rotation's new key, so it joined the key set after the distribute phase. The ` +
-                            `distributed keys remain dormant; rotate again with a new rotation id so every member ` +
-                            `receives the key before activation.`,
-                    );
-                }
+            const late = this.#memberWithoutNewKey(ctx, key);
+            if (late !== undefined) {
+                throw new RotationPreconditionError(
+                    `Cannot activate group key set ${this.params.groupKeySetId}: peer ${late.id} does not hold ` +
+                        `this rotation's new key, so it joined the key set after the distribute phase. The ` +
+                        `distributed keys remain dormant; rotate again with this same new key so every member ` +
+                        `receives it before activation.`,
+                );
             }
         }
         for (const peer of members) {
             await ctx.setIntent(peer, "groupKey", key, this.#struct(peer, phase), "converge");
         }
         await ctx.awaitCommitted(members.map(peer => ({ peer, kind: "groupKey", key })));
+        // The writes and the barrier above both yield, and provisioning a group takes no lock on its key set, so
+        // the member set can grow after the check at phase entry.
+        if (phase === "activate") {
+            const late = this.#memberWithoutNewKey(ctx, key);
+            if (late !== undefined) {
+                throw new RotationPreconditionError(
+                    `Cannot complete activation of group key set ${this.params.groupKeySetId}: peer ${late.id} ` +
+                        `joined the key set during the activate phase and does not hold this rotation's new key, ` +
+                        `so it cannot decrypt traffic from the members that already transmit with it. The old key ` +
+                        `is still present on those members; rotate again with this same new key, which covers ` +
+                        `every current member.`,
+                );
+            }
+        }
+    }
+
+    /** A member holding an intent for this key set that does not carry this rotation's new key, if there is one. */
+    #memberWithoutNewKey(ctx: TaskContext, key: string): ClientNode | undefined {
+        for (const peer of ctx.peersWithIntent("groupKey", key)) {
+            const current = this.#currentIntent(peer);
+            if (current === undefined || !this.#holdsNewKey(current)) {
+                return peer;
+            }
+        }
+        return undefined;
     }
 
     #currentIntent(peer: ClientNode): GroupKeyGrant | undefined {

--- a/packages/node-manager/src/task/groups/RotateGroupKey.ts
+++ b/packages/node-manager/src/task/groups/RotateGroupKey.ts
@@ -17,7 +17,11 @@ export const ROTATE_GROUP_KEY_TYPE = "rotateGroupKey";
 export interface RotateGroupKeyParams {
     groupKeySetId: number;
     newEpochKey: Uint8Array;
-    /** Unique per rotation operation; re-issuing the same rotationId is idempotent, a new one starts a new rotation. */
+    /**
+     * Unique per rotation operation: a new `rotationId` starts a new rotation. Re-issuing a live one is refused
+     * unless the request carries the `externalId` that rotation was started under; once it is terminal, the same
+     * `rotationId` may be run again.
+     */
     rotationId: string;
     groupKeySecurityPolicy?: GroupKeyManagement.GroupKeySecurityPolicy;
 }

--- a/packages/node-manager/src/task/types.ts
+++ b/packages/node-manager/src/task/types.ts
@@ -12,8 +12,8 @@ export interface TaskStatus {
     type: string;
     state: TaskState;
     phaseIndex: number;
-    /** Every id a caller of `run` asked for this task under, in the order they arrived. */
-    externalIds: string[];
+    /** Id the caller of `run` asked for this task under, if it supplied one. */
+    externalId?: string;
     error?: string;
     revertTaskId?: string;
     revertOf?: string;

--- a/packages/node-manager/src/task/types.ts
+++ b/packages/node-manager/src/task/types.ts
@@ -12,7 +12,8 @@ export interface TaskStatus {
     type: string;
     state: TaskState;
     phaseIndex: number;
-    externalId?: string;
+    /** Every id a caller of `run` asked for this task under, in the order they arrived. */
+    externalIds: string[];
     error?: string;
     revertTaskId?: string;
     revertOf?: string;

--- a/packages/node-manager/test/task/CancelRobustnessTest.ts
+++ b/packages/node-manager/test/task/CancelRobustnessTest.ts
@@ -264,19 +264,22 @@ describe("cancel robustness", () => {
         const node = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-rerun" });
         await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
 
-        // The re-run is attempted while the cancelled task unwinds, i.e. while cancel() waits on its drive.
+        // The re-run is attempted while the cancelled task unwinds, i.e. while cancel() waits on its drive. It
+        // re-issues under the external id the task runs with, so only the cancel in flight can refuse it.
         let rerun: unknown = "not attempted";
         SyntheticTask.phasesByTag["cancelrerun"] = [
             slowUnwindGatePhase("cx", "groupMembership", "C", async () => {
                 try {
-                    rerun = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "cancelrerun" }));
+                    rerun = await node.act(a =>
+                        a.get(TestTaskManager).run("synthetic", { tag: "cancelrerun" }, { externalId: "own" }),
+                    );
                 } catch (e) {
                     rerun = e;
                 }
             }),
         ];
 
-        await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "cancelrerun" }));
+        await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "cancelrerun" }, { externalId: "own" }));
         await pumpUntil("intent written", () => peer.items[itemMapKey("groupMembership", "C")] !== undefined);
 
         const handle = await MockTime.resolve(node.act(a => a.get(TestTaskManager).cancel("synthetic:cancelrerun")));

--- a/packages/node-manager/test/task/CancelRobustnessTest.ts
+++ b/packages/node-manager/test/task/CancelRobustnessTest.ts
@@ -5,7 +5,7 @@
  */
 
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
-import { TaskConflictError, TaskManagerClosingError } from "#task/errors.js";
+import { TaskConflictError, TaskFailedError, TaskManagerClosingError } from "#task/errors.js";
 import { TaskPersistence } from "#task/Task.js";
 import { TaskHandle, TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { TaskPhase, TaskState } from "#task/types.js";
@@ -32,6 +32,23 @@ class TestTaskManager extends TaskManagerBehavior {
     /** True once cancel() has accepted the request, before it settles. */
     isCancelling(id: string): boolean {
         return this.internal.cancelling.has(id);
+    }
+
+    /** True while a task's drive promise has not settled. */
+    isDriven(id: string): boolean {
+        return this.internal.driving.has(id);
+    }
+
+    /** Occupy the persist mutex so the next persist queues behind the returned release. */
+    holdPersistMutex(): () => void {
+        const mutex = this.internal.persistMutex;
+        if (mutex === undefined) {
+            throw new Error("The persist mutex does not exist yet; run a task first");
+        }
+        let release!: () => void;
+        const held = new Promise<void>(resolve => (release = resolve));
+        mutex.run(() => held);
+        return release;
     }
 
     protected override taskReconciler(): ReconcilerBehavior {
@@ -337,6 +354,51 @@ describe("cancel robustness", () => {
         await node2.close();
     });
 
+    it("refuses a cancel whose record cannot be written because shutdown began while it queued", async () => {
+        const environment = new Environment("test");
+        const peer = new FakePeer("qw");
+        TestTaskManager.peers.set("qw", peer);
+        TestTaskManager.reconcilerPeer = peer;
+
+        SyntheticTask.phasesByTag["queued"] = [gatePhase("qw", "groupMembership", "Q")];
+
+        const node1 = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-queued" });
+        await node1.act(a => a.get(TestTaskManager).register("synthetic", TracedTask));
+        let manager!: TestTaskManager;
+        await node1.act(a => {
+            manager = a.get(TestTaskManager);
+        });
+        await node1.act(a => a.get(TestTaskManager).run("synthetic", { tag: "queued" }));
+        await pumpUntil("intent written", () => peer.items[itemMapKey("groupMembership", "Q")] !== undefined);
+
+        // Hold the mutex so the cancel's write cannot run when it is enqueued, then start shutdown in that window:
+        // a synchronous check before the enqueue cannot see the shutdown that begins after it.
+        const release = await node1.act(a => a.get(TestTaskManager).holdPersistMutex());
+        const cancelling = node1.act(a => a.get(TestTaskManager).cancel("synthetic:queued"));
+        await pumpUntil("cancel write enqueued", () => manager.get("synthetic:queued")?.status.state === "cancelled");
+
+        const closing = node1.close();
+        await pumpUntil("node no longer active", () => node1.construction.status !== Lifecycle.Status.Active);
+        release();
+
+        await expect(MockTime.resolve(cancelling)).rejectedWith(TaskManagerClosingError);
+        await MockTime.resolve(closing);
+
+        // The refused write leaves no trace: state as it was, no rollback linked, none live, nothing rolled back.
+        const task = TracedTask.instance("synthetic:queued");
+        expect(task.progress.state).equals("running");
+        expect(task.revertTaskId).equals(undefined);
+        expect(manager.tasks.map(t => t.id)).deep.equals(["synthetic:queued"]);
+        expect(peer.removeOrder).deep.equals([]);
+
+        const node2 = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-queued" });
+        const persisted = node2.stateOf(TestTaskManager).tasks;
+        expect(persisted["synthetic:queued"].state).equals("running");
+        expect(persisted["synthetic:queued"].revertTaskId).equals(undefined);
+        expect(persisted["revert:synthetic:queued"]).equals(undefined);
+        await node2.close();
+    });
+
     it("does not report a crashed manager as shutting down", async () => {
         const environment = new Environment("test");
         const peer = new FakePeer("cd");
@@ -408,6 +470,51 @@ describe("cancel robustness", () => {
         expect(persisted["synthetic:shutfail"].state).equals("running");
         expect(persisted["revert:synthetic:shutfail"]).equals(undefined);
         await node2.close();
+    });
+
+    it("leaves no rollback behind when a failure state cannot be recorded", async () => {
+        const environment = new Environment("test");
+        const peer = new FakePeer("cf");
+        TestTaskManager.peers.set("cf", peer);
+        TestTaskManager.reconcilerPeer = peer;
+
+        let releasePhase!: () => void;
+        const held = new Promise<void>(resolve => (releasePhase = resolve));
+        let phaseEntered = false;
+        SyntheticTask.phasesByTag["failwrite"] = [
+            {
+                name: "touch",
+                run: async ctx => {
+                    await ctx.setIntent(ctx.resolvePeer("cf"), "groupMembership", "W", {});
+                    phaseEntered = true;
+                    await held;
+                    throw new TaskFailedError("forced failure");
+                },
+            },
+        ];
+
+        const node = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-failwrite" });
+        await node.act(a => a.get(TestTaskManager).register("synthetic", TracedTask));
+        let manager!: TestTaskManager;
+        await node.act(a => {
+            manager = a.get(TestTaskManager);
+        });
+        await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "failwrite" }));
+        await pumpUntil("phase in flight", () => phaseEntered);
+
+        // The task fails against a crashed node, so neither the failure nor a rollback of it can be recorded.
+        node.construction.setStatus(Lifecycle.Status.Crashed);
+        releasePhase();
+        await pumpUntil("drive settled", () => !manager.isDriven("synthetic:failwrite"));
+        expect(manager.get("synthetic:failwrite")?.status.state).equals("failed");
+
+        // A rollback the record does not name must not exist: it would block every future run of the id, and
+        // nothing would ever drive it.
+        expect(manager.get("synthetic:failwrite")?.status.revertTaskId).equals(undefined);
+        expect(manager.tasks.map(t => t.id)).deep.equals(["synthetic:failwrite"]);
+        expect(peer.removeOrder).deep.equals([]);
+
+        await node.close();
     });
 
     it("refuses a task started while the manager is shutting down", async () => {

--- a/packages/node-manager/test/task/CancelRobustnessTest.ts
+++ b/packages/node-manager/test/task/CancelRobustnessTest.ts
@@ -1,0 +1,531 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
+import { TaskConflictError, TaskManagerClosingError } from "#task/errors.js";
+import { TaskPersistence } from "#task/Task.js";
+import { TaskHandle, TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
+import { TaskPhase, TaskState } from "#task/types.js";
+import { CrashedDependencyError, Environment, Lifecycle, MaybePromise } from "@matter/general";
+import { Behavior, ClientNode, ItemKind, itemMapKey } from "@matter/node";
+import { MockServerNode } from "@matter/node/testing";
+import { FakePeer, SyntheticTask } from "./helpers.js";
+
+class TestTaskManager extends TaskManagerBehavior {
+    static override readonly schema = TaskManagerBehavior.schema;
+    static peers = new Map<string, FakePeer>();
+    static reconcilerPeer?: FakePeer;
+
+    /** Fires while the driver builds a phase context: the gate exists but the phase has not run yet. */
+    static atContext?: (manager: TestTaskManager) => void;
+
+    /** Fires before the shutdown abort pass, so a test can release a task into the pre-gate window. */
+    static atShutdown?: (manager: TestTaskManager) => void;
+
+    protected override resolvePeerNode(peerId: string): ClientNode | undefined {
+        return TestTaskManager.peers.get(peerId)?.asNode();
+    }
+
+    /** True once cancel() has accepted the request, before it settles. */
+    isCancelling(id: string): boolean {
+        return this.internal.cancelling.has(id);
+    }
+
+    protected override taskReconciler(): ReconcilerBehavior {
+        TestTaskManager.atContext?.(this);
+        return TestTaskManager.reconcilerPeer as unknown as ReconcilerBehavior;
+    }
+
+    override async [Symbol.asyncDispose]() {
+        TestTaskManager.atShutdown?.(this);
+        await super[Symbol.asyncDispose]();
+    }
+}
+
+/** SyntheticTask that keeps its instances reachable, so a test can inspect task state after the node is gone. */
+class TracedTask extends SyntheticTask {
+    static instances = new Array<TracedTask>();
+
+    /** The state of every record written for this task, in order. */
+    readonly persistedStates = new Array<TaskState>();
+
+    constructor(id: string, params: { tag: string }, persisted?: Partial<TaskPersistence>) {
+        super(id, params, persisted);
+        TracedTask.instances.push(this);
+    }
+
+    override toPersistence(): TaskPersistence {
+        const record = super.toPersistence();
+        this.persistedStates.push(record.state);
+        return record;
+    }
+    static instance(id: string): TracedTask {
+        const found = TracedTask.instances.filter(t => t.id === id);
+        expect(found.length).equals(1);
+        return found[0];
+    }
+}
+
+/**
+ * Registers a task type from its own teardown. Declaring the manager a dependency closes this behavior first,
+ * which is the window that matters: the manager is closing but its state is still readable, so an unguarded
+ * register() gets as far as resuming and driving.
+ */
+class ShutdownRegistrarBehavior extends Behavior {
+    static override readonly id = "shutdownRegistrar";
+    static override readonly early = true;
+    static override readonly dependencies = [TestTaskManager];
+    static atClose?: (manager: TestTaskManager) => void;
+
+    override async [Symbol.asyncDispose]() {
+        ShutdownRegistrarBehavior.atClose?.(this.agent.get(TestTaskManager));
+        await super[Symbol.asyncDispose]?.();
+    }
+}
+
+const RootEndpoint = MockServerNode.RootEndpoint.with(TestTaskManager);
+
+const RegistrarRootEndpoint = MockServerNode.RootEndpoint.with(TestTaskManager, ShutdownRegistrarBehavior);
+
+async function pumpUntil(name: string, condition: () => MaybePromise<boolean>) {
+    for (let i = 0; i < 10_000; i++) {
+        if (await condition()) {
+            return;
+        }
+        await MockTime.advance(1);
+    }
+    throw new Error(`Condition "${name}" never held`);
+}
+
+/** A phase that sets an intent then gates on it committing; the device never "has" it, so the gate parks. */
+function gatePhase(peerId: string, kind: string, key: string): TaskPhase {
+    return {
+        name: "gate",
+        run: async ctx => {
+            const peer = ctx.resolvePeer(peerId);
+            await ctx.setIntent(peer, kind, key, {});
+            await ctx.awaitCommitted([{ peer, kind, key }]);
+        },
+    };
+}
+
+/** Like {@link gatePhase}, but holds the driver inside the phase while it unwinds from an abort. */
+function slowUnwindGatePhase(peerId: string, kind: string, key: string, unwinding: () => Promise<void>): TaskPhase {
+    return {
+        name: "gate",
+        run: async ctx => {
+            const peer = ctx.resolvePeer(peerId);
+            await ctx.setIntent(peer, kind, key, {});
+            try {
+                await ctx.awaitCommitted([{ peer, kind, key }]);
+            } catch (e) {
+                await unwinding();
+                throw e;
+            }
+        },
+    };
+}
+
+/**
+ * A peer whose capacity read blocks until released, holding a task in the driver's pre-gate window
+ * (admission and first persist, before a phase has built its gate).
+ */
+function blockingAdmissionPeer(id: string) {
+    let release!: () => void;
+    const blocked = new Promise<void>(resolve => (release = resolve));
+    const state = { entered: false, release: () => release() };
+    const peer = new FakePeer(id);
+    peer.itemKind = (kind: string): ItemKind | undefined =>
+        kind === "cap"
+            ? {
+                  kind: "cap",
+                  priority: 0,
+                  async apply() {},
+                  async capacity() {
+                      state.entered = true;
+                      await blocked;
+                      return { limit: 10, used: 0 };
+                  },
+              }
+            : undefined;
+    return { peer, state };
+}
+
+describe("cancel robustness", () => {
+    before(() => MockTime.init());
+
+    it("a cancel accepted before the task's first gate exists takes effect and settles", async () => {
+        const environment = new Environment("test");
+        const { peer, state } = blockingAdmissionPeer("pg");
+        TestTaskManager.peers.set("pg", peer);
+        TestTaskManager.reconcilerPeer = peer;
+
+        SyntheticTask.plannedChangesByTag["pregate"] = [{ peerId: "pg", kind: "cap", key: "x", intent: {} }];
+        SyntheticTask.phasesByTag["pregate"] = [gatePhase("pg", "groupMembership", "X")];
+
+        const node = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-pregate" });
+        await node.act(a => a.get(TestTaskManager).register("synthetic", TracedTask));
+        await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "pregate" }));
+        await pumpUntil("admission in flight", () => state.entered);
+
+        const cancelling = node.act(a => a.get(TestTaskManager).cancel("synthetic:pregate"));
+        await pumpUntil("cancel accepted", () =>
+            node.act(a => a.get(TestTaskManager).isCancelling("synthetic:pregate")),
+        );
+        state.release();
+
+        const handle = await MockTime.resolve(cancelling);
+
+        // Nothing was written to the peer after the cancel was accepted, so there is nothing to revert.
+        expect(peer.items[itemMapKey("groupMembership", "X")]).equals(undefined);
+        expect(handle).equals(undefined);
+
+        const status = await node.act(a => a.get(TestTaskManager).get("synthetic:pregate")?.status);
+        expect(status?.state).equals("cancelled");
+        expect(node.stateOf(TestTaskManager).tasks["synthetic:pregate"].state).equals("cancelled");
+
+        // The only record ever written is the cancelled one: a task whose cancel is already accepted must not be
+        // stored as running, which a crash before the cancel completes would resume.
+        expect(TracedTask.instance("synthetic:pregate").persistedStates).deep.equals(["cancelled"]);
+
+        await node.close();
+    });
+
+    it("a cancel accepted between phase context and phase run issues no device write", async () => {
+        const environment = new Environment("test");
+        const peer = new FakePeer("cr");
+        TestTaskManager.peers.set("cr", peer);
+        TestTaskManager.reconcilerPeer = peer;
+
+        SyntheticTask.phasesByTag["ctxrace"] = [gatePhase("cr", "groupMembership", "Z")];
+
+        const node = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-ctxrace" });
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+
+        let cancelling: Promise<TaskHandle | undefined> | undefined;
+        TestTaskManager.atContext = manager => {
+            TestTaskManager.atContext = undefined;
+            cancelling = manager.cancel("synthetic:ctxrace");
+        };
+        try {
+            await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "ctxrace" }));
+            await pumpUntil("cancel issued from phase context", () => cancelling !== undefined);
+        } finally {
+            TestTaskManager.atContext = undefined;
+        }
+
+        const handle = await MockTime.resolve(cancelling);
+
+        expect(peer.items[itemMapKey("groupMembership", "Z")]).equals(undefined);
+        expect(handle).equals(undefined);
+        const status = await node.act(a => a.get(TestTaskManager).get("synthetic:ctxrace")?.status);
+        expect(status?.state).equals("cancelled");
+
+        await node.close();
+    });
+
+    it("has the revert persisted by the time cancel resolves", async () => {
+        const environment = new Environment("test");
+        const peer = new FakePeer("dp");
+        TestTaskManager.peers.set("dp", peer);
+        TestTaskManager.reconcilerPeer = peer;
+        peer.markHas("groupMembership", "D");
+
+        SyntheticTask.phasesByTag["durable"] = [gatePhase("dp", "groupMembership", "D")];
+
+        const node = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-durable" });
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+        await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "durable" }));
+        await pumpUntil("task complete", async () => {
+            const state = await node.act(a => a.get(TestTaskManager).state.tasks["synthetic:durable"]?.state);
+            return state === "completed";
+        });
+
+        const handle = await MockTime.resolve(node.act(a => a.get(TestTaskManager).cancel("synthetic:durable")));
+        expect(handle?.id).equals("revert:synthetic:durable");
+
+        // A promised revert that is not yet durable is lost to a crash while the forward record already names it.
+        const persisted = node.stateOf(TestTaskManager).tasks;
+        expect(persisted["synthetic:durable"].revertTaskId).equals("revert:synthetic:durable");
+        expect(persisted["revert:synthetic:durable"]).not.equals(undefined);
+
+        await node.close();
+    });
+
+    it("refuses a re-run of an id whose cancel is still settling", async () => {
+        const environment = new Environment("test");
+        const peer = new FakePeer("cx");
+        TestTaskManager.peers.set("cx", peer);
+        TestTaskManager.reconcilerPeer = peer;
+
+        const node = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-rerun" });
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+
+        // The re-run is attempted while the cancelled task unwinds, i.e. while cancel() waits on its drive.
+        let rerun: unknown = "not attempted";
+        SyntheticTask.phasesByTag["cancelrerun"] = [
+            slowUnwindGatePhase("cx", "groupMembership", "C", async () => {
+                try {
+                    rerun = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "cancelrerun" }));
+                } catch (e) {
+                    rerun = e;
+                }
+            }),
+        ];
+
+        await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "cancelrerun" }));
+        await pumpUntil("intent written", () => peer.items[itemMapKey("groupMembership", "C")] !== undefined);
+
+        const handle = await MockTime.resolve(node.act(a => a.get(TestTaskManager).cancel("synthetic:cancelrerun")));
+        expect(handle?.id).equals("revert:synthetic:cancelrerun");
+        expect(rerun).instanceOf(TaskConflictError);
+
+        const status = await node.act(a => a.get(TestTaskManager).get("synthetic:cancelrerun")?.status);
+        expect(status?.state).equals("cancelled");
+        await node.close();
+    });
+
+    it("refuses a cancel that cannot be recorded because shutdown intervened", async () => {
+        const environment = new Environment("test");
+        const peer = new FakePeer("sd");
+        TestTaskManager.peers.set("sd", peer);
+        TestTaskManager.reconcilerPeer = peer;
+
+        let releaseUnwind!: () => void;
+        const unwinding = new Promise<void>(resolve => (releaseUnwind = resolve));
+        let unwindReached = false;
+        SyntheticTask.phasesByTag["shutrace"] = [
+            slowUnwindGatePhase("sd", "groupMembership", "S", () => {
+                unwindReached = true;
+                return unwinding;
+            }),
+        ];
+
+        const node1 = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-shutrace" });
+        await node1.act(a => a.get(TestTaskManager).register("synthetic", TracedTask));
+        await node1.act(a => a.get(TestTaskManager).run("synthetic", { tag: "shutrace" }));
+        await pumpUntil("intent written", () => peer.items[itemMapKey("groupMembership", "S")] !== undefined);
+
+        // Cancel is accepted while the node is still up, then shutdown takes over the unwind.
+        const cancelling = node1.act(a => a.get(TestTaskManager).cancel("synthetic:shutrace"));
+        await pumpUntil("cancel observed by the gate", () => unwindReached);
+
+        const closing = node1.close();
+        await pumpUntil("node no longer active", () => node1.construction.status !== Lifecycle.Status.Active);
+        releaseUnwind();
+
+        await expect(MockTime.resolve(cancelling)).rejectedWith(TaskManagerClosingError);
+        await MockTime.resolve(closing);
+
+        // The task keeps a resumable state: nothing claims the cancel took effect.
+        const task = TracedTask.instance("synthetic:shutrace");
+        expect(task.progress.state).equals("running");
+        expect(task.revertTaskId).equals(undefined);
+
+        // Storage must agree: non-terminal, no dangling revert.
+        const node2 = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-shutrace" });
+        const persisted = node2.stateOf(TestTaskManager).tasks;
+        expect(persisted["synthetic:shutrace"].state).equals("running");
+        expect(persisted["synthetic:shutrace"].revertTaskId).equals(undefined);
+        expect(persisted["revert:synthetic:shutrace"]).equals(undefined);
+        await node2.close();
+    });
+
+    it("does not report a crashed manager as shutting down", async () => {
+        const environment = new Environment("test");
+        const peer = new FakePeer("cd");
+        TestTaskManager.peers.set("cd", peer);
+        TestTaskManager.reconcilerPeer = peer;
+        peer.markHas("groupMembership", "C");
+
+        SyntheticTask.phasesByTag["crashed"] = [gatePhase("cd", "groupMembership", "C")];
+
+        const node = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-crashed" });
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+        let manager!: TestTaskManager;
+        await node.act(a => {
+            manager = a.get(TestTaskManager);
+        });
+        await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "crashed" }));
+        await pumpUntil("task complete", async () => {
+            const state = await node.act(a => a.get(TestTaskManager).state.tasks["synthetic:crashed"]?.state);
+            return state === "completed";
+        });
+
+        // A crashed manager cannot record a cancel either, but it is not shutting down and a re-issue after the
+        // next start is not the remedy — so it must not claim it is.
+        node.construction.setStatus(Lifecycle.Status.Crashed);
+        await expect(MockTime.resolve(manager.cancel("synthetic:crashed"))).rejectedWith(CrashedDependencyError);
+
+        await node.close();
+    });
+
+    it("leaves a task that fails during shutdown resumable instead of rolling it back", async () => {
+        const environment = new Environment("test");
+        const peer = new FakePeer("sf");
+        TestTaskManager.peers.set("sf", peer);
+        TestTaskManager.reconcilerPeer = peer;
+
+        let releasePhase!: () => void;
+        const held = new Promise<void>(resolve => (releasePhase = resolve));
+        let phaseEntered = false;
+        SyntheticTask.phasesByTag["shutfail"] = [
+            {
+                name: "hold",
+                run: async ctx => {
+                    await ctx.setIntent(ctx.resolvePeer("sf"), "groupMembership", "F", {});
+                    phaseEntered = true;
+                    await held;
+                },
+            },
+        ];
+
+        const node = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-shutfail" });
+        await node.act(a => a.get(TestTaskManager).register("synthetic", TracedTask));
+        await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "shutfail" }));
+        await pumpUntil("phase in flight", () => phaseEntered);
+
+        // The phase completes as shutdown drains the driver, so its next persist meets a closing endpoint.
+        TestTaskManager.atShutdown = releasePhase;
+        try {
+            await MockTime.resolve(node.close());
+        } finally {
+            TestTaskManager.atShutdown = undefined;
+        }
+
+        const task = TracedTask.instance("synthetic:shutfail");
+        expect(task.progress.state).equals("running");
+        expect(task.revertTaskId).equals(undefined);
+
+        const node2 = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-shutfail" });
+        const persisted = node2.stateOf(TestTaskManager).tasks;
+        expect(persisted["synthetic:shutfail"].state).equals("running");
+        expect(persisted["revert:synthetic:shutfail"]).equals(undefined);
+        await node2.close();
+    });
+
+    it("refuses a task started while the manager is shutting down", async () => {
+        const environment = new Environment("test");
+        const peer = new FakePeer("sb");
+        TestTaskManager.peers.set("sb", peer);
+        TestTaskManager.reconcilerPeer = peer;
+
+        SyntheticTask.phasesByTag["shutstart"] = [gatePhase("sb", "groupMembership", "B")];
+
+        const node = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-shutstart" });
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+
+        let started: unknown = "not attempted";
+        TestTaskManager.atShutdown = manager => {
+            try {
+                started = manager.run("synthetic", { tag: "shutstart" });
+            } catch (e) {
+                started = e;
+            }
+        };
+        try {
+            await MockTime.resolve(node.close());
+        } finally {
+            TestTaskManager.atShutdown = undefined;
+        }
+
+        expect(started).instanceOf(TaskManagerClosingError);
+        expect(peer.items[itemMapKey("groupMembership", "B")]).equals(undefined);
+
+        const node2 = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-shutstart" });
+        expect(node2.stateOf(TestTaskManager).tasks["synthetic:shutstart"]).equals(undefined);
+        await node2.close();
+    });
+
+    it("refuses a task type registered while the manager is shutting down", async () => {
+        const environment = new Environment("test");
+        const peer = new FakePeer("sr");
+        peer.markHas("groupMembership", "R");
+        TestTaskManager.peers.set("sr", peer);
+        TestTaskManager.reconcilerPeer = peer;
+
+        SyntheticTask.phasesByTag["shutresume"] = [gatePhase("sr", "groupMembership", "R")];
+
+        const node = await MockServerNode.create(RegistrarRootEndpoint, { environment, id: "cancel-shutresume" });
+        await node.act(a => {
+            // A persisted task of a type this start never registers, so nothing resumes it before shutdown.
+            a.get(TestTaskManager).state.tasks = {
+                "synthetic:shutresume": {
+                    type: "synthetic",
+                    params: { tag: "shutresume" },
+                    phaseIndex: 0,
+                    state: "running",
+                    changeSet: [],
+                },
+            };
+        });
+
+        let registered: unknown = "not attempted";
+        let liveAfterRegister = -1;
+        ShutdownRegistrarBehavior.atClose = manager => {
+            try {
+                registered = manager.register("synthetic", SyntheticTask);
+            } catch (e) {
+                registered = e;
+            }
+            liveAfterRegister = manager.tasks.length;
+        };
+        try {
+            await MockTime.resolve(node.close());
+        } finally {
+            ShutdownRegistrarBehavior.atClose = undefined;
+        }
+
+        expect(registered).instanceOf(TaskManagerClosingError);
+        // Resuming during teardown creates and drives a task the dispose drain may already have passed.
+        expect(liveAfterRegister).equals(0);
+        expect(peer.items[itemMapKey("groupMembership", "R")]).equals(undefined);
+
+        // The refusal costs the task nothing: the next start resumes it as usual.
+        const node2 = await MockServerNode.create(RegistrarRootEndpoint, { environment, id: "cancel-shutresume" });
+        await node2.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+        await pumpUntil("resumed task complete", async () => {
+            const state = await node2.act(a => a.get(TestTaskManager).state.tasks["synthetic:shutresume"]?.state);
+            return state === "completed";
+        });
+        await node2.close();
+    });
+
+    it("shutdown suspends a task in the pre-gate window instead of failing it", async () => {
+        const environment = new Environment("test");
+        const { peer, state } = blockingAdmissionPeer("pd");
+        TestTaskManager.peers.set("pd", peer);
+        TestTaskManager.reconcilerPeer = peer;
+
+        SyntheticTask.plannedChangesByTag["predispose"] = [{ peerId: "pd", kind: "cap", key: "x", intent: {} }];
+        SyntheticTask.phasesByTag["predispose"] = [gatePhase("pd", "groupMembership", "Y")];
+
+        const node = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-predispose" });
+        await node.act(a => a.get(TestTaskManager).register("synthetic", TracedTask));
+        await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "predispose" }));
+        await pumpUntil("admission in flight", () => state.entered);
+
+        // Release the task into the pre-gate window as shutdown begins, before the abort pass.
+        TestTaskManager.atShutdown = state.release;
+        try {
+            await MockTime.resolve(node.close());
+        } finally {
+            TestTaskManager.atShutdown = undefined;
+        }
+
+        const task = TracedTask.instance("synthetic:predispose");
+        expect(task.progress.state).equals("running");
+        expect(task.error).equals(undefined);
+        expect(peer.items[itemMapKey("groupMembership", "Y")]).equals(undefined);
+
+        // Suspending before the first persist means there is nothing to resume: the task is gone after a restart.
+        // Shutdown cannot write state, so a task that never got that far is lost either way — but it must not be
+        // recorded as failed.
+        const node2 = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-predispose" });
+        expect(node2.stateOf(TestTaskManager).tasks["synthetic:predispose"]).equals(undefined);
+        await node2.close();
+    });
+});

--- a/packages/node-manager/test/task/TaskContextGateTest.ts
+++ b/packages/node-manager/test/task/TaskContextGateTest.ts
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { RunningTaskContext } from "#task/RunningTaskContext.js";
+import { TaskCancelledSignal, TaskFailedError } from "#task/errors.js";
+import { GateControl, RunningTaskContext } from "#task/RunningTaskContext.js";
 import { Task } from "#task/Task.js";
 import { TaskState } from "#task/types.js";
+import { Observable } from "@matter/general";
+import { ClientNode, itemMapKey } from "@matter/node";
 import { FakePeer } from "./helpers.js";
 
 class GateTask extends Task {
@@ -16,15 +19,37 @@ class GateTask extends Task {
     }
 }
 
-function makeContext(peer: FakePeer) {
+function makeContext(peer: FakePeer, gate?: GateControl, setState?: (state: TaskState) => void) {
     const task = new GateTask("gate-test:1", {});
     const states = new Array<TaskState>();
-    const setState = (s: TaskState) => {
-        task.progress.state = s;
-        states.push(s);
-    };
-    const ctx = new RunningTaskContext(task, () => peer.asNode(), peer, setState);
+    const record =
+        setState ??
+        ((s: TaskState) => {
+            task.progress.state = s;
+            states.push(s);
+        });
+    const ctx = new RunningTaskContext(task, () => peer.asNode(), peer, record, gate);
     return { task, ctx, states };
+}
+
+/** The manager's gate control, reduced to what a gate reads: a recorded abort and a wake for it. */
+function makeGate() {
+    let aborted: unknown;
+    const wake = new Observable<[]>();
+    const control: GateControl = {
+        aborted: () => aborted,
+        onAbort: w => {
+            wake.on(w);
+            return () => wake.off(w);
+        },
+    };
+    return {
+        control,
+        abort: (reason: unknown) => {
+            aborted = reason;
+            wake.emit();
+        },
+    };
 }
 
 describe("TaskContext gates", () => {
@@ -60,6 +85,41 @@ describe("TaskContext gates", () => {
         expect(peer.subscriptionStatusChanged.isObserved).equals(false);
     });
 
+    it("observes a change announced while its own first evaluation is still running", async () => {
+        /** Announces the device's acceptance during the gate's first reconcile pass, and never again. */
+        class LateAnnouncePeer extends FakePeer {
+            passes = 0;
+            override async reconcile(node: ClientNode, options?: { verify?: boolean }) {
+                if (++this.passes > 1) {
+                    await super.reconcile(node, options);
+                    return;
+                }
+                // The item stays pending, so this pass cannot satisfy the gate; the announcement is the only
+                // wakeup the gate will ever get.
+                this.markHas("groupMembership", "1");
+                this.itemChanged.emit(this.items[itemMapKey("groupMembership", "1")]);
+            }
+        }
+
+        const peer = new LateAnnouncePeer("p1");
+        peer.addItem("groupMembership", "1", "pending");
+        const { ctx } = makeContext(peer);
+
+        let settled = false;
+        const gate = ctx
+            .awaitCommitted([{ peer: peer.asNode(), kind: "groupMembership", key: "1" }])
+            .then(() => (settled = true));
+
+        // Bounded so a gate that lost the announcement fails here rather than hanging.
+        for (let i = 0; i < 100 && !settled; i++) {
+            await MockTime.advance(1);
+        }
+        expect(settled).equals(true);
+        await MockTime.resolve(gate);
+        expect(peer.passes).greaterThan(1);
+        expect(peer.items[itemMapKey("groupMembership", "1")]?.status.state).equals("committed");
+    });
+
     it("parks while a relevant node is unreachable, resumes on reachability change", async () => {
         const peer = new FakePeer("p1");
         peer.addItem("groupMembership", "1", "pending");
@@ -78,6 +138,145 @@ describe("TaskContext gates", () => {
         expect(states).contains("parked");
         expect(states).contains("running");
         expect(task.progress.state).equals("running");
+    });
+
+    it("fails once its own evaluation drops the awaited item after an unrecoverable rejection", async () => {
+        const peer = new FakePeer("p1");
+        peer.addItem("groupMembership", "1", "pending");
+        peer.markRejects("groupMembership", "1");
+        const { ctx, task } = makeContext(peer);
+
+        const gate = ctx.awaitCommitted([{ peer: peer.asNode(), kind: "groupMembership", key: "1" }]);
+
+        await expect(MockTime.resolve(gate)).rejectedWith(TaskFailedError);
+        expect(peer.items[itemMapKey("groupMembership", "1")]).equals(undefined);
+        expect(task.progress.state).does.not.equal("completed");
+        // The failure takes two reconcile passes: one to record the rejection, the next to give up on the item.
+        expect(peer.reconciles).greaterThan(1);
+    });
+
+    it("waits through a recoverable commit failure instead of failing the task", async () => {
+        const peer = new FakePeer("p1");
+        peer.addItem("groupMembership", "1", "pending");
+        peer.markFailsRecoverably("groupMembership", "1", 2);
+        peer.markHas("groupMembership", "1");
+        const { ctx, task } = makeContext(peer);
+
+        let settled = false;
+        let failure: unknown;
+        const gate = ctx.awaitCommitted([{ peer: peer.asNode(), kind: "groupMembership", key: "1" }]).then(
+            () => (settled = true),
+            e => (failure = e),
+        );
+
+        // Bounded so a gate that never resolves fails here rather than hanging.
+        for (let i = 0; i < 100 && !settled && failure === undefined; i++) {
+            await MockTime.advance(1);
+        }
+
+        // A failure the reconciler intends to retry is not the end of the item, so the gate must wait for the
+        // retry that succeeds rather than treat the failure as terminal.
+        expect(failure).equals(undefined);
+        expect(settled).equals(true);
+        await MockTime.resolve(gate);
+        expect(peer.items[itemMapKey("groupMembership", "1")]?.status.state).equals("committed");
+        expect(task.progress.state).equals("running");
+        // Two failing applies and the retry that succeeds: the gate resolved through the retry path.
+        expect(peer.reconciles).greaterThan(2);
+    });
+
+    it("touches the peer no further once an abort has settled it", async () => {
+        /** Announces a change and then aborts the gate, both while its evaluation is still in flight. */
+        class AbortMidEvaluatePeer extends FakePeer {
+            passes = 0;
+            onFirstPass?: () => void;
+            override async reconcile(node: ClientNode, options?: { verify?: boolean }) {
+                if (++this.passes > 1) {
+                    await super.reconcile(node, options);
+                    return;
+                }
+                this.setState("groupMembership", "1", "pending");
+                this.onFirstPass?.();
+            }
+        }
+
+        const peer = new AbortMidEvaluatePeer("p1");
+        peer.addItem("groupMembership", "1", "pending");
+        const gateControl = makeGate();
+        const { ctx } = makeContext(peer, gateControl.control);
+        peer.onFirstPass = () => gateControl.abort(new TaskCancelledSignal("cancelled"));
+
+        const gate = ctx.awaitCommitted([{ peer: peer.asNode(), kind: "groupMembership", key: "1" }]);
+        await expect(MockTime.resolve(gate)).rejectedWith(TaskCancelledSignal);
+
+        // A reconcile started after the driver unwound races the rollback the cancel spawns next, and no longer
+        // belongs to anything that awaits it.
+        for (let i = 0; i < 20; i++) {
+            await MockTime.advance(1);
+        }
+        expect(peer.passes).equals(1);
+    });
+
+    it("releases its peer observers when a state change throws", async () => {
+        const peer = new FakePeer("p1");
+        peer.addItem("groupMembership", "1", "pending");
+        const { ctx } = makeContext(peer, undefined, () => {
+            throw new Error("state write refused");
+        });
+
+        const gate = ctx.awaitCommitted([{ peer: peer.asNode(), kind: "groupMembership", key: "1" }]);
+        await expect(MockTime.resolve(gate)).rejectedWith("state write refused");
+
+        // Observers outliving the gate keep reconciling the peer for a task that is already gone.
+        expect(peer.itemChanged.isObserved).equals(false);
+        expect(peer.itemRemoved.isObserved).equals(false);
+        expect(peer.subscriptionStatusChanged.isObserved).equals(false);
+    });
+
+    it("fails when an awaited item is dropped while the gate is parked", async () => {
+        const peer = new FakePeer("p1");
+        peer.addItem("groupMembership", "1", "pending");
+        const { ctx } = makeContext(peer);
+
+        const gate = ctx.awaitCommitted([{ peer: peer.asNode(), kind: "groupMembership", key: "1" }]);
+
+        // Let the initial evaluate settle so the gate is parked on the peer's observers.
+        await MockTime.resolve(Promise.resolve());
+
+        // A reconcile pass this gate did not drive gives up on the item and drops it.
+        peer.dropItem("groupMembership", "1");
+
+        await expect(MockTime.resolve(gate)).rejectedWith(TaskFailedError);
+        expect(peer.itemChanged.isObserved).equals(false);
+        expect(peer.itemRemoved.isObserved).equals(false);
+        expect(peer.subscriptionStatusChanged.isObserved).equals(false);
+    });
+
+    it("resolves a parked removal gate when the reconciler drops a rejected item", async () => {
+        const peer = new FakePeer("p1");
+        peer.addItem("groupMembership", "1", "pending");
+        const { ctx } = makeContext(peer);
+
+        let settled = false;
+        const gate = ctx
+            .awaitGate([peer.asNode()], () => ctx.itemAbsent(peer.asNode(), "groupMembership", "1"))
+            .then(() => (settled = true));
+
+        // Let the initial evaluate settle so the gate is parked on the peer's observers.
+        await MockTime.resolve(Promise.resolve());
+        expect(settled).equals(false);
+
+        // The device rejects the item unrecoverably, and a reconcile pass this gate did not drive drops it.
+        peer.markRejects("groupMembership", "1");
+        await peer.reconcile(peer.asNode(), { verify: true });
+
+        // Bounded so a gate that never wakes fails here rather than hanging.
+        for (let i = 0; i < 100 && !settled; i++) {
+            await MockTime.advance(1);
+        }
+        expect(settled).equals(true);
+        await MockTime.resolve(gate);
+        expect(peer.items[itemMapKey("groupMembership", "1")]).equals(undefined);
     });
 
     it("does not resolve on cached committed state while a node is unreachable", async () => {

--- a/packages/node-manager/test/task/TaskLifecycleTest.ts
+++ b/packages/node-manager/test/task/TaskLifecycleTest.ts
@@ -6,10 +6,9 @@
 
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
 import { TaskConflictError, TaskFailedError } from "#task/errors.js";
-import { Task } from "#task/Task.js";
 import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { TaskPhase } from "#task/types.js";
-import { Environment, fromJson, toJson } from "@matter/general";
+import { Environment } from "@matter/general";
 import { ClientNode, itemMapKey, ServerNode } from "@matter/node";
 import { MockServerNode } from "@matter/node/testing";
 import { FakePeer, SyntheticTask } from "./helpers.js";
@@ -27,11 +26,6 @@ class TestTaskManager extends TaskManagerBehavior {
     }
     protected override taskReconciler(): ReconcilerBehavior {
         return TestTaskManager.reconcilerPeer as unknown as ReconcilerBehavior;
-    }
-
-    /** True while a drive of `id` owns this id's gate and driving entries. */
-    isDriven(id: string): boolean {
-        return this.internal.driving.has(id) || this.internal.gates.has(id);
     }
 }
 
@@ -141,175 +135,7 @@ describe("Task lifecycle", () => {
             await node2.close();
         });
 
-        it("dedups an identical request against a resumed task whose optional parameter storage dropped", async () => {
-            const environment = new Environment("test");
-            const peer = new FakePeer("op");
-            TestTaskManager.peers.set("op", peer);
-            TestTaskManager.reconcilerPeer = peer;
-
-            class OptionalParamTask extends Task<{ tag: string; label?: string }> {
-                override readonly type = "optional";
-                override get phases(): TaskPhase[] {
-                    return [gatePhase("op", "groupMembership", "1")];
-                }
-                static override idFor(params: { tag: string }) {
-                    return `optional:${params.tag}`;
-                }
-            }
-
-            const node = await makeNode(environment);
-
-            // Serializing storage drops a property whose value is undefined, so a resumed task carries fewer
-            // parameter keys than the request that started it.
-            const params = fromJson(toJson({ tag: "o", label: undefined }));
-            expect(toJson(params)).equals(`{"tag":"o"}`);
-            await node.act(a => {
-                a.get(TestTaskManager).state.tasks = {
-                    "optional:o": { type: "optional", params, phaseIndex: 0, state: "running", changeSet: [] },
-                };
-            });
-            await node.act(a => a.get(TestTaskManager).register("optional", OptionalParamTask));
-            await awaitPhase(node, "optional:o", 0);
-
-            const handle = await node.act(a => a.get(TestTaskManager).run("optional", { tag: "o", label: undefined }));
-            expect(handle.id).equals("optional:o");
-            expect(await node.act(a => a.get(TestTaskManager).tasks.length)).equals(1);
-
-            // A value the resumed task does not carry is a different request, not an idempotent one.
-            await expect(
-                (async () => node.act(a => a.get(TestTaskManager).run("optional", { tag: "o", label: "x" })))(),
-            ).rejectedWith(TaskConflictError);
-            await node.close();
-        });
-
-        it("dedups an identical request against a resumed task whose nested optional storage dropped", async () => {
-            const environment = new Environment("test");
-            const peer = new FakePeer("np");
-            TestTaskManager.peers.set("np", peer);
-            TestTaskManager.reconcilerPeer = peer;
-
-            interface NestedParams {
-                tag: string;
-                entries: Array<{ key: string; prior?: { intent: unknown } }>;
-            }
-
-            class NestedParamTask extends Task<NestedParams> {
-                override readonly type = "nested";
-                override get phases(): TaskPhase[] {
-                    return [gatePhase("np", "groupMembership", "1")];
-                }
-                static override idFor(params: { tag: string }) {
-                    return `nested:${params.tag}`;
-                }
-            }
-
-            const node = await makeNode(environment);
-
-            // A revert's changeSet has this shape: an entry whose `prior` is absent for an intent the task created.
-            const request = { tag: "n", entries: [{ key: "k", prior: undefined }] };
-            const params = fromJson(toJson(request));
-            expect(toJson(params)).equals(`{"tag":"n","entries":[{"key":"k"}]}`);
-            await node.act(a => {
-                a.get(TestTaskManager).state.tasks = {
-                    "nested:n": { type: "nested", params, phaseIndex: 0, state: "running", changeSet: [] },
-                };
-            });
-            await node.act(a => a.get(TestTaskManager).register("nested", NestedParamTask));
-            await awaitPhase(node, "nested:n", 0);
-
-            const handle = await node.act(a => a.get(TestTaskManager).run("nested", request));
-            expect(handle.id).equals("nested:n");
-            expect(await node.act(a => a.get(TestTaskManager).tasks.length)).equals(1);
-
-            // A nested value the resumed task does not carry is still a different request.
-            await expect(
-                (async () =>
-                    node.act(a =>
-                        a.get(TestTaskManager).run("nested", {
-                            tag: "n",
-                            entries: [{ key: "k", prior: { intent: {} } }],
-                        }),
-                    ))(),
-            ).rejectedWith(TaskConflictError);
-            await node.close();
-        });
-
-        it("dedups an identical request against a resumed task whose array gap storage dropped", async () => {
-            const environment = new Environment("test");
-            const peer = new FakePeer("gp");
-            TestTaskManager.peers.set("gp", peer);
-            TestTaskManager.reconcilerPeer = peer;
-
-            class GapParamTask extends Task<{ tag: string; entries: Array<{ key: string } | undefined> }> {
-                override readonly type = "gap";
-                override get phases(): TaskPhase[] {
-                    return [gatePhase("gp", "groupMembership", "1")];
-                }
-                static override idFor(params: { tag: string }) {
-                    return `gap:${params.tag}`;
-                }
-            }
-
-            const node = await makeNode(environment);
-
-            // Storage returns an array element that is undefined as a gap, so the resumed array is not the same
-            // shape as the one the request carried.
-            const request = { tag: "g", entries: [undefined, { key: "k" }] };
-            await node.act(a => {
-                a.get(TestTaskManager).state.tasks = {
-                    "gap:g": {
-                        type: "gap",
-                        params: fromJson(toJson(request)),
-                        phaseIndex: 0,
-                        state: "running",
-                        changeSet: [],
-                    },
-                };
-            });
-            await node.act(a => a.get(TestTaskManager).register("gap", GapParamTask));
-            await awaitPhase(node, "gap:g", 0);
-
-            const handle = await node.act(a => a.get(TestTaskManager).run("gap", request));
-            expect(handle.id).equals("gap:g");
-            expect(await node.act(a => a.get(TestTaskManager).tasks.length)).equals(1);
-            await node.close();
-        });
-
-        it("rejects a re-run whose only difference is inside a map parameter", async () => {
-            const environment = new Environment("test");
-            const peer = new FakePeer("mp");
-            TestTaskManager.peers.set("mp", peer);
-            TestTaskManager.reconcilerPeer = peer;
-
-            class MapParamTask extends Task<{ tag: string; labels: Map<string, string> }> {
-                override readonly type = "mapped";
-                override get phases(): TaskPhase[] {
-                    return [gatePhase("mp", "groupMembership", "1")];
-                }
-                static override idFor(params: { tag: string }) {
-                    return `mapped:${params.tag}`;
-                }
-            }
-
-            const node = await makeNode(environment);
-            await node.act(a => a.get(TestTaskManager).register("mapped", MapParamTask));
-            await node.act(a => a.get(TestTaskManager).run("mapped", { tag: "m", labels: new Map([["a", "1"]]) }));
-            await awaitPhase(node, "mapped:m", 0);
-
-            const handle = await node.act(a =>
-                a.get(TestTaskManager).run("mapped", { tag: "m", labels: new Map([["a", "1"]]) }),
-            );
-            expect(handle.id).equals("mapped:m");
-
-            // A map compares by content: dedup here would drop the caller's parameters without applying them.
-            await expect(
-                (async () =>
-                    node.act(a => a.get(TestTaskManager).run("mapped", { tag: "m", labels: new Map([["a", "2"]]) })))(),
-            ).rejectedWith(TaskConflictError);
-            await node.close();
-        });
-
-        it("keeps the external id of a deduped caller across a restart", async () => {
+        it("still answers to its caller's external id after a restart", async () => {
             const environment = new Environment("test");
             const peer = new FakePeer("xp");
             peer.setReachable(false);
@@ -319,90 +145,14 @@ describe("Task lifecycle", () => {
 
             const node1 = await makeNode(environment);
             await node1.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
-            await node1.act(a => a.get(TestTaskManager).run("synthetic", { tag: "alias" }, { externalId: "first" }));
+            await node1.act(a => a.get(TestTaskManager).run("synthetic", { tag: "alias" }, { externalId: "owner" }));
             await awaitState(node1, "synthetic:alias", "parked");
-
-            const second = await node1.act(a =>
-                a.get(TestTaskManager).run("synthetic", { tag: "alias" }, { externalId: "second" }),
-            );
-            expect(second.id).equals("synthetic:alias");
-
-            // An id only in memory is lost on restart, leaving the second caller with a handle onto nothing.
-            for (let i = 0; i < 10_000; i++) {
-                const persisted = node1.stateOf(TestTaskManager).tasks["synthetic:alias"];
-                if (persisted?.externalIds?.includes("second")) {
-                    break;
-                }
-                await MockTime.advance(1);
-            }
-            expect(node1.stateOf(TestTaskManager).tasks["synthetic:alias"].externalIds).deep.equals([
-                "first",
-                "second",
-            ]);
+            expect(node1.stateOf(TestTaskManager).tasks["synthetic:alias"].externalId).equals("owner");
             await node1.close();
 
             const node2 = await makeNode(environment);
             await node2.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
-            expect(await node2.act(a => a.get(TestTaskManager).get("second")?.id)).equals("synthetic:alias");
-            await node2.close();
-        });
-
-        it("keeps a terminal task observable after a restart without driving it again", async () => {
-            const environment = new Environment("test");
-            let runs = 0;
-            SyntheticTask.phasesByTag["done"] = [
-                {
-                    name: "noop",
-                    run: async () => {
-                        runs++;
-                    },
-                },
-            ];
-            const node1 = await makeNode(environment);
-            await node1.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
-            await node1.act(a => a.get(TestTaskManager).run("synthetic", { tag: "done" }));
-            await awaitState(node1, "synthetic:done", "completed");
-            expect(runs).equals(1);
-            await node1.close();
-
-            const node2 = await makeNode(environment);
-            await node2.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
-            const status = await node2.act(a => a.get(TestTaskManager).get("synthetic:done")?.status);
-            expect(status?.state).equals("completed");
-            expect(await node2.act(a => a.get(TestTaskManager).tasks.map(t => t.id))).deep.equals(["synthetic:done"]);
-
-            // Retained history is observable, not work: it owns no driver bookkeeping, so nothing persists,
-            // gates or drains on its behalf, and its phase never runs a second time.
-            expect(await node2.act(a => a.get(TestTaskManager).isDriven("synthetic:done"))).equals(false);
-            for (let i = 0; i < 50; i++) {
-                await MockTime.advance(1);
-            }
-            expect(runs).equals(1);
-            await node2.close();
-        });
-
-        it("cancels a task that completed before the restart", async () => {
-            const environment = new Environment("test");
-            const peer = new FakePeer("cb");
-            peer.markHas("groupMembership", "1");
-            TestTaskManager.peers.set("cb", peer);
-            TestTaskManager.reconcilerPeer = peer;
-            SyntheticTask.phasesByTag["cancelafter"] = [gatePhase("cb", "groupMembership", "1")];
-
-            const node1 = await makeNode(environment);
-            await node1.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
-            await node1.act(a => a.get(TestTaskManager).run("synthetic", { tag: "cancelafter" }));
-            await awaitState(node1, "synthetic:cancelafter", "completed");
-            expect(peer.items[itemMapKey("groupMembership", "1")]?.status.state).equals("committed");
-            await node1.close();
-
-            // The changeSet of finished work is what makes it undoable, so a restart must not cost it that.
-            const node2 = await makeNode(environment);
-            await node2.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
-            const handle = await node2.act(a => a.get(TestTaskManager).cancel("synthetic:cancelafter"));
-            expect(handle?.id).equals("revert:synthetic:cancelafter");
-            await awaitState(node2, "revert:synthetic:cancelafter", "completed");
-            expect(peer.items[itemMapKey("groupMembership", "1")]).equals(undefined);
+            expect(await node2.act(a => a.get(TestTaskManager).get("owner")?.id)).equals("synthetic:alias");
             await node2.close();
         });
     });
@@ -604,12 +354,12 @@ describe("Task lifecycle", () => {
             await node.close();
         });
 
-        it("cancels through the external id of a caller that deduped onto the task", async () => {
+        it("cancels through the external id its caller ran the task under", async () => {
             const environment = new Environment("test");
             const peer = new FakePeer("ac");
             TestTaskManager.peers.set("ac", peer);
             TestTaskManager.reconcilerPeer = peer;
-            // The device never "has" the item, so the gate is still in flight when the second caller arrives.
+            // The device never "has" the item, so the gate is still in flight when the cancel arrives.
 
             SyntheticTask.phasesByTag["aliascancel"] = [gatePhase("ac", "groupMembership", "X")];
 
@@ -621,12 +371,9 @@ describe("Task lifecycle", () => {
             for (let i = 0; i < 10_000 && peer.items[itemMapKey("groupMembership", "X")] === undefined; i++) {
                 await MockTime.advance(1);
             }
-            await node.act(a =>
-                a.get(TestTaskManager).run("synthetic", { tag: "aliascancel" }, { externalId: "joiner" }),
-            );
 
-            // The joiner's id must reach the same work, all the way to rolling it back.
-            const handle = await node.act(a => a.get(TestTaskManager).cancel("joiner"));
+            // The caller's own id must reach its work, all the way to rolling it back.
+            const handle = await node.act(a => a.get(TestTaskManager).cancel("owner"));
             expect(handle?.id).equals("revert:synthetic:aliascancel");
             const status = await node.act(a => a.get(TestTaskManager).get("owner")?.status);
             expect(status?.state).equals("cancelled");

--- a/packages/node-manager/test/task/TaskLifecycleTest.ts
+++ b/packages/node-manager/test/task/TaskLifecycleTest.ts
@@ -27,6 +27,11 @@ class TestTaskManager extends TaskManagerBehavior {
     protected override taskReconciler(): ReconcilerBehavior {
         return TestTaskManager.reconcilerPeer as unknown as ReconcilerBehavior;
     }
+
+    /** True while a drive of `id` owns this id's gate and driving entries. */
+    isDriven(id: string): boolean {
+        return this.internal.driving.has(id) && this.internal.gates.has(id);
+    }
 }
 
 const RootEndpoint = MockServerNode.RootEndpoint.with(TestTaskManager);
@@ -273,10 +278,15 @@ describe("Task lifecycle", () => {
                 (async () => node.act(a => a.get(TestTaskManager).cancel("synthetic:blockedcancel")))(),
             ).rejectedWith(TaskConflictError);
 
-            // Memory must not claim a cancel that storage never saw.
+            // Memory must not claim a cancel that storage never saw. Liveness bookkeeping may differ transiently:
+            // a declined cancel re-drives the task, and the driver re-persists parked/running as it goes.
             const status = await node.act(a => a.get(TestTaskManager).get("synthetic:blockedcancel")?.status);
             expect(status?.state).does.not.equal("cancelled");
-            expect(node.stateOf(TestTaskManager).tasks["synthetic:blockedcancel"].state).equals(status?.state);
+            expect(node.stateOf(TestTaskManager).tasks["synthetic:blockedcancel"].state).does.not.equal("cancelled");
+
+            // The abort stopped the driver and dropped the gate; declining the cancel must give both back, or the
+            // task sits non-terminal with nothing left to advance it until a restart.
+            expect(await node.act(a => a.get(TestTaskManager).isDriven("synthetic:blockedcancel"))).equals(true);
             await node.close();
         });
     });

--- a/packages/node-manager/test/task/TaskLifecycleTest.ts
+++ b/packages/node-manager/test/task/TaskLifecycleTest.ts
@@ -5,9 +5,11 @@
  */
 
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
+import { TaskConflictError, TaskFailedError } from "#task/errors.js";
+import { Task } from "#task/Task.js";
 import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { TaskPhase } from "#task/types.js";
-import { Environment } from "@matter/general";
+import { Environment, fromJson, toJson } from "@matter/general";
 import { ClientNode, itemMapKey, ServerNode } from "@matter/node";
 import { MockServerNode } from "@matter/node/testing";
 import { FakePeer, SyntheticTask } from "./helpers.js";
@@ -25,6 +27,11 @@ class TestTaskManager extends TaskManagerBehavior {
     }
     protected override taskReconciler(): ReconcilerBehavior {
         return TestTaskManager.reconcilerPeer as unknown as ReconcilerBehavior;
+    }
+
+    /** True while a drive of `id` owns this id's gate and driving entries. */
+    isDriven(id: string): boolean {
+        return this.internal.driving.has(id) || this.internal.gates.has(id);
     }
 }
 
@@ -134,20 +141,393 @@ describe("Task lifecycle", () => {
             await node2.close();
         });
 
-        it("does not resume terminal tasks", async () => {
+        it("dedups an identical request against a resumed task whose optional parameter storage dropped", async () => {
             const environment = new Environment("test");
-            SyntheticTask.phasesByTag["done"] = [{ name: "noop", run: async () => {} }];
+            const peer = new FakePeer("op");
+            TestTaskManager.peers.set("op", peer);
+            TestTaskManager.reconcilerPeer = peer;
+
+            class OptionalParamTask extends Task<{ tag: string; label?: string }> {
+                override readonly type = "optional";
+                override get phases(): TaskPhase[] {
+                    return [gatePhase("op", "groupMembership", "1")];
+                }
+                static override idFor(params: { tag: string }) {
+                    return `optional:${params.tag}`;
+                }
+            }
+
+            const node = await makeNode(environment);
+
+            // Serializing storage drops a property whose value is undefined, so a resumed task carries fewer
+            // parameter keys than the request that started it.
+            const params = fromJson(toJson({ tag: "o", label: undefined }));
+            expect(toJson(params)).equals(`{"tag":"o"}`);
+            await node.act(a => {
+                a.get(TestTaskManager).state.tasks = {
+                    "optional:o": { type: "optional", params, phaseIndex: 0, state: "running", changeSet: [] },
+                };
+            });
+            await node.act(a => a.get(TestTaskManager).register("optional", OptionalParamTask));
+            await awaitPhase(node, "optional:o", 0);
+
+            const handle = await node.act(a => a.get(TestTaskManager).run("optional", { tag: "o", label: undefined }));
+            expect(handle.id).equals("optional:o");
+            expect(await node.act(a => a.get(TestTaskManager).tasks.length)).equals(1);
+
+            // A value the resumed task does not carry is a different request, not an idempotent one.
+            await expect(
+                (async () => node.act(a => a.get(TestTaskManager).run("optional", { tag: "o", label: "x" })))(),
+            ).rejectedWith(TaskConflictError);
+            await node.close();
+        });
+
+        it("dedups an identical request against a resumed task whose nested optional storage dropped", async () => {
+            const environment = new Environment("test");
+            const peer = new FakePeer("np");
+            TestTaskManager.peers.set("np", peer);
+            TestTaskManager.reconcilerPeer = peer;
+
+            interface NestedParams {
+                tag: string;
+                entries: Array<{ key: string; prior?: { intent: unknown } }>;
+            }
+
+            class NestedParamTask extends Task<NestedParams> {
+                override readonly type = "nested";
+                override get phases(): TaskPhase[] {
+                    return [gatePhase("np", "groupMembership", "1")];
+                }
+                static override idFor(params: { tag: string }) {
+                    return `nested:${params.tag}`;
+                }
+            }
+
+            const node = await makeNode(environment);
+
+            // A revert's changeSet has this shape: an entry whose `prior` is absent for an intent the task created.
+            const request = { tag: "n", entries: [{ key: "k", prior: undefined }] };
+            const params = fromJson(toJson(request));
+            expect(toJson(params)).equals(`{"tag":"n","entries":[{"key":"k"}]}`);
+            await node.act(a => {
+                a.get(TestTaskManager).state.tasks = {
+                    "nested:n": { type: "nested", params, phaseIndex: 0, state: "running", changeSet: [] },
+                };
+            });
+            await node.act(a => a.get(TestTaskManager).register("nested", NestedParamTask));
+            await awaitPhase(node, "nested:n", 0);
+
+            const handle = await node.act(a => a.get(TestTaskManager).run("nested", request));
+            expect(handle.id).equals("nested:n");
+            expect(await node.act(a => a.get(TestTaskManager).tasks.length)).equals(1);
+
+            // A nested value the resumed task does not carry is still a different request.
+            await expect(
+                (async () =>
+                    node.act(a =>
+                        a.get(TestTaskManager).run("nested", {
+                            tag: "n",
+                            entries: [{ key: "k", prior: { intent: {} } }],
+                        }),
+                    ))(),
+            ).rejectedWith(TaskConflictError);
+            await node.close();
+        });
+
+        it("dedups an identical request against a resumed task whose array gap storage dropped", async () => {
+            const environment = new Environment("test");
+            const peer = new FakePeer("gp");
+            TestTaskManager.peers.set("gp", peer);
+            TestTaskManager.reconcilerPeer = peer;
+
+            class GapParamTask extends Task<{ tag: string; entries: Array<{ key: string } | undefined> }> {
+                override readonly type = "gap";
+                override get phases(): TaskPhase[] {
+                    return [gatePhase("gp", "groupMembership", "1")];
+                }
+                static override idFor(params: { tag: string }) {
+                    return `gap:${params.tag}`;
+                }
+            }
+
+            const node = await makeNode(environment);
+
+            // Storage returns an array element that is undefined as a gap, so the resumed array is not the same
+            // shape as the one the request carried.
+            const request = { tag: "g", entries: [undefined, { key: "k" }] };
+            await node.act(a => {
+                a.get(TestTaskManager).state.tasks = {
+                    "gap:g": {
+                        type: "gap",
+                        params: fromJson(toJson(request)),
+                        phaseIndex: 0,
+                        state: "running",
+                        changeSet: [],
+                    },
+                };
+            });
+            await node.act(a => a.get(TestTaskManager).register("gap", GapParamTask));
+            await awaitPhase(node, "gap:g", 0);
+
+            const handle = await node.act(a => a.get(TestTaskManager).run("gap", request));
+            expect(handle.id).equals("gap:g");
+            expect(await node.act(a => a.get(TestTaskManager).tasks.length)).equals(1);
+            await node.close();
+        });
+
+        it("rejects a re-run whose only difference is inside a map parameter", async () => {
+            const environment = new Environment("test");
+            const peer = new FakePeer("mp");
+            TestTaskManager.peers.set("mp", peer);
+            TestTaskManager.reconcilerPeer = peer;
+
+            class MapParamTask extends Task<{ tag: string; labels: Map<string, string> }> {
+                override readonly type = "mapped";
+                override get phases(): TaskPhase[] {
+                    return [gatePhase("mp", "groupMembership", "1")];
+                }
+                static override idFor(params: { tag: string }) {
+                    return `mapped:${params.tag}`;
+                }
+            }
+
+            const node = await makeNode(environment);
+            await node.act(a => a.get(TestTaskManager).register("mapped", MapParamTask));
+            await node.act(a => a.get(TestTaskManager).run("mapped", { tag: "m", labels: new Map([["a", "1"]]) }));
+            await awaitPhase(node, "mapped:m", 0);
+
+            const handle = await node.act(a =>
+                a.get(TestTaskManager).run("mapped", { tag: "m", labels: new Map([["a", "1"]]) }),
+            );
+            expect(handle.id).equals("mapped:m");
+
+            // A map compares by content: dedup here would drop the caller's parameters without applying them.
+            await expect(
+                (async () =>
+                    node.act(a => a.get(TestTaskManager).run("mapped", { tag: "m", labels: new Map([["a", "2"]]) })))(),
+            ).rejectedWith(TaskConflictError);
+            await node.close();
+        });
+
+        it("keeps the external id of a deduped caller across a restart", async () => {
+            const environment = new Environment("test");
+            const peer = new FakePeer("xp");
+            peer.setReachable(false);
+            TestTaskManager.peers.set("xp", peer);
+            TestTaskManager.reconcilerPeer = peer;
+            SyntheticTask.phasesByTag["alias"] = [gatePhase("xp", "groupMembership", "1")];
+
             const node1 = await makeNode(environment);
             await node1.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
-            await node1.act(a => a.get(TestTaskManager).run("synthetic", { tag: "done" }));
-            await awaitState(node1, "synthetic:done", "completed");
+            await node1.act(a => a.get(TestTaskManager).run("synthetic", { tag: "alias" }, { externalId: "first" }));
+            await awaitState(node1, "synthetic:alias", "parked");
+
+            const second = await node1.act(a =>
+                a.get(TestTaskManager).run("synthetic", { tag: "alias" }, { externalId: "second" }),
+            );
+            expect(second.id).equals("synthetic:alias");
+
+            // An id only in memory is lost on restart, leaving the second caller with a handle onto nothing.
+            for (let i = 0; i < 10_000; i++) {
+                const persisted = node1.stateOf(TestTaskManager).tasks["synthetic:alias"];
+                if (persisted?.externalIds?.includes("second")) {
+                    break;
+                }
+                await MockTime.advance(1);
+            }
+            expect(node1.stateOf(TestTaskManager).tasks["synthetic:alias"].externalIds).deep.equals([
+                "first",
+                "second",
+            ]);
             await node1.close();
 
             const node2 = await makeNode(environment);
             await node2.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
-            const live = await node2.act(a => a.get(TestTaskManager).tasks.length);
-            expect(live).equals(0);
+            expect(await node2.act(a => a.get(TestTaskManager).get("second")?.id)).equals("synthetic:alias");
             await node2.close();
+        });
+
+        it("keeps a terminal task observable after a restart without driving it again", async () => {
+            const environment = new Environment("test");
+            let runs = 0;
+            SyntheticTask.phasesByTag["done"] = [
+                {
+                    name: "noop",
+                    run: async () => {
+                        runs++;
+                    },
+                },
+            ];
+            const node1 = await makeNode(environment);
+            await node1.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+            await node1.act(a => a.get(TestTaskManager).run("synthetic", { tag: "done" }));
+            await awaitState(node1, "synthetic:done", "completed");
+            expect(runs).equals(1);
+            await node1.close();
+
+            const node2 = await makeNode(environment);
+            await node2.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+            const status = await node2.act(a => a.get(TestTaskManager).get("synthetic:done")?.status);
+            expect(status?.state).equals("completed");
+            expect(await node2.act(a => a.get(TestTaskManager).tasks.map(t => t.id))).deep.equals(["synthetic:done"]);
+
+            // Retained history is observable, not work: it owns no driver bookkeeping, so nothing persists,
+            // gates or drains on its behalf, and its phase never runs a second time.
+            expect(await node2.act(a => a.get(TestTaskManager).isDriven("synthetic:done"))).equals(false);
+            for (let i = 0; i < 50; i++) {
+                await MockTime.advance(1);
+            }
+            expect(runs).equals(1);
+            await node2.close();
+        });
+
+        it("cancels a task that completed before the restart", async () => {
+            const environment = new Environment("test");
+            const peer = new FakePeer("cb");
+            peer.markHas("groupMembership", "1");
+            TestTaskManager.peers.set("cb", peer);
+            TestTaskManager.reconcilerPeer = peer;
+            SyntheticTask.phasesByTag["cancelafter"] = [gatePhase("cb", "groupMembership", "1")];
+
+            const node1 = await makeNode(environment);
+            await node1.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+            await node1.act(a => a.get(TestTaskManager).run("synthetic", { tag: "cancelafter" }));
+            await awaitState(node1, "synthetic:cancelafter", "completed");
+            expect(peer.items[itemMapKey("groupMembership", "1")]?.status.state).equals("committed");
+            await node1.close();
+
+            // The changeSet of finished work is what makes it undoable, so a restart must not cost it that.
+            const node2 = await makeNode(environment);
+            await node2.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+            const handle = await node2.act(a => a.get(TestTaskManager).cancel("synthetic:cancelafter"));
+            expect(handle?.id).equals("revert:synthetic:cancelafter");
+            await awaitState(node2, "revert:synthetic:cancelafter", "completed");
+            expect(peer.items[itemMapKey("groupMembership", "1")]).equals(undefined);
+            await node2.close();
+        });
+    });
+
+    describe("device rejection", () => {
+        it("fails the task and rolls back when a parked gate sees the reconciler drop a rejected intent", async () => {
+            const environment = new Environment("test");
+            const peer = new FakePeer("rj");
+            peer.markHas("groupMembership", "OK");
+            TestTaskManager.peers.set("rj", peer);
+            TestTaskManager.reconcilerPeer = peer;
+
+            SyntheticTask.phasesByTag["reject"] = [
+                {
+                    name: "create",
+                    run: async ctx => {
+                        const node = ctx.resolvePeer("rj");
+                        await ctx.setIntent(node, "groupMembership", "OK", {});
+                        await ctx.setIntent(node, "groupMembership", "R", {});
+                        await ctx.awaitCommitted([
+                            { peer: node, kind: "groupMembership", key: "OK" },
+                            { peer: node, kind: "groupMembership", key: "R" },
+                        ]);
+                    },
+                },
+            ];
+
+            const node = await makeNode(environment);
+            await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+            await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "reject" }));
+
+            // The gate parks on its observers: OK commits, R stays pending.
+            for (let i = 0; i < 10_000 && !peer.itemRemoved.isObserved; i++) {
+                await MockTime.advance(1);
+            }
+            expect(peer.items[itemMapKey("groupMembership", "OK")]?.status.state).equals("committed");
+            expect(peer.items[itemMapKey("groupMembership", "R")]?.status.state).equals("pending");
+
+            // The device rejects R unrecoverably, and a reconcile pass this gate did not drive drops it.
+            peer.markRejects("groupMembership", "R");
+            await peer.reconcile(peer.asNode(), { verify: true });
+
+            await awaitState(node, "synthetic:reject", "failed");
+            const status = await node.act(a => a.get(TestTaskManager).get("synthetic:reject")?.status);
+            expect(status?.error).contains("groupMembership:R");
+            expect(status?.revertTaskId).equals("revert:synthetic:reject");
+
+            await awaitState(node, "revert:synthetic:reject", "completed");
+            expect(peer.items[itemMapKey("groupMembership", "OK")]).equals(undefined);
+            await node.close();
+        });
+    });
+
+    describe("rollback refusal", () => {
+        it("records a failure whose rollback the manager refuses", async () => {
+            const environment = new Environment("test");
+            const peer = new FakePeer("rb");
+            peer.setReachable(false);
+            TestTaskManager.peers.set("rb", peer);
+            TestTaskManager.reconcilerPeer = peer;
+
+            SyntheticTask.phasesByTag["blockedrollback"] = [
+                {
+                    name: "touch",
+                    run: async ctx => {
+                        await ctx.setIntent(ctx.resolvePeer("rb"), "groupMembership", "B", {});
+                        throw new TaskFailedError("forced failure");
+                    },
+                },
+            ];
+
+            const node = await makeNode(environment);
+            await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+
+            // A rollback of this id is already in flight for a different changeSet, and parks on the offline peer.
+            await node.act(a =>
+                a.get(TestTaskManager).run("revert", {
+                    originalId: "synthetic:blockedrollback",
+                    entries: [{ peerId: "rb", kind: "groupMembership", key: "A" }],
+                }),
+            );
+            await awaitState(node, "revert:synthetic:blockedrollback", "parked", "running");
+
+            await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "blockedrollback" }));
+
+            // The refused rollback must not cost the task its recorded outcome.
+            await awaitState(node, "synthetic:blockedrollback", "failed");
+            const status = await node.act(a => a.get(TestTaskManager).get("synthetic:blockedrollback")?.status);
+            expect(status?.error).contains("forced failure");
+            expect(status?.revertTaskId).equals(undefined);
+            await node.close();
+        });
+
+        it("leaves a task untouched when its cancel cannot spawn a rollback", async () => {
+            const environment = new Environment("test");
+            const peer = new FakePeer("cr2");
+            peer.setReachable(false);
+            TestTaskManager.peers.set("cr2", peer);
+            TestTaskManager.reconcilerPeer = peer;
+
+            SyntheticTask.phasesByTag["blockedcancel"] = [gatePhase("cr2", "groupMembership", "K")];
+
+            const node = await makeNode(environment);
+            await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+            await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "blockedcancel" }));
+            await awaitState(node, "synthetic:blockedcancel", "parked");
+
+            // A rollback of this id is already in flight for a different changeSet, and parks on the offline peer.
+            await node.act(a =>
+                a.get(TestTaskManager).run("revert", {
+                    originalId: "synthetic:blockedcancel",
+                    entries: [{ peerId: "cr2", kind: "groupMembership", key: "OTHER" }],
+                }),
+            );
+            await awaitState(node, "revert:synthetic:blockedcancel", "parked", "running");
+
+            await expect(
+                (async () => node.act(a => a.get(TestTaskManager).cancel("synthetic:blockedcancel")))(),
+            ).rejectedWith(TaskConflictError);
+
+            // Memory must not claim a cancel that storage never saw.
+            const status = await node.act(a => a.get(TestTaskManager).get("synthetic:blockedcancel")?.status);
+            expect(status?.state).does.not.equal("cancelled");
+            expect(node.stateOf(TestTaskManager).tasks["synthetic:blockedcancel"].state).equals(status?.state);
+            await node.close();
         });
     });
 
@@ -191,6 +571,68 @@ describe("Task lifecycle", () => {
             const status = await node.act(a => a.get(TestTaskManager).get("synthetic:cancel")?.status);
             expect(status?.state).equals("completed");
             expect(status?.revertTaskId).equals("revert:synthetic:cancel");
+            await node.close();
+        });
+
+        it("refuses a re-run while the rollback of a previous run is in flight", async () => {
+            const environment = new Environment("test");
+            const peer = new FakePeer("rr");
+            TestTaskManager.peers.set("rr", peer);
+            TestTaskManager.reconcilerPeer = peer;
+            peer.markHas("groupMembership", "1");
+
+            SyntheticTask.phasesByTag["rerun"] = [gatePhase("rr", "groupMembership", "1")];
+
+            const node = await makeNode(environment);
+            await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+            await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "rerun" }));
+            await awaitState(node, "synthetic:rerun", "completed");
+
+            // The peer goes away, so the rollback parks instead of finishing.
+            peer.setReachable(false);
+            const revert = await node.act(a => a.get(TestTaskManager).cancel("synthetic:rerun"));
+            expect(revert?.id).equals("revert:synthetic:rerun");
+            await awaitState(node, "revert:synthetic:rerun", "parked", "running");
+
+            // Re-running now would re-apply exactly the intents the rollback is removing.
+            await expect(
+                (async () => node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "rerun" })))(),
+            ).rejectedWith(TaskConflictError);
+
+            peer.setReachable(true);
+            await awaitState(node, "revert:synthetic:rerun", "completed");
+            await node.close();
+        });
+
+        it("cancels through the external id of a caller that deduped onto the task", async () => {
+            const environment = new Environment("test");
+            const peer = new FakePeer("ac");
+            TestTaskManager.peers.set("ac", peer);
+            TestTaskManager.reconcilerPeer = peer;
+            // The device never "has" the item, so the gate is still in flight when the second caller arrives.
+
+            SyntheticTask.phasesByTag["aliascancel"] = [gatePhase("ac", "groupMembership", "X")];
+
+            const node = await makeNode(environment);
+            await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+            await node.act(a =>
+                a.get(TestTaskManager).run("synthetic", { tag: "aliascancel" }, { externalId: "owner" }),
+            );
+            for (let i = 0; i < 10_000 && peer.items[itemMapKey("groupMembership", "X")] === undefined; i++) {
+                await MockTime.advance(1);
+            }
+            await node.act(a =>
+                a.get(TestTaskManager).run("synthetic", { tag: "aliascancel" }, { externalId: "joiner" }),
+            );
+
+            // The joiner's id must reach the same work, all the way to rolling it back.
+            const handle = await node.act(a => a.get(TestTaskManager).cancel("joiner"));
+            expect(handle?.id).equals("revert:synthetic:aliascancel");
+            const status = await node.act(a => a.get(TestTaskManager).get("owner")?.status);
+            expect(status?.state).equals("cancelled");
+
+            await awaitState(node, "revert:synthetic:aliascancel", "completed");
+            expect(peer.items[itemMapKey("groupMembership", "X")]).equals(undefined);
             await node.close();
         });
 

--- a/packages/node-manager/test/task/TaskLifecycleTest.ts
+++ b/packages/node-manager/test/task/TaskLifecycleTest.ts
@@ -287,6 +287,11 @@ describe("Task lifecycle", () => {
             // The abort stopped the driver and dropped the gate; declining the cancel must give both back, or the
             // task sits non-terminal with nothing left to advance it until a restart.
             expect(await node.act(a => a.get(TestTaskManager).isDriven("synthetic:blockedcancel"))).equals(true);
+
+            // ...and it still converges once the device has the item, which it cannot do without a driver.
+            peer.markHas("groupMembership", "K");
+            peer.setReachable(true);
+            await awaitState(node, "synthetic:blockedcancel", "completed");
             await node.close();
         });
     });

--- a/packages/node-manager/test/task/TaskManagerBehaviorTest.ts
+++ b/packages/node-manager/test/task/TaskManagerBehaviorTest.ts
@@ -132,6 +132,19 @@ describe("TaskManagerBehavior", () => {
         expect(status?.state).equals("completed");
     });
 
+    it("keeps a handle answering for its task as the task progresses", async () => {
+        await using node = await makeNode();
+        SyntheticTask.phasesByTag["held"] = [{ name: "a", run: async () => {} }];
+        await node.act(async agent => {
+            agent.get(TaskManagerBehavior).register("synthetic", SyntheticTask);
+        });
+        const handle = await node.act(agent => agent.get(TaskManagerBehavior).run("synthetic", { tag: "held" }));
+        expect(handle.status.state).equals("running");
+
+        await awaitTaskDone(node, "synthetic:held");
+        expect(handle.status.state).equals("completed");
+    });
+
     it("dedups an in-flight task by deterministic id, and re-runs a terminal one", async () => {
         await using node = await makeNode();
         let runs = 0;

--- a/packages/node-manager/test/task/TaskManagerBehaviorTest.ts
+++ b/packages/node-manager/test/task/TaskManagerBehaviorTest.ts
@@ -5,9 +5,9 @@
  */
 
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
-import { TaskFailedError } from "#task/errors.js";
+import { TaskConflictError, TaskFailedError, TaskNotFoundError } from "#task/errors.js";
 import { RotateGroupKey } from "#task/groups/RotateGroupKey.js";
-import { Task } from "#task/Task.js";
+import { Task, TaskPersistence } from "#task/Task.js";
 import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { TaskPhase } from "#task/types.js";
 import { Environment } from "@matter/general";
@@ -17,18 +17,80 @@ import { SyntheticTask } from "./helpers.js";
 
 const RootEndpoint = MockServerNode.RootEndpoint.with(TaskManagerBehavior);
 
+/** Retention limit lowered so eviction is observable without driving dozens of tasks. */
+class RetentionTaskManager extends TaskManagerBehavior {
+    static override readonly schema = TaskManagerBehavior.schema;
+
+    /** True while a drive of `id` owns this id's gate and driving entries. */
+    isDriven(id: string): boolean {
+        return this.internal.driving.has(id) && this.internal.gates.has(id);
+    }
+
+    protected override get terminalRetention() {
+        return 2;
+    }
+}
+
+/** A controller that keeps no finished history at all. */
+class ZeroRetentionTaskManager extends TaskManagerBehavior {
+    static override readonly schema = TaskManagerBehavior.schema;
+    protected override get terminalRetention() {
+        return 0;
+    }
+}
+
+/**
+ * Fires a hook while its terminal record is being serialized for storage, i.e. after the task is terminal but
+ * before its drive promise settles.
+ */
+class HookedTask extends SyntheticTask {
+    static atTerminalWrite?: () => void;
+
+    override toPersistence(): TaskPersistence {
+        const record = super.toPersistence();
+        if (record.state === "completed") {
+            const hook = HookedTask.atTerminalWrite;
+            HookedTask.atTerminalWrite = undefined;
+            hook?.();
+        }
+        return record;
+    }
+}
+
+const RetentionRootEndpoint = MockServerNode.RootEndpoint.with(RetentionTaskManager);
+
+const ZeroRetentionRootEndpoint = MockServerNode.RootEndpoint.with(ZeroRetentionTaskManager);
+
+function terminalRecord(tag: string): TaskPersistence {
+    return { type: "synthetic", params: { tag }, phaseIndex: 1, state: "completed", changeSet: [] };
+}
+
 async function makeNode(environment?: Environment) {
     return MockServerNode.create(RootEndpoint, { environment, id: "tm-test" });
+}
+
+async function pumpUntil(name: string, condition: () => boolean | Promise<boolean>) {
+    for (let i = 0; i < 10_000; i++) {
+        if (await condition()) {
+            return;
+        }
+        await MockTime.advance(1);
+    }
+    throw new Error(`Condition "${name}" never held`);
 }
 
 /**
  * Advances MockTime until the persisted state for the task reaches a terminal state.
  * Polling persisted state (state.tasks[id]) ensures #drive's final #persist has completed.
  */
-async function awaitTaskDone(node: ServerNode, id: string): Promise<void> {
+async function awaitTaskDone(
+    node: ServerNode,
+    id: string,
+    type: typeof TaskManagerBehavior = TaskManagerBehavior,
+): Promise<void> {
     // Bound the poll loop so a never-terminating task fails clearly instead of spinning.
     for (let i = 0; i < 10_000; i++) {
-        const state = await node.act(a => a.get(TaskManagerBehavior).state.tasks[id]?.state);
+        const state = await node.act(a => a.get(type).state.tasks[id]?.state);
         if (state === "completed" || state === "failed") return;
         await MockTime.advance(1);
     }
@@ -70,16 +132,154 @@ describe("TaskManagerBehavior", () => {
         expect(status?.state).equals("completed");
     });
 
-    it("dedups by deterministic id (re-run returns the same task)", async () => {
+    it("dedups an in-flight task by deterministic id, and re-runs a terminal one", async () => {
         await using node = await makeNode();
-        SyntheticTask.phasesByTag["dup"] = [{ name: "a", run: async () => {} }];
+        let runs = 0;
+        let release!: () => void;
+        const blocked = new Promise<void>(resolve => (release = resolve));
+        SyntheticTask.phasesByTag["dup"] = [
+            {
+                name: "a",
+                run: async () => {
+                    runs++;
+                    await blocked;
+                },
+            },
+        ];
         await node.act(agent => agent.get(TaskManagerBehavior).register("synthetic", SyntheticTask));
+
         const h1 = await node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "dup" }));
+        await pumpUntil("first run in flight", () => runs === 1);
+
+        // A live, non-terminal task with identical parameters dedups.
+        try {
+            const h2 = await node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "dup" }));
+            expect(h2.id).equals(h1.id);
+            expect(runs).equals(1);
+            expect(await node.act(a => a.get(TaskManagerBehavior).tasks.length)).equals(1);
+        } finally {
+            release();
+        }
         await awaitTaskDone(node, "synthetic:dup");
-        const h2 = await node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "dup" }));
-        expect(h1.id).equals(h2.id);
-        const count = await node.act(a => a.get(TaskManagerBehavior).tasks.length);
-        expect(count).equals(1);
+
+        // A terminal task no longer dedups: the requested work runs again under the same deterministic id.
+        const h3 = await node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "dup" }));
+        expect(h3.id).equals(h1.id);
+        await pumpUntil("re-run in flight", () => runs === 2);
+        await pumpUntil("re-run complete", async () => {
+            const state = await node.act(a => a.get(TaskManagerBehavior).get("synthetic:dup")?.status.state);
+            return state === "completed";
+        });
+        expect(await node.act(a => a.get(TaskManagerBehavior).tasks.length)).equals(1);
+    });
+
+    it("rejects a re-run of a live task whose parameters differ", async () => {
+        await using node = await makeNode();
+        let runs = 0;
+        let release!: () => void;
+        const blocked = new Promise<void>(resolve => (release = resolve));
+
+        class PartialIdTask extends Task<{ tag: string; value: number }> {
+            override readonly type = "partialId";
+            override get phases(): TaskPhase[] {
+                return [
+                    {
+                        name: "hold",
+                        run: async () => {
+                            runs++;
+                            await blocked;
+                        },
+                    },
+                ];
+            }
+            // The id covers only `tag`, so `value` can differ between requests for the same id.
+            static override idFor(params: { tag: string }) {
+                return `partialId:${params.tag}`;
+            }
+        }
+
+        await node.act(a => a.get(TaskManagerBehavior).register("partialId", PartialIdTask));
+        const h1 = await node.act(a => a.get(TaskManagerBehavior).run("partialId", { tag: "p", value: 1 }));
+        await pumpUntil("task in flight", () => runs === 1);
+
+        try {
+            // `act` returns a MaybePromise, so normalize before asserting on the rejection.
+            await expect(
+                (async () => node.act(a => a.get(TaskManagerBehavior).run("partialId", { tag: "p", value: 2 })))(),
+            ).rejectedWith(TaskConflictError);
+
+            // An identical request stays idempotent.
+            const h2 = await node.act(a => a.get(TaskManagerBehavior).run("partialId", { tag: "p", value: 1 }));
+            expect(h2.id).equals(h1.id);
+            expect(runs).equals(1);
+        } finally {
+            release();
+        }
+        await awaitTaskDone(node, "partialId:p");
+    });
+
+    it("retains only the most recent terminal tasks", async () => {
+        await using node = await MockServerNode.create(RetentionRootEndpoint, { id: "tm-retention" });
+        SyntheticTask.phasesByTag["r1"] = [{ name: "a", run: async () => {} }];
+        SyntheticTask.phasesByTag["r2"] = [{ name: "a", run: async () => {} }];
+        SyntheticTask.phasesByTag["r3"] = [{ name: "a", run: async () => {} }];
+        await node.act(a => a.get(RetentionTaskManager).register("synthetic", SyntheticTask));
+
+        for (const tag of ["r1", "r2", "r3"]) {
+            await node.act(a => a.get(RetentionTaskManager).run("synthetic", { tag }));
+            await awaitTaskDone(node, `synthetic:${tag}`, RetentionTaskManager);
+        }
+
+        const ids = await node.act(a => a.get(RetentionTaskManager).tasks.map(t => t.id));
+        expect([...ids].sort()).deep.equals(["synthetic:r2", "synthetic:r3"]);
+        expect(await node.act(a => a.get(RetentionTaskManager).get("synthetic:r1"))).equals(undefined);
+        expect(Object.keys(node.stateOf(RetentionTaskManager).tasks).sort()).deep.equals([
+            "synthetic:r2",
+            "synthetic:r3",
+        ]);
+    });
+
+    it("keeps storage bounded for a controller that retains no finished history", async () => {
+        await using node = await MockServerNode.create(ZeroRetentionRootEndpoint, { id: "tm-retention-zero" });
+        for (const tag of ["z1", "z2", "z3"]) {
+            SyntheticTask.phasesByTag[tag] = [{ name: "a", run: async () => {} }];
+        }
+        await node.act(a => a.get(ZeroRetentionTaskManager).register("synthetic", SyntheticTask));
+
+        for (const tag of ["z1", "z2", "z3"]) {
+            await node.act(a => a.get(ZeroRetentionTaskManager).run("synthetic", { tag }));
+            await awaitTaskDone(node, `synthetic:${tag}`, ZeroRetentionTaskManager);
+        }
+
+        // A record the current write also stores cannot be forgotten by that write, so it stays in the retention
+        // queue and a later write prunes it. Otherwise every finished task leaks into storage forever.
+        expect(Object.keys(node.stateOf(ZeroRetentionTaskManager).tasks)).deep.equals(["synthetic:z3"]);
+    });
+
+    it("prunes inherited terminal records down to the retention bound at startup", async () => {
+        const environment = new Environment("test");
+        const node1 = await MockServerNode.create(RetentionRootEndpoint, { environment, id: "tm-retention-inherit" });
+        await node1.act(a => {
+            a.get(RetentionTaskManager).state.tasks = {
+                "synthetic:i1": terminalRecord("i1"),
+                "synthetic:i2": terminalRecord("i2"),
+                "synthetic:i3": terminalRecord("i3"),
+                "synthetic:i4": terminalRecord("i4"),
+            };
+        });
+        await node1.close();
+
+        const node2 = await MockServerNode.create(RetentionRootEndpoint, { environment, id: "tm-retention-inherit" });
+        await node2.close();
+
+        // Asserted only against freshly loaded storage: an in-memory prune would leave a start that retains far
+        // more with all four records again.
+        const node3 = await MockServerNode.create(RootEndpoint, { environment, id: "tm-retention-inherit" });
+        expect(Object.keys(node3.stateOf(TaskManagerBehavior).tasks).sort()).deep.equals([
+            "synthetic:i3",
+            "synthetic:i4",
+        ]);
+        await node3.close();
     });
 
     it("looks up by external id", async () => {
@@ -89,7 +289,126 @@ describe("TaskManagerBehavior", () => {
         await node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "ext" }, { externalId: "myref" }));
         await awaitTaskDone(node, "synthetic:ext");
         const found = await node.act(a => a.get(TaskManagerBehavior).get("myref"));
-        expect(found?.status.externalId).equals("myref");
+        expect(found?.status.externalIds).deep.equals(["myref"]);
+    });
+
+    it("resolves the external id of every caller that deduped onto one task", async () => {
+        await using node = await makeNode();
+        let release!: () => void;
+        const blocked = new Promise<void>(resolve => (release = resolve));
+        let runs = 0;
+        SyntheticTask.phasesByTag["shared"] = [
+            {
+                name: "a",
+                run: async () => {
+                    runs++;
+                    await blocked;
+                },
+            },
+        ];
+        await node.act(a => a.get(TaskManagerBehavior).register("synthetic", SyntheticTask));
+
+        const first = await node.act(a =>
+            a.get(TaskManagerBehavior).run("synthetic", { tag: "shared" }, { externalId: "first" }),
+        );
+        await pumpUntil("task in flight", () => runs === 1);
+        try {
+            const second = await node.act(a =>
+                a.get(TaskManagerBehavior).run("synthetic", { tag: "shared" }, { externalId: "second" }),
+            );
+            expect(second.id).equals(first.id);
+            expect(runs).equals(1);
+
+            // Both callers hold a working handle on the one task that does their work.
+            expect(second.status.externalIds).deep.equals(["first", "second"]);
+            expect(await node.act(a => a.get(TaskManagerBehavior).get("first")?.id)).equals(first.id);
+            expect(await node.act(a => a.get(TaskManagerBehavior).get("second")?.id)).equals(first.id);
+
+            // A caller re-issuing its own request under its own id is idempotent, not a conflict with itself.
+            const again = await node.act(a =>
+                a.get(TaskManagerBehavior).run("synthetic", { tag: "shared" }, { externalId: "second" }),
+            );
+            expect(again.id).equals(first.id);
+            expect(again.status.externalIds).deep.equals(["first", "second"]);
+            expect(runs).equals(1);
+        } finally {
+            release();
+        }
+        await awaitTaskDone(node, "synthetic:shared");
+    });
+
+    it("reuses an external id retained by finished work for the live task that claims it", async () => {
+        await using node = await makeNode();
+        let release!: () => void;
+        const blocked = new Promise<void>(resolve => (release = resolve));
+        SyntheticTask.phasesByTag["was"] = [{ name: "a", run: async () => {} }];
+        SyntheticTask.phasesByTag["now"] = [{ name: "a", run: async () => await blocked }];
+        await node.act(a => a.get(TaskManagerBehavior).register("synthetic", SyntheticTask));
+
+        await node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "was" }, { externalId: "nightly" }));
+        await awaitTaskDone(node, "synthetic:was");
+
+        // Retained history keeps the id it ran under, but the caller means its current request by it.
+        await node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "now" }, { externalId: "nightly" }));
+        try {
+            expect(await node.act(a => a.get(TaskManagerBehavior).get("nightly")?.id)).equals("synthetic:now");
+        } finally {
+            release();
+        }
+        await awaitTaskDone(node, "synthetic:now");
+
+        // Both runs are retained under the id now, and it still means the one that ran most recently.
+        expect(await node.act(a => a.get(TaskManagerBehavior).get("nightly")?.id)).equals("synthetic:now");
+    });
+
+    it("refuses an external id that already names other live work", async () => {
+        await using node = await makeNode();
+        let release!: () => void;
+        const blocked = new Promise<void>(resolve => (release = resolve));
+        let runs = 0;
+        for (const tag of ["taken", "other"]) {
+            SyntheticTask.phasesByTag[tag] = [
+                {
+                    name: "a",
+                    run: async () => {
+                        runs++;
+                        await blocked;
+                    },
+                },
+            ];
+        }
+        await node.act(a => a.get(TaskManagerBehavior).register("synthetic", SyntheticTask));
+        await node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "taken" }, { externalId: "ref" }));
+        await pumpUntil("task in flight", () => runs === 1);
+
+        try {
+            // An id that resolves to someone else's task would let this caller observe and cancel the wrong work.
+            await expect(
+                (async () =>
+                    node.act(a =>
+                        a.get(TaskManagerBehavior).run("synthetic", { tag: "other" }, { externalId: "ref" }),
+                    ))(),
+            ).rejectedWith(TaskConflictError);
+
+            // Nor may it shadow a live task's own id.
+            await expect(
+                (async () =>
+                    node.act(a =>
+                        a
+                            .get(TaskManagerBehavior)
+                            .run("synthetic", { tag: "other" }, { externalId: "synthetic:taken" }),
+                    ))(),
+            ).rejectedWith(TaskConflictError);
+
+            // The refused requests started nothing.
+            expect(runs).equals(1);
+            expect(await node.act(a => a.get(TaskManagerBehavior).tasks.map(t => t.id))).deep.equals([
+                "synthetic:taken",
+            ]);
+        } finally {
+            release();
+        }
+        await awaitTaskDone(node, "synthetic:taken");
     });
 
     it("marks a rotation non-revertible once activate begins; tasks are revertible by default", () => {
@@ -155,6 +474,204 @@ describe("TaskManagerBehavior", () => {
         expect(nonRevertible?.state).equals("failed");
         expect(nonRevertible?.revertTaskId).equals(undefined);
         expect(await node.act(a => a.get(TaskManagerBehavior).state.tasks["revert:hardFail:final"])).equals(undefined);
+    });
+
+    it("prunes terminal records inherited from a previous start", async () => {
+        const environment = new Environment("test");
+        SyntheticTask.phasesByTag["p1"] = [{ name: "a", run: async () => {} }];
+        SyntheticTask.phasesByTag["p2"] = [{ name: "a", run: async () => {} }];
+        SyntheticTask.phasesByTag["p3"] = [{ name: "a", run: async () => {} }];
+
+        const node1 = await MockServerNode.create(RetentionRootEndpoint, { environment, id: "tm-retention-restart" });
+        await node1.act(a => a.get(RetentionTaskManager).register("synthetic", SyntheticTask));
+        for (const tag of ["p1", "p2"]) {
+            await node1.act(a => a.get(RetentionTaskManager).run("synthetic", { tag }));
+            await awaitTaskDone(node1, `synthetic:${tag}`, RetentionTaskManager);
+        }
+        expect(Object.keys(node1.stateOf(RetentionTaskManager).tasks).length).equals(2);
+        await node1.close();
+
+        const node2 = await MockServerNode.create(RetentionRootEndpoint, { environment, id: "tm-retention-restart" });
+        await node2.act(a => a.get(RetentionTaskManager).register("synthetic", SyntheticTask));
+        await node2.act(a => a.get(RetentionTaskManager).run("synthetic", { tag: "p3" }));
+        await awaitTaskDone(node2, "synthetic:p3", RetentionTaskManager);
+
+        expect(Object.keys(node2.stateOf(RetentionTaskManager).tasks).sort()).deep.equals([
+            "synthetic:p2",
+            "synthetic:p3",
+        ]);
+        await node2.close();
+    });
+
+    it("does not evict a re-run that reuses the id of a retired task", async () => {
+        await using node = await MockServerNode.create(RetentionRootEndpoint, { id: "tm-retention-rerun" });
+        let release!: () => void;
+        const blocked = new Promise<void>(resolve => (release = resolve));
+        let holding = false;
+        let runs = 0;
+        SyntheticTask.phasesByTag["k1"] = [
+            {
+                name: "a",
+                run: async () => {
+                    runs++;
+                    if (holding) {
+                        await blocked;
+                    }
+                },
+            },
+        ];
+        for (const tag of ["k2", "k3", "k4"]) {
+            SyntheticTask.phasesByTag[tag] = [{ name: "a", run: async () => {} }];
+        }
+        await node.act(a => a.get(RetentionTaskManager).register("synthetic", SyntheticTask));
+
+        // Fill the retention queue with two terminal tasks.
+        for (const tag of ["k1", "k2"]) {
+            await node.act(a => a.get(RetentionTaskManager).run("synthetic", { tag }));
+            await awaitTaskDone(node, `synthetic:${tag}`, RetentionTaskManager);
+        }
+
+        holding = true;
+        await node.act(a => a.get(RetentionTaskManager).run("synthetic", { tag: "k1" }));
+        await pumpUntil("re-run in flight", () => runs === 2);
+
+        try {
+            // Two more terminal tasks refill the queue, so the second one's write evicts.
+            for (const tag of ["k3", "k4"]) {
+                await node.act(a => a.get(RetentionTaskManager).run("synthetic", { tag }));
+                await awaitTaskDone(node, `synthetic:${tag}`, RetentionTaskManager);
+            }
+            expect(node.stateOf(RetentionTaskManager).tasks["synthetic:k2"]).equals(undefined);
+
+            const status = await node.act(a => a.get(RetentionTaskManager).get("synthetic:k1")?.status);
+            expect(status?.state).equals("running");
+            expect(node.stateOf(RetentionTaskManager).tasks["synthetic:k1"]).not.equals(undefined);
+        } finally {
+            release();
+        }
+    });
+
+    it("keeps driver bookkeeping of a re-run started while the previous drive still settles", async () => {
+        await using node = await MockServerNode.create(RetentionRootEndpoint, { id: "tm-rerun-race" });
+        let release!: () => void;
+        const blocked = new Promise<void>(resolve => (release = resolve));
+        let holding = false;
+        let runs = 0;
+        SyntheticTask.phasesByTag["race"] = [
+            {
+                name: "a",
+                run: async () => {
+                    if (++runs > 1) {
+                        holding = true;
+                        await blocked;
+                    }
+                },
+            },
+        ];
+        await node.act(a => a.get(RetentionTaskManager).register("synthetic", HookedTask));
+        let manager!: RetentionTaskManager;
+        await node.act(a => {
+            manager = a.get(RetentionTaskManager);
+        });
+
+        // Re-run from inside the terminal write of the first run: its drive promise has not settled yet.
+        HookedTask.atTerminalWrite = () => manager.run("synthetic", { tag: "race" });
+        try {
+            await node.act(a => a.get(RetentionTaskManager).run("synthetic", { tag: "race" }));
+            await pumpUntil("re-run in flight", () => holding);
+
+            expect(await node.act(a => a.get(RetentionTaskManager).isDriven("synthetic:race"))).equals(true);
+        } finally {
+            HookedTask.atTerminalWrite = undefined;
+            release();
+        }
+    });
+
+    it("keeps a re-run that took over a retired id alive through a later eviction", async () => {
+        await using node = await MockServerNode.create(RetentionRootEndpoint, { id: "tm-rerun-evict" });
+        let release!: () => void;
+        const blocked = new Promise<void>(resolve => (release = resolve));
+        let holding = false;
+        let runs = 0;
+        SyntheticTask.phasesByTag["own"] = [
+            {
+                name: "a",
+                run: async () => {
+                    if (++runs > 1) {
+                        holding = true;
+                        await blocked;
+                    }
+                },
+            },
+        ];
+        for (const tag of ["e1", "e2"]) {
+            SyntheticTask.phasesByTag[tag] = [{ name: "a", run: async () => {} }];
+        }
+        await node.act(a => a.get(RetentionTaskManager).register("synthetic", HookedTask));
+        let manager!: RetentionTaskManager;
+        await node.act(a => {
+            manager = a.get(RetentionTaskManager);
+        });
+
+        HookedTask.atTerminalWrite = () => manager.run("synthetic", { tag: "own" });
+        try {
+            await node.act(a => a.get(RetentionTaskManager).run("synthetic", { tag: "own" }));
+            await pumpUntil("re-run in flight", () => holding);
+
+            // The terminal record wrote while the re-run already owned the id, so the id must not be queued for
+            // eviction: dropping it would take the live re-run and its record with it.
+            for (const tag of ["e1", "e2"]) {
+                await node.act(a => a.get(RetentionTaskManager).run("synthetic", { tag }));
+                await awaitTaskDone(node, `synthetic:${tag}`, RetentionTaskManager);
+            }
+
+            const status = await node.act(a => a.get(RetentionTaskManager).get("synthetic:own")?.status);
+            expect(status?.state).equals("running");
+            expect(node.stateOf(RetentionTaskManager).tasks["synthetic:own"]).not.equals(undefined);
+        } finally {
+            HookedTask.atTerminalWrite = undefined;
+            release();
+        }
+    });
+
+    it("distinguishes an unretained task from a task with nothing to roll back", async () => {
+        const environment = new Environment("test");
+        const node = await MockServerNode.create(RootEndpoint, { environment, id: "tm-cancel-unknown" });
+        SyntheticTask.phasesByTag["nothing"] = [{ name: "a", run: async () => {} }];
+        await node.act(a => a.get(TaskManagerBehavior).register("synthetic", SyntheticTask));
+        await node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "nothing" }));
+        await awaitTaskDone(node, "synthetic:nothing");
+
+        // A task that touched nothing has nothing to roll back, and says so.
+        expect(await node.act(a => a.get(TaskManagerBehavior).cancel("synthetic:nothing"))).equals(undefined);
+
+        // An id nobody is holding work under is a different answer, not the same one.
+        await expect(
+            (async () => node.act(a => a.get(TaskManagerBehavior).cancel("synthetic:never-existed")))(),
+        ).rejectedWith(TaskNotFoundError);
+        expect(await node.act(a => a.get(TaskManagerBehavior).get("synthetic:never-existed"))).equals(undefined);
+
+        // So is a rollback the task recorded but retention has since forgotten.
+        await node.act(a => {
+            a.get(TaskManagerBehavior).state.tasks = {
+                "synthetic:orphan": {
+                    type: "synthetic",
+                    params: { tag: "orphan" },
+                    phaseIndex: 1,
+                    state: "cancelled",
+                    changeSet: [],
+                    revertTaskId: "revert:synthetic:orphan",
+                },
+            };
+        });
+        await node.close();
+
+        const node2 = await MockServerNode.create(RootEndpoint, { environment, id: "tm-cancel-unknown" });
+        await node2.act(a => a.get(TaskManagerBehavior).register("synthetic", SyntheticTask));
+        await expect(
+            (async () => node2.act(a => a.get(TaskManagerBehavior).cancel("synthetic:orphan")))(),
+        ).rejectedWith(TaskNotFoundError);
+        await node2.close();
     });
 
     it("persists task records in nonvolatile state", async () => {

--- a/packages/node-manager/test/task/TaskManagerBehaviorTest.ts
+++ b/packages/node-manager/test/task/TaskManagerBehaviorTest.ts
@@ -17,25 +17,13 @@ import { SyntheticTask } from "./helpers.js";
 
 const RootEndpoint = MockServerNode.RootEndpoint.with(TaskManagerBehavior);
 
-/** Retention limit lowered so eviction is observable without driving dozens of tasks. */
-class RetentionTaskManager extends TaskManagerBehavior {
+/** Exposes the driver bookkeeping a test cannot otherwise observe. */
+class TracingTaskManager extends TaskManagerBehavior {
     static override readonly schema = TaskManagerBehavior.schema;
 
     /** True while a drive of `id` owns this id's gate and driving entries. */
     isDriven(id: string): boolean {
         return this.internal.driving.has(id) && this.internal.gates.has(id);
-    }
-
-    protected override get terminalRetention() {
-        return 2;
-    }
-}
-
-/** A controller that keeps no finished history at all. */
-class ZeroRetentionTaskManager extends TaskManagerBehavior {
-    static override readonly schema = TaskManagerBehavior.schema;
-    protected override get terminalRetention() {
-        return 0;
     }
 }
 
@@ -57,13 +45,7 @@ class HookedTask extends SyntheticTask {
     }
 }
 
-const RetentionRootEndpoint = MockServerNode.RootEndpoint.with(RetentionTaskManager);
-
-const ZeroRetentionRootEndpoint = MockServerNode.RootEndpoint.with(ZeroRetentionTaskManager);
-
-function terminalRecord(tag: string): TaskPersistence {
-    return { type: "synthetic", params: { tag }, phaseIndex: 1, state: "completed", changeSet: [] };
-}
+const TracingRootEndpoint = MockServerNode.RootEndpoint.with(TracingTaskManager);
 
 async function makeNode(environment?: Environment) {
     return MockServerNode.create(RootEndpoint, { environment, id: "tm-test" });
@@ -83,14 +65,10 @@ async function pumpUntil(name: string, condition: () => boolean | Promise<boolea
  * Advances MockTime until the persisted state for the task reaches a terminal state.
  * Polling persisted state (state.tasks[id]) ensures #drive's final #persist has completed.
  */
-async function awaitTaskDone(
-    node: ServerNode,
-    id: string,
-    type: typeof TaskManagerBehavior = TaskManagerBehavior,
-): Promise<void> {
+async function awaitTaskDone(node: ServerNode, id: string): Promise<void> {
     // Bound the poll loop so a never-terminating task fails clearly instead of spinning.
     for (let i = 0; i < 10_000; i++) {
-        const state = await node.act(a => a.get(type).state.tasks[id]?.state);
+        const state = await node.act(a => a.get(TaskManagerBehavior).state.tasks[id]?.state);
         if (state === "completed" || state === "failed") return;
         await MockTime.advance(1);
     }
@@ -145,7 +123,7 @@ describe("TaskManagerBehavior", () => {
         expect(handle.status.state).equals("completed");
     });
 
-    it("dedups an in-flight task by deterministic id, and re-runs a terminal one", async () => {
+    it("refuses an anonymous re-run of a live task, and re-runs a terminal one", async () => {
         await using node = await makeNode();
         let runs = 0;
         let release!: () => void;
@@ -164,10 +142,13 @@ describe("TaskManagerBehavior", () => {
         const h1 = await node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "dup" }));
         await pumpUntil("first run in flight", () => runs === 1);
 
-        // A live, non-terminal task with identical parameters dedups.
         try {
-            const h2 = await node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "dup" }));
-            expect(h2.id).equals(h1.id);
+            // Nothing in this request identifies it as the one already running, and the id need not cover every
+            // parameter, so the live task's outcome is not necessarily the outcome asked for.
+            // `act` returns a MaybePromise, so normalize before asserting on the rejection.
+            await expect(
+                (async () => node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "dup" })))(),
+            ).rejectedWith(TaskConflictError);
             expect(runs).equals(1);
             expect(await node.act(a => a.get(TaskManagerBehavior).tasks.length)).equals(1);
         } finally {
@@ -175,7 +156,7 @@ describe("TaskManagerBehavior", () => {
         }
         await awaitTaskDone(node, "synthetic:dup");
 
-        // A terminal task no longer dedups: the requested work runs again under the same deterministic id.
+        // A terminal task does not hold its id, so the request runs again under it.
         const h3 = await node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "dup" }));
         expect(h3.id).equals(h1.id);
         await pumpUntil("re-run in flight", () => runs === 2);
@@ -186,131 +167,12 @@ describe("TaskManagerBehavior", () => {
         expect(await node.act(a => a.get(TaskManagerBehavior).tasks.length)).equals(1);
     });
 
-    it("rejects a re-run of a live task whose parameters differ", async () => {
+    it("joins a live task only for the caller re-issuing it under its own external id", async () => {
         await using node = await makeNode();
         let runs = 0;
         let release!: () => void;
         const blocked = new Promise<void>(resolve => (release = resolve));
-
-        class PartialIdTask extends Task<{ tag: string; value: number }> {
-            override readonly type = "partialId";
-            override get phases(): TaskPhase[] {
-                return [
-                    {
-                        name: "hold",
-                        run: async () => {
-                            runs++;
-                            await blocked;
-                        },
-                    },
-                ];
-            }
-            // The id covers only `tag`, so `value` can differ between requests for the same id.
-            static override idFor(params: { tag: string }) {
-                return `partialId:${params.tag}`;
-            }
-        }
-
-        await node.act(a => a.get(TaskManagerBehavior).register("partialId", PartialIdTask));
-        const h1 = await node.act(a => a.get(TaskManagerBehavior).run("partialId", { tag: "p", value: 1 }));
-        await pumpUntil("task in flight", () => runs === 1);
-
-        try {
-            // `act` returns a MaybePromise, so normalize before asserting on the rejection.
-            await expect(
-                (async () => node.act(a => a.get(TaskManagerBehavior).run("partialId", { tag: "p", value: 2 })))(),
-            ).rejectedWith(TaskConflictError);
-
-            // An identical request stays idempotent.
-            const h2 = await node.act(a => a.get(TaskManagerBehavior).run("partialId", { tag: "p", value: 1 }));
-            expect(h2.id).equals(h1.id);
-            expect(runs).equals(1);
-        } finally {
-            release();
-        }
-        await awaitTaskDone(node, "partialId:p");
-    });
-
-    it("retains only the most recent terminal tasks", async () => {
-        await using node = await MockServerNode.create(RetentionRootEndpoint, { id: "tm-retention" });
-        SyntheticTask.phasesByTag["r1"] = [{ name: "a", run: async () => {} }];
-        SyntheticTask.phasesByTag["r2"] = [{ name: "a", run: async () => {} }];
-        SyntheticTask.phasesByTag["r3"] = [{ name: "a", run: async () => {} }];
-        await node.act(a => a.get(RetentionTaskManager).register("synthetic", SyntheticTask));
-
-        for (const tag of ["r1", "r2", "r3"]) {
-            await node.act(a => a.get(RetentionTaskManager).run("synthetic", { tag }));
-            await awaitTaskDone(node, `synthetic:${tag}`, RetentionTaskManager);
-        }
-
-        const ids = await node.act(a => a.get(RetentionTaskManager).tasks.map(t => t.id));
-        expect([...ids].sort()).deep.equals(["synthetic:r2", "synthetic:r3"]);
-        expect(await node.act(a => a.get(RetentionTaskManager).get("synthetic:r1"))).equals(undefined);
-        expect(Object.keys(node.stateOf(RetentionTaskManager).tasks).sort()).deep.equals([
-            "synthetic:r2",
-            "synthetic:r3",
-        ]);
-    });
-
-    it("keeps storage bounded for a controller that retains no finished history", async () => {
-        await using node = await MockServerNode.create(ZeroRetentionRootEndpoint, { id: "tm-retention-zero" });
-        for (const tag of ["z1", "z2", "z3"]) {
-            SyntheticTask.phasesByTag[tag] = [{ name: "a", run: async () => {} }];
-        }
-        await node.act(a => a.get(ZeroRetentionTaskManager).register("synthetic", SyntheticTask));
-
-        for (const tag of ["z1", "z2", "z3"]) {
-            await node.act(a => a.get(ZeroRetentionTaskManager).run("synthetic", { tag }));
-            await awaitTaskDone(node, `synthetic:${tag}`, ZeroRetentionTaskManager);
-        }
-
-        // A record the current write also stores cannot be forgotten by that write, so it stays in the retention
-        // queue and a later write prunes it. Otherwise every finished task leaks into storage forever.
-        expect(Object.keys(node.stateOf(ZeroRetentionTaskManager).tasks)).deep.equals(["synthetic:z3"]);
-    });
-
-    it("prunes inherited terminal records down to the retention bound at startup", async () => {
-        const environment = new Environment("test");
-        const node1 = await MockServerNode.create(RetentionRootEndpoint, { environment, id: "tm-retention-inherit" });
-        await node1.act(a => {
-            a.get(RetentionTaskManager).state.tasks = {
-                "synthetic:i1": terminalRecord("i1"),
-                "synthetic:i2": terminalRecord("i2"),
-                "synthetic:i3": terminalRecord("i3"),
-                "synthetic:i4": terminalRecord("i4"),
-            };
-        });
-        await node1.close();
-
-        const node2 = await MockServerNode.create(RetentionRootEndpoint, { environment, id: "tm-retention-inherit" });
-        await node2.close();
-
-        // Asserted only against freshly loaded storage: an in-memory prune would leave a start that retains far
-        // more with all four records again.
-        const node3 = await MockServerNode.create(RootEndpoint, { environment, id: "tm-retention-inherit" });
-        expect(Object.keys(node3.stateOf(TaskManagerBehavior).tasks).sort()).deep.equals([
-            "synthetic:i3",
-            "synthetic:i4",
-        ]);
-        await node3.close();
-    });
-
-    it("looks up by external id", async () => {
-        await using node = await makeNode();
-        SyntheticTask.phasesByTag["ext"] = [{ name: "a", run: async () => {} }];
-        await node.act(a => a.get(TaskManagerBehavior).register("synthetic", SyntheticTask));
-        await node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "ext" }, { externalId: "myref" }));
-        await awaitTaskDone(node, "synthetic:ext");
-        const found = await node.act(a => a.get(TaskManagerBehavior).get("myref"));
-        expect(found?.status.externalIds).deep.equals(["myref"]);
-    });
-
-    it("resolves the external id of every caller that deduped onto one task", async () => {
-        await using node = await makeNode();
-        let release!: () => void;
-        const blocked = new Promise<void>(resolve => (release = resolve));
-        let runs = 0;
-        SyntheticTask.phasesByTag["shared"] = [
+        SyntheticTask.phasesByTag["mine"] = [
             {
                 name: "a",
                 run: async () => {
@@ -322,106 +184,47 @@ describe("TaskManagerBehavior", () => {
         await node.act(a => a.get(TaskManagerBehavior).register("synthetic", SyntheticTask));
 
         const first = await node.act(a =>
-            a.get(TaskManagerBehavior).run("synthetic", { tag: "shared" }, { externalId: "first" }),
+            a.get(TaskManagerBehavior).run("synthetic", { tag: "mine" }, { externalId: "owner" }),
         );
         await pumpUntil("task in flight", () => runs === 1);
+
         try {
-            const second = await node.act(a =>
-                a.get(TaskManagerBehavior).run("synthetic", { tag: "shared" }, { externalId: "second" }),
-            );
-            expect(second.id).equals(first.id);
-            expect(runs).equals(1);
-
-            // Both callers hold a working handle on the one task that does their work.
-            expect(second.status.externalIds).deep.equals(["first", "second"]);
-            expect(await node.act(a => a.get(TaskManagerBehavior).get("first")?.id)).equals(first.id);
-            expect(await node.act(a => a.get(TaskManagerBehavior).get("second")?.id)).equals(first.id);
-
-            // A caller re-issuing its own request under its own id is idempotent, not a conflict with itself.
             const again = await node.act(a =>
-                a.get(TaskManagerBehavior).run("synthetic", { tag: "shared" }, { externalId: "second" }),
+                a.get(TaskManagerBehavior).run("synthetic", { tag: "mine" }, { externalId: "owner" }),
             );
             expect(again.id).equals(first.id);
-            expect(again.status.externalIds).deep.equals(["first", "second"]);
+            expect(await node.act(a => a.get(TaskManagerBehavior).tasks.length)).equals(1);
+            // The join must reach the running task, not replace it under its id: a replacement would drive the
+            // phases a second time against the same peers.
+            for (let i = 0; i < 20; i++) {
+                await MockTime.advance(1);
+            }
             expect(runs).equals(1);
-        } finally {
-            release();
-        }
-        await awaitTaskDone(node, "synthetic:shared");
-    });
 
-    it("reuses an external id retained by finished work for the live task that claims it", async () => {
-        await using node = await makeNode();
-        let release!: () => void;
-        const blocked = new Promise<void>(resolve => (release = resolve));
-        SyntheticTask.phasesByTag["was"] = [{ name: "a", run: async () => {} }];
-        SyntheticTask.phasesByTag["now"] = [{ name: "a", run: async () => await blocked }];
-        await node.act(a => a.get(TaskManagerBehavior).register("synthetic", SyntheticTask));
-
-        await node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "was" }, { externalId: "nightly" }));
-        await awaitTaskDone(node, "synthetic:was");
-
-        // Retained history keeps the id it ran under, but the caller means its current request by it.
-        await node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "now" }, { externalId: "nightly" }));
-        try {
-            expect(await node.act(a => a.get(TaskManagerBehavior).get("nightly")?.id)).equals("synthetic:now");
-        } finally {
-            release();
-        }
-        await awaitTaskDone(node, "synthetic:now");
-
-        // Both runs are retained under the id now, and it still means the one that ran most recently.
-        expect(await node.act(a => a.get(TaskManagerBehavior).get("nightly")?.id)).equals("synthetic:now");
-    });
-
-    it("refuses an external id that already names other live work", async () => {
-        await using node = await makeNode();
-        let release!: () => void;
-        const blocked = new Promise<void>(resolve => (release = resolve));
-        let runs = 0;
-        for (const tag of ["taken", "other"]) {
-            SyntheticTask.phasesByTag[tag] = [
-                {
-                    name: "a",
-                    run: async () => {
-                        runs++;
-                        await blocked;
-                    },
-                },
-            ];
-        }
-        await node.act(a => a.get(TaskManagerBehavior).register("synthetic", SyntheticTask));
-        await node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "taken" }, { externalId: "ref" }));
-        await pumpUntil("task in flight", () => runs === 1);
-
-        try {
-            // An id that resolves to someone else's task would let this caller observe and cancel the wrong work.
+            // Another caller's id is not the one the live task runs under, so it is refused rather than resolved
+            // onto work that caller never asked for.
             await expect(
                 (async () =>
                     node.act(a =>
-                        a.get(TaskManagerBehavior).run("synthetic", { tag: "other" }, { externalId: "ref" }),
+                        a.get(TaskManagerBehavior).run("synthetic", { tag: "mine" }, { externalId: "other" }),
                     ))(),
             ).rejectedWith(TaskConflictError);
-
-            // Nor may it shadow a live task's own id.
-            await expect(
-                (async () =>
-                    node.act(a =>
-                        a
-                            .get(TaskManagerBehavior)
-                            .run("synthetic", { tag: "other" }, { externalId: "synthetic:taken" }),
-                    ))(),
-            ).rejectedWith(TaskConflictError);
-
-            // The refused requests started nothing.
             expect(runs).equals(1);
-            expect(await node.act(a => a.get(TaskManagerBehavior).tasks.map(t => t.id))).deep.equals([
-                "synthetic:taken",
-            ]);
+            expect(await node.act(a => a.get(TaskManagerBehavior).tasks.length)).equals(1);
         } finally {
             release();
         }
-        await awaitTaskDone(node, "synthetic:taken");
+        await awaitTaskDone(node, "synthetic:mine");
+    });
+
+    it("looks up by external id", async () => {
+        await using node = await makeNode();
+        SyntheticTask.phasesByTag["ext"] = [{ name: "a", run: async () => {} }];
+        await node.act(a => a.get(TaskManagerBehavior).register("synthetic", SyntheticTask));
+        await node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "ext" }, { externalId: "myref" }));
+        await awaitTaskDone(node, "synthetic:ext");
+        const found = await node.act(a => a.get(TaskManagerBehavior).get("myref"));
+        expect(found?.status.externalId).equals("myref");
     });
 
     it("marks a rotation non-revertible once activate begins; tasks are revertible by default", () => {
@@ -489,83 +292,8 @@ describe("TaskManagerBehavior", () => {
         expect(await node.act(a => a.get(TaskManagerBehavior).state.tasks["revert:hardFail:final"])).equals(undefined);
     });
 
-    it("prunes terminal records inherited from a previous start", async () => {
-        const environment = new Environment("test");
-        SyntheticTask.phasesByTag["p1"] = [{ name: "a", run: async () => {} }];
-        SyntheticTask.phasesByTag["p2"] = [{ name: "a", run: async () => {} }];
-        SyntheticTask.phasesByTag["p3"] = [{ name: "a", run: async () => {} }];
-
-        const node1 = await MockServerNode.create(RetentionRootEndpoint, { environment, id: "tm-retention-restart" });
-        await node1.act(a => a.get(RetentionTaskManager).register("synthetic", SyntheticTask));
-        for (const tag of ["p1", "p2"]) {
-            await node1.act(a => a.get(RetentionTaskManager).run("synthetic", { tag }));
-            await awaitTaskDone(node1, `synthetic:${tag}`, RetentionTaskManager);
-        }
-        expect(Object.keys(node1.stateOf(RetentionTaskManager).tasks).length).equals(2);
-        await node1.close();
-
-        const node2 = await MockServerNode.create(RetentionRootEndpoint, { environment, id: "tm-retention-restart" });
-        await node2.act(a => a.get(RetentionTaskManager).register("synthetic", SyntheticTask));
-        await node2.act(a => a.get(RetentionTaskManager).run("synthetic", { tag: "p3" }));
-        await awaitTaskDone(node2, "synthetic:p3", RetentionTaskManager);
-
-        expect(Object.keys(node2.stateOf(RetentionTaskManager).tasks).sort()).deep.equals([
-            "synthetic:p2",
-            "synthetic:p3",
-        ]);
-        await node2.close();
-    });
-
-    it("does not evict a re-run that reuses the id of a retired task", async () => {
-        await using node = await MockServerNode.create(RetentionRootEndpoint, { id: "tm-retention-rerun" });
-        let release!: () => void;
-        const blocked = new Promise<void>(resolve => (release = resolve));
-        let holding = false;
-        let runs = 0;
-        SyntheticTask.phasesByTag["k1"] = [
-            {
-                name: "a",
-                run: async () => {
-                    runs++;
-                    if (holding) {
-                        await blocked;
-                    }
-                },
-            },
-        ];
-        for (const tag of ["k2", "k3", "k4"]) {
-            SyntheticTask.phasesByTag[tag] = [{ name: "a", run: async () => {} }];
-        }
-        await node.act(a => a.get(RetentionTaskManager).register("synthetic", SyntheticTask));
-
-        // Fill the retention queue with two terminal tasks.
-        for (const tag of ["k1", "k2"]) {
-            await node.act(a => a.get(RetentionTaskManager).run("synthetic", { tag }));
-            await awaitTaskDone(node, `synthetic:${tag}`, RetentionTaskManager);
-        }
-
-        holding = true;
-        await node.act(a => a.get(RetentionTaskManager).run("synthetic", { tag: "k1" }));
-        await pumpUntil("re-run in flight", () => runs === 2);
-
-        try {
-            // Two more terminal tasks refill the queue, so the second one's write evicts.
-            for (const tag of ["k3", "k4"]) {
-                await node.act(a => a.get(RetentionTaskManager).run("synthetic", { tag }));
-                await awaitTaskDone(node, `synthetic:${tag}`, RetentionTaskManager);
-            }
-            expect(node.stateOf(RetentionTaskManager).tasks["synthetic:k2"]).equals(undefined);
-
-            const status = await node.act(a => a.get(RetentionTaskManager).get("synthetic:k1")?.status);
-            expect(status?.state).equals("running");
-            expect(node.stateOf(RetentionTaskManager).tasks["synthetic:k1"]).not.equals(undefined);
-        } finally {
-            release();
-        }
-    });
-
     it("keeps driver bookkeeping of a re-run started while the previous drive still settles", async () => {
-        await using node = await MockServerNode.create(RetentionRootEndpoint, { id: "tm-rerun-race" });
+        await using node = await MockServerNode.create(TracingRootEndpoint, { id: "tm-rerun-race" });
         let release!: () => void;
         const blocked = new Promise<void>(resolve => (release = resolve));
         let holding = false;
@@ -581,73 +309,26 @@ describe("TaskManagerBehavior", () => {
                 },
             },
         ];
-        await node.act(a => a.get(RetentionTaskManager).register("synthetic", HookedTask));
-        let manager!: RetentionTaskManager;
+        await node.act(a => a.get(TracingTaskManager).register("synthetic", HookedTask));
+        let manager!: TracingTaskManager;
         await node.act(a => {
-            manager = a.get(RetentionTaskManager);
+            manager = a.get(TracingTaskManager);
         });
 
         // Re-run from inside the terminal write of the first run: its drive promise has not settled yet.
         HookedTask.atTerminalWrite = () => manager.run("synthetic", { tag: "race" });
         try {
-            await node.act(a => a.get(RetentionTaskManager).run("synthetic", { tag: "race" }));
+            await node.act(a => a.get(TracingTaskManager).run("synthetic", { tag: "race" }));
             await pumpUntil("re-run in flight", () => holding);
 
-            expect(await node.act(a => a.get(RetentionTaskManager).isDriven("synthetic:race"))).equals(true);
+            expect(await node.act(a => a.get(TracingTaskManager).isDriven("synthetic:race"))).equals(true);
         } finally {
             HookedTask.atTerminalWrite = undefined;
             release();
         }
     });
 
-    it("keeps a re-run that took over a retired id alive through a later eviction", async () => {
-        await using node = await MockServerNode.create(RetentionRootEndpoint, { id: "tm-rerun-evict" });
-        let release!: () => void;
-        const blocked = new Promise<void>(resolve => (release = resolve));
-        let holding = false;
-        let runs = 0;
-        SyntheticTask.phasesByTag["own"] = [
-            {
-                name: "a",
-                run: async () => {
-                    if (++runs > 1) {
-                        holding = true;
-                        await blocked;
-                    }
-                },
-            },
-        ];
-        for (const tag of ["e1", "e2"]) {
-            SyntheticTask.phasesByTag[tag] = [{ name: "a", run: async () => {} }];
-        }
-        await node.act(a => a.get(RetentionTaskManager).register("synthetic", HookedTask));
-        let manager!: RetentionTaskManager;
-        await node.act(a => {
-            manager = a.get(RetentionTaskManager);
-        });
-
-        HookedTask.atTerminalWrite = () => manager.run("synthetic", { tag: "own" });
-        try {
-            await node.act(a => a.get(RetentionTaskManager).run("synthetic", { tag: "own" }));
-            await pumpUntil("re-run in flight", () => holding);
-
-            // The terminal record wrote while the re-run already owned the id, so the id must not be queued for
-            // eviction: dropping it would take the live re-run and its record with it.
-            for (const tag of ["e1", "e2"]) {
-                await node.act(a => a.get(RetentionTaskManager).run("synthetic", { tag }));
-                await awaitTaskDone(node, `synthetic:${tag}`, RetentionTaskManager);
-            }
-
-            const status = await node.act(a => a.get(RetentionTaskManager).get("synthetic:own")?.status);
-            expect(status?.state).equals("running");
-            expect(node.stateOf(RetentionTaskManager).tasks["synthetic:own"]).not.equals(undefined);
-        } finally {
-            HookedTask.atTerminalWrite = undefined;
-            release();
-        }
-    });
-
-    it("distinguishes an unretained task from a task with nothing to roll back", async () => {
+    it("distinguishes an id no live task answers to from a task with nothing to roll back", async () => {
         const environment = new Environment("test");
         const node = await MockServerNode.create(RootEndpoint, { environment, id: "tm-cancel-unknown" });
         SyntheticTask.phasesByTag["nothing"] = [{ name: "a", run: async () => {} }];
@@ -664,7 +345,7 @@ describe("TaskManagerBehavior", () => {
         ).rejectedWith(TaskNotFoundError);
         expect(await node.act(a => a.get(TaskManagerBehavior).get("synthetic:never-existed"))).equals(undefined);
 
-        // So is a rollback the task recorded but retention has since forgotten.
+        // So is a terminal record from a previous start: it is not resumed, so no live task answers to its id.
         await node.act(a => {
             a.get(TaskManagerBehavior).state.tasks = {
                 "synthetic:orphan": {
@@ -673,7 +354,6 @@ describe("TaskManagerBehavior", () => {
                     phaseIndex: 1,
                     state: "cancelled",
                     changeSet: [],
-                    revertTaskId: "revert:synthetic:orphan",
                 },
             };
         });

--- a/packages/node-manager/test/task/groups/RotateGroupKeyIntegrationTest.ts
+++ b/packages/node-manager/test/task/groups/RotateGroupKeyIntegrationTest.ts
@@ -52,6 +52,12 @@ const writesB = new Array<bigint[]>();
 let afterWriteB: ((starts: bigint[]) => void) | undefined;
 
 /**
+ * Fires after device A commits a keySetWrite, with that write's start-time set. Symmetric to {@link afterWriteB}:
+ * flipping A offline as its distribute write lands parks the rotation inside activate's barrier.
+ */
+let afterWriteA: ((starts: bigint[]) => void) | undefined;
+
+/**
  * When armed, pauses #drive inside distribute's phase AFTER it commits but BEFORE the driver advances to
  * activate — the exact between-phase gap the cancel-race guard closes. `releaseDistribute` unblocks it.
  */
@@ -93,7 +99,7 @@ function recordingRoot(sink: bigint[][], afterWrite?: (starts: bigint[]) => void
     return MockServerNode.RootEndpoint.with(RecordingGroupKeyManagementServer);
 }
 
-const DeviceRootA = recordingRoot(writesA);
+const DeviceRootA = recordingRoot(writesA, s => afterWriteA?.(s));
 const DeviceRootB = recordingRoot(writesB, s => afterWriteB?.(s));
 
 function addParamsFor(peerId: string): AddNodeToGroupParams {
@@ -233,6 +239,7 @@ describe("RotateGroupKey task integration (two members)", () => {
     beforeEach(() => {
         writesA.length = 0;
         writesB.length = 0;
+        afterWriteA = undefined;
         afterWriteB = undefined;
         armBarrier = false;
         releaseDistribute = undefined;
@@ -294,6 +301,71 @@ describe("RotateGroupKey task integration (two members)", () => {
         expect(writesB.map(s => s.length)).deep.equals([1]);
         expect(deviceStarts(deviceB, GROUP_KEY_SET_ID)).deep.equals([OP_START]);
         expect(deviceKey0(deviceA, GROUP_KEY_SET_ID)).deep.equals(OP_KEY);
+    });
+
+    it("refuses to complete activation when a member joined the key set during the activate phase", async () => {
+        await using site = new MockSite();
+        const { controller, deviceA, deviceB, peerA, peerB } = await twoMemberGroup(site, { addB: false });
+
+        // Flip A offline as its distribute write lands: activate then writes its intent but parks in the barrier,
+        // which is the window in which a member can join after activate's opening check.
+        const subscriptionA = subscriptionOf(peerA);
+        let flipped = false;
+        afterWriteA = s => {
+            if (!flipped && s.length === 2) {
+                flipped = true;
+                subscriptionA.active.emit(false);
+            }
+        };
+
+        await controller.act(a => a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS));
+        await awaitParkedInPhase(controller, ROTATE_ID, 1);
+
+        writesA.length = writesB.length = 0;
+        await controller.act(a => a.get(TaskManagerBehavior).run("addNodeToGroup", addParamsFor(peerB.id)));
+        await awaitState(controller, addTaskId(peerB.id), "completed");
+
+        await MockTime.resolve(subscriptionA.active.emit(true), { macrotasks: true });
+        await awaitState(controller, ROTATE_ID, "failed");
+
+        const status = await controller.act(a => a.get(TaskManagerBehavior).get(ROTATE_ID)?.status);
+        expect(status?.error).contains("during the activate phase");
+
+        // Cleanup never ran, so no member lost the old key: A holds the 3-key activate struct, B only its own
+        // provisioning write, and the late member still holds the old key material.
+        expect(writesA.some(s => s.length === 1)).equals(false);
+        expect(writesB.some(s => s.length === 1)).equals(true); // the join itself
+        expect(writesB.some(s => s.length === 3)).equals(false);
+        expect(deviceStarts(deviceA, GROUP_KEY_SET_ID).length).equals(3);
+        expect(deviceStarts(deviceB, GROUP_KEY_SET_ID)).deep.equals([OP_START]);
+        expect(Bytes.areEqual(deviceKey0(deviceB, GROUP_KEY_SET_ID), OP_KEY)).equals(true);
+
+        // The rotation stopped at its point of no return, so it is not rolled back.
+        expect(status?.revertTaskId).equals(undefined);
+
+        // The remedy the failure prescribes must work: rotating to a DIFFERENT key is refused while the members
+        // still carry the dormant one, so only the same key can finish what this rotation started.
+        await controller.act(a =>
+            a.get(TaskManagerBehavior).run("rotateGroupKey", {
+                groupKeySetId: GROUP_KEY_SET_ID,
+                newEpochKey: new Uint8Array(16).fill(0xef),
+                rotationId: "rOther",
+            }),
+        );
+        await awaitState(controller, rotateId("rOther"), "failed");
+        const otherStatus = await controller.act(a => a.get(TaskManagerBehavior).get(rotateId("rOther"))?.status);
+        expect(otherStatus?.error).contains("single-key steady state");
+
+        // Re-issued with the same new key, distribute covers the whole current member set, so the late member is
+        // carried through the rotation with everyone else.
+        await controller.act(a =>
+            a.get(TaskManagerBehavior).run("rotateGroupKey", { ...ROTATE_PARAMS, rotationId: "r2" }),
+        );
+        await awaitState(controller, rotateId("r2"), "completed");
+        for (const device of [deviceA, deviceB]) {
+            expect(deviceStarts(device, GROUP_KEY_SET_ID)).deep.equals([OP_START]);
+            expect(Bytes.areEqual(deviceKey0(device, GROUP_KEY_SET_ID), NEW_KEY)).equals(true);
+        }
     });
 
     it("parks when a member is offline, holding the barrier, then converges once it returns", async () => {

--- a/packages/node-manager/test/task/groups/RotateGroupKeyIntegrationTest.ts
+++ b/packages/node-manager/test/task/groups/RotateGroupKeyIntegrationTest.ts
@@ -506,8 +506,8 @@ describe("RotateGroupKey task integration (two members)", () => {
             expect(Bytes.areEqual(deviceKey0(device, GROUP_KEY_SET_ID), KEY_A)).equals(true);
         }
 
-        // A distinct rotationId is a distinct task id, so this rotation actually runs instead of deduping onto the
-        // completed r1 handle — the recovery path (rotate a bad key to another) depends on it.
+        // A distinct rotationId is a distinct task id, so the recovery path — rotating a bad key to another —
+        // runs as its own task with its own record.
         await controller.act(a =>
             a.get(TaskManagerBehavior).run("rotateGroupKey", {
                 groupKeySetId: GROUP_KEY_SET_ID,
@@ -581,18 +581,33 @@ describe("RotateGroupKey task integration (two members)", () => {
         expect(await controller.act(a => a.get(TaskManagerBehavior).state.tasks[rotateId("r2")])).equals(undefined);
     });
 
-    it("dedups an idempotent re-issue of the same rotationId to the same handle", async () => {
+    it("refuses a re-issue of a live rotationId, and joins the caller that owns it", async () => {
         await using site = new MockSite();
         const { controller, peerB } = await twoMemberGroup(site);
 
         // Park so the task stays live/non-terminal across both issues.
         await MockTime.resolve(subscriptionOf(peerB).active.emit(false), { macrotasks: true });
-        const first = await controller.act(a => a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS));
+        const first = await controller.act(a =>
+            a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS, { externalId: "nightly" }),
+        );
+        expect(first.id).equals(ROTATE_ID);
         await awaitState(controller, ROTATE_ID, "parked");
 
-        const second = await controller.act(a => a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS));
-        expect(second.id).equals(first.id);
-        expect(second.id).equals(ROTATE_ID);
+        // `act` returns a MaybePromise, so normalize before asserting on the rejection.
+        await expect(
+            (async () => controller.act(a => a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS)))(),
+        ).rejectedWith(TaskConflictError);
+
+        // The owner reaches the parked rotation itself: a replacement task under the same id would answer as
+        // freshly running and leave the parked one driving with nothing observing it.
+        const before = await controller.act(a => a.get(TaskManagerBehavior).tasks.length);
+        const again = await controller.act(a =>
+            a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS, { externalId: "nightly" }),
+        );
+        expect(again.id).equals(ROTATE_ID);
+        expect(again.status.state).equals("parked");
+        expect(again.status.phaseIndex).equals(0);
+        expect(await controller.act(a => a.get(TaskManagerBehavior).tasks.length)).equals(before);
     });
 
     it("declines cancel during the activate phase and leaves the rotation in place", async () => {

--- a/packages/node-manager/test/task/groups/RotateGroupKeyIntegrationTest.ts
+++ b/packages/node-manager/test/task/groups/RotateGroupKeyIntegrationTest.ts
@@ -183,7 +183,8 @@ async function awaitParkedInPhase(node: ServerNode, id: string, phaseIndex: numb
 }
 
 /** Commission two member devices onto one controller and provision both into the shared key set 42. */
-async function twoMemberGroup(site: MockSite) {
+async function twoMemberGroup(site: MockSite, options: { addB?: boolean } = {}) {
+    const { addB = true } = options;
     const controller = await site.addNode(ControllerRoot, {
         online: false,
         id: "controller1",
@@ -219,7 +220,7 @@ async function twoMemberGroup(site: MockSite) {
     await subscribedPeer(controller, peerA.id);
     await subscribedPeer(controller, peerB.id);
 
-    for (const peer of peers) {
+    for (const peer of addB ? peers : peers.slice(0, 1)) {
         await controller.act(a => a.get(TaskManagerBehavior).run("addNodeToGroup", addParamsFor(peer.id)));
         await awaitState(controller, addTaskId(peer.id), "completed");
     }
@@ -267,6 +268,32 @@ describe("RotateGroupKey task integration (two members)", () => {
             expect(intentState(peer, GROUP_KEY_SET_ID)).equals("committed");
             expect(intentStarts(peer, GROUP_KEY_SET_ID)).deep.equals([OP_START]);
         }
+    });
+
+    it("refuses to activate when a member joined the key set after distribute", async () => {
+        await using site = new MockSite();
+        const { controller, deviceA, deviceB, peerA, peerB } = await twoMemberGroup(site, { addB: false });
+
+        // Park the rotation at distribute so the second member can join the key set mid-rotation.
+        await MockTime.resolve(subscriptionOf(peerA).active.emit(false), { macrotasks: true });
+        await controller.act(a => a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS));
+        await awaitParkedInPhase(controller, ROTATE_ID, 0);
+
+        writesA.length = writesB.length = 0;
+        await controller.act(a => a.get(TaskManagerBehavior).run("addNodeToGroup", addParamsFor(peerB.id)));
+        await awaitState(controller, addTaskId(peerB.id), "completed");
+
+        await MockTime.resolve(subscriptionOf(peerA).active.emit(true), { macrotasks: true });
+        await awaitState(controller, ROTATE_ID, "failed");
+
+        const status = await controller.act(a => a.get(TaskManagerBehavior).get(ROTATE_ID)?.status);
+        expect(status?.error).contains("joined the key set after the distribute phase");
+
+        // A saw distribute only (2 starts, the new key future-dated and dormant); neither member was activated.
+        expect(writesA.map(s => s.length)).deep.equals([2]);
+        expect(writesB.map(s => s.length)).deep.equals([1]);
+        expect(deviceStarts(deviceB, GROUP_KEY_SET_ID)).deep.equals([OP_START]);
+        expect(deviceKey0(deviceA, GROUP_KEY_SET_ID)).deep.equals(OP_KEY);
     });
 
     it("parks when a member is offline, holding the barrier, then converges once it returns", async () => {

--- a/packages/node-manager/test/task/groups/RotateGroupKeyIntegrationTest.ts
+++ b/packages/node-manager/test/task/groups/RotateGroupKeyIntegrationTest.ts
@@ -166,6 +166,22 @@ async function awaitState(node: ServerNode, id: string, ...states: string[]): Pr
     throw new Error(`Task ${id} did not reach state ${states.join("|")}`);
 }
 
+/**
+ * Pump until the task is parked in a specific phase. A gate parks whenever a peer it watches goes away, so a task
+ * can be parked transiently in an earlier phase that still had everything it needed.
+ */
+async function awaitParkedInPhase(node: ServerNode, id: string, phaseIndex: number): Promise<void> {
+    for (let i = 0; i < 2_000; i++) {
+        const p = await node.act(a => a.get(TaskManagerBehavior).state.tasks[id]);
+        if (p?.state === "parked" && p.phaseIndex === phaseIndex) {
+            return;
+        }
+        await MockTime.advance(100);
+        await MockTime.macrotask;
+    }
+    throw new Error(`Task ${id} did not park in phase ${phaseIndex}`);
+}
+
 /** Commission two member devices onto one controller and provision both into the shared key set 42. */
 async function twoMemberGroup(site: MockSite) {
     const controller = await site.addNode(ControllerRoot, {
@@ -568,10 +584,7 @@ describe("RotateGroupKey task integration (two members)", () => {
         };
 
         await controller.act(a => a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS));
-        await awaitState(controller, ROTATE_ID, "parked");
-
-        const phaseIndex = await controller.act(a => a.get(TaskManagerBehavior).state.tasks[ROTATE_ID]?.phaseIndex);
-        expect(phaseIndex).equals(1); // parked in activate, not distribute
+        await awaitParkedInPhase(controller, ROTATE_ID, 1); // parked in activate, not distribute
 
         // Distribute committed the 2-key struct on both members (old key still present); activate never wrote.
         const parkedStartsA = deviceStarts(deviceA, GROUP_KEY_SET_ID);

--- a/packages/node-manager/test/task/helpers.ts
+++ b/packages/node-manager/test/task/helpers.ts
@@ -8,6 +8,12 @@ import { Task } from "#task/Task.js";
 import { PlannedChange, TaskPhase } from "#task/types.js";
 import { Observable } from "@matter/general";
 import { ClientNode, DesiredStateBehavior, ItemKind, ItemMode, ItemState, ManagedItem, itemMapKey } from "@matter/node";
+import { Status } from "@matter/types";
+
+/** Mirrors the reconciler's default recoverability rule for a failure status code. */
+function recoverable(code?: number): boolean {
+    return code === Status.Timeout || code === Status.Busy;
+}
 
 /** A synthetic task whose phases are supplied inline; for unit-testing the manager/driver. */
 export class SyntheticTask extends Task<{ tag: string }> {
@@ -30,11 +36,19 @@ export class SyntheticTask extends Task<{ tag: string }> {
  * `DesiredStateBehavior` items + `itemChanged`, `NetworkClient` subscription status, and the reachability
  * source of truth (`behaviors.internalsOf(NetworkClient).activeSubscription`). The fake doubles as the
  * reconciler: `reconcile(node, {verify})` flips the peer's items to `committed` for keys the device "has".
+ *
+ * One simplification of the real engine: a key the device neither has nor fails stays `pending` instead of
+ * committing, which is how a test holds a gate parked.
  */
 export class FakePeer {
     readonly items: Record<string, ManagedItem> = {};
     readonly has = new Set<string>();
+    /** Keys the device rejects with an unrecoverable status: apply fails, and the following pass drops them. */
+    readonly rejects = new Set<string>();
+    /** Remaining recoverable apply failures per key: each pass consumes one, then the key behaves normally. */
+    readonly transientFailures = new Map<string, number>();
     readonly itemChanged = new Observable<[item: ManagedItem]>();
+    readonly itemRemoved = new Observable<[kind: string, key: string]>();
     readonly subscriptionStatusChanged = new Observable<[isActive: boolean]>();
     #subscribed = true;
     reconciles = 0;
@@ -107,25 +121,74 @@ export class FakePeer {
         this.has.add(itemMapKey(kind, key));
     }
 
-    setState(kind: string, key: string, state: ItemState) {
+    /** Mark a key the device refuses with an unrecoverable status. */
+    markRejects(kind: string, key: string) {
+        this.rejects.add(itemMapKey(kind, key));
+    }
+
+    /** Mark a key whose next `times` applies fail with a recoverable status, so the reconciler retries them. */
+    markFailsRecoverably(kind: string, key: string, times: number) {
+        this.transientFailures.set(itemMapKey(kind, key), times);
+    }
+
+    /** DesiredStateBehavior.dropItem stand-in: forget the item and announce it on `itemRemoved`. */
+    dropItem(kind: string, key: string) {
+        if (this.items[itemMapKey(kind, key)] === undefined) {
+            return;
+        }
+        delete this.items[itemMapKey(kind, key)];
+        this.itemRemoved.emit(kind, key);
+    }
+
+    setState(kind: string, key: string, state: ItemState, failureCode?: number) {
         const item = this.items[itemMapKey(kind, key)];
-        item.status = { ...item.status, state };
+        item.status = { ...item.status, state, failureCode };
         this.itemChanged.emit(item);
     }
 
-    /** Fake ReconcilerBehavior.reconcile: on verify, commit pending items the device "has" while reachable. */
+    /**
+     * Fake ReconcilerBehavior.reconcile over one peer's items, one pass per call, mirroring what
+     * `planActions`/`executeActions` do with each item state: apply a pending item, retry or drop a failed one
+     * by the recoverability of its status code, and drop a removal once the device has taken it.
+     */
     async reconcile(node: ClientNode, options?: { verify?: boolean }) {
         this.reconciles++;
         if (!options?.verify || !this.#subscribed) {
             return;
         }
-        const items = (node as unknown as FakePeer).items;
-        for (const item of Object.values(items)) {
-            if (item.status.state === "pending" && this.has.has(itemMapKey(item.kind, item.key))) {
-                item.status = { ...item.status, state: "committed" };
-            } else if (item.status.state === "deletePending") {
-                delete items[itemMapKey(item.kind, item.key)];
+        const peer = node as unknown as FakePeer;
+        for (const item of Object.values(peer.items)) {
+            switch (item.status.state) {
+                case "pending":
+                    peer.#apply(item);
+                    break;
+                case "commitFailed":
+                    if (recoverable(item.status.failureCode)) {
+                        peer.#apply(item);
+                    } else {
+                        peer.dropItem(item.kind, item.key);
+                    }
+                    break;
+                case "deletePending":
+                    peer.dropItem(item.kind, item.key);
+                    break;
+                case "committed":
+                    break;
             }
+        }
+    }
+
+    /** One apply attempt against the device, with the status it writes back. */
+    #apply(item: ManagedItem) {
+        const id = itemMapKey(item.kind, item.key);
+        const transient = this.transientFailures.get(id) ?? 0;
+        if (transient > 0) {
+            this.transientFailures.set(id, transient - 1);
+            this.setState(item.kind, item.key, "commitFailed", Status.Busy);
+        } else if (this.rejects.has(id)) {
+            this.setState(item.kind, item.key, "commitFailed", Status.ConstraintError);
+        } else if (this.has.has(id)) {
+            this.setState(item.kind, item.key, "committed");
         }
     }
 
@@ -136,7 +199,7 @@ export class FakePeer {
 
     eventsOf(type: unknown): unknown {
         return type === DesiredStateBehavior
-            ? { itemChanged: this.itemChanged }
+            ? { itemChanged: this.itemChanged, itemRemoved: this.itemRemoved }
             : { subscriptionStatusChanged: this.subscriptionStatusChanged };
     }
 


### PR DESCRIPTION
Hardening pass over the Task layer's cancel, shutdown and gate paths. Every defect fixed here is pre-existing (it predates Increment 3) and none was covered by a test. Base is `node-manager`, so CI runs via umbrella #3948 — the full local gate below is the only gate this PR itself gets.

**Scope note:** this PR was deliberately reduced. An earlier revision also reworked task identity, terminal-task retention and caller correlation; a design review found that area unsound and it has been cut back out (last commit). See "What was cut, and why" below.

## Defects fixed

**Abort intent had nowhere to live but the gate, and the gate was created late.** `#abortGate` silently no-ops when no gate entry exists, and the driver only created one inside `#drive`, after `#admit` and the first `#persist`. A cancel arriving in that window was discarded: the task then wrote its intents to the peer *after* the cancel was accepted, parked on a peer that would never commit, and `cancel()` never settled — holding the caller's enclosing `act` transaction open with it. The gate is now created in `#track` before driving starts, and the driver re-checks for a recorded abort after admission and again after the phase context is built. That second checkpoint matters: a check at the loop top still let a cancel arriving during `endpoint.act` through to a device write.

**A cancel overlapping shutdown was lost.** `cancel()` had no shutdown guard, and everything after its `await` ran outside what `asyncDispose` waits for: dispose overwrote the gate's abort reason, the drive unwound *without persisting*, and `cancel()`'s continuation then marked the task cancelled in memory and spawned a rollback whose driving dispose had already passed over — persisting into a mutex about to close (`Mutex.run` throws synchronously once closed). Storage kept the forward task non-terminal with no rollback, so the next start re-applied exactly what was cancelled. `cancel()` now refuses with `TaskManagerClosingError` once the endpoint leaves `Lifecycle.Status.Active`, and the cancelled record and rollback record are written in one transaction. A task that fails during teardown is left resumable rather than rolled back outside the drain, and a task type registered during teardown no longer resumes into it.

**A commit gate only ever observed success.** Reconciliation turns an apply error into `commitFailed`, and an unrecoverable follow-up drops the item — but the wait predicate looked only for `committed`, so a real device rejection parked its task forever and blocked the automatic rollback. Such a gate now fails with `TaskFailedError`, which the driver routes into the normal failure path. Underneath that: `dropItem` announces on `itemRemoved` while the gate watched only `itemChanged`, so a *parked* gate had no wake source at all.

**A gate could park on an event already gone.** The predicate was evaluated once before the parking observers were registered, so a change, removal or reachability flip arriving in that window was announced before anything listened. Registration now precedes the first evaluation, which goes through the same coalescing path as any later wakeup — closing the window without adding a verify-reconcile to every park.

**A terminal task blocked re-running its own work.** Ids are deterministic and nothing released them, so re-running after a cancel returned the cancelled handle: no phase ran, nothing persisted, no error was raised, and the requested change was never applied for the rest of the process lifetime — a restart "fixed" it, which is the worst possible signature. A terminal task no longer holds its id.

**A rotation could activate a member that never received the new key.** `RotateGroupKey` re-derives its member set per phase, which is what lets a peer whose intent was meanwhile removed drop out of the barrier. The opposite case was unguarded: a peer joining the key set between distribute and activate reached activate without holding the new key, so once members that already committed activate flipped their transmit key it could not decrypt their traffic — precisely the gap the three-phase barrier exists to close. Activate now refuses unless every current member already carries this rotation's new key in slot 1. A member joining at cleanup needs no guard; it converges onto the surviving key with no gap.

**`TaskHandle.status` was a snapshot**, so a caller holding a handle and polling it saw the state frozen at creation. It now reads through to the task.

## What was cut, and why

Deciding whether two requests are "the same request" by structurally comparing parameters cannot be made correct: the comparator had to stay bit-exact with the storage codec, with a deep-equality helper that cannot compare a `Map` at all, and with a backend that keeps raw references in memory but JSON on disk. It produced a defect in four consecutive review rounds. Admission is now decided by the task id alone — one live task per id, joined only by the caller whose `externalId` it carries, refused with `TaskConflictError` for anyone else. That deliberately narrows the earlier promise that an anonymous identical re-issue is idempotent; a refusal naming the live task is more honest than a guess.

Terminal-task retention went with it, because it bounded a history the keying cannot keep: records are stored per id and last-writer-wins, so re-running a task overwrites its finished record, and cancelling that re-run overwrites the previous rollback's record too. Per-task sets of external ids went back to the single optional id they were, since a second caller's id resolved to the first caller's task and left the second unable to observe or cancel its own work.

Identity, lookup and retention are being redesigned together — per-run ids, a slot key that carries exclusion, history separate from the live table. This PR removes what that redesign replaces so the cancellation and gate fixes land on their own.

## Contracts

- **Admission** is by id. One live task per id; the caller passing a matching `externalId` joins; anyone else is refused. A terminal id is free.
- **Cancel vs shutdown: refuse.** Once teardown starts no state write can land, so completing the cancel from inside the behavior is not achievable; the alternative is an in-memory-only cancel that storage contradicts on the next start. The guard reads the endpoint's construction status rather than a behavior-local flag, because the behavior's own dispose runs after the drive resumes (measured). This depends on `Construction.close` applying `Destroying` before the destructor reaches `behaviors.close()`.
- **`cancel()` outcomes** are three distinct answers: a rollback handle, `undefined` for "nothing to roll back", and `TaskNotFoundError` for an id no live task answers to.

## Refuted while investigating

- The shutdown variant of the pre-gate defect does **not** hang. Once `close()` begins every `endpoint.act` throws `DestroyedDependencyError`, so such a task fails on its next act rather than parking. The real (smaller) defect was shutdown turning a resumable task into an in-memory `failed`; that is fixed.
- Freezing the rotation member set at task start — what the design document specifies — would be *worse* than re-deriving it: the barrier would gate on peers whose intent was removed, which the new terminal-failure gate now turns into a task failure.

## Known limitations, deliberately not addressed here

- `live` and persisted task state grow without bound again, as they did before this branch. Bounding them needs a history representation that survives a repeat of the same work; that is the redesign's job, and a partial bound now would be the same case-law-instead-of-design that caused the cut.
- The join gate is the `externalId` alone, so an owner re-issuing with changed parameters joins a task running the old ones wherever the id does not cover every parameter.
- A refused caller has no supported way to reach the live task: `idFor` is not public and the conflict error carries the id only in its message.
- An `externalId` is not exclusive against internal ids, so a caller can choose one that resolves elsewhere. Pre-existing; the redesign gives external ids their own namespace.

## Verification

Every fix was written test-first and mutation-proofed per hunk (revert the hunk, confirm red, restore). Notable reds: `Test timeout: Promise did not resolve within one (virtual) hour` at the `cancel()` await; a device write present after an accepted cancel; a test-suite crash from an unhandled rejection when `#spawnRevert` threw out of `#drive`'s catch; and `Task rotateGroupKey:42:r1 did not reach state failed` for the rotation guard.

Four review rounds, including an independent adversarial pass over the cumulative diff and a model-diverse design review of the concept. The independent pass caught that three tests claiming to cover the new `itemRemoved` subscription did not — the fake peer dropped the item during the *initial* evaluation, so the gate returned before observers registered and deleting the production line left all three green. `FakePeer` now models the reconciler's real two-pass recoverable/unrecoverable behaviour.

Gates (repository root):

```
npm run build-clean    exit 0
npm run format-verify  All matched files use Prettier code style!
npm run lint           exit 0
npm test -p packages/node-manager   175/175 ESM + CJS + Web
npm test -p packages/node           1723 ESM / 1723 CJS / 1714 Web
```

No CHANGELOG entry: the package is unreleased on this branch and the entry lands at umbrella merge. No type casts added in production code.

## Carried forward

`#resumeType` bypasses the admission guards `#spawn` enforces (only the closing guard was added here). Reachable when the paired persist in `#drive`'s catch fails while the rollback's own persist succeeds: a forward task and its own rollback then both resume non-terminal and write opposing intents.

Reconcile-layer defects found in passing, untouched: `planActions` maps a failed *remove* to `retry`, which calls `apply` and re-adds the item a rollback was deleting; `ReconcilerBehavior.#wirePeer` ignores `itemRemoved`, so a drop triggers no reconcile pass; `defaultRecoverable(0)` treats any non-Matter-status apply exception as unrecoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
