### PR TITLE
test(testing): add TC-DD-3.21, commissioning a device with several endpoints

### DIFF
--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1265,3 +1265,18 @@ interface and need nothing.
 before that finds only devices this run is not looking for — every cert TH in the process uses
 discriminator 3840, which is all discovery matches on. `expectMdns(th, { commissionable: true })`
 before the next attempt closes that race and records the wait as the step's own network evidence.
+
+## The commissioning-flow block shares one support module (`TC-DD-3.21`)
+
+Everything the DD plans repeat — reading the TH's own payload, recording what the DUT parsed out of
+it, waiting for the commissionable advertisement, and onboarding from a payload — lives in
+`tc-dd-support.ts`, on the same "a second TC needs the same shape" trigger every other promotion in
+this file followed. `record` (record a check, throw if it failed) moved to `tc-support.ts` at the same
+time, since three TCs had their own copy.
+
+**Read the TH's endpoint topology, don't assume it.** TC-DD-3.21 needs every endpoint implementing the
+On/Off light device type. Both flavors happen to put one on endpoints 1 and 2, but that is a
+requirement the plan states of the *TH*, so the TC walks `Descriptor.partsList` and each endpoint's
+`Descriptor.deviceTypeList` for device type 0x0100 instead of naming endpoints. A TH that stops
+satisfying the precondition then fails the step that says so, rather than silently proving less: the
+step also asserts the plan's own "at least 2".

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1280,3 +1280,14 @@ requirement the plan states of the *TH*, so the TC walks `Descriptor.partsList` 
 `Descriptor.deviceTypeList` for device type 0x0100 instead of naming endpoints. A TH that stops
 satisfying the precondition then fails the step that says so, rather than silently proving less: the
 step also asserts the plan's own "at least 2".
+
+## Known flake: TC-IDM-4.1 step 4's first write reports nothing (unresolved)
+
+`step 4: write 1/3 to {"endpoint":0,"cluster":40,"attribute":5} produced no subscription report
+carrying "tc-idm-4-1-a" within 30s`. Seen on a loaded developer host with the matter.js controller, and
+once in CI on the chip-tool leg; the same commit passed on re-run, and the cert workflow is otherwise
+green on main. Both controller legs have produced it, so it is the step's own report wait rather than
+either adapter, and `subscribeAndModify` only reaches that wait on a device flavor whose log check is
+`unverified` (see "Deterministic per-write report/ack evidence"). Not root-caused. A run that hits it
+again is worth capturing rather than re-running blind: the evidence bundle's controller log shows
+whether the report arrived late or never.

--- a/support/chip-testing/test/cert/TC-DD-1.8.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-1.8.test.ts
@@ -7,22 +7,9 @@
 import { Bytes, InternalError } from "@matter/main";
 import type { QrCodeData } from "@matter/main/types";
 import { QrPairingCodeCodec } from "@matter/main/types";
-import type { CertDevice, CertStepContext, CheckRecord } from "@matter/testing";
 import { certTest } from "@matter/testing";
