### PR TITLE
test(testing): add TC-DD-3.14, refusing an invalid onboarding QR code

### DIFF
--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -48,7 +48,7 @@ import type { ChipToolCommissionerName } from "../chip-tool/chip-tool-client.js"
 import { ChipToolClient, resolveChipToolBinary } from "../chip-tool/chip-tool-client.js";
 import { chipJsonToMatter, matterToChipJson, stringifyChipJson } from "../chip-tool/json-codec.js";
 import { certClusterModelFor, findCertCluster } from "./custom-clusters.js";
-import { singleQrPayload } from "./onboarding-payload.js";
+import { assertSingleQrPayload } from "./onboarding-payload.js";
 import { timedInteractionTimeoutOf } from "./timed-interaction.js";
 
 /** Name {@link UnsupportedByControllerError} reports for this adapter. */
@@ -71,6 +71,11 @@ export const CHIP_TOOL_CONTROLLER_PICS: PicsValues = {
 
     // A concatenated payload names several commissionees and is refused; the caller is told to split it.
     "MCORE.DD.CTRL_CONCATENATED_QR_CODE_1": 0,
+
+    // This harness wires the controller onto the IP network only, so it discovers no commissionee
+    // over BLE or Wi-Fi PAF whatever the binary was built with.
+    "MCORE.DD.DISCOVERY_BLE": 0,
+    "MCORE.DD.DISCOVERY_PAF": 0,
 };
 
 const WILDCARD_CLUSTER = 0xffffffff;
