### PR TITLE
Publish the chip image multi-arch and bake cert-test app binaries

### DIFF
--- a/.github/actions/load-chip/action.yml
+++ b/.github/actions/load-chip/action.yml
@@ -4,6 +4,11 @@
 
 name: 'Load CHIP from artifact'
 description: 'Installs CHIP docker image from build artifact into runner'
+inputs:
+  artifact-name:
+    description: 'Name of the uploaded chip image artifact'
+    required: false
+    default: 'chip-image'
 
 runs:
   using: 'composite'
@@ -11,7 +16,7 @@ runs:
     - name: Install artifact image
       uses: actions/download-artifact@v8
       with:
-        name: chip-image
+        name: ${{ inputs.artifact-name }}
         path: /tmp
 
     - name: Load image from artifact

--- a/.github/actions/run-chip-tests/action.yml
+++ b/.github/actions/run-chip-tests/action.yml
@@ -9,6 +9,11 @@ inputs:
     description: 'Container source (artifact or repository)'
     required: true
 
+  artifact-name:
+    description: 'Name of the uploaded chip image artifact, when image-source is "artifact"'
+    required: false
+    default: 'chip-image'
+
   test-group:
     description: 'Name of the test group to run'
     required: true
@@ -43,6 +48,8 @@ runs:
     - name: Load image from artifact
       if: inputs.image-source == 'artifact'
       uses: ./.github/actions/load-chip
+      with:
+        artifact-name: ${{ inputs.artifact-name }}
 
     - name: Run tests
       shell: bash

--- a/.github/workflows/build-test.chip.yml
+++ b/.github/workflows/build-test.chip.yml
@@ -196,9 +196,9 @@ jobs:
           cd support/chip
           ./bin/build chip-artifact
 
-      # The CHIP test jobs run against the amd64 image only, so this is the sole gate between an arm64 build and a
-      # published arm64 manifest. Exit status 126 or above means the shell could not execute the binary at all
-      # (wrong architecture, missing loader); anything below that proves it ran.
+      # test-core-arm64 exercises chip-tool against this image but never starts the app binaries, so they get an
+      # execution check here. Exit status 126 or above means the shell could not execute the binary at all (wrong
+      # architecture, missing loader); anything below that proves it ran.
       - name: Smoke-test arm64 image
         run: |
           docker load -i /tmp/chip.tar
@@ -240,6 +240,22 @@ jobs:
           image-source: ${{ needs.chip-image-amd64.outputs.source }}
           test-group: core
           use-local-controller: ${{ matrix.controller == 'matterjs' }}
+
+  # Every other test group runs against the amd64 image, so this is what stands between an arm64 build and the
+  # published manifest. The core group against chip-tool is the cheapest run that exercises the arm64 binaries for
+  # real rather than just proving they start.
+  test-core-arm64:
+    needs: [workflow-conditions, chip-image-arm64]
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Check out matter.js
+        uses: actions/checkout@v7
+
+      - uses: ./.github/actions/run-chip-tests
+        with:
+          image-source: ${{ needs.chip-image-arm64.outputs.source }}
+          artifact-name: chip-image-arm64
+          test-group: core
 
   test-app-fast:
     needs: [workflow-conditions, chip-image-amd64]
@@ -385,6 +401,7 @@ jobs:
       workflow-conditions,
       chip-image-arm64,
       test-core,
+      test-core-arm64,
       test-app-fast,
       test-app-slow,
       test-app-cc-1,

--- a/.github/workflows/build-test.chip.yml
+++ b/.github/workflows/build-test.chip.yml
@@ -135,7 +135,7 @@ jobs:
   # Build the CHIP container if necessary. CHIP compiles natively per architecture (QEMU emulation of the toolchain
   # is prohibitively slow), so amd64 and arm64 are separate jobs on runners native to each; publish-manifest later
   # combines the two into a multi-arch manifest.
-  chip-image:
+  chip-image-amd64:
     needs: workflow-conditions
     runs-on: ubuntu-latest
     outputs:
@@ -225,7 +225,7 @@ jobs:
           path: /tmp/chip.tar
 
   test-core:
-    needs: [workflow-conditions, chip-image]
+    needs: [workflow-conditions, chip-image-amd64]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -237,12 +237,12 @@ jobs:
 
       - uses: ./.github/actions/run-chip-tests
         with:
-          image-source: ${{ needs.chip-image.outputs.source }}
+          image-source: ${{ needs.chip-image-amd64.outputs.source }}
           test-group: core
           use-local-controller: ${{ matrix.controller == 'matterjs' }}
 
   test-app-fast:
-    needs: [workflow-conditions, chip-image]
+    needs: [workflow-conditions, chip-image-amd64]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -254,12 +254,12 @@ jobs:
 
       - uses: ./.github/actions/run-chip-tests
         with:
-          image-source: ${{ needs.chip-image.outputs.source }}
+          image-source: ${{ needs.chip-image-amd64.outputs.source }}
           test-group: app-fast
           use-local-controller: ${{ matrix.controller == 'matterjs' }}
 
   test-app-slow:
-    needs: [workflow-conditions, chip-image]
+    needs: [workflow-conditions, chip-image-amd64]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -271,12 +271,12 @@ jobs:
 
       - uses: ./.github/actions/run-chip-tests
         with:
-          image-source: ${{ needs.chip-image.outputs.source }}
+          image-source: ${{ needs.chip-image-amd64.outputs.source }}
           test-group: app-slow
           use-local-controller: ${{ matrix.controller == 'matterjs' }}
 
   test-app-cc-1:
-    needs: [workflow-conditions, chip-image]
+    needs: [workflow-conditions, chip-image-amd64]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -288,12 +288,12 @@ jobs:
 
       - uses: ./.github/actions/run-chip-tests
         with:
-          image-source: ${{ needs.chip-image.outputs.source }}
+          image-source: ${{ needs.chip-image-amd64.outputs.source }}
           test-group: app-cc-1
           use-local-controller: ${{ matrix.controller == 'matterjs' }}
 
   test-app-cc-2:
-    needs: [workflow-conditions, chip-image]
+    needs: [workflow-conditions, chip-image-amd64]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -305,12 +305,12 @@ jobs:
 
       - uses: ./.github/actions/run-chip-tests
         with:
-          image-source: ${{ needs.chip-image.outputs.source }}
+          image-source: ${{ needs.chip-image-amd64.outputs.source }}
           test-group: app-cc-2
           use-local-controller: ${{ matrix.controller == 'matterjs' }}
 
   test-icd:
-    needs: [workflow-conditions, chip-image]
+    needs: [workflow-conditions, chip-image-amd64]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -322,7 +322,7 @@ jobs:
 
       - uses: ./.github/actions/run-chip-tests
         with:
-          image-source: ${{ needs.chip-image.outputs.source }}
+          image-source: ${{ needs.chip-image-amd64.outputs.source }}
           test-group: icd
           use-local-controller: ${{ matrix.controller == 'matterjs' }}
 
@@ -335,7 +335,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [
       workflow-conditions,
-      chip-image,
+      chip-image-amd64,
       test-core,
       test-app-fast,
       test-app-slow,
@@ -344,7 +344,7 @@ jobs:
       test-icd
     ]
     if: >-