-import { expectMdns } from "../../src/cert/mdns-check.js";
-import { CertCheckFailedError, CommissionedRefs, expectSequence } from "./tc-support.js";
-
-const LOG_TIMEOUT_MS = 30_000;
-const MDNS_TIMEOUT_MS = 30_000;
-
-/** Outlives the rest of the run, so a later step never pairs against a window that closed on its own. */
-const WINDOW_TIMEOUT_SECONDS = 300;
-
-/** Both device flavors print the payload they publish on this line; chip prints one per commissioning flow. */
-const SETUP_QR_CODE = /SetupQRCode: \[(MT:[^\]]+)\]/;
-
-/** chip-all-clusters-app announces a completed commissioning; matter.js has no equivalent line. */
-const COMMISSIONING_COMPLETE = /Commissioning completed successfully/;
+import { commissionByQr, recordParse, thQrPayload } from "./tc-dd-support.js";
+import { CommissionedRefs } from "./tc-support.js";
 
 /**
  * The plan's own example TLV payload (§ 5.1.5): an anonymous structure carrying serial number
@@ -42,79 +29,12 @@ const LARGE_TLV_STRING_LENGTH = 135;
 
 const commissioned = new CommissionedRefs();
 
-function record(cx: CertStepContext, check: CheckRecord, what: string) {
-    cx.recorder.check(check);
-    if (check.verdict === "fail") {
-        throw new CertCheckFailedError(`${what} check failed: ${JSON.stringify(check)}`);
-    }
-}
-
-/**
- * The onboarding payload the TH publishes for its own setup code. A subject that renders one reports
- * it directly; a chip app only prints it, and the first of the two it prints is the standard
- * commissioning flow's.
- */
-async function thQrPayload(th: CertDevice): Promise<string> {
-    if (th.commissioning.qrPairingCode) {
-        return th.commissioning.qrPairingCode;
-    }
-
-    const result = await th.log.expect(
-        { chip: SETUP_QR_CODE, matterjs: SETUP_QR_CODE },
-        { flavor: th.flavor, from: 0, timeoutMs: LOG_TIMEOUT_MS },
-    );
-    if (result.verdict === "unverified") {
-        throw new InternalError(`${th.flavor} devices neither report nor print an onboarding payload`);
-    }
-
-    const payload = SETUP_QR_CODE.exec(result.matched.text)?.[1];
-    if (payload === undefined) {
-        throw new InternalError(`Matched a SetupQRCode line carrying no payload: ${result.matched.text}`);
-    }
-    return payload;
-}
-
 function decodeSingle(payload: string): QrCodeData {
     const payloads = QrPairingCodeCodec.decode(payload);
     if (payloads.length !== 1) {
         throw new InternalError(`Expected one onboarding payload, decoded ${payloads.length}`);
     }
     return payloads[0];
-}
-
-/**
- * Records what the DUT read out of `payload` and whether the setup code it read is the TH's own. The
- * parse is the DUT's, not this test's: a step that decoded the payload itself would pass against a
- * controller that cannot read one at all.
- */
-async function recordParse(cx: CertStepContext, payload: string): Promise<void> {
-    const th = cx.devices.th;
-
-    let parsed;
-    try {
-        parsed = await cx.controllers.dut.parseQrPayload(payload);
-    } catch (e) {
-        cx.recorder.check({ type: "response", verdict: "fail", detail: `DUT could not parse the payload: ${e}` });
-        throw e;
-    }
-
-    const matches =
-        parsed.discriminator === th.commissioning.discriminator && parsed.passcode === th.commissioning.passcode;
-
-    record(
-        cx,
-        {
-            type: "response",
-            verdict: matches ? "pass" : "fail",
-            detail:
-                `DUT read the ${payload.length}-character payload as version=${parsed.version} ` +
-                `vendorId=${parsed.vendorId} productId=${parsed.productId} flowType=${parsed.flowType} ` +
-                `discoveryCapabilities=0b${parsed.discoveryCapabilities.toString(2).padStart(8, "0")} ` +
-                `discriminator=${parsed.discriminator} passcode=${parsed.passcode}; the TH's own setup code is ` +
-                `discriminator=${th.commissioning.discriminator} passcode=${th.commissioning.passcode}`,
-        },
-        "Onboarding payload parse",
-    );
 }
 
 /** `payload` with `tlvData` appended, which the plan expects the DUT to parse and may then ignore. */
@@ -141,58 +61,6 @@ function largeQrPayload(payload: string): string {
     return large;
 }
 
