### PR TITLE
fix(testing): verify a subscription report from the harness device, not from chip-tool's callbacks

### DIFF
--- a/support/chip-testing/src/chip-tool/chip-tool-client.ts
+++ b/support/chip-testing/src/chip-tool/chip-tool-client.ts
@@ -687,8 +687,9 @@ export class ChipToolClient {
     }
 
     #send(frame: string) {
+        // ws reports success as `null` rather than by omitting the argument
         this.#socket?.send(frame, cause => {
-            if (cause !== undefined) {
+            if (cause !== undefined && cause !== null) {
                 this.#options.onLog(`chip-tool frame ${JSON.stringify(frame)} failed to send: ${cause}`);
             }
         });

--- a/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
@@ -24,6 +24,7 @@ import {
 import { registerCertCustomCluster } from "../../src/cert/custom-clusters.js";
 import { ChipToolExitError } from "../../src/chip-tool/chip-tool-client.js";
 import { FaultInjectionCluster } from "../cert/fault-injection.js";
+import { countMatches } from "../cert/tc-support.js";
 import { delay, FakeChipTool, waitFor, writeStandInBinary } from "./fake-chip-tool.js";
 
 const BASIC_INFORMATION = Matter.clusters.require("BasicInformation");
@@ -202,6 +203,15 @@ describe("ChipToolControllerAdapter", function () {
         expect(fake.commands).deep.equal([`pairing onnetwork-long ${FIRST_NODE} 20202021 3840`]);
         expect(await started.commission({ manualPairingCode: "36217551633" })).equal("4098");
         expect(fake.commands[1]).equal("pairing code 4098 36217551633");
+    });
+
+    it("does not report a successful frame as a failure, which would hide a real one", async () => {
+        // ws hands its callback `null` on success rather than leaving the argument out
+        const started = await start();
+        await started.commission({ passcode: 20202021, discriminator: 3840 });
+
+        await new Promise(resolve => setImmediate(resolve));
+        expect(countMatches(started.log, "chip-tool", /failed to send/, 0)).equal(0);
     });
 
     it("pairs from a QR onboarding payload, which chip-tool reads with the same command", async () => {

--- a/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
@@ -269,17 +269,19 @@ describe("subscribeAndModify", () => {
         });
     });
 
-    it("fails when the reported values are not the written ones in order", async () => {
+    it("records, rather than fails, callbacks that do not carry the written values in order", async () => {
         const fixture = new Fixture("chip-local", (f, _index) => {
             f.pushReport(SUBSCRIPTION_ID);
             f.report(true);
         });
 
         await withFixture(fixture, async f => {
-            await expect(f.run(VALUES, IMPATIENT)).rejectedWith(
-                CertCheckFailedError,
-                /does not carry the written values \[true,false,true\] in order \(matched 1\/3\)/,
-            );
+            await f.run(VALUES, IMPATIENT);
+
+            expect(f.failures).deep.equal([]);
+            const unverified = f.checks.filter(check => check.verdict === "unverified");
+            expect(unverified).to.have.lengthOf(1);
+            expect(unverified[0].detail).match(/matched 1\/3/);
         });
     });
 
@@ -320,32 +322,32 @@ describe("subscribeAndModify", () => {
         });
     });
 
-    it("confirms a write through onUpdate when the log carries no subscription id", async () => {
-        const fixture = new Fixture("matterjs", (f, _index, value) => {
-            f.report(value);
-            f.report(value);
-        });
+    it("passes on the TH's own report and ack when the controller's callbacks lag behind", async () => {
+        // chip-tool's interactive server hands over only the first result of a batch, so a report the
+        // TH coalesced with another attribute reaches no callback — the log is what proves the write
+        const fixture = new Fixture("chip-local", f => f.pushReport(SUBSCRIPTION_ID));
 
         await withFixture(fixture, async f => {
-            await f.run();
+            await f.run(VALUES, IMPATIENT);
 
             expect(f.failures).deep.equal([]);
-            const summary = f.passes[f.passes.length - 1];
-            expect(summary.detail).match(/3 by onUpdate/);
-            expect(summary.detail).match(/onUpdate delivered 6 reports carrying the written values in order/);
+            const unverified = f.checks.filter(check => check.verdict === "unverified");
+            expect(unverified).to.have.lengthOf(1);
+            expect(unverified[0].detail).match(/matched 0\/3/);
+            expect(unverified[0].detail).match(/confirmed by the TH's own report and its Success ack/);
         });
     });
 
-    it("fails by timeout when the log carries no subscription id and onUpdate never fires", async () => {
-        const fixture = new Fixture("matterjs", () => {});
+    it("fails when the TH's log carries no report for this write, whatever the callbacks say", async () => {
+        const fixture = new Fixture("chip-local", (f, _index, value) => {
+            f.report(value);
+        });
 
         await withFixture(fixture, async f => {
             await expect(f.run(VALUES, IMPATIENT)).rejectedWith(
                 CertCheckFailedError,
-                /produced no subscription report carrying true/,
+                /StatusResponse ack check failed/,
             );
-
-            expect(f.failures[f.failures.length - 1].type).equal("response");
         });
     });
 });

--- a/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
@@ -230,8 +230,8 @@ describe("subscribeAndModify", () => {
 
             expect(f.failures).deep.equal([]);
             const summary = f.passes[f.passes.length - 1];
-            expect(summary.detail).match(/3 confirmed by their own report on subscription 0x2a/);
-            expect(summary.detail).match(/onUpdate delivered 6 reports carrying the written values in order/);
+            expect(summary.detail).match(/each confirmed by its own report on subscription 0x2a/);
+            expect(summary.detail).match(/onUpdate delivered 6 reports, 3\/3 of the written values in order/);
         });
     });
 

--- a/support/chip-testing/test/cert-framework/tc-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-support.test.ts
@@ -18,7 +18,9 @@ import {
     expectChunkedTransfer,
     expectCommandInvoke,
     expectMessageWithPath,
+    expectReportAck,
     expectSequence,
+    expectSubscriptionId,
     fabricFilteredPattern,
     READ_REQUEST_MESSAGE,
     requireId,
@@ -334,6 +336,88 @@ describe("expectMessageWithPath", () => {
 
         expect(record.verdict).equal("fail");
         expect(elapsed).lessThan(timeoutMs * 1.25);
+    });
+});
+
+describe("expectSubscriptionId and expectReportAck against a matter.js TH", () => {
+    // Lines a matter.js TH writes for one subscription: the response naming the id it minted, the
+    // report it then sends on that subscription, and the DUT's answer to that very report — the
+    // payload is a StatusResponseMessage whose context tag 0 holds the status, so 00 is Success
+    const SUBSCRIBE_RESPONSE =
+        "DEBUG MessageChannel Message » for: I/SubscribeResponse sub#: 54c99e7e maxInterval: 1m 27s " +
+        "id: @1:1b669•2d86⇵7689✉05ab904c type: 0x1/0x4";
+    const REPORT =
+        "DEBUG MessageChannel Message » for: I/ReportData sub#: 54c99e7e attr: 1 backOff: 342ms " +
+        "id: @1:1b669•2d86⇵7689✉05ab904b type: 0x1/0x5";
+    const ACK =
+        "DEBUG MessageExchange Message « for: I/StatusResponse id: @1:1b669•2d86⇵7689✉082f5518 type: 0x1/0x1 " +
+        "acked: 05ab904b reqAck size: 8 payload: 1524000024ff0c18";
+
+    async function ack(lines: string[], subscriptionId = 0x54c99e7e) {
+        return withFollower(lines, follower => expectReportAck(follower, "matterjs", subscriptionId, 0, 200), {
+            endSource: true,
+        });
+    }
+
+    it("reads the id the TH minted", async () => {
+        const lookup = await withFollower([SUBSCRIBE_RESPONSE], follower =>
+            expectSubscriptionId(follower, "matterjs", 0, 200),
+        );
+
+        expect(lookup.subscriptionId).equal(0x54c99e7e);
+        expect(lookup.check.verdict).equal("pass");
+    });
+
+    it("passes when the DUT acked this report with Success", async () => {
+        const record = await ack([REPORT, ACK]);
+
+        expect(record.verdict).equal("pass");
+        expect(record.matched).equal(ACK);
+    });
+
+    it("fails on an ack for another report, however close it sits", async () => {
+        const record = await ack([REPORT, ACK.replace("acked: 05ab904b", "acked: 05ab9999")]);
+
+        expect(record.verdict).equal("fail");
+    });
+
+    it("fails on a report of another subscription", async () => {
+        const record = await ack([REPORT.replace("sub#: 54c99e7e", "sub#: 54c99e7f"), ACK]);
+
+        expect(record.verdict).equal("fail");
+    });
+
+    it("ignores the keepalive an idle subscription sends, which carries no data", async () => {
+        const keepalive = REPORT.replace("attr: 1", "empty").replace("✉05ab904b", "✉05ab9052");
+        const keepaliveAck = ACK.replace("acked: 05ab904b", "acked: 05ab9052");
+
+        expect((await ack([keepalive, keepaliveAck])).verdict).equal("fail");
+        expect((await ack([keepalive, keepaliveAck, REPORT, ACK])).verdict).equal("pass");
+    });
+
+    it("matches the id by value, which a report pads to eight digits and the response does not", async () => {
+        const record = await ack([REPORT.replace("sub#: 54c99e7e", "sub#: 054c99e7e"), ACK]);
+
+        expect(record.verdict).equal("pass");
+    });
+
+    it("does not take a longer id that merely starts with ours", async () => {
+        const record = await ack([REPORT.replace("sub#: 54c99e7e", "sub#: 54c99e7ef"), ACK]);
+
+        expect(record.verdict).equal("fail");
+    });
+
+    it("accepts an event report, which says `ev:` where an attribute report says `attr:`", async () => {
+        const record = await ack([REPORT.replace("attr: 1", "ev: 1"), ACK]);
+
+        expect(record.verdict).equal("pass");
+    });
+
+    it("fails when the DUT acked with a status other than Success", async () => {
+        const record = await ack([REPORT, ACK.replace("payload: 15240000", "payload: 15240001")]);
+
+        expect(record.verdict).equal("fail");
+        expect(record.detail).match(/status 0x01/);
     });
 });
 

--- a/support/chip-testing/test/cert-framework/tc-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-support.test.ts
@@ -395,8 +395,9 @@ describe("expectSubscriptionId and expectReportAck against a matter.js TH", () =
         expect((await ack([keepalive, keepaliveAck, REPORT, ACK])).verdict).equal("pass");
     });
 