@@ -1184,8 +1189,9 @@ export class ChipToolControllerAdapter implements ControllerAdapter {
         let command: string;
         if (target.qrPairingCode) {
             // `pairing code` reads either payload format, a concatenated one included — and would pair
-            // with whichever commissionee that names first, which is what this refuses.
-            singleQrPayload(target.qrPairingCode);
+            // with whichever commissionee that names first, which is what this refuses. Everything else
+            // the payload can get wrong is chip-tool's own to refuse.
+            assertSingleQrPayload(target.qrPairingCode);
             command = `pairing code ${node} ${quoteArg(target.qrPairingCode)}`;
         } else if (target.manualPairingCode !== undefined) {
             command = `pairing code ${node} ${quoteArg(target.manualPairingCode)}`;

--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -605,6 +605,23 @@ function eventStatusFor(statuses: ChipPathStatus[], paths: EventPathSpec[]) {
 export class ChipToolCommandError extends MatterError {}
 
 /**
+ * chip-tool refused the onboarding payload itself, before it looked for any commissionee.
+ *
+ * `SetupPayload::FromStringRepresentation` is where chip-tool applies § 5.1's payload rules, and it
+ * reports the refusal with its own source location. That location is the only thing separating "the
+ * commissioner would not use this code" from every later way a commissioning fails — discovery, PASE,
+ * attestation and a command timeout all reach {@link ChipToolCommandError} too, so a step asserting a
+ * refusal must not accept the base type.
+ */
+export class ChipToolPayloadError extends ChipToolCommandError {}
+
+/**
+ * chip-tool's own marker for a failure raised inside its setup-payload layer, as
+ * `CHIP_ERROR`'s formatter renders it: `Run command failure: src/setup_payload/<file>:<line>: …`.
+ */
+const PAYLOAD_FAILURE = /Run command failure: src\/setup_payload\//;
+
+/**
  * For read/write/invoke. A pathless status is one chip-tool derived from a raw `CHIP_ERROR`
  * (`RemoteDataModelLogger::LogErrorAsJSON(const CHIP_ERROR &)`, called from `ReportCommand::OnError`
  * and its write and invoke siblings), and `ClusterStatusCode(CHIP_ERROR)` maps only the error's IM
@@ -1199,7 +1216,11 @@ export class ChipToolControllerAdapter implements ControllerAdapter {
             );
         }
 
-        const reply = await this.execute(command);
+        const { reply, logs } = await this.executeWithLogs(command);
+        if (reply.commandFailed && logs.some(line => PAYLOAD_FAILURE.test(line))) {
+            const detail = logs.find(line => PAYLOAD_FAILURE.test(line))?.trim();
+            throw new ChipToolPayloadError(`chip-tool refused the onboarding payload for node ${node}: ${detail}`);
+        }
         assertCommandSucceeded(reply, `commissioning of node ${node}`);
 
         return node;

--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -71,11 +71,6 @@ export const CHIP_TOOL_CONTROLLER_PICS: PicsValues = {
 
     // A concatenated payload names several commissionees and is refused; the caller is told to split it.
     "MCORE.DD.CTRL_CONCATENATED_QR_CODE_1": 0,
-
-    // This harness wires the controller onto the IP network only, so it discovers no commissionee
-    // over BLE or Wi-Fi PAF whatever the binary was built with.
-    "MCORE.DD.DISCOVERY_BLE": 0,
-    "MCORE.DD.DISCOVERY_PAF": 0,
 };
 
 const WILDCARD_CLUSTER = 0xffffffff;

--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -48,7 +48,7 @@ import type { ChipToolCommissionerName } from "../chip-tool/chip-tool-client.js"
 import { ChipToolClient, resolveChipToolBinary } from "../chip-tool/chip-tool-client.js";
 import { chipJsonToMatter, matterToChipJson, stringifyChipJson } from "../chip-tool/json-codec.js";
 import { certClusterModelFor, findCertCluster } from "./custom-clusters.js";
-import { assertSingleQrPayload } from "./onboarding-payload.js";
+import { assertSingleQrPayload, OnboardingPayloadRefusedError } from "./onboarding-payload.js";
 import { timedInteractionTimeoutOf } from "./timed-interaction.js";
 
 /** Name {@link UnsupportedByControllerError} reports for this adapter. */
@@ -605,19 +605,13 @@ function eventStatusFor(statuses: ChipPathStatus[], paths: EventPathSpec[]) {
 export class ChipToolCommandError extends MatterError {}
 
 /**
- * chip-tool refused the onboarding payload itself, before it looked for any commissionee.
+ * chip-tool's own marker for a failure raised inside its setup-payload layer, as `CHIP_ERROR`'s
+ * formatter renders it: `Run command failure: src/setup_payload/<file>:<line>: …`.
  *
- * `SetupPayload::FromStringRepresentation` is where chip-tool applies § 5.1's payload rules, and it
- * reports the refusal with its own source location. That location is the only thing separating "the
- * commissioner would not use this code" from every later way a commissioning fails — discovery, PASE,
- * attestation and a command timeout all reach {@link ChipToolCommandError} too, so a step asserting a
- * refusal must not accept the base type.
- */
-export class ChipToolPayloadError extends ChipToolCommandError {}
-
-/**
- * chip-tool's own marker for a failure raised inside its setup-payload layer, as
- * `CHIP_ERROR`'s formatter renders it: `Run command failure: src/setup_payload/<file>:<line>: …`.
+ * `SetupPayload::FromStringRepresentation` is where chip-tool applies § 5.1's payload rules, and this
+ * location is the only thing separating "the commissioner would not use this code" from every later
+ * way a commissioning fails: discovery, PASE, attestation and a command timeout all reach
+ * {@link ChipToolCommandError} alike.
  */
 const PAYLOAD_FAILURE = /Run command failure: src\/setup_payload\//;
 
@@ -1219,7 +1213,9 @@ export class ChipToolControllerAdapter implements ControllerAdapter {
         const { reply, logs } = await this.executeWithLogs(command);
         if (reply.commandFailed && logs.some(line => PAYLOAD_FAILURE.test(line))) {
             const detail = logs.find(line => PAYLOAD_FAILURE.test(line))?.trim();
-            throw new ChipToolPayloadError(`chip-tool refused the onboarding payload for node ${node}: ${detail}`);
+            throw new OnboardingPayloadRefusedError(
+                `chip-tool refused the onboarding payload for node ${node}: ${detail}`,
+            );
         }
         assertCommandSucceeded(reply, `commissioning of node ${node}`);
 

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -96,6 +96,11 @@ export const MATTERJS_CONTROLLER_PICS: PicsValues = {
 
     // A concatenated payload names several commissionees and is refused; the caller is told to split it.
     "MCORE.DD.CTRL_CONCATENATED_QR_CODE_1": 0,
+
+    // This harness wires the controller onto the IP network only, so it discovers no commissionee
+    // over BLE or Wi-Fi PAF.
+    "MCORE.DD.DISCOVERY_BLE": 0,
+    "MCORE.DD.DISCOVERY_PAF": 0,
 };
 
 const adapterStreams = new Map<string, LineQueue>();

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -96,11 +96,6 @@ export const MATTERJS_CONTROLLER_PICS: PicsValues = {
 
     // A concatenated payload names several commissionees and is refused; the caller is told to split it.
     "MCORE.DD.CTRL_CONCATENATED_QR_CODE_1": 0,
-
-    // This harness wires the controller onto the IP network only, so it discovers no commissionee
-    // over BLE or Wi-Fi PAF.
-    "MCORE.DD.DISCOVERY_BLE": 0,
-    "MCORE.DD.DISCOVERY_PAF": 0,
 };
 
 const adapterStreams = new Map<string, LineQueue>();

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -74,7 +74,7 @@ import type {
 import { LineQueue, LogFollower } from "@matter/testing";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { certClusterModelFor, findCertCluster } from "./custom-clusters.js";
-import { singleQrPayload } from "./onboarding-payload.js";
+import { refusalOf, singleQrPayload } from "./onboarding-payload.js";
 import { timedInteractionTimeoutOf } from "./timed-interaction.js";
 
 /**
@@ -284,7 +284,11 @@ function resolveCommissioningTarget(target: CommissioningTarget): ResolvedCommis
         return { identifierData: { longDiscriminator: discriminator }, passcode };
     }
     if (target.manualPairingCode !== undefined) {
-        const { shortDiscriminator, passcode } = ManualPairingCodeCodec.decode(target.manualPairingCode);
+        const code = target.manualPairingCode;
+        const { shortDiscriminator, passcode } = refusalOf(
+            () => ManualPairingCodeCodec.decode(code),
+            `manual pairing code ${code}`,
+        );
         if (shortDiscriminator === undefined) {
             throw new ImplementationError("Manual pairing code did not decode to a short discriminator");
         }

--- a/support/chip-testing/src/cert/onboarding-payload.ts
+++ b/support/chip-testing/src/cert/onboarding-payload.ts
@@ -18,10 +18,39 @@ import { QrPairingCodeCodec } from "@matter/main/types";
 export function singleQrPayload(code: string): QrCodeData {
     const payloads = QrPairingCodeCodec.decode(code);
     if (payloads.length !== 1) {
-        throw new ImplementationError(
-            `QR pairing code carries ${payloads.length} payloads; commission() pairs one device, so a ` +
-                "concatenated code must be split by the caller",
-        );
+        throw new ImplementationError(concatenationRefusal(payloads.length));
     }
     return payloads[0];
+}
+
+const QR_PREFIX = "MT:";
+
+/** The delimiter § 5.1.3.2 joins a concatenated code's payloads with. */
+const PAYLOAD_SEPARATOR = "*";
+
+/**
+ * Refuses a concatenated code the way {@link singleQrPayload} does, and judges nothing else about
+ * `code`.
+ *
+ * For a controller that parses onboarding payloads itself, that division matters: a step asserting
+ * "the DUT refuses this payload" needs the controller's own verdict, and a code matter.js rejected
+ * first would put matter.js's verdict in the evidence instead. Concatenation is the exception,
+ * because a controller told to pair one device from such a code silently pairs whichever of them
+ * answers first.
+ */
+export function assertSingleQrPayload(code: string): void {
+    if (!code.startsWith(QR_PREFIX)) {
+        return;
+    }
+    const count = code.slice(QR_PREFIX.length).split(PAYLOAD_SEPARATOR).length;
+    if (count !== 1) {
+        throw new ImplementationError(concatenationRefusal(count));
+    }
+}
+
+function concatenationRefusal(count: number): string {
+    return (
+        `QR pairing code carries ${count} payloads; commission() pairs one device, so a concatenated code ` +
+        "must be split by the caller"
+    );
 }

--- a/support/chip-testing/src/cert/onboarding-payload.ts
+++ b/support/chip-testing/src/cert/onboarding-payload.ts
@@ -4,9 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ImplementationError } from "@matter/main";
+import { ImplementationError, MatterError, UnexpectedDataError } from "@matter/main";
 import type { QrCodeData } from "@matter/main/types";
 import { QrPairingCodeCodec } from "@matter/main/types";
+
+/**
+ * A controller refused an onboarding payload itself, before it looked for any commissionee.
+ *
+ * A step asserting "the DUT terminates commissioning" needs this and nothing broader. Both
+ * controllers report a later failure — discovery, PASE, attestation, an invalid CSR response, a
+ * command timeout — through error types that a payload refusal would otherwise share, so a
+ * commissioner that *accepted* a forbidden code and only then failed would be recorded as having
+ * refused it.
+ */
+export class OnboardingPayloadRefusedError extends MatterError {}
 
 /**
  * The one onboarding payload `code` carries.
@@ -16,11 +27,28 @@ import { QrPairingCodeCodec } from "@matter/main/types";
  * whichever device answers first.
  */
 export function singleQrPayload(code: string): QrCodeData {
-    const payloads = QrPairingCodeCodec.decode(code);
+    const payloads = refusalOf(() => QrPairingCodeCodec.decode(code), `onboarding payload ${code}`);
     if (payloads.length !== 1) {
         throw new ImplementationError(concatenationRefusal(payloads.length));
     }
     return payloads[0];
+}
+
+/**
+ * Runs `decode`, reporting the codec's own rejection of `what` as an
+ * {@link OnboardingPayloadRefusedError}. matter.js raises {@link UnexpectedDataError} from the
+ * commissioning flow as well, so the refusal has to be marked where it happens rather than
+ * recognised by type afterwards.
+ */
+export function refusalOf<T>(decode: () => T, what: string): T {
+    try {
+        return decode();
+    } catch (e) {
+        if (e instanceof UnexpectedDataError) {
+            throw new OnboardingPayloadRefusedError(`Refused ${what}: ${e.message}`);
+        }
+        throw e;
+    }
 }
 
 const QR_PREFIX = "MT:";

--- a/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
@@ -19,6 +19,7 @@ import { env } from "node:process";
 import {
     ChipToolCommandError,
     ChipToolControllerAdapter,
+    ChipToolPayloadError,
     ChipToolUnmappedStatusError,
 } from "../../src/cert/ChipToolControllerAdapter.js";
 import { registerCertCustomCluster } from "../../src/cert/custom-clusters.js";
@@ -290,6 +291,37 @@ describe("ChipToolControllerAdapter", function () {
 
         expect(ref).equal(FIRST_NODE);
         expect(fake.commands).deep.equal([`pairing code ${FIRST_NODE} MT:034J042C00KA0648G00`]);
+    });
+
+    it("separates chip-tool refusing the payload from chip-tool failing later", async () => {
+        const started = await start();
+
+        // `SetupPayload::FromStringRepresentation`'s own refusal, as chip-tool renders a CHIP_ERROR
+        fake.reply = () => ({
+            status: 1,
+            logs: [
+                "Run command failure: src/setup_payload/SetupPayload.cpp:361: CHIP Error 0x0000002F: Invalid argument",
+            ],
+        });
+
+        const refusal = await rejectionOf(started.commission({ qrPairingCode: "MT:034J042C00KA0648G00" }));
+        expect(refusal).instanceOf(ChipToolPayloadError);
+    });
+
+    it("does not report a handshake failure as a refused payload", async () => {
+        const started = await start();
+
+        // A commissioner that took the code and only then failed reaching the device
+        fake.reply = () => ({
+            status: 1,
+            logs: [
+                "Run command failure: src/protocols/secure_channel/PASESession.cpp:610: CHIP Error 0x00000032: Timeout",
+            ],
+        });
+
+        const failure = await rejectionOf(started.commission({ qrPairingCode: "MT:-24J042C00KA0648G00" }));
+        expect(failure).instanceOf(ChipToolCommandError);
+        expect(failure).not.instanceOf(ChipToolPayloadError);
     });
 
     it("reads a concrete path and decodes the value through the model", async () => {

--- a/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
@@ -19,10 +19,10 @@ import { env } from "node:process";
 import {
     ChipToolCommandError,
     ChipToolControllerAdapter,
-    ChipToolPayloadError,
     ChipToolUnmappedStatusError,
 } from "../../src/cert/ChipToolControllerAdapter.js";
 import { registerCertCustomCluster } from "../../src/cert/custom-clusters.js";
+import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload.js";
 import { ChipToolExitError } from "../../src/chip-tool/chip-tool-client.js";
 import { FaultInjectionCluster } from "../cert/fault-injection.js";
 import { countMatches } from "../cert/tc-support.js";
@@ -305,7 +305,7 @@ describe("ChipToolControllerAdapter", function () {
         });
 
         const refusal = await rejectionOf(started.commission({ qrPairingCode: "MT:034J042C00KA0648G00" }));
-        expect(refusal).instanceOf(ChipToolPayloadError);
+        expect(refusal).instanceOf(OnboardingPayloadRefusedError);
     });
 
     it("does not report a handshake failure as a refused payload", async () => {
@@ -321,7 +321,7 @@ describe("ChipToolControllerAdapter", function () {
 
         const failure = await rejectionOf(started.commission({ qrPairingCode: "MT:-24J042C00KA0648G00" }));
         expect(failure).instanceOf(ChipToolCommandError);
-        expect(failure).not.instanceOf(ChipToolPayloadError);
+        expect(failure).not.instanceOf(OnboardingPayloadRefusedError);
     });
 
     it("reads a concrete path and decodes the value through the model", async () => {

--- a/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
@@ -280,6 +280,18 @@ describe("ChipToolControllerAdapter", function () {
         expect(fake.commands).deep.equal([]);
     });
 
+    it("leaves a payload chip-tool would refuse for chip-tool to refuse", async () => {
+        const started = await start();
+
+        // Version 2, which chip-tool's own `SetupPayload::FromStringRepresentation` rejects. A refusal
+        // raised here instead would put matter.js's verdict in a cert test's evidence in place of the
+        // controller's.
+        const ref = await started.commission({ qrPairingCode: "MT:034J042C00KA0648G00" });
+
+        expect(ref).equal(FIRST_NODE);
+        expect(fake.commands).deep.equal([`pairing code ${FIRST_NODE} MT:034J042C00KA0648G00`]);
+    });
+
     it("reads a concrete path and decodes the value through the model", async () => {
         const { ref, node } = await commissioned();
 

--- a/support/chip-testing/test/cert-framework/controller-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/controller-adapter.test.ts
@@ -21,6 +21,7 @@ import { env } from "node:process";
 import { AllClustersTestInstance } from "../../src/AllClustersTestInstance.js";
 import { CHIP_TOOL_CONTROLLER_PICS, ChipToolControllerAdapter } from "../../src/cert/ChipToolControllerAdapter.js";
 import { InProcessControllerAdapter, MATTERJS_CONTROLLER_PICS } from "../../src/cert/InProcessControllerAdapter.js";
+import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload.js";
 
 function fakeControllerAdapter(id: string): ControllerAdapter {
     return {
@@ -134,6 +135,17 @@ describe("InProcessControllerAdapter", () => {
         const ref = await adapter.commission({ qrPairingCode: device.commissioning.qrPairingCode });
 
         await adapter.node(ref).decommission();
+    });
+
+    it("marks its own refusal of an onboarding payload, so a later failure cannot pass for one", async () => {
+        // Version 2, which QrPairingCodeCodec rejects. matter.js raises UnexpectedDataError from the
+        // commissioning flow too, so the refusal has to carry its own marker.
+        const refusal = await rejectionOf(adapter.commission({ qrPairingCode: "MT:034J042C00KA0648G00" }));
+
+        expect(refusal).instanceOf(OnboardingPayloadRefusedError);
+        expect(await rejectionOf(adapter.parseQrPayload("MT:034J042C00KA0648G00"))).instanceOf(
+            OnboardingPayloadRefusedError,
+        );
     });
 
     it("reports the fields it reads out of an onboarding payload", async function () {

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InternalError } from "@matter/main";
+import { InternalError, UnexpectedDataError } from "@matter/main";
+import type { CertNodeApi, CertNodeRef, CertStepContext, ControllerAdapter } from "@matter/testing";
+import { LogFollower } from "@matter/testing";
 import { expect } from "chai";
-import { qrPayloadWith, qrPayloadWithPrefix } from "../cert/tc-dd-support.js";
+import { CommissioningRefusals, ON_NETWORK_ONLY, qrPayloadWith, qrPayloadWithPrefix } from "../cert/tc-dd-support.js";
+import { CertCheckFailedError, CertCleanupError } from "../cert/tc-support.js";
 
 /**
  * `devicediscovery.adoc`'s own example payload for TC-DD-3.14: vendor id 0xFFF1, product id 0x8001,
@@ -41,6 +44,13 @@ describe("qrPayloadWith", () => {
         }
     });
 
+    it("substitutes the discovery capabilities, which is what makes a BLE-only TH testable", () => {
+        // chip-all-clusters-app's own payload, whose bitmask is BLE alone
+        expect(qrPayloadWith("MT:-24J042C00KA0648G00", { discoveryCapabilities: ON_NETWORK_ONLY })).equal(
+            "MT:-24J0AFN00KA0648G00",
+        );
+    });
+
     it("leaves every other field where it was", () => {
         expect(qrPayloadWith(PLAN_PAYLOAD, {})).equal(PLAN_PAYLOAD);
     });
@@ -60,6 +70,12 @@ describe("qrPayloadWith", () => {
         expect(() => qrPayloadWith(PLAN_PAYLOAD, { version: 0b1000 })).throw(InternalError);
         expect(() => qrPayloadWith(PLAN_PAYLOAD, { passcode: 2 ** 27 })).throw(InternalError);
     });
+
+    it("refuses a value the bitwise operators would coerce", () => {
+        expect(() => qrPayloadWith(PLAN_PAYLOAD, { version: 1.5 })).throw(InternalError);
+        expect(() => qrPayloadWith(PLAN_PAYLOAD, { passcode: NaN })).throw(InternalError);
+        expect(() => qrPayloadWith(PLAN_PAYLOAD, { version: -1 })).throw(InternalError);
+    });
 });
 
 describe("qrPayloadWithPrefix", () => {
@@ -69,5 +85,120 @@ describe("qrPayloadWithPrefix", () => {
 
     it("refuses a code that is not a QR onboarding payload", () => {
         expect(() => qrPayloadWithPrefix("34970112336552132769", "AB:")).throw(InternalError);
+    });
+});
+
+describe("CommissioningRefusals", () => {
+    const BUDGETS = { refusalTimeoutMs: 100, settleTimeoutMs: 100 };
+
+    function contextWith(
+        commission: () => Promise<CertNodeRef>,
+        decommission: (ref: CertNodeRef) => Promise<void> = async () => {},
+    ): CertStepContext {
+        const unused = () => Promise.reject(new InternalError("not used by these tests"));
+        const noLines = async function* (): AsyncGenerator<string> {};
+
+        const nodeFor = (ref: CertNodeRef) =>
+            ({
+                invoke: unused,
+                invokeBatch: unused,
+                readAttribute: unused,
+                readAttributes: unused,
+                writeAttribute: unused,
+                writeAttributes: unused,
+                subscribe: unused,
+                readEvents: unused,
+                subscribeEvents: unused,
+                openCommissioningWindow: unused,
+                operationalMdnsInstanceName: unused,
+                decommission: () => decommission(ref),
+            }) satisfies CertNodeApi;
+
+        const dut = {
+            id: "dut",
+            log: new LogFollower(noLines(), "dut"),
+            async start() {},
+            async close() {},
+            commission,
+            parseQrPayload: unused,
+            node: nodeFor,
+        } satisfies ControllerAdapter;
+
+        return {
+            controllers: { dut },
+            devices: {},
+            recorder: {
+                beginStep() {},
+                check() {},
+                endStep() {
+                    return [];
+                },
+                async flush() {
+                    return "";
+                },
+            },
+        };
+    }
+
+    it("passes when the controller refuses the payload itself", async () => {
+        const cx = contextWith(() => Promise.reject(new UnexpectedDataError("Invalid passcode 0")));
+        const refusals = new CommissioningRefusals(BUDGETS);
+
+        await refusals.requireRefusal(cx, "MT:whatever", "must be refused");
+        await refusals.settle(cx);
+    });
+
+    it("fails on a rejection that says nothing about the payload", async () => {
+        const cx = contextWith(() => Promise.reject(new InternalError("chip-tool produced no reply")));
+        const refusals = new CommissioningRefusals(BUDGETS);
+
+        await expect(refusals.requireRefusal(cx, "MT:whatever", "must be refused")).rejectedWith(
+            CertCheckFailedError,
+            /unrelated reason/,
+        );
+    });
+
+    it("removes the fabric of a commissioning that succeeded after its own budget expired", async () => {
+        let finish: (ref: CertNodeRef) => void = () => {};
+        const removed = new Array<CertNodeRef>();
+        const cx = contextWith(
+            () => new Promise<CertNodeRef>(resolve => (finish = resolve)),
+            async ref => {
+                removed.push(ref);
+            },
+        );
+        const refusals = new CommissioningRefusals(BUDGETS);
+
+        await expect(refusals.requireRefusal(cx, "MT:whatever", "must be refused")).rejectedWith(CertCheckFailedError);
+
+        // On a macrotask, so a settle() that did not actually wait returns with nothing to remove
+        const settling = refusals.settle(cx);
+        setTimeout(() => finish("late-ref"), 20);
+        await settling;
+
+        expect(removed).deep.equal(["late-ref"]);
+    });
+
+    it("reports a stray fabric it could not remove", async () => {
+        const cx = contextWith(
+            () => Promise.resolve("stray-ref"),
+            async () => {
+                throw new InternalError("node is unreachable");
+            },
+        );
+        const refusals = new CommissioningRefusals(BUDGETS);
+
+        await expect(refusals.requireRefusal(cx, "MT:whatever", "must be refused")).rejectedWith(CertCheckFailedError);
+
+        await expect(refusals.settle(cx)).rejectedWith(CertCleanupError, /stray-ref: node is unreachable/);
+    });
+
+    it("gives up on an attempt that never settles rather than holding the run open", async () => {
+        const cx = contextWith(() => new Promise<CertNodeRef>(() => {}));
+        const refusals = new CommissioningRefusals(BUDGETS);
+
+        await expect(refusals.requireRefusal(cx, "MT:whatever", "must be refused")).rejected;
+
+        await expect(refusals.settle(cx)).rejectedWith(CertCleanupError, /still running/);
     });
 });

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -8,7 +8,8 @@ import { InternalError, UnexpectedDataError } from "@matter/main";
 import type { CertNodeApi, CertNodeRef, CertStepContext, ControllerAdapter } from "@matter/testing";
 import { LogFollower } from "@matter/testing";
 import { expect } from "chai";
-import { ChipToolCommandError, ChipToolPayloadError } from "../../src/cert/ChipToolControllerAdapter.js";
+import { ChipToolCommandError } from "../../src/cert/ChipToolControllerAdapter.js";
+import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload.js";
 import { CommissioningRefusals, ON_NETWORK_ONLY, qrPayloadWith, qrPayloadWithPrefix } from "../cert/tc-dd-support.js";
 import { CertCheckFailedError, CertCleanupError } from "../cert/tc-support.js";
 
@@ -141,12 +142,14 @@ describe("CommissioningRefusals", () => {
         };
     }
 
-    it("passes when the controller refuses the payload itself", async () => {
-        const cx = contextWith(() => Promise.reject(new UnexpectedDataError("Invalid passcode 0")));
+    it("does not accept a bare UnexpectedDataError, which commissioning raises after taking the payload", async () => {
+        const cx = contextWith(() => Promise.reject(new UnexpectedDataError("Invalid response from device")));
         const refusals = new CommissioningRefusals(BUDGETS);
 
-        await refusals.requireRefusal(cx, "MT:whatever", "must be refused");
-        await refusals.settle(cx);
+        await expect(refusals.requireRefusal(cx, "MT:whatever", "must be refused")).rejectedWith(
+            CertCheckFailedError,
+            /unrelated reason/,
+        );
     });
 
     it("fails on a rejection that says nothing about the payload", async () => {
@@ -169,8 +172,10 @@ describe("CommissioningRefusals", () => {
         );
     });
 
-    it("accepts chip-tool refusing the payload in its own setup-payload layer", async () => {
-        const cx = contextWith(() => Promise.reject(new ChipToolPayloadError("chip-tool refused the payload")));
+    it("accepts a controller that marked the payload itself as refused", async () => {
+        const cx = contextWith(() =>
+            Promise.reject(new OnboardingPayloadRefusedError("chip-tool refused the payload")),
+        );
         const refusals = new CommissioningRefusals(BUDGETS);
 
         await refusals.requireRefusal(cx, "MT:whatever", "must be refused");

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -8,6 +8,7 @@ import { InternalError, UnexpectedDataError } from "@matter/main";
 import type { CertNodeApi, CertNodeRef, CertStepContext, ControllerAdapter } from "@matter/testing";
 import { LogFollower } from "@matter/testing";
 import { expect } from "chai";
+import { ChipToolCommandError, ChipToolPayloadError } from "../../src/cert/ChipToolControllerAdapter.js";
 import { CommissioningRefusals, ON_NETWORK_ONLY, qrPayloadWith, qrPayloadWithPrefix } from "../cert/tc-dd-support.js";
 import { CertCheckFailedError, CertCleanupError } from "../cert/tc-support.js";
 
@@ -156,6 +157,24 @@ describe("CommissioningRefusals", () => {
             CertCheckFailedError,
             /unrelated reason/,
         );
+    });
+
+    it("does not accept chip-tool failing after it took the payload", async () => {
+        const cx = contextWith(() => Promise.reject(new ChipToolCommandError("chip-tool commissioning failed")));
+        const refusals = new CommissioningRefusals(BUDGETS);
+
+        await expect(refusals.requireRefusal(cx, "MT:whatever", "must be refused")).rejectedWith(
+            CertCheckFailedError,
+            /unrelated reason/,
+        );
+    });
+
+    it("accepts chip-tool refusing the payload in its own setup-payload layer", async () => {
+        const cx = contextWith(() => Promise.reject(new ChipToolPayloadError("chip-tool refused the payload")));
+        const refusals = new CommissioningRefusals(BUDGETS);
+
+        await refusals.requireRefusal(cx, "MT:whatever", "must be refused");
+        await refusals.settle(cx);
     });
 
     it("removes the fabric of a commissioning that succeeded after its own budget expired", async () => {

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InternalError } from "@matter/main";
+import { expect } from "chai";
+import { qrPayloadWith, qrPayloadWithPrefix } from "../cert/tc-dd-support.js";
+
+/**
+ * `devicediscovery.adoc`'s own example payload for TC-DD-3.14: vendor id 0xFFF1, product id 0x8001,
+ * custom commissioning flow, OnNetwork discovery, discriminator 0xF00, passcode 20202021.
+ */
+const PLAN_PAYLOAD = "MT:-24J029Q00KA0648G00";
+
+/** The payloads the plan itself expects for each substitution, keyed by what it substituted. */
+const PLAN_INVALID_PASSCODE_PAYLOADS: [passcode: number, payload: string][] = [
+    [0, "MT:-24J029Q00OC0000000"],
+    [11111111, "MT:-24J029Q00KMSP0Z800"],
+    [22222222, "MT:-24J029Q00GWID1WH00"],
+    [33333333, "MT:-24J029Q00C4912TQ00"],
+    [44444444, "MT:-24J029Q008E.Q2QZ00"],
+    [55555555, "MT:-24J029Q004ORE3N610"],
+    [66666666, "MT:-24J029Q000YH24KF10"],
+    [77777777, "MT:-24J029Q00Y58S4HO10"],
+    [88888888, "MT:-24J029Q00UF-F5EX10"],
+    [99999999, "MT:-24J029Q00QPQ36B420"],
+    [12345678, "MT:-24J029Q004QG46Y900"],
+    [87654321, "MT:-24J029Q00YX018EW10"],
+];
+
+describe("qrPayloadWith", () => {
+    it("substitutes the version the plan's own example payload does", () => {
+        expect(qrPayloadWith(PLAN_PAYLOAD, { version: 0b010 })).equal("MT:034J029Q00KA0648G00");
+    });
+
+    it("substitutes each forbidden passcode the plan's own example payloads do", () => {
+        for (const [passcode, expected] of PLAN_INVALID_PASSCODE_PAYLOADS) {
+            expect(qrPayloadWith(PLAN_PAYLOAD, { passcode })).equal(expected, `passcode ${passcode}`);
+        }
+    });
+
+    it("leaves every other field where it was", () => {
+        expect(qrPayloadWith(PLAN_PAYLOAD, {})).equal(PLAN_PAYLOAD);
+    });
+
+    it("carries appended TLV data through", () => {
+        // The plan payload with § 5.1.5's own example TLV: serial number "1234567890" under tag 0x00
+        const withTlv = "MT:-24J029Q00KA064IJ3P0IXZB0DK5N1K8SQ1RYCU1-A40";
+
+        expect(qrPayloadWith(withTlv, { passcode: 12345678 })).equal("MT:-24J029Q004QG466D3P0IXZB0DK5N1K8SQ1RYCU1-A40");
+    });
+
+    it("refuses a code that is not a QR onboarding payload", () => {
+        expect(() => qrPayloadWith("34970112336552132769", { version: 2 })).throw(InternalError);
+    });
+
+    it("refuses a value too wide for the field it substitutes", () => {
+        expect(() => qrPayloadWith(PLAN_PAYLOAD, { version: 0b1000 })).throw(InternalError);
+        expect(() => qrPayloadWith(PLAN_PAYLOAD, { passcode: 2 ** 27 })).throw(InternalError);
+    });
+});
+
+describe("qrPayloadWithPrefix", () => {
+    it("substitutes the prefix the plan's own example payload does", () => {
+        expect(qrPayloadWithPrefix(PLAN_PAYLOAD, "AB:")).equal("AB:-24J029Q00KA0648G00");
+    });
+
+    it("refuses a code that is not a QR onboarding payload", () => {
+        expect(() => qrPayloadWithPrefix("34970112336552132769", "AB:")).throw(InternalError);
+    });
+});

--- a/support/chip-testing/test/cert-framework/tc-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-support.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InternalError } from "@matter/main";
+import { InternalError, Time } from "@matter/main";
 import type { CertNodeApi, CertStepContext, ControllerAdapter } from "@matter/testing";
 import { LogFollower } from "@matter/testing";
 import {
@@ -18,6 +18,7 @@ import {
     expectChunkedTransfer,
     expectCommandInvoke,
     expectMessageWithPath,
+    expectRejection,
     expectReportAck,
     expectSequence,
     expectSubscriptionId,
@@ -637,5 +638,62 @@ describe("CommissionedRefs", () => {
         await refs.decommissionAll(cx);
 
         expect(attempts).deep.equal(["dut"]);
+    });
+});
+
+describe("expectRejection", () => {
+    const BUDGET_MS = 200;
+
+    it("passes on a rejection and reports what it rejected with", async () => {
+        const check = await expectRejection("op", Promise.reject(new Error("refused")), BUDGET_MS);
+
+        expect(check.verdict).equal("pass");
+        expect(check.detail).match(/^op rejected after .*: refused$/);
+    });
+
+    it("fails on an unexpected success", async () => {
+        const check = await expectRejection("op", Promise.resolve("commissioned"), BUDGET_MS);
+
+        expect(check.verdict).equal("fail");
+        expect(check.detail).match(/^op unexpectedly succeeded after /);
+    });
+
+    it("fails once the budget expires rather than waiting for the call", async () => {
+        const check = await expectRejection("op", new Promise(() => {}), BUDGET_MS);
+
+        expect(check.verdict).equal("fail");
+        expect(check.detail).match(/^op neither resolved nor rejected within /);
+    });
+
+    it("fails a rejection the caller does not accept", async () => {
+        const check = await expectRejection(
+            "op",
+            Promise.reject(new InternalError("the process died")),
+            BUDGET_MS,
+            error => error instanceof TypeError,
+        );
+
+        expect(check.verdict).equal("fail");
+        expect(check.detail).match(/^op failed after .* for an unrelated reason: InternalError: the process died$/);
+    });
+
+    it("passes a rejection the caller accepts", async () => {
+        const check = await expectRejection(
+            "op",
+            Promise.reject(new InternalError("refused")),
+            BUDGET_MS,
+            error => error instanceof InternalError,
+        );
+
+        expect(check.verdict).equal("pass");
+    });
+
+    it("leaves no timer armed after a settled call", async () => {
+        // A budget nothing waits out would otherwise hold the process open past teardown
+        const before = Time.timers.size;
+
+        await expectRejection("op", Promise.reject(new Error("refused")), 60_000);
+
+        expect(Time.timers.size).equal(before);
     });
 });

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1300,22 +1300,32 @@ Integrity check failed` for a prefix that is not `MT:` (chip-tool treats a non-`
 one). matter.js rejects the same three in `QrPairingCodeCodec`, inside a millisecond.
 
 **"It failed" is not the assertion; "it refused this payload" is.** `expectRejection` takes an
-`accept` predicate, and `CommissioningRefusals` accepts only `UnexpectedDataError` (matter.js's
-codec) or `ChipToolPayloadError`. Without it the steps pass on a controller that crashed, timed out
-or was never asked — `ChipToolClient.execute` alone has a 3-minute budget whose expiry is a rejection
-like any other, and both adapters refuse these payloads before touching the network, so the steps
-would also pass with no TH running at all.
+`accept` predicate, and `CommissioningRefusals` accepts only `OnboardingPayloadRefusedError`. Without
+a predicate the steps pass on a controller that crashed, timed out or was never asked —
+`ChipToolClient.execute` alone has a 3-minute budget whose expiry is a rejection like any other, and
+both adapters refuse these payloads before touching the network, so the steps would also pass with no
+TH running at all.
 
-**`ChipToolCommandError` is not that assertion either, and this is the subtle one.** Its own doc says
-chip-tool funnels discovery, PASE, attestation, CASE, timeout and argument-parse failures into the
-same bare marker. So a commissioner that *accepted* a forbidden passcode and only then failed its
-handshake raises exactly the error a refusal raises — the false pass this whole TC exists to prevent,
-reintroduced through the check meant to prevent it. What separates them is where chip-tool says the
-failure came from: `SetupPayload::FromStringRepresentation` reports its own source location, so
-`ChipToolControllerAdapter.commission` matches `Run command failure: src/setup_payload/` in the
-command's logs and raises `ChipToolPayloadError` for that case alone. Real evidence from both
-chip-tool legs: `chip-tool refused the onboarding payload for node 4097: Run command failure:
-src/setup_payload/SetupPayload.cpp:361: CHIP Error 0x0000002F: Invalid argument`.
+**Neither controller's own error types are enough, and this is the subtle part — it caught two
+rounds of review.** chip-tool funnels discovery, PASE, attestation, CASE, timeout and argument-parse
+failures into one `ChipToolCommandError`; matter.js raises `UnexpectedDataError` from the
+commissioning flow as well (`ControllerCommissioningFlow.ts`'s "Invalid response from device", for
+one). Accepting either type means a commissioner that *took* a forbidden passcode and only then
+failed its handshake is recorded as having refused the code — the exact false pass this TC exists to
+prevent, reintroduced through the check meant to prevent it.
+
+So the refusal is marked **where it happens**, never recognised by type afterwards.
+`OnboardingPayloadRefusedError` (`onboarding-payload.ts`) is the one marker, raised by both adapters:
+
+- matter.js — `refusalOf()` wraps the codec call in `singleQrPayload` and in the manual-code branch of
+  `resolveCommissioningTarget`, so only the codec's own rejection carries it.
+- chip-tool — `commission()` matches `Run command failure: src/setup_payload/` in the command's logs.
+  `SetupPayload::FromStringRepresentation` is where chip-tool applies § 5.1's payload rules and it
+  names its own source location; that location is the only discriminator chip-tool offers.
+
+Real evidence from all four legs: `chip-tool refused the onboarding payload for node 4097: Run command
+failure: src/setup_payload/SetupPayload.cpp:361: CHIP Error 0x0000002F: Invalid argument`, and
+`Refused onboarding payload MT:034J042C00KA0648G00: Unsupported onboarding payload version 2`.
 
 **A negative check needs a bound and a cleanup path.** `expectRejection` (promoted from
 `TC-CADMIN-1.17` to `tc-support.ts`, now taking its own timeout) reports `"fail"` for a call that

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1281,6 +1281,47 @@ requirement the plan states of the *TH*, so the TC walks `Descriptor.partsList` 
 satisfying the precondition then fails the step that says so, rather than silently proving less: the
 step also asserts the plan's own "at least 2".
 
+## A refusal must be the controller's own (`TC-DD-3.14`)
+
+The negative payload plans all read "DUT parses the code and terminates the commissioning process".
+The only way to record that is to hand the payload to `commission()` and require a rejection — and
+that only proves something about the DUT if the DUT is what refused.
+
+`ChipToolControllerAdapter.commission` used to run every payload through matter.js's own codec first
+(`singleQrPayload`), so on a chip-tool leg matter.js refused before chip-tool ever saw the code, and
+the evidence would have carried matter.js's message under chip-tool's name. It now calls
+`assertSingleQrPayload`, which refuses a **concatenated** code and judges nothing else: that one is
+the harness's to refuse, because chip-tool told to pair one device from such a code silently pairs
+whichever answers first. Everything else reaches chip-tool, which rejects it in
+`SetupPayload::FromStringRepresentation` — captured in this TC's own evidence as
+`src/setup_payload/SetupPayload.cpp:361: CHIP Error 0x0000002F: Invalid argument` for an unsupported
+version and each forbidden passcode, and as `ManualSetupPayloadParser.cpp:46: CHIP Error 0x00000013:
+Integrity check failed` for a prefix that is not `MT:` (chip-tool treats a non-`MT:` code as a manual
+one). matter.js rejects the same three in `QrPairingCodeCodec`, inside a millisecond.
+
+**A negative check needs a bound and a cleanup path.** `expectRejection` (promoted from
+`TC-CADMIN-1.17` to `tc-support.ts`, now taking its own timeout) reports `"fail"` for a call that
+neither resolved nor rejected, which is what a controller that skipped the payload rules and went
+looking for the commissionee produces — verified by deleting matter.js's passcode validation, where
+step 5.b turned into "neither resolved nor rejected within 30s" rather than hanging the run.
+`expectCommissioningRefused` records the ref *before* judging the check, so a refusal that never came
+leaves the accidental fabric to the run's own `finalize`, not to whatever runs next.
+
+**Building a payload the encoder refuses to write.** Every value these plans substitute — a non-zero
+version, the twelve trivial passcodes — is exactly what `QrPairingCodeCodec.encode` validates
+against, so `qrPayloadWith` writes the bits into the decoded structure directly (§ 5.1.3.1 Table 59's
+own offsets) and re-encodes base38, carrying any appended TLV data through untouched. The plan prints
+its own expected payload for each substitution against its example code; `tc-dd-support.test.ts`
+asserts all thirteen of them, which is what caught the first version of the bit writer setting bits
+without clearing them.
+
+**Steps 3 and 4 are `notApplicable`, not PICS-gated.** They ask the DUT to commission over a
+capability it prefers over IP, which needs `MCORE.DD.DISCOVERY_BLE`/`MCORE.DD.DISCOVERY_PAF`; both
+controller overlays now declare those 0, since this harness wires either controller onto the IP
+network alone. That declaration gates the steps under `matterjs` only — per-step PICS is inert on the
+chip flavors (see "PICS handling" above), where the steps would otherwise run with nothing to check —
+so the reason is carried by `notApplicable` and the PICS stays as transcription.
+
 ## chip-tool delivers one result per async report and discards the rest
 
 `step 4: write 1/3 … produced no subscription report carrying "tc-idm-4-1-a" within 30s`,

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1285,7 +1285,7 @@ step also asserts the plan's own "at least 2".
 
 The negative payload plans all read "DUT parses the code and terminates the commissioning process".
 The only way to record that is to hand the payload to `commission()` and require a rejection — and
-that only proves something about the DUT if the DUT is what refused.
+that only proves something about the DUT if the DUT is what refused, for the reason under test.
 
 `ChipToolControllerAdapter.commission` used to run every payload through matter.js's own codec first
 (`singleQrPayload`), so on a chip-tool leg matter.js refused before chip-tool ever saw the code, and
@@ -1299,13 +1299,23 @@ version and each forbidden passcode, and as `ManualSetupPayloadParser.cpp:46: CH
 Integrity check failed` for a prefix that is not `MT:` (chip-tool treats a non-`MT:` code as a manual
 one). matter.js rejects the same three in `QrPairingCodeCodec`, inside a millisecond.
 
+**"It failed" is not the assertion; "it refused this payload" is.** `expectRejection` takes an
+`accept` predicate, and `CommissioningRefusals` only accepts `UnexpectedDataError` (matter.js's
+codec) or `ChipToolCommandError` (chip-tool's own verdict). Without it the steps pass on a controller
+that crashed, timed out or was never asked — `ChipToolClient.execute` alone has a 3-minute budget
+whose expiry is a rejection like any other, and both adapters refuse these payloads before touching
+the network, so the steps would also pass with no TH running at all.
+
 **A negative check needs a bound and a cleanup path.** `expectRejection` (promoted from
 `TC-CADMIN-1.17` to `tc-support.ts`, now taking its own timeout) reports `"fail"` for a call that
-neither resolved nor rejected, which is what a controller that skipped the payload rules and went
-looking for the commissionee produces — verified by deleting matter.js's passcode validation, where
-step 5.b turned into "neither resolved nor rejected within 30s" rather than hanging the run.
-`expectCommissioningRefused` records the ref *before* judging the check, so a refusal that never came
-leaves the accidental fabric to the run's own `finalize`, not to whatever runs next.
+neither resolved nor rejected — verified by deleting matter.js's passcode validation, where step 5.b
+turned into "neither resolved nor rejected" rather than hanging the run. `CommissioningRefusals`
+keeps every attempt it started and `settle()` decommissions the fabric of any that succeeded after
+its own budget expired; it owns those refs rather than writing them into the TC's `CommissionedRefs`,
+which holds one ref per role and would collapse two stray fabrics into one. Its budget is under
+`CertTest`'s own 2-minute finalization timeout, and deliberately does not try to outwait a chip-tool
+command stuck in its 3-minute one — a controller stuck that long has left the TH in a state this run
+cannot report on, which is what the `CertCleanupError` says.
 
 **Building a payload the encoder refuses to write.** Every value these plans substitute — a non-zero
 version, the twelve trivial passcodes — is exactly what `QrPairingCodeCodec.encode` validates
@@ -1315,12 +1325,21 @@ its own expected payload for each substitution against its example code; `tc-dd-
 asserts all thirteen of them, which is what caught the first version of the bit writer setting bits
 without clearing them.
 
-**Steps 3 and 4 are `notApplicable`, not PICS-gated.** They ask the DUT to commission over a
-capability it prefers over IP, which needs `MCORE.DD.DISCOVERY_BLE`/`MCORE.DD.DISCOVERY_PAF`; both
-controller overlays now declare those 0, since this harness wires either controller onto the IP
-network alone. That declaration gates the steps under `matterjs` only — per-step PICS is inert on the
-chip flavors (see "PICS handling" above), where the steps would otherwise run with nothing to check —
-so the reason is carried by `notApplicable` and the PICS stays as transcription.
+**Steps 3 and 4 substitute the discovery bitmask — they are not skippable.** They read as a
+precondition on the TH ("ensure the TH's Discovery Capability bit string is NOT set to BLE"), but for
+a TC that drives everything itself that is one more substitution, and `qrPayloadWith` takes
+`discoveryCapabilities` for it. It is load-bearing rather than cosmetic: `chip-all-clusters-app`
+publishes a **BLE-only** bitmask (`0b00000010`), so on that TH the precondition does not hold at all
+and an unsubstituted step 3.a fails. With the OnNetwork form both steps commission for real and
+record the DUT onboarding the TH over IP, which is the plan's own expected outcome.
+
+Their `pics` (`MCORE.DD.DISCOVERY_BLE`, `MCORE.DD.DISCOVERY_PAF`) stays as transcription and gates
+only under `matterjs`, where CHIP's `ci-pics-values` answers `DISCOVERY_PAF=0` and step 4 records a
+PICS skip. Do **not** answer these from a controller overlay to force a skip: `certPicsFile()` feeds
+every cert test's report, so a device-scoped key set there makes every other run's evidence claim
+something false about its TH. And note `notApplicable` is evaluated *before* both the `flavors` and
+the PICS gate in `cert-test.ts`, so a step carrying both never evaluates its PICS on any flavor —
+combining them documents nothing and hides the gate that would otherwise fire.
 
 ## chip-tool delivers one result per async report and discards the rest
 

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1300,11 +1300,22 @@ Integrity check failed` for a prefix that is not `MT:` (chip-tool treats a non-`
 one). matter.js rejects the same three in `QrPairingCodeCodec`, inside a millisecond.
 
 **"It failed" is not the assertion; "it refused this payload" is.** `expectRejection` takes an
-`accept` predicate, and `CommissioningRefusals` only accepts `UnexpectedDataError` (matter.js's
-codec) or `ChipToolCommandError` (chip-tool's own verdict). Without it the steps pass on a controller
-that crashed, timed out or was never asked — `ChipToolClient.execute` alone has a 3-minute budget
-whose expiry is a rejection like any other, and both adapters refuse these payloads before touching
-the network, so the steps would also pass with no TH running at all.
+`accept` predicate, and `CommissioningRefusals` accepts only `UnexpectedDataError` (matter.js's
+codec) or `ChipToolPayloadError`. Without it the steps pass on a controller that crashed, timed out
+or was never asked — `ChipToolClient.execute` alone has a 3-minute budget whose expiry is a rejection
+like any other, and both adapters refuse these payloads before touching the network, so the steps
+would also pass with no TH running at all.
+
+**`ChipToolCommandError` is not that assertion either, and this is the subtle one.** Its own doc says
+chip-tool funnels discovery, PASE, attestation, CASE, timeout and argument-parse failures into the
+same bare marker. So a commissioner that *accepted* a forbidden passcode and only then failed its
+handshake raises exactly the error a refusal raises — the false pass this whole TC exists to prevent,
+reintroduced through the check meant to prevent it. What separates them is where chip-tool says the
+failure came from: `SetupPayload::FromStringRepresentation` reports its own source location, so
+`ChipToolControllerAdapter.commission` matches `Run command failure: src/setup_payload/` in the
+command's logs and raises `ChipToolPayloadError` for that case alone. Real evidence from both
+chip-tool legs: `chip-tool refused the onboarding payload for node 4097: Run command failure:
+src/setup_payload/SetupPayload.cpp:361: CHIP Error 0x0000002F: Invalid argument`.
 
 **A negative check needs a bound and a cleanup path.** `expectRejection` (promoted from
 `TC-CADMIN-1.17` to `tc-support.ts`, now taking its own timeout) reports `"fail"` for a call that

--- a/support/chip-testing/test/cert/TC-CADMIN-1.17.test.ts
+++ b/support/chip-testing/test/cert/TC-CADMIN-1.17.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Duration, InternalError, Millis, Time } from "@matter/main";
+import { InternalError } from "@matter/main";
 import { Matter } from "@matter/model";
 import type {
     CertNodeApi,
@@ -17,7 +17,7 @@ import type {
 } from "@matter/testing";
 import { CertLogClosedError, CertLogTimeoutError, certTest } from "@matter/testing";
 import { expectMdns } from "../../src/cert/mdns-check.js";
-import { CommissionedRefs, PendingPairingCode } from "./tc-support.js";
+import { CommissionedRefs, expectRejection, PendingPairingCode } from "./tc-support.js";
 
 const BASIC_INFORMATION = Matter.clusters.require("BasicInformation");
 const VENDOR_ID = BASIC_INFORMATION.attributes.require("vendorId");
@@ -217,50 +217,6 @@ async function openWindowAndCheck(cx: CertStepContext): Promise<void> {
     }
 }
 
-type SettleOutcome = { kind: "resolved" } | { kind: "rejected"; error: unknown } | { kind: "timeout" };
-
-function settled(promise: Promise<unknown>): Promise<SettleOutcome> {
-    return promise.then(
-        (): SettleOutcome => ({ kind: "resolved" }),
-        (error: unknown): SettleOutcome => ({ kind: "rejected", error }),
-    );
-}
-
-/**
- * Asserts `op` rejects (the TH_CR2-post-removal expectation) rather than resolves, bounded by
- * {@link POST_REMOVAL_TIMEOUT_MS} so a session that neither errors nor times out at the transport layer
- * can't hang this step for the full mocha timeout. `settled()` attaches its handlers before the race
- * starts, so a late resolution/rejection after the timeout branch wins is still observed, just not
- * awaited — no unhandled-rejection risk.
- */
-async function expectRejection(label: string, op: Promise<unknown>): Promise<CheckRecord> {
-    const start = Time.nowMs;
-    const timeout = Time.sleep("TC-CADMIN-1.17 post-removal check timeout", Millis(POST_REMOVAL_TIMEOUT_MS));
-    let outcome: SettleOutcome;
-    try {
-        outcome = await Promise.race([settled(op), timeout.then((): SettleOutcome => ({ kind: "timeout" }))]);
-    } finally {
-        // A lost race leaves the sleep armed for its full duration, keeping the process alive past teardown
-        timeout.cancel();
-    }
-    const elapsed = Duration.format(Millis(Time.nowMs - start));
-
-    switch (outcome.kind) {
-        case "resolved":
-            return { type: "response", verdict: "fail", detail: `${label} unexpectedly succeeded after ${elapsed}` };
-        case "timeout":
-            return {
-                type: "response",
-                verdict: "fail",
-                detail: `${label} neither resolved nor rejected within ${Duration.format(Millis(POST_REMOVAL_TIMEOUT_MS))}`,
-            };
-        case "rejected": {
-            const message = outcome.error instanceof Error ? outcome.error.message : String(outcome.error);
-            return { type: "response", verdict: "pass", detail: `${label} rejected after ${elapsed}: ${message}` };
-        }
-    }
-}
-
 certTest("TC-CADMIN-1.17", {
     plan: "multiplefabrics.adoc",
     pics: ["CADMIN.C", "CADMIN.C.C00.Tx"],
@@ -426,10 +382,15 @@ certTest("TC-CADMIN-1.17", {
             const writeCheck = await expectRejection(
                 "writeAttribute(NodeLabel)",
                 node.writeAttribute(path, "post-removal"),
+                POST_REMOVAL_TIMEOUT_MS,
             );
             cx.recorder.check(writeCheck);
 
-            const readCheck = await expectRejection("readAttribute(NodeLabel)", node.readAttribute(path));
+            const readCheck = await expectRejection(
+                "readAttribute(NodeLabel)",
+                node.readAttribute(path),
+                POST_REMOVAL_TIMEOUT_MS,
+            );
             cx.recorder.check(readCheck);
 
             if (writeCheck.verdict !== "pass" || readCheck.verdict !== "pass") {

--- a/support/chip-testing/test/cert/TC-DD-3.14.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.14.test.ts
@@ -6,9 +6,12 @@
 
 import { certTest } from "@matter/testing";
 import {
-    expectCommissioningRefused,
+    CommissioningRefusals,
+    commissionByQr,
     qrPayloadWith,
     qrPayloadWithPrefix,
+    onNetworkOnlyPayload,
+    recordDiscoveryCapabilityAbsent,
     recordParse,
     thQrPayload,
 } from "./tc-dd-support.js";
@@ -28,9 +31,8 @@ const INVALID_PASSCODES = [
     0, 11111111, 22222222, 33333333, 44444444, 55555555, 66666666, 77777777, 88888888, 99999999, 12345678, 87654321,
 ];
 
-const IP_ONLY = "The controllers in this harness discover over IP only";
-
 const commissioned = new CommissionedRefs();
+const refusals = new CommissioningRefusals();
 
 certTest("TC-DD-3.14", {
     plan: "devicediscovery.adoc",
@@ -68,7 +70,7 @@ certTest("TC-DD-3.14", {
         "Scan/read the QR code, generated in the previous step, using the DUT",
         async cx => {
             const payload = qrPayloadWith(await thQrPayload(cx.devices.th), { version: INVALID_VERSION });
-            await expectCommissioningRefused(cx, payload, commissioned, "Invalid-version payload refused");
+            await refusals.requireRefusal(cx, payload, "Invalid-version payload refused");
         },
         {
             expected:
@@ -80,24 +82,56 @@ certTest("TC-DD-3.14", {
         "3.a",
         "Using the QR code from Step 1, ensure the TH's Discovery Capability bit string is NOT set to BLE for " +
             "discovery (i.e. set to OnNetwork discovery capability)",
-        async () => {},
-        { pics: "MCORE.DD.DISCOVERY_BLE", notApplicable: `${IP_ONLY}, so MCORE.DD.DISCOVERY_BLE is 0` },
+        async cx =>
+            recordDiscoveryCapabilityAbsent(cx, await onNetworkOnlyPayload(cx), "ble", "Payload does not offer BLE"),
+        {
+            pics: "MCORE.DD.DISCOVERY_BLE",
+            expected: "User has a QR code generated to pass into DUT.",
+        },
     )
-    .step("3.b", "Scan/read the QR code of the TH device using the DUT", async () => {}, {
-        pics: "MCORE.DD.DISCOVERY_BLE",
-        notApplicable: `${IP_ONLY}, so MCORE.DD.DISCOVERY_BLE is 0`,
-    })
+    .step(
+        "3.b",
+        "Scan/read the QR code of the TH device using the DUT",
+        async cx => {
+            await commissionByQr(cx, await onNetworkOnlyPayload(cx), commissioned);
+        },
+        {
+            pics: "MCORE.DD.DISCOVERY_BLE",
+            expected:
+                "If TH Commissionee's Discovery Capabilities do not support BLE, ensure that the DUT commissions " +
+                "the TH onto the Matter network over a capability that is NOT BLE. In this example, over OnNetwork.",
+        },
+    )
     .step(
         "4.a",
         "Using the QR code from Step 1, ensure the TH's Discovery Capability bit string is NOT set to Wi-Fi PAF " +
             "for discovery (i.e. set to OnNetwork discovery capability)",
-        async () => {},
-        { pics: "MCORE.DD.DISCOVERY_PAF", notApplicable: `${IP_ONLY}, so MCORE.DD.DISCOVERY_PAF is 0` },
+        async cx =>
+            recordDiscoveryCapabilityAbsent(
+                cx,
+                await onNetworkOnlyPayload(cx),
+                "wifiPublicActionFrame",
+                "Payload does not offer Wi-Fi PAF",
+            ),
+        {
+            pics: "MCORE.DD.DISCOVERY_PAF",
+            expected: "User has a QR code generated to pass into DUT.",
+        },
     )
-    .step("4.b", "Scan/read the QR code of the TH device using the DUT", async () => {}, {
-        pics: "MCORE.DD.DISCOVERY_PAF",
-        notApplicable: `${IP_ONLY}, so MCORE.DD.DISCOVERY_PAF is 0`,
-    })
+    .step(
+        "4.b",
+        "Scan/read the QR code of the TH device using the DUT",
+        async cx => {
+            await commissionByQr(cx, await onNetworkOnlyPayload(cx), commissioned);
+        },
+        {
+            pics: "MCORE.DD.DISCOVERY_PAF",
+            expected:
+                "If TH Commissionee's Discovery Capabilities do not support Wi-Fi PAF, ensure that the DUT " +
+                "commissions the TH onto the Matter network over a capability that is NOT Wi-Fi PAF. In this " +
+                "example, over OnNetwork.",
+        },
+    )
     .step(
         "5.a",
         "Passcode: Using the QR code from Step 1, generate a new QR code using all the same Onboarding Payload " +
@@ -132,10 +166,9 @@ certTest("TC-DD-3.14", {
         async cx => {
             const th = await thQrPayload(cx.devices.th);
             for (const passcode of INVALID_PASSCODES) {
-                await expectCommissioningRefused(
+                await refusals.requireRefusal(
                     cx,
                     qrPayloadWith(th, { passcode }),
-                    commissioned,
                     `Payload carrying passcode ${passcode} refused`,
                 );
             }
@@ -161,7 +194,7 @@ certTest("TC-DD-3.14", {
         "Scan/read the QR code, generated in the previous step, using the DUT",
         async cx => {
             const payload = qrPayloadWithPrefix(await thQrPayload(cx.devices.th), INVALID_PREFIX);
-            await expectCommissioningRefused(cx, payload, commissioned, "Invalid-prefix payload refused");
+            await refusals.requireRefusal(cx, payload, "Invalid-prefix payload refused");
         },
         {
             expected:
@@ -169,4 +202,10 @@ certTest("TC-DD-3.14", {
                 "commissioning process in a DUT-specific manner according to the DUT manufacturer's instructions.",
         },
     )
-    .finalize(cx => commissioned.decommissionAll(cx));
+    .finalize(async cx => {
+        try {
+            await refusals.settle(cx);
+        } finally {
+            await commissioned.decommissionAll(cx);
+        }
+    });

--- a/support/chip-testing/test/cert/TC-DD-3.14.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.14.test.ts
@@ -1,0 +1,172 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { certTest } from "@matter/testing";
+import {
+    expectCommissioningRefused,
+    qrPayloadWith,
+    qrPayloadWithPrefix,
+    recordParse,
+    thQrPayload,
+} from "./tc-dd-support.js";
+import { CommissionedRefs, record } from "./tc-support.js";
+
+/** The plan's own substitute for the specification's `000`; any non-zero 3-bit value works. */
+const INVALID_VERSION = 0b010;
+
+/** The plan's own substitute for `MT:`. */
+const INVALID_PREFIX = "AB:";
+
+/**
+ * The trivial passcodes § 5.1.7.1 forbids, transcribed from the plan's step 5.a rather than taken
+ * from matter.js's own list, so a divergence between the two shows up as a failing step.
+ */
+const INVALID_PASSCODES = [
+    0, 11111111, 22222222, 33333333, 44444444, 55555555, 66666666, 77777777, 88888888, 99999999, 12345678, 87654321,
+];
+
+const IP_ONLY = "The controllers in this harness discover over IP only";
+
+const commissioned = new CommissionedRefs();
+
+certTest("TC-DD-3.14", {
+    plan: "devicediscovery.adoc",
+    pics: ["MCORE.ROLE.COMMISSIONER", "MCORE.DD.QR_COMMISSIONING"],
+    app: "all-clusters",
+})
+    .step(
+        1,
+        "Locate and scan/read the Commissionee's QR code using DUT",
+        async cx => {
+            await recordParse(cx, await thQrPayload(cx.devices.th));
+        },
+        { expected: "Verify the DUT is able to scan/read the QR code" },
+    )
+    .step(
+        "2.a",
+        "Version String: Using the QR code from Step 1, generate a new QR code but substituting out the current " +
+            "Version String with an invalid Version String (i.e. '010' or any non-zero 3-bit value)",
+        async cx => {
+            const payload = qrPayloadWith(await thQrPayload(cx.devices.th), { version: INVALID_VERSION });
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: "pass",
+                    detail: `Generated ${payload} carrying version ${INVALID_VERSION}`,
+                },
+                "Invalid-version payload",
+            );
+        },
+        { expected: "User has a QR code generated to pass into DUT." },
+    )
+    .step(
+        "2.b",
+        "Scan/read the QR code, generated in the previous step, using the DUT",
+        async cx => {
+            const payload = qrPayloadWith(await thQrPayload(cx.devices.th), { version: INVALID_VERSION });
+            await expectCommissioningRefused(cx, payload, commissioned, "Invalid-version payload refused");
+        },
+        {
+            expected:
+                "DUT parses QR code and DUT terminates the commissioning process in a DUT-specific manner " +
+                "according to the DUT manufacturer's instructions.",
+        },
+    )
+    .step(
+        "3.a",
+        "Using the QR code from Step 1, ensure the TH's Discovery Capability bit string is NOT set to BLE for " +
+            "discovery (i.e. set to OnNetwork discovery capability)",
+        async () => {},
+        { pics: "MCORE.DD.DISCOVERY_BLE", notApplicable: `${IP_ONLY}, so MCORE.DD.DISCOVERY_BLE is 0` },
+    )
+    .step("3.b", "Scan/read the QR code of the TH device using the DUT", async () => {}, {
+        pics: "MCORE.DD.DISCOVERY_BLE",
+        notApplicable: `${IP_ONLY}, so MCORE.DD.DISCOVERY_BLE is 0`,
+    })
+    .step(
+        "4.a",
+        "Using the QR code from Step 1, ensure the TH's Discovery Capability bit string is NOT set to Wi-Fi PAF " +
+            "for discovery (i.e. set to OnNetwork discovery capability)",
+        async () => {},
+        { pics: "MCORE.DD.DISCOVERY_PAF", notApplicable: `${IP_ONLY}, so MCORE.DD.DISCOVERY_PAF is 0` },
+    )
+    .step("4.b", "Scan/read the QR code of the TH device using the DUT", async () => {}, {
+        pics: "MCORE.DD.DISCOVERY_PAF",
+        notApplicable: `${IP_ONLY}, so MCORE.DD.DISCOVERY_PAF is 0`,
+    })
+    .step(
+        "5.a",
+        "Passcode: Using the QR code from Step 1, generate a new QR code using all the same Onboarding Payload " +
+            "components except for the Passcode. For each passcode in the following list, set the Passcode " +
+            "component to one of the invalid Passcodes and generate a new QR code using all the same Onboarding " +
+            "Payload components and one Passcode from the list: 00000000, 11111111, 22222222, 33333333, 44444444, " +
+            "55555555, 66666666, 77777777, 88888888, 99999999, 12345678, 87654321",
+        async cx => {
+            const th = await thQrPayload(cx.devices.th);
+            const payloads = INVALID_PASSCODES.map(passcode => qrPayloadWith(th, { passcode }));
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: "pass",
+                    detail: `Generated ${payloads.length} payloads: ${payloads
+                        .map((payload, i) => `${payload} (${INVALID_PASSCODES[i]})`)
+                        .join(", ")}`,
+                },
+                "Invalid-passcode payloads",
+            );
+        },
+        {
+            expected:
+                "User has 12 QR codes (one for each passcode in the list of invalid passcodes) generated to pass " +
+                "into DUT",
+        },
+    )
+    .step(
+        "5.b",
+        "Scan each of the generated QR codes from the previous step using DUT",
+        async cx => {
+            const th = await thQrPayload(cx.devices.th);
+            for (const passcode of INVALID_PASSCODES) {
+                await expectCommissioningRefused(
+                    cx,
+                    qrPayloadWith(th, { passcode }),
+                    commissioned,
+                    `Payload carrying passcode ${passcode} refused`,
+                );
+            }
+        },
+        {
+            expected:
+                "DUT parses QR code and DUT terminates the commissioning process in a DUT-specific manner " +
+                "according to the DUT manufacturer's instructions.",
+        },
+    )
+    .step(
+        "6.a",
+        "Prefix: Using the QR code from Step 1, generate a new QR code but substituting out the current Prefix " +
+            "with an invalid Prefix that is not 'MT:' (i.e. Prefix='AB:')",
+        async cx => {
+            const payload = qrPayloadWithPrefix(await thQrPayload(cx.devices.th), INVALID_PREFIX);
+            record(cx, { type: "response", verdict: "pass", detail: `Generated ${payload}` }, "Invalid-prefix payload");
+        },
+        { expected: "User has a QR code generated to pass into DUT." },
+    )
+    .step(
+        "6.b",
+        "Scan/read the QR code, generated in the previous step, using the DUT",
+        async cx => {
+            const payload = qrPayloadWithPrefix(await thQrPayload(cx.devices.th), INVALID_PREFIX);
+            await expectCommissioningRefused(cx, payload, commissioned, "Invalid-prefix payload refused");
+        },
+        {
+            expected:
+                "DUT commissioner does not react successfully to scanning the QR code and DUT terminates the " +
+                "commissioning process in a DUT-specific manner according to the DUT manufacturer's instructions.",
+        },
+    )
+    .finalize(cx => commissioned.decommissionAll(cx));

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, Duration, InternalError, Millis, Time, UnexpectedDataError } from "@matter/main";
+import { Bytes, Duration, InternalError, Millis, Time } from "@matter/main";
 import { Base38, DiscoveryCapabilitiesBitmap, DiscoveryCapabilitiesSchema } from "@matter/main/types";
 import type { CertNodeRef, CertStepContext } from "@matter/testing";
 import type { CertDevice } from "@matter/testing";
-import { ChipToolPayloadError } from "../../src/cert/ChipToolControllerAdapter.js";
 import { expectMdns } from "../../src/cert/mdns-check.js";
+import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload.js";
 import { CertCleanupError, CommissionedRefs, expectRejection, expectSequence, record } from "./tc-support.js";
 
 export const LOG_TIMEOUT_MS = 30_000;
@@ -298,15 +298,14 @@ export class CommissioningRefusals {
 
 /**
  * Whether `error` is a controller refusing the onboarding payload rather than failing for some other
- * reason. matter.js's codec raises {@link UnexpectedDataError}; chip-tool's driver raises
- * {@link ChipToolPayloadError} only for a failure its setup-payload layer reported.
- *
- * The base `ChipToolCommandError` is deliberately not accepted: chip-tool funnels discovery, PASE,
- * attestation and command timeouts into it as well, so a commissioner that took a forbidden passcode
- * and only then failed its handshake would be recorded as having refused the code.
+ * reason. Both adapters mark that refusal where it happens, because neither controller's own error
+ * types distinguish it: chip-tool funnels discovery, PASE, attestation and command timeouts into one
+ * command error, and matter.js raises `UnexpectedDataError` from the commissioning flow as well (an
+ * invalid CSR response, for one). Either would let a commissioner that took a forbidden code and only
+ * then failed be recorded as having refused it.
  */
 function isPayloadRefusal(error: unknown): boolean {
-    return error instanceof UnexpectedDataError || error instanceof ChipToolPayloadError;
+    return error instanceof OnboardingPayloadRefusedError;
 }
 
 /**

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -4,11 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, InternalError } from "@matter/main";
-import { Base38 } from "@matter/main/types";
-import type { CertDevice, CertStepContext } from "@matter/testing";
+import { Bytes, Duration, InternalError, Millis, Time, UnexpectedDataError } from "@matter/main";
+import { Base38, DiscoveryCapabilitiesBitmap, DiscoveryCapabilitiesSchema } from "@matter/main/types";
+import type { CertNodeRef, CertStepContext } from "@matter/testing";
+import type { CertDevice } from "@matter/testing";
+import { ChipToolCommandError } from "../../src/cert/ChipToolControllerAdapter.js";
 import { expectMdns } from "../../src/cert/mdns-check.js";
-import { CommissionedRefs, expectRejection, expectSequence, record } from "./tc-support.js";
+import { CertCleanupError, CommissionedRefs, expectRejection, expectSequence, record } from "./tc-support.js";
 
 export const LOG_TIMEOUT_MS = 30_000;
 export const MDNS_TIMEOUT_MS = 30_000;
@@ -18,7 +20,15 @@ export const MDNS_TIMEOUT_MS = 30_000;
  * before they touch the network, so a refusal lands in milliseconds; the budget is what keeps a
  * controller that instead went looking for the commissionee from hanging the step.
  */
-export const REFUSAL_TIMEOUT_MS = 30_000;
+export const REFUSAL_TIMEOUT_MS = 15_000;
+
+/**
+ * Bounds the cleanup's wait for an attempt that outlived {@link REFUSAL_TIMEOUT_MS}. A commissioning
+ * that is going to succeed does so in seconds; what this cannot outwait is a chip-tool command stuck
+ * in its own 3-minute budget, and that is deliberate — `CertTest`'s whole finalizer gets 2 minutes,
+ * and a controller stuck that long has left the TH in a state this run cannot report on anyway.
+ */
+export const REFUSAL_SETTLE_TIMEOUT_MS = 30_000;
 
 /** Outlives the rest of a run, so a later step never pairs against a window that closed on its own. */
 const WINDOW_TIMEOUT_SECONDS = 300;
@@ -91,13 +101,60 @@ export async function recordParse(cx: CertStepContext, payload: string): Promise
 
 const QR_PREFIX = "MT:";
 
+/** § 5.1.3.1 Table 60's OnNetwork-only bitmask, which the discovery-capability steps ask for. */
+export const ON_NETWORK_ONLY = DiscoveryCapabilitiesSchema.encode({ onIpNetwork: true });
+
+/**
+ * The TH's onboarding payload with its discovery capabilities reduced to OnNetwork.
+ *
+ * The plan states this as a precondition on the TH ("ensure the TH's Discovery Capability bit string
+ * is NOT set to BLE"), which for a TC that drives everything itself means substituting the field the
+ * way its neighbouring steps substitute theirs. It is not cosmetic: `chip-all-clusters-app` publishes
+ * a BLE-only bitmask, so the precondition does not otherwise hold on that TH at all.
+ */
+export async function onNetworkOnlyPayload(cx: CertStepContext): Promise<string> {
+    return qrPayloadWith(await thQrPayload(cx.devices.th), { discoveryCapabilities: ON_NETWORK_ONLY });
+}
+
+/**
+ * Records that `payload` does not offer `capability`, read back through the DUT so a controller that
+ * cannot report a bitmask fails here rather than silently proving nothing.
+ */
+export async function recordDiscoveryCapabilityAbsent(
+    cx: CertStepContext,
+    payload: string,
+    capability: keyof typeof DiscoveryCapabilitiesBitmap,
+    what: string,
+): Promise<void> {
+    const parsed = await cx.controllers.dut.parseQrPayload(payload);
+    const offered = DiscoveryCapabilitiesSchema.decode(parsed.discoveryCapabilities);
+    const names = Object.entries(offered)
+        .filter(([, set]) => set)
+        .map(([name]) => name);
+
+    record(
+        cx,
+        {
+            type: "response",
+            verdict: offered[capability] ? "fail" : "pass",
+            detail:
+                `DUT read ${payload} as offering discovery over ${names.join(", ") || "nothing"} ` +
+                `(bitmask 0b${parsed.discoveryCapabilities.toString(2).padStart(8, "0")}), so ${capability} is ` +
+                `${offered[capability] ? "offered" : "not offered"}`,
+        },
+        what,
+    );
+}
+
 /** Bit offset and length of § 5.1.3.1 Table 59's fields inside the payload's fixed structure. */
 const VERSION_BITS = { offset: 0, length: 3 };
 const PASSCODE_BITS = { offset: 57, length: 27 };
+const DISCOVERY_BITS = { offset: 37, length: 8 };
 
 function writeBits(data: Uint8Array, { offset, length }: { offset: number; length: number }, value: number): void {
-    if (value < 0 || value >= 2 ** length) {
-        // Silently dropping the high bits would put a payload nobody asked for into the evidence
+    if (!Number.isInteger(value) || value < 0 || value >= 2 ** length) {
+        // The bitwise operators below coerce a fraction and NaN silently, which would put a payload
+        // nobody asked for into the evidence
         throw new InternalError(`${value} does not fit the ${length} bits at offset ${offset}`);
     }
     for (let i = 0; i < length; i++) {
@@ -120,7 +177,10 @@ function writeBits(data: Uint8Array, { offset, length }: { offset: number; lengt
  * are exactly what it validates against on the way out (§ 5.1.3.1, § 5.1.7.1). The TLV data that may
  * follow the fixed 11-byte structure is carried through untouched.
  */
-export function qrPayloadWith(payload: string, fields: { version?: number; passcode?: number }): string {
+export function qrPayloadWith(
+    payload: string,
+    fields: { version?: number; passcode?: number; discoveryCapabilities?: number },
+): string {
     if (!payload.startsWith(QR_PREFIX)) {
         throw new InternalError(`Cannot substitute fields into "${payload}", which is not a QR onboarding payload`);
     }
@@ -131,6 +191,9 @@ export function qrPayloadWith(payload: string, fields: { version?: number; passc
     }
     if (fields.passcode !== undefined) {
         writeBits(data, PASSCODE_BITS, fields.passcode);
+    }
+    if (fields.discoveryCapabilities !== undefined) {
+        writeBits(data, DISCOVERY_BITS, fields.discoveryCapabilities);
     }
     return QR_PREFIX + Base38.encode(data);
 }
@@ -144,30 +207,103 @@ export function qrPayloadWithPrefix(payload: string, prefix: string): string {
 }
 
 /**
- * Records that the DUT refuses to commission from `payload`, which is how the negative plans phrase
- * "the DUT terminates the commissioning process in a DUT-specific manner".
+ * The commissioning attempts a TC has told the DUT to refuse.
  *
- * A refusal that never came leaves the TH commissioned, so the ref reaches `commissioned` before the
- * check is judged — the run's own cleanup then takes the fabric back off the TH rather than leaving
- * it for whatever runs next. A controller that neither refuses nor finishes inside
- * {@link REFUSAL_TIMEOUT_MS} is the one case that can still strand a fabric, since its ref arrives
- * after the cleanup ran; the budget is orders of magnitude above either controller's own refusal.
- *
- * The ref lands under the `"dut"` role, so a TC that also commissions the TH legitimately must not
- * hold a live ref there while this runs.
+ * A TC's `finalize` must {@link settle} this. An attempt outlives the check that judged it —
+ * {@link expectRejection} stops waiting at its budget but the commissioning carries on — so a
+ * fabric this class asked for can land after every other cleanup has run.
  */
-export async function expectCommissioningRefused(
-    cx: CertStepContext,
-    payload: string,
-    commissioned: CommissionedRefs,
-    what: string,
-): Promise<void> {
-    const attempt = cx.controllers.dut.commission({ qrPairingCode: payload }).then(ref => {
-        commissioned.set("dut", ref);
-        return ref;
-    });
+export class CommissioningRefusals {
+    #attempts = new Array<Promise<CertNodeRef | undefined>>();
+    #refusalTimeoutMs: number;
+    #settleTimeoutMs: number;
 
-    record(cx, await expectRejection(`commissioning from ${payload}`, attempt, REFUSAL_TIMEOUT_MS), what);
+    /** Budgets are injectable because the unit tests cannot wait out the real ones. */
+    constructor(budgets?: { refusalTimeoutMs?: number; settleTimeoutMs?: number }) {
+        this.#refusalTimeoutMs = budgets?.refusalTimeoutMs ?? REFUSAL_TIMEOUT_MS;
+        this.#settleTimeoutMs = budgets?.settleTimeoutMs ?? REFUSAL_SETTLE_TIMEOUT_MS;
+    }
+
+    /**
+     * Records that the DUT refuses to commission from `payload`, which is how the negative plans
+     * phrase "the DUT terminates the commissioning process in a DUT-specific manner".
+     *
+     * Only a refusal of the payload itself counts (see {@link isPayloadRefusal}). Accepting any
+     * rejection would let the step pass on a controller that died, timed out or was never asked —
+     * outcomes that say nothing about what the DUT made of the code.
+     */
+    async requireRefusal(cx: CertStepContext, payload: string, what: string): Promise<void> {
+        const attempt = cx.controllers.dut.commission({ qrPairingCode: payload });
+        // Kept as a settled outcome so an attempt nobody awaits again cannot surface as an unhandled
+        // rejection, and so settle() can collect the ref of one that succeeded after its budget
+        this.#attempts.push(
+            attempt.then(
+                ref => ref,
+                () => undefined,
+            ),
+        );
+
+        record(
+            cx,
+            await expectRejection(`commissioning from ${payload}`, attempt, this.#refusalTimeoutMs, isPayloadRefusal),
+            what,
+        );
+    }
+
+    /**
+     * Waits out every attempt still running and removes the fabric of any that succeeded anyway.
+     * Gives up rather than holding the run open — the TH's state is then genuinely unknown, which is
+     * what the cleanup error says.
+     */
+    async settle(cx: CertStepContext): Promise<void> {
+        const attempts = this.#attempts.splice(0);
+        if (attempts.length === 0) {
+            return;
+        }
+
+        const timeout = Time.sleep("outstanding refused commissionings", Millis(this.#settleTimeoutMs));
+        let refs;
+        try {
+            refs = await Promise.race([Promise.all(attempts), timeout.then(() => undefined)]);
+        } finally {
+            timeout.cancel();
+        }
+
+        if (refs === undefined) {
+            throw new CertCleanupError(
+                `${attempts.length} commissioning attempt(s) the DUT was asked to refuse are still running after ` +
+                    `${Duration.format(Millis(this.#settleTimeoutMs))}; one that succeeds now cannot be cleaned up`,
+            );
+        }
+
+        const failures = new Array<string>();
+        for (const ref of refs) {
+            if (ref === undefined) {
+                continue;
+            }
+            try {
+                await cx.controllers.dut.node(ref).decommission();
+            } catch (e) {
+                failures.push(`${ref}: ${e instanceof Error ? e.message : String(e)}`);
+            }
+        }
+        if (failures.length) {
+            throw new CertCleanupError(
+                `The DUT commissioned the TH from a payload it was asked to refuse and the fabric could not be ` +
+                    `removed: ${failures.join("; ")}`,
+            );
+        }
+    }
+}
+
+/**
+ * Whether `error` is a controller refusing the onboarding payload rather than failing for some other
+ * reason. matter.js's codec raises {@link UnexpectedDataError}; chip-tool reports its own verdict as
+ * a failed command, where a dead process, a closed client or an expired command budget raise their
+ * own types instead.
+ */
+function isPayloadRefusal(error: unknown): boolean {
+    return error instanceof UnexpectedDataError || error instanceof ChipToolCommandError;
 }
 
 /**

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -4,13 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InternalError } from "@matter/main";
+import { Bytes, InternalError } from "@matter/main";
+import { Base38 } from "@matter/main/types";
 import type { CertDevice, CertStepContext } from "@matter/testing";
 import { expectMdns } from "../../src/cert/mdns-check.js";
-import { CommissionedRefs, expectSequence, record } from "./tc-support.js";
+import { CommissionedRefs, expectRejection, expectSequence, record } from "./tc-support.js";
 
 export const LOG_TIMEOUT_MS = 30_000;
 export const MDNS_TIMEOUT_MS = 30_000;
+
+/**
+ * Bounds a "the DUT must refuse this" commissioning attempt. Both controllers read the payload
+ * before they touch the network, so a refusal lands in milliseconds; the budget is what keeps a
+ * controller that instead went looking for the commissionee from hanging the step.
+ */
+export const REFUSAL_TIMEOUT_MS = 30_000;
 
 /** Outlives the rest of a run, so a later step never pairs against a window that closed on its own. */
 const WINDOW_TIMEOUT_SECONDS = 300;
@@ -79,6 +87,87 @@ export async function recordParse(cx: CertStepContext, payload: string): Promise
         },
         "Onboarding payload parse",
     );
+}
+
+const QR_PREFIX = "MT:";
+
+/** Bit offset and length of § 5.1.3.1 Table 59's fields inside the payload's fixed structure. */
+const VERSION_BITS = { offset: 0, length: 3 };
+const PASSCODE_BITS = { offset: 57, length: 27 };
+
+function writeBits(data: Uint8Array, { offset, length }: { offset: number; length: number }, value: number): void {
+    if (value < 0 || value >= 2 ** length) {
+        // Silently dropping the high bits would put a payload nobody asked for into the evidence
+        throw new InternalError(`${value} does not fit the ${length} bits at offset ${offset}`);
+    }
+    for (let i = 0; i < length; i++) {
+        const bit = offset + i;
+        const mask = 1 << (bit % 8);
+        if ((value >>> i) & 1) {
+            data[bit >> 3] |= mask;
+        } else {
+            data[bit >> 3] &= ~mask;
+        }
+    }
+}
+
+/**
+ * `payload` with the named fields substituted, which is what the negative device-discovery plans ask
+ * a tester to produce with a QR generator.
+ *
+ * The fields go in as bits rather than through matter.js's own encoder, because every value these
+ * plans want is one that encoder refuses to write: an unsupported version and the trivial passcodes
+ * are exactly what it validates against on the way out (§ 5.1.3.1, § 5.1.7.1). The TLV data that may
+ * follow the fixed 11-byte structure is carried through untouched.
+ */
+export function qrPayloadWith(payload: string, fields: { version?: number; passcode?: number }): string {
+    if (!payload.startsWith(QR_PREFIX)) {
+        throw new InternalError(`Cannot substitute fields into "${payload}", which is not a QR onboarding payload`);
+    }
+
+    const data = Uint8Array.from(Bytes.of(Base38.decode(payload.slice(QR_PREFIX.length))));
+    if (fields.version !== undefined) {
+        writeBits(data, VERSION_BITS, fields.version);
+    }
+    if (fields.passcode !== undefined) {
+        writeBits(data, PASSCODE_BITS, fields.passcode);
+    }
+    return QR_PREFIX + Base38.encode(data);
+}
+
+/** `payload` carrying `prefix` in place of the specification's `MT:` (§ 5.1.3). */
+export function qrPayloadWithPrefix(payload: string, prefix: string): string {
+    if (!payload.startsWith(QR_PREFIX)) {
+        throw new InternalError(`Cannot re-prefix "${payload}", which is not a QR onboarding payload`);
+    }
+    return prefix + payload.slice(QR_PREFIX.length);
+}
+
+/**
+ * Records that the DUT refuses to commission from `payload`, which is how the negative plans phrase
+ * "the DUT terminates the commissioning process in a DUT-specific manner".
+ *
+ * A refusal that never came leaves the TH commissioned, so the ref reaches `commissioned` before the
+ * check is judged — the run's own cleanup then takes the fabric back off the TH rather than leaving
+ * it for whatever runs next. A controller that neither refuses nor finishes inside
+ * {@link REFUSAL_TIMEOUT_MS} is the one case that can still strand a fabric, since its ref arrives
+ * after the cleanup ran; the budget is orders of magnitude above either controller's own refusal.
+ *
+ * The ref lands under the `"dut"` role, so a TC that also commissions the TH legitimately must not
+ * hold a live ref there while this runs.
+ */
+export async function expectCommissioningRefused(
+    cx: CertStepContext,
+    payload: string,
+    commissioned: CommissionedRefs,
+    what: string,
+): Promise<void> {
+    const attempt = cx.controllers.dut.commission({ qrPairingCode: payload }).then(ref => {
+        commissioned.set("dut", ref);
+        return ref;
+    });
+
+    record(cx, await expectRejection(`commissioning from ${payload}`, attempt, REFUSAL_TIMEOUT_MS), what);
 }
 
 /**

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -8,7 +8,7 @@ import { Bytes, Duration, InternalError, Millis, Time, UnexpectedDataError } fro
 import { Base38, DiscoveryCapabilitiesBitmap, DiscoveryCapabilitiesSchema } from "@matter/main/types";
 import type { CertNodeRef, CertStepContext } from "@matter/testing";
 import type { CertDevice } from "@matter/testing";
-import { ChipToolCommandError } from "../../src/cert/ChipToolControllerAdapter.js";
+import { ChipToolPayloadError } from "../../src/cert/ChipToolControllerAdapter.js";
 import { expectMdns } from "../../src/cert/mdns-check.js";
 import { CertCleanupError, CommissionedRefs, expectRejection, expectSequence, record } from "./tc-support.js";
 
@@ -298,12 +298,15 @@ export class CommissioningRefusals {
 
 /**
  * Whether `error` is a controller refusing the onboarding payload rather than failing for some other
- * reason. matter.js's codec raises {@link UnexpectedDataError}; chip-tool reports its own verdict as
- * a failed command, where a dead process, a closed client or an expired command budget raise their
- * own types instead.
+ * reason. matter.js's codec raises {@link UnexpectedDataError}; chip-tool's driver raises
+ * {@link ChipToolPayloadError} only for a failure its setup-payload layer reported.
+ *
+ * The base `ChipToolCommandError` is deliberately not accepted: chip-tool funnels discovery, PASE,
+ * attestation and command timeouts into it as well, so a commissioner that took a forbidden passcode
+ * and only then failed its handshake would be recorded as having refused the code.
  */
 function isPayloadRefusal(error: unknown): boolean {
-    return error instanceof UnexpectedDataError || error instanceof ChipToolCommandError;
+    return error instanceof UnexpectedDataError || error instanceof ChipToolPayloadError;
 }
 
 /**

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InternalError, MatterError, Time } from "@matter/main";
+import { Duration, InternalError, MatterError, Millis, Time } from "@matter/main";
 import type {
     AttributePathSpec,
     CertNodeRef,
@@ -978,6 +978,52 @@ export async function expectReportAck(
             return { type: "device-log", verdict: "fail", pattern, detail: e.message, logLine: from };
         }
         throw e;
+    }
+}
+
+type SettleOutcome = { kind: "resolved" } | { kind: "rejected"; error: unknown } | { kind: "timeout" };
+
+function settled(promise: Promise<unknown>): Promise<SettleOutcome> {
+    return promise.then(
+        (): SettleOutcome => ({ kind: "resolved" }),
+        (error: unknown): SettleOutcome => ({ kind: "rejected", error }),
+    );
+}
+
+/**
+ * Asserts `op` rejects rather than resolves, bounded by `timeoutMs` so an implementation that
+ * neither errors nor gives up cannot hang the step for the whole mocha timeout — which is useless as
+ * either evidence or a fast local failure. A timeout is reported `"fail"`, same as an unexpected
+ * success, and the elapsed time reaches the evidence either way.
+ *
+ * `settled()` attaches its handlers before the race starts, so a late settlement after the timeout
+ * branch wins is still observed, just not awaited — no unhandled-rejection risk.
+ */
+export async function expectRejection(label: string, op: Promise<unknown>, timeoutMs: number): Promise<CheckRecord> {
+    const start = Time.nowMs;
+    const timeout = Time.sleep(`${label} rejection timeout`, Millis(timeoutMs));
+    let outcome: SettleOutcome;
+    try {
+        outcome = await Promise.race([settled(op), timeout.then((): SettleOutcome => ({ kind: "timeout" }))]);
+    } finally {
+        // A lost race leaves the sleep armed for its full duration, keeping the process alive past teardown
+        timeout.cancel();
+    }
+    const elapsed = Duration.format(Millis(Time.nowMs - start));
+
+    switch (outcome.kind) {
+        case "resolved":
+            return { type: "response", verdict: "fail", detail: `${label} unexpectedly succeeded after ${elapsed}` };
+        case "timeout":
+            return {
+                type: "response",
+                verdict: "fail",
+                detail: `${label} neither resolved nor rejected within ${Duration.format(Millis(timeoutMs))}`,
+            };
+        case "rejected": {
+            const message = outcome.error instanceof Error ? outcome.error.message : String(outcome.error);
+            return { type: "response", verdict: "pass", detail: `${label} rejected after ${elapsed}: ${message}` };
+        }
     }
 }
 

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -996,11 +996,19 @@ function settled(promise: Promise<unknown>): Promise<SettleOutcome> {
  * either evidence or a fast local failure. A timeout is reported `"fail"`, same as an unexpected
  * success, and the elapsed time reaches the evidence either way.
  *
- * `settled()` attaches its handlers before the race starts, so a late settlement after the timeout
- * branch wins is still observed, just not awaited — no unhandled-rejection risk.
+ * `accept` narrows *which* rejection counts. Without it any error passes, including one that says
+ * nothing about the behaviour under test — a controller that crashed, timed out or was never asked.
+ * A step whose evidence is "it failed" rather than "it failed for this reason" should pass one.
  */
-export async function expectRejection(label: string, op: Promise<unknown>, timeoutMs: number): Promise<CheckRecord> {
-    const start = Time.nowMs;
+export async function expectRejection(
+    label: string,
+    op: Promise<unknown>,
+    timeoutMs: number,
+    accept?: (error: unknown) => boolean,
+): Promise<CheckRecord> {
+    // nowUs is the monotonic clock despite the name; nowMs tracks UTC and a step of it would put a
+    // negative elapsed into the evidence
+    const start = Time.nowUs;
     const timeout = Time.sleep(`${label} rejection timeout`, Millis(timeoutMs));
     let outcome: SettleOutcome;
     try {
@@ -1009,7 +1017,7 @@ export async function expectRejection(label: string, op: Promise<unknown>, timeo
         // A lost race leaves the sleep armed for its full duration, keeping the process alive past teardown
         timeout.cancel();
     }
-    const elapsed = Duration.format(Millis(Time.nowMs - start));
+    const elapsed = Duration.format(Millis(Time.nowUs - start));
 
     switch (outcome.kind) {
         case "resolved":
@@ -1021,7 +1029,15 @@ export async function expectRejection(label: string, op: Promise<unknown>, timeo
                 detail: `${label} neither resolved nor rejected within ${Duration.format(Millis(timeoutMs))}`,
             };
         case "rejected": {
-            const message = outcome.error instanceof Error ? outcome.error.message : String(outcome.error);
+            const { error } = outcome;
+            const message = error instanceof Error ? `${error.constructor.name}: ${error.message}` : String(error);
+            if (accept !== undefined && !accept(error)) {
+                return {
+                    type: "response",
+                    verdict: "fail",
+                    detail: `${label} failed after ${elapsed} for an unrelated reason: ${message}`,
+                };
+            }
             return { type: "response", verdict: "pass", detail: `${label} rejected after ${elapsed}: ${message}` };
         }
     }


### PR DESCRIPTION
Certification case TC-DD-3.14: a commissioner reads a device's QR onboarding code and refuses to commission from one that is wrong, in each of the three ways the plan names.

Four commits: the test case, then three acting on reviews of it. Each review found the same defect one layer deeper — a way the case could report a pass without the commissioner having judged anything — so the review commits are where the substance is.

## What the case checks

| Plan step | What it does | Outcome |
| --- | --- | --- |
| 1 | read the device's own code | the commissioner reports what it read |
| 2.a/2.b | substitute a version number the specification does not define | refused |
| 3.a/3.b | substitute a code offering only IP discovery, then commission | commissioned over IP |
| 4.a/4.b | same, for Wi-Fi Public Action Frame | commissioned over IP |
| 5.a/5.b | substitute each of the twelve trivial passcodes the specification forbids | refused, all twelve |
| 6.a/6.b | substitute a prefix that is not `MT:` | refused |

All six certification runs pass — matter.js and chip-tool as the commissioner, each against a matter.js harness device, the official chip binaries, and chip binaries built from source.

## Building a code the encoder will not write

Every value the plan substitutes is one matter.js's own encoder rejects, so the test writes the bits into the decoded code directly and re-encodes it, carrying any extra data the code may hold through untouched. The plan prints the code it expects for each substitution against its own example; a unit test asserts all thirteen of them. That caught a first version of the bit writer which set bits without clearing the ones already there — it produced the right code only when the new value happened to have no zeroes where the old one had ones.

## The refusal has to be the commissioner's own, for the right reason

Three ways this could have passed without meaning anything, each closed by a review:

**The harness answering for the commissioner.** The chip-tool driver used to run every code through matter.js's decoder before handing it over, so on a chip-tool run matter.js refused first and the evidence would have carried matter.js's reason under chip-tool's name. It now refuses only a code that names several devices at once — that one is the harness's to refuse, because a commissioner told to pair one device from such a code silently pairs whichever answers first — and lets the commissioner judge everything else.

**"It failed" standing in for "it refused".** A commissioner that crashed, that timed out, or that was never reached passed these steps exactly like one that read the code and refused it; and because both read the code before touching the network, they would also have passed with no harness device running at all. The bounded "this must fail" helper now takes a predicate for which failure counts.

**Neither commissioner's own error types being able to express that predicate.** chip-tool reports discovery, handshake, attestation and timeout failures through the same error as a refused code. matter.js's decoder error is likewise raised part-way through a commissioning that already accepted a code — for an invalid CSR response, for one. Accepting either type means a commissioner that *took* a forbidden passcode and only then failed to reach the device is recorded as having refused the code, which is precisely the false pass this case exists to catch.

So the refusal is marked where it happens rather than recognised by type afterwards. One error means it, and both drivers raise it: matter.js's driver wraps its own decoder calls, and chip-tool's recognises the source location chip-tool names when it applies the code's rules. The recorded evidence is the commissioner's own words:

```
chip-tool refused the onboarding payload for node 4097: Run command failure:
  src/setup_payload/SetupPayload.cpp:361: CHIP Error 0x0000002F: Invalid argument

Refused onboarding payload MT:034J042C00KA0648G00: Unsupported onboarding payload version 2
```

## Steps 3 and 4 substitute the discovery bitmask

These read as a precondition on the harness device — "ensure the device's Discovery Capability bit string is NOT set to BLE" — but for a case that drives everything itself that is one more substitution, like the version and the passcode beside it. They are not skippable, and the substitution is not cosmetic: the reference chip application publishes a **Bluetooth-only** bitmask, so on that device the precondition does not hold at all and an unsubstituted step fails against it. With the IP-only form both steps commission for real and record the commissioner onboarding the device over IP, which is the plan's own expected outcome.

An earlier version of this branch skipped them and declared the two matching capabilities absent on both commissioners to justify it. Those declarations describe a *device*, and one declaration file backs every certification run in the process, so they would have made every other run's evidence claim something false about its own harness device. Withdrawn.

## Cleanup

A commissioning that succeeded after the step stopped waiting used to hand its result to a cleanup that keeps one entry per commissioner, so two of them would have collapsed into one and left a membership behind on the device for the next run to trip over. The refusals now keep their own results and remove any membership they caused. Their budget also no longer claims to outwait a stalled command that runs longer than the whole cleanup is allowed to take; when that happens the run reports the device's state as unknown rather than pretending otherwise.

## Verification

- Full build, format check, lint and the whole test suite green from the repository root
- `test/cert-framework` 432/432, including 21 new unit tests
- TC-DD-3.14 passes on all four commissioner × device combinations locally and all six in CI
- TC-CADMIN-1.17 re-run after the shared helper moved out of it: 13/13 steps pass
- Each change mutation-tested separately, with compiling mutations. Reverting any one of these fails the test that covers it: the chip-tool hand-over, the bit writer's clearing, the acceptance predicate, its narrowing, either driver's marking of a refusal, the stray-membership cleanup, the bitmask substitution, and matter.js's own version and passcode checks. One test that turned out unable to fail was deleted rather than kept; another was inverted into a regression test once the behaviour it asserted became wrong.

## Found, not fixed

matter.js cannot decode an onboarding code whose payload length is a multiple of three bytes: `Base38Schema.ts`'s decoder falls through to its error case for those lengths. It is a pre-existing hole unrelated to this test — no code produced here reaches it — but it means a real device publishing extra data of such a length has a code matter.js cannot read. Raised separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)