### PR TITLE
feat(testing): commission a cert test's device from a QR onboarding payload, and add TC-DD-1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: A cert test declares a cluster outside the Matter specification with the model annotations and `registerCertCustomCluster()`, and both controllers then address it
     - Fix: A cert test's own PICS expression now gates the test, which previously only tinted its label in the report; a controller declares the client capabilities the device's PICS file cannot, and those overlay it
     - Enhancement: `certTest()` accepts test-level `flavors`, skipping a test whose device cannot exist on the run's flavor before the device starts
+    - Enhancement: A cert test's controller commissions from a QR onboarding payload via `CommissioningTarget.qrPairingCode`, on both the matter.js and the chip-tool controller
 
 - @project-chip/matter.js
     - Deprecation: Every class, type, and function of the legacy controller API is now marked deprecated and scheduled for removal in 0.19; use the `ServerNode.peers` / `ClientNode` API of `@matter/node` instead

--- a/packages/testing/src/chip/cert/controller-adapter.ts
+++ b/packages/testing/src/chip/cert/controller-adapter.ts
@@ -26,10 +26,14 @@ export type CertNodeRef = string;
  * Structurally compatible with {@link Subject.CommissioningParameters} so a step can pass
  * `subject.commissioning` directly for a device's original setup code.
  *
