### PR TITLE
Drive the cert controller adapter through ClientNode

### DIFF
--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -6,6 +6,9 @@
 
 import {
     Boot,
+    ClientNode,
+    ControllerBehavior,
+    Duration,
     Environment,
     ImplementationError,
     InternalError,
@@ -13,22 +16,37 @@ import {
     LogFormat,
     Logger,
     MockStorageService,
+    ObserverGroup,
     Seconds,
+    ServerNode,
+    Time,
 } from "@matter/main";
 import { GeneralCommissioning } from "@matter/main/clusters";
 import {
+    ClientRead,
+    CommissionableDeviceIdentifiers,
+    Fabric,
+    FabricAuthority,
+    getOperationalDeviceQname,
+    Invoke,
+    PeerSet,
+    Read,
+    ReadResult,
+    Subscribe,
+    Write,
+    WriteResult,
+} from "@matter/main/protocol";
+import {
     AttributeId,
     ClusterId,
-    ClusterType,
+    CommandId,
     EndpointNumber,
     ManualPairingCodeCodec,
     NodeId,
+    Status,
     StatusResponseError,
 } from "@matter/main/types";
 import { AttributeModel, ClusterModel, Matter } from "@matter/model";
-import { CommissionableDeviceIdentifiers, getOperationalDeviceQname, PeerSet } from "@matter/main/protocol";
-import { CommissioningController } from "@project-chip/matter.js";
-import { AsyncLocalStorage } from "node:async_hooks";
 import type {
     AttributePathSpec,
     CertNodeApi,
@@ -39,6 +57,7 @@ import type {
     SubscribeOptions,
 } from "@matter/testing";
 import { LineQueue, LogFollower } from "@matter/testing";
+import { AsyncLocalStorage } from "node:async_hooks";
 
 /**
  * Attributes a matter.js controller `write`/`invoke` call to the {@link InProcessControllerAdapter} whose
@@ -80,6 +99,15 @@ function toIds(path: AttributePathSpec) {
 
 function isConcretePath(path: AttributePathSpec) {
     return path.endpoint !== undefined && path.cluster !== undefined && path.attribute !== undefined;
+}
+
+function toWireValues(values: ReadResult.AttributeValue[]) {
+    return values.map(({ path: { endpointId, clusterId, attributeId }, value }) => ({
+        endpoint: endpointId,
+        cluster: clusterId,
+        attribute: attributeId,
+        value,
+    }));
 }
 
 /**
@@ -143,71 +171,103 @@ function clusterModelFor(cluster: string | number): { model: ClusterModel; id: n
 
 class InProcessCertNodeApi implements CertNodeApi {
     readonly #adapterId: string;
-    readonly #controller: CommissioningController;
+    readonly #controller: ServerNode;
+    readonly #fabric: Fabric;
     readonly #nodeId: NodeId;
 
-    constructor(adapterId: string, controller: CommissioningController, ref: CertNodeRef) {
+    constructor(adapterId: string, controller: ServerNode, fabric: Fabric, ref: CertNodeRef) {
         this.#adapterId = adapterId;
         this.#controller = controller;
+        this.#fabric = fabric;
         this.#nodeId = NodeId(ref);
     }
 
-    async #node() {
-        return this.#controller.getNode(this.#nodeId);
-    }
-
-    async #interactionClient() {
-        return (await this.#node()).getInteractionClient();
+    get #peer(): ClientNode {
+        const peer = this.#controller.peers.get(this.#fabric.addressOf(this.#nodeId));
+        if (peer === undefined) {
+            throw new ImplementationError(
+                `Controller "${this.#adapterId}" has no commissioned peer with node id ${this.#nodeId}`,
+            );
+        }
+        return peer;
     }
 
     invoke(cluster: string | number, command: string, args?: object, endpoint = 0): Promise<unknown> {
         return runTagged(this.#adapterId, async () => {
             const { model: clusterModel, id: clusterId } = clusterModelFor(cluster);
-            const clusterType = ClusterType(clusterModel) as ClusterType.Concrete;
-            const commandType = clusterType.commands?.[command];
-            if (commandType === undefined) {
+            const commandModel = clusterModel.commands(command);
+            if (commandModel?.id === undefined) {
                 throw new ImplementationError(`Unknown command "${command}" on cluster ${cluster}`);
             }
-            const client = await this.#interactionClient();
-            return await client.invoke({
-                endpointId: EndpointNumber(endpoint),
-                clusterId: ClusterId(clusterId),
-                command: commandType,
-                // Argument-less commands require an absent payload — {} fails TLV validation ("expected void")
-                request: args !== undefined && Object.keys(args).length > 0 ? args : undefined,
+            const request = Invoke({
+                commands: [
+                    Invoke.ConcreteCommandRequest({
+                        endpoint: EndpointNumber(endpoint),
+                        cluster: { id: ClusterId(clusterId), name: clusterModel.name },
+                        command: {
+                            id: CommandId(commandModel.id),
+                            name: commandModel.name,
+                            schema: commandModel,
+                        },
+                        // Argument-less commands require an absent payload — {} fails TLV validation ("expected void")
+                        fields: args !== undefined && Object.keys(args).length > 0 ? args : undefined,
+                    }),
+                ],
             });
+            for await (const chunk of this.#peer.interaction.invoke(request)) {
+                for (const entry of chunk) {
+                    switch (entry.kind) {
+                        case "cmd-status":
+                            if (entry.status !== Status.Success) {
+                                throw StatusResponseError.create(entry.status, undefined, entry.clusterStatus);
+                            }
+                            return undefined;
+
+                        case "cmd-response":
+                            return entry.data;
+                    }
+                }
+            }
+            return undefined;
         });
     }
 
     readAttribute(path: AttributePathSpec, options?: ReadAttributeOptions): Promise<unknown> {
         return runTagged(this.#adapterId, async () => {
-            const client = await this.#interactionClient();
             const { endpointId, clusterId, attributeId } = toIds(path);
-            const { attributeData, attributeStatus } = await client.getMultipleAttributesAndStatus({
-                attributes: [{ endpointId, clusterId, attributeId }],
-                isFabricFiltered: options?.fabricFiltered,
-            });
-            if (isConcretePath(path)) {
-                if (attributeStatus?.length) {
-                    throw new StatusResponseError(
-                        `readAttribute ${JSON.stringify(path)} failed`,
-                        attributeStatus[0].status,
-                    );
+            const values = new Array<ReadResult.AttributeValue>();
+            const statuses = new Array<ReadResult.AttributeStatus>();
+            // A cert step asserts on what the device actually reports, so the read must never be answered
+            // with "unchanged" against versions the node's own subscription cached.
+            const request: ClientRead = {
+                ...Read({
+                    attributes: [{ endpointId, clusterId, attributeId }],
+                    fabricFilter: options?.fabricFiltered,
+                }),
+                includeKnownVersions: true,
+            };
+            for await (const chunk of this.#peer.interaction.read(request)) {
+                for await (const report of chunk) {
+                    if (report.kind === "attr-value") {
+                        values.push(report);
+                    } else if (report.kind === "attr-status") {
+                        statuses.push(report);
+                    }
                 }
-                if (attributeData.length === 0) {
+            }
+            if (isConcretePath(path)) {
+                if (statuses.length) {
+                    throw new StatusResponseError(`readAttribute ${JSON.stringify(path)} failed`, statuses[0].status);
+                }
+                if (values.length === 0) {
                     throw new InternalError(`readAttribute ${JSON.stringify(path)} returned no data`);
                 }
-                return attributeData[0].value;
+                return values[0].value;
             }
             // A wildcard expansion legitimately mixes data with per-item statuses (e.g.
             // UNSUPPORTED_ATTRIBUTE for a path the expansion reached but that doesn't apply there) —
             // unlike a concrete path's status, that's not itself a read failure.
-            return attributeData.map(({ path: { endpointId, clusterId, attributeId }, value }) => ({
-                endpoint: endpointId,
-                cluster: clusterId,
-                attribute: attributeId,
-                value,
-            }));
+            return toWireValues(values);
         });
     }
 
@@ -217,45 +277,57 @@ class InProcessCertNodeApi implements CertNodeApi {
             if (endpoint === undefined || cluster === undefined || attribute === undefined) {
                 throw new ImplementationError("writeAttribute requires a concrete endpoint/cluster/attribute path");
             }
-            const attributeModel =
-                Matter.clusters(cluster)?.attributes(attribute) ?? inferAttributeModel(attribute, value);
-            const client = await this.#interactionClient();
-            await client.setAttribute({
-                attributeData: {
-                    endpointId: EndpointNumber(endpoint),
-                    clusterId: ClusterId(cluster),
-                    attribute: { id: AttributeId(attribute), name: attributeModel.name, schema: attributeModel },
-                    value,
-                },
-            });
+            const clusterModel = Matter.clusters(cluster);
+            const attributeModel = clusterModel?.attributes(attribute) ?? inferAttributeModel(attribute, value);
+            const result = await this.#peer.interaction.write(
+                Write(
+                    Write.Attribute({
+                        endpoint: EndpointNumber(endpoint),
+                        cluster: { id: ClusterId(cluster), name: clusterModel?.name ?? `cluster_${cluster}` },
+                        attributes: {
+                            id: AttributeId(attribute),
+                            name: attributeModel.name,
+                            schema: attributeModel,
+                        },
+                        value,
+                    }),
+                ),
+            );
+            WriteResult.assertSuccess(result);
         });
     }
 
     subscribe(path: AttributePathSpec, opts: SubscribeOptions): Promise<unknown> {
         return runTagged(this.#adapterId, async () => {
-            const client = await this.#interactionClient();
             const { endpointId, clusterId, attributeId } = toIds(path);
+            const seed = new Array<ReadResult.AttributeValue>();
             let seeding = true;
-            const { attributeReports = [] } = await client.subscribeMultipleAttributesAndEvents({
+            const request = Subscribe({
                 attributes: [{ endpointId, clusterId, attributeId }],
-                minIntervalFloorSeconds: opts.minIntervalFloorSeconds,
-                maxIntervalCeilingSeconds: opts.maxIntervalCeilingSeconds,
-                attributeListener: data => {
-                    if (seeding) return;
-                    opts.onUpdate?.(data.value);
-                },
                 keepSubscriptions: true,
+                minIntervalFloor: Seconds(opts.minIntervalFloorSeconds),
+                maxIntervalCeiling: Seconds(opts.maxIntervalCeilingSeconds),
             });
+            request.updated = async data => {
+                for await (const chunk of data) {
+                    for await (const report of chunk) {
+                        if (report.kind !== "attr-value") {
+                            continue;
+                        }
+                        if (seeding) {
+                            seed.push(report);
+                        } else {
+                            opts.onUpdate?.(report.value);
+                        }
+                    }
+                }
+            };
+            await this.#peer.interaction.subscribe(request);
             seeding = false;
             if (isConcretePath(path)) {
-                return attributeReports[0]?.value;
+                return seed[0]?.value;
             }
-            return attributeReports.map(({ path: { endpointId, clusterId, attributeId }, value }) => ({
-                endpoint: endpointId,
-                cluster: clusterId,
-                attribute: attributeId,
-                value,
-            }));
+            return toWireValues(seed);
         });
     }
 
@@ -264,25 +336,24 @@ class InProcessCertNodeApi implements CertNodeApi {
         enhanced: boolean;
     }): Promise<{ manualPairingCode?: string; qrPairingCode?: string }> {
         return runTagged(this.#adapterId, async () => {
-            const node = await this.#node();
+            const peer = this.#peer;
             if (opts.enhanced) {
-                return await node.openEnhancedCommissioningWindow(opts.timeout);
+                return await peer.openEnhancedCommissioningWindow(Seconds(opts.timeout));
             }
-            await node.openBasicCommissioningWindow(opts.timeout);
+            await peer.openBasicCommissioningWindow(Seconds(opts.timeout));
             return {};
         });
     }
 
     decommission(): Promise<void> {
         return runTagged(this.#adapterId, async () => {
-            const node = await this.#node();
-            await node.decommission();
+            await this.#peer.decommission();
         });
     }
 
     operationalMdnsInstanceName(): Promise<string> {
         return runTagged(this.#adapterId, async () => {
-            return getOperationalDeviceQname(this.#controller.fabric.globalId, this.#nodeId);
+            return getOperationalDeviceQname(this.#fabric.globalId, this.#nodeId);
         });
     }
 }
@@ -298,7 +369,33 @@ class InProcessCertNodeApi implements CertNodeApi {
 const CERT_PEER_CONNECTION_TIMEOUT = Seconds(15);
 
 /**
- * Wraps a legacy {@link CommissioningController} as a {@link ControllerAdapter} for cert tests.
+ * Bounds the wait for a freshly commissioned peer's structure. `lifecycle.seeded` never emits for a peer that
+ * went offline between commissioning and its first report, and an unbounded wait there would hang the step
+ * rather than fail it.
+ */
+const CERT_PEER_SEEDING_TIMEOUT = Seconds(30);
+
+async function awaitSeeded(peer: ClientNode) {
+    if (peer.lifecycle.isSeeded) {
+        return;
+    }
+    const observers = new ObserverGroup();
+    const expiry = Time.sleep("cert peer seeding", CERT_PEER_SEEDING_TIMEOUT);
+    try {
+        const seeded = new Promise<void>(resolve => observers.on(peer.lifecycle.seeded, () => resolve()));
+        if (!(await Promise.race([seeded.then(() => true), expiry.then(() => false)]))) {
+            throw new InternalError(
+                `Peer ${peer.id} did not report its structure within ${Duration.format(CERT_PEER_SEEDING_TIMEOUT)}`,
+            );
+        }
+    } finally {
+        expiry.cancel();
+        observers.close();
+    }
+}
+
+/**
+ * Wraps a controller {@link ServerNode} as a {@link ControllerAdapter} for cert tests.
  *
  * Each instance gets its own {@link Environment} (child of {@link Environment.default}) with in-memory
  * storage, so multiple adapters (e.g. "dut", "th_cr2") in the same process never share fabric/session
@@ -307,8 +404,10 @@ const CERT_PEER_CONNECTION_TIMEOUT = Seconds(15);
 export class InProcessControllerAdapter implements ControllerAdapter {
     readonly id: string;
     readonly log: LogFollower;
-    readonly #controller: CommissioningController;
+    readonly #env: Environment;
     readonly #logStream = new LineQueue();
+    #controller?: ServerNode;
+    #fabric?: Fabric;
 
     constructor(id: string) {
         if (adapterStreams.has(id)) {
@@ -320,22 +419,45 @@ export class InProcessControllerAdapter implements ControllerAdapter {
         }
 
         this.id = id;
-        const env = new Environment(`cert-${id}`, Environment.default);
-        new MockStorageService(env);
-        this.#controller = new CommissioningController({
-            environment: { environment: env, id },
-            autoConnect: false,
-            adminFabricLabel: id,
-        });
+        this.#env = new Environment(`cert-${id}`, Environment.default);
+        new MockStorageService(this.#env);
         this.log = new LogFollower(this.#logStream.follow(), id);
 
         adapterStreams.set(id, this.#logStream);
     }
 
+    get #startedController(): ServerNode {
+        if (this.#controller === undefined) {
+            throw new ImplementationError(`Controller adapter "${this.id}" was used before start()`);
+        }
+        return this.#controller;
+    }
+
+    get #adminFabric(): Fabric {
+        if (this.#fabric === undefined) {
+            throw new ImplementationError(`Controller adapter "${this.id}" was used before start()`);
+        }
+        return this.#fabric;
+    }
+
     start(): Promise<void> {
         return runTagged(this.id, async () => {
-            await this.#controller.start();
-            this.#controller.node.env.get(PeerSet).timing = {
+            const controller = await ServerNode.create(ServerNode.RootEndpoint.with(ControllerBehavior), {
+                environment: this.#env,
+                id: this.id,
+                commissioning: { enabled: false },
+                controller: { adminFabricLabel: this.id },
+                network: { autoStartCommissionedPeers: false },
+                subscriptions: { persistenceEnabled: false },
+            });
+            this.#controller = controller;
+
+            const fabricAuthority = await controller.env.load(FabricAuthority);
+            this.#fabric = await fabricAuthority.defaultFabric({ adminFabricLabel: this.id });
+
+            await controller.start();
+
+            controller.env.get(PeerSet).timing = {
                 defaultConnectionTimeout: CERT_PEER_CONNECTION_TIMEOUT,
             };
         });
@@ -343,7 +465,9 @@ export class InProcessControllerAdapter implements ControllerAdapter {
 
     async close(): Promise<void> {
         try {
-            await runTagged(this.id, () => this.#controller.close());
+            await runTagged(this.id, async () => {
+                await this.#controller?.close();
+            });
         } finally {
             adapterStreams.delete(this.id);
             this.#logStream.close();
@@ -353,20 +477,28 @@ export class InProcessControllerAdapter implements ControllerAdapter {
     commission(target: CommissioningTarget): Promise<CertNodeRef> {
         return runTagged(this.id, async () => {
             const { identifierData, passcode } = resolveCommissioningTarget(target);
-            const nodeId = await this.#controller.commissionNode({
-                commissioning: {
-                    regulatoryLocation: GeneralCommissioning.RegulatoryLocationType.IndoorOutdoor,
-                    regulatoryCountryCode: "XX",
-                    onAttestationFailure: true,
-                },
-                discovery: { identifierData },
+            // A commissioned peer holds the sustained wildcard subscription that bootstraps its own structure
+            // read, so the standalone post-commissioning read is suppressed — one read, not two.
+            const peer = await this.#startedController.peers.commission({
+                ...identifierData,
                 passcode,
+                autoStateInitialize: false,
+                regulatoryLocation: GeneralCommissioning.RegulatoryLocationType.IndoorOutdoor,
+                regulatoryCountryCode: "XX",
+                onAttestationFailure: () => true,
             });
-            return nodeId.toString();
+            const address = peer.peerAddress;
+            if (address === undefined) {
+                throw new InternalError(`Commissioned peer ${peer.id} has no peer address`);
+            }
+            // A step may operate on the peer's clusters in the line after commissioning, so resolve only once
+            // its structure has arrived — the behaviors a cluster operation needs do not exist before that.
+            await awaitSeeded(peer);
+            return address.nodeId.toString();
         });
     }
 
     node(ref: CertNodeRef): CertNodeApi {
-        return new InProcessCertNodeApi(this.id, this.#controller, ref);
+        return new InProcessCertNodeApi(this.id, this.#startedController, this.#adminFabric, ref);
     }
 }

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -383,7 +383,12 @@ class InProcessCertNodeApi implements CertNodeApi {
  */
 const CERT_PEER_CONNECTION_TIMEOUT = Seconds(15);
 
-const CERT_PEER_SETTLE_TIMEOUT = Seconds(30);
+/**
+ * Long enough to cover one interaction-timeout-and-retry cycle: a peer that stops mid-report leaves the
+ * controller waiting out its message timeout before it reads again, and only that second read reaches the
+ * subscription.
+ */
+const CERT_PEER_SETTLE_TIMEOUT = Seconds(45);
 
 /**
  * Waits for the peer's sustained subscription to become active (`isConnected` tracks `subscriptionActive`,

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -369,23 +369,40 @@ class InProcessCertNodeApi implements CertNodeApi {
 const CERT_PEER_CONNECTION_TIMEOUT = Seconds(15);
 
 /**
- * Bounds the wait for a freshly commissioned peer's structure. `lifecycle.seeded` never emits for a peer that
- * went offline between commissioning and its first report, and an unbounded wait there would hang the step
- * rather than fail it.
+ * Bounds the wait for a freshly commissioned peer. Neither signal below ever arrives for a peer that went
+ * offline right after commissioning, and an unbounded wait there would hang the step rather than fail it.
  */
-const CERT_PEER_SEEDING_TIMEOUT = Seconds(30);
+const CERT_PEER_READY_TIMEOUT = Seconds(30);
 
-async function awaitSeeded(peer: ClientNode) {
-    if (peer.lifecycle.isSeeded) {
+/**
+ * Resolves once the peer holds its structure and its sustained subscription (`isConnected` tracks
+ * `subscriptionActive`).
+ *
+ * A step's own subscription must not be in flight while that sustained one is still establishing: it carries
+ * `keepSubscriptions: false`, so the device drops the step's subscription and answers it `InvalidAction`.
+ */
+async function awaitPeerReady(peer: ClientNode) {
+    const isReady = () => peer.lifecycle.isSeeded && peer.lifecycle.isConnected;
+    if (isReady()) {
         return;
     }
     const observers = new ObserverGroup();
-    const expiry = Time.sleep("cert peer seeding", CERT_PEER_SEEDING_TIMEOUT);
+    const expiry = Time.sleep("cert peer readiness", CERT_PEER_READY_TIMEOUT);
     try {
-        const seeded = new Promise<void>(resolve => observers.on(peer.lifecycle.seeded, () => resolve()));
-        if (!(await Promise.race([seeded.then(() => true), expiry.then(() => false)]))) {
+        const ready = new Promise<void>(resolve => {
+            const check = () => {
+                if (isReady()) {
+                    resolve();
+                }
+            };
+            observers.on(peer.lifecycle.seeded, check);
+            observers.on(peer.lifecycle.connectionStateChanged, check);
+            check();
+        });
+        if (!(await Promise.race([ready.then(() => true), expiry.then(() => false)]))) {
             throw new InternalError(
-                `Peer ${peer.id} did not report its structure within ${Duration.format(CERT_PEER_SEEDING_TIMEOUT)}`,
+                `Peer ${peer.id} was not ready within ${Duration.format(CERT_PEER_READY_TIMEOUT)} ` +
+                    `(seeded: ${peer.lifecycle.isSeeded}, connected: ${peer.lifecycle.isConnected})`,
             );
         }
     } finally {
@@ -491,9 +508,7 @@ export class InProcessControllerAdapter implements ControllerAdapter {
             if (address === undefined) {
                 throw new InternalError(`Commissioned peer ${peer.id} has no peer address`);
             }
-            // A step may operate on the peer's clusters in the line after commissioning, so resolve only once
-            // its structure has arrived — the behaviors a cluster operation needs do not exist before that.
-            await awaitSeeded(peer);
+            await awaitPeerReady(peer);
             return address.nodeId.toString();
         });
     }

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -85,6 +85,8 @@ Boot.init(() => {
     });
 });
 
+const logger = Logger.get("CertControllerAdapter");
+
 function runTagged<T>(id: string, fn: () => Promise<T>): Promise<T> {
     return activeAdapterId.run(id, fn);
 }
@@ -368,41 +370,39 @@ class InProcessCertNodeApi implements CertNodeApi {
  */
 const CERT_PEER_CONNECTION_TIMEOUT = Seconds(15);
 
-/**
- * Bounds the wait for a freshly commissioned peer. Neither signal below ever arrives for a peer that went
- * offline right after commissioning, and an unbounded wait there would hang the step rather than fail it.
- */
-const CERT_PEER_READY_TIMEOUT = Seconds(30);
+const CERT_PEER_SETTLE_TIMEOUT = Seconds(30);
 
 /**
- * Resolves once the peer holds its structure and its sustained subscription (`isConnected` tracks
- * `subscriptionActive`).
+ * Waits for the peer's sustained subscription to become active (`isConnected` tracks `subscriptionActive`,
+ * and the subscription bootstraps with the structure read, so this covers both).
  *
  * A step's own subscription must not be in flight while that sustained one is still establishing: it carries
  * `keepSubscriptions: false`, so the device drops the step's subscription and answers it `InvalidAction`.
+ *
+ * A peer that never gets there is reported, not failed: a step addresses the peer through raw interaction
+ * paths, which work without a subscription, so refusing to continue would fail test cases whose device holds
+ * a cluster matter.js cannot build a behavior for.
  */
-async function awaitPeerReady(peer: ClientNode) {
-    const isReady = () => peer.lifecycle.isSeeded && peer.lifecycle.isConnected;
-    if (isReady()) {
+async function settlePeer(peer: ClientNode) {
+    if (peer.lifecycle.isConnected) {
         return;
     }
     const observers = new ObserverGroup();
-    const expiry = Time.sleep("cert peer readiness", CERT_PEER_READY_TIMEOUT);
+    const expiry = Time.sleep("cert peer settling", CERT_PEER_SETTLE_TIMEOUT);
     try {
-        const ready = new Promise<void>(resolve => {
+        const connected = new Promise<void>(resolve => {
             const check = () => {
-                if (isReady()) {
+                if (peer.lifecycle.isConnected) {
                     resolve();
                 }
             };
-            observers.on(peer.lifecycle.seeded, check);
             observers.on(peer.lifecycle.connectionStateChanged, check);
             check();
         });
-        if (!(await Promise.race([ready.then(() => true), expiry.then(() => false)]))) {
-            throw new InternalError(
-                `Peer ${peer.id} was not ready within ${Duration.format(CERT_PEER_READY_TIMEOUT)} ` +
-                    `(seeded: ${peer.lifecycle.isSeeded}, connected: ${peer.lifecycle.isConnected})`,
+        if (!(await Promise.race([connected.then(() => true), expiry.then(() => false)]))) {
+            logger.warn(
+                `Peer ${peer.id} held no subscription after ${Duration.format(CERT_PEER_SETTLE_TIMEOUT)} ` +
+                    `(seeded: ${peer.lifecycle.isSeeded}, state: ${peer.lifecycle.connectionState}); continuing`,
             );
         }
     } finally {
@@ -508,7 +508,7 @@ export class InProcessControllerAdapter implements ControllerAdapter {
             if (address === undefined) {
                 throw new InternalError(`Commissioned peer ${peer.id} has no peer address`);
             }
-            await awaitPeerReady(peer);
+            await settlePeer(peer);
             return address.nodeId.toString();
         });
     }

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -383,12 +383,7 @@ class InProcessCertNodeApi implements CertNodeApi {
  */
 const CERT_PEER_CONNECTION_TIMEOUT = Seconds(15);
 
-/**
- * Long enough to cover one interaction-timeout-and-retry cycle: a peer that stops mid-report leaves the
- * controller waiting out its message timeout before it reads again, and only that second read reaches the
- * subscription.
- */
-const CERT_PEER_SETTLE_TIMEOUT = Seconds(45);
+const CERT_PEER_SETTLE_TIMEOUT = Seconds(30);
 
 /**
  * Waits for the peer's sustained subscription to become active (`isConnected` tracks `subscriptionActive`,

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -21,7 +21,7 @@ import {
     ServerNode,
     Time,
 } from "@matter/main";
-import { GeneralCommissioning } from "@matter/main/clusters";
+import { GeneralCommissioning, OperationalCredentials } from "@matter/main/clusters";
 import {
     ClientRead,
     CommissionableDeviceIdentifiers,
@@ -349,7 +349,20 @@ class InProcessCertNodeApi implements CertNodeApi {
 
     decommission(): Promise<void> {
         return runTagged(this.#adapterId, async () => {
-            await this.#peer.decommission();
+            const peer = this.#peer;
+            try {
+                await peer.decommission();
+                return;
+            } catch (e) {
+                // Decommissioning acts through the peer's OperationalCredentials behavior, which exists only once a
+                // report has carried that cluster. A peer whose structure read aborted holds no such behavior.
+                if (!peer.lifecycle.isCommissioned) {
+                    throw e;
+                }
+                logger.info(`Decommissioning ${peer.id} failed, reading its credentials and retrying:`, e);
+            }
+            await this.readAttribute({ endpoint: 0, cluster: OperationalCredentials.id });
+            await peer.decommission();
         });
     }
 

--- a/support/chip-testing/test/cert-framework/controller-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/controller-adapter.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { InternalError } from "@matter/main";
+import { StatusResponseError } from "@matter/main/types";
 import { Matter } from "@matter/model";
 import { expect } from "chai";
 import { AllClustersTestInstance } from "../../src/AllClustersTestInstance.js";
@@ -17,6 +18,25 @@ const VENDOR_ID_ATTRIBUTE = BASIC_INFORMATION.attributes.require("vendorId");
 const ON_OFF_ATTRIBUTE = ON_OFF.attributes.require("onOff");
 const NODE_LABEL_ATTRIBUTE = BASIC_INFORMATION.attributes.require("nodeLabel");
 const FABRICS_ATTRIBUTE = OPERATIONAL_CREDENTIALS.attributes.require("fabrics");
+
+async function rejectionOf(promise: Promise<unknown>): Promise<unknown> {
+    try {
+        await promise;
+    } catch (e) {
+        return e;
+    }
+    throw new InternalError("Expected the operation to reject but it resolved");
+}
+
+async function waitFor(condition: () => boolean) {
+    const deadline = Date.now() + 5_000;
+    while (!condition()) {
+        if (Date.now() > deadline) {
+            throw new InternalError("Timed out waiting for a subscription update");
+        }
+        await new Promise(resolve => setTimeout(resolve, 20));
+    }
+}
 
 describe("InProcessControllerAdapter", () => {
     let device: AllClustersTestInstance;
@@ -105,6 +125,72 @@ describe("InProcessControllerAdapter", () => {
             { minIntervalFloorSeconds: 1, maxIntervalCeilingSeconds: 10 },
         );
         expect(value).to.be.a("boolean");
+
+        await node.decommission();
+    });
+
+    it("throws a StatusResponseError when the device rejects an invoke", async function () {
+        this.timeout(30_000);
+
+        const ref = await adapter.commission({ passcode: 20202021, discriminator: 3840 });
+        const node = adapter.node(ref);
+
+        expect(await rejectionOf(node.invoke("OnOff", "on", {}, 0))).to.be.instanceOf(StatusResponseError);
+
+        await node.decommission();
+    });
+
+    it("throws when the device rejects a write", async function () {
+        this.timeout(30_000);
+
+        const ref = await adapter.commission({ passcode: 20202021, discriminator: 3840 });
+        const node = adapter.node(ref);
+
+        expect(
+            await rejectionOf(
+                node.writeAttribute(
+                    { endpoint: 0, cluster: BASIC_INFORMATION.id, attribute: VENDOR_ID_ATTRIBUTE.id },
+                    1,
+                ),
+            ),
+        ).to.be.instanceOf(Error);
+
+        await node.decommission();
+    });
+
+    it("throws on a concrete read the device declines but tolerates statuses in a wildcard expansion", async function () {
+        this.timeout(30_000);
+
+        const ref = await adapter.commission({ passcode: 20202021, discriminator: 3840 });
+        const node = adapter.node(ref);
+
+        expect(
+            await rejectionOf(node.readAttribute({ endpoint: 0, cluster: ON_OFF.id, attribute: ON_OFF_ATTRIBUTE.id })),
+        ).to.be.instanceOf(Error);
+
+        const wildcard = await node.readAttribute({ endpoint: 0, cluster: BASIC_INFORMATION.id });
+        expect(wildcard).to.be.an("array").that.is.not.empty;
+
+        await node.decommission();
+    });
+
+    it("reports later changes as updates but not the seeding report", async function () {
+        this.timeout(30_000);
+
+        const ref = await adapter.commission({ passcode: 20202021, discriminator: 3840 });
+        const node = adapter.node(ref);
+
+        const updates = new Array<unknown>();
+        const seed = await node.subscribe(
+            { endpoint: 1, cluster: ON_OFF.id, attribute: ON_OFF_ATTRIBUTE.id },
+            { minIntervalFloorSeconds: 0, maxIntervalCeilingSeconds: 10, onUpdate: value => updates.push(value) },
+        );
+        expect(seed).to.be.a("boolean");
+        expect(updates).to.be.empty;
+
+        await node.invoke("OnOff", "toggle", {}, 1);
+        await waitFor(() => updates.length > 0);
+        expect(updates).to.deep.equal([!seed]);
 
         await node.decommission();
     });

--- a/support/chip-testing/test/cert-framework/controller-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/controller-adapter.test.ts
@@ -166,7 +166,7 @@ describe("InProcessControllerAdapter", () => {
 
         expect(
             await rejectionOf(node.readAttribute({ endpoint: 0, cluster: ON_OFF.id, attribute: ON_OFF_ATTRIBUTE.id })),
-        ).to.be.instanceOf(Error);
+        ).to.be.instanceOf(StatusResponseError);
 
         const wildcard = await node.readAttribute({ endpoint: 0, cluster: BASIC_INFORMATION.id });
         expect(wildcard).to.be.an("array").that.is.not.empty;


### PR DESCRIPTION
Step 1 of the agreed cert-harness sequence: move `InProcessControllerAdapter` off the deprecated `CommissioningController` / `PairedNode` / `InteractionClient` API onto `ClientNode`. The six existing cert test cases are the regression suite.

## What moved

The adapter holds a controller `ServerNode` with `ControllerBehavior`; peers are `ClientNode`s from `serverNode.peers`; the five `CertNodeApi` operations go through `clientNode.interaction` with the `Read` / `Write` / `Invoke` / `Subscribe` request DSL. `CertNodeApi`, `ControllerAdapter` and the adapter factory in `packages/testing` are untouched, so every test case compiles unchanged.

The legacy path already delegated to this same interaction stack — `PairedNode.getInteractionClient()` returns an `InteractionClient` wrapping `clientNode.interaction`, and `CommissioningController` is a controller `ServerNode` internally — so the protocol behaviour is preserved by construction. What changed is call shape, result handling, error propagation, and peer lifecycle.

## Preserving the traffic the tests were authored against

- **Commissioning** suppresses the standalone post-commissioning structure read (`autoStateInitialize: false`) and leaves the sustained subscription enabled, matching the legacy path: `MatterController.commission` suppressed the `NetworkClient` read and `PairedNode` then activated the subscription, whose bootstrap read seeded the node.
- **Reads** set `includeKnownVersions`, as the legacy `InteractionClient` did. Without it the node's cached versions are injected as `DataVersionFilters` and the device answers a wildcard read with nothing.
- **`commission()`** waits for the peer's sustained subscription to become active before resolving. Without that wait a step's own `SubscribeRequest` races the sustained one, which carries `keepSubscriptions: false`, so the device drops the step's subscription and answers `InvalidAction` — TC-IDM-4.1 failed exactly this way on both chip flavors. A peer that never gets there is logged and the run continues, since steps address peers through raw interaction paths that need no subscription.
- **`decommission()`** falls back to reading the peer's `OperationalCredentials` cluster and retrying once. Decommissioning acts through that behavior, which exists only once a report has carried the cluster.

Error semantics are restored explicitly, since the new API reports rather than throws: invoke raises a non-Success `cmd-status`, writes assert through `WriteResult.assertSuccess`, and a concrete read carrying a status still throws while a wildcard expansion still tolerates per-path statuses.

The `ClusterType.Concrete` cast is gone — the command specifier is built from the cluster model directly.

## Verification

Cert run 31673691719 green on all three flavors (matterjs, cert-bins, own-built). Diffed against baseline run 31640339352:

- Every test case's verdict and every step's verdict identical.
- Device-log checks identical: 82 pass per chip flavor, zero unverified; matterjs unchanged.
- `finalizationError` null throughout, as before.

Two intentional device-side traffic differences, everything else being chunk-count noise:

1. **Writes are no longer always timed** (TC-IDM-3.1, TC-IDM-4.1: 45 `TimedRequest` → 0 per chip run). The legacy client destructured `timedRequestTimeout = DEFAULT_TIMED_REQUEST_TIMEOUT` and passed it into `Write()`, whose `timedRequest: !!timed || !!timeout` therefore made *every* legacy write timed. The migration sends a timed write only when the attribute's access demands it. Every write check still passes. Worth knowing for consumers still on the legacy API — they pay a round trip per write.
2. **The chip bridge peer holds no sustained subscription** (TC-ACT-3.2: 3 `SubscribeRequest` → 0), because the device stalls its structure read. See findings.

Mutation proof, each conversion reverted separately:

| Hunk removed | Failing test | Failure |
| --- | --- | --- |
| invoke `cmd-status` throw | "throws a StatusResponseError when the device rejects an invoke" | `Expected the operation to reject but it resolved` |
| `WriteResult.assertSuccess` | "throws when the device rejects a write" | `Expected the operation to reject but it resolved` |
| concrete-read status throw | "throws on a concrete read the device declines…" | `expected Error: readAttribute {"endpoint":0,"cluster":6,"attribute":0} returned no data to be an instance of StatusResponseError` |

The third mutation initially survived: the no-data guard behind the status check throws too, so asserting "rejects" proved nothing. The test now pins the error class.

Repository gates green: `npm run build`, `npm run format-verify`, `npm run lint`, `npm test`; `test/cert-framework/controller-adapter.test.ts` 7/7 and `test/cert/**` 7/7 locally on the matterjs flavor.

## Findings for separate consideration, not addressed here

**The chip bridge stops mid-report, and both the legacy and the new path wait it out.** Reading `PowerSource` `GeneratedCommandList` on endpoint 6 fails inside the device: its log shows `TLVWriter.cpp:697: CHIP Error 0x00000024: Invalid TLV tag`, it rolls back, moves the read handler to `AwaitingDestruction`, then acknowledges our `StatusResponse` without sending the remaining chunks it had announced with `moreChunkedMessages`. The controller waits out its message timeout and reads again about 30 seconds later; that second read carries data-version filters, skips the cluster that cannot be encoded, and the subscription follows within milliseconds.

This sequence is identical in the baseline and in this branch — same error, same device state machine, same recovery — so it is a device-side defect this branch neither introduces nor changes. What differed was only how long the harness waited: the legacy path blocked inside commissioning on `PairedNode` initialization for the full ~50 seconds and so had its subscription before the test case began, while the settle window here expired one second before the retry. Widening the window does not fix it: the delay before the controller's retry comes from message-retransmission backoff, not a fixed timeout — 29.7s in one run, 44.8s in the next, which missed a 45s window by 179ms. The wait stays at 30 seconds, which is what a healthy peer needs for the guarantee it exists for, and the bridge test case simply runs without a sustained subscription. Nothing in it depends on one: every step addresses the peer through raw interaction paths.

Worth reporting upstream: a report that announces `moreChunkedMessages` and then stops leaves the peer waiting out a timeout instead of receiving a status. Raw device log in the `cert-evidence-own-built` artifact, `*-TC-ACT-3.2/device-th.log`.

**`Subscribe.Options.update` and `.closed` are dropped.** `Subscribe()` reads only `keepSubscriptions` and the intervals, and `Read()` ignores the rest, so a caller passing `update` gets a subscription with no listener. The adapter assigns `updated` on the built request instead, as `NetworkClient` and the legacy `InteractionClient` both do. Either wire them up or remove them from the options type.

