### PR TITLE
fix(nodejs-ble): retry a connection attempt reported as failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,13 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Breaking: `FileStorageDriver`'s constructor no longer accepts a `clear` argument; clearing is handled by `StorageService`
     - Fix: Ensure that `--storage-clear`/`MATTER_STORAGE_CLEAR` is honored again and clears the storage on start
 
+- @matter/nodejs-ble
+    - Fix: A connection attempt that BLE reports as failed is retried instead of failing commissioning on the first try
+    - Fix: A peripheral whose connection attempt failed is no longer rejected as unusable for the lifetime of the process
+    - Fix: Giving up on a peripheral reports the last connection failure as cause
+    - Fix: A disconnect that never completes no longer leaves the channel request pending forever
+    - Fix: Aborting a BLE connection attempt now stops its retries and closes a connection that completed anyway
+
 - @matter/nodejs-shell
     - Feature: Added `--cleanup-legacy-storage` to irreversibly remove the leftover pre-0.16 storage artifacts once they have been migrated to the current format
 
@@ -77,6 +84,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Deprecation: The legacy `ClusterType` command request surface (`Invoke.LegacyCommandRequest`, `Specifier.ClusterTypeCommand`) and `SessionManager.owner` are scheduled for removal in 0.19
     - Enhancement: Network profiles accept a separate `bdxAdditionalMrpDelay` for bulk transfer, defaulting to the profile's messaging margin
     - Enhancement: New `CertificateAuthority.erase()` discards the authority's key material, persisted and in memory
+    - Fix: Cancelling BLE commissioning aborts the in-flight channel open
     - Fix: A subscription's `maxIntervalCeiling` is transmitted exactly as requested; jitter now applies only when we derive the ceiling ourselves
 
 - @matter/react-native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A peripheral whose connection attempt failed is no longer rejected as unusable for the lifetime of the process
     - Fix: Giving up on a peripheral reports the last connection failure as cause
     - Fix: A disconnect that never completes no longer leaves the channel request pending forever
-    - Fix: Aborting a BLE connection attempt now stops its retries and closes a connection that completed anyway
+    - Fix: Aborting a BLE connection attempt now stops its retries and releases a link the attempt already established
 
 - @matter/nodejs-shell
     - Feature: Added `--cleanup-legacy-storage` to irreversibly remove the leftover pre-0.16 storage artifacts once they have been migrated to the current format

