### PR TITLE
feat(testing): send a cert test's invoke or write as a timed interaction, and add TC-IDM-5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A composite `PicsSource` no longer patches the PICS file cached for its first source
     - Fix: TC-SC-3.5 turns off `PICS_SDK_CI_ONLY` so the script prompts for commissioning instead of acting as its own commissioner, and drives whichever controller `MATTER_CERT_CONTROLLER` selects
     - Enhancement: A cert test's controller reads and subscribes to events via `CertNodeApi.readEvents()`/`subscribeEvents()`, on both the matter.js and the chip-tool controller
+    - Enhancement: A cert test's controller sends an invoke or attribute write as a timed interaction via `CertNodeApi`'s `timedInteractionTimeoutMs`, on both the matter.js and the chip-tool controller
 
 - @project-chip/matter.js
     - Deprecation: Every class, type, and function of the legacy controller API is now marked deprecated and scheduled for removal in 0.19; use the `ServerNode.peers` / `ClientNode` API of `@matter/node` instead

--- a/packages/testing/src/chip/cert/controller-adapter.ts
+++ b/packages/testing/src/chip/cert/controller-adapter.ts
@@ -149,6 +149,22 @@ export interface AttributeWriteStatus {
     status: number;
 }
 
+/**
+ * Asks for an interaction to be sent as a timed one (Matter Core § 8.7): the controller precedes it
+ * with a `TimedRequest` carrying `timedInteractionTimeoutMs`, waits for the device's status response,
+ * and must then deliver the interaction itself inside that window or the device rejects it.
+ *
+ * Omitted, the controller sends the interaction untimed unless the command or attribute requires
+ * timed interaction on its own.
+ *
+ * The field is a `uint16` on the wire (§ 10.6.11's `TimedRequestMessage`), and chip-tool bounds its own
+ * argument the same way; a larger or fractional value is rejected by whichever controller runs, each in
+ * its own way.
+ */
+export interface TimedInteractionOptions {
+    timedInteractionTimeoutMs?: number;
+}
+
 export interface ReadAttributeOptions {
     /**
      * Whether the read is fabric-filtered (Matter Core § 8.9.2's `FabricFiltered` flag; default
@@ -169,7 +185,13 @@ export interface ReadAttributeOptions {
  * instead.
  */
 export interface CertNodeApi {
-    invoke(cluster: string | number, command: string, args?: object, endpoint?: number): Promise<unknown>;
+    invoke(
+        cluster: string | number,
+        command: string,
+        args?: object,
+        endpoint?: number,
+        options?: TimedInteractionOptions,
+    ): Promise<unknown>;
     readAttribute(path: AttributePathSpec, options?: ReadAttributeOptions): Promise<unknown>;
 
     /**
@@ -180,7 +202,7 @@ export interface CertNodeApi {
      * would exercise a different interaction.
      */
     readAttributes(paths: AttributePathSpec[], options?: ReadAttributeOptions): Promise<AttributeReadEntry[]>;
-    writeAttribute(path: AttributePathSpec, value: unknown): Promise<void>;
+    writeAttribute(path: AttributePathSpec, value: unknown, options?: TimedInteractionOptions): Promise<void>;
 
     /**
      * Writes several attributes in one request, optionally through wildcard paths or conditional on a

--- a/packages/testing/src/chip/cert/controller-adapter.ts
+++ b/packages/testing/src/chip/cert/controller-adapter.ts
@@ -157,9 +157,8 @@ export interface AttributeWriteStatus {
  * Omitted, the controller sends the interaction untimed unless the command or attribute requires
  * timed interaction on its own.
  *
- * The field is a `uint16` on the wire (§ 10.6.11's `TimedRequestMessage`), and chip-tool bounds its own
- * argument the same way; a larger or fractional value is rejected by whichever controller runs, each in
- * its own way.
+ * The field is a `uint16` on the wire (§ 10.6.11's `TimedRequestMessage`). A value outside that range,
+ * or a fractional one, is refused by every adapter before it issues anything.
  */
 export interface TimedInteractionOptions {
     timedInteractionTimeoutMs?: number;

--- a/packages/testing/src/chip/index.ts
+++ b/packages/testing/src/chip/index.ts
@@ -52,6 +52,7 @@ export type {
     ReadEventOptions,
     SubscribeEventOptions,
     SubscribeOptions,
+    TimedInteractionOptions,
 } from "./cert/controller-adapter.js";
 export { resolveControllerImplementation, resolveDeviceFlavor } from "./cert/device-config.js";
 export type { ControllerImplementation } from "./cert/device-config.js";

--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -43,6 +43,7 @@ import { env } from "node:process";
 import type { ChipToolCommissionerName } from "../chip-tool/chip-tool-client.js";
 import { ChipToolClient, resolveChipToolBinary } from "../chip-tool/chip-tool-client.js";
 import { chipJsonToMatter, matterToChipJson, stringifyChipJson } from "../chip-tool/json-codec.js";
+import { timedInteractionTimeoutOf } from "./timed-interaction.js";
 
 /** Name {@link UnsupportedByControllerError} reports for this adapter. */
 const CONTROLLER = "chip-tool";
@@ -105,9 +106,8 @@ function quoteArg(value: string) {
 
 /** chip-tool's own name for the timed-interaction timeout, on `command-by-id` and `write-by-id` alike. */
 function timedArg(options?: TimedInteractionOptions) {
-    return options?.timedInteractionTimeoutMs === undefined
-        ? ""
-        : ` --timedInteractionTimeoutMs ${options.timedInteractionTimeoutMs}`;
+    const timeout = timedInteractionTimeoutOf(options);
+    return timeout === undefined ? "" : ` --timedInteractionTimeoutMs ${timeout}`;
 }
 
 function clusterArg(path: AttributePathSpec) {

--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -33,6 +33,7 @@ import type {
     ReadEventOptions,
     SubscribeEventOptions,
     SubscribeOptions,
+    TimedInteractionOptions,
 } from "@matter/testing";
 import { LineQueue, LogFollower, UnsupportedByControllerError } from "@matter/testing";
 import { mkdtemp, rm } from "node:fs/promises";
@@ -100,6 +101,13 @@ function quoteArg(value: string) {
         return value;
     }
     return `'${value.replace(/[\\']/g, match => `\\${match}`)}'`;
+}
+
+/** chip-tool's own name for the timed-interaction timeout, on `command-by-id` and `write-by-id` alike. */
+function timedArg(options?: TimedInteractionOptions) {
+    return options?.timedInteractionTimeoutMs === undefined
+        ? ""
+        : ` --timedInteractionTimeoutMs ${options.timedInteractionTimeoutMs}`;
 }
 
 function clusterArg(path: AttributePathSpec) {
@@ -648,7 +656,13 @@ class ChipToolCertNodeApi implements CertNodeApi {
         return this.#nodeId.toString();
     }
 
-    async invoke(cluster: string | number, command: string, args?: object, endpoint = 0): Promise<unknown> {
+    async invoke(
+        cluster: string | number,
+        command: string,
+        args?: object,
+        endpoint = 0,
+        options?: TimedInteractionOptions,
+    ): Promise<unknown> {
         const { cluster: clusterModel, clusterId, command: commandModel } = commandModelFor(cluster, command);
         const fields =
             args !== undefined && Object.keys(args).length > 0
@@ -657,7 +671,7 @@ class ChipToolCertNodeApi implements CertNodeApi {
 
         const reply = await this.#adapter.execute(
             `any command-by-id ${hex(clusterId)} ${hex(commandModel.id)} ${quoteArg(fields)} ` +
-                `${this.#node} ${endpoint}`,
+                `${this.#node} ${endpoint}${timedArg(options)}`,
         );
 
         const operation = `invoke ${clusterModel.name}.${commandModel.name}`;
@@ -726,13 +740,13 @@ class ChipToolCertNodeApi implements CertNodeApi {
         return toReadEntries(reply.values);
     }
 
-    async writeAttribute(path: AttributePathSpec, value: unknown): Promise<void> {
+    async writeAttribute(path: AttributePathSpec, value: unknown, options?: TimedInteractionOptions): Promise<void> {
         const { endpoint, cluster, attribute } = path;
         if (endpoint === undefined || cluster === undefined || attribute === undefined) {
             throw new ImplementationError("writeAttribute requires a concrete endpoint/cluster/attribute path");
         }
 
-        const reply = await this.#write([{ path, value }], "writeAttribute");
+        const reply = await this.#write([{ path, value }], "writeAttribute", options);
         assertNoFailure(reply, `write ${JSON.stringify(path)}`);
 
         const status = statusFor(reply.statuses, { endpoint, cluster, attribute });
@@ -945,7 +959,7 @@ class ChipToolCertNodeApi implements CertNodeApi {
         return this.#adapter.execute(command, { attributes: paths });
     }
 
-    #write(entries: AttributeWriteEntry[], operation: string) {
+    #write(entries: AttributeWriteEntry[], operation: string, options?: TimedInteractionOptions) {
         const values = entries.map(({ path: { cluster, endpoint, attribute }, value }) => {
             if (cluster === undefined || attribute === undefined) {
                 throw new ImplementationError(`${operation} requires a concrete cluster and attribute`);
@@ -971,6 +985,7 @@ class ChipToolCertNodeApi implements CertNodeApi {
         if (versions.length) {
             command += ` --data-version ${versions.join(",")}`;
         }
+        command += timedArg(options);
 
         return this.#adapter.execute(command, { attributes: entries.map(({ path }) => path) });
     }

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -15,6 +15,7 @@ import {
     LogDestination,
     LogFormat,
     Logger,
+    Millis,
     MockStorageService,
     ObserverGroup,
     Seconds,
@@ -63,6 +64,7 @@ import type {
     ReadEventOptions,
     SubscribeEventOptions,
     SubscribeOptions,
+    TimedInteractionOptions,
 } from "@matter/testing";
 import { LineQueue, LogFollower } from "@matter/testing";
 import { AsyncLocalStorage } from "node:async_hooks";
@@ -105,6 +107,20 @@ function toIds(path: AttributePathSpec) {
         clusterId: path.cluster !== undefined ? ClusterId(path.cluster) : undefined,
         attributeId: path.attribute !== undefined ? AttributeId(path.attribute) : undefined,
     };
+}
+
+/**
+ * `Invoke`/`Write` derive `timedRequest` from either flag, and a zero timeout is falsy — asking for one
+ * without `timed` would send the interaction untimed, where chip-tool sends a real timed request for
+ * the same call. An absent option stays absent rather than becoming a default the caller did not ask
+ * for.
+ */
+function timedInteraction(options?: TimedInteractionOptions) {
+    const { timedInteractionTimeoutMs } = options ?? {};
+    if (timedInteractionTimeoutMs === undefined) {
+        return {};
+    }
+    return { timed: true, timeout: Millis(timedInteractionTimeoutMs) };
 }
 
 function isConcretePath(path: AttributePathSpec) {
@@ -265,7 +281,13 @@ class InProcessCertNodeApi implements CertNodeApi {
         return peer;
     }
 
-    invoke(cluster: string | number, command: string, args?: object, endpoint = 0): Promise<unknown> {
+    invoke(
+        cluster: string | number,
+        command: string,
+        args?: object,
+        endpoint = 0,
+        options?: TimedInteractionOptions,
+    ): Promise<unknown> {
         return runTagged(this.#adapterId, async () => {
             const { model: clusterModel, id: clusterId } = clusterModelFor(cluster);
             const commandModel = clusterModel.commands(command);
@@ -273,6 +295,7 @@ class InProcessCertNodeApi implements CertNodeApi {
                 throw new ImplementationError(`Unknown command "${command}" on cluster ${cluster}`);
             }
             const request = Invoke({
+                ...timedInteraction(options),
                 commands: [
                     Invoke.ConcreteCommandRequest({
                         endpoint: EndpointNumber(endpoint),
@@ -365,7 +388,7 @@ class InProcessCertNodeApi implements CertNodeApi {
         });
     }
 
-    writeAttribute(path: AttributePathSpec, value: unknown): Promise<void> {
+    writeAttribute(path: AttributePathSpec, value: unknown, options?: TimedInteractionOptions): Promise<void> {
         return runTagged(this.#adapterId, async () => {
             const { endpoint, cluster, attribute } = path;
             if (endpoint === undefined || cluster === undefined || attribute === undefined) {
@@ -373,6 +396,7 @@ class InProcessCertNodeApi implements CertNodeApi {
             }
             const result = await this.#peer.interaction.write(
                 Write(
+                    timedInteraction(options),
                     Write.Attribute({
                         endpoint: EndpointNumber(endpoint),
                         ...attributeSpecFor(cluster, attribute, value),

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -68,6 +68,7 @@ import type {
 } from "@matter/testing";
 import { LineQueue, LogFollower } from "@matter/testing";
 import { AsyncLocalStorage } from "node:async_hooks";
+import { timedInteractionTimeoutOf } from "./timed-interaction.js";
 
 /**
  * Attributes a matter.js controller `write`/`invoke` call to the {@link InProcessControllerAdapter} whose
@@ -116,11 +117,11 @@ function toIds(path: AttributePathSpec) {
  * for.
  */
 function timedInteraction(options?: TimedInteractionOptions) {
-    const { timedInteractionTimeoutMs } = options ?? {};
-    if (timedInteractionTimeoutMs === undefined) {
+    const timeout = timedInteractionTimeoutOf(options);
+    if (timeout === undefined) {
         return {};
     }
-    return { timed: true, timeout: Millis(timedInteractionTimeoutMs) };
+    return { timed: true, timeout: Millis(timeout) };
 }
 
 function isConcretePath(path: AttributePathSpec) {

--- a/support/chip-testing/src/cert/timed-interaction.ts
+++ b/support/chip-testing/src/cert/timed-interaction.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ImplementationError } from "@matter/main";
+import type { TimedInteractionOptions } from "@matter/testing";
+
+/**
+ * The timeout a timed interaction asks for, or `undefined` for an untimed one.
+ *
+ * Validated here so both adapters refuse the same values: the field is a `uint16` on the wire (Matter
+ * Core § 10.6.11), which chip-tool's own argument bounds too, but matter.js's TLV layer checks bounds
+ * without checking integrality — so a fractional timeout would reach one controller as a truncated
+ * integer and the other as a usage error.
+ */
+export function timedInteractionTimeoutOf(options?: TimedInteractionOptions): number | undefined {
+    const timeout = options?.timedInteractionTimeoutMs;
+    if (timeout === undefined) {
+        return undefined;
+    }
+    if (!Number.isInteger(timeout) || timeout < 0 || timeout > 0xffff) {
+        throw new ImplementationError(`A timed interaction timeout must be an integer from 0 to 65535, not ${timeout}`);
+    }
+    return timeout;
+}

--- a/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
@@ -1081,6 +1081,47 @@ describe("ChipToolControllerAdapter", function () {
         });
     });
 
+    describe("timed interactions", () => {
+        it("asks chip-tool for a timed invoke and a timed write", async () => {
+            const { ref, node } = await commissioned();
+
+            fake.reply = () => ({ results: [] });
+            await node.invoke(requireId(ON_OFF.id, "OnOff"), "on", undefined, 1, { timedInteractionTimeoutMs: 200 });
+            await node.writeAttribute({ endpoint: 1, cluster: LEVEL_CONTROL.id, attribute: ON_LEVEL.id }, 5, {
+                timedInteractionTimeoutMs: 200,
+            });
+
+            expect(fake.commands).deep.equal([
+                `any command-by-id 0x6 0x1 {} ${ref} 1 --timedInteractionTimeoutMs 200`,
+                `any write-by-id 0x8 0x11 5 ${ref} 1 --timedInteractionTimeoutMs 200`,
+            ]);
+        });
+
+        it("sends nothing about timing for an interaction that asked for none", async () => {
+            const { ref, node } = await commissioned();
+
+            fake.reply = () => ({ results: [] });
+            await node.invoke(requireId(ON_OFF.id, "OnOff"), "on", undefined, 1);
+
+            expect(fake.commands).deep.equal([`any command-by-id 0x6 0x1 {} ${ref} 1`]);
+        });
+
+        it("refuses a timeout the wire cannot carry, before issuing anything", async () => {
+            const { node } = await commissioned();
+
+            for (const timedInteractionTimeoutMs of [200.5, -1, 0x10000]) {
+                expect(
+                    await rejectionOf(
+                        node.invoke(requireId(ON_OFF.id, "OnOff"), "on", undefined, 1, { timedInteractionTimeoutMs }),
+                    ),
+                    `timeout ${timedInteractionTimeoutMs}`,
+                ).instanceOf(ImplementationError);
+            }
+
+            expect(fake.commands).deep.equal([]);
+        });
+    });
+
     describe("subscribe", () => {
         const PATH = { endpoint: 1, cluster: ON_OFF.id, attribute: ON_OFF_ATTRIBUTE.id };
         const INTERVALS = { minIntervalFloorSeconds: 1, maxIntervalCeilingSeconds: 10 };

--- a/support/chip-testing/test/cert-framework/tc-idm-5.1-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-5.1-support.test.ts
@@ -1,0 +1,253 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LineQueue, LogFollower } from "@matter/testing";
+import {
+    expectTimedFollowUp,
+    expectTimedRequest,
+    expectUnicastReceipt,
+    timedRequestSequence,
+    timestampMsOf,
+} from "../cert/tc-idm-5.1-support.js";
+import { INVOKE_REQUEST_MESSAGE, WRITE_REQUEST_MESSAGE } from "../cert/tc-support.js";
+
+const TIMEOUT_MS = 200;
+
+/** One chip log line: its own timestamp prefix, then the module tag the matchers anchor on. */
+function line(atMs: number, text: string) {
+    const seconds = Math.floor(atMs / 1000);
+    const millis = Math.round(atMs - seconds * 1000);
+    return `[${seconds}.${millis.toString().padStart(3, "0")}] [42:42] ${text}`;
+}
+
+const T0 = 1786711488_000;
+
+function receipt(atMs: number, category: "S" | "U" | "G", type: string, exchange = "1r") {
+    return line(
+        atMs,
+        `[EM] >>> [E:${exchange} S:2 M:3] (${category}) Msg RX from 1:000000000001B669 --- Type 0001:${type}`,
+    );
+}
+
+function timedRequestLines(atMs: number, category: "S" | "U" | "G" = "S") {
+    return [
+        receipt(atMs, category, "0a (IM:TimedRequest)"),
+        line(atMs, "[DMG] TimedRequestMessage ="),
+        line(atMs, "[DMG] {"),
+        line(atMs, `[DMG] \tTimeoutMs = 0x${TIMEOUT_MS.toString(16)},`),
+        line(atMs, "[DMG] }"),
+    ];
+}
+
+function invokeLines(atMs: number, options: { suppressResponse?: boolean; timed?: boolean; exchange?: string } = {}) {
+    const { suppressResponse = true, timed = true, exchange = "1r" } = options;
+    return [
+        receipt(atMs, "S", "08 (IM:InvokeCommandRequest)", exchange),
+        line(atMs, "[DMG] InvokeRequestMessage ="),
+        line(atMs, "[DMG] {"),
+        ...(suppressResponse ? [line(atMs, "[DMG] \tsuppressResponse = false, ")] : []),
+        ...(timed ? [line(atMs, "[DMG] \ttimedRequest = true, ")] : []),
+        line(atMs, "[DMG] \tInvokeRequests ="),
+    ];
+}
+
+async function withFollower<T>(lines: string[], body: (follower: LogFollower) => Promise<T>): Promise<T> {
+    const source = new LineQueue();
+    const follower = new LogFollower(source.follow(), "th");
+    for (const text of lines) {
+        source.push(text);
+    }
+    try {
+        return await body(follower);
+    } finally {
+        source.close();
+        await follower.close();
+    }
+}
+
+describe("timestampMsOf", () => {
+    it("reads a millisecond fraction, as the harness image's own build prints", () => {
+        expect(timestampMsOf("[1786711488.301] [42:42] [DMG] x")).equal(1786711488_301);
+    });
+
+    it("reads a microsecond fraction, as the certification captures carry", () => {
+        expect(timestampMsOf("[1655797318.626273][7331:7331] CHIP:DMG: x")).equal(1655797318_626.273);
+    });
+
+    it("is undefined for a line carrying no timestamp", () => {
+        expect(timestampMsOf("[DMG] TimedRequestMessage =")).equal(undefined);
+    });
+});
+
+describe("timedRequestSequence", () => {
+    it("asks for the timeout in chip's own bare lowercase hex", () => {
+        const sequence = timedRequestSequence(200);
+
+        expect(sequence).to.have.lengthOf(3);
+        expect(sequence[2].test("[DMG] \tTimeoutMs = 0xc8,")).equal(true);
+        expect(sequence[2].test("[DMG] \tTimeoutMs = 0xc9,")).equal(false);
+    });
+});
+
+describe("expectTimedRequest", () => {
+    it("matches the block and returns the line it matched", async () => {
+        const result = await withFollower(timedRequestLines(T0), follower =>
+            expectTimedRequest(follower, "chip-local", TIMEOUT_MS, 0, 500),
+        );
+
+        expect(result.check.verdict).equal("pass");
+        expect(result.line?.text).contains("TimeoutMs = 0xc8,");
+    });
+
+    it("fails when the device was asked for a different timeout", async () => {
+        const result = await withFollower(timedRequestLines(T0), follower =>
+            expectTimedRequest(follower, "chip-local", 300, 0, 200),
+        );
+
+        expect(result.check.verdict).equal("fail");
+        expect(result.line).equal(undefined);
+    });
+
+    it("reports unverified for a flavor with no pattern for the message", async () => {
+        const result = await withFollower(timedRequestLines(T0), follower =>
+            expectTimedRequest(follower, "matterjs", TIMEOUT_MS, 0, 500),
+        );
+
+        expect(result.check.verdict).equal("unverified");
+    });
+});
+
+describe("expectUnicastReceipt", () => {
+    async function categoryVerdict(category: "S" | "U" | "G") {
+        return withFollower(timedRequestLines(T0, category), async follower => {
+            const timed = await expectTimedRequest(follower, "chip-local", TIMEOUT_MS, 0, 500);
+            return expectUnicastReceipt(timed);
+        });
+    }
+
+    it("passes for a secure unicast session", async () => {
+        expect((await categoryVerdict("S")).verdict).equal("pass");
+    });
+
+    it("passes for an unencrypted unicast session", async () => {
+        expect((await categoryVerdict("U")).verdict).equal("pass");
+    });
+
+    it("fails for a group session", async () => {
+        const check = await categoryVerdict("G");
+
+        expect(check.verdict).equal("fail");
+        expect(check.detail).contains("group session");
+    });
+
+    it("fails when no receive line precedes the message", async () => {
+        const check = await withFollower(timedRequestLines(T0).slice(1), async follower => {
+            const timed = await expectTimedRequest(follower, "chip-local", TIMEOUT_MS, 0, 500);
+            return expectUnicastReceipt(timed);
+        });
+
+        expect(check.verdict).equal("fail");
+        expect(check.detail).contains("No receive line");
+    });
+
+    it("reports unverified when the timed request itself was not located", () => {
+        expect(expectUnicastReceipt({ check: { type: "device-log", verdict: "unverified" } }).verdict).equal(
+            "unverified",
+        );
+    });
+});
+
+describe("expectTimedFollowUp", () => {
+    async function followUp(lines: string[], message = INVOKE_REQUEST_MESSAGE) {
+        return withFollower(lines, async follower => {
+            const timed = await expectTimedRequest(follower, "chip-local", TIMEOUT_MS, 0, 500);
+            return expectTimedFollowUp(follower, "chip-local", message, timed, TIMEOUT_MS, 500);
+        });
+    }
+
+    it("passes when the flagged message follows inside the window", async () => {
+        const check = await followUp([...timedRequestLines(T0), ...invokeLines(T0 + 20)]);
+
+        expect(check.verdict).equal("pass");
+        expect(check.detail).contains("20.0ms");
+    });
+
+    it("passes when the optional suppressResponse line is absent, as a matter.js write is", async () => {
+        const lines = [
+            ...timedRequestLines(T0),
+            receipt(T0 + 5, "S", "06 (IM:WriteRequest)"),
+            line(T0 + 5, "[DMG] WriteRequestMessage ="),
+            line(T0 + 5, "[DMG] {"),
+            line(T0 + 5, "[DMG] \ttimedRequest = true, "),
+        ];
+
+        expect((await followUp(lines, WRITE_REQUEST_MESSAGE)).verdict).equal("pass");
+    });
+
+    it("fails when the message arrives after the window it was promised", async () => {
+        const check = await followUp([...timedRequestLines(T0), ...invokeLines(T0 + TIMEOUT_MS + 1)]);
+
+        expect(check.verdict).equal("fail");
+        expect(check.detail).contains("201.0ms");
+    });
+
+    it("does not accept a later message's flag as this one's", async () => {
+        const check = await followUp([
+            ...timedRequestLines(T0),
+            ...invokeLines(T0 + 10, { timed: false }),
+            ...invokeLines(T0 + 20),
+        ]);
+
+        expect(check.verdict).equal("fail");
+        expect(check.detail).contains("carries no timedRequest flag");
+    });
+
+    it("reports unverified when the timed request itself was not located", async () => {
+        const check = await withFollower([], follower =>
+            expectTimedFollowUp(
+                follower,
+                "chip-local",
+                INVOKE_REQUEST_MESSAGE,
+                { check: { type: "device-log", verdict: "unverified" } },
+                TIMEOUT_MS,
+                500,
+            ),
+        );
+
+        expect(check.verdict).equal("unverified");
+    });
+
+    it("skips an interaction on another exchange and reports the one this request opened", async () => {
+        const check = await followUp([
+            ...timedRequestLines(T0),
+            ...invokeLines(T0 + 10, { exchange: "9r" }),
+            ...invokeLines(T0 + 20),
+        ]);
+
+        expect(check.verdict).equal("pass");
+        expect(check.detail).contains("20.0ms");
+    });
+
+    it("fails when only another exchange's interaction follows", async () => {
+        const check = await followUp([...timedRequestLines(T0), ...invokeLines(T0 + 10, { exchange: "9r" })]);
+
+        expect(check.verdict).equal("fail");
+    });
+
+    it("fails when the log's own clock moved backwards between the two messages", async () => {
+        const check = await followUp([...timedRequestLines(T0), ...invokeLines(T0 - 40)]);
+
+        expect(check.verdict).equal("fail");
+        expect(check.detail).contains("-40.0ms");
+    });
+
+    it("names the message when it carries no flag and nothing later does either", async () => {
+        const check = await followUp([...timedRequestLines(T0), ...invokeLines(T0 + 10, { timed: false })]);
+
+        expect(check.verdict).equal("fail");
+        expect(check.detail).contains("carries no timedRequest flag");
+    });
+});

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1022,6 +1022,44 @@ an `expectAdjacentLines` result as a `CheckRecord`, turning a timeout into a rec
 out of TC-IDM-4.1's own `expectSubscribeEnvelope` at the same time; that TC now calls the shared
 helper with its own sequence and label.
 
+## Timed interactions (`TC-IDM-5.1`)
+
+`CertNodeApi.invoke` and `.writeAttribute` take a `TimedInteractionOptions` with a
+`timedInteractionTimeoutMs`, which turns the interaction into a timed one (Matter Core § 8.7): the
+controller sends a `TimedRequest` carrying that timeout, waits for the device's status response, and
+must deliver the interaction itself inside the window. matter.js's own `Invoke`/`Write` builders derive
+`timedRequest` from a `timeout`, so the adapter only has to pass one through; chip-tool takes
+`--timedInteractionTimeoutMs`, the same option name on `command-by-id` and `write-by-id`.
+
+Do not give the option a default. An absent timeout must stay absent, or every invoke and write in
+every TC silently becomes a timed interaction.
+
+What the plan asks to verify, and how each part is evidenced:
+
+- **The timeout the device was asked for** — `TimedRequestMessage =` / `{` / `TimeoutMs = 0xc8,`, all
+  consecutive; the field is bare lowercase hex and the block closes with a bare `}`.
+- **The message was unicast** — chip's own receive line categorises the session: `(S)` secure unicast,
+  `(U)` unencrypted unicast, `(G)` secure groupcast (`src/messaging/README.md`). `expectUnicastReceipt`
+  scans *backward* from the decode dump for the nearest `Msg RX from` line, which is this message's own
+  since chip logs one message at a time.
+- **The follow-up is the one this request opened** — matched by chip's own exchange id, read off both
+  messages' receive lines, not by "the next message after the timed request". A retry of this
+  interaction, or a second administrator's own timed interaction with the same TH, otherwise stands in
+  for it: the check then passes on someone else's evidence, or fails on a span measured between two
+  different interactions. This is the same rule the subscription checks follow (see "Anchor a
+  subscription ack on its own subscription id"), and it is why `expectUnicastReceipt` and the follow-up
+  check share one receive-line lookup.
+- **The follow-up carried `timedRequest = true`** — matched by *proximity*, not adjacency: chip prints
+  `suppressResponse` before it, and that field is **mandatory on an invoke but optional on a write**
+  (`TlvWriteRequest`), which matter.js omits and chip-tool sends. So the check anchors on the message's
+  opening brace and requires the flag within two lines; a flag further away belongs to a later message.
+- **The follow-up arrived inside the window** — from the two messages' own log timestamps.
+  `timestampMsOf` reads chip's `[<seconds>.<fraction>]` prefix and scales by the fraction's digit count:
+  the harness image prints milliseconds, the certification YAML captures microseconds.
+
+Step 3 (the device withholds its answer to the timed request) is `notApplicable`: the plan itself says
+"might not be testable" and `Test_TC_IDM_5_1.yaml` says "Mark this as not testable /NA. Out of Scope".
+
 ## Why the cert adapter shortens its peer-connection timeout
 
 `CERT_PEER_CONNECTION_TIMEOUT` (15s, `InProcessControllerAdapter.ts`) bounds how long a cert step's

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1034,6 +1034,11 @@ must deliver the interaction itself inside the window. matter.js's own `Invoke`/
 Do not give the option a default. An absent timeout must stay absent, or every invoke and write in
 every TC silently becomes a timed interaction.
 
+Both adapters route the value through `timedInteractionTimeoutOf` (`src/cert/timed-interaction.ts`),
+which refuses anything but an integer in the `uint16` range the wire carries: matter.js's TLV layer
+checks bounds but not integrality, so without it a fractional timeout would reach one controller as a
+truncated integer and the other as a chip-tool usage error.
+
 What the plan asks to verify, and how each part is evidenced:
 
 - **The timeout the device was asked for** — `TimedRequestMessage =` / `{` / `TimeoutMs = 0xc8,`, all

--- a/support/chip-testing/test/cert/TC-IDM-5.1.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-5.1.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Matter } from "@matter/model";
+import type { CheckRecord, CertStepContext } from "@matter/testing";
+import { certTest } from "@matter/testing";
+import { expectTimedFollowUp, expectTimedRequest, expectUnicastReceipt } from "./tc-idm-5.1-support.js";
+import { CommissionedRefs, INVOKE_REQUEST_MESSAGE, requireId, WRITE_REQUEST_MESSAGE } from "./tc-support.js";
+
+const ON_OFF = Matter.clusters.require("OnOff");
+const ON_OFF_ID = requireId(ON_OFF.id, "OnOff cluster");
+const ON_TIME = requireId(ON_OFF.attributes.require("onTime").id, "OnOff.onTime");
+
+const ENDPOINT_1 = 1;
+
+// The timeout Test_TC_IDM_5_1.yaml's own captures ask for, which the plan quotes as its example. The
+// device enforces it, so a late follow-up fails on the device's own answer as well as on the check below.
+const TIMED_INTERACTION_TIMEOUT_MS = 200;
+
+const LOG_TIMEOUT_MS = 15_000;
+
+const commissioned = new CommissionedRefs();
+
+async function recordTimedInteraction(cx: CertStepContext, message: RegExp, from: number): Promise<void> {
+    const th = cx.devices.th;
+
+    const timed = await expectTimedRequest(th.log, th.flavor, TIMED_INTERACTION_TIMEOUT_MS, from, LOG_TIMEOUT_MS);
+    record(cx, timed.check, "TimedRequestMessage");
+
+    record(cx, expectUnicastReceipt(timed), "Timed request session");
+
+    const followUp = await expectTimedFollowUp(
+        th.log,
+        th.flavor,
+        message,
+        timed,
+        TIMED_INTERACTION_TIMEOUT_MS,
+        LOG_TIMEOUT_MS,
+    );
+    record(cx, followUp, "Timed follow-up");
+}
+
+function record(cx: CertStepContext, check: CheckRecord, what: string) {
+    cx.recorder.check(check);
+    if (check.verdict === "fail") {
+        throw new Error(`${what} check failed: ${JSON.stringify(check)}`);
+    }
+}
+
+certTest("TC-IDM-5.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C"], app: "all-clusters" })
+    .step(
+        1,
+        "DUT sends the Timed Request to the TH and then sends an Invoke Request Message to the TH after receiving " +
+            "the status response message from the TH. The Timed Request Message should contain a timeout value in " +
+            "milliseconds. (Example - 200 milliseconds)",
+        async cx => {
+            const dut = cx.controllers.dut;
+            const th = cx.devices.th;
+
+            const ref = await dut.commission({
+                passcode: th.commissioning.passcode,
+                discriminator: th.commissioning.discriminator,
+            });
+            commissioned.set("dut", ref);
+
+            const from = th.log.mark();
+            await dut.node(ref).invoke(ON_OFF_ID, "on", undefined, ENDPOINT_1, {
+                timedInteractionTimeoutMs: TIMED_INTERACTION_TIMEOUT_MS,
+            });
+            cx.recorder.check({
+                type: "response",
+                verdict: "pass",
+                detail: `timed invoke of OnOff.on on endpoint ${ENDPOINT_1} succeeded`,
+            });
+
+            await recordTimedInteraction(cx, INVOKE_REQUEST_MESSAGE, from);
+        },
+        {
+            pics: "MCORE.IDM.C.InvokeRequest",
+            expected:
+                "On the TH verify the received timed request message has the timeout value as sent by the DUT. " +
+                "Verify that the message is unicast. Verify that the DUT sends the Invoke Request Message to the TH " +
+                "before the specified timeout value. Verify that the Invoke Request has TimedRequest set to True.",
+        },
+    )
+    .step(
+        2,
+        "DUT sends the Timed Request to the TH and then sends a WriteRequestMessage to the TH after receiving the " +
+            "status response message from the TH. The Timed Request Message should contain a timeout value in " +
+            "milliseconds. (Example - 200 milliseconds)",
+        commissioned.withRef("dut", async (cx, ref) => {
+            const th = cx.devices.th;
+
+            const from = th.log.mark();
+            await cx.controllers.dut
+                .node(ref)
+                .writeAttribute({ endpoint: ENDPOINT_1, cluster: ON_OFF_ID, attribute: ON_TIME }, 2, {
+                    timedInteractionTimeoutMs: TIMED_INTERACTION_TIMEOUT_MS,
+                });
+            cx.recorder.check({
+                type: "response",
+                verdict: "pass",
+                detail: `timed write of OnOff.onTime on endpoint ${ENDPOINT_1} succeeded`,
+            });
+
+            await recordTimedInteraction(cx, WRITE_REQUEST_MESSAGE, from);
+        }),
+        {
+            pics: "MCORE.IDM.C.WriteRequest",
+            expected:
+                "On the TH verify the received timed request message has the timeout value as sent by the DUT. " +
+                "Verify that the message is unicast. Verify that the DUT sends the WriteRequestMessage to the TH " +
+                "before the specified timeout value. Verify the WriteRequestMessage has the TimedRequest field set " +
+                "to TRUE.",
+        },
+    )
+    .step(
+        3,
+        "DUT sends the Timed Request to the TH The Timed Request Message should contain a timeout value in " +
+            "milliseconds. (Example - 200 milliseconds) Force the TH to not send a response back to the DUT for the " +
+            "received timed request.",
+        async () => {},
+        {
+            pics: "MCORE.IDM.C.WriteRequest || MCORE.IDM.C.InvokeRequest",
+            notApplicable: "Not testable / Out of Scope in CHIP's certification harness",
+            expected:
+                "Verify that the DUT does not send a follow up message to the TH as it did not receive the initial " +
+                "response for the Timed request.",
+        },
+    )
+    .finalize(cx => commissioned.decommissionAll(cx));

--- a/support/chip-testing/test/cert/TC-IDM-5.1.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-5.1.test.ts
@@ -8,7 +8,13 @@ import { Matter } from "@matter/model";
 import type { CheckRecord, CertStepContext } from "@matter/testing";
 import { certTest } from "@matter/testing";
 import { expectTimedFollowUp, expectTimedRequest, expectUnicastReceipt } from "./tc-idm-5.1-support.js";
-import { CommissionedRefs, INVOKE_REQUEST_MESSAGE, requireId, WRITE_REQUEST_MESSAGE } from "./tc-support.js";
+import {
+    CertCheckFailedError,
+    CommissionedRefs,
+    INVOKE_REQUEST_MESSAGE,
+    requireId,
+    WRITE_REQUEST_MESSAGE,
+} from "./tc-support.js";
 
 const ON_OFF = Matter.clusters.require("OnOff");
 const ON_OFF_ID = requireId(ON_OFF.id, "OnOff cluster");
@@ -46,7 +52,7 @@ async function recordTimedInteraction(cx: CertStepContext, message: RegExp, from
 function record(cx: CertStepContext, check: CheckRecord, what: string) {
     cx.recorder.check(check);
     if (check.verdict === "fail") {
-        throw new Error(`${what} check failed: ${JSON.stringify(check)}`);
+        throw new CertCheckFailedError(`${what} check failed: ${JSON.stringify(check)}`);
     }
 }
 

--- a/support/chip-testing/test/cert/TC-IDM-5.1.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-5.1.test.ts
@@ -130,7 +130,7 @@ certTest("TC-IDM-5.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C"
             "received timed request.",
         async () => {},
         {
-            pics: "MCORE.IDM.C.WriteRequest || MCORE.IDM.C.InvokeRequest",
+            pics: "MCORE.IDM.C.WriteRequest | MCORE.IDM.C.InvokeRequest",
             notApplicable: "Not testable / Out of Scope in CHIP's certification harness",
             expected:
                 "Verify that the DUT does not send a follow up message to the TH as it did not receive the initial " +

--- a/support/chip-testing/test/cert/tc-idm-5.1-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-5.1-support.ts
@@ -1,0 +1,292 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Time } from "@matter/main";
+import type { CheckRecord, LogFollower, LogLine } from "@matter/testing";
+import { CertLogClosedError, CertLogTimeoutError } from "@matter/testing";
+import { expectAdjacentLines } from "./tc-support.js";
+
+// TC-IDM-5.1's own checks live beside the test case rather than inside it because a `TC-*.test.ts`
+// registers a device-driven mocha test at import time, so the cert-framework spec set cannot import
+// one to unit-test what it declares.
+
+export const TIMED_REQUEST_MESSAGE = /\[DMG\] TimedRequestMessage =\s*$/;
+
+/** `TimedRequestMessage::Parser::PrettyPrint` — one field, printed as bare lowercase hex. */
+export function timedRequestSequence(timeoutMs: number): RegExp[] {
+    return [TIMED_REQUEST_MESSAGE, /\{\s*$/, new RegExp(`TimeoutMs = 0x${timeoutMs.toString(16)},\\s*$`)];
+}
+
+const TIMED_REQUEST_FLAG = /timedRequest = true,\s*$/;
+
+/**
+ * chip's own receive line, which names both the exchange the message arrived on and the category of
+ * the session it came over: `(S)` secure unicast, `(U)` unencrypted unicast, `(G)` secure groupcast
+ * (`src/messaging/README.md`).
+ */
+const RECEIPT_LINE = /\[E:(\d+[ir])[^\]]*\] \((S|U|G)\) Msg RX from/;
+
+/**
+ * How many lines after a request message's opening brace its `timedRequest` flag may appear. chip
+ * prints the message's fields in tag order, and only `suppressResponse` precedes `timedRequest`
+ * (`InvokeRequestMessage.cpp`, `WriteRequestMessage.cpp`) — and it is optional on a write, which
+ * matter.js omits and chip-tool sends. Anything further away belongs to another message.
+ */
+const FLAG_WITHIN_LINES = 2;
+
+/**
+ * How long the flag may lag its own message's opening brace. The two come from one decode dump, so
+ * this covers the follower's pump lag only — bounding it is what turns a message that simply carries
+ * no flag into that finding rather than into a generic timeout at the end of the step's whole budget.
+ */
+const FLAG_WAIT_MS = 2_000;
+
+/**
+ * chip prefixes every line with its own timestamp, `[<seconds>.<fraction>]`, whose fraction is
+ * milliseconds in the harness image's build and microseconds in the captures the certification YAML
+ * carries. The digit count is what says which, so both are read rather than one assumed.
+ */
+export function timestampMsOf(text: string): number | undefined {
+    const match = /^\[(\d+)\.(\d+)\]/.exec(text.trim());
+    if (match === null) {
+        return undefined;
+    }
+    const [, seconds, fraction] = match;
+    return Number(seconds) * 1000 + Number(fraction) / 10 ** (fraction.length - 3);
+}
+
+/** The receive line one message arrived on. */
+export interface Receipt {
+    index: number;
+    text: string;
+    /** chip's own exchange id, role suffix included (e.g. `32870r`). */
+    exchange: string;
+    category: "S" | "U" | "G";
+}
+
+/**
+ * The receive line for the message whose decode dump starts at `index`: the nearest one preceding it,
+ * since chip logs one message at a time, so no other message's own receive line can land in between.
+ */
+function receiptBefore(lines: readonly LogLine[], index: number): Receipt | undefined {
+    for (let i = index - 1; i >= 0; i--) {
+        const { text, synthetic } = lines[i];
+        if (synthetic) {
+            continue;
+        }
+        const match = RECEIPT_LINE.exec(text);
+        if (match !== null) {
+            return { index: i, text, exchange: match[1], category: match[2] as Receipt["category"] };
+        }
+    }
+    return undefined;
+}
+
+export interface TimedRequestLookup {
+    check: CheckRecord;
+    /** Absent when the lookup failed, and for the matterjs flavor. */
+    line?: LogLine;
+    /** Absent when the lookup failed, and when the log carries no receive line for the message. */
+    receipt?: Receipt;
+}
+
+/**
+ * Confirms the device received a `TimedRequestMessage` asking for `timeoutMs` at or after `from`, and
+ * returns what a follow-up check needs to attribute the interaction that follows to this request.
+ */
+export async function expectTimedRequest(
+    log: LogFollower,
+    flavor: string,
+    timeoutMs: number,
+    from: number,
+    waitMs: number,
+): Promise<TimedRequestLookup> {
+    const pattern = `TimedRequestMessage(TimeoutMs = 0x${timeoutMs.toString(16)})`;
+    try {
+        const result = await expectAdjacentLines(log, flavor, timedRequestSequence(timeoutMs), from, waitMs);
+        if (result.verdict === "unverified") {
+            return { check: { type: "device-log", verdict: "unverified" } };
+        }
+        return {
+            line: result.last,
+            receipt: receiptBefore(log.lines, result.last.index),
+            check: {
+                type: "device-log",
+                verdict: "pass",
+                pattern,
+                matched: result.last.text,
+                logLine: result.last.index,
+            },
+        };
+    } catch (e) {
+        if (e instanceof CertLogTimeoutError || e instanceof CertLogClosedError) {
+            return { check: { type: "device-log", verdict: "fail", pattern, detail: e.message, logLine: from } };
+        }
+        throw e;
+    }
+}
+
+/** Confirms the session the timed request arrived on was unicast. */
+export function expectUnicastReceipt(timed: TimedRequestLookup): CheckRecord {
+    if (timed.line === undefined) {
+        return { type: "device-log", verdict: "unverified" };
+    }
+
+    const { receipt } = timed;
+    if (receipt === undefined) {
+        return {
+            type: "device-log",
+            verdict: "fail",
+            pattern: String(RECEIPT_LINE),
+            detail: `No receive line precedes the timed request at log line ${timed.line.index}`,
+            logLine: timed.line.index,
+        };
+    }
+
+    return {
+        type: "device-log",
+        verdict: receipt.category === "G" ? "fail" : "pass",
+        pattern: String(RECEIPT_LINE),
+        detail:
+            receipt.category === "G"
+                ? "The timed request arrived over a group session"
+                : `unicast session, exchange ${receipt.exchange}`,
+        matched: receipt.text,
+        logLine: receipt.index,
+    };
+}
+
+/**
+ * Confirms the interaction the timed request opened followed it on the same exchange, inside the
+ * window it asked for, carrying `timedRequest = true`.
+ *
+ * The follow-up is attributed by exchange id, not by "the next message after the timed request": a
+ * second administrator's own timed interaction with this device, or a retry of this one, otherwise
+ * stands in for it — passing on someone else's evidence, or failing on a span measured between two
+ * different interactions.
+ *
+ * The flag is matched by proximity to the message's own opening brace rather than adjacency (see
+ * {@link FLAG_WITHIN_LINES}). Elapsed time comes from the two messages' own log timestamps, which is
+ * what the plan asks for: the device is the party that has to see the follow-up inside the window.
+ */
+export async function expectTimedFollowUp(
+    log: LogFollower,
+    flavor: string,
+    message: RegExp,
+    timed: TimedRequestLookup,
+    budgetMs: number,
+    waitMs: number,
+): Promise<CheckRecord> {
+    const { line: timedLine, receipt } = timed;
+    if (timedLine === undefined) {
+        return { type: "device-log", verdict: "unverified" };
+    }
+
+    const pattern = `${message.source} with ${TIMED_REQUEST_FLAG.source} within ${budgetMs}ms`;
+    if (receipt === undefined) {
+        return {
+            type: "device-log",
+            verdict: "fail",
+            pattern,
+            detail: `The timed request at log line ${timedLine.index} has no receive line to take an exchange from`,
+            logLine: timedLine.index,
+        };
+    }
+
+    const deadline = Time.nowMs + waitMs;
+    const remaining = () => Math.max(1, deadline - Time.nowMs);
+    let cursor = timedLine.index + 1;
+
+    try {
+        for (;;) {
+            const block = await expectAdjacentLines(log, flavor, [message, /\{\s*$/], cursor, remaining());
+            if (block.verdict === "unverified") {
+                return { type: "device-log", verdict: "unverified" };
+            }
+            cursor = block.last.index + 1;
+
+            const lines = log.lines;
+            if (receiptBefore(lines, block.last.index)?.exchange !== receipt.exchange) {
+                continue;
+            }
+
+            const messageLine = lines[block.last.index - 1];
+            const flagged =
+                lines
+                    .slice(block.last.index + 1, block.last.index + 1 + FLAG_WITHIN_LINES)
+                    .some(({ synthetic, text }) => !synthetic && TIMED_REQUEST_FLAG.test(text)) ||
+                (await waitForLaggingFlag(log, flavor, block.last.index, remaining()));
+            if (flagged === "unverified") {
+                return { type: "device-log", verdict: "unverified" };
+            }
+            if (!flagged) {
+                return {
+                    type: "device-log",
+                    verdict: "fail",
+                    pattern,
+                    detail: `The message at log line ${messageLine.index} carries no timedRequest flag`,
+                    matched: messageLine.text,
+                    logLine: messageLine.index,
+                };
+            }
+
+            const started = timestampMsOf(timedLine.text);
+            const arrived = timestampMsOf(messageLine.text);
+            if (started === undefined || arrived === undefined) {
+                return {
+                    type: "device-log",
+                    verdict: "fail",
+                    pattern,
+                    detail: "A message line carries no readable timestamp, so the elapsed time cannot be measured",
+                    logLine: messageLine.index,
+                };
+            }
+
+            // A clock that moved backwards between the two lines is no evidence of promptness
+            const elapsed = arrived - started;
+            return {
+                type: "device-log",
+                verdict: elapsed >= 0 && elapsed <= budgetMs ? "pass" : "fail",
+                pattern,
+                detail: `arrived ${elapsed.toFixed(1)}ms after the timed request (budget ${budgetMs}ms)`,
+                matched: messageLine.text,
+                logLine: messageLine.index,
+            };
+        }
+    } catch (e) {
+        if (e instanceof CertLogTimeoutError || e instanceof CertLogClosedError) {
+            return { type: "device-log", verdict: "fail", pattern, detail: e.message, logLine: timedLine.index };
+        }
+        throw e;
+    }
+}
+
+/**
+ * Whether the flag arrives within {@link FLAG_WAIT_MS} of a message whose own buffered lines did not
+ * carry it yet, and close enough to still be that message's own.
+ */
+async function waitForLaggingFlag(
+    log: LogFollower,
+    flavor: string,
+    braceIndex: number,
+    remainingMs: number,
+): Promise<boolean | "unverified"> {
+    try {
+        const flag = await log.expect(
+            { chip: TIMED_REQUEST_FLAG },
+            { flavor, timeoutMs: Math.min(FLAG_WAIT_MS, remainingMs), from: braceIndex + 1 },
+        );
+        if (flag.verdict === "unverified") {
+            return "unverified";
+        }
+        return flag.matched.index <= braceIndex + FLAG_WITHIN_LINES;
+    } catch (e) {
+        if (e instanceof CertLogTimeoutError || e instanceof CertLogClosedError) {
+            return false;
+        }
+        throw e;
+    }
+}


### PR DESCRIPTION
## What this is

Another controller-side certification test case, and the framework capability it needed.

A Matter client may precede an invoke or an attribute write with a **timed request**: it tells the
device "the real message follows within N milliseconds", and the device rejects that message if it
arrives late. TC-IDM-5.1 exists to prove a controller does this correctly, and the certification
framework had no way to ask for it — so `CertNodeApi.invoke` and `.writeAttribute` gained a
`timedInteractionTimeoutMs` option, implemented for matter.js's own controller and for chip-tool.

The option has no default. An absent timeout stays absent, or every invoke and write in every
certification test would silently become a timed interaction.

## The test case

Three steps, transcribed from the plan. Two are executable — a timed invoke and a timed write, both
with the 200ms the plan quotes and CHIP's own captures use. The third asks for the harness device to
withhold its answer to the timed request; the plan itself calls it possibly untestable and CHIP's
harness marks it "Mark this as not testable /NA. Out of Scope", so it is recorded as skipped with that
reason rather than faked.

What the two executable steps prove, from the harness device's own log: it received a timed request
asking for the timeout the controller was given, over a unicast session, and the interaction itself
followed on the same exchange, inside that window, carrying the timed-request flag.

## Notable choices

**The follow-up is tied to its own timed request by the exchange identifier** chip prints for both, not
by "the next message after this one". A retry, or a second administrator's timed interaction with the
same device, would otherwise stand in for it — passing on someone else's evidence, or failing on a span
measured between two unrelated interactions. This is the same discipline the subscription checks in
this series already follow.

**The timed-request flag is matched by proximity rather than exact position.** chip prints an optional
`suppressResponse` field before it, and that field is mandatory on an invoke but optional on a write —
which matter.js omits and chip-tool sends. So the check anchors on the message's opening brace and
allows the flag within two lines; anything further away belongs to a later message.

**Elapsed time comes from the device's own log timestamps**, whose fraction is milliseconds in the
harness image but microseconds in the certification captures, so it is scaled by the digit count rather
than assuming one. A span that comes out negative — a clock that stepped backwards — is a failure, not
a pass.

## Evidence

The matchers have unit tests, each mutation-checked: widening the flag-proximity bound, forcing the
timing verdict, flattening the timestamp scaling, dropping the exchange correlation and allowing a
negative span each break exactly the test that covers them.

Locally the whole certification set passes against a matter.js harness device, where both the timed
invoke and the timed write succeed — a late follow-up would have been rejected by the device itself.
Certification CI covers the chip-flavored runs, where the device-log checks are the ones that actually
match chip output.

## Note on ordering

This shares one small change with #4246 (the error class used for a failed evidence check moving beside
the other shared helpers). Whichever merges first, the other needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)