-      needs.chip-image.outputs.source == 'artifact' &&
+      needs.chip-image-amd64.outputs.source == 'artifact' &&
       (
         github.event_name == 'schedule' ||
         github.event_name == 'workflow_dispatch'
@@ -423,7 +423,7 @@ jobs:
           ./bin/info
           ./bin/publish-arch arm64
 
-  # TODO - create PR to commit SHA from chip-image action?
+  # TODO - create PR to commit SHA from the chip-image-amd64 job?
   publish-manifest:
     name: Publish multi-arch manifest
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test.chip.yml
+++ b/.github/workflows/build-test.chip.yml
@@ -54,7 +54,7 @@ jobs:
     outputs:
       build-needed: ${{ steps.check-rebuild.outputs.build-needed }}
       controllers: ${{ steps.controllers.outputs.controllers }}
-      rebuild-marker: ${{ steps.marker.outputs.present }}
+      chip-sha: ${{ steps.get-sha.outputs.chip-sha }}
     steps:
       - name: Check out matter.js
         uses: actions/checkout@v7
@@ -112,43 +112,53 @@ jobs:
             echo 'controllers=["chiptool"]' >> $GITHUB_OUTPUT
           fi
 
-  # Build the CHIP container if necessary
-  chip-image:
-    needs: workflow-conditions
-    runs-on: ubuntu-latest
-    outputs:
-      source: ${{ needs.workflow-conditions.outputs.build-needed == 'true' && 'artifact' || 'repository' }}
-      chip-sha: ${{ steps.get-sha.outputs.chip-sha }}
-    steps:
-      - name: Check out matter.js
-        if: needs.workflow-conditions.outputs.build-needed == 'true'
-        uses: actions/checkout@v7
-
       # A [rebuild-chip] rebuild exists to test against the current CHIP master, so refresh the SHA before building.
       # The resulting sha.txt is used only for this run's build; it is never committed on push/pull_request (see
-      # publish-image), so no SHA bump leaks into the PR.
+      # publish-manifest), so no SHA bump leaks into the PR. Computed once here (rather than once per architecture
+      # job) so the amd64 and arm64 builds compile the identical CHIP commit.
       - name: Increment CHIP SHA
         id: increment-sha
         if: >-
           github.event_name == 'schedule' ||
           (github.event_name == 'workflow_dispatch' && inputs.updateChipSha) ||
-          needs.workflow-conditions.outputs.rebuild-marker == 'true'
+          steps.marker.outputs.present == 'true'
         run: |
           cd support/chip
           ./bin/update-version
 
       - name: Get CHIP SHA
         id: get-sha
-        if: >-
-          github.event_name == 'schedule' ||
-          github.event_name == 'workflow_dispatch' ||
-          needs.workflow-conditions.outputs.rebuild-marker == 'true'
         run: |
           cd support/chip
           echo chip-sha=$(cat sha.txt) >> $GITHUB_OUTPUT
 
-      - name: Build chip image
+  # Build the CHIP container if necessary. CHIP compiles natively per architecture (QEMU emulation of the toolchain
+  # is prohibitively slow), so amd64 and arm64 are separate jobs on runners native to each; publish-manifest later
+  # combines the two into a multi-arch manifest.
+  chip-image:
+    needs: workflow-conditions
+    runs-on: ubuntu-latest
+    outputs:
+      source: ${{ needs.workflow-conditions.outputs.build-needed == 'true' && 'artifact' || 'repository' }}
+    steps:
+      - name: Maximize build space
         if: needs.workflow-conditions.outputs.build-needed == 'true'
+        uses: easimon/maximize-build-space@v10
+        with:
+          root-reserve-mb: 4096
+          temp-reserve-mb: 3096
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+
+      - name: Check out matter.js
+        if: needs.workflow-conditions.outputs.build-needed == 'true'
+        uses: actions/checkout@v7
+
+      - name: Build chip image (amd64)
+        if: needs.workflow-conditions.outputs.build-needed == 'true'
+        env:
+          CHIP_COMMIT: ${{ needs.workflow-conditions.outputs.chip-sha }}
         run: |
           cd support/chip
           ./bin/build chip-artifact
@@ -158,6 +168,60 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: chip-image
+          path: /tmp/chip.tar
+
+  chip-image-arm64:
+    needs: workflow-conditions
+    if: needs.workflow-conditions.outputs.build-needed == 'true'
+    runs-on: ubuntu-24.04-arm
+    outputs:
+      source: ${{ needs.workflow-conditions.outputs.build-needed == 'true' && 'artifact' || 'repository' }}
+    steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@v10
+        with:
+          root-reserve-mb: 4096
+          temp-reserve-mb: 3096
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+
+      - name: Check out matter.js
+        uses: actions/checkout@v7
+
+      - name: Build chip image (arm64)
+        env:
+          CHIP_COMMIT: ${{ needs.workflow-conditions.outputs.chip-sha }}
+        run: |
+          cd support/chip
+          ./bin/build chip-artifact
+
+      # The CHIP test jobs run against the amd64 image only, so this is the sole gate between an arm64 build and a
+      # published arm64 manifest. Exit status 126 or above means the shell could not execute the binary at all
+      # (wrong architecture, missing loader); anything below that proves it ran.
+      - name: Smoke-test arm64 image
+        run: |
+          docker load -i /tmp/chip.tar
+          arch=$(docker inspect --format '{{ .Architecture }}' ghcr.io/matter-js/chip:latest)
+          if [ "$arch" != "arm64" ]; then
+            echo "Built image reports architecture \"$arch\", expected arm64" >&2
+            exit 1
+          fi
+          docker run --rm --entrypoint /bin/sh ghcr.io/matter-js/chip:latest -c '
+            for bin in chip-tool chip-all-clusters-app chip-all-clusters-app-nlfaultinject chip-bridge-app; do
+              "$bin" --help >/dev/null 2>&1
+              status=$?
+              if [ "$status" -ge 126 ]; then
+                echo "$bin: exit $status, binary did not execute" >&2
+                exit 1
+              fi
+            done
+          '
+
+      - name: Upload chip artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: chip-image-arm64
           path: /tmp/chip.tar
 
   test-core:
@@ -262,12 +326,15 @@ jobs:
           test-group: icd
           use-local-controller: ${{ matrix.controller == 'matterjs' }}
 
-  # Publish if this is nightly run or triggered manually
-  # TODO - create PR to commit SHA from chip-image action?
-  publish-image:
-    name: Publish docker image
+  # Publish if this is nightly run or triggered manually. Each architecture pushes its natively-built image under an
+  # arch-suffixed tag (publish-arch); publish-manifest then combines those into the multi-arch "latest" and
+  # CHIP-commit tags. A PR-triggered run never reaches these jobs (see the "if" below), so it only builds and tests,
+  # never pushes.
+  publish-image-amd64:
+    name: Publish docker image (amd64)
     runs-on: ubuntu-latest
     needs: [
+      workflow-conditions,
       chip-image,
       test-core,
       test-app-fast,
@@ -295,19 +362,94 @@ jobs:
 
       - name: Load image from artifact
         uses: ./.github/actions/load-chip
+        with:
+          artifact-name: chip-image
 
       - name: Sync CHIP SHA with built version
         env:
-          CHIP_SHA: ${{ needs.chip-image.outputs.chip-sha }}
+          CHIP_SHA: ${{ needs.workflow-conditions.outputs.chip-sha }}
         run: |
           cd support/chip
           echo "$CHIP_SHA" > sha.txt
 
-      - name: Publish docker image
+      - name: Publish amd64 image
         run: |
           cd support/chip
           ./bin/info
-          ./bin/publish
+          ./bin/publish-arch amd64
+
+  publish-image-arm64:
+    name: Publish docker image (arm64)
+    runs-on: ubuntu-24.04-arm
+    needs: [
+      workflow-conditions,
+      chip-image-arm64,
+      test-core,
+      test-app-fast,
+      test-app-slow,
+      test-app-cc-1,
+      test-app-cc-2,
+      test-icd
+    ]
+    if: >-
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+      needs.chip-image-arm64.outputs.source == 'artifact'
+    steps:
+      - name: Check out matter.js
+        uses: actions/checkout@v7
+
+      - name: Login to GitHub Docker Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: Automator77
+          password: ${{ secrets.MATTERJS_DOCKER_TOKEN }}
+
+      - name: Load image from artifact
+        uses: ./.github/actions/load-chip
+        with:
+          artifact-name: chip-image-arm64
+
+      - name: Sync CHIP SHA with built version
+        env:
+          CHIP_SHA: ${{ needs.workflow-conditions.outputs.chip-sha }}
+        run: |
+          cd support/chip
+          echo "$CHIP_SHA" > sha.txt
+
+      - name: Publish arm64 image
+        run: |
+          cd support/chip
+          ./bin/info
+          ./bin/publish-arch arm64
+
+  # TODO - create PR to commit SHA from chip-image action?
+  publish-manifest:
+    name: Publish multi-arch manifest
+    runs-on: ubuntu-latest
+    needs: [workflow-conditions, publish-image-amd64, publish-image-arm64]
+    steps:
+      - name: Check out matter.js
+        uses: actions/checkout@v7
+
+      - name: Login to GitHub Docker Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: Automator77
+          password: ${{ secrets.MATTERJS_DOCKER_TOKEN }}
+
+      - name: Sync CHIP SHA with built version
+        env:
+          CHIP_SHA: ${{ needs.workflow-conditions.outputs.chip-sha }}
+        run: |
+          cd support/chip
+          echo "$CHIP_SHA" > sha.txt
+
+      - name: Publish multi-arch manifest
+        run: |
+          cd support/chip
+          ./bin/publish-manifest amd64 arm64
 
       # TODO - right now we PR the CHIP SHA after publishing container.  Not exactly correct but it's not a big deal if
       # the SHA somehow doesn't get committed.  To fix we will need to figure out how to load the tar artifact from this
@@ -316,13 +458,13 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.PR_TOKEN }}
-          commit-message: "[CHIP BUILD] ${{ needs.chip-image.outputs.chip-sha }}"
+          commit-message: "[CHIP BUILD] ${{ needs.workflow-conditions.outputs.chip-sha }}"
           committer: Automator77 <github-automation@fischer-ka.de>
           author: Automator77 <github-automation@fischer-ka.de>
           signoff: false
           branch: chip-image
           delete-branch: true
