### PR TITLE
fix(types): reject onboarding codes the specification forbids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,8 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Deprecation: The `ClusterType()` factory compat layer (`RetiredClusterType`, `RetiredElements`, the TLV `element` reverse mapping) is scheduled for removal in 0.19
     - Deprecation: The generated `Cluster`, `Complete` and `<Name>Cluster` aliases and the `ClusterType.WithCompat` `with()` shim are scheduled for removal in 0.19
     - Fix: `Cluster.with()` rejects a feature the cluster does not define and returns one frozen namespace per selection
+    - Fix: An onboarding payload carrying a vendor ID past the last test vendor, or a product ID of 0 beside a real vendor ID, is now rejected
+    - Fix: A manual pairing code whose `VID_PID_PRESENT` bit disagrees with its length is now rejected
 
 - @matter/testing
     - Enhancement: `certTest()` defines controller-side certification tests with per-step PICS gating, device-log expectations, and evidence recording; devices run as chip apps (docker or local binary) or matter.js test apps, selected via `MATTER_CERT_DEVICE`

--- a/packages/types/src/schema/PairingCodeSchema.ts
+++ b/packages/types/src/schema/PairingCodeSchema.ts
@@ -176,6 +176,35 @@ export function assertValidPasscode(passcode: number): void {
     }
 }
 
