### PR TITLE
feat(storage): let the storage driver decide how long client cache writes are buffered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: DNS-SD ignores SRV records with port 0, an empty target or an out-of-range port
     - Fix: DNS-SD resolution queries A/AAAA for the SRV target host instead of the service instance name
     - Fix: The `Symbol.metadata` polyfill no longer conflicts with `lib.esnext.decorators` in the published declarations
+    - Enhancement: A storage driver states how long a consumer may buffer dirty values via `StorageDriver.writeCoalescingInterval`, defaulting to 20 minutes; `MemoryStorageDriver` reports zero
 
 - @matter/model
     - Breaking: A provisional element is no longer mandatory; conformance following a `P` describes the conformance intended once the element leaves provisional state
@@ -68,10 +69,13 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Writing a fabric-scoped list entry that stems from a cluster whose schema could not be resolved no longer produces two conflicting fabricIndex fields
     - Fix: A rejected write to an attribute served by dynamic properties restores the previous value instead of deleting the property, and a rejected write to a previously absent attribute leaves no slot behind instead of one holding `undefined`
     - Fix: Factory reset removes commissioned peers and the certificate authority's key material; a peer that cannot be torn down no longer blocks the reset
+    - Adjustment: `NetworkServer.State.clientCacheFlushInterval` defaults to the storage driver's `writeCoalescingInterval` instead of a fixed 20 minutes; set it to zero to persist every change immediately
+    - Adjustment: A `SoftwareUpdateManager.State.announcementInterval` of zero disables OTA provider announcements
 
 - @matter/nodejs
     - Breaking: `FileStorageDriver`'s constructor no longer accepts a `clear` argument; clearing is handled by `StorageService`
     - Fix: Ensure that `--storage-clear`/`MATTER_STORAGE_CLEAR` is honored again and clears the storage on start
+    - Adjustment: `SqliteStorageDriver` and `JsonFileStorageDriver` report a `writeCoalescingInterval` of zero, so client cache data is no longer held back for 20 minutes on these drivers
 
 - @matter/nodejs-ble
     - Fix: A connection attempt that BLE reports as failed is retried instead of failing commissioning on the first try
@@ -112,6 +116,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @project-chip/matter.js
     - Deprecation: Every class, type and function of the legacy controller API is now marked deprecated and scheduled for removal in 0.19; use the `ServerNode.peers` / `ClientNode` API of `@matter/node` instead
+    - Feature: `CommissioningController` accepts `clientCacheFlushInterval` to override how long node state is buffered before it is written to storage
 
 ## 0.17.9 (2026-08-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: DNS-SD ignores SRV records with port 0, an empty target or an out-of-range port
     - Fix: DNS-SD resolution queries A/AAAA for the SRV target host instead of the service instance name
     - Fix: The `Symbol.metadata` polyfill no longer conflicts with `lib.esnext.decorators` in the published declarations
-    - Enhancement: A storage driver states how long a consumer may buffer dirty values via `StorageDriver.writeCoalescingInterval`, defaulting to 20 minutes; `MemoryStorageDriver` reports zero
+    - Enhancement: A storage driver states how long a consumer may buffer dirty values via `StorageDriver.writeCoalescingInterval`, defaulting to 20 minutes; `MemoryStorageDriver` reports `Instant`
 
 - @matter/model
     - Breaking: A provisional element is no longer mandatory; conformance following a `P` describes the conformance intended once the element leaves provisional state
@@ -69,13 +69,13 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Writing a fabric-scoped list entry that stems from a cluster whose schema could not be resolved no longer produces two conflicting fabricIndex fields
     - Fix: A rejected write to an attribute served by dynamic properties restores the previous value instead of deleting the property, and a rejected write to a previously absent attribute leaves no slot behind instead of one holding `undefined`
     - Fix: Factory reset removes commissioned peers and the certificate authority's key material; a peer that cannot be torn down no longer blocks the reset
-    - Adjustment: `NetworkServer.State.clientCacheFlushInterval` defaults to the storage driver's `writeCoalescingInterval` instead of a fixed 20 minutes; set it to zero to persist every change immediately
-    - Adjustment: A `SoftwareUpdateManager.State.announcementInterval` of zero disables OTA provider announcements
+    - Adjustment: `NetworkServer.State.clientCacheFlushInterval` defaults to the storage driver's `writeCoalescingInterval` instead of a fixed 20 minutes; set it to `Instant` to persist every change immediately
+    - Adjustment: A `SoftwareUpdateManager.State.announcementInterval` of `Instant` disables OTA provider announcements
 
 - @matter/nodejs
     - Breaking: `FileStorageDriver`'s constructor no longer accepts a `clear` argument; clearing is handled by `StorageService`
     - Fix: Ensure that `--storage-clear`/`MATTER_STORAGE_CLEAR` is honored again and clears the storage on start
-    - Adjustment: `SqliteStorageDriver` and `JsonFileStorageDriver` report a `writeCoalescingInterval` of zero, so client cache data is no longer held back for 20 minutes on these drivers
+    - Adjustment: `SqliteStorageDriver` and `JsonFileStorageDriver` report a `writeCoalescingInterval` of `Instant`, so client cache data is no longer held back for 20 minutes on these drivers
 
 - @matter/nodejs-ble
     - Fix: A connection attempt that BLE reports as failed is retried instead of failing commissioning on the first try

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/general
     - Enhancement: New `MatterAggregateError.settleSeries()` runs tasks in order, continuing past a failure, and reports the accumulated errors