-          title: "[CHIP BUILD] ${{ needs.chip-image.outputs.chip-sha }}"
+          title: "[CHIP BUILD] ${{ needs.workflow-conditions.outputs.chip-sha }}"
           body: |
             New CHIP SHA from CI container build
           labels: |

--- a/support/chip/Dockerfile
+++ b/support/chip/Dockerfile
@@ -118,6 +118,16 @@ FROM source AS bins
 # Build chip-tool
 RUN build-one chip-tool
 
+# Build the all-clusters app twice: once plain, once with CHIP's nlfaultinjection GN arg so
+# TC-SC-3.5 and other CASE fault-injection cert tests can drive its FaultInjection cluster as
+# TH_SERVER. Binary name follows CHIP's own build_examples.py convention (host.py's ALL_CLUSTERS +
+# use_nl_fault_injection rename step) so th_server_app_path expectations line up.
+RUN build-one all-clusters-app/linux chip-all-clusters-app
+RUN build-one all-clusters-app/linux chip-all-clusters-app chip-all-clusters-app-nlfaultinject chip_with_nlfaultinjection=true
+
+# TC-ACT-3.2's TH app for the cert tests' chip-local flavor, which spawns from this image's /bin
+RUN build-one bridge-app/linux chip-bridge-app
+
 # Install Python stuff
 COPY support/install-chip-python /bin
 RUN install-chip-python
