### PR TITLE
Transmit an explicitly requested subscription ceiling unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Deprecation: The legacy `DecodedDataReport` / `Decoded{Attribute,Event}Report*` types and the `normalize*` / `normalizeAndDecode*` helpers now announce removal in 0.19 instead of 0.18
     - Deprecation: The legacy `ClusterType` command request surface (`Invoke.LegacyCommandRequest`, `Specifier.ClusterTypeCommand`) and `SessionManager.owner` are scheduled for removal in 0.19
     - Enhancement: Network profiles accept a separate `bdxAdditionalMrpDelay` for bulk transfer, defaulting to the profile's messaging margin
+    - Fix: A subscription's `maxIntervalCeiling` is transmitted exactly as requested; jitter now applies only when we derive the ceiling ourselves
 
 - @matter/react-native
     - Fix: The `storage.clear` variable now clears the storage on start as it does on Node.js

--- a/packages/protocol/src/peer/PhysicalDeviceProperties.ts
+++ b/packages/protocol/src/peer/PhysicalDeviceProperties.ts
@@ -124,6 +124,7 @@ export namespace PhysicalDeviceProperties {
                 : supportsThread
                   ? DEFAULT_SUBSCRIPTION_CEILING_THREAD
                   : DEFAULT_SUBSCRIPTION_CEILING_WIFI;
+        const isExplicitCeiling = maxIntervalCeiling !== undefined;
         if (maxIntervalCeiling === undefined) {
             maxIntervalCeiling = defaultCeiling;
         }
@@ -136,6 +137,10 @@ export namespace PhysicalDeviceProperties {
         if (isIcdCeiling) {
             // The ICD peer reports on its own idleModeDuration clock regardless of our requested ceiling, so jitter
             // would only push our request above idle for no benefit.
+            maxIntervalCeiling = Duration.max(minIntervalFloor, maxIntervalCeiling);
+        } else if (isExplicitCeiling) {
+            // A caller-supplied ceiling is transmitted as requested, with no jitter; only the floor clamp still
+            // applies, since a ceiling below the floor is incoherent (max < min).
             maxIntervalCeiling = Duration.max(minIntervalFloor, maxIntervalCeiling);
         } else {
             // Jitter is added, never subtracted, so it spreads out device responses without raising report

--- a/packages/protocol/test/peer/PhysicalDevicePropertiesTest.ts
+++ b/packages/protocol/test/peer/PhysicalDevicePropertiesTest.ts
@@ -178,12 +178,38 @@ describe("PhysicalDeviceProperties", () => {
                 expectJittered(maxIntervalCeiling, 60);
             });
 
-            it("applies jitter to an explicitly requested ceiling", () => {
+            it("passes an explicitly requested ceiling through unchanged, with no jitter", () => {
+                // Run enough times that a regression to unconditional jitter would show up: jitter is randomized,
+                // so any single run has a nonzero chance of coincidentally landing on the un-jittered value.
+                for (let i = 0; i < 200; i++) {
+                    const { maxIntervalCeiling } = subscriptionIntervalBoundsFor({
+                        request: { maxIntervalCeiling: Seconds(80) },
+                    });
+
+                    expect(maxIntervalCeiling).to.equal(Seconds(80));
+                }
+            });
+
+            it("still derives jitter when the caller omits a ceiling", () => {
+                // Collect distinct values across many runs: bounds-only checks would still pass a jitter-free
+                // implementation (the un-jittered base value satisfies "at least/at most" trivially), so proving
+                // jitter is actually applied requires observing more than one outcome.
+                const observed = new Set<number>();
+                for (let i = 0; i < 200; i++) {
+                    const { maxIntervalCeiling } = subscriptionIntervalBoundsFor();
+
+                    expectJittered(maxIntervalCeiling, 60);
+                    observed.add(maxIntervalCeiling);
+                }
+                expect(observed.size).to.be.greaterThan(1);
+            });
+
+            it("clamps an explicitly requested ceiling below the floor up to the floor", () => {
                 const { maxIntervalCeiling } = subscriptionIntervalBoundsFor({
-                    request: { maxIntervalCeiling: Seconds(45) },
+                    request: { minIntervalFloor: Seconds(30), maxIntervalCeiling: Seconds(10) },
                 });
 
-                expectJittered(maxIntervalCeiling, 45);
+                expect(maxIntervalCeiling).to.equal(Seconds(30));
             });
 
             it("applies jitter regardless of network type", () => {


### PR DESCRIPTION
`PhysicalDeviceProperties.subscriptionIntervalBoundsFor` added random jitter (up to 10%, minimum 10 s) to a subscription's `maxIntervalCeiling` on every non-ICD subscribe — including one whose caller named a concrete value. A caller asking for 80 s got 80–90 s on the wire, randomly, with no way to opt out.

Found by a certification test asserting on the transmitted value: it requested 80 and chip's decode dump showed `MaxIntervalCeilingSeconds = 0x51`.

Jitter now applies only where its rationale holds — when we derive the ceiling from the device's own characteristics because the caller expressed no preference. A caller-supplied ceiling is transmitted as requested; it still clamps up to the floor, since a ceiling below the floor is incoherent, and the existing `MAX_SUBSCRIPTION_CEILING` clamp still applies.

## The decision this PR needs

The blast radius is wider than the case that motivated it, and I would rather you weigh it explicitly than have it merge quietly:

- **The legacy manual-subscribe API takes a mandatory ceiling.** `AttributeClient.subscribe`, `EventClient.subscribe`, `ClusterClient.subscribeAllAttributes` and `InteractionClient.subscribe*` all declare `maxIntervalCeilingSeconds` as a required `number` — there is no way to call them without supplying one. So every subscription made through that surface now loses jitter, whether the caller chose the number deliberately or just passes the same constant while iterating over nodes.
- **`CommissioningController`/`PairedNode`'s `subscribeMaxIntervalCeilingSeconds` is a controller-wide default.** Set it once and every peer under that controller now receives a byte-identical ceiling instead of N slightly different jittered ones.

Both reintroduce the synchronised-reporting the jitter comment says it exists to prevent, for a larger population than the single node that motivated the change. Consumers who want spreading can jitter their own value; the alternative is to treat a value the API *forced* a caller to supply as a preference rather than a request.

## Verification

`packages/protocol` suite 29/29; full `npm test` clean across the workspace. The passthrough test asserts an explicit ceiling is unchanged across 200 iterations and fails against the previous implementation (`expected 85000 to equal 80000`) — the two other tests in that block are characterization tests that also pass against the old code, and are labelled as such rather than counted as evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)