### PR TITLE
fix(node): erase peers and CA key material on factory reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 ## __WORK IN PROGRESS__
 
 - @matter/general
+    - Enhancement: New `MatterAggregateError.settleSeries()` runs tasks in order, continuing past a failure, and reports the accumulated errors
     - Fix: Opening a namespace whose `driver.json` names an unregistered storage driver now throws `NoProviderError` instead of silently opening the existing data with a mismatched driver
     - Fix: DNS-SD ignores SRV records with port 0, an empty target or an out-of-range port
     - Fix: DNS-SD resolution queries A/AAAA for the SRV target host instead of the service instance name
@@ -62,7 +63,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Client node values persisted under property names by earlier versions are migrated to their attribute id on load, so they stay readable
     - Fix: Writing a fabric-scoped list entry that stems from a cluster whose schema could not be resolved no longer produces two conflicting fabricIndex fields
     - Fix: A rejected write to an attribute served by dynamic properties restores the previous value instead of deleting the property, and a rejected write to a previously absent attribute leaves no slot behind instead of one holding `undefined`
-    - Fix: Factory reset also removes commissioned peers and the certificate authority's key material, so a controller with peers is bootable after reset; a peer that cannot be torn down no longer blocks the reset
+    - Fix: Factory reset removes commissioned peers and the certificate authority's key material; a peer that cannot be torn down no longer blocks the reset
 
 - @matter/nodejs
     - Breaking: `FileStorageDriver`'s constructor no longer accepts a `clear` argument; clearing is handled by `StorageService`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Client node values persisted under property names by earlier versions are migrated to their attribute id on load, so they stay readable
     - Fix: Writing a fabric-scoped list entry that stems from a cluster whose schema could not be resolved no longer produces two conflicting fabricIndex fields
     - Fix: A rejected write to an attribute served by dynamic properties restores the previous value instead of deleting the property, and a rejected write to a previously absent attribute leaves no slot behind instead of one holding `undefined`
+    - Fix: Factory reset also removes commissioned peers and the certificate authority's key material, so a controller with peers is bootable after reset; a peer that cannot be torn down no longer blocks the reset
 
 - @matter/nodejs
     - Breaking: `FileStorageDriver`'s constructor no longer accepts a `clear` argument; clearing is handled by `StorageService`
@@ -74,6 +75,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Deprecation: The legacy `DecodedDataReport` / `Decoded{Attribute,Event}Report*` types and the `normalize*` / `normalizeAndDecode*` helpers now announce removal in 0.19 instead of 0.18
     - Deprecation: The legacy `ClusterType` command request surface (`Invoke.LegacyCommandRequest`, `Specifier.ClusterTypeCommand`) and `SessionManager.owner` are scheduled for removal in 0.19
     - Enhancement: Network profiles accept a separate `bdxAdditionalMrpDelay` for bulk transfer, defaulting to the profile's messaging margin
+    - Enhancement: New `CertificateAuthority.erase()` discards the authority's key material, persisted and in memory
     - Fix: A subscription's `maxIntervalCeiling` is transmitted exactly as requested; jitter now applies only when we derive the ceiling ourselves
 
 - @matter/react-native

--- a/packages/general/src/MatterError.ts
+++ b/packages/general/src/MatterError.ts
@@ -258,6 +258,29 @@ export class MatterAggregateError extends AggregateError {
         return (results as PromiseFulfilledResult<T>[]).map(result => result.value);
     }
 
+    /**
+     * Run tasks in order, continuing past a task that throws, and throw the accumulated errors as
+     * MatterAggregateError (or extended class) once every task has run.
+     *
+     * Use where ordering matters and each step must run regardless of its predecessors, such as teardown that must
+     * not leave state behind when one area fails.
+     */
+    static async settleSeries(tasks: Iterable<() => MaybePromise<unknown>>, message = "Errors happened") {
+        const errors = new Array<unknown>();
+
+        for (const task of tasks) {
+            try {
+                await task();
+            } catch (error) {
+                errors.push(error);
+            }
+        }
+
+        if (errors.length) {
+            throw new this(errors, message);
+        }
+    }
+
     format = MatterError.prototype.format;
 }
 