--- a/packages/nodejs-ble/package.json
+++ b/packages/nodejs-ble/package.json
@@ -25,7 +25,11 @@
     "scripts": {
         "clean": "nacho-build clean",
         "build": "nacho-build",
-        "build-clean": "nacho-build --clean"
+        "build-clean": "nacho-build --clean",
+        "test": "matter-test"
+    },
+    "devDependencies": {
+        "@matter/testing": "*"
     },
     "dependencies": {
         "@matter/general": "*",

--- a/packages/nodejs-ble/src/NobleBleChannel.ts
+++ b/packages/nodejs-ble/src/NobleBleChannel.ts
@@ -102,14 +102,14 @@ export class NobleBleCentralInterface implements Transport {
     }
 
     openChannel(address: ServerAddress, options?: Transport.OpenChannelOptions): Promise<Channel<Bytes>> {
-        return this.#openChannel(address, 1, undefined, options?.abort);
+        return this.#openChannel(address, 1, options?.abort);
     }
 
     #openChannel(
         address: ServerAddress,
         tryCount: number,
-        lastError?: unknown,
         abort?: AbortSignal,
+        lastError?: unknown,
     ): Promise<Channel<Bytes>> {
         if (this.#closed) {
             // A retry can reach this from an event listener, where a synchronous throw escapes into noble's emit
@@ -292,7 +292,7 @@ export class NobleBleCentralInterface implements Transport {
                 }
 
                 // Try again and chain promises
-                this.#openChannel(address, tryCount + 1, cause, abort)
+                this.#openChannel(address, tryCount + 1, abort, cause)
                     .then(resolveOnce)
                     .catch(rejectOnce);
             };

--- a/packages/nodejs-ble/src/NobleBleChannel.ts
+++ b/packages/nodejs-ble/src/NobleBleChannel.ts
@@ -12,13 +12,16 @@ import {
     InternalError,
     Logger,
     Minutes,
+    AbortedError,
     NetworkError,
+    Seconds,
     ServerAddress,
     Time,
     Timer,
     Transport,
     asError,
     createPromise,
+    withTimeout,
 } from "@matter/general";
 import {
     BleChannel,
@@ -34,6 +37,9 @@ import { BleScanner } from "./BleScanner.js";
 import { nobleDisconnectReason } from "./NobleBleClient.js";
 
 const logger = Logger.get("BleChannel");
+
+/** noble waits for a disconnect event that a vanished peripheral never sends, so the wait needs its own bound. */
+const BLE_DISCONNECT_TIMEOUT = Seconds(5);
 
 /**
  * Detect noble errors that indicate the BLE connection is no longer usable.
@@ -95,13 +101,19 @@ export class NobleBleCentralInterface implements Transport {
         this.#bleScanner = bleScanner;
     }
 
-    openChannel(address: ServerAddress, _options?: Transport.OpenChannelOptions): Promise<Channel<Bytes>> {
-        return this.#openChannel(address, 1);
+    openChannel(address: ServerAddress, options?: Transport.OpenChannelOptions): Promise<Channel<Bytes>> {
+        return this.#openChannel(address, 1, undefined, options?.abort);
     }
 
-    #openChannel(address: ServerAddress, tryCount: number): Promise<Channel<Bytes>> {
+    #openChannel(
+        address: ServerAddress,
+        tryCount: number,
+        lastError?: unknown,
+        abort?: AbortSignal,
+    ): Promise<Channel<Bytes>> {
         if (this.#closed) {
-            throw new NetworkError("Network interface is closed");
+            // A retry can reach this from an event listener, where a synchronous throw escapes into noble's emit
+            return Promise.reject(new NetworkError("Network interface is closed"));
         }
         return new Promise((resolve, reject) => {
             let resolvedOrRejected = false;
@@ -114,12 +126,13 @@ export class NobleBleCentralInterface implements Transport {
                 }
             }
             function resolveOnce(value: Channel<Bytes>) {
-                if (!resolvedOrRejected) {
-                    resolvedOrRejected = true;
-                    resolve(value);
-                } else {
+                if (resolvedOrRejected) {
                     logger.debug(`Already resolved or rejected, ignore success`);
+                    return false;
                 }
+                resolvedOrRejected = true;
+                resolve(value);
+                return true;
             }
 
             if (this.#onMatterMessageListener === undefined) {
@@ -133,8 +146,17 @@ export class NobleBleCentralInterface implements Transport {
                 return;
             }
             const { peripheralAddress } = address;
+            if (abort?.aborted) {
+                rejectOnce(new AbortedError(`Connection to peripheral ${peripheralAddress} was aborted`));
+                return;
+            }
             if (tryCount > 3) {
-                rejectOnce(new BleError(`Failed to connect to peripheral ${peripheralAddress}`));
+                rejectOnce(
+                    new BleError(
+                        `Failed to connect to peripheral ${peripheralAddress}`,
+                        lastError === undefined ? undefined : { cause: lastError },
+                    ),
+                );
                 return;
             }
 
@@ -156,17 +178,6 @@ export class NobleBleCentralInterface implements Transport {
             }
             // Reserve slot immediately so parallel openChannel calls for the same peripheral are rejected
             this.#connectionsInProgress.add(peripheralAddress);
-
-            if (peripheral.state === "error") {
-                // Weired state, so better cancel here and try a re-discovery
-                this.#connectionsInProgress.delete(peripheralAddress);
-                rejectOnce(
-                    new BleError(
-                        `Can not connect to peripheral "${peripheralAddress}" because unexpected state "${peripheral.state}"`,
-                    ),
-                );
-                return;
-            }
 
             // Wrapped listener for "connect" event — assigned after connectHandler is defined.
             // Stored here so timeout/retry handlers can remove it by reference.
@@ -218,29 +229,46 @@ export class NobleBleCentralInterface implements Transport {
                 interviewTimeout?.stop();
                 disconnectTimeout?.stop();
                 this.#connectionGuards.delete(connectionGuard);
+                abort?.removeEventListener("abort", onAbort);
             };
+
+            const onAbort = () => {
+                logger.debug(`Peripheral ${peripheralAddress}: Connection aborted`);
+                peripheral.removeListener("connect", connectListener);
+                peripheral.removeListener("disconnect", reTryHandler);
+                clearConnectionGuard();
+                this.#connectionsInProgress.delete(peripheralAddress);
+                rejectOnce(new AbortedError(`Connection to peripheral ${peripheralAddress} was aborted`));
+            };
+            abort?.addEventListener("abort", onAbort, { once: true });
+
+            // Set once a retry owns the connection slot, so this attempt's cleanup does not release the retry's.
+            let retryStarted = false;
 
             // Handler to retry the connection. Called on disconnections (with a noble disconnect reason) and errors.
             const reTryHandler = (errorOrReason?: unknown) => {
+                retryStarted = true;
+
                 // Cancel tracking states because we are done in this context
                 clearConnectionGuard();
                 this.#connectionsInProgress.delete(peripheralAddress);
                 peripheral.removeListener("connect", connectListener);
                 peripheral.removeListener("disconnect", reTryHandler);
 
+                let cause: unknown;
                 if (errorOrReason instanceof Error) {
-                    logger.info(
-                        `Peripheral ${peripheralAddress} disconnected while trying to connect, try again`,
-                        errorOrReason,
-                    );
+                    cause = errorOrReason;
+                    logger.info(`Peripheral ${peripheralAddress}: connection attempt failed, try again`, errorOrReason);
                 } else {
+                    const reason = nobleDisconnectReason(errorOrReason);
+                    cause = new BleError(`Peripheral ${peripheralAddress} disconnected (reason ${reason})`);
                     logger.info(
-                        `Peripheral ${peripheralAddress} disconnected while trying to connect (reason ${nobleDisconnectReason(errorOrReason)}), try again`,
+                        `Peripheral ${peripheralAddress} disconnected while trying to connect (reason ${reason}), try again`,
                     );
                 }
 
                 // Try again and chain promises
-                this.#openChannel(address, tryCount + 1)
+                this.#openChannel(address, tryCount + 1, cause, abort)
                     .then(resolveOnce)
                     .catch(rejectOnce);
             };
@@ -252,12 +280,9 @@ export class NobleBleCentralInterface implements Transport {
                     return;
                 }
                 if (error) {
-                    clearConnectionGuard();
-                    this.#connectionsInProgress.delete(peripheralAddress);
-                    peripheral.removeListener("disconnect", reTryHandler);
-                    rejectOnce(
-                        new BleError(`Error while connecting to peripheral ${peripheralAddress}`, { cause: error }),
-                    );
+                    // noble emits no disconnect for a connection that never established, so the disconnect-driven
+                    // retry below never sees this failure
+                    reTryHandler(asError(error));
                     return;
                 }
                 if (this.#onMatterMessageListener === undefined) {
@@ -342,17 +367,19 @@ export class NobleBleCentralInterface implements Transport {
                         this.#openChannels.set(peripheralAddress, peripheral);
                         peripheral.once("disconnect", () => this.#openChannels.delete(peripheralAddress));
                         try {
-                            resolveOnce(
-                                await NobleBleChannel.create(
-                                    peripheral,
-                                    characteristicC1ForWrite,
-                                    characteristicC2ForSubscribe,
-                                    this.#onMatterMessageListener,
-                                    additionalCommissioningRelatedData,
-                                ),
+                            const channel = await NobleBleChannel.create(
+                                peripheral,
+                                characteristicC1ForWrite,
+                                characteristicC2ForSubscribe,
+                                this.#onMatterMessageListener,
+                                additionalCommissioningRelatedData,
                             );
                             clearConnectionGuard();
                             this.#connectionsInProgress.delete(peripheralAddress);
+                            if (!resolveOnce(channel)) {
+                                // The caller already gave up on this channel, so nothing else will close it
+                                await channel.close();
+                            }
                             return;
                         } catch (error) {
                             this.#connectionsInProgress.delete(peripheralAddress);
@@ -361,14 +388,9 @@ export class NobleBleCentralInterface implements Transport {
                                 logger.debug(
                                     `Disconnect because of initialization error of peripheral ${ServerAddress.urlFor(address)}`,
                                 );
-                                await peripheral
-                                    .disconnectAsync()
-                                    .catch(error =>
-                                        logger.debug(
-                                            `Peripheral ${peripheral.address}: Error while disconnecting`,
-                                            error,
-                                        ),
-                                    );
+                                await withTimeout(BLE_DISCONNECT_TIMEOUT, peripheral.disconnectAsync()).catch(error =>
+                                    logger.debug(`Peripheral ${peripheral.address}: Error while disconnecting`, error),
+                                );
                             }
                             reTryHandler(error);
                             return;
@@ -384,8 +406,10 @@ export class NobleBleCentralInterface implements Transport {
                     }
                     return;
                 } finally {
-                    this.#connectionsInProgress.delete(peripheralAddress);
-                    clearConnectionGuard();
+                    if (!retryStarted) {
+                        this.#connectionsInProgress.delete(peripheralAddress);
+                        clearConnectionGuard();
+                    }
                 }
 
                 peripheral.removeListener("disconnect", reTryHandler);
@@ -420,14 +444,18 @@ export class NobleBleCentralInterface implements Transport {
                 tryCount--;
                 peripheral.once("disconnect", reTryHandler);
             } else {
-                if (peripheral.state === "connecting") {
+                // "error" is the state noble leaves behind after a connection attempt that never established, and
+                // nothing in its discovery path resets it, so it has to be treated as connectable
+                const stateBeforeConnect = peripheral.state;
+                if (stateBeforeConnect === "connecting") {
                     peripheral.cancelConnect(); // Send cancel to noble to make sure we can connect
                 }
-                // connecting, disconnected
                 connectionGuard.connectTimeout.start();
                 peripheral.once("connect", connectListener);
                 peripheral.once("disconnect", reTryHandler);
-                logger.debug(`Peripheral ${peripheralAddress}: Connect to Peripheral now (try ${tryCount})`);
+                logger.debug(
+                    `Peripheral ${peripheralAddress}: Connect to Peripheral now (try ${tryCount}, state ${stateBeforeConnect})`,
+                );
                 peripheral.connectAsync().catch(error => {
                     if (!this.#connectionGuards.has(connectionGuard)) {
                         // Seems that the response was delayed and this process was cancelled in the meantime

--- a/packages/nodejs-ble/src/NobleBleChannel.ts
+++ b/packages/nodejs-ble/src/NobleBleChannel.ts
@@ -179,6 +179,18 @@ export class NobleBleCentralInterface implements Transport {
             // Reserve slot immediately so parallel openChannel calls for the same peripheral are rejected
             this.#connectionsInProgress.add(peripheralAddress);
 
+            /**
+             * Release the reservation this attempt made, once. A later attempt may already own the address, and an
+             * abandoned attempt resuming after an abort or a timeout must not take the reservation away from it.
+             */
+            let ownsSlot = true;
+            const releaseSlot = () => {
+                if (ownsSlot) {
+                    ownsSlot = false;
+                    this.#connectionsInProgress.delete(peripheralAddress);
+                }
+            };
+
             // Wrapped listener for "connect" event — assigned after connectHandler is defined.
             // Stored here so timeout/retry handlers can remove it by reference.
             let connectListener: (error?: any) => void;
@@ -194,14 +206,14 @@ export class NobleBleCentralInterface implements Transport {
                     peripheral.removeListener("connect", connectListener);
                     peripheral.removeListener("disconnect", reTryHandler);
                     clearConnectionGuard();
-                    this.#connectionsInProgress.delete(peripheralAddress);
+                    releaseSlot();
                     rejectOnce(new BleError(`Timeout while connecting to peripheral ${peripheralAddress}`));
                 }),
                 disconnectTimeout: Time.getTimer("BLE disconnect timeout", Minutes.one, () => {
                     logger.debug(`Timeout while disconnecting to peripheral ${peripheralAddress}`);
                     peripheral.removeListener("disconnect", reTryHandler);
                     clearConnectionGuard();
-                    this.#connectionsInProgress.delete(peripheralAddress);
+                    releaseSlot();
                     rejectOnce(new BleError(`Timeout while disconnecting to peripheral ${peripheralAddress}`));
                 }),
                 // Timeout when trying to interview the device because sometimes when no response from device
@@ -210,7 +222,7 @@ export class NobleBleCentralInterface implements Transport {
                     logger.debug(`Timeout while interviewing peripheral ${peripheralAddress}`);
                     peripheral.removeListener("disconnect", reTryHandler);
                     clearConnectionGuard();
-                    this.#connectionsInProgress.delete(peripheralAddress);
+                    releaseSlot();
                     if (peripheral.state === "connected") {
                         // We accept the dangling promise potentially because we got a timeout on reading data,
                         // so chance is high also disconnect does not work reliably for now
@@ -237,21 +249,33 @@ export class NobleBleCentralInterface implements Transport {
                 peripheral.removeListener("connect", connectListener);
                 peripheral.removeListener("disconnect", reTryHandler);
                 clearConnectionGuard();
-                this.#connectionsInProgress.delete(peripheralAddress);
+                releaseSlot();
+                releasePeripheral();
                 rejectOnce(new AbortedError(`Connection to peripheral ${peripheralAddress} was aborted`));
             };
             abort?.addEventListener("abort", onAbort, { once: true });
 
-            // Set once a retry owns the connection slot, so this attempt's cleanup does not release the retry's.
-            let retryStarted = false;
+            /**
+             * Hand back a link this attempt may already hold. The peripheral is not in {@link #openChannels} until the
+             * interview completes, so nothing else would ever disconnect it.
+             */
+            const releasePeripheral = () => {
+                if (peripheral.state === "connecting") {
+                    peripheral.cancelConnect();
+                    return;
+                }
+                if (peripheral.state === "connected") {
+                    withTimeout(BLE_DISCONNECT_TIMEOUT, peripheral.disconnectAsync()).catch(error =>
+                        logger.debug(`Peripheral ${peripheralAddress}: Error while disconnecting`, error),
+                    );
+                }
+            };
 
             // Handler to retry the connection. Called on disconnections (with a noble disconnect reason) and errors.
             const reTryHandler = (errorOrReason?: unknown) => {
-                retryStarted = true;
-
                 // Cancel tracking states because we are done in this context
                 clearConnectionGuard();
-                this.#connectionsInProgress.delete(peripheralAddress);
+                releaseSlot();
                 peripheral.removeListener("connect", connectListener);
                 peripheral.removeListener("disconnect", reTryHandler);
 
@@ -287,7 +311,7 @@ export class NobleBleCentralInterface implements Transport {
                 }
                 if (this.#onMatterMessageListener === undefined) {
                     clearConnectionGuard();
-                    this.#connectionsInProgress.delete(peripheralAddress);
+                    releaseSlot();
                     peripheral.removeListener("disconnect", reTryHandler);
                     rejectOnce(new InternalError(`Network Interface was not added to the system yet or was cleared.`));
                     return;
@@ -375,14 +399,14 @@ export class NobleBleCentralInterface implements Transport {
                                 additionalCommissioningRelatedData,
                             );
                             clearConnectionGuard();
-                            this.#connectionsInProgress.delete(peripheralAddress);
+                            releaseSlot();
                             if (!resolveOnce(channel)) {
                                 // The caller already gave up on this channel, so nothing else will close it
                                 await channel.close();
                             }
                             return;
                         } catch (error) {
-                            this.#connectionsInProgress.delete(peripheralAddress);
+                            releaseSlot();
                             this.#openChannels.delete(peripheralAddress);
                             if (peripheral.state === "connected") {
                                 logger.debug(
@@ -406,10 +430,8 @@ export class NobleBleCentralInterface implements Transport {
                     }
                     return;
                 } finally {
-                    if (!retryStarted) {
-                        this.#connectionsInProgress.delete(peripheralAddress);
-                        clearConnectionGuard();
-                    }
+                    releaseSlot();
+                    clearConnectionGuard();
                 }
 
                 peripheral.removeListener("disconnect", reTryHandler);
@@ -423,7 +445,7 @@ export class NobleBleCentralInterface implements Transport {
                 connectHandler(error).catch(handlerError => {
                     logger.warn(`Peripheral ${peripheralAddress}: Unexpected error in connect handler`, handlerError);
                     clearConnectionGuard();
-                    this.#connectionsInProgress.delete(peripheralAddress);
+                    releaseSlot();
                     peripheral.removeListener("disconnect", reTryHandler);
                     rejectOnce(handlerError);
                 });
@@ -434,7 +456,7 @@ export class NobleBleCentralInterface implements Transport {
                 connectHandler().catch(error => {
                     logger.warn(`Peripheral ${peripheralAddress}: Unexpected error in connect handler`, error);
                     clearConnectionGuard();
-                    this.#connectionsInProgress.delete(peripheralAddress);
+                    releaseSlot();
                     peripheral.removeListener("disconnect", reTryHandler);
                     rejectOnce(error);
                 });
@@ -444,8 +466,6 @@ export class NobleBleCentralInterface implements Transport {
                 tryCount--;
                 peripheral.once("disconnect", reTryHandler);
             } else {
-                // "error" is the state noble leaves behind after a connection attempt that never established, and
-                // nothing in its discovery path resets it, so it has to be treated as connectable
                 const stateBeforeConnect = peripheral.state;
                 if (stateBeforeConnect === "connecting") {
                     peripheral.cancelConnect(); // Send cancel to noble to make sure we can connect

--- a/packages/nodejs-ble/test/NobleBleChannelTest.ts
+++ b/packages/nodejs-ble/test/NobleBleChannelTest.ts
@@ -44,6 +44,7 @@ class FakePeripheral extends EventEmitter {
 
     readonly #attemptWaiters = new Map<number, () => void>();
     #disconnected?: () => void;
+    #discoveryStarted?: () => void;
 
     constructor(private readonly onAttempt: (peripheral: FakePeripheral, attempt: number) => void) {
         super();
@@ -73,6 +74,7 @@ class FakePeripheral extends EventEmitter {
             return new Promise<void>(() => {});
         }
         this.state = "disconnected";
+        this.emit("disconnect", undefined);
         this.#disconnected?.();
     }
 
@@ -81,10 +83,22 @@ class FakePeripheral extends EventEmitter {
         return new Promise<void>(resolve => (this.#disconnected = resolve));
     }
 
-    cancelConnect() {}
+    cancelConnects = 0;
+
+    cancelConnect() {
+        this.cancelConnects++;
+        this.state = "disconnected";
+    }
+
+    /** Set to leave `discoverServicesAsync()` pending, holding the attempt inside the interview. */
+    discoveryHangs = false;
 
     async discoverServicesAsync(_serviceUuids?: string[]) {
         this.serviceDiscoveries++;
+        this.#discoveryStarted?.();
+        if (this.discoveryHangs) {
+            return new Promise<Service[]>(() => {});
+        }
         if (this.discoveryFailures > 0) {
             this.discoveryFailures--;
             this.state = "disconnected";
@@ -106,6 +120,11 @@ class FakePeripheral extends EventEmitter {
     dropConnection(reason: unknown) {
         this.state = "disconnected";
         this.emit("disconnect", reason);
+    }
+
+    /** Resolves once `discoverServicesAsync()` has run. */
+    whenDiscoveryStarts() {
+        return new Promise<void>(resolve => (this.#discoveryStarted = resolve));
     }
 
     /** Resolves once `connectAsync()` has run for the given attempt. Register before the attempt can start. */
@@ -399,6 +418,57 @@ describe("NobleBleCentralInterface", () => {
             expect(peripheral.connectAttempts).equals(3);
             expect(listeners.size).equals(0);
             await central.close();
+        });
+
+        it("disconnects the peripheral when the abort lands during the interview", async () => {
+            const aborter = new AbortController();
+            const peripheral = new FakePeripheral(p => p.completeConnect());
+            peripheral.discoveryHangs = true;
+            const central = centralInterfaceFor(peripheral);
+
+            const disconnected = peripheral.whenDisconnected();
+            const opening = central.openChannel(ADDRESS, { abort: aborter.signal });
+            await peripheral.whenDiscoveryStarts();
+
+            aborter.abort();
+            await expect(opening).rejectedWith(`Connection to peripheral ${PERIPHERAL_ADDRESS} was aborted`);
+
+            // The interview never reached #openChannels, so nothing else would ever release this link
+            await disconnected;
+            expect(peripheral.state).equals("disconnected");
+            await central.close();
+        });
+
+        it("cancels a pending connect when the abort lands before the peripheral answers", async () => {
+            const aborter = new AbortController();
+            const peripheral = new FakePeripheral(() => {});
+            const central = centralInterfaceFor(peripheral);
+
+            const opening = central.openChannel(ADDRESS, { abort: aborter.signal });
+            await peripheral.whenAttemptStarts(1);
+
+            aborter.abort();
+            await expect(opening).rejectedWith(`Connection to peripheral ${PERIPHERAL_ADDRESS} was aborted`);
+
+            expect(peripheral.cancelConnects).equals(1);
+            await central.close();
+        });
+
+        it("rejects rather than throws when a disconnect-driven retry races the interface closing", async () => {
+            const peripheral = new FakePeripheral(() => {});
+            const central = centralInterfaceFor(peripheral);
+
+            const opening = central.openChannel(ADDRESS).then(
+                () => "resolved",
+                (error: unknown) => (error instanceof Error ? error.message : `${error}`),
+            );
+            await peripheral.whenAttemptStarts(1);
+            await central.close();
+
+            // noble delivers this from its own emit, so the retry must not throw back into it
+            peripheral.dropConnection(undefined);
+
+            expect(await opening).equals("Network interface is closed");
         });
 
         it("closes a channel that completes after the caller aborted", async () => {

--- a/packages/nodejs-ble/test/NobleBleChannelTest.ts
+++ b/packages/nodejs-ble/test/NobleBleChannelTest.ts
@@ -1,0 +1,439 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { asError, Bytes, MatterError, ServerAddress } from "@matter/general";
+import { BtpCodec, MatterBle } from "@matter/protocol";
+import type { Peripheral, PeripheralState, Service } from "@stoprocent/noble";
+import { EventEmitter } from "node:events";
+import type { BleScanner } from "../src/BleScanner.js";
+import { NobleBleCentralInterface } from "../src/NobleBleChannel.js";
+
+const PERIPHERAL_ADDRESS = "c5:c3:4e:78:3c:6e";
+const ADDRESS = ServerAddress({ type: "ble", peripheralAddress: PERIPHERAL_ADDRESS });
+
+/** The BlueZ failure reason behind a rejected `Device.Connect()`. */
+const CONNECT_ERROR = "le-connection-abort-by-local";
+
+/**
+ * Peripheral stand-in that reports the outcome of each connect attempt through noble's `connect` event.
+ *
+ * State transitions mirror noble's `Noble._onConnect`, which moves a peripheral to "error" before emitting a failed
+ * `connect` and never follows such a failure with a `disconnect`.
+ *
+ * `onAttempt` runs in a microtask unless `reportsSynchronously` is set, matching noble's hci binding, which reports
+ * some failures from inside `connect()` itself.
+ */
+class FakePeripheral extends EventEmitter {
+    readonly address = PERIPHERAL_ADDRESS;
+    readonly mtu = null;
+    state: PeripheralState = "disconnected";
+    connectAttempts = 0;
+    serviceDiscoveries = 0;
+    discoveryFailures = 0;
+
+    reportsSynchronously = false;
+
+    /** Services `discoverServicesAsync()` reports. Empty means the peripheral carries no Matter service. */
+    services = new Array<Service>();
+
+    /** Set to leave `disconnectAsync()` pending forever, as noble does when the disconnect event never arrives. */
+    disconnectHangs = false;
+
+    readonly #attemptWaiters = new Map<number, () => void>();
+    #disconnected?: () => void;
+
+    constructor(private readonly onAttempt: (peripheral: FakePeripheral, attempt: number) => void) {
+        super();
+    }
+
+    async connectAsync() {
+        const attempt = ++this.connectAttempts;
+        this.state = "connecting";
+        this.#attemptWaiters.get(attempt)?.();
+
+        // noble resolves or rejects this from the same `connect` event it emits on the peripheral, so a failure
+        // reaches the transport twice
+        const settled = new Promise<void>((resolve, reject) => {
+            this.once("connect", error => (error === undefined ? resolve() : reject(asError(error))));
+        });
+        if (this.reportsSynchronously) {
+            this.onAttempt(this, attempt);
+        } else {
+            queueMicrotask(() => this.onAttempt(this, attempt));
+        }
+        await settled;
+    }
+
+    async disconnectAsync() {
+        if (this.disconnectHangs) {
+            this.state = "disconnecting";
+            return new Promise<void>(() => {});
+        }
+        this.state = "disconnected";
+        this.#disconnected?.();
+    }
+
+    /** Resolves once `disconnectAsync()` completes. Register before the disconnect can happen. */
+    whenDisconnected() {
+        return new Promise<void>(resolve => (this.#disconnected = resolve));
+    }
+
+    cancelConnect() {}
+
+    async discoverServicesAsync(_serviceUuids?: string[]) {
+        this.serviceDiscoveries++;
+        if (this.discoveryFailures > 0) {
+            this.discoveryFailures--;
+            this.state = "disconnected";
+            throw new Error("Service discovery failed");
+        }
+        return this.services;
+    }
+
+    failConnect(error: unknown = CONNECT_ERROR) {
+        this.state = "error";
+        this.emit("connect", error);
+    }
+
+    completeConnect() {
+        this.state = "connected";
+        this.emit("connect", undefined);
+    }
+
+    dropConnection(reason: unknown) {
+        this.state = "disconnected";
+        this.emit("disconnect", reason);
+    }
+
+    /** Resolves once `connectAsync()` has run for the given attempt. Register before the attempt can start. */
+    whenAttemptStarts(attempt: number) {
+        return new Promise<void>(resolve => {
+            if (this.connectAttempts >= attempt) {
+                resolve();
+            } else {
+                this.#attemptWaiters.set(attempt, resolve);
+            }
+        });
+    }
+
+    get asNoble() {
+        return this as unknown as Peripheral;
+    }
+}
+
+function matterService(characteristics: { c1: unknown; c2: unknown }) {
+    return {
+        uuid: MatterBle.SERVICE_UUID_SHORT,
+        async discoverCharacteristicsAsync() {
+            return [characteristics.c1, characteristics.c2];
+        },
+    } as unknown as Service;
+}
+
+const nobleUuid = (uuid: string) => uuid.replace(/-/g, "");
+
+/** Matter service whose C1 write fails, so `NobleBleChannel.create()` throws after the interview succeeded. */
+function unwritableMatterService() {
+    const characteristic = (uuid: string) => ({
+        uuid: nobleUuid(uuid),
+        properties: [],
+        async writeAsync() {
+            throw new Error("Write failed");
+        },
+        on() {},
+        removeListener() {},
+        async subscribeAsync() {},
+        async unsubscribeAsync() {},
+    });
+
+    return matterService({
+        c1: characteristic(MatterBle.C1_CHARACTERISTIC_UUID),
+        c2: characteristic(MatterBle.C2_CHARACTERISTIC_UUID),
+    });
+}
+
+/**
+ * Matter service that completes the BTP handshake, so `NobleBleChannel.create()` returns a live channel.
+ *
+ * `onSubscribe` runs once the transport is committed to the channel but before the handshake completes.
+ */
+function respondingMatterService(onSubscribe?: () => void) {
+    const c2 = new EventEmitter();
+    const handshakeResponse = Buffer.from(
+        Bytes.of(BtpCodec.encodeBtpHandshakeResponse({ version: 4, attMtu: 23, windowSize: 4 })),
+    );
+
+    return matterService({
+        c1: {
+            uuid: nobleUuid(MatterBle.C1_CHARACTERISTIC_UUID),
+            properties: [],
+            async writeAsync() {},
+        },
+        c2: Object.assign(c2, {
+            uuid: nobleUuid(MatterBle.C2_CHARACTERISTIC_UUID),
+            properties: [],
+            async subscribeAsync() {
+                onSubscribe?.();
+                queueMicrotask(() => c2.emit("data", handshakeResponse, true));
+            },
+            async unsubscribeAsync() {},
+        }),
+    });
+}
+
+/** Wraps a signal so a test can observe the listeners a channel attempt registers on it. */
+function observedSignal(controller: AbortController) {
+    const listeners = new Set<unknown>();
+    const signal = new Proxy(controller.signal, {
+        get(target, property) {
+            if (property === "addEventListener" || property === "removeEventListener") {
+                return (...args: Parameters<AbortSignal["addEventListener"]>) => {
+                    const [, listener] = args;
+                    if (property === "addEventListener") {
+                        listeners.add(listener);
+                    } else {
+                        listeners.delete(listener);
+                    }
+                    return target[property](...args);
+                };
+            }
+            const value = Reflect.get(target, property, target);
+            return typeof value === "function" ? value.bind(target) : value;
+        },
+    });
+    return { signal, listeners };
+}
+
+function centralInterfaceFor(peripheral: FakePeripheral) {
+    const scanner = {
+        getDiscoveredDevice: () => ({ peripheral: peripheral.asNoble, hasAdditionalAdvertisementData: false }),
+    } as unknown as BleScanner;
+
+    const central = new NobleBleCentralInterface(scanner);
+    central.onData(() => {});
+    return central;
+}
+
+describe("NobleBleCentralInterface", () => {
+    describe("openChannel", () => {
+        it("retries a connect reported as failed and gives up after three attempts", async () => {
+            const peripheral = new FakePeripheral(p => p.failConnect());
+            const central = centralInterfaceFor(peripheral);
+
+            await expect(central.openChannel(ADDRESS)).rejectedWith(
+                `Failed to connect to peripheral ${PERIPHERAL_ADDRESS}`,
+            );
+
+            expect(peripheral.connectAttempts).equals(3);
+            await central.close();
+        });
+
+        it("reports the last connect error as cause", async () => {
+            const peripheral = new FakePeripheral(p => p.failConnect());
+            const central = centralInterfaceFor(peripheral);
+
+            const error = await central.openChannel(ADDRESS).then(
+                () => undefined,
+                (error: unknown) => (error instanceof MatterError ? error : undefined),
+            );
+
+            const cause = error?.cause;
+            expect(error?.message).equals(`Failed to connect to peripheral ${PERIPHERAL_ADDRESS}`);
+            expect(cause instanceof Error ? cause.message : undefined).equals(CONNECT_ERROR);
+            await central.close();
+        });
+
+        it("retries a connect error reported as an Error instance", async () => {
+            const peripheral = new FakePeripheral(p => p.failConnect(new Error(CONNECT_ERROR)));
+            const central = centralInterfaceFor(peripheral);
+
+            await expect(central.openChannel(ADDRESS)).rejectedWith(
+                `Failed to connect to peripheral ${PERIPHERAL_ADDRESS}`,
+            );
+
+            expect(peripheral.connectAttempts).equals(3);
+            await central.close();
+        });
+
+        it("connects a peripheral a previous call left in the failed state", async () => {
+            let failing = true;
+            const peripheral = new FakePeripheral(p => (failing ? p.failConnect() : p.completeConnect()));
+            const central = centralInterfaceFor(peripheral);
+
+            await expect(central.openChannel(ADDRESS)).rejectedWith(
+                `Failed to connect to peripheral ${PERIPHERAL_ADDRESS}`,
+            );
+            expect(peripheral.state).equals("error");
+
+            failing = false;
+            await expect(central.openChannel(ADDRESS)).rejectedWith(
+                `Peripheral ${PERIPHERAL_ADDRESS} does not have the required Matter characteristics`,
+            );
+
+            expect(peripheral.connectAttempts).equals(4);
+            await central.close();
+        });
+
+        it("bounds the attempts when the connect error is reported from within connectAsync", async () => {
+            const peripheral = new FakePeripheral(p => p.failConnect(new Error("adapter state is poweredOff")));
+            peripheral.reportsSynchronously = true;
+            const central = centralInterfaceFor(peripheral);
+
+            await expect(central.openChannel(ADDRESS)).rejectedWith(
+                `Failed to connect to peripheral ${PERIPHERAL_ADDRESS}`,
+            );
+
+            expect(peripheral.connectAttempts).equals(3);
+            await central.close();
+        });
+
+        it("continues with the connected peripheral once a retried connect succeeds", async () => {
+            const peripheral = new FakePeripheral((p, attempt) =>
+                attempt < 3 ? p.failConnect() : p.completeConnect(),
+            );
+            const central = centralInterfaceFor(peripheral);
+
+            await expect(central.openChannel(ADDRESS)).rejectedWith(
+                `Peripheral ${PERIPHERAL_ADDRESS} does not have the required Matter characteristics`,
+            );
+
+            expect(peripheral.connectAttempts).equals(3);
+            expect(peripheral.serviceDiscoveries).equals(1);
+            await central.close();
+        });
+
+        it("retries a link that drops while connecting and reports the disconnect reason as cause", async () => {
+            const peripheral = new FakePeripheral(p => p.dropConnection("connection-abort-peer"));
+            const central = centralInterfaceFor(peripheral);
+
+            const error = await central.openChannel(ADDRESS).then(
+                () => undefined,
+                (error: unknown) => (error instanceof MatterError ? error : undefined),
+            );
+
+            const cause = error?.cause;
+            expect(error?.message).equals(`Failed to connect to peripheral ${PERIPHERAL_ADDRESS}`);
+            expect(cause instanceof Error ? cause.message : undefined).equals(
+                `Peripheral ${PERIPHERAL_ADDRESS} disconnected (reason connection-abort-peer)`,
+            );
+            expect(peripheral.connectAttempts).equals(3);
+            await central.close();
+        });
+
+        it("keeps the peripheral reserved while a retry started from the interview runs", async () => {
+            const peripheral = new FakePeripheral((p, attempt) => {
+                if (attempt === 1) {
+                    p.completeConnect();
+                }
+            });
+            peripheral.discoveryFailures = 1;
+            const central = centralInterfaceFor(peripheral);
+
+            const secondAttempt = peripheral.whenAttemptStarts(2);
+            const opening = central.openChannel(ADDRESS).then(
+                () => "resolved",
+                (error: unknown) => (error instanceof Error ? error.message : `${error}`),
+            );
+            await secondAttempt;
+
+            await expect(central.openChannel(ADDRESS)).rejectedWith(
+                `Connection to peripheral ${PERIPHERAL_ADDRESS} is already in progress.`,
+            );
+
+            peripheral.completeConnect();
+            expect(await opening).equals(
+                `Peripheral ${PERIPHERAL_ADDRESS} does not have the required Matter characteristics`,
+            );
+            expect(peripheral.connectAttempts).equals(2);
+            await central.close();
+        });
+
+        it("rejects without connecting when the abort signal is already set", async () => {
+            const peripheral = new FakePeripheral(p => p.completeConnect());
+            const central = centralInterfaceFor(peripheral);
+
+            await expect(central.openChannel(ADDRESS, { abort: AbortSignal.abort() })).rejectedWith(
+                `Connection to peripheral ${PERIPHERAL_ADDRESS} was aborted`,
+            );
+
+            expect(peripheral.connectAttempts).equals(0);
+            await central.close();
+        });
+
+        it("stops retrying when the abort signal fires between attempts", async () => {
+            const aborter = new AbortController();
+            const peripheral = new FakePeripheral((p, attempt) => {
+                if (attempt === 2) {
+                    aborter.abort();
+                }
+                p.failConnect();
+            });
+            const central = centralInterfaceFor(peripheral);
+
+            await expect(central.openChannel(ADDRESS, { abort: aborter.signal })).rejectedWith(
+                `Connection to peripheral ${PERIPHERAL_ADDRESS} was aborted`,
+            );
+
+            expect(peripheral.connectAttempts).equals(2);
+
+            // The aborted attempt must release the peripheral rather than leave it reserved
+            await expect(central.openChannel(ADDRESS)).rejectedWith(
+                `Failed to connect to peripheral ${PERIPHERAL_ADDRESS}`,
+            );
+
+            await central.close();
+        });
+
+        it("leaves no abort listener behind once the attempts end", async () => {
+            const { signal, listeners } = observedSignal(new AbortController());
+            const peripheral = new FakePeripheral(p => p.failConnect());
+            const central = centralInterfaceFor(peripheral);
+
+            await expect(central.openChannel(ADDRESS, { abort: signal })).rejectedWith(
+                `Failed to connect to peripheral ${PERIPHERAL_ADDRESS}`,
+            );
+
+            expect(peripheral.connectAttempts).equals(3);
+            expect(listeners.size).equals(0);
+            await central.close();
+        });
+
+        it("closes a channel that completes after the caller aborted", async () => {
+            const aborter = new AbortController();
+            const peripheral = new FakePeripheral(p => p.completeConnect());
+            peripheral.services = [respondingMatterService(() => aborter.abort())];
+            const central = centralInterfaceFor(peripheral);
+
+            const disconnected = peripheral.whenDisconnected();
+            await expect(central.openChannel(ADDRESS, { abort: aborter.signal })).rejectedWith(
+                `Connection to peripheral ${PERIPHERAL_ADDRESS} was aborted`,
+            );
+
+            // A channel nobody received must not stay connected
+            await disconnected;
+            expect(peripheral.state).equals("disconnected");
+            await central.close();
+        });
+
+        it("bounds a disconnect that never completes after a failed channel setup", async () => {
+            MockTime.init();
+            const peripheral = new FakePeripheral(p => p.completeConnect());
+            peripheral.services = [unwritableMatterService()];
+            peripheral.disconnectHangs = true;
+            const central = centralInterfaceFor(peripheral);
+
+            const opening = central.openChannel(ADDRESS).then(
+                () => "resolved",
+                (error: unknown) => (error instanceof Error ? error.message : `${error}`),
+            );
+
+            expect(await MockTime.resolve(opening, { stepMs: 1000 })).equals(
+                `Timeout while disconnecting to peripheral ${PERIPHERAL_ADDRESS}`,
+            );
+            await central.close();
+        });
+    });
+});

--- a/packages/nodejs-ble/test/tsconfig.json
+++ b/packages/nodejs-ble/test/tsconfig.json
@@ -1,10 +1,12 @@
 // Managed by nacho-build.  Nacho will update references automatically but otherwise preserves your edits.
 // Use `nacho-build configure` to overwrite with defaults.
 {
-    "extends": "../../../tsc/tsconfig.lib.json",
+    "extends": "../../../tsc/tsconfig.test.json",
     "compilerOptions": {
         "types": [
-            "node"
+            "mocha",
+            "node",
+            "@matter/testing"
         ]
     },
     "references": [
@@ -19,6 +21,9 @@
         },
         {
             "path": "../../types/src"
+        },
+        {
+            "path": "../src"
         }
     ]
 }

--- a/packages/nodejs-ble/tsconfig.json
+++ b/packages/nodejs-ble/tsconfig.json
@@ -1,5 +1,5 @@
 {
     "compilerOptions": { "composite": true },
     "files": [],
-    "references": [{ "path": "src" }]
+    "references": [{ "path": "src" }, { "path": "test" }]
 }

--- a/packages/protocol/src/peer/ControllerCommissioner.ts
+++ b/packages/protocol/src/peer/ControllerCommissioner.ts
@@ -363,7 +363,7 @@ export class ControllerCommissioner {
                     `BLE interface not initialized. Cannot use ${address.peripheralAddress} for commissioning.`,
                 );
             }
-            paseChannel = await Abort.attempt(signal, ble.openChannel(address));
+            paseChannel = await Abort.attempt(signal, ble.openChannel(address, { abort: signal }));
         } else {
             throw new ImplementationError(`Unsupported address type for Matter PASE commissioning`);
         }


### PR DESCRIPTION
## Problem

BLE commissioning of an IKEA GRILLPLATS plug fails on the first connect attempt and is never retried on the `dbus` noble backend, while the same underlying failure on `hci` recovers on the second attempt and commissions successfully.

```
Cause #0: [ble] Error while connecting to peripheral C5:C3:4E:78:3C:6E
Caused by: le-connection-abort-by-local
… No device could be commissioned (1 of 1 started attempt(s) failed, 1 discovered)
```

One attempt, no retry. The HCI capture from that session shows exactly one `LE Create Connection` in 160 s while the plug advertised 1532 times and stayed discoverable throughout.

A connection attempt that never established arrives from noble as connect-with-error, and noble deliberately emits **no** disconnect for it so the peripheral stays retryable. `#openChannel` registered two handlers with different policies — `disconnect` retried, `connect`-with-error called `rejectOnce` and gave up. On bindings where BlueZ rejects `Device.Connect()` outright, the failure can only ever surface on the path that does not retry. The retry machinery and its `tryCount` bound already existed and were simply not wired to it.

`hci` only looked healthier by accident: there the link *did* complete (`LE Connection Complete` status `0x00`) and dropped afterwards with reason `0x3e`, so noble emitted `disconnect` — the retrying path. The plug intermittently fails link establishment regardless of backend; the retry is the only thing that makes commissioning succeed.

## The `state === "error"` guard

Reaching the retry also required removing the `state === "error"` bail-out, because noble sets `peripheral.state = 'error'` *before* it emits the failed `connect`, so every retry landed straight on that guard.

That guard was introduced together with a compensating reset in `BleScanner` which cleared the state on rediscovery. The reset was later removed during a noble upgrade, on the expectation that noble would do it itself. It does not — the only resets are `cancelConnect` (from `"connecting"`) and `_onDisconnect`, and `_onDiscover` leaves state untouched. **Since then a peripheral has been rejected as unusable for the lifetime of the process after its first failed connect, on every backend.** noble's own `Peripheral.connect` treats `"error"` as connectable, so it now falls through with the other connectable states and the state is logged instead.

## Backends

The "no disconnect after a failed connect" contract and clean reconnect were verified in all four bindings, not extrapolated from one:

| binding | failed connect | retry |
|---|---|---|
| hci-socket | non-zero `LeConnComplete` registers no handle, emits `connect(error)`, cannot later emit disconnect | shifts the queue and nulls the pending uuid |
| dbus | rejects and tears down the half-open proxy, explicitly so a retry starts clean | clean |
| mac | `didFailToConnectPeripheral`, mutually exclusive with `didDisconnectPeripheral` | `connect:` re-acquires via `retrievePeripheralsWithIdentifiers` |
| win | `ConnectionStatusChanged` token registered only after a successful connect, so no disconnect path exists | `device` left unset, next `Connect` re-enters |

## Also fixed

- The exhausted-attempts error carries the last failure as **cause** — the old hard-fail reported `le-connection-abort-by-local`, the retry path had dropped it.
- The interview's `finally` no longer releases the connection slot a retry has already reserved, which left the retry unprotected against a concurrent `openChannel`.
- The **disconnect after a failed channel setup is bounded** (`withTimeout`, 5 s, same idiom as `NodeJsTcpConnection`'s close). noble waits on a disconnect event with no timeout, so a peripheral that vanished left `connectHandler` suspended inside the `try`: no retry, no `finally`, and no guard timer able to fire — the caller's promise never settled.
- **Abort is honored.** `openChannel` accepts `options.abort` and threads the signal through its retries, and the BLE commissioning call site passes it. The signal is per candidate address, so a losing PASE candidate now stops retrying and releases the peripheral instead of running on detached — making the documented `externalAbort` contract ("terminates all in-flight PASE attempts immediately") true for BLE. An abort during connect cancels it, an abort during the interview disconnects, and a channel that completes after the caller gave up is closed rather than stranded — at that point the peripheral is not yet in `#openChannels`, so nothing else would ever release it.
- `#openChannel` rejects instead of throwing synchronously when closed; a retry reaches it from an event listener, where a throw escapes into noble's `emit`.

## Tests

First test suite for this package (16 tests). Every production hunk was mutation-proven individually — the hunk reverted, the failure observed, the hunk restored.

The fixture mirrors noble's observable behavior deliberately, including that a failed connect is delivered **twice** (once on the peripheral's `connect` event, once as the `connectAsync` rejection). That is what makes the existing duplicate-retry guard load-bearing: deleting it fails 5 tests, and before the fixture modelled it the guard had no coverage at all.

## Review follow-up (second commit)

An independent review of the above found two defects, both fixed with tests:

- **An abort during connect or the interview stranded the link.** The abort handler rejected the caller but never disconnected, and it had just stopped the interview timeout — the one handler that disconnects in that state. It now mirrors that handler.
- **The connection reservation was released by address, not by ownership.** An attempt resuming after its own abort or timeout could delete a reservation belonging to a later caller, admitting a third concurrent attempt against the same peripheral. Every exit now releases through a helper that acts only while the attempt still owns the address, which also retired the previous retry-only flag.

The review also showed one of my tests was not discriminating: the closed-interface case only matters when the retry is driven from the `disconnect` listener, where a throw escapes into noble's `emit`; driven from the async connect handler it rejects either way. Retargeted, and the fake now emits the `disconnect` event from `disconnectAsync` as noble does so channel teardown actually runs.

## Known, not addressed

- `npm test -- -p packages/nodejs-ble` exits 1 in the web phase: the root script is `matter-test -w`, and with `-p` the harness forces web tests on regardless of whether the package opted in. nodejs-ble cannot run in a browser (it loads native bindings). `npm test -- -p packages/nodejs` fails the same way today, and the full `npm test` that CI runs exits 0 — `supportsWebTests` gates correctly for workspace runs. The gap is in `packages/testing/src/cli.ts`, not here.
- `packages/react-native/src/ble/ReactNativeBleChannel.ts` still ignores `options.abort`, so that transport does not yet honour the documented contract.
- The `connectTimeout` handler has the same disconnect gap the abort handler just fixed; its own comment notes noble sometimes swallows the event, which means the link may well be up. Pre-existing.
- `close()` does not abort in-flight attempts — it only disconnects `#openChannels` entries.

## Not addressed

The BTP first-packet problem on adapters without Data Length Extension described in the same thread is a separate device/BTP-layer issue.

Refs matter-js/matterjs-server#929

## Trade-off worth a second opinion

Fail-fast on `"error"` is gone, and there is no backoff between retries. A genuinely wedged peripheral now costs up to 3 × the 2-minute `connectTimeout` instead of rejecting instantly. The field capture argues for immediate retry (attempt 2 succeeded ~200 ms later), but capping `error`-state entry at fewer tries is an easy change if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