+/** Inclusive upper bound of a product identifier, which § 5.1.3.1 Table 59 carries in 16 bits. */
+const PRODUCT_ID_MAX = 0xffff;
+
+/**
+ * Rejects a vendor/product identifier pair an onboarding payload may not carry: a vendor id past the
+ * last test vendor (§ 2.5.2), or a product id outside 16 bits. Product id 0 announces an anonymized
+ * product and is reserved for a payload that names no vendor either, so it may not accompany a real
+ * vendor id (§ 2.5.3).
+ *
+ * Mirrors CHIP's `PayloadContents::CheckPayloadCommonConstraints`, which applies to both onboarding
+ * code forms.
+ *
+ * Applied when reading a code, never when writing one: `CommissioningServer` renders a node's pairing
+ * codes from `BasicInformation` state that may still carry the pre-default product id 0, and a node
+ * whose own code cannot be generated does not start at all. What a commissioner must refuse to *act*
+ * on is a separate question from what a device may render.
+ */
+export function assertValidPayloadIdentity(vendorId: number, productId: number): void {
+    if (!VendorId.isValid(vendorId)) {
+        throw new UnexpectedDataError(`Invalid vendor ID ${vendorId} in onboarding payload`);
+    }
+    if (!Number.isInteger(productId) || productId < 0 || productId > PRODUCT_ID_MAX) {
+        throw new UnexpectedDataError(`Invalid product ID ${productId} in onboarding payload`);
+    }
+    if (productId === 0 && vendorId !== 0) {
+        throw new UnexpectedDataError(`Product ID 0 is reserved and cannot accompany vendor ID ${vendorId}`);
+    }
+}
+
 const PREFIX = "MT:";
 
 /**
@@ -230,6 +259,17 @@ class QrPairingCodeSchema extends Schema<QrCodeData[], string> {
             }
             assertValidPasscode(passcode);
         }
+    }
+
+    /** Adds the identity rules {@link assertValidPayloadIdentity} applies to a code being read. */
+    override decode(encoded: string, validate = true): QrCodeData[] {
+        const payloads = super.decode(encoded, validate);
+        if (validate) {
+            for (const { vendorId, productId } of payloads) {
+                assertValidPayloadIdentity(vendorId, productId);
+            }
+        }
+        return payloads;
     }
 
     protected encodeInternal(payloadData: QrCodeData[]): string {
@@ -384,6 +424,15 @@ class ManualPairingCodeSchema extends Schema<ManualPairingData, string> {
         return result;
     }
 
+    /** Adds the identity rules {@link assertValidPayloadIdentity} applies to a code being read. */
+    override decode(encoded: string, validate = true): ManualPairingData {
+        const data = super.decode(encoded, validate);
+        if (validate && data.vendorId !== undefined && data.productId !== undefined) {
+            assertValidPayloadIdentity(data.vendorId, data.productId);
+        }
+        return data;
+    }
+
     protected decodeInternal(encoded: string): ManualPairingData {
         encoded = encoded.replace(/\D/g, ""); // we SHALL be robust against other characters
         if (encoded.length !== 11 && encoded.length !== 21) {
@@ -396,7 +445,16 @@ class ManualPairingCodeSchema extends Schema<ManualPairingData, string> {
         if (new Verhoeff().computeChecksum(encoded.slice(0, -1)) !== parseInt(encoded.slice(-1))) {
             throw new UnexpectedDataError("Invalid checksum");
         }
+        // § 5.1.4.1 Table 62/64: the VID_PID_PRESENT bit and the code's length state the same thing, so a
+        // code whose bit disagrees with its length is malformed rather than a short code with a long tail
         const hasVendorProductIds = !!(parseInt(encoded[0]) & (1 << 2));
+        if (hasVendorProductIds !== (encoded.length === 21)) {
+            throw new UnexpectedDataError(
+                encoded.length === 21
+                    ? "A 21-digit manual pairing code must set VID_PID_PRESENT"
+                    : "An 11-digit manual pairing code must not set VID_PID_PRESENT",
+            );
+        }
         const shortDiscriminator = ((parseInt(encoded[0]) & 0x03) << 2) | ((parseInt(encoded.slice(1, 6)) >> 14) & 0x3);
         const passcode = (parseInt(encoded.slice(1, 6)) & 0x3fff) | (parseInt(encoded.slice(6, 10)) << 14);
         let vendorId: VendorId | undefined;

--- a/packages/types/test/schema/PairingCodeSchemaTest.ts
+++ b/packages/types/test/schema/PairingCodeSchemaTest.ts
@@ -424,6 +424,12 @@ describe("ManualPairingCodeCodec", () => {
             );
         });
 
+        it("rejects the mismatch even when validation is disabled, since it is structural", () => {
+            expect(() => ManualPairingCodeCodec.decode("349701123365521327696", false)).throw(
+                "A 21-digit manual pairing code must set VID_PID_PRESENT",
+            );
+        });
+
         it("accepts the plan's own 21-digit example", () => {
             const decoded = ManualPairingCodeCodec.decode("749701123365521327694");
 
@@ -442,6 +448,11 @@ describe("ManualPairingCodeCodec", () => {
 
         it("decodes it when validation is disabled", () => {
             expect(ManualPairingCodeCodec.decode("749701123365521000006", false).productId).equal(0);
+        });
+
+        it("rejects a product ID the field cannot hold", () => {
+            // Five digits reach 99999, so a manual code can name a product ID past 16 bits
+            expect(() => ManualPairingCodeCodec.decode("749701123365521655363")).throw("Invalid product ID 65536");
         });
     });
 

--- a/packages/types/test/schema/PairingCodeSchemaTest.ts
+++ b/packages/types/test/schema/PairingCodeSchemaTest.ts
@@ -195,6 +195,30 @@ describe("QrPairingCodeCodec", () => {
         });
     });
 
+    describe("vendor and product identifier validation", () => {
+        it("rejects decoding a product ID of 0 beside a real vendor ID", () => {
+            expect(() => QrPairingCodeCodec.decode("MT:Y.K904KP00KA0648G00")).throw(
+                "Product ID 0 is reserved and cannot accompany vendor ID 65521",
+            );
+        });
+
+        it("accepts a product ID of 0 when the payload names no vendor either", () => {
+            const [decoded] = QrPairingCodeCodec.decode("MT:000004KP00KA0648G00");
+
+            expect(decoded.vendorId).equal(0);
+            expect(decoded.productId).equal(0);
+        });
+
+        it("rejects decoding a vendor ID past the last test vendor", () => {
+            expect(() => QrPairingCodeCodec.decode("MT:U34J029Q00KA0648G00")).throw("Invalid vendor ID 65525");
+        });
+
+        it("decodes either when validation is disabled", () => {
+            expect(QrPairingCodeCodec.decode("MT:Y.K904KP00KA0648G00", false)[0].productId).equal(0);
+            expect(QrPairingCodeCodec.decode("MT:U34J029Q00KA0648G00", false)[0].vendorId).equal(65525);
+        });
+    });
+
     describe("Encode/Decode TlvData", () => {
         it("encodes and decodes just serialNumber as string", () => {
             const tlvData = Bytes.fromHex("152C000A3132333435363738393018"); // from Specs
@@ -383,6 +407,41 @@ describe("ManualPairingCodeCodec", () => {
     describe("reserved version", () => {
         it("rejects decoding a manual code whose first digit marks a future format", () => {
             expect(() => ManualPairingCodeCodec.decode("80000000000")).throw("Unsupported onboarding payload version");
+        });
+    });
+
+    describe("VID_PID_PRESENT agrees with the code length", () => {
+        it("rejects a 21-digit code whose VID_PID_PRESENT bit is clear", () => {
+            // devicediscovery.adoc TC-DD-3.17 step 3.a's own example payload
+            expect(() => ManualPairingCodeCodec.decode("349701123365521327696")).throw(
+                "A 21-digit manual pairing code must set VID_PID_PRESENT",
+            );
+        });
+
+        it("rejects an 11-digit code whose VID_PID_PRESENT bit is set", () => {
+            expect(() => ManualPairingCodeCodec.decode("74970112334")).throw(
+                "An 11-digit manual pairing code must not set VID_PID_PRESENT",
+            );
+        });
+
+        it("accepts the plan's own 21-digit example", () => {
+            const decoded = ManualPairingCodeCodec.decode("749701123365521327694");
+
+            expect(decoded.vendorId).equal(0xfff1);
+            expect(decoded.productId).equal(0x8001);
+        });
+    });
+
+    describe("vendor and product identifier validation", () => {
+        it("rejects a product ID of 0 beside a real vendor ID", () => {
+            // devicediscovery.adoc TC-DD-3.17 step 7.a's own example payload
+            expect(() => ManualPairingCodeCodec.decode("749701123365521000006")).throw(
+                "Product ID 0 is reserved and cannot accompany vendor ID 65521",
+            );
+        });
+
+        it("decodes it when validation is disabled", () => {
+            expect(ManualPairingCodeCodec.decode("749701123365521000006", false).productId).equal(0);
         });
     });
 


### PR DESCRIPTION
Reading an onboarding code, matter.js accepted three forms the specification does not allow and the reference implementation refuses.

## What was accepted

**A 21-digit manual pairing code that says it carries no vendor or product identifier.** The code's first digit states whether those five-digit fields follow, and that has to agree with the code's length (§ 5.1.4.1, Tables 62 and 64). A code where it disagrees was read as though the trailing digits were meaningful, producing a payload from data the writer did not intend. CHIP checks this in `ManualSetupPayloadParser::CheckCodeLengthValidity`.

**A vendor identifier past the last one reserved for testing** (§ 2.5.2). The `VendorId` type already refuses these, but only the manual code's decoder ran a value through it; a QR code's decoder read the field straight out of its bits.

**A product identifier of zero beside a real vendor identifier** (§ 2.5.3). Zero announces an anonymized product and is reserved for a payload that names no vendor either, so it cannot accompany a real one. Also rejects a manual code whose five product digits exceed sixteen bits, which the field cannot hold.

## Reading, not writing

The identifier rules apply when a code is read. They deliberately do not apply when one is written.

`CommissioningServer` renders a node's own pairing codes from `BasicInformation` state, and that read can happen while the product identifier is still the placeholder `0` — `BasicInformationServer` substitutes its development default in its own initialization, which has not necessarily run first. Validating on write therefore makes a node fail to start, which is what the first version of this change did: `ServerNode ➡ announces and expires correctly` failed with `Error initializing node0.commissioning`, caused by `Product ID 0 is reserved and cannot accompany vendor ID 65501`.

What a commissioner must refuse to act on is a separate question from what a device may render, and only the first is a correctness matter here. The length rule stays structural and applies to any read, since a code whose own header contradicts its length cannot be interpreted at all.

## Test vectors

The device-discovery test plan prints worked examples for two of these cases, and those are what the tests assert against — the specification's own numbers rather than numbers derived from this implementation:

- `349701123365521327696` — 21 digits, `VID_PID_PRESENT` clear
- `749701123365521000006` — product identifier 0

Their check digits were verified before use. The QR vectors were constructed by substituting the field in the plan's own example payload.

## Verification

- Clean build, format check, lint and the full test suite green from the repository root
- 9 new tests in `PairingCodeSchemaTest`; a compiling mutation that removes each refusal fails exactly the tests covering it
- No existing test changed. The one that broke against the first design is what produced the reading/writing split above, and passes unmodified now.

## Noted, not addressed

The same investigation showed a node's advertised pairing code is computed from `BasicInformation` state that may not yet carry its defaults — in the test above the code encodes product identifier 0 while the node advertises vendor 65501. Nothing fails today, but the code a user scans need not match the device's eventual identity. Worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)