### PR TITLE
Run the arm64 core tests even when the image is not rebuilt

### DIFF
--- a/.github/workflows/build-test.chip.yml
+++ b/.github/workflows/build-test.chip.yml
@@ -170,14 +170,17 @@ jobs:
           name: chip-image
           path: /tmp/chip.tar
 
+  # Mirrors chip-image's shape rather than carrying a job-level "if": the job always runs so test-core-arm64 can
+  # depend on it, and its steps build only when a build is needed. Without this the arm64 test job would skip
+  # whenever the image isn't rebuilt, leaving every ordinary code change with no arm64 coverage at all.
   chip-image-arm64:
     needs: workflow-conditions
-    if: needs.workflow-conditions.outputs.build-needed == 'true'
     runs-on: ubuntu-24.04-arm
     outputs:
       source: ${{ needs.workflow-conditions.outputs.build-needed == 'true' && 'artifact' || 'repository' }}
     steps:
       - name: Maximize build space
+        if: needs.workflow-conditions.outputs.build-needed == 'true'
         uses: easimon/maximize-build-space@v10
         with:
           root-reserve-mb: 4096
@@ -187,9 +190,11 @@ jobs:
           remove-haskell: 'true'
 
       - name: Check out matter.js
+        if: needs.workflow-conditions.outputs.build-needed == 'true'
         uses: actions/checkout@v7
 
       - name: Build chip image (arm64)
+        if: needs.workflow-conditions.outputs.build-needed == 'true'
         env:
           CHIP_COMMIT: ${{ needs.workflow-conditions.outputs.chip-sha }}
         run: |
@@ -200,6 +205,7 @@ jobs:
       # execution check here. Exit status 126 or above means the shell could not execute the binary at all (wrong
       # architecture, missing loader); anything below that proves it ran.
       - name: Smoke-test arm64 image
+        if: needs.workflow-conditions.outputs.build-needed == 'true'
         run: |
           docker load -i /tmp/chip.tar
           arch=$(docker inspect --format '{{ .Architecture }}' ghcr.io/matter-js/chip:latest)
@@ -219,6 +225,7 @@ jobs:
           '
 
       - name: Upload chip artifact
+        if: needs.workflow-conditions.outputs.build-needed == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: chip-image-arm64

--- a/.github/workflows/build-test.chip.yml
+++ b/.github/workflows/build-test.chip.yml
@@ -170,9 +170,7 @@ jobs:
           name: chip-image
           path: /tmp/chip.tar
 
-  # Mirrors chip-image's shape rather than carrying a job-level "if": the job always runs so test-core-arm64 can
-  # depend on it, and its steps build only when a build is needed. Without this the arm64 test job would skip
-  # whenever the image isn't rebuilt, leaving every ordinary code change with no arm64 coverage at all.
+  # This job must complete on every run because skipping a required dependency also skips test-core-arm64.
   chip-image-arm64:
     needs: workflow-conditions
     runs-on: ubuntu-24.04-arm


### PR DESCRIPTION
`test-core-arm64` (added with the multi-arch publish work) depends on `chip-image-arm64`, which carried a job-level `if: build-needed == 'true'`. On any run that does not rebuild the image — which is every ordinary pull request — that job skipped and the test skipped with it.

The effect: arm64 was only ever exercised on runs that happened to build it (schedule, manual dispatch, a `support/chip` change, or `[rebuild-chip]`). A normal code change got no arm64 coverage at all, while amd64 ran on every PR.

The amd64 job already solves this: it always runs, its build steps are individually conditional, and its `source` output reports `repository` when nothing was built so the test job pulls the published image instead. `chip-image-arm64` now has the same shape. Its `source` output already produced the same `artifact`/`repository` distinction, and `publish-image-arm64` already gates on `source == 'artifact'`, so nothing can publish an image that was not built.

Cost is one arm64 runner job per pull request, pulling the published arm64 image rather than building one.

Verified with `actionlint` (only the workflow's pre-existing SC2086 informationals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)