@@ -203,32 +213,3 @@ COPY --from=source /etc/chip-version /etc
 
 # Configure avahi
 RUN echo allow-interfaces
-
-
-################################################################################
-#
-# STAGE 6 - build example app
-#
-
-FROM install AS app-bins
-
-ARG APP_TARGET
-
-# Build binaries
-RUN build-one "$APP_TARGET"
-
-
-################################################################################
-#
-# STAGE 7 - augment base container with app
-#
-
-FROM chip AS chip-app
-
-ARG APP_BIN
-
-COPY --from=app-bins "/dist/bin/$APP_BIN" /bin
-
-ENV APP_BIN="$APP_BIN"
-
-ENTRYPOINT "/bin/$APP_BIN"

--- a/support/chip/README.md
+++ b/support/chip/README.md
@@ -6,13 +6,23 @@ This is the source for **ghcr.io/matter-js/chip** published here: https://github
 
 The matter.js test harness pulls this image automatically when running CHIP tests.
 
+Besides `chip-tool`, the image ships app binaries used as TH_SERVER/DUT for cert tests:
+`chip-all-clusters-app` and `chip-all-clusters-app-nlfaultinject` (built with CHIP's
+`chip_with_nlfaultinjection=true` GN arg so its FaultInjection cluster is present, as required by
+tests such as TC-SC-3.5) and `chip-bridge-app` (TC-ACT-3.2's TH).
+
 The [bin](./bin) directory contains additional helper scripts you can use on the host:
 
 * [build](./bin/build) builds the image
 * [rebuild](./bin/rebuild) builds the image from scratch
 * [shell](./bin/shell) starts an interactive bash shell inside a local container
 * [tool](./bin/tool) runs chip-tool inside a local container
-* [publish](./bin/publish) pushes the image to GHCR with "latest" tag
+* [publish](./bin/publish) pushes the current build to GHCR with the "latest" tag; for local,
+  single-architecture use
+* [publish-arch](./bin/publish-arch) and [publish-manifest](./bin/publish-manifest) push a
+  per-architecture build under an arch-suffixed tag and combine the arch-suffixed tags already
+  pushed into the multi-arch "latest" and CHIP-commit manifest lists; used by CI, see "Building"
+  below
 * [pull](./bin/pull) pulls the image from GHCR
 
 The container currently requires host networking and access to a local Avahi for MDNS.  In the future we will run Avahi
@@ -25,10 +35,14 @@ chip-tool and [connectedhomeip](https://github.com/project-chip/connectedhomeip)
 
 Run [build](./bin/build) to build.
 
-See [publish](./bin/publish) for details on how to push updated images.
+CHIP's build under QEMU emulation is prohibitively slow, so `ghcr.io/matter-js/chip` is published
+as a multi-arch (amd64+arm64) manifest assembled from two natively-built, single-architecture
+images rather than from one cross-compiling `buildx` invocation: CI builds each architecture on a
+runner native to it (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64), pushes each under an
+arch-suffixed tag with [publish-arch](./bin/publish-arch), then combines those tags into the
+published "latest" and CHIP-commit tags with [publish-manifest](./bin/publish-manifest) — see
+[build-test.chip.yml](../../.github/workflows/build-test.chip.yml).
 
-We currently build for **linux/amd64** and use emulation on Arm Macs.  x86 is appropriate for GitHub CI. Building for
-Arm under emulation is way to slow and running under emulation on MacOS works fine.
-
-Cross-compilation is theoretically possible with chip tooling.  Patient volunteers with buildx, gn and ninja experience
-welcome. 😉
+True cross-compilation (building an arm64 image on an amd64 host or vice versa) remains
+unsupported; running the image itself under emulation (e.g. on an Arm Mac pulling the amd64
+variant) works fine.

--- a/support/chip/bin/publish-arch
+++ b/support/chip/bin/publish-arch
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# @license
+# Copyright 2022-2026 Matter.js Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Publishes the currently loaded "ghcr.io/matter-js/chip:latest" image under a per-architecture
+# tag. publish-manifest later combines these into the multi-arch "latest" and CHIP-commit tags.
+#
+# Usage: publish-arch <arch-suffix>   (e.g. "amd64" or "arm64")
+
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh"
+
+ARCH_SUFFIX=$1
+if [ -z "$ARCH_SUFFIX" ]; then
+    echo "Usage: publish-arch <arch-suffix>" >&2
+    exit 1
+fi
+
+CHIP_COMMIT="$(cat "$CHIP_DIR/sha.txt")"
+TAG="ghcr.io/matter-js/chip:${CHIP_COMMIT}-${ARCH_SUFFIX}"
+
+docker tag ghcr.io/matter-js/chip:latest "$TAG"
+docker push "$TAG"

--- a/support/chip/bin/publish-manifest
+++ b/support/chip/bin/publish-manifest
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# @license
+# Copyright 2022-2026 Matter.js Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Combines the per-architecture images already pushed by publish-arch into the published
+# multi-arch manifest list tags: "latest" and the CHIP commit.
+#
+# Usage: publish-manifest <arch-suffix>...
+
+source "$(dirname "${BASH_SOURCE[0]}")/config.sh"
+
+if [ "$#" -eq 0 ]; then
+    echo "Usage: publish-manifest <arch-suffix>..." >&2
+    exit 1
+fi
+
+CHIP_COMMIT="$(cat "$CHIP_DIR/sha.txt")"
+
+SOURCES=()
+for ARCH_SUFFIX in "$@"; do
+    SOURCES+=("ghcr.io/matter-js/chip:${CHIP_COMMIT}-${ARCH_SUFFIX}")
+done
+
+docker buildx imagetools create \
+    -t ghcr.io/matter-js/chip:latest \
+    -t "ghcr.io/matter-js/chip:${CHIP_COMMIT}" \
+    "${SOURCES[@]}"

--- a/support/chip/docker-bake.hcl
+++ b/support/chip/docker-bake.hcl
@@ -21,7 +21,7 @@ target "chip" {
 
     tags = [
         "ghcr.io/matter-js/chip:latest",
-        "ghcr.io/matter.js-chip:${CHIP_COMMIT}",
+        "ghcr.io/matter-js/chip:${CHIP_COMMIT}",
         "chip:latest",
     ]
 
@@ -56,94 +56,6 @@ target "chip-artifact" {
             type = "docker"
             dest = "${TMPDIR}/chip.tar"
         }
-    ]
-}
-
-target "app" {
-    name = "${app.name}"
-
-    matrix = {
-        app = [
-            {
-                name: "all-clusters",
-                target: "all-clusters",
-                bin: "chip-all-clusters-app",
-            },
-
-            {
-                name: "all-devices",
-                target: "all-devices",
-                bin: "all-devices-app",
-            },
-
-            {
-                name: "lock",
-                target: "lock",
-                bin: "chip-lock-app",
-            },
-
-            {
-                name: "tv",
-                target: "tv-app",
-                bin: "chip-tv-app",
-            },
-
-            {
-                name: "bridge",
-                target: "bridge",
-                bin: "chip-bridge-app",
-            },
-
-            {
-                name: "lit-icd",
-                target: "lit-icd",
-                bin: "lit-icd-app",
-            },
-
-            {
-                name: "microwave",
-                target: "microwave-oven",
-                bin: "chip-microwave-oven-app",
-            },
-
-            {
-                name: "rvc",
-                target: "rvc",
-                bin: "chip-rvc-app",
-            },
-
-            {
-                name: "network-manager",
-                target: "network-manager",
-                bin: "matter-network-manager-app",
-            },
-
-            {
-                name: "energy-gateway",
-                target: "energy-gateway",
-                bin: "chip-energy-gateway-app",
-            },
-
-            {
-                name: "evse",
-                target: "evse",
-                bin: "chip-evse-app",
-            },
-        ]
-    }
-
-    inherits = [ "chip" ]
-    target = "chip-app"
-
-    args = {
-        APP_TARGET = "${app.target}"
-        APP_BIN = "${app.bin}"
-    }
-
-    tags = [
-        "ghcr.io/matter-js/chip-${app.name}:latest",
-        "ghcr.io/matter-js/chip-${app.name}:${CHIP_COMMIT}",
-        "chip-${app.name}:latest",
     ]
 }
 

--- a/support/chip/support/build-one
+++ b/support/chip/support/build-one
@@ -5,10 +5,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Creates a binary using build-examples.py.  Strips, installs into /dist/bin and removes build artifacts
+#
+# Usage: build-one <example-dir> [ninja-target] [output-name] [extra gn arg]...
+#
+# <example-dir> is relative to examples/ and becomes the gn root.  [ninja-target] defaults to
+# <example-dir> (today's chip-tool usage, where the two are identical). [output-name] renames the
+# installed binary; omit it to keep whatever ninja produced. Further arguments are appended to
+# GN_ARGS verbatim, e.g. chip_with_nlfaultinjection=true.
 
 set -e
 
 NAME=$1
+TARGET_NAME=${2:-$1}
+OUT_NAME=$3
+shift $(( $# >= 3 ? 3 : $# ))
+
 OPTIONS=ipv6only-no-ble-no-wifi-no-thread-no-shell-platform-mdns-clang
 
 die() {
@@ -56,6 +67,7 @@ GN_ARGS=(
     matter_enable_tracing_support=false
     matter_trace_config='"///src/tracing/none"'
     matter_commandline_enable_perfetto_tracing=false
+    "$@"
 )
 
 gn gen out \
@@ -64,7 +76,7 @@ gn gen out \
     --root=examples/$NAME \
     --args="${GN_ARGS[*]}"
 
-ninja -C out $NAME
+ninja -C out "$TARGET_NAME"
 
 BINPATH="$(find "out" -type f -executable)"
 if [ ! -x "$BINPATH" ]; then
@@ -73,7 +85,11 @@ fi
 
 strip "$BINPATH"
 mkdir -p /dist/bin
-mv "$BINPATH" /dist/bin
+if [ -n "$OUT_NAME" ]; then
+    mv "$BINPATH" "/dist/bin/$OUT_NAME"
+else
+    mv "$BINPATH" /dist/bin
+fi
 
 #rm -rf "out/$TARGET"
 rm -rf out


### PR DESCRIPTION
Companion PR to #4216, split out so the published base container is ready before the cert-test workflow lands. #4216 currently rebuilds the CHIP image in-job on every run — amd64 because the published image predates the app binaries it needs, arm64 because no arm64 image exists at all. Once this merges and `:latest` is refreshed, those in-job builds come out of #4216 and both jobs go back to a plain `docker pull`.

## Multi-arch publishing

CHIP's compile under QEMU is prohibitively slow, and the Dockerfile's `build`/`source`/`bins` stages pin themselves to `$BUILDPLATFORM`, so a single `--platform linux/amd64,linux/arm64` bake would either emulate or silently produce wrong binaries. Each architecture is therefore built on a runner native to it (`ubuntu-latest`, `ubuntu-24.04-arm`), pushed under an arch-suffixed tag by the new `bin/publish-arch`, and the two tags are combined into the published `latest` and CHIP-commit manifest lists by the new `bin/publish-manifest`. `bin/publish` is unchanged and remains the local, single-arch path.

The CHIP SHA is now resolved once in `workflow-conditions` and handed to both build jobs via `CHIP_COMMIT`. Resolving it per job would let two live `git ls-remote` calls seconds apart return different commits and assemble a manifest whose two platforms point at different upstream sources.

Failure behaviour: `publish-manifest` runs only after both architectures publish, so a half-failed run leaves `:latest` pointing at the previous good manifest. The arch-suffixed tag of the arch that did succeed stays in the registry — deliberate, and useful for pulling a specific platform directly.

## Cert-test app binaries

The image gains `chip-all-clusters-app`, `chip-all-clusters-app-nlfaultinject` (built with `chip_with_nlfaultinjection=true`, so its FaultInjection cluster is present for tests such as TC-SC-3.5) and `chip-bridge-app`. `build-one` takes an optional ninja target, output name and extra GN args to support that. This content is byte-identical to what is already on #4216's branch, where CI has built it repeatedly.

## Removals

`Dockerfile`'s `app-bins`/`chip-app` stages and `docker-bake.hcl`'s per-app image matrix are gone. Both were broken — the `app-bins` stage inherits from a nonexistent `install` stage, and the matrix's GN roots are wrong — and orphaned: nothing referenced `ghcr.io/matter-js/chip-<app>`, and the per-app binaries those names promised are built by `prepare-chip-testing` through connectedhomeip's own `build_examples.py`. Resurrecting per-app images would need a fresh design, not these stages.

Also corrected: the `chip-artifact` commit tag named `ghcr.io/matter.js-chip`, a registry path that does not exist.

## Known gaps

- **The arm64 image is functionally untested.** Every CHIP test job consumes the amd64 artifact, and `publish-image-arm64` gates on those same jobs. The only check between an arm64 build and its published manifest is the new smoke step: it asserts the image's architecture label and that each baked binary actually executes (exit status below 126), which catches a broken or mislabeled build but not an arch-specific runtime defect. Running the full matrix a second time on arm64 runners is the fix if that ever bites; it did not seem worth the CI minutes up front.
- **`bin/shell` and `bin/app` are stale**, pre-existing and untouched here: `bin/shell` names `ghcr.io/matter-js/chip-apps`, which has never existed in any bake file, and `bin/app` resolves names such as `lock`, `tv`, `microwave`, `rvc` and `evse` to binaries the image does not contain. Only its `all-clusters` and `bridge` cases match what is actually baked. Worth a separate cleanup.
- `ChipDockerDevice` in #4216 pulls `ghcr.io/matter-js/chip-<app>:latest`. Nothing publishes those images and nothing did before, so that cert-test flavor stays unusable until per-app images get a real design; cert CI exercises the `chip-local` and `matterjs` flavors.

## Validation

`actionlint` reports only the pre-existing SC2086 informationals. `docker buildx bake --print chip-artifact` resolves cleanly with the corrected tags. CHIP itself was not built locally — CI proves the build, and the Dockerfile/`build-one` content is what #4216's runs already compiled on both architectures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)