+    - Enhancement: A storage driver states how long a consumer may buffer dirty values via `StorageDriver.writeCoalescingInterval`, defaulting to 20 minutes; `MemoryStorageDriver` reports `Instant`
     - Fix: Opening a namespace whose `driver.json` names an unregistered storage driver now throws `NoProviderError` instead of silently opening the existing data with a mismatched driver
     - Fix: DNS-SD ignores SRV records with port 0, an empty target or an out-of-range port
     - Fix: DNS-SD resolution queries A/AAAA for the SRV target host instead of the service instance name
     - Fix: The `Symbol.metadata` polyfill no longer conflicts with `lib.esnext.decorators` in the published declarations
-    - Enhancement: A storage driver states how long a consumer may buffer dirty values via `StorageDriver.writeCoalescingInterval`, defaulting to 20 minutes; `MemoryStorageDriver` reports `Instant`
 
 - @matter/model
     - Breaking: A provisional element is no longer mandatory; conformance following a `P` describes the conformance intended once the element leaves provisional state
@@ -40,7 +40,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Breaking: A LongIdleTimeSupport ICD must select CheckInProtocolSupport and UserActiveModeTrigger
     - Breaking: A node that accepts more than one path per invoke must select the General Diagnostics DataModelTest feature
     - Breaking: An unreported client node attribute reads its schema default, else the specification's fallback value for its type, when the attribute is mandatory under the peer's supported features, and `undefined` otherwise — regardless of the peer's AttributeList (an enum attribute reads `undefined`, as the specification defines its fallback as manufacturer-specific). The value is a detached copy, so mutating a struct or list read from an unreported attribute does not write through
-    - Breaking: Configured options, environment variables and state-class field initializers no longer seed a client node's cluster state; the peer's reports are the only source of values
+    - Breaking: Configured options, environment variables, and state-class field initializers no longer seed a client node's cluster state; the peer's reports are the only source of values
     - Breaking: Adding a server cluster to an endpoint fails when its selected features violate the conformance of its FeatureMap
     - Breaking: Provisional elements are no longer implemented by default; supply a state value or use `ClusterBehavior.enable()` to implement one
     - Breaking: `SoftwareUpdateManager.addUpdateConsent()` and `forceUpdate()` take the update as an object instead of three positional arguments, so it can carry per-update options
@@ -59,6 +59,8 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: `network.profiles` accepts `bdxAdditionalMrpDelay`
     - Adjustment: A node with commissioning disabled (e.g. a controller) now binds an ephemeral operational port instead of the standard Matter port (5540) when `NetworkServer.port` is unset; commissionable nodes still default to 5540 and an explicit port is always honored
     - Adjustment: A commissioned peer's fabric label is new reconciled to the controller's once after its subscription is first established on start by `ClientNode`
+    - Adjustment: `NetworkServer.State.clientCacheFlushInterval` defaults to the storage driver's `writeCoalescingInterval` instead of a fixed 20 minutes; set it to `Instant` to persist every change immediately
+    - Adjustment: A `SoftwareUpdateManager.State.announcementInterval` of `Instant` disables OTA provider announcements
     - Fix: Struct validation resolves a member stored under its TLV tag number, so a constraint violation there is caught and a mandatory member present only at its id no longer raises a conformance error
     - Fix: `endpoints.size` no longer double-counts the root endpoint
     - Fix: A commissioned peer's connection state leaves `Connected` as soon as its last operational session is lost
@@ -69,13 +71,11 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Writing a fabric-scoped list entry that stems from a cluster whose schema could not be resolved no longer produces two conflicting fabricIndex fields
     - Fix: A rejected write to an attribute served by dynamic properties restores the previous value instead of deleting the property, and a rejected write to a previously absent attribute leaves no slot behind instead of one holding `undefined`
     - Fix: Factory reset removes commissioned peers and the certificate authority's key material; a peer that cannot be torn down no longer blocks the reset
-    - Adjustment: `NetworkServer.State.clientCacheFlushInterval` defaults to the storage driver's `writeCoalescingInterval` instead of a fixed 20 minutes; set it to `Instant` to persist every change immediately
-    - Adjustment: A `SoftwareUpdateManager.State.announcementInterval` of `Instant` disables OTA provider announcements
 
 - @matter/nodejs
     - Breaking: `FileStorageDriver`'s constructor no longer accepts a `clear` argument; clearing is handled by `StorageService`
-    - Fix: Ensure that `--storage-clear`/`MATTER_STORAGE_CLEAR` is honored again and clears the storage on start
     - Adjustment: `SqliteStorageDriver` and `JsonFileStorageDriver` report a `writeCoalescingInterval` of `Instant`, so client cache data is no longer held back for 20 minutes on these drivers
+    - Fix: Ensure that `--storage-clear`/`MATTER_STORAGE_CLEAR` is honored again and clears the storage on start
 
 - @matter/nodejs-ble
     - Fix: A connection attempt that BLE reports as failed is retried instead of failing commissioning on the first try
@@ -106,7 +106,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: `Cluster.with()` rejects a feature the cluster does not define and returns one frozen namespace per selection
 
 - @matter/testing