-/**
- * Onboards the TH from `payload`, after taking the fabric an earlier step commissioned back off it.
- *
- * A chip TH does not return to commissioning mode when its last fabric goes, so the window is opened
- * while the fabric is still there. It is a basic one: that is the window whose PASE verifier is the
- * device's own setup code, which is what this TC's payload carries.
- */
-async function commissionByQr(cx: CertStepContext, payload: string): Promise<void> {
-    const dut = cx.controllers.dut;
-    const th = cx.devices.th;
-
-    const previous = commissioned.get("dut");
-    if (previous !== undefined) {
-        await dut.node(previous).openCommissioningWindow({ timeout: WINDOW_TIMEOUT_SECONDS, enhanced: false });
-        await dut.node(previous).decommission();
-        commissioned.clear("dut");
-
-        // Removing the fabric returns as soon as the TH answers; the TH advertises itself
-        // commissionable again on its own schedule, and a discovery started before that finds only
-        // the devices this run is not looking for.
-        record(
-            cx,
-            await expectMdns(th, { commissionable: true }, { timeoutMs: MDNS_TIMEOUT_MS }),
-            "TH back in commissioning mode",
-        );
-    }
-
-    const from = th.log.mark();
-    let ref;
-    try {
-        ref = await dut.commission({ qrPairingCode: payload });
-    } catch (e) {
-        cx.recorder.check({ type: "response", verdict: "fail", detail: `commissioning by payload failed: ${e}` });
-        throw e;
-    }
-    commissioned.set("dut", ref);
-    cx.recorder.check({ type: "response", verdict: "pass", detail: `commissioned as node ${ref}` });
-
-    record(
-        cx,
-        await expectSequence(
-            th.log,
-            th.flavor,
-            "commissioning complete",
-            [COMMISSIONING_COMPLETE],
-            from,
-            LOG_TIMEOUT_MS,
-        ),
-        "TH commissioning",
-    );
-}
-
 certTest("TC-DD-1.8", {
     plan: "devicediscovery.adoc",
     pics: ["MCORE.ROLE.COMMISSIONER", "MCORE.DD.QR_COMMISSIONING"],
@@ -212,7 +80,7 @@ certTest("TC-DD-1.8", {
         async cx => {
             const payload = await thQrPayload(cx.devices.th);
             await recordParse(cx, payload);
-            await commissionByQr(cx, payload);
+            await commissionByQr(cx, payload, commissioned);
         },
         { expected: "Verify the TH's QR code was parsed successfully by the DUT" },
     )
@@ -230,7 +98,7 @@ certTest("TC-DD-1.8", {
         async cx => {
             const payload = withTlvData(await thQrPayload(cx.devices.th), PLAN_TLV_DATA);
             await recordParse(cx, payload);
-            await commissionByQr(cx, payload);
+            await commissionByQr(cx, payload, commissioned);
         },
         {
             expected:
@@ -253,7 +121,7 @@ certTest("TC-DD-1.8", {
         async cx => {
             const payload = largeQrPayload(await thQrPayload(cx.devices.th));
             await recordParse(cx, payload);
-            await commissionByQr(cx, payload);
+            await commissionByQr(cx, payload, commissioned);
         },
         {
             expected:

--- a/support/chip-testing/test/cert/TC-DD-3.21.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.21.test.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InternalError } from "@matter/main";
+import { Matter } from "@matter/model";
+import type { CertNodeRef, CertStepContext } from "@matter/testing";
+import { certTest } from "@matter/testing";
+import { commissionByQr, LOG_TIMEOUT_MS, recordCommissionable, recordParse, thQrPayload } from "./tc-dd-support.js";
+import { CommissionedRefs, expectCommandInvoke, record, requireId } from "./tc-support.js";
+
+const DESCRIPTOR = Matter.clusters.require("Descriptor");
+const DESCRIPTOR_ID = requireId(DESCRIPTOR.id, "Descriptor cluster");
+const PARTS_LIST = requireId(DESCRIPTOR.attributes.require("partsList").id, "Descriptor.partsList");
+const DEVICE_TYPE_LIST = requireId(DESCRIPTOR.attributes.require("deviceTypeList").id, "Descriptor.deviceTypeList");
+
+const ON_OFF = Matter.clusters.require("OnOff");
+const ON_OFF_ID = requireId(ON_OFF.id, "OnOff cluster");
+const ON = requireId(ON_OFF.commands.require("on").id, "OnOff.on");
+const ON_OFF_ATTRIBUTE = requireId(ON_OFF.attributes.require("onOff").id, "OnOff.onOff");
+
+const ROOT_ENDPOINT = 0;
+
+/** `MA-onofflight`, the device type the plan requires on at least two non-zero endpoints. */
+const ON_OFF_LIGHT_DEVICE_TYPE = 0x0100;
+
+const commissioned = new CommissionedRefs();
+
+function isDeviceType(entry: unknown, deviceType: number): boolean {
+    return typeof entry === "object" && entry !== null && "deviceType" in entry && entry.deviceType === deviceType;
+}
+
+/**
+ * The TH's own endpoints implementing the On/Off light device type, read off its descriptors rather
+ * than assumed: the plan states the topology as a requirement on the TH, and this TC's two device
+ * flavors are separate implementations of it.
+ */
+async function onOffLightEndpoints(cx: CertStepContext, ref: CertNodeRef): Promise<number[]> {
+    const node = cx.controllers.dut.node(ref);
+
+    const parts = await node.readAttribute({
+        endpoint: ROOT_ENDPOINT,
+        cluster: DESCRIPTOR_ID,
+        attribute: PARTS_LIST,
+    });
+    if (!Array.isArray(parts)) {
+        throw new InternalError(`TH reported a parts list that is not a list: ${JSON.stringify(parts)}`);
+    }
+
+    const endpoints = new Array<number>();
+    for (const part of parts) {
+        if (typeof part !== "number") {
+            throw new InternalError(`TH reported a parts list entry that is not an endpoint: ${JSON.stringify(part)}`);
+        }
+        const deviceTypes = await node.readAttribute({
+            endpoint: part,
+            cluster: DESCRIPTOR_ID,
+            attribute: DEVICE_TYPE_LIST,
+        });
+        if (!Array.isArray(deviceTypes)) {
+            throw new InternalError(
+                `TH endpoint ${part} reported a device type list that is not a list: ${JSON.stringify(deviceTypes)}`,
+            );
+        }
+        if (deviceTypes.some(entry => isDeviceType(entry, ON_OFF_LIGHT_DEVICE_TYPE))) {
+            endpoints.push(part);
+        }
+    }
+    return endpoints;
+}
+
+certTest("TC-DD-3.21", {
+    plan: "devicediscovery.adoc",
+    pics: ["MCORE.ROLE.COMMISSIONER", "MCORE.DD.QR_COMMISSIONING"],
+    app: "all-clusters",
+})
+    .step(
+        1,
+        "Place TH into commissioning mode using the TH manufacturer's means to be discovered by the DUT Commissioner",
+        recordCommissionable,
+        { expected: "Verify that the TH is advertising and able to be discovered by the DUT commissioner." },
+    )
+    .step(
+        "2.a",
+        "Scan TH's QR code using the DUT Commissioner.",
+        async cx => {
+            await recordParse(cx, await thQrPayload(cx.devices.th));
+        },
+        { pics: "MCORE.DD.SCAN_QR_CODE", expected: "Verify the QR code has been scanned successfully." },
+    )
+    .step(
+        "2.b",
+        "DUT parses TH's QR code. Follow any steps needed for the Commissioner/Commissionee to complete the " +
+            "commissioning process over the TH Commissionee's method of device discovery",
+        async cx => {
+            const payload = await thQrPayload(cx.devices.th);
+            await recordParse(cx, payload);
+            await commissionByQr(cx, payload, commissioned);
+        },
+        {
+            expected:
+                "DUT parses TH's QR code and DUT commissions TH to the Matter network. Verify that the TH has " +
+                "been commissioned onto the Matter network.",
+        },
+    )
+    .step(
+        3,
+        "For each TH Endpoint that implements the On/Off light device, verify that the DUT acknowledges the " +
+            "existence of the Endpoint through DUT issuing an On command to the respective Endpoint",
+        commissioned.withRef("dut", async (cx, ref) => {
+            const th = cx.devices.th;
+            const endpoints = await onOffLightEndpoints(cx, ref);
+
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: endpoints.length >= 2 ? "pass" : "fail",
+                    detail: `TH implements the On/Off light device type on endpoints ${JSON.stringify(endpoints)}`,
+                },
+                "TH endpoint topology",
+            );
+
+            for (const endpoint of endpoints) {
+                const from = th.log.mark();
+                await cx.controllers.dut.node(ref).invoke("OnOff", "on", {}, endpoint);
+                record(
+                    cx,
+                    await expectCommandInvoke(th.log, th.flavor, endpoint, ON_OFF_ID, ON, [], from, LOG_TIMEOUT_MS),
+                    `OnOff.on reached endpoint ${endpoint}`,
+                );
+
+                const onOff = await cx.controllers.dut
+                    .node(ref)
+                    .readAttribute({ endpoint, cluster: ON_OFF_ID, attribute: ON_OFF_ATTRIBUTE });
+                record(
+                    cx,
+                    {
+                        type: "response",
+                        verdict: onOff === true ? "pass" : "fail",
+                        detail: `endpoint ${endpoint} reports OnOff.onOff = ${JSON.stringify(onOff)} after the command`,
+                    },
+                    `Endpoint ${endpoint} turned on`,
+                );
+            }
+        }),
+        {
+            expected:
+                "TH verifies that the DUT has successfully sent the On command to each of the endpoints which " +
+                "expose an On/Off light device type.",
+        },
+    )
+    .finalize(cx => commissioned.decommissionAll(cx));

--- a/support/chip-testing/test/cert/TC-IDM-1.3.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-1.3.test.ts
@@ -7,7 +7,7 @@
 import { InternalError } from "@matter/main";
 import { Status } from "@matter/main/types";
 import { Matter } from "@matter/model";
-import type { BatchCommandResult, BatchCommandSpec, CertStepContext, CheckRecord, DeviceFlavor } from "@matter/testing";
+import type { BatchCommandResult, BatchCommandSpec, CertStepContext, DeviceFlavor } from "@matter/testing";
 import { certTest } from "@matter/testing";
 import { registerCertCustomCluster } from "../../src/cert/custom-clusters.js";
 import { ChipFault, FAULT_TYPE_CHIP, FaultInjectionCluster } from "./fault-injection.js";
@@ -18,7 +18,7 @@ import {
     expectInvokeCount,
     expectNoInjectedFault,
 } from "./tc-idm-1.3-support.js";
-import { CertCheckFailedError, CommissionedRefs, requireId } from "./tc-support.js";
+import { CommissionedRefs, record, requireId } from "./tc-support.js";
 
 const ON_OFF = Matter.clusters.require("OnOff");
 const ON_OFF_ID = requireId(ON_OFF.id, "OnOff cluster");
@@ -59,13 +59,6 @@ const LOG_TIMEOUT_MS = 15_000;
 const CW_TIMEOUT_SECONDS = 180;
 
 const commissioned = new CommissionedRefs<"dut" | "th_client">();
-
-function record(cx: CertStepContext, check: CheckRecord, what: string) {
-    cx.recorder.check(check);
-    if (check.verdict === "fail") {
-        throw new CertCheckFailedError(`${what} check failed: ${JSON.stringify(check)}`);
-    }
-}
 
 /**
  * Records the device's answers to a batch as the step's response evidence. Arrival order is part of the

--- a/support/chip-testing/test/cert/TC-IDM-5.1.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-5.1.test.ts
@@ -5,16 +5,10 @@
  */
 
 import { Matter } from "@matter/model";
-import type { CheckRecord, CertStepContext } from "@matter/testing";
+import type { CertStepContext } from "@matter/testing";
 import { certTest } from "@matter/testing";
 import { expectTimedFollowUp, expectTimedRequest, expectUnicastReceipt } from "./tc-idm-5.1-support.js";
-import {
-    CertCheckFailedError,
-    CommissionedRefs,
-    INVOKE_REQUEST_MESSAGE,
-    requireId,
-    WRITE_REQUEST_MESSAGE,
-} from "./tc-support.js";
+import { CommissionedRefs, INVOKE_REQUEST_MESSAGE, record, requireId, WRITE_REQUEST_MESSAGE } from "./tc-support.js";
 
 const ON_OFF = Matter.clusters.require("OnOff");
 const ON_OFF_ID = requireId(ON_OFF.id, "OnOff cluster");
@@ -47,13 +41,6 @@ async function recordTimedInteraction(cx: CertStepContext, message: RegExp, from
         LOG_TIMEOUT_MS,
     );
     record(cx, followUp, "Timed follow-up");
-}
-
-function record(cx: CertStepContext, check: CheckRecord, what: string) {
-    cx.recorder.check(check);
-    if (check.verdict === "fail") {
-        throw new CertCheckFailedError(`${what} check failed: ${JSON.stringify(check)}`);
-    }
 }
 
 certTest("TC-IDM-5.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C"], app: "all-clusters" })

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -1,0 +1,145 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InternalError } from "@matter/main";
+import type { CertDevice, CertStepContext } from "@matter/testing";
+import { expectMdns } from "../../src/cert/mdns-check.js";
+import { CommissionedRefs, expectSequence, record } from "./tc-support.js";
+
+export const LOG_TIMEOUT_MS = 30_000;
+export const MDNS_TIMEOUT_MS = 30_000;
+
+/** Outlives the rest of a run, so a later step never pairs against a window that closed on its own. */
+const WINDOW_TIMEOUT_SECONDS = 300;
+
+/** Both device flavors print the payload they publish on this line; chip prints one per commissioning flow. */
+const SETUP_QR_CODE = /SetupQRCode: \[(MT:[^\]]+)\]/;
+
+/** chip-all-clusters-app announces a completed commissioning; matter.js has no equivalent line. */
+const COMMISSIONING_COMPLETE = /Commissioning completed successfully/;
+
+/**
+ * The onboarding payload the TH publishes for its own setup code. A subject that renders one reports
+ * it directly; a chip app only prints it, and the first of the two it prints is the standard
+ * commissioning flow's.
+ */
+export async function thQrPayload(th: CertDevice): Promise<string> {
+    if (th.commissioning.qrPairingCode) {
+        return th.commissioning.qrPairingCode;
+    }
+
+    const result = await th.log.expect(
+        { chip: SETUP_QR_CODE, matterjs: SETUP_QR_CODE },
+        { flavor: th.flavor, from: 0, timeoutMs: LOG_TIMEOUT_MS },
+    );
+    if (result.verdict === "unverified") {
+        throw new InternalError(`${th.flavor} devices neither report nor print an onboarding payload`);
+    }
+
+    const payload = SETUP_QR_CODE.exec(result.matched.text)?.[1];
+    if (payload === undefined) {
+        throw new InternalError(`Matched a SetupQRCode line carrying no payload: ${result.matched.text}`);
+    }
+    return payload;
+}
+
+/**
+ * Records what the DUT read out of `payload` and whether the setup code it read is the TH's own. The
+ * parse is the DUT's, not the step's: a step that decoded the payload itself would pass against a
+ * controller that cannot read one at all.
+ */
+export async function recordParse(cx: CertStepContext, payload: string): Promise<void> {
+    const th = cx.devices.th;
+
+    let parsed;
+    try {
+        parsed = await cx.controllers.dut.parseQrPayload(payload);
+    } catch (e) {
+        cx.recorder.check({ type: "response", verdict: "fail", detail: `DUT could not parse the payload: ${e}` });
+        throw e;
+    }
+
+    const matches =
+        parsed.discriminator === th.commissioning.discriminator && parsed.passcode === th.commissioning.passcode;
+
+    record(
+        cx,
+        {
+            type: "response",
+            verdict: matches ? "pass" : "fail",
+            detail:
+                `DUT read the ${payload.length}-character payload as version=${parsed.version} ` +
+                `vendorId=${parsed.vendorId} productId=${parsed.productId} flowType=${parsed.flowType} ` +
+                `discoveryCapabilities=0b${parsed.discoveryCapabilities.toString(2).padStart(8, "0")} ` +
+                `discriminator=${parsed.discriminator} passcode=${parsed.passcode}; the TH's own setup code is ` +
+                `discriminator=${th.commissioning.discriminator} passcode=${th.commissioning.passcode}`,
+        },
+        "Onboarding payload parse",
+    );
+}
+
+/**
+ * Records that the TH is discoverable as a commissionable device, which every commissioning-flow plan
+ * states as its own step or precondition.
+ */
+export async function recordCommissionable(
+    cx: CertStepContext,
+    what = "TH advertising as commissionable",
+): Promise<void> {
+    record(cx, await expectMdns(cx.devices.th, { commissionable: true }, { timeoutMs: MDNS_TIMEOUT_MS }), what);
+}
+
+/**
+ * Onboards the TH from `payload`, first taking off a fabric an earlier step commissioned.
+ *
+ * A chip TH does not return to commissioning mode when its last fabric goes, so the window is opened
+ * while the fabric is still there. It is a basic one: that is the window whose PASE verifier is the
+ * device's own setup code, which is what an onboarding payload carries.
+ */
+export async function commissionByQr(
+    cx: CertStepContext,
+    payload: string,
+    commissioned: CommissionedRefs,
+): Promise<void> {
+    const dut = cx.controllers.dut;
+    const th = cx.devices.th;
+
+    const previous = commissioned.get("dut");
+    if (previous !== undefined) {
+        await dut.node(previous).openCommissioningWindow({ timeout: WINDOW_TIMEOUT_SECONDS, enhanced: false });
+        await dut.node(previous).decommission();
+        commissioned.clear("dut");
+
+        // Removing the fabric returns as soon as the TH answers; the TH advertises itself
+        // commissionable again on its own schedule, and a discovery started before that finds only
+        // the devices this run is not looking for.
+        await recordCommissionable(cx, "TH back in commissioning mode");
+    }
+
+    const from = th.log.mark();
+    let ref;
+    try {
+        ref = await dut.commission({ qrPairingCode: payload });
+    } catch (e) {
+        cx.recorder.check({ type: "response", verdict: "fail", detail: `commissioning by payload failed: ${e}` });
+        throw e;
+    }
+    commissioned.set("dut", ref);
+    cx.recorder.check({ type: "response", verdict: "pass", detail: `commissioned as node ${ref}` });
+
+    record(
+        cx,
+        await expectSequence(
+            th.log,
+            th.flavor,
+            "commissioning complete",
+            [COMMISSIONING_COMPLETE],
+            from,
+            LOG_TIMEOUT_MS,
+        ),
+        "TH commissioning",
+    );
+}

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -24,6 +24,17 @@ export class CertCleanupError extends MatterError {}
 export class CertCheckFailedError extends MatterError {}
 
 /**
+ * Records `check` and fails the step if it did not pass. `recorder.check()` only records — a step
+ * whose evidence must gate it has to throw for itself, which is the single easiest thing to forget.
+ */
+export function record(cx: CertStepContext, check: CheckRecord, what: string) {
+    cx.recorder.check(check);
+    if (check.verdict === "fail") {
+        throw new CertCheckFailedError(`${what} check failed: ${JSON.stringify(check)}`);
+    }
+}
+
+/**
  * Tracks commissioned node refs by role for one cert-test run. Each controller's own
  * `decommission()` only removes *that controller's* fabric via its own CASE session, so cleanup has
  * to visit every role independently. Shared by `TC-IDM-2.1.test.ts`/`TC-ACT-3.2.test.ts`/

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -24,8 +24,10 @@ export class CertCleanupError extends MatterError {}
 export class CertCheckFailedError extends MatterError {}
 
 /**
- * Records `check` and fails the step if it did not pass. `recorder.check()` only records — a step
- * whose evidence must gate it has to throw for itself, which is the single easiest thing to forget.
+ * Records `check` and fails the step on a `"fail"` verdict — `recorder.check()` only records, so a
+ * step whose evidence must gate it has to throw for itself, which is the single easiest thing to
+ * forget. `"unverified"` passes through: that is what a log check reports on a flavor nobody wrote a
+ * pattern for, and it is not a failure (see the flavor-pattern policy in this directory's AGENTS.md).
  */
 export function record(cx: CertStepContext, check: CheckRecord, what: string) {
     cx.recorder.check(check);


### PR DESCRIPTION
Second case of the device-discovery block, on top of #4251.

## TC-DD-3.21

The case checks that a commissioner onboards a device carrying more than one endpoint and can then address each of them. Four steps, all executable here: the harness device advertises itself, the commissioner reads and parses its onboarding payload, onboards from it, and then sends an On command to every endpoint that exposes an on/off light — confirming both that the device received each command and that the endpoint changed state.

**The endpoint layout is read, not assumed.** The plan states "on/off light on at least 2 non-zero endpoints" as a requirement on the *harness device*, so the step walks `Descriptor.partsList` and each endpoint's `Descriptor.deviceTypeList` looking for device type `0x0100`, and asserts it found at least two. Both device kinds happen to use endpoints 1 and 2, but hard-coding that would let a harness that no longer meets the requirement pass while proving less. Evidence records what it found:

```
TH implements the On/Off light device type on endpoints [1,2]
```

## Shared helpers

Everything the device-discovery plans repeat — reading the device's own onboarding payload, recording what the commissioner parsed out of it, waiting for the commissionable advertisement, and onboarding from a payload — moves from TC-DD-1.8 into `tc-dd-support.ts`, on the same "a second case needs the same shape" trigger the suite's earlier promotions used. `record` (record a check, fail the step if the check failed) moves into `tc-support.ts`; three cases had their own copy. No behaviour change in TC-DD-1.8: it runs the same four legs green.

No new framework capability, so no CHANGELOG entry.

## Verification

All four controller × device legs pass locally — matter.js and chip-tool controllers, each against a matter.js device and a real `chip-all-clusters-app`. The chip legs carry device-side evidence: `Commissioning completed successfully`, and one `CommandDataIB CommandId=0x1` match per endpoint. Full cert suite 13/13, cert framework 394/394, plus build, format, lint and the repository test suite.