- * Either `manualPairingCode` or both `passcode`/`discriminator` must be present. An enhanced
- * commissioning window (`CertNodeApi.openCommissioningWindow({enhanced: true})`) generates a fresh
- * random discriminator/passcode pair that only the returned `manualPairingCode` carries — a step
- * commissioning through that window has no other way to obtain them.
+ * A `qrPairingCode`, a `manualPairingCode`, or both `passcode`/`discriminator` must be present; an
+ * adapter reads them in that order, so passing a whole `subject.commissioning` pairs through its
+ * onboarding payload where the subject publishes one and through its setup code otherwise (a
+ * subject that cannot render a payload reports it as an empty string).
+ *
+ * An enhanced commissioning window (`CertNodeApi.openCommissioningWindow({enhanced: true})`)
+ * generates a fresh random discriminator/passcode pair that only the returned pairing codes carry —
+ * a step commissioning through that window has no other way to obtain them.
  */
 export interface CommissioningTarget {
     passcode?: number;

--- a/packages/testing/src/chip/cert/controller-adapter.ts
+++ b/packages/testing/src/chip/cert/controller-adapter.ts
@@ -361,8 +361,38 @@ export interface ControllerAdapter {
     start(): Promise<void>;
     close(): Promise<void>;
     commission(target: CommissioningTarget): Promise<CertNodeRef>;
+
+    /**
+     * What the controller itself reads out of a QR onboarding payload, so a step asserts on the
+     * controller's own parse rather than on one the step performed for it. Rejects a payload the
+     * controller would refuse to commission from.
+     */
+    parseQrPayload(code: string): Promise<OnboardingPayloadFields>;
+
     node(ref: CertNodeRef): CertNodeApi;
     log: LogFollower;
+}
+
+/**
+ * An onboarding payload's fixed fields, as {@link ControllerAdapter.parseQrPayload} reports them.
+ *
+ * @see {@link MatterSpecification.v16.Core} § 5.1.3.1
+ */
+export interface OnboardingPayloadFields {
+    version: number;
+    vendorId: number;
+    productId: number;
+
+    /** 0 standard, 1 user intent, 2 custom (§ 5.1.3.1 Table 59). */
+    flowType: number;
+
+    /** § 5.1.3.1 Table 60's bitmask, as it appears on the wire. */
+    discoveryCapabilities: number;
+
+    /** The full 12-bit form; a QR payload never carries the manual code's 4-bit one. */
+    discriminator: number;
+
+    passcode: number;
 }
 
 /**

--- a/packages/testing/src/chip/index.ts
+++ b/packages/testing/src/chip/index.ts
@@ -56,6 +56,7 @@ export type {
     ControllerAdapterFactory,
     EventPathSpec,
     EventReadEntry,
+    OnboardingPayloadFields,
     ReadAttributeOptions,
     ReadEventOptions,
     SubscribeEventOptions,

--- a/packages/types/src/schema/PairingCodeSchema.ts
+++ b/packages/types/src/schema/PairingCodeSchema.ts
@@ -31,7 +31,12 @@ import {
 } from "./BitmapSchema.js";
 import { Schema } from "./Schema.js";
 
-/** See {@link MatterSpecification.v16.Core} §5.1.3.2. */
+/**
+ * Counted over the whole code, `MT:` prefix included: § 5.1.3.2's own 255 characters yield 1208 bits,
+ * of which 1120 (140 octets) are TLV data, which only works out with the prefix counted.
+ *
+ * See {@link MatterSpecification.v16.Core} §5.1.3.2.
+ */
 export const MATTER_QR_CODE_SINGLE_PAYLOAD_MAX_LENGTH = 255;
 
 /** See {@link MatterSpecification.v16.Core} §5.1.3.2. */
@@ -239,9 +244,10 @@ class QrPairingCodeSchema extends Schema<QrCodeData[], string> {
                             ? Bytes.of(Bytes.concat(QrCodeDataSchema.encode(payloadData), tlvData))
                             : QrCodeDataSchema.encode(payloadData);
                     const result = Base38.encode(data);
-                    if (result.length > MATTER_QR_CODE_SINGLE_PAYLOAD_MAX_LENGTH) {
+                    const length = PREFIX.length + result.length;
+                    if (length > MATTER_QR_CODE_SINGLE_PAYLOAD_MAX_LENGTH) {
                         throw new UnexpectedDataError(
-                            `Encoded pairing code is too long: ${result.length} characters (max ${MATTER_QR_CODE_SINGLE_PAYLOAD_MAX_LENGTH})`,
+                            `Encoded pairing code is too long: ${length} characters (max ${MATTER_QR_CODE_SINGLE_PAYLOAD_MAX_LENGTH})`,
                         );
                     }
                     return result;

--- a/packages/types/test/schema/PairingCodeSchemaTest.ts
+++ b/packages/types/test/schema/PairingCodeSchemaTest.ts
@@ -133,6 +133,30 @@ describe("QrPairingCodeCodec", () => {
         });
     });
 
+    describe("length validation", () => {
+        // § 5.1.3.2's 255 characters carry 1120 bits (140 octets) of TLV data beyond the 11-byte
+        // structure, which only adds up with the `MT:` prefix counted
+        function tlvDataOf(length: number) {
+            return Bytes.concat(
+                Bytes.fromHex(`152c82${length.toString(16)}`),
+                Bytes.fromString("1".repeat(length)),
+                Bytes.fromHex("18"),
+            );
+        }
+
+        it("encodes a payload of the maximum length", () => {
+            const encoded = QrPairingCodeCodec.encode([{ ...QR_CODE_DATA, tlvData: tlvDataOf(135) }]);
+
+            expect(encoded.length).equal(255);
+        });
+
+        it("rejects a payload one base38 group past it", () => {
+            expect(() => QrPairingCodeCodec.encode([{ ...QR_CODE_DATA, tlvData: tlvDataOf(136) }])).throw(
+                "Encoded pairing code is too long: 257 characters (max 255)",
+            );
+        });
+    });
+
     describe("passcode validation", () => {
         it("rejects encoding an invalid passcode", () => {
             expect(() => QrPairingCodeCodec.encode([{ ...QR_CODE_DATA, passcode: 12345678 }])).throw(

--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -47,6 +47,7 @@ import type { ChipToolCommissionerName } from "../chip-tool/chip-tool-client.js"
 import { ChipToolClient, resolveChipToolBinary } from "../chip-tool/chip-tool-client.js";
 import { chipJsonToMatter, matterToChipJson, stringifyChipJson } from "../chip-tool/json-codec.js";
 import { certClusterModelFor, findCertCluster } from "./custom-clusters.js";
+import { singleQrPayload } from "./onboarding-payload.js";
 import { timedInteractionTimeoutOf } from "./timed-interaction.js";
 
 /** Name {@link UnsupportedByControllerError} reports for this adapter. */
@@ -59,6 +60,16 @@ const CONTROLLER = "chip-tool";
 export const CHIP_TOOL_CONTROLLER_PICS: PicsValues = {
     // command-by-id sends one command path per invoke and no CommandRef.
     "MCORE.IDM.C.InvokeRequest.BatchCommands": 0,
+
+    "MCORE.ROLE.COMMISSIONER": 1,
+
+    // `pairing code` takes either onboarding payload, the scanned `MT:…` form included.
+    "MCORE.DD.QR_COMMISSIONING": 1,
+    "MCORE.DD.MANUAL_PC_COMMISSIONING": 1,
+    "MCORE.DD.SCAN_QR_CODE": 1,
+
+    // A concatenated payload names several commissionees and is refused; the caller is told to split it.
+    "MCORE.DD.CTRL_CONCATENATED_QR_CODE_1": 0,
 };
 
 const WILDCARD_CLUSTER = 0xffffffff;
@@ -1139,13 +1150,19 @@ export class ChipToolControllerAdapter implements ControllerAdapter {
         }
 
         let command: string;
-        if (target.manualPairingCode !== undefined) {
+        if (target.qrPairingCode) {
+            // `pairing code` reads either payload format, a concatenated one included — and would pair
+            // with whichever commissionee that names first, which is what this refuses.
+            singleQrPayload(target.qrPairingCode);
+            command = `pairing code ${node} ${quoteArg(target.qrPairingCode)}`;
+        } else if (target.manualPairingCode !== undefined) {
             command = `pairing code ${node} ${quoteArg(target.manualPairingCode)}`;
         } else if (target.passcode !== undefined && target.discriminator !== undefined) {
             command = `pairing onnetwork-long ${node} ${target.passcode} ${target.discriminator}`;
         } else {
             throw new ImplementationError(
-                "commission() requires either target.manualPairingCode or both target.passcode and target.discriminator",
+                "commission() requires a target.qrPairingCode, a target.manualPairingCode, or both target.passcode " +
+                    "and target.discriminator",
             );
         }
 

--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -31,6 +31,7 @@ import type {
     ControllerAdapter,
     EventPathSpec,
     EventReadEntry,
+    OnboardingPayloadFields,
     ReadAttributeOptions,
     ReadEventOptions,
     SubscribeEventOptions,
@@ -1017,6 +1018,22 @@ class ChipToolCertNodeApi implements CertNodeApi {
     }
 }
 
+/**
+ * One field of chip-tool's own `payload parse-setup-payload` output. Absent means chip-tool parsed the
+ * payload into something other than what a QR code carries — a manual code's short discriminator, say —
+ * which no caller can act on, so it is an error rather than a hole in the returned fields.
+ */
+function payloadField(logs: string[], code: string, pattern: RegExp, radix = 10): number {
+    const value = matchLog(logs, pattern);
+    if (value === undefined) {
+        throw new InternalError(
+            `chip-tool parsed onboarding payload ${code} without logging ${pattern}. Reply logs: ` +
+                JSON.stringify(logs),
+        );
+    }
+    return Number.parseInt(value, radix);
+}
+
 function matchLog(logs: string[], pattern: RegExp) {
     for (const line of logs) {
         const match = pattern.exec(line);
@@ -1133,6 +1150,21 @@ export class ChipToolControllerAdapter implements ControllerAdapter {
                 this.#logStream.close();
             }
         }
+    }
+
+    async parseQrPayload(code: string): Promise<OnboardingPayloadFields> {
+        const { reply, logs } = await this.executeWithLogs(`payload parse-setup-payload ${quoteArg(code)}`);
+        assertCommandSucceeded(reply, `parse of onboarding payload ${code}`);
+
+        return {
+            version: payloadField(logs, code, /Version:\s+(\d+)/),
+            vendorId: payloadField(logs, code, /VendorID:\s+(\d+)/),
+            productId: payloadField(logs, code, /ProductID:\s+(\d+)/),
+            flowType: payloadField(logs, code, /Custom flow:\s+(\d+)/),
+            discoveryCapabilities: payloadField(logs, code, /Discovery Bitmask:\s+0x([0-9A-Fa-f]{2})/, 16),
+            discriminator: payloadField(logs, code, /Long discriminator:\s+(\d+)/),
+            passcode: payloadField(logs, code, /Passcode:\s+(\d+)/),
+        };
     }
 
     async commission(target: CommissioningTarget): Promise<CertNodeRef> {

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -63,6 +63,7 @@ import type {
     ControllerAdapter,
     EventPathSpec,
     EventReadEntry,
+    OnboardingPayloadFields,
     ReadAttributeOptions,
     ReadEventOptions,
     SubscribeEventOptions,
@@ -792,6 +793,12 @@ export class InProcessControllerAdapter implements ControllerAdapter {
             adapterStreams.delete(this.id);
             this.#logStream.close();
         }
+    }
+
+    async parseQrPayload(code: string): Promise<OnboardingPayloadFields> {
+        const { version, vendorId, productId, flowType, discoveryCapabilities, discriminator, passcode } =
+            singleQrPayload(code);
+        return { version, vendorId, productId, flowType, discoveryCapabilities, discriminator, passcode };
     }
 
     commission(target: CommissioningTarget): Promise<CertNodeRef> {

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -73,6 +73,7 @@ import type {
 import { LineQueue, LogFollower } from "@matter/testing";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { certClusterModelFor, findCertCluster } from "./custom-clusters.js";
+import { singleQrPayload } from "./onboarding-payload.js";
 import { timedInteractionTimeoutOf } from "./timed-interaction.js";
 
 /**
@@ -85,6 +86,15 @@ const activeAdapterId = new AsyncLocalStorage<string>();
 /** As `ChipToolControllerAdapter`'s own declarations: what this controller claims the device's PICS cannot. */
 export const MATTERJS_CONTROLLER_PICS: PicsValues = {
     "MCORE.IDM.C.InvokeRequest.BatchCommands": 1,
+    "MCORE.ROLE.COMMISSIONER": 1,
+    "MCORE.DD.QR_COMMISSIONING": 1,
+    "MCORE.DD.MANUAL_PC_COMMISSIONING": 1,
+
+    // Takes the scanned payload itself (`MT:…`), not only the digits of a manual code.
+    "MCORE.DD.SCAN_QR_CODE": 1,
+
+    // A concatenated payload names several commissionees and is refused; the caller is told to split it.
+    "MCORE.DD.CTRL_CONCATENATED_QR_CODE_1": 0,
 };
 
 const adapterStreams = new Map<string, LineQueue>();
@@ -262,8 +272,16 @@ interface ResolvedCommissioningTarget {
  * (§ 5.1.4.1's 4-bit form) and the window's freshly-generated passcode — never the device's original
  * setup passcode/discriminator, which `openEnhancedCommissioningWindow` deliberately replaces per
  * window. `target.passcode`/`target.discriminator` are for the device's original setup code instead.
+ *
+ * A `qrPairingCode` carries the full 12-bit discriminator, so it discovers by the long form. Its
+ * remaining fields (vendor and product id, commissioning flow, discovery capabilities) describe the
+ * commissionee rather than how to reach it; a step asserting on them decodes the payload itself.
  */
 function resolveCommissioningTarget(target: CommissioningTarget): ResolvedCommissioningTarget {
+    if (target.qrPairingCode) {
+        const { discriminator, passcode } = singleQrPayload(target.qrPairingCode);
+        return { identifierData: { longDiscriminator: discriminator }, passcode };
+    }
     if (target.manualPairingCode !== undefined) {
         const { shortDiscriminator, passcode } = ManualPairingCodeCodec.decode(target.manualPairingCode);
         if (shortDiscriminator === undefined) {
@@ -273,7 +291,8 @@ function resolveCommissioningTarget(target: CommissioningTarget): ResolvedCommis
     }
     if (target.passcode === undefined || target.discriminator === undefined) {
         throw new ImplementationError(
-            "commission() requires either target.manualPairingCode or both target.passcode and target.discriminator",
+            "commission() requires a target.qrPairingCode, a target.manualPairingCode, or both target.passcode " +
+                "and target.discriminator",
         );
     }
     return { identifierData: { longDiscriminator: target.discriminator }, passcode: target.passcode };

--- a/support/chip-testing/src/cert/onboarding-payload.ts
+++ b/support/chip-testing/src/cert/onboarding-payload.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ImplementationError } from "@matter/main";
+import type { QrCodeData } from "@matter/main/types";
+import { QrPairingCodeCodec } from "@matter/main/types";
+
+/**
+ * The one onboarding payload `code` carries.
+ *
+ * A concatenated code (Matter Core § 5.1.3.2) names several commissionees. `ControllerAdapter.commission()`
+ * pairs one, and neither controller can be told which, so such a code is refused rather than paired with
+ * whichever device answers first.
+ */
+export function singleQrPayload(code: string): QrCodeData {
+    const payloads = QrPairingCodeCodec.decode(code);
+    if (payloads.length !== 1) {
+        throw new ImplementationError(
+            `QR pairing code carries ${payloads.length} payloads; commission() pairs one device, so a ` +
+                "concatenated code must be split by the caller",
+        );
+    }
+    return payloads[0];
+}

--- a/support/chip-testing/test/cert-framework/cert-test.test.ts
+++ b/support/chip-testing/test/cert-framework/cert-test.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { InternalError } from "@matter/main";
 import type {
     CertDevice,
     CertNodeApi,
@@ -146,6 +147,9 @@ function stubControllerAdapter(log: LogFollower): ControllerAdapter {
         log,
         async start() {},
         async close() {},
+        async parseQrPayload(): Promise<never> {
+            throw new InternalError("not used in this test");
+        },
         async commission() {
             return "ref";
         },
@@ -888,6 +892,9 @@ describe("CertTest", () => {
             async close() {},
             async commission() {
                 return "ref-dut";
+            },
+            async parseQrPayload(): Promise<never> {
+                throw new InternalError("not used in this test");
             },
             node: () => nodeFor("dut"),
         };

--- a/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
@@ -213,6 +213,53 @@ describe("ChipToolControllerAdapter", function () {
         expect(fake.commands).deep.equal([`pairing code ${FIRST_NODE} MT:-24J042C00KA0648G00`]);
     });
 
+    it("reads an onboarding payload through chip-tool's own parser", async () => {
+        const started = await start();
+
+        // `SetupPayloadParseCommand::Print`'s own lines, as chip-tool logs them
+        fake.reply = () => ({
+            logs: [
+                "Version:             0",
+                "VendorID:            65521",
+                "ProductID:           32769",
+                "Custom flow:         0    (STANDARD)",
+                "Discovery Bitmask:   0x04 (On IP network)",
+                "Long discriminator:  3840   (0xf00)",
+                "Passcode:            20202021",
+            ],
+        });
+
+        expect(await started.parseQrPayload("MT:-24J042C00KA0648G00")).deep.equal({
+            version: 0,
+            vendorId: 65521,
+            productId: 32769,
+            flowType: 0,
+            discoveryCapabilities: 0x04,
+            discriminator: 3840,
+            passcode: 20202021,
+        });
+        expect(fake.commands).deep.equal(["payload parse-setup-payload MT:-24J042C00KA0648G00"]);
+    });
+
+    it("rejects a payload chip-tool parsed into something other than a QR code's fields", async () => {
+        const started = await start();
+
+        // A manual code parses to a short discriminator, which no caller of this can act on
+        fake.reply = () => ({
+            logs: [
+                "Version:             0",
+                "VendorID:            65521",
+                "ProductID:           32769",
+                "Custom flow:         0    (STANDARD)",
+                "Discovery Bitmask:   0x04 (On IP network)",
+                "Short discriminator: 15   (0xf)",
+                "Passcode:            20202021",
+            ],
+        });
+
+        expect(await rejectionOf(started.parseQrPayload("MT:-24J042C00KA0648G00"))).instanceOf(InternalError);
+    });
+
     it("refuses a concatenated onboarding payload instead of letting chip-tool choose a device", async () => {
         const started = await start();
 

--- a/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
@@ -204,6 +204,25 @@ describe("ChipToolControllerAdapter", function () {
         expect(fake.commands[1]).equal("pairing code 4098 36217551633");
     });
 
+    it("pairs from a QR onboarding payload, which chip-tool reads with the same command", async () => {
+        const started = await start();
+
+        const ref = await started.commission({ qrPairingCode: "MT:-24J042C00KA0648G00" });
+
+        expect(ref).equal(FIRST_NODE);
+        expect(fake.commands).deep.equal([`pairing code ${FIRST_NODE} MT:-24J042C00KA0648G00`]);
+    });
+
+    it("refuses a concatenated onboarding payload instead of letting chip-tool choose a device", async () => {
+        const started = await start();
+
+        await expect(started.commission({ qrPairingCode: "MT:-24J042C00KA0648G00*-24J042C00KA0648G00" })).rejectedWith(
+            ImplementationError,
+            /carries 2 payloads/,
+        );
+        expect(fake.commands).deep.equal([]);
+    });
+
     it("reads a concrete path and decodes the value through the model", async () => {
         const { ref, node } = await commissioned();
 

--- a/support/chip-testing/test/cert-framework/controller-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/controller-adapter.test.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InternalError } from "@matter/main";
-import { Status, StatusResponseError } from "@matter/main/types";
+import { ImplementationError, InternalError } from "@matter/main";
+import { QrPairingCodeCodec, Status, StatusResponseError } from "@matter/main/types";
 import { Matter } from "@matter/model";
 import {
     controllerPicsOverridesFor,
@@ -123,6 +123,23 @@ describe("InProcessControllerAdapter", () => {
         });
 
         await adapter.node(ref).decommission();
+    });
+
+    it("commissions from the device's own QR onboarding payload", async function () {
+        this.timeout(30_000);
+
+        const ref = await adapter.commission({ qrPairingCode: device.commissioning.qrPairingCode });
+
+        await adapter.node(ref).decommission();
+    });
+
+    it("refuses a concatenated onboarding payload, which names more than one device", async function () {
+        const [payload] = QrPairingCodeCodec.decode(device.commissioning.qrPairingCode);
+
+        await expect(adapter.commission({ qrPairingCode: QrPairingCodeCodec.encode([payload, payload]) })).rejectedWith(
+            ImplementationError,
+            /carries 2 payloads/,
+        );
     });
 
     it("commissions, reads an attribute, invokes a command, and decommissions", async function () {
@@ -497,6 +514,13 @@ describe("ControllerAdapter registry", () => {
         expect(controllerPicsOverridesFor("chip-tool")).deep.equal(CHIP_TOOL_CONTROLLER_PICS);
         expect(MATTERJS_CONTROLLER_PICS["MCORE.IDM.C.InvokeRequest.BatchCommands"]).equal(1);
         expect(CHIP_TOOL_CONTROLLER_PICS["MCORE.IDM.C.InvokeRequest.BatchCommands"]).equal(0);
+
+        for (const pics of [MATTERJS_CONTROLLER_PICS, CHIP_TOOL_CONTROLLER_PICS]) {
+            expect(pics["MCORE.ROLE.COMMISSIONER"]).equal(1);
+            expect(pics["MCORE.DD.QR_COMMISSIONING"]).equal(1);
+            expect(pics["MCORE.DD.SCAN_QR_CODE"]).equal(1);
+            expect(pics["MCORE.DD.CTRL_CONCATENATED_QR_CODE_1"]).equal(0);
+        }
     });
 
     it("reports no declarations for an implementation registered without them", () => {

--- a/support/chip-testing/test/cert-framework/controller-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/controller-adapter.test.ts
@@ -31,6 +31,9 @@ function fakeControllerAdapter(id: string): ControllerAdapter {
         async commission() {
             throw new InternalError("not used in this test");
         },
+        async parseQrPayload() {
+            throw new InternalError("not used in this test");
+        },
         node() {
             throw new InternalError("not used in this test");
         },
@@ -131,6 +134,20 @@ describe("InProcessControllerAdapter", () => {
         const ref = await adapter.commission({ qrPairingCode: device.commissioning.qrPairingCode });
 
         await adapter.node(ref).decommission();
+    });
+
+    it("reports the fields it reads out of an onboarding payload", async function () {
+        const parsed = await adapter.parseQrPayload(device.commissioning.qrPairingCode);
+
+        expect(parsed).deep.equal({
+            version: 0,
+            vendorId: 0xfff1,
+            productId: 0x8001,
+            flowType: 0,
+            discoveryCapabilities: 0b100,
+            discriminator: 3840,
+            passcode: 20202021,
+        });
     });
 
     it("refuses a concatenated onboarding payload, which names more than one device", async function () {
@@ -518,6 +535,7 @@ describe("ControllerAdapter registry", () => {
         for (const pics of [MATTERJS_CONTROLLER_PICS, CHIP_TOOL_CONTROLLER_PICS]) {
             expect(pics["MCORE.ROLE.COMMISSIONER"]).equal(1);
             expect(pics["MCORE.DD.QR_COMMISSIONING"]).equal(1);
+            expect(pics["MCORE.DD.MANUAL_PC_COMMISSIONING"]).equal(1);
             expect(pics["MCORE.DD.SCAN_QR_CODE"]).equal(1);
             expect(pics["MCORE.DD.CTRL_CONCATENATED_QR_CODE_1"]).equal(0);
         }

--- a/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
@@ -135,6 +135,9 @@ class Fixture {
             async commission() {
                 return "ref";
             },
+            async parseQrPayload() {
+                throw new InternalError("not used in this test");
+            },
             node: () => node,
         };
 

--- a/support/chip-testing/test/cert-framework/tc-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-support.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { InternalError } from "@matter/main";
 import type { CertNodeApi, CertStepContext, ControllerAdapter } from "@matter/testing";
 import { LogFollower } from "@matter/testing";
 import {
@@ -488,6 +489,9 @@ describe("CommissionedRefs", () => {
             async close() {},
             async commission() {
                 return "ref";
+            },
+            async parseQrPayload() {
+                throw new InternalError("not used in this test");
             },
             node: () => nodeFor(role),
         });

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1225,12 +1225,12 @@ TLV payload". That arithmetic only works with the `MT:` prefix counted — 252 b
 bytes, of which the fixed structure takes 11 — so the TC's payload is 255 characters including the
 prefix and carries the full 140 TLV octets.
 
-`QrPairingCodeCodec.encode` measures its own 255 against the base38 characters *alone*
-(`MATTER_QR_CODE_SINGLE_PAYLOAD_MAX_LENGTH`, `PairingCodeSchema.ts`), so it admits a payload three
-characters over what the specification allows; it is not the boundary this TC sits on. Decoding bounds
-nothing at all, which is what lets `Test_TC_DD_1_8.yaml`'s own (older, larger) 1000-byte TLV example
-still parse. The TC asserts the length it built rather than trusting the arithmetic, since a filler
-byte count that misses lands on a payload the plan did not ask for.
+`QrPairingCodeCodec.encode` refuses anything longer (`MATTER_QR_CODE_SINGLE_PAYLOAD_MAX_LENGTH`,
+`PairingCodeSchema.ts`) — it used to measure that against the base38 characters alone and so admitted
+three characters over the limit, which this TC's own arithmetic exposed. Decoding bounds nothing at
+all, which is what lets `Test_TC_DD_1_8.yaml`'s own (older, larger) 1000-byte TLV example still parse.
+The TC asserts the length it built rather than trusting the arithmetic, since a filler byte count that
+misses lands on a payload the plan did not ask for.
 
 **Onboarding the same TH twice: open a basic window before removing the fabric.** A chip TH does not
 return to commissioning mode when its last fabric goes — after `RemoveFabric succeeds` its log stops

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1192,3 +1192,70 @@ The same code is the TC's own TH-side evidence: it announces every injected resp
 `Injecting the following response:<description>`, and the three descriptions distinguish which fault
 fired. The device never pretty-prints its own outgoing `InvokeResponseMessage`, so these two lines — plus
 the arrival order the controller itself observed — are the whole of the response-shape evidence.
+
+## Commissioning from an onboarding payload (`TC-DD-1.8`)
+
+`CommissioningTarget.qrPairingCode` was declared but decoded by neither adapter; both read it now, and
+a target is resolved in the order `qrPairingCode` → `manualPairingCode` → `passcode`+`discriminator`.
+A QR payload carries the full 12-bit discriminator, so it discovers by the long form where a manual
+code's 4-bit short form does not (§ 5.1.4.1); chip-tool takes either through the same `pairing code`
+command. A concatenated payload (several devices joined by `*`) is refused rather than pairing with
+whichever of them answers first.
+
+**Where a step gets the TH's payload.** A matterjs subject reports it as
+`subject.commissioning.qrPairingCode`; a chip subject reports an empty string there, because rendering
+one needs the base38 encoder that `packages/testing` may not depend on — but the app prints it, once
+per commissioning flow, as `SetupQRCode: [MT:…]`, standard flow first. A TC needing a payload on both
+flavors therefore falls back to the device log.
+
+**PICS.** `MCORE.DD.SCAN_QR_CODE` asks whether the commissioner takes the *scanned* payload — the
+`MT:…` form — rather than only the digits of a manual pairing code. Both controllers do, so both
+declare it; it is not a question about owning a camera. `MCORE.ROLE.COMMISSIONER`,
+`MCORE.DD.QR_COMMISSIONING` and `MCORE.DD.MANUAL_PC_COMMISSIONING` come from the overlay too: CHIP's
+`ci-pics-values` describes a device and answers 0 to all three, so without it every DUT-as-commissioner
+test would be filtered out. `MCORE.DD.CTRL_CONCATENATED_QR_CODE_1` is declared 0 — neither controller
+splits a concatenated payload, which is the one piece of § 5.1.6 missing here.
+`CTRL_CONCATENATED_QR_CODE_2` (does the commissioner *tell the user* to commission the devices
+individually) is deliberately left to the device's file: the adapters' own refusal says exactly that,
+but nothing here proves a user ever sees it.
+
+**The plan's 255-character payload is exactly matter.js's own limit.** The plan's step 4 asks for a
+payload of 255 characters counted with its `MT:` prefix, so 252 base38 characters — the largest single
+payload § 5.1.3.2 allows, which `QrPairingCodeCodec.encode` enforces and `MATTER_QR_CODE_SINGLE_PAYLOAD_MAX_LENGTH`
+names. Decoding has no such bound, which is what lets `Test_TC_DD_1_8.yaml`'s own (older, larger)
+1000-byte TLV example still parse. The TC asserts the length it built rather than trusting the
+arithmetic, since a filler byte count that misses lands on a payload the plan did not ask for.
+
+**Onboarding the same TH twice: open a basic window before removing the fabric.** A chip TH does not
+return to commissioning mode when its last fabric goes — after `RemoveFabric succeeds` its log stops
+there, and the next commissioning fails as `No device could be commissioned (1 of 1 started attempt(s)
+failed, 1 discovered)` against a stale advertisement. Spec-wise the plans cover this with a
+precondition ("place the TH back into commissioning mode using the TH manufacturer's means"), which for
+a TC that drives everything itself means opening the window before the fabric it needs to open it is
+gone. It must be a **basic** window (`openCommissioningWindow({ enhanced: false })`): its PASE verifier
+is the device's own setup code, so the TH's own onboarding payload still pairs, where an enhanced
+window would mint a fresh discriminator and passcode instead (see "Pairing-code commissioning" above).
+
+A restart would satisfy the same precondition, and TC-DD-3.20 asks for one explicitly — but a step
+cannot stop a device today: `raceAgainstDeviceExit` (`cert-test.ts`) treats any device exit during a
+step as the run's failure. Deliberate-restart support is the framework piece that block still needs.
+
+**A factory reset is not the same operation on both flavors.** Removing the last fabric leaves a chip
+app's KVS in place; the storage has to be deleted and the app restarted for it to come up factory-new,
+which is also why it stays out of commissioning mode above. matter.js returns to commissioning mode on
+its own instead. The specification allows either, so a TC whose precondition is a factory-reset TH must
+ask the device for one — per flavor, `ChipLocalDevice`'s own storage directory versus a matterjs
+subject's storage — rather than assume `RemoveFabric` delivered it.
+
+**On a developer host, limit mDNS to one interface.** With VPN tunnels up (`utun*`), a local run of the
+whole cert suite floods `UDP send timeout`/`EMSGSIZE` on every extra interface, stretches a 1m 40s run to
+12–20 minutes, and turns timing-sensitive steps in unrelated TCs into failures — including the
+harness's own "process did not exit cleanly" check. `MATTER_MDNS_NETWORKINTERFACE=en0` (matter.js's
+`mdns.networkInterface` variable) is what makes a local run representative; CI runners have one
+interface and need nothing.
+
+**And an mDNS gate after the removal.** `decommission()` returns as soon as the TH answers
+`RemoveFabric`; the TH re-advertises itself commissionable a moment later, and a discovery started
+before that finds only devices this run is not looking for — every cert TH in the process uses
+discriminator 3840, which is all discovery matches on. `expectMdns(th, { commissionable: true })`
+before the next attempt closes that race and records the wait as the step's own network evidence.

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1219,12 +1219,18 @@ splits a concatenated payload, which is the one piece of § 5.1.6 missing here.
 individually) is deliberately left to the device's file: the adapters' own refusal says exactly that,
 but nothing here proves a user ever sees it.
 
-**The plan's 255-character payload is exactly matter.js's own limit.** The plan's step 4 asks for a
-payload of 255 characters counted with its `MT:` prefix, so 252 base38 characters — the largest single
-payload § 5.1.3.2 allows, which `QrPairingCodeCodec.encode` enforces and `MATTER_QR_CODE_SINGLE_PAYLOAD_MAX_LENGTH`
-names. Decoding has no such bound, which is what lets `Test_TC_DD_1_8.yaml`'s own (older, larger)
-1000-byte TLV example still parse. The TC asserts the length it built rather than trusting the
-arithmetic, since a filler byte count that misses lands on a payload the plan did not ask for.
+**The plan's 255-character payload is the specification's own maximum.** § 5.1.3.2: a single product's
+onboarding payload "SHALL NOT exceed 255 characters", yielding 1208 bits and "1120 bits (140 octets) of
+TLV payload". That arithmetic only works with the `MT:` prefix counted — 252 base38 characters are 151
+bytes, of which the fixed structure takes 11 — so the TC's payload is 255 characters including the
+prefix and carries the full 140 TLV octets.
+
+`QrPairingCodeCodec.encode` measures its own 255 against the base38 characters *alone*
+(`MATTER_QR_CODE_SINGLE_PAYLOAD_MAX_LENGTH`, `PairingCodeSchema.ts`), so it admits a payload three
+characters over what the specification allows; it is not the boundary this TC sits on. Decoding bounds
+nothing at all, which is what lets `Test_TC_DD_1_8.yaml`'s own (older, larger) 1000-byte TLV example
+still parse. The TC asserts the length it built rather than trusting the arithmetic, since a filler
+byte count that misses lands on a payload the plan did not ask for.
 
 **Onboarding the same TH twice: open a basic window before removing the fabric.** A chip TH does not
 return to commissioning mode when its last fabric goes — after `RemoveFabric succeeds` its log stops

--- a/support/chip-testing/test/cert/TC-DD-1.8.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-1.8.test.ts
@@ -1,0 +1,258 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Bytes, InternalError } from "@matter/main";
+import type { QrCodeData } from "@matter/main/types";
+import { QrPairingCodeCodec } from "@matter/main/types";
+import type { CertDevice, CertStepContext, CheckRecord } from "@matter/testing";
+import { certTest } from "@matter/testing";
+import { expectMdns } from "../../src/cert/mdns-check.js";
+import { CertCheckFailedError, CommissionedRefs, expectSequence } from "./tc-support.js";
+
+const LOG_TIMEOUT_MS = 30_000;
+const MDNS_TIMEOUT_MS = 30_000;
+
+/** Outlives the rest of the run, so a later step never pairs against a window that closed on its own. */
+const WINDOW_TIMEOUT_SECONDS = 300;
+
+/** Both device flavors print the payload they publish on this line; chip prints one per commissioning flow. */
+const SETUP_QR_CODE = /SetupQRCode: \[(MT:[^\]]+)\]/;
+
+/** chip-all-clusters-app announces a completed commissioning; matter.js has no equivalent line. */
+const COMMISSIONING_COMPLETE = /Commissioning completed successfully/;
+
+/**
+ * The plan's own example TLV payload (§ 5.1.5): an anonymous structure carrying serial number
+ * "1234567890" under context tag 0x00.
+ */
+const PLAN_TLV_DATA = Bytes.fromHex("152c000a3132333435363738393018");
+
+/** The plan's step 4 payload length, counted over the whole string including its `MT:` prefix. */
+const LARGE_QR_CODE_LENGTH = 255;
+
+/**
+ * A UTF-8 string of this length under a manufacturer-specific tag fills the payload to exactly
+ * {@link LARGE_QR_CODE_LENGTH}: 5 bytes of TLV framing plus the fixed 11-byte structure is 151 bytes,
+ * which base38 renders as 252 characters.
+ */
+const LARGE_TLV_STRING_LENGTH = 135;
+
+const commissioned = new CommissionedRefs();
+
+function record(cx: CertStepContext, check: CheckRecord, what: string) {
+    cx.recorder.check(check);
+    if (check.verdict === "fail") {
+        throw new CertCheckFailedError(`${what} check failed: ${JSON.stringify(check)}`);
+    }
+}
+
+/**
+ * The onboarding payload the TH publishes for its own setup code. A subject that renders one reports
+ * it directly; a chip app only prints it, and the first of the two it prints is the standard
+ * commissioning flow's.
+ */
+async function thQrPayload(th: CertDevice): Promise<string> {
+    if (th.commissioning.qrPairingCode) {
+        return th.commissioning.qrPairingCode;
+    }
+
+    const result = await th.log.expect(
+        { chip: SETUP_QR_CODE, matterjs: SETUP_QR_CODE },
+        { flavor: th.flavor, from: 0, timeoutMs: LOG_TIMEOUT_MS },
+    );
+    if (result.verdict === "unverified") {
+        throw new InternalError(`${th.flavor} devices neither report nor print an onboarding payload`);
+    }
+
+    const payload = SETUP_QR_CODE.exec(result.matched.text)?.[1];
+    if (payload === undefined) {
+        throw new InternalError(`Matched a SetupQRCode line carrying no payload: ${result.matched.text}`);
+    }
+    return payload;
+}
+
+function decodeSingle(payload: string): QrCodeData {
+    const payloads = QrPairingCodeCodec.decode(payload);
+    if (payloads.length !== 1) {
+        throw new InternalError(`Expected one onboarding payload, decoded ${payloads.length}`);
+    }
+    return payloads[0];
+}
+
+/**
+ * Records what the DUT read out of `payload` and whether the setup code it carries is the TH's own.
+ * This is the step's actual claim: the remaining fields describe the commissionee, and the plan asks
+ * only that they parse.
+ */
+function recordParse(cx: CertStepContext, payload: string): QrCodeData {
+    const th = cx.devices.th;
+    const decoded = decodeSingle(payload);
+    const matches =
+        decoded.discriminator === th.commissioning.discriminator && decoded.passcode === th.commissioning.passcode;
+
+    record(
+        cx,
+        {
+            type: "response",
+            verdict: matches ? "pass" : "fail",
+            detail:
+                `${payload.length}-character payload parsed as version=${decoded.version} ` +
+                `vendorId=${decoded.vendorId} productId=${decoded.productId} flowType=${decoded.flowType} ` +
+                `discoveryCapabilities=0b${decoded.discoveryCapabilities.toString(2).padStart(8, "0")} ` +
+                `discriminator=${decoded.discriminator} passcode=${decoded.passcode}` +
+                (decoded.tlvData === undefined ? "" : ` tlvData=${Bytes.toHex(decoded.tlvData)}`),
+        },
+        "Onboarding payload parse",
+    );
+
+    return decoded;
+}
+
+/** `payload` with `tlvData` appended, which the plan expects the DUT to parse and may then ignore. */
+function withTlvData(payload: string, tlvData: Bytes): string {
+    return QrPairingCodeCodec.encode([{ ...decodeSingle(payload), tlvData }]);
+}
+
+/** An anonymous structure holding one UTF-8 string, 1-octet length, under manufacturer tag 0x82. */
+function largeTlvData(): Bytes {
+    return Bytes.concat(
+        Bytes.fromHex(`152c82${LARGE_TLV_STRING_LENGTH.toString(16)}`),
+        Bytes.fromString("1".repeat(LARGE_TLV_STRING_LENGTH)),
+        Bytes.fromHex("18"),
+    );
+}
+
+function largeQrPayload(payload: string): string {
+    const large = withTlvData(payload, largeTlvData());
+    if (large.length !== LARGE_QR_CODE_LENGTH) {
+        throw new InternalError(
+            `Large onboarding payload is ${large.length} characters, not the plan's ${LARGE_QR_CODE_LENGTH}`,
+        );
+    }
+    return large;
+}
+
+/**
+ * Onboards the TH from `payload`, after taking the fabric an earlier step commissioned back off it.
+ *
+ * A chip TH does not return to commissioning mode when its last fabric goes, so the window is opened
+ * while the fabric is still there. It is a basic one: that is the window whose PASE verifier is the
+ * device's own setup code, which is what this TC's payload carries.
+ */
+async function commissionByQr(cx: CertStepContext, payload: string): Promise<void> {
+    const dut = cx.controllers.dut;
+    const th = cx.devices.th;
+
+    const previous = commissioned.get("dut");
+    if (previous !== undefined) {
+        await dut.node(previous).openCommissioningWindow({ timeout: WINDOW_TIMEOUT_SECONDS, enhanced: false });
+        await dut.node(previous).decommission();
+        commissioned.clear("dut");
+
+        // Removing the fabric returns as soon as the TH answers; the TH advertises itself
+        // commissionable again on its own schedule, and a discovery started before that finds only
+        // the devices this run is not looking for.
+        record(
+            cx,
+            await expectMdns(th, { commissionable: true }, { timeoutMs: MDNS_TIMEOUT_MS }),
+            "TH back in commissioning mode",
+        );
+    }
+
+    const from = th.log.mark();
+    let ref;
+    try {
+        ref = await dut.commission({ qrPairingCode: payload });
+    } catch (e) {
+        cx.recorder.check({ type: "response", verdict: "fail", detail: `commissioning by payload failed: ${e}` });
+        throw e;
+    }
+    commissioned.set("dut", ref);
+    cx.recorder.check({ type: "response", verdict: "pass", detail: `commissioned as node ${ref}` });
+
+    record(
+        cx,
+        await expectSequence(
+            th.log,
+            th.flavor,
+            "commissioning complete",
+            [COMMISSIONING_COMPLETE],
+            from,
+            LOG_TIMEOUT_MS,
+        ),
+        "TH commissioning",
+    );
+}
+
+certTest("TC-DD-1.8", {
+    plan: "devicediscovery.adoc",
+    pics: ["MCORE.ROLE.COMMISSIONER", "MCORE.DD.QR_COMMISSIONING"],
+    app: "all-clusters",
+})
+    .step(
+        1,
+        "Scan the TH Device's QR code using DUT",
+        async cx => {
+            recordParse(cx, await thQrPayload(cx.devices.th));
+        },
+        { pics: "MCORE.DD.SCAN_QR_CODE", expected: "Verify the QR code has been scanned successfully." },
+    )
+    .step(
+        2,
+        "Using the DUT, parse the TH's QR code to onboard the TH Device onto the Matter network.",
+        async cx => {
+            const payload = await thQrPayload(cx.devices.th);
+            recordParse(cx, payload);
+            await commissionByQr(cx, payload);
+        },
+        { expected: "Verify the TH's QR code was parsed successfully by the DUT" },
+    )
+    .step(
+        "3.a",
+        "Scan the TH Device's QR code (that includes the additional TLV data) using DUT.",
+        async cx => {
+            recordParse(cx, withTlvData(await thQrPayload(cx.devices.th), PLAN_TLV_DATA));
+        },
+        { pics: "MCORE.DD.SCAN_QR_CODE", expected: "Verify the QR code has been scanned successfully." },
+    )
+    .step(
+        "3.b",
+        "Using the DUT, parse the TH's QR code to onboard the TH Device onto the Matter network.",
+        async cx => {
+            const payload = withTlvData(await thQrPayload(cx.devices.th), PLAN_TLV_DATA);
+            recordParse(cx, payload);
+            await commissionByQr(cx, payload);
+        },
+        {
+            expected:
+                "Verify the TH's QR code with the appended TLV data was parsed successfully by the DUT (where the " +
+                "DUT may ignore the TLV contents)",
+        },
+    )
+    .step(
+        "4.a",
+        `Scan the TH Device's QR code using the DUT. The number of alphanumeric characters in the QR code is ` +
+            `${LARGE_QR_CODE_LENGTH} characters.`,
+        async cx => {
+            recordParse(cx, largeQrPayload(await thQrPayload(cx.devices.th)));
+        },
+        { pics: "MCORE.DD.SCAN_QR_CODE", expected: "Verify the QR code has been scanned successfully." },
+    )
+    .step(
+        "4.b",
+        "Using the DUT, parse the TH's QR code to onboard the TH Device onto the Matter network.",
+        async cx => {
+            const payload = largeQrPayload(await thQrPayload(cx.devices.th));
+            recordParse(cx, payload);
+            await commissionByQr(cx, payload);
+        },
+        {
+            expected:
+                "Verify the TH's QR code with the appended TLV data was parsed successfully by the DUT (where the " +
+                "DUT may ignore the TLV contents)",
+        },
+    )
+    .finalize(cx => commissioned.decommissionAll(cx));

--- a/support/chip-testing/test/cert/TC-DD-1.8.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-1.8.test.ts
@@ -83,15 +83,23 @@ function decodeSingle(payload: string): QrCodeData {
 }
 
 /**
- * Records what the DUT read out of `payload` and whether the setup code it carries is the TH's own.
- * This is the step's actual claim: the remaining fields describe the commissionee, and the plan asks
- * only that they parse.
+ * Records what the DUT read out of `payload` and whether the setup code it read is the TH's own. The
+ * parse is the DUT's, not this test's: a step that decoded the payload itself would pass against a
+ * controller that cannot read one at all.
  */
-function recordParse(cx: CertStepContext, payload: string): QrCodeData {
+async function recordParse(cx: CertStepContext, payload: string): Promise<void> {
     const th = cx.devices.th;
-    const decoded = decodeSingle(payload);
+
+    let parsed;
+    try {
+        parsed = await cx.controllers.dut.parseQrPayload(payload);
+    } catch (e) {
+        cx.recorder.check({ type: "response", verdict: "fail", detail: `DUT could not parse the payload: ${e}` });
+        throw e;
+    }
+
     const matches =
-        decoded.discriminator === th.commissioning.discriminator && decoded.passcode === th.commissioning.passcode;
+        parsed.discriminator === th.commissioning.discriminator && parsed.passcode === th.commissioning.passcode;
 
     record(
         cx,
@@ -99,16 +107,14 @@ function recordParse(cx: CertStepContext, payload: string): QrCodeData {
             type: "response",
             verdict: matches ? "pass" : "fail",
             detail:
-                `${payload.length}-character payload parsed as version=${decoded.version} ` +
-                `vendorId=${decoded.vendorId} productId=${decoded.productId} flowType=${decoded.flowType} ` +
-                `discoveryCapabilities=0b${decoded.discoveryCapabilities.toString(2).padStart(8, "0")} ` +
-                `discriminator=${decoded.discriminator} passcode=${decoded.passcode}` +
-                (decoded.tlvData === undefined ? "" : ` tlvData=${Bytes.toHex(decoded.tlvData)}`),
+                `DUT read the ${payload.length}-character payload as version=${parsed.version} ` +
+                `vendorId=${parsed.vendorId} productId=${parsed.productId} flowType=${parsed.flowType} ` +
+                `discoveryCapabilities=0b${parsed.discoveryCapabilities.toString(2).padStart(8, "0")} ` +
+                `discriminator=${parsed.discriminator} passcode=${parsed.passcode}; the TH's own setup code is ` +
+                `discriminator=${th.commissioning.discriminator} passcode=${th.commissioning.passcode}`,
         },
         "Onboarding payload parse",
     );
-
-    return decoded;
 }
 
 /** `payload` with `tlvData` appended, which the plan expects the DUT to parse and may then ignore. */
@@ -196,7 +202,7 @@ certTest("TC-DD-1.8", {
         1,
         "Scan the TH Device's QR code using DUT",
         async cx => {
-            recordParse(cx, await thQrPayload(cx.devices.th));
+            await recordParse(cx, await thQrPayload(cx.devices.th));
         },
         { pics: "MCORE.DD.SCAN_QR_CODE", expected: "Verify the QR code has been scanned successfully." },
     )
@@ -205,7 +211,7 @@ certTest("TC-DD-1.8", {
         "Using the DUT, parse the TH's QR code to onboard the TH Device onto the Matter network.",
         async cx => {
             const payload = await thQrPayload(cx.devices.th);
-            recordParse(cx, payload);
+            await recordParse(cx, payload);
             await commissionByQr(cx, payload);
         },
         { expected: "Verify the TH's QR code was parsed successfully by the DUT" },
@@ -214,7 +220,7 @@ certTest("TC-DD-1.8", {
         "3.a",
         "Scan the TH Device's QR code (that includes the additional TLV data) using DUT.",
         async cx => {
-            recordParse(cx, withTlvData(await thQrPayload(cx.devices.th), PLAN_TLV_DATA));
+            await recordParse(cx, withTlvData(await thQrPayload(cx.devices.th), PLAN_TLV_DATA));
         },
         { pics: "MCORE.DD.SCAN_QR_CODE", expected: "Verify the QR code has been scanned successfully." },
     )
@@ -223,7 +229,7 @@ certTest("TC-DD-1.8", {
         "Using the DUT, parse the TH's QR code to onboard the TH Device onto the Matter network.",
         async cx => {
             const payload = withTlvData(await thQrPayload(cx.devices.th), PLAN_TLV_DATA);
-            recordParse(cx, payload);
+            await recordParse(cx, payload);
             await commissionByQr(cx, payload);
         },
         {
@@ -237,7 +243,7 @@ certTest("TC-DD-1.8", {
         `Scan the TH Device's QR code using the DUT. The number of alphanumeric characters in the QR code is ` +
             `${LARGE_QR_CODE_LENGTH} characters.`,
         async cx => {
-            recordParse(cx, largeQrPayload(await thQrPayload(cx.devices.th)));
+            await recordParse(cx, largeQrPayload(await thQrPayload(cx.devices.th)));
         },
         { pics: "MCORE.DD.SCAN_QR_CODE", expected: "Verify the QR code has been scanned successfully." },
     )
@@ -246,7 +252,7 @@ certTest("TC-DD-1.8", {
         "Using the DUT, parse the TH's QR code to onboard the TH Device onto the Matter network.",
         async cx => {
             const payload = largeQrPayload(await thQrPayload(cx.devices.th));
-            recordParse(cx, payload);
+            await recordParse(cx, payload);
             await commissionByQr(cx, payload);
         },
         {


### PR DESCRIPTION
A Matter device is onboarded from a setup code its owner reads off the device: either the digits of a manual pairing code, or the `MT:…` payload behind its QR code. Cert tests could hand a controller the digits but not the payload, so the whole family of certification tests that begins with "scan the device's QR code" had no way to run. This is the first of the device-discovery block; further TC-DD cases will follow on this branch, one at a time.

## What this adds

**Commissioning from a QR payload, on both controllers.** `CommissioningTarget.qrPairingCode` is read by matter.js's controller and by chip-tool. matter.js decodes the payload and looks the device up by the full 12-bit discriminator it carries — a manual code only ever carries a 4-bit short form — while chip-tool hands the payload to its own `pairing code`, which takes either format. A target is read as QR payload, then manual code, then passcode plus discriminator, so a step can pass a device's whole commissioning description and get whichever of them that device publishes.

**A concatenated payload is refused.** One code may carry several payloads, one per device. Neither controller can be told which to pair with, so both refuse it and say to split it, rather than pairing with whichever device answers first.

**Each controller declares what it is.** It is a commissioner; it accepts a QR payload and a manual code; it takes the scanned `MT:…` form rather than only digits; it does not split a concatenated payload. CHIP's own PICS file describes a *device* and answers no to all of these, so without these declarations every test whose subject is a commissioner is filtered out of a run.

**TC-DD-1.8.** Reads the harness device's own payload, checks what the controller parsed out of it against the device's real setup code, and onboards the device from it three times: plain, with the plan's example TLV data appended, and at the 255-character maximum a single payload may have.

## Two device behaviours the test had to be built around

Both are now written down in the suite's `AGENTS.md`.

A chip device does not return to commissioning mode when its last fabric is removed — its storage has to be deleted and the app restarted for that — while matter.js does. The specification allows either. The test therefore opens a *basic* commissioning window before it removes a fabric: that is the window whose password is the device's own setup code, so the same payload still pairs afterwards. An enhanced window would mint a fresh discriminator and passcode instead.

Removing a fabric returns as soon as the device answers, but the device re-announces itself as commissionable a moment later. A commissioning started before that finds only devices the run is not looking for, so the test waits for the announcement and records the wait as evidence.

## Verification

Run against both controllers and both device kinds — matter.js and chip-tool, each against a matter.js device and a real `chip-all-clusters-app`; all four pass, and the chip legs carry the device's own "Commissioning completed successfully" line as evidence for each of the three onboardings. Full cert suite 12/12, cert framework suite 391/391, plus build, format, lint and the repository test suite. Each production change was mutation-tested against its own test.

Not covered here: splitting a concatenated payload, and restarting a device from inside a step — the latter is what TC-DD-3.20 will need, since the step engine currently treats any device exit during a step as the run's failure.