-    - Enhancement: `certTest()` defines controller-side certification tests with per-step PICS gating, device-log expectations and evidence recording; devices run as chip apps (docker or local binary) or matter.js test apps, selected via `MATTER_CERT_DEVICE`
+    - Enhancement: `certTest()` defines controller-side certification tests with per-step PICS gating, device-log expectations, and evidence recording; devices run as chip apps (docker or local binary) or matter.js test apps, selected via `MATTER_CERT_DEVICE`
     - Enhancement: A cert test step can declare itself `notApplicable`, recording it as skipped with a reason instead of running it
     - Enhancement: `PromptDrivenPythonTest` drives chip python test scripts that prompt for manual commissioning steps
     - Enhancement: `matter-test`'s post-test clean-exit grace period is overridable via `MATTER_TEST_SHUTDOWN_TIMEOUT_MS`
@@ -115,7 +115,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: Certification controller tests run against a controller × device matrix, adding chip-tool as a second controller alongside matter.js's own
 
 - @project-chip/matter.js
-    - Deprecation: Every class, type and function of the legacy controller API is now marked deprecated and scheduled for removal in 0.19; use the `ServerNode.peers` / `ClientNode` API of `@matter/node` instead
+    - Deprecation: Every class, type, and function of the legacy controller API is now marked deprecated and scheduled for removal in 0.19; use the `ServerNode.peers` / `ClientNode` API of `@matter/node` instead
     - Feature: `CommissioningController` accepts `clientCacheFlushInterval` to override how long node state is buffered before it is written to storage
 
 ## 0.17.9 (2026-08-06)
@@ -190,7 +190,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Thermostat adjusts the coupled setpoint limit to preserve the AutoMode deadband instead of rejecting the write
     - Fix: Choice conformance no longer requires a member gated by an inapplicable condition (e.g. `[ICTL].b+` when the feature is unsupported)
     - Fix: Support the `!=` (not-equal) operator in value conformance expressions
-    - Fix: Ensure `FabricAuthority` is fully constructed before it is used in the WebRTC Transport Requestor, OTA Software Update Provider and Software Update clusters
+    - Fix: Ensure `FabricAuthority` is fully constructed before it is used in the WebRTC Transport Requestor, OTA Software Update Provider, and Software Update clusters
     - Fix: Consider existing node IDs when determining the next node ID to commission
     - Fix: Determine the network medium of nodes without a Network Commissioning cluster from the WiFi or Thread Network Diagnostics cluster on their root endpoint
 
@@ -379,7 +379,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: The MRP retransmission interval is no longer capped below the peer's idle interval
     - Fix: The connection fallback address is now compared by value, so a rediscovered last-known address is no longer mistaken for an address change
     - Fix: Ensures that subscriptions established through an interaction are closed when the interaction closes (e.g. node disable/disconnect or decommission)
-    - Fix: Ensures spec-compliant read/subscribe/write/invoke responses for a model-known but absent high-privilege attribute, event or command
+    - Fix: Ensures spec-compliant read/subscribe/write/invoke responses for a model-known but absent high-privilege attribute, event, or command
     - Fix: Decodes VendorID/ProductID from the "fallback method" (`Mvid:`/`Mpid:` in the commonName) of attestation certificates
 
 - @matter/types
@@ -484,7 +484,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - Breaking: Matter 1.5/1.5.1 specification introduces some changes, as always with new Matter specification versions. You might need to adjust your code.
     - Some Namespaces were renamed and now have a "Common*" prefix
-    - Several previous "Zigbee only" features, attributes and commands were removed because they were never allowed for Matter
+    - Several previous "Zigbee only" features, attributes, and commands were removed because they were never allowed for Matter
 
 - @matter/\*
     - Upgraded to Matter specification version 1.5/1.5.1

--- a/packages/general/src/storage/MemoryStorageDriver.ts
+++ b/packages/general/src/storage/MemoryStorageDriver.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Duration } from "#time/Duration.js";
+import { Instant } from "#time/TimeUnit.js";
 import { deepCopy } from "#util/DeepCopy.js";
 import { CloneableStorage, StorageDriver, StorageError } from "./StorageDriver.js";
 import { SupportedStorageTypes } from "./StringifyTools.js";