--- a/packages/node/src/node/ClientNode.ts
+++ b/packages/node/src/node/ClientNode.ts
@@ -187,12 +187,14 @@ export class ClientNode extends Node<ClientNode.RootEndpoint> {
     override async delete() {
         const address = this.peerAddress;
 
-        await super.delete();
-
-        // Ensure there is no remaining @matter/protocol Peer installed.  This may occur if deleted while still
-        // commissioned
-        if (address) {
-            await this.env.maybeGet(PeerSet)?.get(address)?.delete();
+        try {
+            await super.delete();
+        } finally {
+            // Ensure there is no remaining @matter/protocol Peer installed.  This may occur if deleted while still
+            // commissioned, and must hold even when teardown fails or the peer outlives its fabric
+            if (address) {
+                await this.env.maybeGet(PeerSet)?.get(address)?.delete();
+            }
         }
     }
 

--- a/packages/node/src/node/ServerNode.ts
+++ b/packages/node/src/node/ServerNode.ts
@@ -15,8 +15,17 @@ import { SubscriptionsServer } from "#behavior/system/subscriptions/Subscription
 import { Endpoint } from "#endpoint/Endpoint.js";
 import { ServerNodeStore } from "#storage/server/ServerNodeStore.js";
 import type { Environment } from "@matter/general";
-import { asyncNew, Construction, DiagnosticSource, errorOf, Identity, MatterError } from "@matter/general";
 import {
+    asyncNew,
+    Construction,
+    DiagnosticSource,
+    errorOf,
+    Identity,
+    MatterAggregateError,
+    MatterError,
+} from "@matter/general";
+import {
+    CertificateAuthority,
     FabricManager,
     Interactable,
     OccurrenceManager,
@@ -213,10 +222,41 @@ export class ServerNode<T extends ServerNode.RootEndpoint = ServerNode.RootEndpo
      * @see {@link MatterSpecification.v16.Core} § 13.4
      */
     protected async resetStorage() {
-        await this.env.get(SessionManager).clear();
-        await this.env.get(FabricManager).clear();
-        await this.env.get(OccurrenceManager).clear();
-        await this.env.get(ServerNodeStore).erase();
+        // Peers first so their teardown still sees the fabrics and sessions it depends on.  Every area is erased even
+        // if an earlier one fails, so a partial reset cannot leave key material behind
+        const errors = new Array<unknown>();
+
+        for (const erase of [
+            () => this.#peers?.erase(),
+            () => this.env.get(SessionManager).clear(),
+            () => this.env.get(FabricManager).clear(),
+            () => this.env.get(OccurrenceManager).clear(),
+            () => this.#eraseCertificateAuthority(),
+            () => this.env.get(ServerNodeStore).erase(),
+        ]) {
+            try {
+                await erase();
+            } catch (error) {
+                errors.push(error);
+            }
+        }
+
+        if (errors.length) {
+            throw new MatterAggregateError(errors, `Error erasing storage of ${this}`);
+        }
+    }
+
+    /**
+     * The authority caches its key material for the lifetime of the instance, so it is dropped from the environment
+     * along with the material it persists.  An authority the node did not create belongs to whoever supplied it.
+     */
+    async #eraseCertificateAuthority() {
+        if (!this.env.owns(CertificateAuthority)) {
+            return;
+        }
+
+        await this.env.get(CertificateAuthority).erase();
+        this.env.delete(CertificateAuthority);
     }
 
     /**

--- a/packages/node/src/node/ServerNode.ts
+++ b/packages/node/src/node/ServerNode.ts
@@ -255,8 +255,11 @@ export class ServerNode<T extends ServerNode.RootEndpoint = ServerNode.RootEndpo
             return;
         }
 
-        await this.env.get(CertificateAuthority).erase();
-        this.env.delete(CertificateAuthority);
+        try {
+            await this.env.get(CertificateAuthority).erase();
+        } finally {
+            this.env.delete(CertificateAuthority);
+        }
     }
 
     /**

--- a/packages/node/src/node/ServerNode.ts
+++ b/packages/node/src/node/ServerNode.ts
@@ -25,7 +25,6 @@ import {
     MatterError,
 } from "@matter/general";
 import {
-    CertificateAuthority,
     FabricManager,
     Interactable,
     OccurrenceManager,
@@ -222,44 +221,19 @@ export class ServerNode<T extends ServerNode.RootEndpoint = ServerNode.RootEndpo
      * @see {@link MatterSpecification.v16.Core} § 13.4
      */
     protected async resetStorage() {
-        // Peers first so their teardown still sees the fabrics and sessions it depends on.  Every area is erased even
-        // if an earlier one fails, so a partial reset cannot leave key material behind
-        const errors = new Array<unknown>();
+        await MatterAggregateError.settleSeries(
+            [
+                // Peers first so their teardown still sees the fabrics and sessions it depends on
+                () => this.#peers?.erase(),
 
-        for (const erase of [
-            () => this.#peers?.erase(),
-            () => this.env.get(SessionManager).clear(),
-            () => this.env.get(FabricManager).clear(),
-            () => this.env.get(OccurrenceManager).clear(),
-            () => this.#eraseCertificateAuthority(),
-            () => this.env.get(ServerNodeStore).erase(),
-        ]) {
-            try {
-                await erase();
-            } catch (error) {
-                errors.push(error);
-            }
-        }
-
-        if (errors.length) {
-            throw new MatterAggregateError(errors, `Error erasing storage of ${this}`);
-        }
-    }
-
-    /**
-     * The authority caches its key material for the lifetime of the instance, so it is dropped from the environment
-     * along with the material it persists.  An authority the node did not create belongs to whoever supplied it.
-     */
-    async #eraseCertificateAuthority() {
-        if (!this.env.owns(CertificateAuthority)) {
-            return;
-        }
-
-        try {
-            await this.env.get(CertificateAuthority).erase();
-        } finally {
-            this.env.delete(CertificateAuthority);
-        }
+                () => this.env.get(SessionManager).clear(),
+                () => this.env.get(FabricManager).clear(),
+                () => this.env.get(OccurrenceManager).clear(),
+                () => ServerEnvironment.eraseCredentials(this),
+                () => this.env.get(ServerNodeStore).erase(),
+            ],
+            `Error erasing storage of ${this}`,
+        );
     }
 
     /**

--- a/packages/node/src/node/client/Peers.ts
+++ b/packages/node/src/node/client/Peers.ts
@@ -56,6 +56,7 @@ import {
     Peer,
     PeerAddress,
     PeerLeftError,
+    PeerSet,
     SessionManager,
 } from "@matter/protocol";
 import { FabricIndex, NodeId, Status } from "@matter/types";
@@ -442,6 +443,42 @@ export class Peers extends EndpointContainer<ClientNode> {
             });
 
             return node;
+        });
+    }
+
+    /**
+     * Delete every known node and its persisted data.
+     *
+     * A node we cannot tear down cleanly is closed and dropped instead, so it cannot block the factory reset this
+     * serves.
+     */
+    async erase() {
+        await this.#mutex.produce(async () => {
+            for (const node of [...this]) {
+                const address = node.maybeStateOf(CommissioningClient)?.peerAddress;
+
+                try {
+                    await node.delete();
+                    continue;
+                } catch (error) {
+                    MatterError.accept(error);
+                    logger.warn(`Error deleting ${node}:`, error);
+                }
+
+                try {
+                    await node.close();
+                } catch (error) {
+                    MatterError.accept(error);
+                    logger.warn(`Error closing ${node}:`, error);
+                }
+
+                // ClientNode.delete() does this itself; without it the peer outlives the fabric it is addressed on
+                if (address !== undefined) {
+                    await this.owner.env.maybeGet(PeerSet)?.get(address)?.delete();
+                }
+
+                this.delete(node);
+            }
         });
     }
 