-    it("matches the id by value, which a report pads to eight digits and the response does not", async () => {
-        const record = await ack([REPORT.replace("sub#: 54c99e7e", "sub#: 054c99e7e"), ACK]);
+    it("matches an id of fewer digits, which the TH pads to eight", async () => {
+        const short = 0xa6c2b1e;
+        const record = await ack([REPORT.replace("sub#: 54c99e7e", `sub#: 0${short.toString(16)}`), ACK], short);
 
         expect(record.verdict).equal("pass");
     });

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1287,8 +1287,10 @@ step also asserts the plan's own "at least 2".
 intermittently, on the chip-tool controller against a matterjs device — about half of full-suite runs
 locally, once in CI.
 
-**Root cause**, read off a traced reproduction and confirmed in chip-tool's source: while no command
-runs, the client parks an async-report frame (`ChipToolClient`). chip-tool's
+**Root cause**, readable in chip-tool's own source and corroborated by a traced reproduction (add a log
+line to `ChipToolClient`'s frame handler and `ChipToolControllerAdapter.#dispatchReports`, then run the
+whole suite with `MATTER_CERT_CONTROLLER=chip-tool` until a run fails — roughly one in two): while no
+command runs, the client parks an async-report frame (`ChipToolClient`). chip-tool's
 `InteractiveServerCommand::LogJSON` (`examples/chip-tool/commands/interactive/InteractiveCommands.cpp`)
 sends the reply and calls `Reset()` on the **first** result recorded in that mode, and `Reset()` clears
 `mEnabled`, after which `MaybeAddResult` drops the rest. One parked frame yields exactly one attribute;
@@ -1310,9 +1312,10 @@ and `expectReportAck` now have matterjs branches:
   answer to **that** report — matter.js names the acked message counter, which is a tighter correlation
   than the chip path's exchange id — and the byte after `152400` is the status, `00` being Success.
 
-Two traps in those lines: matter.js pads the id to eight digits on a report but not on the response
-that announced it, so the id is matched by value; and an event report says `ev:` where an attribute
-report says `attr:`, which TC-IDM-6.4 needs.
+Two traps in those lines. matter.js renders a subscription id through `Subscription.idStrOf`, which is
+`hex.fixed(id, 8)` — an id built with a plain `toString(16)` matches no line at all whenever the id has
+fewer than eight significant digits. And an event report says `ev:` where an attribute report says
+`attr:`, which TC-IDM-6.4 needs.
 
 With the device's own log carrying every write, `subscribeAndModify` no longer fails a step when the
 controller's `onUpdate` callbacks come up short — it records that as `"unverified"` with the counts.

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1281,13 +1281,40 @@ requirement the plan states of the *TH*, so the TC walks `Descriptor.partsList` 
 satisfying the precondition then fails the step that says so, rather than silently proving less: the
 step also asserts the plan's own "at least 2".
 
-## Known flake: TC-IDM-4.1 step 4's first write reports nothing (unresolved)
+## chip-tool delivers one result per async report and discards the rest
 
-`step 4: write 1/3 to {"endpoint":0,"cluster":40,"attribute":5} produced no subscription report
-carrying "tc-idm-4-1-a" within 30s`. Seen on a loaded developer host with the matter.js controller, and
-once in CI on the chip-tool leg; the same commit passed on re-run, and the cert workflow is otherwise
-green on main. Both controller legs have produced it, so it is the step's own report wait rather than
-either adapter, and `subscribeAndModify` only reaches that wait on a device flavor whose log check is
-`unverified` (see "Deterministic per-write report/ack evidence"). Not root-caused. A run that hits it
-again is worth capturing rather than re-running blind: the evidence bundle's controller log shows
-whether the report arrived late or never.
+`step 4: write 1/3 … produced no subscription report carrying "tc-idm-4-1-a" within 30s`,
+intermittently, on the chip-tool controller against a matterjs device — about half of full-suite runs
+locally, once in CI.
+
+**Root cause**, read off a traced reproduction and confirmed in chip-tool's source: while no command
+runs, the client parks an async-report frame (`ChipToolClient`). chip-tool's
+`InteractiveServerCommand::LogJSON` (`examples/chip-tool/commands/interactive/InteractiveCommands.cpp`)
+sends the reply and calls `Reset()` on the **first** result recorded in that mode, and `Reset()` clears
+`mEnabled`, after which `MaybeAddResult` drops the rest. One parked frame yields exactly one attribute;
+a numeric park does not batch, its timer only logs a timeout error. matter.js reports every changed
+attribute of a cluster in one `ReportData`, and writing `nodeLabel` bumps the whole `BasicInformation`
+data version, so step 3's still-live subscription on `localConfigDisabled` rides along and can win the
+race. Nothing on the client side recovers the dropped result.
+
+**What the plan actually asks for is the TH's own view**: "verify on the TH that the status response
+received from the DUT for every report data sent is a Success". So the fix is to read that from the
+device, as the chip flavors already did, rather than from a controller callback. `expectSubscriptionId`
+and `expectReportAck` now have matterjs branches:
+
+- `Message » for: I/SubscribeResponse sub#: <id>` names the subscription.
+- `Message » for: I/ReportData sub#: <id> attr: N` (or `ev: N`) is a report carrying data; the
+  keepalive an idle subscription sends at its maximum interval is marked `empty` and must not stand in
+  for one.
+- `Message « for: I/StatusResponse … acked: <that report's counter> … payload: 152400 00` is the DUT's
+  answer to **that** report — matter.js names the acked message counter, which is a tighter correlation
+  than the chip path's exchange id — and the byte after `152400` is the status, `00` being Success.
+
+Two traps in those lines: matter.js pads the id to eight digits on a report but not on the response
+that announced it, so the id is matched by value; and an event report says `ev:` where an attribute
+report says `attr:`, which TC-IDM-6.4 needs.
+
+With the device's own log carrying every write, `subscribeAndModify` no longer fails a step when the
+controller's `onUpdate` callbacks come up short — it records that as `"unverified"` with the counts.
+A report carrying a value nobody wrote is still a failure. What this gives up: a controller that
+delivered the values out of order is no longer caught, which the plan never asked about anyway.

--- a/support/chip-testing/test/cert/tc-idm-4.1-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-4.1-support.ts
@@ -83,15 +83,15 @@ export interface SubscribeAndModifyTimeouts {
  * bare mark taken after subscribe() — subscribe() resolving only means the client has sent the priming
  * ack, not that this log has decoded it yet.
  *
- * `onUpdate` asserts values rather than arrival counts: `values` must come back as an in-order
- * subsequence of what it delivers, so a duplicate or keepalive report is an extra element of that
- * sequence and never the next write's confirmation, while a value this step never wrote is a mismatch.
- * A flavor whose log carries no subscription id (matterjs) has nothing to correlate on, so there that
- * subsequence is also what confirms each write.
+ * `onUpdate` is secondary evidence, and asserts values rather than arrival counts: a value this step
+ * never wrote fails it, while `values` failing to come back as an in-order subsequence is recorded
+ * `"unverified"` — chip-tool's interactive server hands over only the first result of a batch and
+ * discards the rest (see this directory's AGENTS.md), so a report a TH coalesced with another
+ * attribute reaches no callback however well the interaction went.
  *
  * What the log confirmation does not prove: that the report it matched carried this write's data
- * rather than being a keepalive on the same subscription. Conversely a report the controller drops
- * before `onUpdate` fails the value assertion even though the interaction itself succeeded.
+ * rather than another change on the same subscription. A report carrying no data at all — the
+ * keepalive an idle subscription sends — is excluded on both flavors.
  */
 export async function subscribeAndModify<Value>(
     cx: CertStepContext,
@@ -179,7 +179,6 @@ export async function subscribeAndModify<Value>(
     }
 
     let ackCursor = primingAckCheck.logLine !== undefined ? primingAckCheck.logLine + 1 : th.log.mark();
-    let logConfirmed = 0;
     for (let i = 0; i < values.length; i++) {
         // A report already in the log when the write was issued cannot be this write's — a further
         // chunk of the priming report, or a keepalive on this same subscription, would otherwise
@@ -205,7 +204,6 @@ export async function subscribeAndModify<Value>(
                 `StatusResponse ack check failed for step ${step}, write ${i + 1}/${values.length}: ${JSON.stringify(ackCheck)}`,
             );
         }
-        logConfirmed++;
         if (ackCheck.logLine !== undefined) {
             ackCursor = ackCheck.logLine + 1;
         }
@@ -247,8 +245,8 @@ export async function subscribeAndModify<Value>(
         type: "response",
         verdict: "pass",
         detail:
-            `step ${step}: ${values.length} distinct writes to ${JSON.stringify(path)} — ${logConfirmed} confirmed ` +
-            `by their own report on subscription ${idText} in the TH's log, ${values.length - logConfirmed} by ` +
-            `onUpdate; onUpdate delivered ${reported.length} reports carrying the written values in order`,
+            `step ${step}: ${values.length} distinct writes to ${JSON.stringify(path)}, each confirmed by its own ` +
+            `report on subscription ${idText} in the TH's log and the DUT's Success ack for it; onUpdate ` +
+            `delivered ${reported.length} reports, ${matched}/${values.length} of the written values in order`,
     });
 }

--- a/support/chip-testing/test/cert/tc-idm-4.1-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-4.1-support.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Duration, Millis, Time } from "@matter/main";
+import { Millis, Time } from "@matter/main";
 import type { AttributePathSpec, CertNodeRef, CertStepContext } from "@matter/testing";
 import {
     ACK_WAIT_TIMEOUT_MS,
@@ -160,6 +160,16 @@ export async function subscribeAndModify<Value>(
         );
     }
 
+    // Every flavor names its subscriptions in its own log. One that does not cannot show the TH's own
+    // side of what this step claims, and the controller's callbacks are no substitute for it — chip-tool
+    // drops reports its device coalesced (see AGENTS.md) — so the step says so rather than proving less.
+    if (idLookup.subscriptionId === undefined) {
+        throw new CertCheckFailedError(
+            `Step ${step} cannot read a subscription id from a ${th.flavor} TH's log, so the reports this step ` +
+                "writes for cannot be attributed to its own subscription",
+        );
+    }
+
     const primingAckCheck = await expectReportAck(th.log, th.flavor, idLookup.subscriptionId, established, establishMs);
     cx.recorder.check(primingAckCheck);
     if (primingAckCheck.verdict === "fail") {
@@ -190,29 +200,14 @@ export async function subscribeAndModify<Value>(
             reportMs,
         );
         cx.recorder.check(ackCheck);
-        if (ackCheck.verdict === "fail") {
+        if (ackCheck.verdict !== "pass") {
             throw new CertCheckFailedError(
                 `StatusResponse ack check failed for step ${step}, write ${i + 1}/${values.length}: ${JSON.stringify(ackCheck)}`,
             );
         }
-        if (ackCheck.verdict === "pass") {
-            logConfirmed++;
-            if (ackCheck.logLine !== undefined) {
-                ackCursor = ackCheck.logLine + 1;
-            }
-        } else {
-            const arrived = await waitForReport(
-                () => matched > i,
-                fn => (notify = fn),
-                reportMs,
-            );
-            if (!arrived) {
-                failResponse(
-                    `step ${step}: write ${i + 1}/${values.length} to ${JSON.stringify(path)} produced no ` +
-                        `subscription report carrying ${JSON.stringify(values[i])} within ` +
-                        Duration.format(Millis(reportMs)),
-                );
-            }
+        logConfirmed++;
+        if (ackCheck.logLine !== undefined) {
+            ackCursor = ackCheck.logLine + 1;
         }
 
         if (mismatch !== undefined) {
@@ -231,11 +226,20 @@ export async function subscribeAndModify<Value>(
         failResponse(`step ${step}: ${mismatch}`);
     }
     if (!allReported) {
-        failResponse(
-            `step ${step}: onUpdate delivered ${JSON.stringify(reported)}, which does not carry the written values ` +
-                `${JSON.stringify(values)} in order (matched ${matched}/${values.length}) within ` +
-                Duration.format(Millis(reportMs)),
-        );
+        // What the plan asks to verify is the TH's own view: it reported, and the DUT acked Success,
+        // which the loop above took from the TH's log for every write. A value missing from the
+        // controller's own callbacks is a gap in that controller's delivery rather than in the
+        // behaviour under test — chip-tool's interactive server hands over only the first result of a
+        // batch and discards the rest, so a report the TH coalesced with another attribute reaches no
+        // callback at all.
+        cx.recorder.check({
+            type: "response",
+            verdict: "unverified",
+            detail:
+                `step ${step}: onUpdate delivered ${JSON.stringify(reported)} of the written values ` +
+                `${JSON.stringify(values)} (matched ${matched}/${values.length}); every write is confirmed by the ` +
+                "TH's own report and its Success ack instead",
+        });
     }
 
     const idText = idLookup.subscriptionId === undefined ? "(none)" : `0x${idLookup.subscriptionId.toString(16)}`;

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -182,11 +182,14 @@ const MATTERJS_SUBSCRIBE_RESPONSE = /Message » for: I\/SubscribeResponse sub#: 
  * keepalive's ack must not stand in for a report's.
  */
 function matterjsReportPattern(subscriptionId: number): RegExp {
-    // matter.js pads the id to eight digits on a report and leaves it unpadded on the response that
-    // announced it, so the id is matched for its value rather than for how it was printed
     return new RegExp(
-        `Message » for: I/ReportData sub#: 0*${subscriptionId.toString(16)}\\b (?:attr|ev): \\d+.*?✉([0-9a-f]+)`,
+        `Message » for: I/ReportData sub#: ${matterjsSubscriptionIdOf(subscriptionId)} (?:attr|ev): \\d+.*?✉([0-9a-f]+)`,
     );
+}
+
+/** As `Subscription.idStrOf` renders it (`hex.fixed(id, 8)`); an unpadded id matches no line at all. */
+function matterjsSubscriptionIdOf(subscriptionId: number): string {
+    return subscriptionId.toString(16).padStart(8, "0");
 }
 
 /**
@@ -616,7 +619,7 @@ export const ACK_WAIT_TIMEOUT_MS = 15_000;
 /** What the TH's own SubscribeResponse says about the subscription a step just established. */
 export interface SubscriptionIdLookup {
     check: CheckRecord;
-    /** Absent when the lookup failed, and for the matterjs flavor. */
+    /** Absent when the lookup failed, or for a flavor whose log names no subscription. */
     subscriptionId?: number;
 }
 
@@ -669,7 +672,8 @@ async function matterjsSubscriptionId(
  * Reads back the id the TH minted for the subscription whose SubscribeResponse it sends at or after
  * `from`. Every step here keeps its subscriptions (`keepSubscriptions: true`) and their max interval
  * is shorter than the whole run, so several subscriptions report concurrently from step 3 onward —
- * the id is what tells one step's reports from another's.
+ * the id is what tells one step's reports from another's. Both flavors name it: chip in its decode
+ * dump, matter.js on the response itself.
  */
 export async function expectSubscriptionId(
     log: LogFollower,
@@ -857,8 +861,11 @@ async function matterjsReportAck(
  * This closes that gap by reading the CHIP Exchange id our report was sent on (see
  * {@link REPORT_SENT_LINE}) and requiring the ack to arrive on that same exchange — a different
  * subscription's own report/ack pair carries its own, different exchange id, so it can no longer
- * stand in for ours. `"unverified"` for the matterjs flavor (no `subscriptionId`, no chip decode
- * dump to match).
+ * stand in for ours.
+ *
+ * Against a matter.js TH the correlation is tighter still: it names the message counter each ack
+ * carries, so the ack is matched to this very report rather than to whatever answered on the same
+ * exchange next.
  */
 export async function expectReportAck(
     log: LogFollower,

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -172,6 +172,32 @@ const STATUS_RESPONSE_RECEIVED = /Msg RX from.*\(IM:StatusResponse\)/;
 export const SUBSCRIBE_RESPONSE_MESSAGE = /\[DMG\] SubscribeResponseMessage =\s*$/;
 export const SUBSCRIPTION_ID_LINE = /SubscriptionId = 0x([0-9a-f]+),\s*$/;
 
+/** matter.js names the subscription it just minted on the response that carries it. */
+const MATTERJS_SUBSCRIBE_RESPONSE = /Message » for: I\/SubscribeResponse sub#: ([0-9a-f]+)/;
+
+/**
+ * matter.js's own outgoing report, tagged with the subscription it belongs to and the message counter
+ * its ack will name. A report says how much it carries — `attr:` for attributes, `ev:` for events —
+ * where the keepalive an idle subscription sends at its maximum interval is marked `empty`, and a
+ * keepalive's ack must not stand in for a report's.
+ */
+function matterjsReportPattern(subscriptionId: number): RegExp {
+    // matter.js pads the id to eight digits on a report and leaves it unpadded on the response that
+    // announced it, so the id is matched for its value rather than for how it was printed
+    return new RegExp(
+        `Message » for: I/ReportData sub#: 0*${subscriptionId.toString(16)}\\b (?:attr|ev): \\d+.*?✉([0-9a-f]+)`,
+    );
+}
+
+/**
+ * The DUT's answer to the report `counter` identifies, whose payload is a `StatusResponseMessage`:
+ * an anonymous structure whose context tag 0 holds the status, so `152400` opens it and the byte after
+ * is the status itself (Matter Core § 8.9.2.3, § A.7.3).
+ */
+function matterjsReportAckPattern(counter: string): RegExp {
+    return new RegExp(`Message « for: I/StatusResponse .*acked: ${counter} .*?payload: 152400([0-9a-f]{2})`);
+}
+
 export function subscriptionIdPattern(subscriptionId: number): RegExp {
     return new RegExp(`SubscriptionId = 0x${subscriptionId.toString(16)},\\s*$`);
 }
@@ -594,12 +620,56 @@ export interface SubscriptionIdLookup {
     subscriptionId?: number;
 }
 
+async function matterjsSubscriptionId(
+    log: LogFollower,
+    flavor: string,
+    from: number,
+    timeoutMs: number,
+): Promise<SubscriptionIdLookup> {
+    const pattern = String(MATTERJS_SUBSCRIBE_RESPONSE);
+    let response: LogExpectResult;
+    try {
+        response = await log.expect({ matterjs: MATTERJS_SUBSCRIBE_RESPONSE }, { flavor, timeoutMs, from });
+    } catch (e) {
+        if (e instanceof CertLogTimeoutError || e instanceof CertLogClosedError) {
+            return { check: { type: "device-log", verdict: "fail", pattern, detail: e.message, logLine: from } };
+        }
+        throw e;
+    }
+    if (response.verdict === "unverified") {
+        return { check: { type: "device-log", verdict: "unverified" } };
+    }
+
+    const id = MATTERJS_SUBSCRIBE_RESPONSE.exec(response.matched.text)?.[1];
+    if (id === undefined) {
+        return {
+            check: {
+                type: "device-log",
+                verdict: "fail",
+                pattern,
+                detail: `SubscribeResponse carries no readable subscription id: ${response.matched.text}`,
+                logLine: response.matched.index,
+            },
+        };
+    }
+
+    return {
+        subscriptionId: parseInt(id, 16),
+        check: {
+            type: "device-log",
+            verdict: "pass",
+            pattern,
+            matched: response.matched.text,
+            logLine: response.matched.index,
+        },
+    };
+}
+
 /**
  * Reads back the id the TH minted for the subscription whose SubscribeResponse it sends at or after
  * `from`. Every step here keeps its subscriptions (`keepSubscriptions: true`) and their max interval
  * is shorter than the whole run, so several subscriptions report concurrently from step 3 onward —
- * the id is what tells one step's reports from another's. `"unverified"` for the matterjs flavor,
- * whose logger emits no decode dump to read an id out of.
+ * the id is what tells one step's reports from another's.
  */
 export async function expectSubscriptionId(
     log: LogFollower,
@@ -607,6 +677,10 @@ export async function expectSubscriptionId(
     from: number,
     timeoutMs: number,
 ): Promise<SubscriptionIdLookup> {
+    if (flavor === "matterjs") {
+        return matterjsSubscriptionId(log, flavor, from, timeoutMs);
+    }
+
     const sequence = [SUBSCRIBE_RESPONSE_MESSAGE, /\{\s*$/, SUBSCRIPTION_ID_LINE];
     try {
         const result = await expectAdjacentLines(log, flavor, sequence, from, timeoutMs);
@@ -706,6 +780,75 @@ function exchangeIdBefore(log: LogFollower, beforeIndex: number): string | undef
 }
 
 /**
+ * As {@link expectReportAck} against a matter.js TH, which names both the subscription a report
+ * belongs to and the message counter its ack carries — so the ack is matched to this very report
+ * rather than to whatever answered on the same exchange next.
+ */
+async function matterjsReportAck(
+    log: LogFollower,
+    flavor: string,
+    subscriptionId: number,
+    from: number,
+    timeoutMs: number,
+): Promise<CheckRecord> {
+    const deadline = Time.nowMs + timeoutMs;
+    const remaining = () => Math.max(1, deadline - Time.nowMs);
+    const reportPattern = matterjsReportPattern(subscriptionId);
+    const pattern = `${reportPattern} then its own Success StatusResponse`;
+
+    try {
+        const report = await log.expect({ matterjs: reportPattern }, { flavor, timeoutMs: remaining(), from });
+        if (report.verdict === "unverified") {
+            return { type: "device-log", verdict: "unverified" };
+        }
+
+        const counter = reportPattern.exec(report.matched.text)?.[1];
+        if (counter === undefined) {
+            return {
+                type: "device-log",
+                verdict: "fail",
+                pattern,
+                detail: `Report carries no readable message counter: ${report.matched.text}`,
+                logLine: report.matched.index,
+            };
+        }
+
+        const ackPattern = matterjsReportAckPattern(counter);
+        const ack = await log.expect(
+            { matterjs: ackPattern },
+            { flavor, timeoutMs: remaining(), from: report.matched.index + 1 },
+        );
+        if (ack.verdict === "unverified") {
+            return { type: "device-log", verdict: "unverified" };
+        }
+
+        const status = ackPattern.exec(ack.matched.text)?.[1];
+        if (status !== "00") {
+            return {
+                type: "device-log",
+                verdict: "fail",
+                pattern,
+                detail: `The DUT acked our report with status 0x${status}`,
+                logLine: ack.matched.index,
+            };
+        }
+
+        return {
+            type: "device-log",
+            verdict: "pass",
+            pattern,
+            matched: ack.matched.text,
+            logLine: ack.matched.index,
+        };
+    } catch (e) {
+        if (e instanceof CertLogTimeoutError || e instanceof CertLogClosedError) {
+            return { type: "device-log", verdict: "fail", pattern, detail: e.message, logLine: from };
+        }
+        throw e;
+    }
+}
+
+/**
  * Confirms the TH sent a report on subscription `subscriptionId` at or after `from` and that the DUT
  * answered *that specific report* with a Success StatusResponse. The subscription id alone only
  * proves the report is ours; several subscriptions' report/ack cycles can be in flight over the
@@ -726,6 +869,10 @@ export async function expectReportAck(
 ): Promise<CheckRecord> {
     if (subscriptionId === undefined) {
         return { type: "device-log", verdict: "unverified" };
+    }
+
+    if (flavor === "matterjs") {
+        return matterjsReportAck(log, flavor, subscriptionId, from, timeoutMs);
     }
 
     const deadline = Time.nowMs + timeoutMs;


### PR DESCRIPTION
Fixes the TC-IDM-4.1 flake seen on #4254's CI — about half of local full-suite runs on the chip-tool controller against a matter.js harness device, once in CI:

```
step 4: write 1/3 to {"endpoint":0,"cluster":40,"attribute":5} produced no
subscription report carrying "tc-idm-4-1-a" within 30s
```

## Root cause

Not timing — structural in chip-tool. While no command runs, the harness parks a frame that chip-tool answers with the next subscription report. `InteractiveServerCommand::LogJSON` sends that answer and calls `Reset()` on the **first** result recorded in async-report mode; `Reset()` clears `mEnabled`, so `MaybeAddResult` drops everything else recorded in that instant. One parked frame yields exactly one attribute. A numeric park does not batch either — its timer only logs a timeout error.

matter.js reports every changed attribute of a cluster in one `ReportData`, and writing `nodeLabel` bumps the whole `BasicInformation` data version, so step 3's still-live subscription on `localConfigDisabled` rides along on step 4's report. A traced reproduction caught exactly that: the delivered frame carried attribute 16 with the data version the `nodeLabel` write produced, and the `nodeLabel` result in the same batch was gone. Which of the two chip-tool records first is what made it intermittent, and why the test passed in isolation but failed in a full suite where step 3's subscription is still alive.

## Fix: read the evidence the plan actually asks for

The plan's expected outcome for steps 3–8 is *"verify on the TH that the status response received from the DUT for every report data sent is a Success"* — the harness device's own view. The chip-flavored device checks already read that from its log; a matter.js device's log carries it too, so the same checks now read it there:

- `Message » for: I/SubscribeResponse sub#: <id>` — the subscription this step established.
- `Message » for: I/ReportData sub#: <id> attr: N` (or `ev: N` for events) — a report carrying data on it. The keepalive an idle subscription sends is marked `empty` and must not stand in for a real report.
- `Message « for: I/StatusResponse … acked: <that report's counter> … payload: 152400 00` — the DUT's answer to **that** report, correlated by the message counter the device names, which is tighter than the chip path's exchange id. The byte after `152400` is the status; `00` is Success.

Two traps, both in the tests: matter.js pads the subscription id to eight digits on a report but not on the response that announced it, so the id is matched by value; and an event report says `ev:` where an attribute report says `attr:`, which TC-IDM-6.4 needs.

With every write confirmed from the device's log, a value missing from the controller's own callbacks is recorded `"unverified"` with the counts instead of failing the step — it is a gap in that controller's delivery, not in the behaviour under test. A report carrying a value nobody wrote still fails. A device flavor whose log names no subscription now fails the step outright rather than silently falling back to the callbacks.

**Given up deliberately:** a controller that delivers the written values *out of order* is no longer caught. The plan does not ask about ordering, and on chip-tool it is not observable.

## Also

The harness logged `chip-tool frame "…" failed to send: null` for every frame it sent successfully — `ws` reports success as `null` rather than by omitting the argument. That noise was hiding what a real send failure would look like.

**Observation for a separate change:** matter.js's own diagnostics print a subscription id padded to eight digits on a report and unpadded on the subscribe response. Harmless, but two formatters for one value.

## Verification

Five consecutive full-suite runs on the previously-flaky leg (chip-tool controller, matter.js device): 13/13 each, where before the fix it failed 2 of 3. Both controller legs of the full suite green, and TC-IDM-4.1 plus TC-IDM-6.4 green against a real `chip-all-clusters-app` with both controllers, so the chip-side path is unchanged. Cert framework suite 403/403 including nine new cases for the matchers — wrong subscription id, an ack for another report, a keepalive, an event report, a padded id, a longer id sharing our prefix, a non-Success status. Each production hunk mutation-tested: a wrong id, an accepted non-Success status, a keepalive allowed to count, and the callback shortfall recorded as a pass each turn a specific test red. Plus build, format, lint and the repository test suite.