@@ -23,7 +24,7 @@ export class MemoryStorageDriver extends StorageDriver implements CloneableStora
     }
 
     override get writeCoalescingInterval(): Duration {
-        return 0;
+        return Instant;
     }
 
     static create(_namespace?: unknown, _descriptor?: StorageDriver.Descriptor) {

--- a/packages/general/src/storage/MemoryStorageDriver.ts
+++ b/packages/general/src/storage/MemoryStorageDriver.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { Duration } from "#time/Duration.js";
 import { deepCopy } from "#util/DeepCopy.js";
 import { CloneableStorage, StorageDriver, StorageError } from "./StorageDriver.js";
 import { SupportedStorageTypes } from "./StringifyTools.js";
@@ -19,6 +20,10 @@ export class MemoryStorageDriver extends StorageDriver implements CloneableStora
 
     get initialized() {
         return this.isInitialized;
+    }
+
+    override get writeCoalescingInterval(): Duration {
+        return 0;
     }
 
     static create(_namespace?: unknown, _descriptor?: StorageDriver.Descriptor) {

--- a/packages/general/src/storage/StorageDriver.ts
+++ b/packages/general/src/storage/StorageDriver.ts
@@ -29,7 +29,8 @@ export abstract class StorageDriver extends BaseStorageDriver {
     /**
      * The interval for which a consumer may buffer dirty values before writing them.
      *
-     * Drivers that coalesce writes themselves, or where a write is cheap, report zero so consumers write immediately.
+     * Drivers that coalesce writes themselves, or where a write is cheap, report `Instant` so consumers write
+     * immediately.
      */
     get writeCoalescingInterval(): Duration {
         return Minutes(20);

--- a/packages/general/src/storage/StorageDriver.ts
+++ b/packages/general/src/storage/StorageDriver.ts
@@ -6,6 +6,8 @@
 
 import type { Directory } from "../fs/Directory.js";
 import { ImplementationError, MatterError } from "../MatterError.js";
+import type { Duration } from "../time/Duration.js";
+import { Minutes } from "../time/TimeUnit.js";
 import { MaybePromise } from "../util/Promises.js";
 import { BaseStorageDriver, type StorageType } from "./BaseStorageDriver.js";
 import { DatafileRoot } from "./DatafileRoot.js";
@@ -23,6 +25,15 @@ export class StorageLockError extends StorageError {}
  */
 export abstract class StorageDriver extends BaseStorageDriver {
     override readonly type = "kv" as const;
+
+    /**
+     * The interval for which a consumer may buffer dirty values before writing them.
+     *
+     * Drivers that coalesce writes themselves, or where a write is cheap, report zero so consumers write immediately.
+     */
+    get writeCoalescingInterval(): Duration {
+        return Minutes(20);
+    }
 
     abstract get(contexts: string[], key: string): MaybePromise<SupportedStorageTypes | undefined>;
     abstract set(contexts: string[], values: Record<string, SupportedStorageTypes>): MaybePromise<void>;
@@ -157,6 +168,10 @@ export namespace StorageDriver {
 
         override get initialized() {
             return this.storage.initialized;
+        }
+
+        override get writeCoalescingInterval() {
+            return this.storage.writeCoalescingInterval;
         }
 
         override initialize(): MaybePromise<void> {

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -240,6 +240,12 @@ export type CommissioningControllerOptions = CommissioningControllerNodeOptions 
     readonly transportPreference?: "tcp" | "udp";
 
     /**
+     * Interval at which state cached for commissioned nodes is flushed to storage. Defaults to the interval the
+     * storage driver asks for. Set to zero to disable buffering and persist every change immediately.
+     */
+    readonly clientCacheFlushInterval?: Duration;
+
+    /**
      * Options for the BasicInformation cluster of the Controller node.
      * The vendorId is determined by the adminVendorId!
      */
@@ -403,6 +409,7 @@ export class CommissioningController {
             rootFabric,
             enableOtaProvider,
             basicInformation = {},
+            clientCacheFlushInterval,
         } = this.#options;
 
         // Initialize the Storage in a compatible way for the legacy API and new style for new API
@@ -427,6 +434,7 @@ export class CommissioningController {
             environment: this.#environment,
             enableOtaProvider,
             basicInformation,
+            clientCacheFlushInterval,
         });
 
         if (!controller.ble) {

--- a/packages/matter.js/src/CommissioningController.ts
+++ b/packages/matter.js/src/CommissioningController.ts
@@ -241,7 +241,7 @@ export type CommissioningControllerOptions = CommissioningControllerNodeOptions 
 
     /**
      * Interval at which state cached for commissioned nodes is flushed to storage. Defaults to the interval the
-     * storage driver asks for. Set to zero to disable buffering and persist every change immediately.
+     * storage driver asks for. Set to `Instant` to disable buffering and persist every change immediately.
      */
     readonly clientCacheFlushInterval?: Duration;
 

--- a/packages/matter.js/src/MatterController.ts
+++ b/packages/matter.js/src/MatterController.ts
@@ -28,6 +28,7 @@ import {
     Construction,
     Crypto,
     Diagnostic,
+    Duration,
     Environment,
     ImplementationError,
     InternalError,
@@ -151,6 +152,7 @@ export class MatterController {
         environment: Environment;
         enableOtaProvider?: boolean;
         basicInformation?: Partial<Omit<BasicInformation.Attributes, "vendorId">>;
+        clientCacheFlushInterval?: Duration;
     }): Promise<MatterController> {
         const {
             rootFabric,
@@ -315,6 +317,7 @@ export class MatterController {
         environment: Environment;
         enableOtaProvider?: boolean;
         basicInformation?: Partial<Omit<BasicInformation.Attributes, "vendorId">>;
+        clientCacheFlushInterval?: Duration;
     }) {
         const crypto = options.environment.get(Crypto);
         const {
@@ -335,6 +338,7 @@ export class MatterController {
             fabric,
             enableOtaProvider = false,
             basicInformation = {},
+            clientCacheFlushInterval,
         } = options;
 
         this.#construction = Construction(this, async () => {
@@ -350,6 +354,7 @@ export class MatterController {
                     port: localPort,
                     tcp,
                     transportPreference,
+                    ...(clientCacheFlushInterval === undefined ? undefined : { clientCacheFlushInterval }),
                 },
                 basicInformation: {
                     ...basicInformation,

--- a/packages/node/src/behavior/system/network/NetworkServer.ts
+++ b/packages/node/src/behavior/system/network/NetworkServer.ts
@@ -5,7 +5,7 @@
  */
 
 import { ServerSubscriptionConfig } from "#node/server/ServerSubscription.js";
-import { DeepPartial, Duration, Logger, Minutes } from "@matter/general";
+import { DeepPartial, Duration, Logger } from "@matter/general";
 import { duration, field, uint16 } from "@matter/model";
 import { Ble, FabricManager, NetworkProfiles, PeerTimingParameters } from "@matter/protocol";
 import { DiscoveryCapabilitiesBitmap, TypeFromPartialBitSchema } from "@matter/types";
@@ -248,11 +248,11 @@ export namespace NetworkServer {
         profiles?: ProfilesConfig;
 
         /**
-         * Interval at which dirty client cache data is flushed to storage.  Set to `undefined` to disable buffering
-         * and persist every change immediately.
+         * Interval at which dirty client cache data is flushed to storage.  Defaults to the write-coalescing interval
+         * the storage driver asks for.  Set to zero to disable buffering and persist every change immediately.
          */
         @field(duration)
-        clientCacheFlushInterval?: Duration = Minutes(20);
+        clientCacheFlushInterval?: Duration = undefined;
     }
 
     /**

--- a/packages/node/src/behavior/system/network/NetworkServer.ts
+++ b/packages/node/src/behavior/system/network/NetworkServer.ts
@@ -249,7 +249,7 @@ export namespace NetworkServer {
 
         /**
          * Interval at which dirty client cache data is flushed to storage.  Defaults to the write-coalescing interval
-         * the storage driver asks for.  Set to zero to disable buffering and persist every change immediately.
+         * the storage driver asks for.  Set to `Instant` to disable buffering and persist every change immediately.
          */
         @field(duration)
         clientCacheFlushInterval?: Duration = undefined;

--- a/packages/node/src/behavior/system/software-update/OtaAnnouncements.ts
+++ b/packages/node/src/behavior/system/software-update/OtaAnnouncements.ts
@@ -58,7 +58,7 @@ export class OtaAnnouncements {
     }
 
     /**
-     * Set the interval to a time value, or to zero to disable announcements
+     * Set the interval to a time value, or to `Instant` to disable announcements
      */
     set interval(interval: Duration | undefined) {
         if (!interval) {

--- a/packages/node/src/behavior/system/software-update/OtaAnnouncements.ts
+++ b/packages/node/src/behavior/system/software-update/OtaAnnouncements.ts
@@ -58,10 +58,10 @@ export class OtaAnnouncements {
     }
 
     /**
-     * Set the interval to a time value or undefined to disable announcements
+     * Set the interval to a time value, or to zero to disable announcements
      */
     set interval(interval: Duration | undefined) {
-        if (interval === undefined) {
+        if (!interval) {
             this.#announcementInterval = undefined;
             this.#announcementTimer?.stop();
             this.#announcementTimer = undefined;

--- a/packages/node/src/behavior/system/software-update/SoftwareUpdateManager.ts
+++ b/packages/node/src/behavior/system/software-update/SoftwareUpdateManager.ts
@@ -1270,7 +1270,7 @@ export namespace SoftwareUpdateManager {
         /** Announce this controller as Update provider to all nodes */
         announceAsDefaultProvider = false;
 
-        /** Interval to Announces this controller as Update provider. Must not be lower than 24h! */
+        /** Interval to Announces this controller as Update provider. Must not be lower than 24h, zero disables. */
         announcementInterval = Hours(24);
 
         /**

--- a/packages/node/src/behavior/system/software-update/SoftwareUpdateManager.ts
+++ b/packages/node/src/behavior/system/software-update/SoftwareUpdateManager.ts
@@ -1270,7 +1270,7 @@ export namespace SoftwareUpdateManager {
         /** Announce this controller as Update provider to all nodes */
         announceAsDefaultProvider = false;
 
-        /** Interval to Announces this controller as Update provider. Must not be lower than 24h, zero disables. */
+        /** Interval to Announces this controller as Update provider. Must not be lower than 24h, `Instant` disables. */
         announcementInterval = Hours(24);
 
         /**

--- a/packages/node/src/storage/client/ClientCacheBuffer.ts
+++ b/packages/node/src/storage/client/ClientCacheBuffer.ts
@@ -34,20 +34,25 @@ export class ClientCacheBuffer {
     /**
      * If buffering is configured on the parent ServerNode, set up the buffer on the store.  The first call creates
      * the buffer and starts the timer; subsequent calls reuse it.
+     *
+     * The flush interval defaults to the storage driver's {@link StorageDriver#writeCoalescingInterval}.  An interval
+     * of zero disables buffering.
      */
     static configure(node: ClientNode, store: ClientNodeStore) {
-        const flushInterval = node.owner.stateOf(NetworkServer).clientCacheFlushInterval;
-        if (flushInterval === undefined) {
+        const parentEnv = node.owner.env;
+        const driver = parentEnv.get(StorageManager).driver;
+        const flushInterval =
+            node.owner.stateOf(NetworkServer).clientCacheFlushInterval ?? driver.writeCoalescingInterval;
+        if (!flushInterval) {
             return;
         }
 
-        const parentEnv = node.owner.env;
         if (parentEnv.has(ClientCacheBuffer)) {
             store.buffer = parentEnv.get(ClientCacheBuffer);
             return;
         }
 
-        const buffer = new ClientCacheBuffer(parentEnv.get(StorageManager).driver, flushInterval);
+        const buffer = new ClientCacheBuffer(driver, flushInterval);
         parentEnv.set(ClientCacheBuffer, buffer);
         buffer.#start();
         store.buffer = buffer;

--- a/packages/node/src/storage/client/ClientCacheBuffer.ts
+++ b/packages/node/src/storage/client/ClientCacheBuffer.ts
@@ -36,7 +36,7 @@ export class ClientCacheBuffer {
      * the buffer and starts the timer; subsequent calls reuse it.
      *
      * The flush interval defaults to the storage driver's {@link StorageDriver#writeCoalescingInterval}.  An interval
-     * of zero disables buffering.
+     * of `Instant` disables buffering.
      */
     static configure(node: ClientNode, store: ClientNodeStore) {
         const parentEnv = node.owner.env;

--- a/packages/node/test/node/ClientCacheBufferTest.ts
+++ b/packages/node/test/node/ClientCacheBufferTest.ts
@@ -6,7 +6,16 @@
 
 import { OnOffClient } from "#behaviors/on-off";
 import { ClientCacheBuffer } from "#storage/client/ClientCacheBuffer.js";
-import { Crypto, deepCopy, Duration, MemoryStorageDriver, Minutes, MockCrypto, Seconds } from "@matter/general";
+import {
+    Crypto,
+    deepCopy,
+    Duration,
+    Instant,
+    MemoryStorageDriver,
+    Minutes,
+    MockCrypto,
+    Seconds,
+} from "@matter/general";
 import { MockSite } from "./mock-site.js";
 import { subscribedPeer } from "./node-helpers.js";
 
@@ -136,7 +145,7 @@ describe("ClientCacheBuffer", () => {
 
     it("does not buffer when the configured interval is zero", async () => {
         await using site = bufferingSite();
-        await expectUnbuffered(site, { controller: { network: { clientCacheFlushInterval: 0 } } as any });
+        await expectUnbuffered(site, { controller: { network: { clientCacheFlushInterval: Instant } } as any });
     });
 
     it("flushes on subscription established", async () => {

--- a/packages/node/test/node/ClientCacheBufferTest.ts
+++ b/packages/node/test/node/ClientCacheBufferTest.ts
@@ -6,9 +6,51 @@
 
 import { OnOffClient } from "#behaviors/on-off";
 import { ClientCacheBuffer } from "#storage/client/ClientCacheBuffer.js";
-import { Crypto, deepCopy, MockCrypto, Seconds } from "@matter/general";
+import { Crypto, deepCopy, Duration, MemoryStorageDriver, Minutes, MockCrypto, Seconds } from "@matter/general";
 import { MockSite } from "./mock-site.js";
 import { subscribedPeer } from "./node-helpers.js";
+
+/** Memory storage does not benefit from buffering, so tests that exercise the buffer need a driver that asks for it */
+class BufferingStorageDriver extends MemoryStorageDriver {
+    override get writeCoalescingInterval(): Duration {
+        return Minutes(20);
+    }
+}
+
+function bufferingSite() {
+    return new MockSite({ createStorageDriver: store => new BufferingStorageDriver(store) });
+}
+
+async function expectUnbuffered(site: MockSite, options?: MockSite.PairOptions) {
+    const { controller, device } = await site.addUncommissionedPair(options);
+
+    const controllerCrypto = controller.env.get(Crypto) as MockCrypto;
+    const deviceCrypto = device.env.get(Crypto) as MockCrypto;
+    controllerCrypto.entropic = deviceCrypto.entropic = true;
+
+    await controller.start();
+
+    const { passcode, discriminator } = device.state.commissioning;
+    await MockTime.resolve(controller.peers.commission({ passcode, discriminator, timeout: Seconds(90) }), {
+        macrotasks: true,
+    });
+
+    controllerCrypto.entropic = deviceCrypto.entropic = false;
+
+    const peer = await subscribedPeer(controller, "peer1");
+
+    expect(controller.env.has(ClientCacheBuffer)).false;
+
+    const storage = site.storageFor("controller1");
+    const storageSnapshot = deepCopy(storage);
+
+    const ep1 = peer.endpoints.require(1);
+    const update = new Promise<boolean>(resolve => ep1.eventsOf(OnOffClient).onOff$Changed.on(resolve));
+    await MockTime.resolve(ep1.commandsOf(OnOffClient).toggle());
+    await MockTime.resolve(update);
+
+    expect(deepCopy(storage)).not.deep.equals(storageSnapshot);
+}
 
 describe("ClientCacheBuffer", () => {
     before(() => {
@@ -16,7 +58,7 @@ describe("ClientCacheBuffer", () => {
     });
 
     it("buffers writes until flush", async () => {
-        await using site = new MockSite();
+        await using site = bufferingSite();
         const { controller } = await site.addCommissionedPair();
         const peer = await subscribedPeer(controller, "peer1");
 
@@ -42,7 +84,7 @@ describe("ClientCacheBuffer", () => {
     });
 
     it("flushes on shutdown", async () => {
-        await using site = new MockSite();
+        await using site = bufferingSite();
         const { controller } = await site.addCommissionedPair();
         const peer = await subscribedPeer(controller, "peer1");
 
@@ -66,7 +108,7 @@ describe("ClientCacheBuffer", () => {
     });
 
     it("persists buffered data across restart", async () => {
-        await using site = new MockSite();
+        await using site = bufferingSite();
         let { controller } = await site.addCommissionedPair();
         const peer = await subscribedPeer(controller, "peer1");
 
@@ -87,45 +129,18 @@ describe("ClientCacheBuffer", () => {
         expect(ep1b.stateOf(OnOffClient).onOff).true;
     });
 
-    it("does not buffer when disabled", async () => {
+    it("does not buffer when the storage driver writes immediately", async () => {
         await using site = new MockSite();
-        const { controller, device } = await site.addUncommissionedPair({
-            controller: { network: { clientCacheFlushInterval: undefined } } as any,
-        });
+        await expectUnbuffered(site);
+    });
 
-        const controllerCrypto = controller.env.get(Crypto) as MockCrypto;
-        const deviceCrypto = device.env.get(Crypto) as MockCrypto;
-        controllerCrypto.entropic = deviceCrypto.entropic = true;
-
-        await controller.start();
-
-        const { passcode, discriminator } = device.state.commissioning;
-        await MockTime.resolve(controller.peers.commission({ passcode, discriminator, timeout: Seconds(90) }), {
-            macrotasks: true,
-        });
-
-        controllerCrypto.entropic = deviceCrypto.entropic = false;
-
-        const peer = await subscribedPeer(controller, "peer1");
-
-        // Should not have a buffer
-        expect(controller.env.has(ClientCacheBuffer)).false;
-
-        const storage = site.storageFor("controller1");
-        const storageSnapshot = deepCopy(storage);
-
-        // Toggle onOff
-        const ep1 = peer.endpoints.require(1);
-        const update = new Promise<boolean>(resolve => ep1.eventsOf(OnOffClient).onOff$Changed.on(resolve));
-        await MockTime.resolve(ep1.commandsOf(OnOffClient).toggle());
-        await MockTime.resolve(update);
-
-        // Without buffering, storage should be updated immediately
-        expect(deepCopy(storage)).not.deep.equals(storageSnapshot);
+    it("does not buffer when the configured interval is zero", async () => {
+        await using site = bufferingSite();
+        await expectUnbuffered(site, { controller: { network: { clientCacheFlushInterval: 0 } } as any });
     });
 
     it("flushes on subscription established", async () => {
-        await using site = new MockSite();
+        await using site = bufferingSite();
         const { controller } = await site.addCommissionedPair();
         await subscribedPeer(controller, "peer1");
 

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -30,7 +30,6 @@ import { ClientNodeFactory } from "#node/client/ClientNodeFactory.js";
 import { ClientStructureEvents } from "#node/client/ClientStructureEvents.js";
 import { ChangeNotificationService } from "#node/integration/ChangeNotificationService.js";
 import { ServerNode } from "#node/ServerNode.js";
-import { ClientCacheBuffer } from "#storage/client/ClientCacheBuffer.js";
 import {
     b$,
     Bytes,
@@ -2701,7 +2700,6 @@ describe("ClientNode", () => {
             const initializer = peer1.env.get(EndpointInitializer) as ClientEndpointInitializer;
             const structure = initializer.structure;
             const request = Read({ attributes: [{}], fabricFilter: structure.subscribedFabricFiltered });
-            const buffer = controller.env.get(ClientCacheBuffer);
 
             const neoStorageKeys = () =>
                 Object.keys(site.storageFor("controller1")).filter(key => key.includes(NEO.toString()));
@@ -2719,7 +2717,6 @@ describe("ClientNode", () => {
             // *** ESTABLISH AND PERSIST NEO ***
 
             await drain(structure.mutate(request, readResult(neoReports(10), descriptorServerListReport(10))));
-            await MockTime.resolve(buffer.flush());
             expect(neoActive(), "NEO should be active").true;
             expect(neoStorageKeys(), "NEO data should be persisted").not.empty;
 
@@ -2728,7 +2725,6 @@ describe("ClientNode", () => {
             // The descriptor still omits NEO and no attribute data is served this interaction, so NEO is genuinely
             // gone and must be removed from both memory and storage.
             await drain(structure.mutate(request, readResult(descriptorServerListReport(11))));
-            await MockTime.resolve(buffer.flush());
 
             expect(neoActive(), "NEO behavior should be dropped").false;
             expect(neoStorageKeys(), "NEO storage should be erased").empty;

--- a/packages/node/test/node/mock-site.ts
+++ b/packages/node/test/node/mock-site.ts
@@ -18,6 +18,7 @@ import {
     Network,
     NetworkSimulator,
     Seconds,
+    StorageDriver,
 } from "@matter/general";
 import { FabricId } from "@matter/types";
 import { MockServerNode } from "./mock-server-node.js";
@@ -30,6 +31,11 @@ export class MockSite {
     #nodes = new Set<ServerNode>();
     #nextNetworkIndex = 1;
     #storage = {} as Record<string, Record<string, any>>;
+    #createStorageDriver: (store: Record<string, any>) => StorageDriver;
+
+    constructor(options?: MockSite.Options) {
+        this.#createStorageDriver = options?.createStorageDriver ?? (store => new MemoryStorageDriver(store));
+    }
 
     addNode<T extends MockServerNode.RootEndpoint = MockServerNode.RootEndpoint>(
         type?: T,
@@ -61,7 +67,7 @@ export class MockSite {
             env.set(Network, (config.simulator ?? this.#simulator).addHost(index));
         }
 
-        new MockStorageService(env, () => new MemoryStorageDriver(this.storageFor(id)));
+        new MockStorageService(env, () => this.#createStorageDriver(this.storageFor(id)));
 
         // Note that we don't use MockServerNode as we don't actually want anything mocked
         const node = new ServerNode(config);
@@ -170,6 +176,10 @@ export class MockSite {
 }
 
 export namespace MockSite {
+    export interface Options {
+        createStorageDriver?: (store: Record<string, any>) => StorageDriver;
+    }
+
     export interface PairOptions {
         controller?: MockServerNode.Configuration<any>;
         device?: MockServerNode.Configuration<any>;

--- a/packages/nodejs/src/storage/fs/JsonFileStorageDriver.ts
+++ b/packages/nodejs/src/storage/fs/JsonFileStorageDriver.ts
@@ -6,6 +6,7 @@
 
 import {
     type DataNamespace,
+    type Duration,
     FilesystemStorageDriver,
     fromJson,
     MemoryStorageDriver,
@@ -57,6 +58,11 @@ export class JsonFileStorageDriver extends FilesystemStorageDriver {
 
     override get initialized() {
         return this.#store.initialized;
+    }
+
+    /** Writes are already coalesced by {@link commitDelay}. */
+    override get writeCoalescingInterval(): Duration {
+        return 0;
     }
 
     override async initialize() {

--- a/packages/nodejs/src/storage/fs/JsonFileStorageDriver.ts
+++ b/packages/nodejs/src/storage/fs/JsonFileStorageDriver.ts
@@ -9,6 +9,7 @@ import {
     type Duration,
     FilesystemStorageDriver,
     fromJson,
+    Instant,
     MemoryStorageDriver,
     Seconds,
     type StorageDriver,
@@ -62,7 +63,7 @@ export class JsonFileStorageDriver extends FilesystemStorageDriver {
 
     /** Writes are already coalesced by {@link commitDelay}. */
     override get writeCoalescingInterval(): Duration {
-        return 0;
+        return Instant;
     }
 
     override async initialize() {

--- a/packages/nodejs/src/storage/sqlite/SqliteStorageDriver.ts
+++ b/packages/nodejs/src/storage/sqlite/SqliteStorageDriver.ts
@@ -7,6 +7,7 @@
 import {
     type CloneableStorage,
     type DataNamespace,
+    type Duration,
     FilesystemStorageDriver,
     fromJson,
     Logger,
@@ -279,6 +280,11 @@ export class SqliteStorageDriver extends FilesystemStorageDriver implements Clon
 
     override get initialized() {
         return this.isInitialized;
+    }
+
+    /** The database coalesces writes itself; it runs in WAL mode with `synchronous = NORMAL`. */
+    override get writeCoalescingInterval(): Duration {
+        return 0;
     }
 
     override async initialize(): Promise<void> {

--- a/packages/nodejs/src/storage/sqlite/SqliteStorageDriver.ts
+++ b/packages/nodejs/src/storage/sqlite/SqliteStorageDriver.ts
@@ -10,6 +10,7 @@ import {
     type Duration,
     FilesystemStorageDriver,
     fromJson,
+    Instant,
     Logger,
     type StorageDriver,
     StorageTransaction,
@@ -284,7 +285,7 @@ export class SqliteStorageDriver extends FilesystemStorageDriver implements Clon
 
     /** The database coalesces writes itself; it runs in WAL mode with `synchronous = NORMAL`. */
     override get writeCoalescingInterval(): Duration {
-        return 0;
+        return Instant;
     }
 
     override async initialize(): Promise<void> {


### PR DESCRIPTION
A controller keeps the state it reads from commissioned nodes in a local cache. Until now those writes were held back for a fixed 20 minutes before being persisted. That number was picked for the write-ahead-log driver, where every commit costs a log entry. It is the wrong number for a database, or for storage that already batches writes itself, and there was no way to change it — which is what #4179 asks for.

## What changes

A storage driver now states how long a consumer may buffer dirty values, through the new `StorageDriver.writeCoalescingInterval`:

- The base value is 20 minutes, so the write-ahead-log driver and the legacy one-file-per-key `FileStorageDriver` behave exactly as before. `FileStorageDriver` is the Node.js default, so a default deployment is unaffected.
- `SqliteStorageDriver` (which runs in WAL mode with `synchronous = NORMAL`), `JsonFileStorageDriver` (which already debounces its writes by one second) and `MemoryStorageDriver` report `Instant` (the project's zero duration), meaning "write immediately".
- A custom driver — the issue reports one backed by Redis — can answer this for itself without any further configuration.

`NetworkServer.State.clientCacheFlushInterval` overrides whatever the driver says, and the legacy `CommissioningController` now accepts the same value as a constructor option, which is what the issue asked for directly.

An OTA provider announcement interval of `Instant` now also disables announcements, instead of logging a warning and silently running at 24 hours.

## Behaviour change to be aware of

`Instant` is now the way to disable client cache buffering. Previously `undefined` did that; `undefined` now means "use whatever the driver asks for". Anyone who disabled buffering explicitly since 0.17 needs to pass `Instant` instead.

On SQLite and JSON-file storage, cached node state is no longer held back for 20 minutes. Both drivers coalesce writes themselves, so this reduces the window in which a crash loses cached state without adding meaningful write load.

## Testing

`npm run build`, `npm test` (full suite), `npm run format-verify` and `npm run lint` all pass.

New and reworked tests in `ClientCacheBufferTest`: buffering follows a driver that asks for it, a driver that writes immediately produces no buffer at all, and an explicitly configured interval of `Instant` disables buffering even when the driver wants it. `MockSite` gained an optional `createStorageDriver` so a test can install a driver with a chosen coalescing interval.

Both production hunks were mutation-tested: removing the driver fallback in `ClientCacheBuffer.configure()` fails the buffering tests, and removing `MemoryStorageDriver`'s `Instant` fails the "writes immediately" test with `expected true to be false`.

Refs #4179

🤖 Generated with [Claude Code](https://claude.com/claude-code)