--- a/packages/node/src/node/client/Peers.ts
+++ b/packages/node/src/node/client/Peers.ts
@@ -454,6 +454,8 @@ export class Peers extends EndpointContainer<ClientNode> {
      */
     async erase() {
         await this.#mutex.produce(async () => {
+            const peers = this.owner.env.maybeGet(PeerSet);
+
             for (const node of [...this]) {
                 const address = node.maybeStateOf(CommissioningClient)?.peerAddress;
 
@@ -461,20 +463,22 @@ export class Peers extends EndpointContainer<ClientNode> {
                     await node.delete();
                     continue;
                 } catch (error) {
-                    MatterError.accept(error);
                     logger.warn(`Error deleting ${node}:`, error);
                 }
 
                 try {
                     await node.close();
                 } catch (error) {
-                    MatterError.accept(error);
                     logger.warn(`Error closing ${node}:`, error);
                 }
 
                 // ClientNode.delete() does this itself; without it the peer outlives the fabric it is addressed on
                 if (address !== undefined) {
-                    await this.owner.env.maybeGet(PeerSet)?.get(address)?.delete();
+                    try {
+                        await peers?.get(address)?.delete();
+                    } catch (error) {
+                        logger.warn(`Error removing peer for ${node}:`, error);
+                    }
                 }
 
                 this.delete(node);

--- a/packages/node/src/node/client/Peers.ts
+++ b/packages/node/src/node/client/Peers.ts
@@ -56,7 +56,6 @@ import {
     Peer,
     PeerAddress,
     PeerLeftError,
-    PeerSet,
     SessionManager,
 } from "@matter/protocol";
 import { FabricIndex, NodeId, Status } from "@matter/types";
@@ -447,18 +446,15 @@ export class Peers extends EndpointContainer<ClientNode> {
     }
 
     /**
-     * Delete every known node and its persisted data.
+     * Delete every known node.
      *
      * A node we cannot tear down cleanly is closed and dropped instead, so it cannot block the factory reset this
-     * serves.
+     * serves; its persisted data outlives this call and is the caller's to discard.  Failures are logged rather than
+     * raised for the same reason.
      */
     async erase() {
         await this.#mutex.produce(async () => {
-            const peers = this.owner.env.maybeGet(PeerSet);
-
             for (const node of [...this]) {
-                const address = node.maybeStateOf(CommissioningClient)?.peerAddress;
-
                 try {
                     await node.delete();
                     continue;
@@ -470,15 +466,6 @@ export class Peers extends EndpointContainer<ClientNode> {
                     await node.close();
                 } catch (error) {
                     logger.warn(`Error closing ${node}:`, error);
-                }
-
-                // ClientNode.delete() does this itself; without it the peer outlives the fabric it is addressed on
-                if (address !== undefined) {
-                    try {
-                        await peers?.get(address)?.delete();
-                    } catch (error) {
-                        logger.warn(`Error removing peer for ${node}:`, error);
-                    }
                 }
 
                 this.delete(node);

--- a/packages/node/src/node/server/ServerEnvironment.ts
+++ b/packages/node/src/node/server/ServerEnvironment.ts
@@ -82,6 +82,35 @@ export namespace ServerEnvironment {
         env.get(Crypto).reportUsage(node.id);
     }
 
+    /**
+     * Discard the credentials the node issues fabrics under.
+     *
+     * The authorities cache key material for the lifetime of their instances, so both are dropped along with what they
+     * persist.  An authority supplied by an ancestor environment belongs to whoever supplied it.
+     */
+    export async function eraseCredentials(node: ServerNode) {
+        const { env } = node;
+
+        env.delete(FabricAuthority);
+
+        if (!env.has(CertificateAuthority)) {
+            // Lazily created, so a controller that ran without commissioning this session has key material on disk
+            // but no instance to erase
+            await CertificateAuthority.eraseFor(env);
+            return;
+        }
+
+        if (!env.owns(CertificateAuthority)) {
+            return;
+        }
+
+        try {
+            await env.get(CertificateAuthority).erase();
+        } finally {
+            env.delete(CertificateAuthority);
+        }
+    }
+
     export async function close(node: ServerNode) {
         const { env } = node;
 

--- a/packages/node/src/node/server/ServerEnvironment.ts
+++ b/packages/node/src/node/server/ServerEnvironment.ts
@@ -86,29 +86,24 @@ export namespace ServerEnvironment {
      * Discard the credentials the node issues fabrics under.
      *
      * The authorities cache key material for the lifetime of their instances, so both are dropped along with what they
-     * persist.  An authority supplied by an ancestor environment belongs to whoever supplied it.
+     * persist.  An authority supplied by an ancestor environment belongs to whoever supplied it, but key material the
+     * node persisted under its own storage is ours to discard either way: the authority is created lazily and may be
+     * configured without storage, so neither its absence nor its presence proves the node's context is empty.
      */
     export async function eraseCredentials(node: ServerNode) {
         const { env } = node;
 
         env.delete(FabricAuthority);
 
-        if (!env.has(CertificateAuthority)) {
-            // Lazily created, so a controller that ran without commissioning this session has key material on disk
-            // but no instance to erase
-            await CertificateAuthority.eraseFor(env);
-            return;
+        if (env.owns(CertificateAuthority)) {
+            try {
+                await env.get(CertificateAuthority).erase();
+            } finally {
+                env.delete(CertificateAuthority);
+            }
         }
 
-        if (!env.owns(CertificateAuthority)) {
-            return;
-        }
-
-        try {
-            await env.get(CertificateAuthority).erase();
-        } finally {
-            env.delete(CertificateAuthority);
-        }
+        await CertificateAuthority.eraseFor(env);
     }
 
     export async function close(node: ServerNode) {

--- a/packages/node/src/storage/client/ClientNodeStore.ts
+++ b/packages/node/src/storage/client/ClientNodeStore.ts
@@ -86,31 +86,24 @@ export class ClientNodeStore extends NodeStore {
     }
 
     override async erase() {
-        // Cascade so caches unregister from the shared ClientCacheBuffer before storage is cleared.  Every endpoint is
-        // visited even if one fails; a cache left registered flushes stale data back into the cleared context
-        const errors = new Array<unknown>();
-        for (const store of this.#stores.values()) {
-            try {
-                await store.erase();
-            } catch (error) {
-                errors.push(error);
-            }
-        }
+        const stores = [...this.#stores.values()];
 
-        this.#stores = new Map();
-        this.#onErase?.();
+        await MatterAggregateError.settleSeries(
+            [
+                // Cascade so caches unregister from the shared ClientCacheBuffer before storage is cleared; one that
+                // stays registered flushes stale data back into the cleared context
+                ...stores.map(store => () => store.erase()),
 
-        try {
-            await this.#storage?.clearAll();
-        } catch (error) {
-            errors.push(error);
-        }
+                () => {
+                    this.#stores = new Map();
+                    this.#onErase?.();
+                    return this.#storage?.clearAll();
+                },
 
-        await this.construction.close();
-
-        if (errors.length) {
-            throw new MatterAggregateError(errors, `Error while erasing ${this}`);
-        }
+                () => this.construction.close(),
+            ],
+            `Error while erasing ${this}`,
+        );
     }
 
     override storeForEndpoint(endpoint: Endpoint) {

--- a/packages/node/src/storage/client/ClientNodeStore.ts
+++ b/packages/node/src/storage/client/ClientNodeStore.ts
@@ -6,7 +6,7 @@
 
 import { Endpoint } from "#endpoint/Endpoint.js";
 import type { ClientNode } from "#node/ClientNode.js";
-import { InternalError, StorageContext, StorageContextFactory } from "@matter/general";
+import { InternalError, MatterAggregateError, StorageContext, StorageContextFactory } from "@matter/general";
 import { EndpointNumber } from "@matter/types";
 import { NodeStore } from "../NodeStore.js";
 import type { ClientCacheBuffer } from "./ClientCacheBuffer.js";
@@ -86,14 +86,31 @@ export class ClientNodeStore extends NodeStore {
     }
 
     override async erase() {
-        // Cascade so caches unregister from the shared ClientCacheBuffer before storage is cleared.
+        // Cascade so caches unregister from the shared ClientCacheBuffer before storage is cleared.  Every endpoint is
+        // visited even if one fails; a cache left registered flushes stale data back into the cleared context
+        const errors = new Array<unknown>();
         for (const store of this.#stores.values()) {
-            await store.erase();
+            try {
+                await store.erase();
+            } catch (error) {
+                errors.push(error);
+            }
         }
+
         this.#stores = new Map();
         this.#onErase?.();
-        await this.#storage?.clearAll();
+
+        try {
+            await this.#storage?.clearAll();
+        } catch (error) {
+            errors.push(error);
+        }
+
         await this.construction.close();
+
+        if (errors.length) {
+            throw new MatterAggregateError(errors, `Error while erasing ${this}`);
+        }
     }
 
     override storeForEndpoint(endpoint: Endpoint) {

--- a/packages/node/src/storage/client/ClientNodeStores.ts
+++ b/packages/node/src/storage/client/ClientNodeStores.ts
@@ -114,6 +114,42 @@ export class ClientNodeStores {
         return Object.keys(this.#stores);
     }
 
+    /**
+     * Discard all persisted node data.  The collection remains usable and IDs are reassigned from the start.
+     */
+    async erase() {
+        this.#construction.assert();
+
+        const stores = Object.values(this.#stores);
+        this.#stores = {};
+
+        const errors = new Array<unknown>();
+        for (const store of stores) {
+            try {
+                await store.erase();
+            } catch (error) {
+                errors.push(error);
+
+                // erase() closes the store itself; a store that failed partway still holds an open construction and
+                // its cache registration
+                try {
+                    await store.construction.close();
+                } catch (closeError) {
+                    errors.push(closeError);
+                }
+            }
+        }
+
+        // Data a store failed to erase must still go: the in-memory index is gone either way, so anything left behind
+        // would resurrect on the next lookup
+        await this.#storage.clearAll();
+        this.#nextAutomaticId = 1;
+
+        if (errors.length) {
+            throw new MatterAggregateError(errors, "Error while erasing client stores");
+        }
+    }
+
     async close() {
         await this.construction.close(async () => {
             const stores = Object.values(this.#stores);

--- a/packages/node/src/storage/client/ClientNodeStores.ts
+++ b/packages/node/src/storage/client/ClientNodeStores.ts
@@ -123,31 +123,17 @@ export class ClientNodeStores {
         const stores = Object.values(this.#stores);
         this.#stores = {};
 
-        const errors = new Array<unknown>();
-        for (const store of stores) {
-            try {
-                await store.erase();
-            } catch (error) {
-                errors.push(error);
+        await MatterAggregateError.settleSeries(
+            [
+                ...stores.map(store => () => store.erase()),
 
-                // erase() closes the store itself; a store that failed partway still holds an open construction and
-                // its cache registration
-                try {
-                    await store.construction.close();
-                } catch (closeError) {
-                    errors.push(closeError);
-                }
-            }
-        }
-
-        // Data a store failed to erase must still go: the in-memory index is gone either way, so anything left behind
-        // would resurrect on the next lookup
-        await this.#storage.clearAll();
-        this.#nextAutomaticId = 1;
-
-        if (errors.length) {
-            throw new MatterAggregateError(errors, "Error while erasing client stores");
-        }
+                // Data a store failed to erase must still go: the index is gone either way, so anything left behind
+                // resurrects on the next lookup
+                () => this.#storage.clearAll(),
+                () => void (this.#nextAutomaticId = 1),
+            ],
+            "Error while erasing client stores",
+        );
     }
 
     async close() {

--- a/packages/node/src/storage/server/ServerNodeStore.ts
+++ b/packages/node/src/storage/server/ServerNodeStore.ts
@@ -16,6 +16,7 @@ import {
     Environment,
     ImplementationError,
     Logger,
+    MatterAggregateError,
     StorageManager,
     StorageService,
 } from "@matter/general";
@@ -129,8 +130,15 @@ export class ServerNodeStore extends NodeStore implements Destructable {
         return this.#bdxHandle.driver;
     }
 
-    erase() {
-        return this.#endpointStores.erase();
+    /**
+     * Discard the endpoint and peer data persisted for the node.  Both are erased even if one fails, so a single
+     * failure cannot leave the other behind.
+     */
+    async erase() {
+        await MatterAggregateError.allSettled(
+            [this.#clientStores?.erase(), this.#endpointStores.erase()],
+            "Error while erasing node storage",
+        );
     }
 
     async load() {

--- a/packages/node/test/node/ServerNodeTest.ts
+++ b/packages/node/test/node/ServerNodeTest.ts
@@ -18,6 +18,7 @@ import { AggregatorEndpoint } from "#endpoints/aggregator";
 import { LocalActorContext } from "#index.js";
 import { ServerEnvironment } from "#node/server/ServerEnvironment.js";
 import { ServerNode } from "#node/ServerNode.js";
+import { ServerNodeStore } from "#storage/server/ServerNodeStore.js";
 import {
     Bytes,
     Crypto,
@@ -49,7 +50,7 @@ import {
     ProtocolMocks,
     Val,
 } from "@matter/protocol";
-import { FabricIndex, VendorId } from "@matter/types";
+import { FabricId, FabricIndex, NodeId, VendorId } from "@matter/types";
 import { BasicInformation as BasicInformationCluster } from "@matter/types/clusters/basic-information";
 import { PumpConfigurationAndControl } from "@matter/types/clusters/pump-configuration-and-control";
 import { MockServerNode } from "./mock-server-node.js";
@@ -467,6 +468,8 @@ describe("ServerNode", () => {
 
         // The authority caches the erased key material, so a holder that kept a reference must fail rather than sign
         expect(() => ca.rootCert).throws();
+        const { publicKey } = await controller.env.get(Crypto).createKeyPair();
+        await expect(ca.generateNoc(publicKey, FabricId(1), NodeId(1))).rejected;
     });
 
     it("completes factory reset when a peer cannot be torn down", async () => {
@@ -488,6 +491,54 @@ describe("ServerNode", () => {
         expect(controller.env.get(PeerSet).get(address)).equals(undefined);
         expect(controller.construction.status).equals(Lifecycle.Status.Active);
         expect(controller.lifecycle.isOnline).equals(true);
+    });
+
+    it("completes factory reset when removing the protocol peer fails", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+
+        const peer = [...controller.peers][0];
+        peer.delete = async () => {
+            throw new ImplementationError("Cannot delete");
+        };
+        const protocolPeer = controller.env.get(PeerSet).get(peer.peerAddress!)!;
+        protocolPeer.delete = async () => {
+            throw new ImplementationError("Cannot remove peer");
+        };
+
+        await MockTime.resolve(controller.erase(), { macrotasks: true });
+
+        expect([...controller.peers].length).equals(0);
+        expect(controller.lifecycle.isOnline).equals(true);
+    });
+
+    it("erases every peer endpoint store when one fails", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+
+        const peer = [...controller.peers][0];
+        const store = controller.env.get(ServerNodeStore).clientStores.storeForNode(peer.id);
+        const [failing, ...rest] = [...store.endpointStores];
+        expect(rest.length).greaterThan(0);
+
+        failing.erase = async () => {
+            throw new ImplementationError("Cannot erase endpoint");
+        };
+
+        // A cache the cascade skips stays registered with ClientCacheBuffer and flushes into the cleared context
+        let erased = 0;
+        for (const endpointStore of rest) {
+            const erase = endpointStore.erase.bind(endpointStore);
+            endpointStore.erase = async () => {
+                erased++;
+                await erase();
+            };
+        }
+
+        await MockTime.resolve(controller.erase(), { macrotasks: true });
+
+        expect(erased).equals(rest.length);
+        expect([...controller.peers].length).equals(0);
     });
 
     it("erases remaining areas when one fails during factory reset", async () => {

--- a/packages/node/test/node/ServerNodeTest.ts
+++ b/packages/node/test/node/ServerNodeTest.ts
@@ -25,7 +25,9 @@ import {
     DnsMessage,
     DnsRecordType,
     Environment,
+    ImplementationError,
     InternalError,
+    Lifecycle,
     isObject,
     MemoryStorageDriver,
     MockCrypto,
@@ -39,9 +41,11 @@ import {
 import { AccessLevel, BasicInformation, ElementTag, FeatureMap } from "@matter/model";
 import {
     AttestationCertificateManager,
+    CertificateAuthority,
     CertificationDeclaration,
     NodeSession,
     OccurrenceManager,
+    PeerSet,
     ProtocolMocks,
     Val,
 } from "@matter/protocol";
@@ -49,6 +53,7 @@ import { FabricIndex, VendorId } from "@matter/types";
 import { BasicInformation as BasicInformationCluster } from "@matter/types/clusters/basic-information";
 import { PumpConfigurationAndControl } from "@matter/types/clusters/pump-configuration-and-control";
 import { MockServerNode } from "./mock-server-node.js";
+import { MockSite } from "./mock-site.js";
 import { CommissioningHelper, FAILSAFE_LENGTH_S, testFactoryReset } from "./node-helpers.js";
 
 const commissioning = CommissioningHelper();
@@ -61,6 +66,26 @@ class CrashingServer extends Behavior {
 
     override initialize() {
         throw new InternalError(CRASH_MESSAGE);
+    }
+}
+
+function storageKeysUnder(storage: Record<string, unknown>, context: string) {
+    return Object.keys(storage).filter(key => key === context || key.startsWith(`${context}.`));
+}
+
+/** Commission {@link device} onto {@link controller}, entropy enabled as {@link MockSite} does for pairing. */
+async function commissionOnto(controller: ServerNode, device: ServerNode) {
+    const controllerCrypto = controller.env.get(Crypto) as MockCrypto;
+    const deviceCrypto = device.env.get(Crypto) as MockCrypto;
+    controllerCrypto.entropic = deviceCrypto.entropic = true;
+
+    try {
+        const { passcode, discriminator } = device.state.commissioning;
+        await MockTime.resolve(controller.peers.commission({ passcode, discriminator, timeout: Seconds(90) }), {
+            macrotasks: true,
+        });
+    } finally {
+        controllerCrypto.entropic = deviceCrypto.entropic = false;
     }
 }
 
@@ -421,6 +446,97 @@ describe("ServerNode", () => {
 
     it("handles factory resets when online but in parallel offline is called correctly", async () => {
         await testFactoryReset("offline-during-reset");
+    });
+
+    it("factory reset of a controller erases peers and CA key material", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+
+        const storage = site.storageFor(controller.id);
+        expect(storageKeysUnder(storage, "nodes")).not.deep.equals([]);
+        expect(storageKeysUnder(storage, "certificates")).not.deep.equals([]);
+
+        const ca = controller.env.get(CertificateAuthority);
+        expect(ca.rootCert).not.equals(undefined);
+
+        await MockTime.resolve(controller.erase(), { macrotasks: true });
+
+        expect(storageKeysUnder(storage, "nodes")).deep.equals([]);
+        expect(storageKeysUnder(storage, "certificates")).deep.equals([]);
+        expect([...controller.peers].length).equals(0);
+
+        // The authority caches the erased key material, so a holder that kept a reference must fail rather than sign
+        expect(() => ca.rootCert).throws();
+    });
+
+    it("completes factory reset when a peer cannot be torn down", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+
+        const storage = site.storageFor(controller.id);
+        const peer = [...controller.peers][0];
+        const address = peer.peerAddress!;
+        peer.delete = async () => {
+            throw new ImplementationError("Cannot delete");
+        };
+
+        await MockTime.resolve(controller.erase(), { macrotasks: true });
+
+        expect(storageKeysUnder(storage, "nodes")).deep.equals([]);
+        expect([...controller.peers].length).equals(0);
+        expect(peer.construction.status).equals(Lifecycle.Status.Destroyed);
+        expect(controller.env.get(PeerSet).get(address)).equals(undefined);
+        expect(controller.construction.status).equals(Lifecycle.Status.Active);
+        expect(controller.lifecycle.isOnline).equals(true);
+    });
+
+    it("erases remaining areas when one fails during factory reset", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+
+        const storage = site.storageFor(controller.id);
+        const events = controller.env.get(OccurrenceManager);
+        events.clear = async () => {
+            throw new ImplementationError("Cannot clear events");
+        };
+
+        await MockTime.resolve(expect(controller.erase()).rejectedWith("Error during factory reset"), {
+            macrotasks: true,
+        });
+
+        // Areas sequenced after the failure must still be erased or key material outlives the reset
+        expect(storageKeysUnder(storage, "certificates")).deep.equals([]);
+        expect(storageKeysUnder(storage, "nodes")).deep.equals([]);
+    });
+
+    it("commissions again on the same controller instance after factory reset", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+
+        await MockTime.resolve(controller.erase(), { macrotasks: true });
+
+        await commissionOnto(controller, await site.addDevice());
+
+        expect(controller.peers.commissioned.length).equals(1);
+        expect(controller.env.owns(CertificateAuthority)).equals(true);
+    });
+
+    it("commissions again after factory reset of a controller with commissioned peers", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+        const id = controller.id;
+
+        await MockTime.resolve(controller.erase(), { macrotasks: true });
+        await controller.close();
+
+        // Boot a new node on the storage the erased controller left behind
+        const rebooted = await site.addController({ id });
+        expect([...rebooted.peers].length).equals(0);
+        await rebooted.start();
+
+        await commissionOnto(rebooted, await site.addDevice());
+
+        expect(rebooted.peers.commissioned.length).equals(1);
     });
 
     it("commissions twice", async () => {

--- a/packages/node/test/node/ServerNodeTest.ts
+++ b/packages/node/test/node/ServerNodeTest.ts
@@ -479,8 +479,10 @@ describe("ServerNode", () => {
         const storage = site.storageFor(controller.id);
         const peer = [...controller.peers][0];
         const address = peer.peerAddress!;
-        peer.delete = async () => {
-            throw new ImplementationError("Cannot delete");
+
+        // Fail inside delete() rather than replacing it, so its own teardown guarantees still apply
+        peer.erase = async () => {
+            throw new ImplementationError("Cannot erase");
         };
 
         await MockTime.resolve(controller.erase(), { macrotasks: true });
@@ -498,9 +500,6 @@ describe("ServerNode", () => {
         const { controller } = await site.addCommissionedPair();
 
         const peer = [...controller.peers][0];
-        peer.delete = async () => {
-            throw new ImplementationError("Cannot delete");
-        };
         const protocolPeer = controller.env.get(PeerSet).get(peer.peerAddress!)!;
         protocolPeer.delete = async () => {
             throw new ImplementationError("Cannot remove peer");
@@ -510,6 +509,24 @@ describe("ServerNode", () => {
 
         expect([...controller.peers].length).equals(0);
         expect(controller.lifecycle.isOnline).equals(true);
+    });
+
+    it("erases CA key material the node never loaded", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair();
+        const id = controller.id;
+        const storage = site.storageFor(id);
+
+        await controller.close();
+        expect(storageKeysUnder(storage, "certificates")).not.deep.equals([]);
+
+        // A node that has not commissioned this session never instantiates the authority
+        const rebooted = await site.addNode(undefined, { id, device: undefined, commissioning: { enabled: false } });
+        expect(rebooted.env.has(CertificateAuthority)).equals(false);
+
+        await MockTime.resolve(rebooted.erase(), { macrotasks: true });
+
+        expect(storageKeysUnder(storage, "certificates")).deep.equals([]);
     });
 
     it("erases every peer endpoint store when one fails", async () => {
@@ -525,7 +542,6 @@ describe("ServerNode", () => {
             throw new ImplementationError("Cannot erase endpoint");
         };
 
-        // A cache the cascade skips stays registered with ClientCacheBuffer and flushes into the cleared context
         let erased = 0;
         for (const endpointStore of rest) {
             const erase = endpointStore.erase.bind(endpointStore);

--- a/packages/protocol/src/certificate/CertificateAuthority.ts
+++ b/packages/protocol/src/certificate/CertificateAuthority.ts
@@ -76,8 +76,18 @@ export class CertificateAuthority {
      * @see {@link MatterSpecification.v16.Core} § 13.4
      */
     async erase() {
-        await this.#storage?.clearAll();
-        await this.#construction.close();
+        // Signing reads these directly rather than through construction, so discarding them is what actually stops a
+        // retained authority from issuing certificates against the erased root
+        this.#rootKeyPair = undefined;
+        this.#rootKeyIdentifier = undefined;
+        this.#rootCertBytes = undefined;
+        this.#icacProps = undefined;
+
+        try {
+            await this.#storage?.clearAll();
+        } finally {
+            await this.#construction.close();
+        }
     }
 
     /**

--- a/packages/protocol/src/certificate/CertificateAuthority.ts
+++ b/packages/protocol/src/certificate/CertificateAuthority.ts
@@ -53,6 +53,7 @@ export class CertificateAuthority {
     #nextCertificateId = BigInt(1);
     #construction: Construction<CertificateAuthority>;
     #icacProps?: IcacProps;
+    #storage?: StorageContext;
 
     get crypto() {
         return this.#crypto;
@@ -64,6 +65,19 @@ export class CertificateAuthority {
 
     close() {
         return this.#construction.close();
+    }
+
+    /**
+     * Discard the key material this authority holds, persisted and in memory.
+     *
+     * The authority is unusable afterwards so a holder that keeps signing with the erased root fails loudly rather
+     * than issuing certificates no fabric can validate.
+     *
+     * @see {@link MatterSpecification.v16.Core} § 13.4
+     */
+    async erase() {
+        await this.#storage?.clearAll();
+        await this.#construction.close();
     }
 
     /**
@@ -109,6 +123,10 @@ export class CertificateAuthority {
             if (typeof options === "boolean") {
                 generateIntermediateCert = options;
                 options = undefined;
+            }
+
+            if (options instanceof StorageContext) {
+                this.#storage = options;
             }
 
             const certValues = options instanceof StorageContext ? await options.values() : (options ?? {});

--- a/packages/protocol/src/certificate/CertificateAuthority.ts
+++ b/packages/protocol/src/certificate/CertificateAuthority.ts
@@ -14,6 +14,7 @@ import {
     ImplementationError,
     InternalError,
     Logger,
+    MatterAggregateError,
     PrivateKey,
     StorageContext,
     StorageManager,
@@ -28,6 +29,8 @@ import { Noc } from "./kinds/Noc.js";
 import { Rcac } from "./kinds/Rcac.js";
 
 const logger = Logger.get("CertificateAuthority");
+
+const CERTIFICATES_CONTEXT = "certificates";
 
 /**
  * Manages the root key pair for a fabric owned by a local node.
@@ -70,24 +73,33 @@ export class CertificateAuthority {
     /**
      * Discard the key material this authority holds, persisted and in memory.
      *
-     * The authority is unusable afterwards so a holder that keeps signing with the erased root fails loudly rather
-     * than issuing certificates no fabric can validate.
-     *
-     * @see {@link MatterSpecification.v16.Core} § 13.4
+     * The authority is unusable afterwards, so a holder that starts a new operation fails loudly rather than issuing
+     * certificates no fabric can validate.  A signing operation already in flight snapshots its key and completes.
      */
     async erase() {
-        // Signing reads these directly rather than through construction, so discarding them is what actually stops a
-        // retained authority from issuing certificates against the erased root
-        this.#rootKeyPair = undefined;
-        this.#rootKeyIdentifier = undefined;
-        this.#rootCertBytes = undefined;
-        this.#icacProps = undefined;
+        await MatterAggregateError.settleSeries(
+            [
+                // Settles construction first: credentials it generates would otherwise land after the wipe
+                () => this.#construction.close(),
 
-        try {
-            await this.#storage?.clearAll();
-        } finally {
-            await this.#construction.close();
-        }
+                () => {
+                    this.#rootKeyPair = undefined;
+                    this.#rootKeyIdentifier = undefined;
+                    this.#rootCertBytes = undefined;
+                    this.#icacProps = undefined;
+                },
+
+                () => this.#storage?.clearAll(),
+            ],
+            "Error erasing certificate authority",
+        );
+    }
+
+    /**
+     * Discard the persisted key material of the authority for {@link env} without instantiating one.
+     */
+    static eraseFor(env: Environment) {
+        return env.get(StorageManager).createContext(CERTIFICATES_CONTEXT).clearAll();
     }
 
     /**
@@ -129,14 +141,15 @@ export class CertificateAuthority {
     ) {
         this.#crypto = crypto;
 
+        // Not deferred to the initializer below: erase() must find the context even mid-construction
+        if (options instanceof StorageContext) {
+            this.#storage = options;
+        }
+
         this.#construction = Construction(this, async () => {
             if (typeof options === "boolean") {
                 generateIntermediateCert = options;
                 options = undefined;
-            }
-
-            if (options instanceof StorageContext) {
-                this.#storage = options;
             }
 
             const certValues = options instanceof StorageContext ? await options.values() : (options ?? {});
@@ -172,7 +185,7 @@ export class CertificateAuthority {
     }
 
     static [Environmental.create](env: Environment) {
-        const storage = env.get(StorageManager).createContext("certificates");
+        const storage = env.get(StorageManager).createContext(CERTIFICATES_CONTEXT);
         const instance = new CertificateAuthority(env.get(Crypto), storage);
         env.set(CertificateAuthority, instance);
         return instance;


### PR DESCRIPTION
## Problem

`ServerNodeStore.erase()` cleared only the endpoint stores. A factory reset of a controller `ServerNode` with commissioned peers therefore destroyed the fabric but left behind:

- the `nodes.<peerId>` client peer stores
- the `certificates` context holding the certificate authority's root key

On the next boot each orphaned peer's `commissioning` behavior looked up the destroyed fabric and the node died:

```
FabricNotFoundError: Fabric index #1 does not exist
  → BehaviorInitializationError: ...commissioning
  → FATAL Unhandled: endpoint-behaviors: Behaviors have errors
```

The surviving CA key material also violates Core § 13.4, which requires all "security- and privacy-related data and key material" to be removed on factory reset.

This is a pre-existing framework bug, reproduced against a normal non-migrated controller store; it is unrelated to the legacy storage migration, which only unmasked it.

## Change

**`Peers.erase()`** deletes every known node under the same mutex as `forAddress()` and the expiration cull. A node that cannot be torn down cleanly is closed and dropped rather than aborting the reset — `ClientNode.delete()` opens with a construction assertion, so a single crashed peer would otherwise make factory reset, the user's escape hatch, impossible. Failures are logged rather than raised, because an aggregate here propagates to `eraseWithMutex()` and crashes the node, which is the outcome the fallback exists to prevent.

**`ClientNode.delete()`** unregisters its protocol peer in a `finally`, so a peer no longer outlives a failed teardown.

**`CertificateAuthority.erase()`** discards the authority's key material, persisted and in memory, and binds its storage context in the constructor so erasing mid-construction cannot silently skip the wipe. Signing reads the key fields directly rather than through construction, so discarding them is what actually stops a retained authority from issuing certificates; a signing call already in flight snapshots its key and completes.

**`ServerEnvironment.eraseCredentials()`** owns credential teardown next to `initialize`/`close`. The authority is created lazily and `ControllerBehavior` is not `early`, so a controller restarted and reset without commissioning in between has key material on disk and no instance — that case erases the persisted context directly. An authority supplied by an ancestor environment is left to its owner. `FabricAuthority` is dropped here rather than relying on `ControllerBehavior`'s dispose, whose errors `Endpoint.reset()` swallows.

**`ClientNodeStores.erase()`** erases each store and then clears the whole `nodes` context, which runs even when a store fails: the in-memory index is gone either way and anything left behind resurrects on the next lookup.

**`MatterAggregateError.settleSeries()`** (new, `@matter/general`) runs tasks in order, continues past a failure and reports the accumulated errors. Every erase path uses it, so a partial reset cannot leave key material behind and `resetStorage()` stays a readable list of areas.

## Tests

Twelve tests in `ServerNodeTest.ts`; each production hunk was mutation-tested by reverting it individually and confirming a specific failure — peer erasure, client-store erasure, CA storage wipe, CA construction close, in-memory key discard, `env.delete` of the authority, `eraseFor` on the never-instantiated path, `ClientNode.delete()`'s `finally`, `node.close()` in the peer fallback, the endpoint-store cascade, and the error-collecting sequence.

Two guards are deliberately not covered: the `#storage` binding moved into the CA constructor (needs an erase racing construction) and the error collection inside `ClientNodeStores.erase()` (needs a `ClientNodeStore` that fails to erase).

## Known limits

- `peer.delete()` is awaited without a deadline. The fallback handles a *throw*; an unresponsive or sleeping peer can still stall the reset. Same class as the unbounded `NetworkRuntime.destruct` wait addressed elsewhere, so it is not duplicated here.
- `Peers.erase()` releases its mutex when the loop ends, so a `forAddress()` queued behind it can register a node before `FabricManager.clear()` runs, and that node's store is wiped underneath it. A guard on owner readiness was tried and withdrawn: the reachable window is not the one a test can drive from outside, and the guard changed behavior for every `forAddress()` caller without provable benefit.
- A factory reset during an in-flight commissioning destroys the node under it; the commissioning fails with a closed-backing error rather than a deliberate `CommissioningError`.
- The inherited-authority path of `ServerEnvironment.eraseCredentials()` has no test. Building a node whose environment inherits an authority from an ancestor leaves an un-closeable node inside `MockSite`, and reshaping the harness for it was not worth the change.
- The BDX blob namespace (`<nodeId>-bdx`, a separate `StorageService` handle) is not erased. `BlobStorageDriver` has no clear API, so that needs new API.

## Gates

`npm run build`, `npm run format-verify`, `npm run lint` and the full `npm test` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

