### PR TITLE
Execute TC-IDM-3.1 steps 2 and 15 (wildcard and data-version writes)

### DIFF
--- a/packages/testing/src/chip/cert/controller-adapter.ts
+++ b/packages/testing/src/chip/cert/controller-adapter.ts
@@ -73,6 +73,18 @@ export interface AttributeWriteEntry {
 }
 
 /**
+ * One attribute of a {@link CertNodeApi.readAttributes} response.
+ */
+export interface AttributeReadEntry {
+    endpoint: number;
+    cluster: number;
+    attribute: number;
+    value: unknown;
+    /** The cluster's data version, which a version-conditional write sends back (TC-IDM-3.1 step 15). */
+    version?: number;
+}
+
+/**
  * The device's per-path answer to one attribute of a write request.
  */
 export interface AttributeWriteStatus {
@@ -100,15 +112,28 @@ export interface ReadAttributeOptions {
 export interface CertNodeApi {
     invoke(cluster: string | number, command: string, args?: object, endpoint?: number): Promise<unknown>;
     readAttribute(path: AttributePathSpec, options?: ReadAttributeOptions): Promise<unknown>;
+
+    /**
+     * Reads several attribute paths in one request.
+     *
+     * A step needing the data versions of two clusters (TC-IDM-3.1 step 15) must obtain them from a
+     * single `ReadRequest`, which is what the plan's procedure describes; issuing one read per cluster
+     * would exercise a different interaction.
+     */
+    readAttributes(paths: AttributePathSpec[], options?: ReadAttributeOptions): Promise<AttributeReadEntry[]>;
     writeAttribute(path: AttributePathSpec, value: unknown): Promise<void>;
 
     /**
      * Writes several attributes in one request, optionally through wildcard paths or conditional on a
      * data version.
      *
-     * Unlike {@link writeAttribute}, a rejected path is reported rather than thrown: a wildcard
-     * expansion legitimately mixes success with per-path failures (an endpoint that lacks the cluster
-     * answers `UnsupportedCluster`), so the step decides which statuses it expected.
+     * Unlike {@link writeAttribute}, a rejected path is reported rather than thrown, so the step
+     * decides which statuses it expected.
+     *
+     * A wildcard path yields a status only for the attributes actually written: Matter Core § 8.9.2.8
+     * has the device skip an endpoint that lacks the cluster, an attribute it does not have, and one
+     * it may not write, silently. A path missing from the result was therefore not written — it is not
+     * a protocol failure, and a step that needs to know an attribute changed reads it back.
      *
      * An adapter whose controller cannot express a multi-path, wildcard or version-conditional write
      * throws {@link NotImplementedError}; a step that needs it then declares the flavors it runs on.

--- a/packages/testing/src/chip/cert/controller-adapter.ts
+++ b/packages/testing/src/chip/cert/controller-adapter.ts
@@ -53,6 +53,36 @@ export interface SubscribeOptions {
     onUpdate?: (value: unknown) => void;
 }
 
+/**
+ * One attribute of a {@link CertNodeApi.writeAttributes} request.
+ */
+export interface AttributeWriteEntry {
+    /**
+     * Omitting `endpoint` writes the attribute on every endpoint that has the cluster (TC-IDM-3.1
+     * step 2).
+     */
+    path: AttributePathSpec;
+
+    value: unknown;
+
+    /**
+     * Writes only if the cluster still holds this data version (TC-IDM-3.1 step 15). Matter Core
+     * § 8.9.2.8.1 forbids a data version on a wildcard path, so this requires a concrete `endpoint`.
+     */
+    dataVersion?: number;
+}
+
+/**
+ * The device's per-path answer to one attribute of a write request.
+ */
+export interface AttributeWriteStatus {
+    endpoint: number;
+    cluster: number;
+    attribute: number;
+    /** Matter Core § 8.10 interaction status; `0` is success. */
+    status: number;
+}
+
 export interface ReadAttributeOptions {
     /**
      * Whether the read is fabric-filtered (Matter Core § 8.9.2's `FabricFiltered` flag; default
@@ -71,6 +101,19 @@ export interface CertNodeApi {
     invoke(cluster: string | number, command: string, args?: object, endpoint?: number): Promise<unknown>;
     readAttribute(path: AttributePathSpec, options?: ReadAttributeOptions): Promise<unknown>;
     writeAttribute(path: AttributePathSpec, value: unknown): Promise<void>;
+
+    /**
+     * Writes several attributes in one request, optionally through wildcard paths or conditional on a
+     * data version.
+     *
+     * Unlike {@link writeAttribute}, a rejected path is reported rather than thrown: a wildcard
+     * expansion legitimately mixes success with per-path failures (an endpoint that lacks the cluster
+     * answers `UnsupportedCluster`), so the step decides which statuses it expected.
+     *
+     * An adapter whose controller cannot express a multi-path, wildcard or version-conditional write
+     * throws {@link NotImplementedError}; a step that needs it then declares the flavors it runs on.
+     */
+    writeAttributes(entries: AttributeWriteEntry[]): Promise<AttributeWriteStatus[]>;
     subscribe(path: AttributePathSpec, opts: SubscribeOptions): Promise<unknown>;
     openCommissioningWindow(opts: {
         timeout: number;

--- a/packages/testing/src/chip/index.ts
+++ b/packages/testing/src/chip/index.ts
@@ -34,6 +34,8 @@ export type { CompositionHandle, DockerHandle } from "./cert/chip-app-subject.js
 export { registerControllerAdapterFactory } from "./cert/controller-adapter.js";
 export type {
     AttributePathSpec,
+    AttributeWriteEntry,
+    AttributeWriteStatus,
     CertNodeApi,
     CertNodeRef,
     CommissioningTarget,

--- a/packages/testing/src/chip/index.ts
+++ b/packages/testing/src/chip/index.ts
@@ -34,6 +34,7 @@ export type { CompositionHandle, DockerHandle } from "./cert/chip-app-subject.js
 export { registerControllerAdapterFactory } from "./cert/controller-adapter.js";
 export type {
     AttributePathSpec,
+    AttributeReadEntry,
     AttributeWriteEntry,
     AttributeWriteStatus,
     CertNodeApi,

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -49,6 +49,7 @@ import {
 import { AttributeModel, ClusterModel, Matter } from "@matter/model";
 import type {
     AttributePathSpec,
+    AttributeReadEntry,
     AttributeWriteEntry,
     AttributeWriteStatus,
     CertNodeApi,
@@ -281,6 +282,27 @@ class InProcessCertNodeApi implements CertNodeApi {
             // A wildcard expansion legitimately mixes data with per-item statuses (e.g.
             // UNSUPPORTED_ATTRIBUTE for a path the expansion reached but that doesn't apply there) —
             // unlike a concrete path's status, that's not itself a read failure.
+            return toWireValues(values);
+        });
+    }
+
+    readAttributes(paths: AttributePathSpec[], options?: ReadAttributeOptions): Promise<AttributeReadEntry[]> {
+        return runTagged(this.#adapterId, async () => {
+            if (paths.length === 0) {
+                throw new ImplementationError("readAttributes requires at least one path");
+            }
+            const values = new Array<ReadResult.AttributeValue>();
+            const request: ClientRead = {
+                ...Read({ attributes: paths.map(toIds), fabricFilter: options?.fabricFiltered }),
+                includeKnownVersions: true,
+            };
+            for await (const chunk of this.#peer.interaction.read(request)) {
+                for await (const report of chunk) {
+                    if (report.kind === "attr-value") {
+                        values.push(report);
+                    }
+                }
+            }
             return toWireValues(values);
         });
     }

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -49,6 +49,8 @@ import {
 import { AttributeModel, ClusterModel, Matter } from "@matter/model";
 import type {
     AttributePathSpec,
+    AttributeWriteEntry,
+    AttributeWriteStatus,
     CertNodeApi,
     CertNodeRef,
     CommissioningTarget,
@@ -104,12 +106,22 @@ function isConcretePath(path: AttributePathSpec) {
 }
 
 function toWireValues(values: ReadResult.AttributeValue[]) {
-    return values.map(({ path: { endpointId, clusterId, attributeId }, value }) => ({
+    return values.map(({ path: { endpointId, clusterId, attributeId }, value, version }) => ({
         endpoint: endpointId,
         cluster: clusterId,
         attribute: attributeId,
         value,
+        version,
     }));
+}
+
+function attributeSpecFor(cluster: number, attribute: number, value: unknown) {
+    const clusterModel = Matter.clusters(cluster);
+    const attributeModel = clusterModel?.attributes(attribute) ?? inferAttributeModel(attribute, value);
+    return {
+        cluster: { id: ClusterId(cluster), name: clusterModel?.name ?? `cluster_${cluster}` },
+        attributes: { id: AttributeId(attribute), name: attributeModel.name, schema: attributeModel },
+    };
 }
 
 /**
@@ -279,23 +291,46 @@ class InProcessCertNodeApi implements CertNodeApi {
             if (endpoint === undefined || cluster === undefined || attribute === undefined) {
                 throw new ImplementationError("writeAttribute requires a concrete endpoint/cluster/attribute path");
             }
-            const clusterModel = Matter.clusters(cluster);
-            const attributeModel = clusterModel?.attributes(attribute) ?? inferAttributeModel(attribute, value);
             const result = await this.#peer.interaction.write(
                 Write(
                     Write.Attribute({
                         endpoint: EndpointNumber(endpoint),
-                        cluster: { id: ClusterId(cluster), name: clusterModel?.name ?? `cluster_${cluster}` },
-                        attributes: {
-                            id: AttributeId(attribute),
-                            name: attributeModel.name,
-                            schema: attributeModel,
-                        },
+                        ...attributeSpecFor(cluster, attribute, value),
                         value,
                     }),
                 ),
             );
             WriteResult.assertSuccess(result);
+        });
+    }
+
+    writeAttributes(entries: AttributeWriteEntry[]): Promise<AttributeWriteStatus[]> {
+        return runTagged(this.#adapterId, async () => {
+            if (entries.length === 0) {
+                throw new ImplementationError("writeAttributes requires at least one attribute");
+            }
+            const attributes = entries.map(({ path: { endpoint, cluster, attribute }, value, dataVersion }) => {
+                if (cluster === undefined || attribute === undefined) {
+                    throw new ImplementationError("writeAttributes requires a concrete cluster and attribute");
+                }
+                const spec = attributeSpecFor(cluster, attribute, value);
+                if (endpoint === undefined) {
+                    return Write.Attribute({ ...spec, value, version: dataVersion });
+                }
+                return Write.Attribute({
+                    endpoint: EndpointNumber(endpoint),
+                    ...spec,
+                    value,
+                    version: dataVersion,
+                });
+            });
+            const result = await this.#peer.interaction.write(Write(...attributes));
+            return result.map(({ path: { endpointId, clusterId, attributeId }, status }) => ({
+                endpoint: endpointId,
+                cluster: clusterId,
+                attribute: attributeId,
+                status,
+            }));
         });
     }
 

--- a/support/chip-testing/test/cert-framework/cert-test.test.ts
+++ b/support/chip-testing/test/cert-framework/cert-test.test.ts
@@ -802,6 +802,7 @@ describe("CertTest", () => {
                 invoke: unused,
                 readAttribute: unused,
                 writeAttribute: unused,
+                writeAttributes: unused,
                 subscribe: unused,
                 openCommissioningWindow: unused,
                 operationalMdnsInstanceName: unused,

--- a/support/chip-testing/test/cert-framework/cert-test.test.ts
+++ b/support/chip-testing/test/cert-framework/cert-test.test.ts
@@ -801,6 +801,7 @@ describe("CertTest", () => {
             return {
                 invoke: unused,
                 readAttribute: unused,
+                readAttributes: unused,
                 writeAttribute: unused,
                 writeAttributes: unused,
                 subscribe: unused,

--- a/support/chip-testing/test/cert-framework/controller-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/controller-adapter.test.ts
@@ -5,19 +5,22 @@
  */
 
 import { InternalError } from "@matter/main";
-import { StatusResponseError } from "@matter/main/types";
+import { Status, StatusResponseError } from "@matter/main/types";
 import { Matter } from "@matter/model";
 import { expect } from "chai";
 import { AllClustersTestInstance } from "../../src/AllClustersTestInstance.js";
 import { InProcessControllerAdapter } from "../../src/cert/InProcessControllerAdapter.js";
+import type { AttributePathSpec, CertNodeApi } from "@matter/testing";
 
 const BASIC_INFORMATION = Matter.clusters.require("BasicInformation");
 const ON_OFF = Matter.clusters.require("OnOff");
+const IDENTIFY = Matter.clusters.require("Identify");
 const OPERATIONAL_CREDENTIALS = Matter.clusters.require("OperationalCredentials");
 const VENDOR_ID_ATTRIBUTE = BASIC_INFORMATION.attributes.require("vendorId");
 const ON_OFF_ATTRIBUTE = ON_OFF.attributes.require("onOff");
 const NODE_LABEL_ATTRIBUTE = BASIC_INFORMATION.attributes.require("nodeLabel");
 const FABRICS_ATTRIBUTE = OPERATIONAL_CREDENTIALS.attributes.require("fabrics");
+const IDENTIFY_TIME_ATTRIBUTE = IDENTIFY.attributes.require("identifyTime");
 
 async function rejectionOf(promise: Promise<unknown>): Promise<unknown> {
     try {
@@ -36,6 +39,20 @@ async function waitFor(condition: () => boolean) {
         }
         await new Promise(resolve => setTimeout(resolve, 20));
     }
+}
+
+/** The data version the peer reports for a path's cluster, read through a cluster-level (non-concrete) path. */
+async function versionOf(node: CertNodeApi, path: AttributePathSpec) {
+    const entries = await node.readAttribute({ endpoint: path.endpoint, cluster: path.cluster });
+    if (!Array.isArray(entries)) {
+        throw new InternalError("Expected a cluster-level read to return entries");
+    }
+    for (const entry of entries) {
+        if (typeof entry === "object" && entry !== null && "version" in entry && typeof entry.version === "number") {
+            return entry.version;
+        }
+    }
+    throw new InternalError(`No data version reported for cluster ${path.cluster}`);
 }
 
 describe("InProcessControllerAdapter", () => {
@@ -191,6 +208,51 @@ describe("InProcessControllerAdapter", () => {
         await node.invoke("OnOff", "toggle", {}, 1);
         await waitFor(() => updates.length > 0);
         expect(updates).to.deep.equal([!seed]);
+
+        await node.decommission();
+    });
+
+    it("writes one attribute across every endpoint that has the cluster", async function () {
+        this.timeout(30_000);
+
+        const ref = await adapter.commission({ passcode: 20202021, discriminator: 3840 });
+        const node = adapter.node(ref);
+
+        const statuses = await node.writeAttributes([
+            { path: { cluster: IDENTIFY.id, attribute: IDENTIFY_TIME_ATTRIBUTE.id }, value: 5 },
+        ]);
+
+        const written = statuses.filter(({ status }) => status === Status.Success);
+        expect(written.length).to.be.greaterThan(1);
+        for (const { endpoint } of written) {
+            expect(
+                await node.readAttribute({
+                    endpoint,
+                    cluster: IDENTIFY.id,
+                    attribute: IDENTIFY_TIME_ATTRIBUTE.id,
+                }),
+            ).to.be.a("number");
+        }
+
+        await node.decommission();
+    });
+
+    it("honors a data version, rejecting a write that carries a stale one", async function () {
+        this.timeout(30_000);
+
+        const ref = await adapter.commission({ passcode: 20202021, discriminator: 3840 });
+        const node = adapter.node(ref);
+
+        const path = { endpoint: 0, cluster: BASIC_INFORMATION.id, attribute: NODE_LABEL_ATTRIBUTE.id };
+        const version = await versionOf(node, path);
+
+        expect(await node.writeAttributes([{ path, value: "version-a", dataVersion: version }])).to.deep.equal([
+            { endpoint: 0, cluster: BASIC_INFORMATION.id, attribute: NODE_LABEL_ATTRIBUTE.id, status: Status.Success },
+        ]);
+
+        const stale = await node.writeAttributes([{ path, value: "version-b", dataVersion: version }]);
+        expect(stale.map(({ status }) => status)).to.deep.equal([Status.DataVersionMismatch]);
+        expect(await node.readAttribute(path)).to.equal("version-a");
 
         await node.decommission();
     });

--- a/support/chip-testing/test/cert-framework/tc-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-support.test.ts
@@ -367,6 +367,7 @@ describe("CommissionedRefs", () => {
                 invoke: unused,
                 readAttribute: unused,
                 writeAttribute: unused,
+                writeAttributes: unused,
                 subscribe: unused,
                 openCommissioningWindow: unused,
                 operationalMdnsInstanceName: unused,

--- a/support/chip-testing/test/cert-framework/tc-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-support.test.ts
@@ -366,6 +366,7 @@ describe("CommissionedRefs", () => {
             return {
                 invoke: unused,
                 readAttribute: unused,
+                readAttributes: unused,
                 writeAttribute: unused,
                 writeAttributes: unused,
                 subscribe: unused,

--- a/support/chip-testing/test/cert/TC-IDM-3.1.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-3.1.test.ts
@@ -79,24 +79,21 @@ async function writeAndCheck(
 }
 
 /**
- * The data version the device reports for `path`'s cluster, obtained through a cluster-level (non-concrete)
- * read — a concrete read returns the bare value, which carries no version.
+ * Data versions for `paths`' clusters, obtained from one ReadRequest carrying every path — the step's
+ * procedure describes a single read of two clusters, so one request per cluster would be a different
+ * interaction.
  */
-async function clusterVersion(node: CertNodeApi, path: AttributePathSpec): Promise<number> {
-    const entries = await node.readAttribute({ endpoint: path.endpoint, cluster: path.cluster });
-    if (Array.isArray(entries)) {
-        for (const entry of entries) {
-            if (
-                typeof entry === "object" &&
-                entry !== null &&
-                "version" in entry &&
-                typeof entry.version === "number"
-            ) {
-                return entry.version;
-            }
+async function clusterVersions(node: CertNodeApi, paths: AttributePathSpec[]): Promise<number[]> {
+    const entries = await node.readAttributes(paths);
+    return paths.map(({ endpoint, cluster }) => {
+        const version = entries.find(
+            entry => entry.endpoint === endpoint && entry.cluster === cluster && entry.version !== undefined,
+        )?.version;
+        if (version === undefined) {
+            throw new Error(`TH reported no data version for cluster ${cluster} on endpoint ${endpoint}`);
         }
-    }
-    throw new Error(`TH reported no data version for cluster ${path.cluster} on endpoint ${path.endpoint}`);
+        return version;
+    });
 }
 
 const commissioned = new CommissionedRefs();
@@ -331,8 +328,7 @@ certTest("TC-IDM-3.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 attribute: requireId(ON_LEVEL.id, "LevelControl.onLevel"),
             };
 
-            const labelVersion = await clusterVersion(node, labelPath);
-            const levelVersion = await clusterVersion(node, levelPath);
+            const [labelVersion, levelVersion] = await clusterVersions(node, [labelPath, levelPath]);
             cx.recorder.check({
                 type: "response",
                 verdict: "pass",
@@ -384,7 +380,7 @@ certTest("TC-IDM-3.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
             const stale = await node.writeAttributes([
                 { path: labelPath, value: "tc-idm-3-1-stale", dataVersion: labelVersion },
             ]);
-            const rejected = stale.every(({ status }) => status === Status.DataVersionMismatch);
+            const rejected = stale.length === 1 && stale[0].status === Status.DataVersionMismatch;
             cx.recorder.check({
                 type: "response",
                 verdict: rejected ? "pass" : "fail",

--- a/support/chip-testing/test/cert/TC-IDM-3.1.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-3.1.test.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Status } from "@matter/main/types";
 import { Matter } from "@matter/model";
-import type { AttributePathSpec, CertNodeRef, CertStepContext } from "@matter/testing";
+import type { AttributePathSpec, CertNodeApi, CertNodeRef, CertStepContext } from "@matter/testing";
 import { certTest } from "@matter/testing";
 import { CommissionedRefs, expectMessageWithPath, requireId, WRITE_REQUEST_MESSAGE } from "./tc-support.js";
 
@@ -13,6 +14,7 @@ const LEVEL_CONTROL = Matter.clusters.require("LevelControl");
 const BASIC_INFORMATION = Matter.clusters.require("BasicInformation");
 const THERMOSTAT_USER_INTERFACE_CONFIGURATION = Matter.clusters.require("ThermostatUserInterfaceConfiguration");
 const COLOR_CONTROL = Matter.clusters.require("ColorControl");
+const IDENTIFY = Matter.clusters.require("Identify");
 
 const LEVEL_CONTROL_ID = requireId(LEVEL_CONTROL.id, "LevelControl cluster");
 const BASIC_INFORMATION_ID = requireId(BASIC_INFORMATION.id, "BasicInformation cluster");
@@ -21,6 +23,7 @@ const THERMOSTAT_USER_INTERFACE_CONFIGURATION_ID = requireId(
     "ThermostatUserInterfaceConfiguration cluster",
 );
 const COLOR_CONTROL_ID = requireId(COLOR_CONTROL.id, "ColorControl cluster");
+const IDENTIFY_ID = requireId(IDENTIFY.id, "Identify cluster");
 
 const ON_LEVEL = LEVEL_CONTROL.attributes.require("onLevel");
 const ON_OFF_TRANSITION_TIME = LEVEL_CONTROL.attributes.require("onOffTransitionTime");
@@ -28,6 +31,10 @@ const LOCAL_CONFIG_DISABLED = BASIC_INFORMATION.attributes.require("localConfigD
 const NODE_LABEL = BASIC_INFORMATION.attributes.require("nodeLabel");
 const TEMPERATURE_DISPLAY_MODE = THERMOSTAT_USER_INTERFACE_CONFIGURATION.attributes.require("temperatureDisplayMode");
 const OPTIONS = COLOR_CONTROL.attributes.require("options");
+const IDENTIFY_TIME = IDENTIFY.attributes.require("identifyTime");
+
+/** Seconds the step-2 wildcard write puts into Identify.identifyTime on every endpoint that has it. */
+const IDENTIFY_TIME_VALUE = 5;
 
 const ENDPOINT_0 = 0;
 const ENDPOINT_1 = 1;
@@ -64,6 +71,27 @@ async function writeAndCheck(
     }
 }
 
+/**
+ * The data version the device reports for `path`'s cluster, obtained through a cluster-level (non-concrete)
+ * read — a concrete read returns the bare value, which carries no version.
+ */
+async function clusterVersion(node: CertNodeApi, path: AttributePathSpec): Promise<number> {
+    const entries = await node.readAttribute({ endpoint: path.endpoint, cluster: path.cluster });
+    if (Array.isArray(entries)) {
+        for (const entry of entries) {
+            if (
+                typeof entry === "object" &&
+                entry !== null &&
+                "version" in entry &&
+                typeof entry.version === "number"
+            ) {
+                return entry.version;
+            }
+        }
+    }
+    throw new Error(`TH reported no data version for cluster ${path.cluster} on endpoint ${path.endpoint}`);
+}
+
 const commissioned = new CommissionedRefs();
 
 certTest("TC-IDM-3.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.WriteRequest"], app: "all-clusters" })
@@ -93,8 +121,47 @@ certTest("TC-IDM-3.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
         2,
         "DUT sends the WriteRequestMessage to the TH to modify one attribute on all Endpoints. On receipt of " +
             "this message, TH should modify the attribute and send a WriteResponseMessage to the DUT.",
-        async () => {},
-        { notApplicable: "Out of Scope for V1.0 per the test plan (write one attribute across all endpoints)" },
+        commissioned.withRef("dut", async (cx, ref) => {
+            const dut = cx.controllers.dut;
+            const th = cx.devices.th;
+            const path: AttributePathSpec = {
+                cluster: IDENTIFY_ID,
+                attribute: requireId(IDENTIFY_TIME.id, "Identify.identifyTime"),
+            };
+            const from = th.log.mark();
+
+            const statuses = await dut.node(ref).writeAttributes([{ path, value: IDENTIFY_TIME_VALUE }]);
+            const written = statuses.filter(({ status }) => status === Status.Success);
+            cx.recorder.check({
+                type: "response",
+                verdict: written.length > 1 ? "pass" : "fail",
+                detail:
+                    `wrote ${IDENTIFY_TIME_VALUE} to Identify.identifyTime on ${written.length} endpoint(s): ` +
+                    JSON.stringify(statuses),
+            });
+            if (written.length <= 1) {
+                throw new Error(`A wildcard write must reach more than one endpoint, got ${JSON.stringify(statuses)}`);
+            }
+
+            const logCheck = await expectMessageWithPath(th.log, th.flavor, WRITE_REQUEST_MESSAGE, path, from, 15_000);
+            cx.recorder.check(logCheck);
+            if (logCheck.verdict === "fail") {
+                throw new Error(`WriteRequestMessage log check failed for step 2: ${JSON.stringify(logCheck)}`);
+            }
+
+            for (const { endpoint } of written) {
+                const value = await dut
+                    .node(ref)
+                    .readAttribute({ endpoint, cluster: IDENTIFY_ID, attribute: IDENTIFY_TIME.id });
+                cx.recorder.check({
+                    type: "response",
+                    // identifyTime counts down from the written value, so the device may already report less
+                    verdict: typeof value === "number" ? "pass" : "fail",
+                    detail: `endpoint ${endpoint} reports identifyTime=${JSON.stringify(value)}`,
+                });
+            }
+        }),
+        { expected: "Verify on the TH that the correct WriteRequestMessage has been received." },
     )
     .step(
         3,
@@ -238,7 +305,89 @@ certTest("TC-IDM-3.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
             "report data action with the attribute values and the dataversions of the clusters. DUT sends a " +
             "WriteRequestMessage to the DUT to both the clusters with the appropriate dataversions(received in " +
             "the previous step) to modify the value of an attribute.",
-        async () => {},
-        { notApplicable: "Out of Scope per the test plan (data-version-conditional write)" },
+        commissioned.withRef("dut", async (cx, ref) => {
+            const dut = cx.controllers.dut;
+            const th = cx.devices.th;
+            const node = dut.node(ref);
+
+            const labelPath: AttributePathSpec = {
+                endpoint: ENDPOINT_0,
+                cluster: BASIC_INFORMATION_ID,
+                attribute: requireId(NODE_LABEL.id, "BasicInformation.nodeLabel"),
+            };
+            const levelPath: AttributePathSpec = {
+                endpoint: ENDPOINT_1,
+                cluster: LEVEL_CONTROL_ID,
+                attribute: requireId(ON_LEVEL.id, "LevelControl.onLevel"),
+            };
+
+            const labelVersion = await clusterVersion(node, labelPath);
+            const levelVersion = await clusterVersion(node, levelPath);
+            cx.recorder.check({
+                type: "response",
+                verdict: "pass",
+                detail: `data versions read: BasicInformation=${labelVersion}, LevelControl=${levelVersion}`,
+            });
+
+            const from = th.log.mark();
+            const statuses = await node.writeAttributes([
+                { path: labelPath, value: "tc-idm-3-1-step-15", dataVersion: labelVersion },
+                { path: levelPath, value: 3, dataVersion: levelVersion },
+            ]);
+            const allSucceeded = statuses.length === 2 && statuses.every(({ status }) => status === Status.Success);
+            cx.recorder.check({
+                type: "response",
+                verdict: allSucceeded ? "pass" : "fail",
+                detail: `version-conditional write answered ${JSON.stringify(statuses)}`,
+            });
+            if (!allSucceeded) {
+                throw new Error(`Version-conditional write was rejected: ${JSON.stringify(statuses)}`);
+            }
+
+            const logCheck = await expectMessageWithPath(
+                th.log,
+                th.flavor,
+                WRITE_REQUEST_MESSAGE,
+                labelPath,
+                from,
+                15_000,
+            );
+            cx.recorder.check(logCheck);
+            if (logCheck.verdict === "fail") {
+                throw new Error(`WriteRequestMessage log check failed for step 15: ${JSON.stringify(logCheck)}`);
+            }
+
+            const label = await node.readAttribute(labelPath);
+            const level = await node.readAttribute(levelPath);
+            const readBackOk = label === "tc-idm-3-1-step-15" && level === 3;
+            cx.recorder.check({
+                type: "response",
+                verdict: readBackOk ? "pass" : "fail",
+                detail: `read back nodeLabel=${JSON.stringify(label)}, onLevel=${JSON.stringify(level)}`,
+            });
+            if (!readBackOk) {
+                throw new Error(`Write did not take effect: nodeLabel=${label}, onLevel=${level}`);
+            }
+
+            // The plan stops at the successful write, which a device ignoring the version would also pass.
+            // Repeating it with the now-stale versions is the only evidence the version was honored.
+            const stale = await node.writeAttributes([
+                { path: labelPath, value: "tc-idm-3-1-stale", dataVersion: labelVersion },
+            ]);
+            const rejected = stale.every(({ status }) => status === Status.DataVersionMismatch);
+            cx.recorder.check({
+                type: "response",
+                verdict: rejected ? "pass" : "fail",
+                detail: `write with the stale data version answered ${JSON.stringify(stale)}`,
+            });
+            if (!rejected) {
+                throw new Error(`A stale data version was accepted: ${JSON.stringify(stale)}`);
+            }
+        }),
+        {
+            expected:
+                "Verify that the TH sends a Write Response message with a success back to the DUT. Verify by " +
+                "sending a ReadRequest that the Write Action on TH was successful.",
+        },
     )
     .finalize(cx => commissioned.decommissionAll(cx));

--- a/support/chip-testing/test/cert/TC-IDM-3.1.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-3.1.test.ts
@@ -6,7 +6,7 @@
 
 import { Status } from "@matter/main/types";
 import { Matter } from "@matter/model";
-import type { AttributePathSpec, CertNodeApi, CertNodeRef, CertStepContext } from "@matter/testing";
+import type { AttributePathSpec, CertNodeApi, CertNodeRef, CertStepContext, DeviceFlavor } from "@matter/testing";
 import { certTest } from "@matter/testing";
 import { CommissionedRefs, expectMessageWithPath, requireId, WRITE_REQUEST_MESSAGE } from "./tc-support.js";
 
@@ -35,6 +35,13 @@ const IDENTIFY_TIME = IDENTIFY.attributes.require("identifyTime");
 
 /** Seconds the step-2 wildcard write puts into Identify.identifyTime on every endpoint that has it. */
 const IDENTIFY_TIME_VALUE = 5;
+
+/**
+ * Step 2's wildcard-endpoint write is valid per Matter Core § 8.9.2.7, but the chip apps answer it
+ * `InvalidAction` after failing to decode the path ("TLVReader.cpp:656: End of TLV"), so the step can
+ * only run against a matter.js TH.
+ */
+const STEP_2_FLAVORS: DeviceFlavor[] = ["matterjs"];
 
 const ENDPOINT_0 = 0;
 const ENDPOINT_1 = 1;
@@ -161,7 +168,10 @@ certTest("TC-IDM-3.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 });
             }
         }),
-        { expected: "Verify on the TH that the correct WriteRequestMessage has been received." },
+        {
+            expected: "Verify on the TH that the correct WriteRequestMessage has been received.",
+            flavors: STEP_2_FLAVORS,
+        },
     )
     .step(
         3,


### PR DESCRIPTION
Step 2 of the cert-harness sequence, on top of the ClientNode migration (#4229). Unlocks the two TC-IDM-3.1 steps that were `notApplicable`.

The test plan marks them out of scope for a harness reason, not a specification one — its own notes say "Test Steps #2 and #15 cannot be executed with V1.0 SDK". matter.js can execute both.

## Seam

`CertNodeApi` gains one method:

```ts
writeAttributes(entries: AttributeWriteEntry[]): Promise<AttributeWriteStatus[]>
```

Each entry carries a path whose `endpoint` may be omitted (wildcard) and an optional `dataVersion`. It returns the device's per-path statuses rather than throwing, because a wildcard expansion legitimately mixes success with per-path failures — the step decides which statuses it expected. `writeAttribute` is untouched, including the throw-on-failure behaviour its tests pin.

Wildcard read entries now also carry the `version` the report already contained, which is how a step obtains the versions its conditional write must send. An adapter that cannot express these writes throws `NotImplementedError`, and a step needing them declares its `flavors` — relevant when chip-tool lands as a second adapter.

## The two steps

**Step 2** writes `Identify.identifyTime` through a wildcard endpoint path. Both the chip all-clusters app and the matter.js instance expose Identify on endpoints 1–4, so the step requires the write to reach more than one endpoint, checks the `WriteRequestMessage` in the device log, and reads the value back per endpoint. The existing `AttributePathIB` matcher already handles a wildcard path — an absent field means no line at all, matched as a strict prefix — so no new log machinery was needed.

**Step 15** reads the data versions of `BasicInformation` and `LevelControl` through cluster-level paths, writes both attributes in one request carrying those versions, and reads the values back.

It then does something the plan does not ask for: it repeats the write with the now-stale versions and requires `DataVersionMismatch`. The plan's own procedure stops at the successful write, which a device that ignores `DataVersion` entirely would pass just as well — the rejection is the only evidence the version was honoured. Filing that as test-plan feedback.

## The chip apps cannot receive step 2's write

Matter Core § 8.9.2.7 lists `Endpoint=Wildcard, Cluster=Specific, Attribute=Specific` as a valid write path, and matter.js emits it correctly, but both chip apps answer `InvalidAction`. Their log shows the path decoded and then the failure:

```
[DMG] AttributePathIB = { Cluster = 0x3, Attribute = 0x0000_0000, }
[DMG] Data = 5 (unsigned),
[DMG] Failed to process write request: src/lib/core/TLVReader.cpp:656: CHIP Error 0x00000021: End of TLV
```

Identical on `own-built` and on the official `cert-bins` image. So step 2 declares the matterjs flavor — which is the same limitation the plan's "cannot be executed with V1.0 SDK" note describes, seen from the device side. Step 15 needs no restriction: the version-conditional write works against the chip apps, stale-version rejection included.

Filed separately with the raw device logs, since a report needs them: the SDK behaviour, and test-plan feedback that the scope note covers step 15 wrongly and that step 15's expected outcome cannot distinguish a device ignoring `DataVersion`.

## Verification

- Local matterjs flavor: TC-IDM-3.1 passes with step 2 reaching endpoints 1, 2, 3 and 4 (`status: 0` each, read-back `identifyTime=5`), and step 15 recording both data versions, a successful conditional write, correct read-back, and `status: 146` for the stale-version write.
- `test/cert-framework/controller-adapter.test.ts` 9/9, including two new cases: a wildcard write reaching more than one endpoint, and a stale data version being rejected while a fresh one succeeds.
- Mutation proof for the version plumbing: dropping `version` from the built request makes the stale-version test fail with `expected [ +0 ] to deeply equal [ 146 ]` — the write silently succeeds without it.
- Repository gates green: `npm run build`, `npm run format`, `npm run lint`, `npm test`; full `test/cert/**` green locally.
- Cert run 31677205278 green on all three flavors. Step 15 passes everywhere, with a real device-log check on both chip flavors; step 2 passes on matterjs and is flavor-skipped on the chip flavors.
