### PR TITLE
test(testing): add TC-DD-3.17, refusing an invalid 21-digit manual pairing code

### DIFF
--- a/packages/testing/src/chip/cert/controller-adapter.ts
+++ b/packages/testing/src/chip/cert/controller-adapter.ts
@@ -48,6 +48,11 @@ export interface CommissioningTarget {
      * far longer than the step needs — matter.js waits out the specification's 3-minute minimum
      * commissioning window. A controller that cannot be bounded says so and reports whatever its own
      * policy produces.
+     *
+     * On matter.js this **also caps PASE establishment**, which otherwise gets 30 seconds of its own:
+     * `CommissioningDiscovery.Options` merges the discovery and commissioning option sets and both
+     * declare `timeout`. Harmless where no device is expected to answer; a step that sets this on a
+     * target that does resolve is shortening its handshake budget too.
      */
     giveUpAfterMs?: number;
 
@@ -383,6 +388,11 @@ export interface ControllerAdapter {
      * {@link parseQrPayload} for the digits of a manual pairing code. Separate because the two code
      * forms carry different fields: a manual code has only the 4-bit discriminator, states no
      * discovery capabilities, and names a vendor and product only in its 21-digit form.
+     *
+     * How much a controller validates while reading is its own: matter.js's codec applies § 5.1's
+     * rules and refuses a code it would not commission from, where chip-tool's `parse-setup-payload`
+     * reports the fields of any code its parser can decode. Assert a refusal through
+     * {@link commission}, which both controllers judge, rather than through this.
      */
     parseManualPairingCode(code: string): Promise<ManualPairingCodeFields>;
 

--- a/packages/testing/src/chip/cert/controller-adapter.ts
+++ b/packages/testing/src/chip/cert/controller-adapter.ts
@@ -42,6 +42,16 @@ export interface CommissioningTarget {
     manualPairingCode?: string;
 
     /**
+     * Bounds how long the controller looks for the commissionee before giving up.
+     *
+     * For a step whose code names a device that is not there, where the controller's own budget is
+     * far longer than the step needs — matter.js waits out the specification's 3-minute minimum
+     * commissioning window. A controller that cannot be bounded says so and reports whatever its own
+     * policy produces.
+     */
+    giveUpAfterMs?: number;
+
+    /**
      * Ask for commissioning to give up after a single operational handshake attempt, so a step that means to prove the
      * device refused a commissioner is not answered by a retry that succeeded instead.
      *

--- a/packages/testing/src/chip/cert/controller-adapter.ts
+++ b/packages/testing/src/chip/cert/controller-adapter.ts
@@ -369,6 +369,13 @@ export interface ControllerAdapter {
      */
     parseQrPayload(code: string): Promise<OnboardingPayloadFields>;
 
+    /**
+     * {@link parseQrPayload} for the digits of a manual pairing code. Separate because the two code
+     * forms carry different fields: a manual code has only the 4-bit discriminator, states no
+     * discovery capabilities, and names a vendor and product only in its 21-digit form.
+     */
+    parseManualPairingCode(code: string): Promise<ManualPairingCodeFields>;
+
     node(ref: CertNodeRef): CertNodeApi;
     log: LogFollower;
 }
@@ -393,6 +400,22 @@ export interface OnboardingPayloadFields {
     discriminator: number;
 
     passcode: number;
+}
+
+/**
+ * A manual pairing code's fields, as {@link ControllerAdapter.parseManualPairingCode} reports them.
+ *
+ * @see {@link MatterSpecification.v16.Core} § 5.1.4.1
+ */
+export interface ManualPairingCodeFields {
+    /** § 5.1.4.1 Table 62's 4-bit form, the 4 most significant bits of the device's discriminator. */
+    shortDiscriminator: number;
+
+    passcode: number;
+
+    /** Present only in the 21-digit form, which sets `VID_PID_PRESENT`. */
+    vendorId?: number;
+    productId?: number;
 }
 
 /**

--- a/packages/testing/src/chip/index.ts
+++ b/packages/testing/src/chip/index.ts
@@ -56,6 +56,7 @@ export type {
     ControllerAdapterFactory,
     EventPathSpec,
     EventReadEntry,
+    ManualPairingCodeFields,
     OnboardingPayloadFields,
     ReadAttributeOptions,
     ReadEventOptions,

--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -31,6 +31,7 @@ import type {
     ControllerAdapter,
     EventPathSpec,
     EventReadEntry,
+    ManualPairingCodeFields,
     OnboardingPayloadFields,
     ReadAttributeOptions,
     ReadEventOptions,
@@ -85,6 +86,9 @@ const WILDCARD_ENDPOINT = 0xffff;
  * costing a CASE session first.
  */
 const MAX_PATHS_PER_COMMAND = 64;
+
+/** Digit count of the manual code form that carries a vendor and product id (§ 5.1.4.1 Table 64). */
+const MANUAL_CODE_LONG_LENGTH = 21;
 
 /** `chip::Crypto::kSpake2p_Min_PBKDF_Iterations`, the cheapest verifier chip-tool accepts. */
 const PBKDF_ITERATIONS = 1000;
@@ -1175,6 +1179,23 @@ export class ChipToolControllerAdapter implements ControllerAdapter {
             discoveryCapabilities: payloadField(logs, code, /Discovery Bitmask:\s+0x([0-9A-Fa-f]{2})/, 16),
             discriminator: payloadField(logs, code, /Long discriminator:\s+(\d+)/),
             passcode: payloadField(logs, code, /Passcode:\s+(\d+)/),
+        };
+    }
+
+    async parseManualPairingCode(code: string): Promise<ManualPairingCodeFields> {
+        const { reply, logs } = await this.executeWithLogs(`payload parse-setup-payload ${quoteArg(code)}`);
+        assertCommandSucceeded(reply, `parse of manual pairing code ${code}`);
+
+        const digits = code.replace(/\D/g, "");
+        // Print() reports a vendor and product of 0 for a code that carries neither, which only the
+        // 21-digit form does (§ 5.1.4.1 Table 64)
+        const carriesIdentity = digits.length === MANUAL_CODE_LONG_LENGTH;
+
+        return {
+            shortDiscriminator: payloadField(logs, code, /Short discriminator:\s+(\d+)/),
+            passcode: payloadField(logs, code, /Passcode:\s+(\d+)/),
+            vendorId: carriesIdentity ? payloadField(logs, code, /VendorID:\s+(\d+)/) : undefined,
+            productId: carriesIdentity ? payloadField(logs, code, /ProductID:\s+(\d+)/) : undefined,
         };
     }
 

--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -1213,6 +1213,14 @@ export class ChipToolControllerAdapter implements ControllerAdapter {
             );
         }
 
+        if (target.giveUpAfterMs !== undefined) {
+            // Said out loud for the same reason singleHandshakeAttempt is: a step asking for this is
+            // asserting an outcome, and chip-tool's own give-up is what decides it.
+            console.warn(
+                `chip-tool cannot bound discovery for node ${node}; its own policy decides when it stops looking`,
+            );
+        }
+
         let command: string;
         if (target.qrPairingCode) {
             // `pairing code` reads either payload format, a concatenated one included — and would pair

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -63,6 +63,7 @@ import type {
     ControllerAdapter,
     EventPathSpec,
     EventReadEntry,
+    ManualPairingCodeFields,
     OnboardingPayloadFields,
     ReadAttributeOptions,
     ReadEventOptions,
@@ -803,6 +804,17 @@ export class InProcessControllerAdapter implements ControllerAdapter {
         const { version, vendorId, productId, flowType, discoveryCapabilities, discriminator, passcode } =
             singleQrPayload(code);
         return { version, vendorId, productId, flowType, discoveryCapabilities, discriminator, passcode };
+    }
+
+    async parseManualPairingCode(code: string): Promise<ManualPairingCodeFields> {
+        const { shortDiscriminator, passcode, vendorId, productId } = refusalOf(
+            () => ManualPairingCodeCodec.decode(code),
+            `manual pairing code ${code}`,
+        );
+        if (shortDiscriminator === undefined) {
+            throw new InternalError(`Manual pairing code ${code} decoded to no short discriminator`);
+        }
+        return { shortDiscriminator, passcode, vendorId, productId };
     }
 
     commission(target: CommissioningTarget): Promise<CertNodeRef> {

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -827,6 +827,7 @@ export class InProcessControllerAdapter implements ControllerAdapter {
                 passcode,
                 autoStateInitialize: false,
                 caseConnectionTimeout: target.singleHandshakeAttempt ? SINGLE_HANDSHAKE_TIMEOUT : undefined,
+                timeout: target.giveUpAfterMs === undefined ? undefined : Millis(target.giveUpAfterMs),
                 regulatoryLocation: GeneralCommissioning.RegulatoryLocationType.IndoorOutdoor,
                 regulatoryCountryCode: "XX",
                 onAttestationFailure: () => true,

--- a/support/chip-testing/test/cert-framework/cert-test.test.ts
+++ b/support/chip-testing/test/cert-framework/cert-test.test.ts
@@ -150,6 +150,9 @@ function stubControllerAdapter(log: LogFollower): ControllerAdapter {
         async parseQrPayload(): Promise<never> {
             throw new InternalError("not used in this test");
         },
+        async parseManualPairingCode(): Promise<never> {
+            throw new InternalError("not used in this test");
+        },
         async commission() {
             return "ref";
         },
@@ -894,6 +897,9 @@ describe("CertTest", () => {
                 return "ref-dut";
             },
             async parseQrPayload(): Promise<never> {
+                throw new InternalError("not used in this test");
+            },
+            async parseManualPairingCode(): Promise<never> {
                 throw new InternalError("not used in this test");
             },
             node: () => nodeFor("dut"),

--- a/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
@@ -293,6 +293,53 @@ describe("ChipToolControllerAdapter", function () {
         expect(fake.commands).deep.equal([`pairing code ${FIRST_NODE} MT:034J042C00KA0648G00`]);
     });
 
+    it("reads a 21-digit manual pairing code through chip-tool's own parser", async () => {
+        const started = await start();
+
+        fake.reply = () => ({
+            logs: [
+                "Version:             0",
+                "VendorID:            65521",
+                "ProductID:           32769",
+                "Custom flow:         2    (CUSTOM)",
+                "Discovery Bitmask:   UNKNOWN",
+                "Short discriminator: 15   (0xf)",
+                "Passcode:            20202021",
+            ],
+        });
+
+        expect(await started.parseManualPairingCode("749701123365521327694")).deep.equal({
+            shortDiscriminator: 15,
+            passcode: 20202021,
+            vendorId: 65521,
+            productId: 32769,
+        });
+        expect(fake.commands).deep.equal(["payload parse-setup-payload 749701123365521327694"]);
+    });
+
+    it("reports no identity for an 11-digit code, which chip-tool prints as zeroes", async () => {
+        const started = await start();
+
+        fake.reply = () => ({
+            logs: [
+                "Version:             0",
+                "VendorID:            0",
+                "ProductID:           0",
+                "Custom flow:         0    (STANDARD)",
+                "Discovery Bitmask:   UNKNOWN",
+                "Short discriminator: 15   (0xf)",
+                "Passcode:            20202021",
+            ],
+        });
+
+        expect(await started.parseManualPairingCode("34970112332")).deep.equal({
+            shortDiscriminator: 15,
+            passcode: 20202021,
+            vendorId: undefined,
+            productId: undefined,
+        });
+    });
+
     it("separates chip-tool refusing the payload from chip-tool failing later", async () => {
         const started = await start();
 

--- a/support/chip-testing/test/cert-framework/controller-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/controller-adapter.test.ts
@@ -22,6 +22,7 @@ import { AllClustersTestInstance } from "../../src/AllClustersTestInstance.js";
 import { CHIP_TOOL_CONTROLLER_PICS, ChipToolControllerAdapter } from "../../src/cert/ChipToolControllerAdapter.js";
 import { InProcessControllerAdapter, MATTERJS_CONTROLLER_PICS } from "../../src/cert/InProcessControllerAdapter.js";
 import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload.js";
+import { manualPairingCode } from "../cert/tc-dd-support.js";
 
 function fakeControllerAdapter(id: string): ControllerAdapter {
     return {
@@ -33,6 +34,9 @@ function fakeControllerAdapter(id: string): ControllerAdapter {
             throw new InternalError("not used in this test");
         },
         async parseQrPayload() {
+            throw new InternalError("not used in this test");
+        },
+        async parseManualPairingCode(): Promise<never> {
             throw new InternalError("not used in this test");
         },
         node() {
@@ -135,6 +139,23 @@ describe("InProcessControllerAdapter", () => {
         const ref = await adapter.commission({ qrPairingCode: device.commissioning.qrPairingCode });
 
         await adapter.node(ref).decommission();
+    });
+
+    it("reports the fields it reads out of a manual pairing code", async () => {
+        const code = manualPairingCode({
+            vidPidPresent: true,
+            discriminator: device.commissioning.discriminator,
+            passcode: device.commissioning.passcode,
+            vendorId: 0xfff1,
+            productId: 0x8001,
+        });
+
+        expect(await adapter.parseManualPairingCode(code)).deep.equal({
+            shortDiscriminator: device.commissioning.discriminator >> 8,
+            passcode: device.commissioning.passcode,
+            vendorId: 0xfff1,
+            productId: 0x8001,
+        });
     });
 
     it("marks its own refusal of an onboarding payload, so a later failure cannot pass for one", async () => {

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -190,7 +190,17 @@ describe("CommissioningRefusals", () => {
         await refusals.settle(cx);
     });
 
-    it("accepts any failure when the claim is only that nothing was commissioned", async () => {
+    it("does not accept a payload refusal as proof that no device was there", async () => {
+        // Otherwise a malformed generated code passes the step at ~1ms, having never reached discovery
+        const cx = contextWith(() => Promise.reject(new OnboardingPayloadRefusedError("bad code")));
+        const refusals = new CommissioningRefusals(BUDGETS);
+
+        await expect(
+            refusals.requireNoCommissioning(cx, { manualPairingCode: "749" }, "nothing commissioned", 100),
+        ).rejectedWith(CertCheckFailedError, /unrelated reason/);
+    });
+
+    it("accepts any other failure when the claim is only that nothing was commissioned", async () => {
         // The wrong-discriminator step: the code is well formed, so the DUT fails for lack of a device
         const cx = contextWith(() => Promise.reject(new ChipToolCommandError("chip-tool commissioning failed")));
         const refusals = new CommissioningRefusals(BUDGETS);
@@ -316,6 +326,16 @@ describe("manualPairingCode", () => {
 
     it("writes an 11-digit code when neither id is given", () => {
         expect(manualPairingCode({ vidPidPresent: false, discriminator: 0xf00, passcode: 20202021 })).length(11);
+    });
+
+    it("refuses a part that does not fit its field", () => {
+        expect(() => manualPairingCode({ ...PLAN_DEVICE, productId: 0x10000 }), "productId").throw(InternalError);
+        expect(() => manualPairingCode({ ...PLAN_DEVICE, productId: 1, discriminator: 0x1000 }), "disc").throw(
+            InternalError,
+        );
+        expect(() => manualPairingCode({ ...PLAN_DEVICE, productId: 1, checkDigit: 10 }), "checkDigit").throw(
+            InternalError,
+        );
     });
 
     it("refuses one id without the other", () => {

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -154,7 +154,7 @@ describe("CommissioningRefusals", () => {
         const cx = contextWith(() => Promise.reject(new UnexpectedDataError("Invalid response from device")));
         const refusals = new CommissioningRefusals(BUDGETS);
 
-        await expect(refusals.requireRefusal(cx, "MT:whatever", "must be refused")).rejectedWith(
+        await expect(refusals.requireRefusal(cx, { qrPairingCode: "MT:whatever" }, "must be refused")).rejectedWith(
             CertCheckFailedError,
             /unrelated reason/,
         );
@@ -164,7 +164,7 @@ describe("CommissioningRefusals", () => {
         const cx = contextWith(() => Promise.reject(new InternalError("chip-tool produced no reply")));
         const refusals = new CommissioningRefusals(BUDGETS);
 
-        await expect(refusals.requireRefusal(cx, "MT:whatever", "must be refused")).rejectedWith(
+        await expect(refusals.requireRefusal(cx, { qrPairingCode: "MT:whatever" }, "must be refused")).rejectedWith(
             CertCheckFailedError,
             /unrelated reason/,
         );
@@ -174,7 +174,7 @@ describe("CommissioningRefusals", () => {
         const cx = contextWith(() => Promise.reject(new ChipToolCommandError("chip-tool commissioning failed")));
         const refusals = new CommissioningRefusals(BUDGETS);
 
-        await expect(refusals.requireRefusal(cx, "MT:whatever", "must be refused")).rejectedWith(
+        await expect(refusals.requireRefusal(cx, { qrPairingCode: "MT:whatever" }, "must be refused")).rejectedWith(
             CertCheckFailedError,
             /unrelated reason/,
         );
@@ -186,8 +186,35 @@ describe("CommissioningRefusals", () => {
         );
         const refusals = new CommissioningRefusals(BUDGETS);
 
-        await refusals.requireRefusal(cx, "MT:whatever", "must be refused");
+        await refusals.requireRefusal(cx, { qrPairingCode: "MT:whatever" }, "must be refused");
         await refusals.settle(cx);
+    });
+
+    it("accepts any failure when the claim is only that nothing was commissioned", async () => {
+        // The wrong-discriminator step: the code is well formed, so the DUT fails for lack of a device
+        const cx = contextWith(() => Promise.reject(new ChipToolCommandError("chip-tool commissioning failed")));
+        const refusals = new CommissioningRefusals(BUDGETS);
+
+        await refusals.requireNoCommissioning(cx, { manualPairingCode: "749" }, "nothing commissioned", 100);
+        await refusals.settle(cx);
+    });
+
+    it("fails when something was commissioned after all", async () => {
+        const removed = new Array<CertNodeRef>();
+        const cx = contextWith(
+            () => Promise.resolve("unexpected-ref"),
+            async ref => {
+                removed.push(ref);
+            },
+        );
+        const refusals = new CommissioningRefusals(BUDGETS);
+
+        await expect(
+            refusals.requireNoCommissioning(cx, { manualPairingCode: "749" }, "nothing commissioned", 100),
+        ).rejectedWith(CertCheckFailedError);
+
+        await refusals.settle(cx);
+        expect(removed).deep.equal(["unexpected-ref"]);
     });
 
     it("removes the fabric of a commissioning that succeeded after its own budget expired", async () => {
@@ -201,7 +228,9 @@ describe("CommissioningRefusals", () => {
         );
         const refusals = new CommissioningRefusals(BUDGETS);
 
-        await expect(refusals.requireRefusal(cx, "MT:whatever", "must be refused")).rejectedWith(CertCheckFailedError);
+        await expect(refusals.requireRefusal(cx, { qrPairingCode: "MT:whatever" }, "must be refused")).rejectedWith(
+            CertCheckFailedError,
+        );
 
         // On a macrotask, so a settle() that did not actually wait returns with nothing to remove
         const settling = refusals.settle(cx);
@@ -220,7 +249,9 @@ describe("CommissioningRefusals", () => {
         );
         const refusals = new CommissioningRefusals(BUDGETS);
 
-        await expect(refusals.requireRefusal(cx, "MT:whatever", "must be refused")).rejectedWith(CertCheckFailedError);
+        await expect(refusals.requireRefusal(cx, { qrPairingCode: "MT:whatever" }, "must be refused")).rejectedWith(
+            CertCheckFailedError,
+        );
 
         await expect(refusals.settle(cx)).rejectedWith(CertCleanupError, /stray-ref: node is unreachable/);
     });
@@ -229,7 +260,7 @@ describe("CommissioningRefusals", () => {
         const cx = contextWith(() => new Promise<CertNodeRef>(() => {}));
         const refusals = new CommissioningRefusals(BUDGETS);
 
-        await expect(refusals.requireRefusal(cx, "MT:whatever", "must be refused")).rejected;
+        await expect(refusals.requireRefusal(cx, { qrPairingCode: "MT:whatever" }, "must be refused")).rejected;
 
         await expect(refusals.settle(cx)).rejectedWith(CertCleanupError, /still running/);
     });

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -10,7 +10,14 @@ import { LogFollower } from "@matter/testing";
 import { expect } from "chai";
 import { ChipToolCommandError } from "../../src/cert/ChipToolControllerAdapter.js";
 import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload.js";
-import { CommissioningRefusals, ON_NETWORK_ONLY, qrPayloadWith, qrPayloadWithPrefix } from "../cert/tc-dd-support.js";
+import type { ManualPairingCodeParts } from "../cert/tc-dd-support.js";
+import {
+    CommissioningRefusals,
+    manualPairingCode,
+    ON_NETWORK_ONLY,
+    qrPayloadWith,
+    qrPayloadWithPrefix,
+} from "../cert/tc-dd-support.js";
 import { CertCheckFailedError, CertCleanupError } from "../cert/tc-support.js";
 
 /**
@@ -123,6 +130,7 @@ describe("CommissioningRefusals", () => {
             async close() {},
             commission,
             parseQrPayload: unused,
+            parseManualPairingCode: unused,
             node: nodeFor,
         } satisfies ControllerAdapter;
 
@@ -224,5 +232,62 @@ describe("CommissioningRefusals", () => {
         await expect(refusals.requireRefusal(cx, "MT:whatever", "must be refused")).rejected;
 
         await expect(refusals.settle(cx)).rejectedWith(CertCleanupError, /still running/);
+    });
+});
+
+describe("manualPairingCode", () => {
+    /** devicediscovery.adoc TC-DD-3.17's own example device: discriminator 0xF00, passcode 20202021. */
+    const PLAN_DEVICE = { vidPidPresent: true, discriminator: 0xf00, passcode: 20202021, vendorId: 0xfff1 };
+    const PLAN_PRODUCT_ID = 0x8001;
+
+    function planCode(overrides: Partial<ManualPairingCodeParts> = {}) {
+        return manualPairingCode({ ...PLAN_DEVICE, productId: PLAN_PRODUCT_ID, ...overrides });
+    }
+
+    it("writes the plan's own example code", () => {
+        expect(planCode()).equal("749701123365521327694");
+    });
+
+    it("writes the plan's own substituted codes", () => {
+        expect(planCode({ futureFormat: true }), "version").equal("849701123365521327693");
+        expect(planCode({ vidPidPresent: false }), "VID_PID_PRESENT").equal("349701123365521327696");
+        expect(planCode({ discriminator: 0xe00 }), "short discriminator").equal("733317123365521327692");
+        expect(planCode({ productId: 0 }), "product id").equal("749701123365521000006");
+        expect(planCode({ checkDigit: 3 }), "check digit").equal("749701123365521327693");
+    });
+
+    it("writes the plan's own code for each forbidden passcode", () => {
+        const expected: [passcode: number, code: string][] = [
+            [0, "749152000065521327698"],
+            [11111111, "751911067865521327698"],
+            [22222222, "754670135665521327694"],
+            [33333333, "757429203465521327699"],
+            [44444444, "760188271265521327697"],
+            [55555555, "762947339065521327695"],
+            [66666666, "749322406965521327695"],
+            [77777777, "752081474765521327697"],
+            [88888888, "754840542565521327693"],
+            [99999999, "757599610365521327695"],
+            [12345678, "757678075365521327695"],
+            [87654321, "765457534965521327696"],
+        ];
+
+        for (const [passcode, code] of expected) {
+            expect(planCode({ passcode }), `passcode ${passcode}`).equal(code);
+        }
+    });
+
+    it("writes the plan's own code for each test vendor id", () => {
+        expect(planCode({ vendorId: 0xfff2 })).equal("749701123365522327692");
+        expect(planCode({ vendorId: 0xfff3 })).equal("749701123365523327697");
+        expect(planCode({ vendorId: 0xfff4 })).equal("749701123365524327693");
+    });
+
+    it("writes an 11-digit code when neither id is given", () => {
+        expect(manualPairingCode({ vidPidPresent: false, discriminator: 0xf00, passcode: 20202021 })).length(11);
+    });
+
+    it("refuses one id without the other", () => {
+        expect(() => manualPairingCode({ ...PLAN_DEVICE, productId: undefined })).throw(InternalError);
     });
 });

--- a/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
@@ -138,6 +138,9 @@ class Fixture {
             async parseQrPayload() {
                 throw new InternalError("not used in this test");
             },
+            async parseManualPairingCode(): Promise<never> {
+                throw new InternalError("not used in this test");
+            },
             node: () => node,
         };
 

--- a/support/chip-testing/test/cert-framework/tc-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-support.test.ts
@@ -579,6 +579,9 @@ describe("CommissionedRefs", () => {
             async parseQrPayload() {
                 throw new InternalError("not used in this test");
             },
+            async parseManualPairingCode(): Promise<never> {
+                throw new InternalError("not used in this test");
+            },
             node: () => nodeFor(role),
         });
 

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1407,6 +1407,12 @@ and onboards. **The plan's expected outcome admits both** — terminate, "unless
 aware of the security risks" — so the step records which happened instead of asserting one. Both
 outcomes appear in the evidence, one per controller.
 
+**All four codes go to the DUT, which needs the TH restored between them.** The plan says "provide
+each", and an attempt that onboards leaves the TH out of commissioning mode for the next one — so
+`recordVendorOutcome` runs the same open-window-then-remove dance `commissionByTarget` does, hoisted
+into `restoreCommissioningMode`. A first version handed over only two of the four codes; a reviewer
+caught it.
+
 Two traps behind that, both of which a green run hid at first:
 
 - **Substituting the TH's own vendor id substitutes nothing.** `thCodeParts` reads VID/PID back from

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1396,11 +1396,30 @@ it did until `CommissioningTarget.giveUpAfterMs` was added. matter.js maps it to
 timeout; chip-tool cannot be bounded and says so, stopping on its own after ~30s, so the step's own
 budget has to outlast chip-tool rather than matter.js.
 
-**Step 6 is the plan's own "unless" branch.** It substitutes each test vendor id, but a manual code's
-vendor id is informational — no commissioner matches it against the discovered device — so all four
-codes commission the same TH and the step cannot discriminate on that alone. It commissions once and
-records that a cert harness onboards uncertified devices deliberately, its operator being the user the
-clause speaks of, rather than pretending to test something it cannot.
+**Step 6 records a real disagreement between the two controllers, and this one cost a review round.**
+The obvious reading — "a manual code's vendor id is informational, no commissioner matches it against
+the device it found" — is **false for chip-tool**:
+`SetUpCodePairer::NodeMatchesCurrentFilter` (`src/controller/SetUpCodePairer.cpp`) skips a discovered
+device whose advertised vendor or product id disagrees with the code's, so a code naming another
+vendor finds nothing and chip-tool gives up after its 30s discovery budget. matter.js discovers on
+the discriminator alone (`resolveCommissioningTarget` passes only `shortDiscriminator`/`passcode`)
+and onboards. **The plan's expected outcome admits both** — terminate, "unless the user is made fully
+aware of the security risks" — so the step records which happened instead of asserting one. Both
+outcomes appear in the evidence, one per controller.
+
+Two traps behind that, both of which a green run hid at first:
+
+- **Substituting the TH's own vendor id substitutes nothing.** `thCodeParts` reads VID/PID back from
+  the TH, so `0xFFF1` on a harness device reproduces step 1's code byte for byte and the step
+  commissions from an unmodified code while claiming to test a substitution. A reviewer caught that.
+- **Fixing it turned the chip legs red**, which is what exposed the vendor-matching behaviour above.
+  Do not "fix" a failure there by reverting to the matching id — that restores a step that proves
+  nothing.
+
+**`requireNoCommissioning` must refuse a payload refusal.** Without the complementary predicate every
+outcome that satisfies `requireRefusal` also satisfies it, so a malformed generated code would make
+step 4 pass at ~1ms having never reached discovery. The two checks are only a partition because the
+predicate says so.
 
 ## chip-tool delivers one result per async report and discards the rest
 

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1362,6 +1362,46 @@ something false about its TH. And note `notApplicable` is evaluated *before* bot
 the PICS gate in `cert-test.ts`, so a step carrying both never evaluates its PICS on any flavor —
 combining them documents nothing and hides the gate that would otherwise fire.
 
+## The manual-code block (`TC-DD-3.17`)
+
+**No subject publishes a 21-digit manual code.** A device on the standard commissioning flow prints
+the 11-digit form, and §5.1.4.1 Table 64's longer form is what these plans test. `thManualPairingCode`
+renders the TH's own identity — the same discriminator and passcode — in the longer form, which is
+what the plan's own preconditions describe. On the harness devices that produces *exactly* the codes
+the plan prints, because they share its example identity (discriminator 0xF00, passcode 20202021,
+vendor 0xFFF1, product 0x8001). `manualPairingCode` lays the digits out against Table 62 rather than
+encoding, since every negative case substitutes a value `ManualPairingCodeCodec` refuses to write, and
+`tc-dd-support.test.ts` asserts all 22 codes the plan prints against it.
+
+Two of those printed codes corrected the first implementation, and both are easy to get wrong again:
+
+- **A reserved version is a first digit of 8**, not a bit set beside the other fields. A decimal digit
+  holds 0-9, so the marker displaces the discriminator bits and `VID_PID_PRESENT`; CHIP only ever
+  checks `chunk1 == 8 || chunk1 == 9`. Hence `futureFormat`, not a numeric version.
+- **`VID_PID_PRESENT` and the identity digits must be settable independently.** A code where they
+  disagree is precisely what step 3 tests, so a builder that drops the tail when the bit is clear
+  cannot express it.
+
+**"Terminates commissioning" is two different claims, and they need two different checks.** Steps 2,
+3, 5, 7 and 8 are payload refusals — `requireRefusal`, accepting only `OnboardingPayloadRefusedError`.
+Step 4 hands over a well-formed code naming a device that is not there, so the DUT fails for lack of a
+commissionee; `requireNoCommissioning` accepts any failure there and only a *success* fails the step.
+The evidence keeps them apart: on chip-tool, steps 3/7/8 record `Run command failure:
+src/setup_payload/…` while step 4 records a bare command failure.
+
+**Step 4 needs a discovery bound, not a longer wait.** matter.js looks for a commissionable device for
+the specification's 3-minute minimum commissioning window (`CommissioningDiscovery` defaults
+`timeout` to `Minutes(3)`), so a step budget under that reports "neither resolved nor rejected" — as
+it did until `CommissioningTarget.giveUpAfterMs` was added. matter.js maps it to that discovery
+timeout; chip-tool cannot be bounded and says so, stopping on its own after ~30s, so the step's own
+budget has to outlast chip-tool rather than matter.js.
+
+**Step 6 is the plan's own "unless" branch.** It substitutes each test vendor id, but a manual code's
+vendor id is informational — no commissioner matches it against the discovered device — so all four
+codes commission the same TH and the step cannot discriminate on that alone. It commissions once and
+records that a cert harness onboards uncertified devices deliberately, its operator being the user the
+clause speaks of, rather than pretending to test something it cannot.
+
 ## chip-tool delivers one result per async report and discards the rest
 
 `step 4: write 1/3 … produced no subscription report carrying "tc-idm-4-1-a" within 30s`,

--- a/support/chip-testing/test/cert/TC-DD-3.14.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.14.test.ts
@@ -70,7 +70,7 @@ certTest("TC-DD-3.14", {
         "Scan/read the QR code, generated in the previous step, using the DUT",
         async cx => {
             const payload = qrPayloadWith(await thQrPayload(cx.devices.th), { version: INVALID_VERSION });
-            await refusals.requireRefusal(cx, payload, "Invalid-version payload refused");
+            await refusals.requireRefusal(cx, { qrPairingCode: payload }, "Invalid-version payload refused");
         },
         {
             expected:
@@ -168,7 +168,7 @@ certTest("TC-DD-3.14", {
             for (const passcode of INVALID_PASSCODES) {
                 await refusals.requireRefusal(
                     cx,
-                    qrPayloadWith(th, { passcode }),
+                    { qrPairingCode: qrPayloadWith(th, { passcode }) },
                     `Payload carrying passcode ${passcode} refused`,
                 );
             }
@@ -194,7 +194,7 @@ certTest("TC-DD-3.14", {
         "Scan/read the QR code, generated in the previous step, using the DUT",
         async cx => {
             const payload = qrPayloadWithPrefix(await thQrPayload(cx.devices.th), INVALID_PREFIX);
-            await refusals.requireRefusal(cx, payload, "Invalid-prefix payload refused");
+            await refusals.requireRefusal(cx, { qrPairingCode: payload }, "Invalid-prefix payload refused");
         },
         {
             expected:

--- a/support/chip-testing/test/cert/TC-DD-3.17.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.17.test.ts
@@ -6,10 +6,13 @@
 
 import { certTest } from "@matter/testing";
 import {
-    CommissioningRefusals,
-    recordManualParse,
-    thManualPairingCode,
     commissionByManualCode,
+    CommissioningRefusals,
+    manualPairingCode,
+    recordManualParse,
+    recordVendorMismatchOutcome,
+    thCodeParts,
+    thManualPairingCode,
 } from "./tc-dd-support.js";
 import { CommissionedRefs, record } from "./tc-support.js";
 
@@ -24,8 +27,11 @@ const INVALID_PASSCODES = [
 /** The test vendor identifiers the plan's step 6.a substitutes. */
 const TEST_VENDOR_IDS = [0xfff1, 0xfff2, 0xfff3, 0xfff4];
 
-/** The plan's own substitute for the TH's discriminator, which changes its 4 most significant bits. */
-const OTHER_DISCRIMINATOR = 0xe00;
+/**
+ * Flips a bit the plan requires to change: § 5.1.4.1 Table 62 carries only the discriminator's 4 most
+ * significant bits, so a substitution the code can express has to land in them.
+ */
+const DISCRIMINATOR_MSB = 0x100;
 
 /**
  * What step 4 gives the DUT to look for a device that is not there. matter.js otherwise waits out
@@ -33,7 +39,15 @@ const OTHER_DISCRIMINATOR = 0xe00;
  * on its own after roughly 45 seconds, so the step's own budget has to outlast that.
  */
 const GIVE_UP_AFTER_MS = 20_000;
+
+/** Step 6's mismatched-vendor attempt, bounded the same way step 4's absent device is. */
+const VENDOR_MISMATCH_TIMEOUT_MS = 20_000;
 const NO_COMMISSIONEE_TIMEOUT_MS = 90_000;
+
+/** The plan repeats this in the expected outcome of every step that generates a code. */
+const GUIDELINES =
+    "The generated Manual Pairing Code follows all guidelines laid out in the Preconditions #2, above, with " +
+    "special attention to the CHECK_DIGIT using the Verhoeff algorithm.";
 
 const commissioned = new CommissionedRefs();
 const refusals = new CommissioningRefusals();
@@ -63,7 +77,7 @@ certTest("TC-DD-3.17", {
                 "Reserved-version code",
             );
         },
-        { expected: "User has a manual code generated to pass into DUT." },
+        { expected: `User has a manual code generated to pass into DUT. ${GUIDELINES}` },
     )
     .step(
         "2.b",
@@ -94,7 +108,7 @@ certTest("TC-DD-3.17", {
                 "Header/length mismatch code",
             );
         },
-        { expected: "User has a manual code generated to pass into DUT." },
+        { expected: `User has a manual code generated to pass into DUT. ${GUIDELINES}` },
     )
     .step(
         "3.b",
@@ -113,9 +127,13 @@ certTest("TC-DD-3.17", {
         "4.a",
         "SHORT DISCRIMINATOR: Using the manual code from Step 1, generate a new manual code but substituting out " +
             "the current SHORT DISCRIMINATOR string with a discriminator value that makes the generated manual code " +
-            "differ from Step 1's manual code",
+            "differ from Step 1's manual code (i.e. Choose a discriminator value that changes any of the 4 " +
+            "most-significant bits of Step 1's 12-bit discriminator value and adheres to rules of section 5.1.1.5. " +
+            '"Discriminator value")',
         async cx => {
-            const code = await thManualPairingCode(cx, { discriminator: OTHER_DISCRIMINATOR });
+            const code = await thManualPairingCode(cx, {
+                discriminator: cx.devices.th.commissioning.discriminator ^ DISCRIMINATOR_MSB,
+            });
             record(
                 cx,
                 {
@@ -126,13 +144,15 @@ certTest("TC-DD-3.17", {
                 "Wrong-discriminator code",
             );
         },
-        { expected: "User has a manual code generated to pass into DUT." },
+        { expected: `User has a manual code generated to pass into DUT. ${GUIDELINES}` },
     )
     .step(
         "4.b",
         "Provide the Manual Pairing Code, generated in the previous step, to the DUT in any format supported by the DUT",
         async cx => {
-            const manualPairingCode = await thManualPairingCode(cx, { discriminator: OTHER_DISCRIMINATOR });
+            const manualPairingCode = await thManualPairingCode(cx, {
+                discriminator: cx.devices.th.commissioning.discriminator ^ DISCRIMINATOR_MSB,
+            });
             await refusals.requireNoCommissioning(
                 cx,
                 { manualPairingCode, giveUpAfterMs: GIVE_UP_AFTER_MS },
@@ -153,7 +173,8 @@ certTest("TC-DD-3.17", {
             "component to one of the invalid Passcode and generate a new manual code: 00000000, 11111111, 22222222, " +
             "33333333, 44444444, 55555555, 66666666, 77777777, 88888888, 99999999, 12345678, 87654321",
         async cx => {
-            const codes = await Promise.all(INVALID_PASSCODES.map(passcode => thManualPairingCode(cx, { passcode })));
+            const parts = await thCodeParts(cx);
+            const codes = INVALID_PASSCODES.map(passcode => manualPairingCode({ ...parts, passcode }));
             record(
                 cx,
                 {
@@ -169,7 +190,7 @@ certTest("TC-DD-3.17", {
         {
             expected:
                 "User has 12 manual codes (one for each passcode in the list of invalid passcodes) generated to " +
-                "pass into DUT",
+                `pass into DUT. ${GUIDELINES}`,
         },
     )
     .step(
@@ -177,10 +198,11 @@ certTest("TC-DD-3.17", {
         "Provide each of the Manual Pairing Codes, generated in the previous step, to the DUT in any format " +
             "supported by the DUT",
         async cx => {
+            const parts = await thCodeParts(cx);
             for (const passcode of INVALID_PASSCODES) {
                 await refusals.requireRefusal(
                     cx,
-                    { manualPairingCode: await thManualPairingCode(cx, { passcode }) },
+                    { manualPairingCode: manualPairingCode({ ...parts, passcode }) },
                     `Code carrying passcode ${passcode} refused`,
                 );
             }
@@ -197,7 +219,8 @@ certTest("TC-DD-3.17", {
             "Payload components except for the VENDOR_ID. For each VENDOR_ID in the following list, set the " +
             "VENDOR_ID component to one of the invalid Test VENDOR_IDs: 0xFFF1, 0xFFF2, 0xFFF3, 0xFFF4",
         async cx => {
-            const codes = await Promise.all(TEST_VENDOR_IDS.map(vendorId => thManualPairingCode(cx, { vendorId })));
+            const parts = await thCodeParts(cx);
+            const codes = TEST_VENDOR_IDS.map(vendorId => manualPairingCode({ ...parts, vendorId }));
             record(
                 cx,
                 {
@@ -213,7 +236,7 @@ certTest("TC-DD-3.17", {
         {
             expected:
                 "User has 4 manual codes (one for each VENDOR_ID in the list of invalid VENDOR_IDs) generated to " +
-                "pass into DUT",
+                `pass into DUT. ${GUIDELINES}`,
         },
     )
     .step(
@@ -223,8 +246,20 @@ certTest("TC-DD-3.17", {
         async cx => {
             // The plan's own "unless" branch: a cert harness commissions uncertified devices on
             // purpose, and its operator is the user the clause speaks of.
-            const manualPairingCode = await thManualPairingCode(cx, { vendorId: TEST_VENDOR_IDS[0] });
-            await commissionByManualCode(cx, manualPairingCode, commissioned);
+            const parts = await thCodeParts(cx);
+            const [mismatched] = TEST_VENDOR_IDS.filter(vendorId => vendorId !== parts.vendorId);
+
+            // A code naming a vendor the TH is not: chip-tool refuses to pair with a device whose
+            // advertisement disagrees, matter.js discovers on the discriminator alone and onboards.
+            // The plan's expected outcome admits both, so the step records which rather than asserting.
+            await recordVendorMismatchOutcome(
+                cx,
+                manualPairingCode({ ...parts, vendorId: mismatched }),
+                `Code naming vendor 0x${mismatched.toString(16)}`,
+                VENDOR_MISMATCH_TIMEOUT_MS,
+            );
+
+            await commissionByManualCode(cx, manualPairingCode({ ...parts, vendorId: parts.vendorId }), commissioned);
         },
         {
             expected:
@@ -246,7 +281,7 @@ certTest("TC-DD-3.17", {
                 "Product-id-0 code",
             );
         },
-        { expected: "User has a manual code generated to pass into DUT." },
+        { expected: `User has a manual code generated to pass into DUT. ${GUIDELINES}` },
     )
     .step(
         "7.b",
@@ -273,7 +308,7 @@ certTest("TC-DD-3.17", {
                 "Wrong-check-digit code",
             );
         },
-        { expected: "User has a manual code generated to pass into DUT." },
+        { expected: `User has a manual code generated to pass into DUT. ${GUIDELINES}` },
     )
     .step(
         "8.b",

--- a/support/chip-testing/test/cert/TC-DD-3.17.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.17.test.ts
@@ -1,0 +1,307 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { certTest } from "@matter/testing";
+import {
+    CommissioningRefusals,
+    recordManualParse,
+    thManualPairingCode,
+    commissionByManualCode,
+} from "./tc-dd-support.js";
+import { CommissionedRefs, record } from "./tc-support.js";
+
+/**
+ * The trivial passcodes § 5.1.7.1 forbids, transcribed from the plan's step 5.a rather than taken
+ * from matter.js's own list, so a divergence between the two shows up as a failing step.
+ */
+const INVALID_PASSCODES = [
+    0, 11111111, 22222222, 33333333, 44444444, 55555555, 66666666, 77777777, 88888888, 99999999, 12345678, 87654321,
+];
+
+/** The test vendor identifiers the plan's step 6.a substitutes. */
+const TEST_VENDOR_IDS = [0xfff1, 0xfff2, 0xfff3, 0xfff4];
+
+/** The plan's own substitute for the TH's discriminator, which changes its 4 most significant bits. */
+const OTHER_DISCRIMINATOR = 0xe00;
+
+/**
+ * What step 4 gives the DUT to look for a device that is not there. matter.js otherwise waits out
+ * the specification's 3-minute minimum commissioning window; chip-tool cannot be bounded and stops
+ * on its own after roughly 45 seconds, so the step's own budget has to outlast that.
+ */
+const GIVE_UP_AFTER_MS = 20_000;
+const NO_COMMISSIONEE_TIMEOUT_MS = 90_000;
+
+const commissioned = new CommissionedRefs();
+const refusals = new CommissioningRefusals();
+
+certTest("TC-DD-3.17", {
+    plan: "devicediscovery.adoc",
+    pics: ["MCORE.ROLE.COMMISSIONER", "MCORE.DD.21_MANUAL_PC"],
+    app: "all-clusters",
+})
+    .step(
+        1,
+        "Provide the 21-digit Manual Pairing Code from the Commissionee to the DUT in any format supported by DUT",
+        async cx => {
+            await recordManualParse(cx, await thManualPairingCode(cx));
+        },
+        { expected: "Verify that the Manual Pairing Code can be provided to DUT" },
+    )
+    .step(
+        "2.a",
+        "VERSION: Using the manual code from Step 1, generate a new manual code but substituting out the current " +
+            "VERSION with an invalid VERSION: 2",
+        async cx => {
+            const code = await thManualPairingCode(cx, { futureFormat: true });
+            record(
+                cx,
+                { type: "response", verdict: "pass", detail: `Generated ${code}, which marks a format after v1` },
+                "Reserved-version code",
+            );
+        },
+        { expected: "User has a manual code generated to pass into DUT." },
+    )
+    .step(
+        "2.b",
+        "Provide the Manual Pairing Code, generated in the previous step, to the DUT in any format supported by the DUT",
+        async cx => {
+            const manualPairingCode = await thManualPairingCode(cx, { futureFormat: true });
+            await refusals.requireRefusal(cx, { manualPairingCode }, "Reserved-version code refused");
+        },
+        {
+            expected:
+                "DUT attempts to parse the Manual Pairing Code and DUT terminates the commissioning process in a " +
+                "DUT-specific manner according to the DUT manufacturer's instructions.",
+        },
+    )
+    .step(
+        "3.a",
+        "VID_PID_PRESENT: Using the manual code from Step 1, generate a new manual code but substituting out the " +
+            "current VID_PID_PRESENT with an invalid VID_PID_PRESENT set to 0",
+        async cx => {
+            const code = await thManualPairingCode(cx, { vidPidPresent: false });
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: "pass",
+                    detail: `Generated ${code}, whose header disagrees with its ${code.length} digits`,
+                },
+                "Header/length mismatch code",
+            );
+        },
+        { expected: "User has a manual code generated to pass into DUT." },
+    )
+    .step(
+        "3.b",
+        "Provide the Manual Pairing Code, generated in the previous step, to the DUT in any format supported by the DUT",
+        async cx => {
+            const manualPairingCode = await thManualPairingCode(cx, { vidPidPresent: false });
+            await refusals.requireRefusal(cx, { manualPairingCode }, "Header/length mismatch refused");
+        },
+        {
+            expected:
+                "DUT attempts to parse the Manual Pairing Code and DUT terminates the commissioning process in a " +
+                "DUT-specific manner according to the DUT manufacturer's instructions.",
+        },
+    )
+    .step(
+        "4.a",
+        "SHORT DISCRIMINATOR: Using the manual code from Step 1, generate a new manual code but substituting out " +
+            "the current SHORT DISCRIMINATOR string with a discriminator value that makes the generated manual code " +
+            "differ from Step 1's manual code",
+        async cx => {
+            const code = await thManualPairingCode(cx, { discriminator: OTHER_DISCRIMINATOR });
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: "pass",
+                    detail: `Generated ${code}, naming a device this network does not carry`,
+                },
+                "Wrong-discriminator code",
+            );
+        },
+        { expected: "User has a manual code generated to pass into DUT." },
+    )
+    .step(
+        "4.b",
+        "Provide the Manual Pairing Code, generated in the previous step, to the DUT in any format supported by the DUT",
+        async cx => {
+            const manualPairingCode = await thManualPairingCode(cx, { discriminator: OTHER_DISCRIMINATOR });
+            await refusals.requireNoCommissioning(
+                cx,
+                { manualPairingCode, giveUpAfterMs: GIVE_UP_AFTER_MS },
+                "No device commissioned from the wrong discriminator",
+                NO_COMMISSIONEE_TIMEOUT_MS,
+            );
+        },
+        {
+            expected:
+                "DUT attempts to parse the Manual Pairing Code and DUT terminates the commissioning process in a " +
+                "DUT-specific manner according to the DUT manufacturer's instructions.",
+        },
+    )
+    .step(
+        "5.a",
+        "Passcode: Using the manual code from Step 1, generate a new manual code using all the same Onboarding " +
+            "Payload components except for the Passcode. For each Passcode in the following list, set the Passcode " +
+            "component to one of the invalid Passcode and generate a new manual code: 00000000, 11111111, 22222222, " +
+            "33333333, 44444444, 55555555, 66666666, 77777777, 88888888, 99999999, 12345678, 87654321",
+        async cx => {
+            const codes = await Promise.all(INVALID_PASSCODES.map(passcode => thManualPairingCode(cx, { passcode })));
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: "pass",
+                    detail: `Generated ${codes.length} codes: ${codes
+                        .map((code, i) => `${code} (${INVALID_PASSCODES[i]})`)
+                        .join(", ")}`,
+                },
+                "Invalid-passcode codes",
+            );
+        },
+        {
+            expected:
+                "User has 12 manual codes (one for each passcode in the list of invalid passcodes) generated to " +
+                "pass into DUT",
+        },
+    )
+    .step(
+        "5.b",
+        "Provide each of the Manual Pairing Codes, generated in the previous step, to the DUT in any format " +
+            "supported by the DUT",
+        async cx => {
+            for (const passcode of INVALID_PASSCODES) {
+                await refusals.requireRefusal(
+                    cx,
+                    { manualPairingCode: await thManualPairingCode(cx, { passcode }) },
+                    `Code carrying passcode ${passcode} refused`,
+                );
+            }
+        },
+        {
+            expected:
+                "DUT attempts to parse the Manual Pairing Code and DUT terminates the commissioning process in a " +
+                "DUT-specific manner according to the DUT manufacturer's instructions.",
+        },
+    )
+    .step(
+        "6.a",
+        "VENDOR_ID: Using the manual code from Step 1, generate a new manual code using all the same Onboarding " +
+            "Payload components except for the VENDOR_ID. For each VENDOR_ID in the following list, set the " +
+            "VENDOR_ID component to one of the invalid Test VENDOR_IDs: 0xFFF1, 0xFFF2, 0xFFF3, 0xFFF4",
+        async cx => {
+            const codes = await Promise.all(TEST_VENDOR_IDS.map(vendorId => thManualPairingCode(cx, { vendorId })));
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: "pass",
+                    detail: `Generated ${codes.length} codes: ${codes
+                        .map((code, i) => `${code} (0x${TEST_VENDOR_IDS[i].toString(16)})`)
+                        .join(", ")}`,
+                },
+                "Test-vendor codes",
+            );
+        },
+        {
+            expected:
+                "User has 4 manual codes (one for each VENDOR_ID in the list of invalid VENDOR_IDs) generated to " +
+                "pass into DUT",
+        },
+    )
+    .step(
+        "6.b",
+        "Provide each of the Manual Pairing Codes, generated in the previous step, to the DUT in any format " +
+            "supported by the DUT",
+        async cx => {
+            // The plan's own "unless" branch: a cert harness commissions uncertified devices on
+            // purpose, and its operator is the user the clause speaks of.
+            const manualPairingCode = await thManualPairingCode(cx, { vendorId: TEST_VENDOR_IDS[0] });
+            await commissionByManualCode(cx, manualPairingCode, commissioned);
+        },
+        {
+            expected:
+                "If the TH's Vendor ID is an invalid Test Vendor ID, DUT attempts to parse the Manual Pairing Code " +
+                "and DUT terminates the commissioning process in a DUT-specific manner according to the DUT " +
+                "manufacturer's instructions, unless the user is made fully aware of the security risks of " +
+                "providing an uncertified device with operational and networking credentials.",
+        },
+    )
+    .step(
+        "7.a",
+        "PRODUCT_ID: Using the manual code from Step 1, generate a new manual code but substituting out the " +
+            "current PRODUCT_ID with an invalid PRODUCT_ID of 0x0000",
+        async cx => {
+            const code = await thManualPairingCode(cx, { productId: 0 });
+            record(
+                cx,
+                { type: "response", verdict: "pass", detail: `Generated ${code}, naming product id 0` },
+                "Product-id-0 code",
+            );
+        },
+        { expected: "User has a manual code generated to pass into DUT." },
+    )
+    .step(
+        "7.b",
+        "Provide the Manual Pairing Code, generated in the previous step, to the DUT in any format supported by the DUT",
+        async cx => {
+            const manualPairingCode = await thManualPairingCode(cx, { productId: 0 });
+            await refusals.requireRefusal(cx, { manualPairingCode }, "Product-id-0 code refused");
+        },
+        {
+            expected:
+                "DUT attempts to parse the Manual Pairing Code and DUT terminates the commissioning process in a " +
+                "DUT-specific manner according to the DUT manufacturer's instructions.",
+        },
+    )
+    .step(
+        "8.a",
+        "Check Digit: Using the manual code from Step 1, generate a new manual code but substituting out the " +
+            "current CHECK_DIGIT with an invalid CHECK_DIGIT",
+        async cx => {
+            const code = await wrongCheckDigitCode(cx);
+            record(
+                cx,
+                { type: "response", verdict: "pass", detail: `Generated ${code}, whose check digit is wrong` },
+                "Wrong-check-digit code",
+            );
+        },
+        { expected: "User has a manual code generated to pass into DUT." },
+    )
+    .step(
+        "8.b",
+        "Provide the Manual Pairing Code, generated in the previous step, to the DUT in any format supported by the DUT",
+        async cx => {
+            await refusals.requireRefusal(
+                cx,
+                { manualPairingCode: await wrongCheckDigitCode(cx) },
+                "Wrong-check-digit code refused",
+            );
+        },
+        {
+            expected:
+                "DUT attempts to parse the Manual Pairing Code and DUT terminates the commissioning process in a " +
+                "DUT-specific manner according to the DUT manufacturer's instructions.",
+        },
+    )
+    .finalize(async cx => {
+        try {
+            await refusals.settle(cx);
+        } finally {
+            await commissioned.decommissionAll(cx);
+        }
+    });
+
+/** The TH's own code with a check digit that is not the one its digits produce. */
+async function wrongCheckDigitCode(cx: Parameters<typeof thManualPairingCode>[0]) {
+    const correct = await thManualPairingCode(cx);
+    const digit = Number(correct.slice(-1));
+    return thManualPairingCode(cx, { checkDigit: (digit + 1) % 10 });
+}

--- a/support/chip-testing/test/cert/TC-DD-3.17.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.17.test.ts
@@ -255,6 +255,7 @@ certTest("TC-DD-3.17", {
             await recordVendorMismatchOutcome(
                 cx,
                 manualPairingCode({ ...parts, vendorId: mismatched }),
+                commissioned,
                 `Code naming vendor 0x${mismatched.toString(16)}`,
                 VENDOR_MISMATCH_TIMEOUT_MS,
             );

--- a/support/chip-testing/test/cert/TC-DD-3.17.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.17.test.ts
@@ -6,11 +6,10 @@
 
 import { certTest } from "@matter/testing";
 import {
-    commissionByManualCode,
     CommissioningRefusals,
     manualPairingCode,
     recordManualParse,
-    recordVendorMismatchOutcome,
+    recordVendorOutcome,
     thCodeParts,
     thManualPairingCode,
 } from "./tc-dd-support.js";
@@ -40,8 +39,8 @@ const DISCRIMINATOR_MSB = 0x100;
  */
 const GIVE_UP_AFTER_MS = 20_000;
 
-/** Step 6's mismatched-vendor attempt, bounded the same way step 4's absent device is. */
-const VENDOR_MISMATCH_TIMEOUT_MS = 20_000;
+/** Step 6's per-vendor attempt, bounded the same way step 4's absent device is. */
+const VENDOR_OUTCOME_TIMEOUT_MS = 20_000;
 const NO_COMMISSIONEE_TIMEOUT_MS = 90_000;
 
 /** The plan repeats this in the expected outcome of every step that generates a code. */
@@ -245,22 +244,20 @@ certTest("TC-DD-3.17", {
             "supported by the DUT",
         async cx => {
             // The plan's own "unless" branch: a cert harness commissions uncertified devices on
-            // purpose, and its operator is the user the clause speaks of.
+            // purpose, and its operator is the user the clause speaks of. A code naming a vendor the TH
+            // is not is where the two commissioners part: chip-tool refuses to pair with a device whose
+            // advertisement disagrees, matter.js discovers on the discriminator alone. Both are outcomes
+            // the plan admits, so the step records which happened for each of the four codes.
             const parts = await thCodeParts(cx);
-            const [mismatched] = TEST_VENDOR_IDS.filter(vendorId => vendorId !== parts.vendorId);
-
-            // A code naming a vendor the TH is not: chip-tool refuses to pair with a device whose
-            // advertisement disagrees, matter.js discovers on the discriminator alone and onboards.
-            // The plan's expected outcome admits both, so the step records which rather than asserting.
-            await recordVendorMismatchOutcome(
-                cx,
-                manualPairingCode({ ...parts, vendorId: mismatched }),
-                commissioned,
-                `Code naming vendor 0x${mismatched.toString(16)}`,
-                VENDOR_MISMATCH_TIMEOUT_MS,
-            );
-
-            await commissionByManualCode(cx, manualPairingCode({ ...parts, vendorId: parts.vendorId }), commissioned);
+            for (const vendorId of TEST_VENDOR_IDS) {
+                await recordVendorOutcome(
+                    cx,
+                    manualPairingCode({ ...parts, vendorId }),
+                    commissioned,
+                    `Code naming vendor 0x${vendorId.toString(16)}`,
+                    VENDOR_OUTCOME_TIMEOUT_MS,
+                );
+            }
         },
         {
             expected:

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, Duration, InternalError, Millis, Time } from "@matter/main";
+import { Bytes, Duration, InternalError, Millis, Time, Verhoeff } from "@matter/main";
 import { Base38, DiscoveryCapabilitiesBitmap, DiscoveryCapabilitiesSchema } from "@matter/main/types";
 import type { CertNodeRef, CertStepContext } from "@matter/testing";
 import type { CertDevice } from "@matter/testing";
@@ -369,4 +369,62 @@ export async function commissionByQr(
         ),
         "TH commissioning",
     );
+}
+
+/** First digit CHIP and matter.js both read as "a format this implementation does not know". */
+const FUTURE_FORMAT_DIGIT = 8;
+
+/**
+ * The parts § 5.1.4.1 Table 62 packs into a manual pairing code, as {@link manualPairingCode} writes
+ * them.
+ */
+export interface ManualPairingCodeParts {
+    /**
+     * Marks a format after v1 (§ 5.1.4.1.2), which sets the first digit to 8. The fields v1 packs
+     * into that digit are not representable alongside the marker, since a decimal digit holds 0-9.
+     */
+    futureFormat?: boolean;
+
+    /**
+     * The `VID_PID_PRESENT` bit. Set independently of whether the ids themselves follow, because a
+     * code where the two disagree is exactly what one of the negative plans asks for.
+     */
+    vidPidPresent: boolean;
+
+    /** The full 12-bit form; only its 4 most significant bits reach the code. */
+    discriminator: number;
+
+    passcode: number;
+    vendorId?: number;
+    productId?: number;
+
+    /** Replaces the Verhoeff digit the parts produce, for a step asking for a wrong one. */
+    checkDigit?: number;
+}
+
+/**
+ * A manual pairing code carrying `parts`, whatever the specification makes of them.
+ *
+ * The negative plans substitute values `ManualPairingCodeCodec` refuses to write — a reserved
+ * version, a forbidden passcode, a product id of 0 — so the digits are laid out here rather than
+ * encoded. The layout is § 5.1.4.1 Table 62's, and every code the plan prints for its own example
+ * device is asserted against this in `tc-dd-support.test.ts`.
+ */
+export function manualPairingCode(parts: ManualPairingCodeParts): string {
+    const { futureFormat = false, vidPidPresent, discriminator, passcode, vendorId, productId, checkDigit } = parts;
+
+    const chunk1 = futureFormat ? FUTURE_FORMAT_DIGIT : (vidPidPresent ? 1 << 2 : 0) | (discriminator >> 10);
+    const chunk2 = (((discriminator & 0x300) << 6) | (passcode & 0x3fff)).toString().padStart(5, "0");
+    const chunk3 = (passcode >>> 14).toString().padStart(4, "0");
+
+    if ((vendorId === undefined) !== (productId === undefined)) {
+        throw new InternalError("A manual pairing code carries a vendor and a product id together or not at all");
+    }
+
+    let digits = `${chunk1}${chunk2}${chunk3}`;
+    if (vendorId !== undefined && productId !== undefined) {
+        digits += vendorId.toString().padStart(5, "0") + productId.toString().padStart(5, "0");
+    }
+
+    return digits + (checkDigit ?? new Verhoeff().computeChecksum(digits));
 }

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -429,8 +429,8 @@ export async function recordCommissionable(
 }
 
 /**
- * Records what the DUT made of a code whose vendor id is not the TH's, where the plan accepts either
- * outcome: terminating commissioning, or onboarding anyway with the user aware of the risk.
+ * Records what the DUT made of a code naming a given vendor, where the plan accepts either outcome:
+ * terminating commissioning, or onboarding anyway with the user aware of the risk.
  *
  * The two controllers genuinely differ. chip-tool matches a code's vendor and product id against the
  * device it discovered (`SetUpCodePairer::NodeMatchesCurrentFilter`) and finds nothing; matter.js
@@ -438,13 +438,15 @@ export async function recordCommissionable(
  * `commissioned`, whose next {@link commissionByManualCode} takes it off the TH the only way a chip
  * TH survives — opening a window before the fabric that opens it is gone.
  */
-export async function recordVendorMismatchOutcome(
+export async function recordVendorOutcome(
     cx: CertStepContext,
     manualPairingCode: string,
     commissioned: CommissionedRefs,
     what: string,
     timeoutMs: number,
 ): Promise<void> {
+    await restoreCommissioningMode(cx, commissioned);
+
     const dut = cx.controllers.dut;
     const attempt = dut.commission({ manualPairingCode, giveUpAfterMs: timeoutMs });
 
@@ -461,12 +463,34 @@ export async function recordVendorMismatchOutcome(
         {
             type: "response",
             verdict: "pass",
-            detail:
-                `DUT onboarded the TH as node ${ref} despite the code naming another vendor, which the ` +
-                `plan allows where the user accepts the risk`,
+            detail: `DUT onboarded the TH as node ${ref}, which the plan allows where the user accepts the risk`,
         },
         what,
     );
+}
+
+/**
+ * Puts the TH back into commissioning mode if a fabric from an earlier onboarding is still on it.
+ *
+ * A chip TH does not return there when its last fabric goes, so the window is opened while the fabric
+ * that can open it is still present. It is a basic one: that is the window whose PASE verifier is the
+ * device's own setup code, which is what an onboarding code carries.
+ */
+async function restoreCommissioningMode(cx: CertStepContext, commissioned: CommissionedRefs): Promise<void> {
+    const previous = commissioned.get("dut");
+    if (previous === undefined) {
+        return;
+    }
+
+    const dut = cx.controllers.dut;
+    await dut.node(previous).openCommissioningWindow({ timeout: WINDOW_TIMEOUT_SECONDS, enhanced: false });
+    await dut.node(previous).decommission();
+    commissioned.clear("dut");
+
+    // Removing the fabric returns as soon as the TH answers; the TH advertises itself commissionable
+    // again on its own schedule, and a discovery started before that finds only the devices this run
+    // is not looking for.
+    await recordCommissionable(cx, "TH back in commissioning mode");
 }
 
 /** {@link commissionByQr} for a manual pairing code, which discovers by the short discriminator. */
@@ -501,17 +525,7 @@ async function commissionByTarget(
     const dut = cx.controllers.dut;
     const th = cx.devices.th;
 
-    const previous = commissioned.get("dut");
-    if (previous !== undefined) {
-        await dut.node(previous).openCommissioningWindow({ timeout: WINDOW_TIMEOUT_SECONDS, enhanced: false });
-        await dut.node(previous).decommission();
-        commissioned.clear("dut");
-
-        // Removing the fabric returns as soon as the TH answers; the TH advertises itself
-        // commissionable again on its own schedule, and a discovery started before that finds only
-        // the devices this run is not looking for.
-        await recordCommissionable(cx, "TH back in commissioning mode");
-    }
+    await restoreCommissioningMode(cx, commissioned);
 
     const from = th.log.mark();
     let ref;

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -434,12 +434,14 @@ export async function recordCommissionable(
  *
  * The two controllers genuinely differ. chip-tool matches a code's vendor and product id against the
  * device it discovered (`SetUpCodePairer::NodeMatchesCurrentFilter`) and finds nothing; matter.js
- * discovers on the discriminator alone and onboards. A fabric that results is removed here rather
- * than left for the step's own cleanup, so it cannot collide with the ref the step keeps.
+ * discovers on the discriminator alone and onboards. A fabric that results is handed to
+ * `commissioned`, whose next {@link commissionByManualCode} takes it off the TH the only way a chip
+ * TH survives — opening a window before the fabric that opens it is gone.
  */
 export async function recordVendorMismatchOutcome(
     cx: CertStepContext,
     manualPairingCode: string,
+    commissioned: CommissionedRefs,
     what: string,
     timeoutMs: number,
 ): Promise<void> {
@@ -453,21 +455,18 @@ export async function recordVendorMismatchOutcome(
     }
 
     const ref = await attempt;
-    try {
-        record(
-            cx,
-            {
-                type: "response",
-                verdict: "pass",
-                detail:
-                    `DUT onboarded the TH as node ${ref} despite the code naming another vendor, which the ` +
-                    `plan allows where the user accepts the risk`,
-            },
-            what,
-        );
-    } finally {
-        await dut.node(ref).decommission();
-    }
+    commissioned.set("dut", ref);
+    record(
+        cx,
+        {
+            type: "response",
+            verdict: "pass",
+            detail:
+                `DUT onboarded the TH as node ${ref} despite the code naming another vendor, which the ` +
+                `plan allows where the user accepts the risk`,
+        },
+        what,
+    );
 }
 
 /** {@link commissionByQr} for a manual pairing code, which discovers by the short discriminator. */

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -6,7 +6,7 @@
 
 import { Bytes, Duration, InternalError, Millis, Time, Verhoeff } from "@matter/main";
 import { Base38, DiscoveryCapabilitiesBitmap, DiscoveryCapabilitiesSchema } from "@matter/main/types";
-import type { CertNodeRef, CertStepContext } from "@matter/testing";
+import type { CertNodeRef, CertStepContext, CommissioningTarget } from "@matter/testing";
 import type { CertDevice } from "@matter/testing";
 import { expectMdns } from "../../src/cert/mdns-check.js";
 import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload.js";
@@ -232,8 +232,8 @@ export class CommissioningRefusals {
      * rejection would let the step pass on a controller that died, timed out or was never asked —
      * outcomes that say nothing about what the DUT made of the code.
      */
-    async requireRefusal(cx: CertStepContext, payload: string, what: string): Promise<void> {
-        const attempt = cx.controllers.dut.commission({ qrPairingCode: payload });
+    async requireRefusal(cx: CertStepContext, target: CommissioningTarget, what: string): Promise<void> {
+        const attempt = cx.controllers.dut.commission(target);
         // Kept as a settled outcome so an attempt nobody awaits again cannot surface as an unhandled
         // rejection, and so settle() can collect the ref of one that succeeded after its budget
         this.#attempts.push(
@@ -245,9 +245,36 @@ export class CommissioningRefusals {
 
         record(
             cx,
-            await expectRejection(`commissioning from ${payload}`, attempt, this.#refusalTimeoutMs, isPayloadRefusal),
+            await expectRejection(
+                `commissioning from ${describeTarget(target)}`,
+                attempt,
+                this.#refusalTimeoutMs,
+                isPayloadRefusal,
+            ),
             what,
         );
+    }
+
+    /**
+     * Records that the DUT does not commission from `target`, without claiming why. The plans use
+     * this where the code is well-formed but names a device that is not there: any failure satisfies
+     * "the DUT terminated commissioning", where a success does not.
+     */
+    async requireNoCommissioning(
+        cx: CertStepContext,
+        target: CommissioningTarget,
+        what: string,
+        timeoutMs: number,
+    ): Promise<void> {
+        const attempt = cx.controllers.dut.commission(target);
+        this.#attempts.push(
+            attempt.then(
+                ref => ref,
+                () => undefined,
+            ),
+        );
+
+        record(cx, await expectRejection(`commissioning from ${describeTarget(target)}`, attempt, timeoutMs), what);
     }
 
     /**
@@ -304,9 +331,73 @@ export class CommissioningRefusals {
  * invalid CSR response, for one). Either would let a commissioner that took a forbidden code and only
  * then failed be recorded as having refused it.
  */
+function describeTarget(target: CommissioningTarget): string {
+    return target.qrPairingCode ?? target.manualPairingCode ?? JSON.stringify(target);
+}
+
 function isPayloadRefusal(error: unknown): boolean {
     return error instanceof OnboardingPayloadRefusedError;
 }
+
+/**
+ * The TH's own setup code rendered as a 21-digit manual pairing code.
+ *
+ * No subject publishes one: a device on the standard commissioning flow prints the 11-digit form,
+ * and § 5.1.4.1 Table 64's longer form is what the manual-code plans test. It names the same device
+ * — the same discriminator and passcode — in the form the plan's preconditions describe.
+ */
+export async function thManualPairingCode(
+    cx: CertStepContext,
+    overrides: Partial<ManualPairingCodeParts> = {},
+): Promise<string> {
+    const th = cx.devices.th;
+    const { vendorId, productId } = await cx.controllers.dut.parseQrPayload(await thQrPayload(th));
+
+    return manualPairingCode({
+        vidPidPresent: true,
+        discriminator: th.commissioning.discriminator,
+        passcode: th.commissioning.passcode,
+        vendorId,
+        productId,
+        ...overrides,
+    });
+}
+
+/**
+ * Records what the DUT read out of `code` and whether it names the TH. As {@link recordParse}, the
+ * parse is the DUT's: a step that decoded the code itself would pass against a controller that
+ * cannot read one.
+ */
+export async function recordManualParse(cx: CertStepContext, code: string): Promise<void> {
+    const th = cx.devices.th;
+
+    let parsed;
+    try {
+        parsed = await cx.controllers.dut.parseManualPairingCode(code);
+    } catch (e) {
+        cx.recorder.check({ type: "response", verdict: "fail", detail: `DUT could not parse ${code}: ${e}` });
+        throw e;
+    }
+
+    const shortDiscriminator = th.commissioning.discriminator >> SHORT_DISCRIMINATOR_SHIFT;
+    const matches = parsed.shortDiscriminator === shortDiscriminator && parsed.passcode === th.commissioning.passcode;
+
+    record(
+        cx,
+        {
+            type: "response",
+            verdict: matches ? "pass" : "fail",
+            detail:
+                `DUT read the ${code.length}-digit code as shortDiscriminator=${parsed.shortDiscriminator} ` +
+                `passcode=${parsed.passcode} vendorId=${parsed.vendorId} productId=${parsed.productId}; the TH's own ` +
+                `setup code is shortDiscriminator=${shortDiscriminator} passcode=${th.commissioning.passcode}`,
+        },
+        "Manual pairing code parse",
+    );
+}
+
+/** § 5.1.4.1 Table 62 carries only the discriminator's 4 most significant bits. */
+const SHORT_DISCRIMINATOR_SHIFT = 8;
 
 /**
  * Records that the TH is discoverable as a commissionable device, which every commissioning-flow plan
@@ -319,6 +410,15 @@ export async function recordCommissionable(
     record(cx, await expectMdns(cx.devices.th, { commissionable: true }, { timeoutMs: MDNS_TIMEOUT_MS }), what);
 }
 
+/** {@link commissionByQr} for a manual pairing code, which discovers by the short discriminator. */
+export async function commissionByManualCode(
+    cx: CertStepContext,
+    manualPairingCode: string,
+    commissioned: CommissionedRefs,
+): Promise<void> {
+    await commissionByTarget(cx, { manualPairingCode }, commissioned);
+}
+
 /**
  * Onboards the TH from `payload`, first taking off a fabric an earlier step commissioned.
  *
@@ -329,6 +429,14 @@ export async function recordCommissionable(
 export async function commissionByQr(
     cx: CertStepContext,
     payload: string,
+    commissioned: CommissionedRefs,
+): Promise<void> {
+    await commissionByTarget(cx, { qrPairingCode: payload }, commissioned);
+}
+
+async function commissionByTarget(
+    cx: CertStepContext,
+    target: CommissioningTarget,
     commissioned: CommissionedRefs,
 ): Promise<void> {
     const dut = cx.controllers.dut;
@@ -349,9 +457,13 @@ export async function commissionByQr(
     const from = th.log.mark();
     let ref;
     try {
-        ref = await dut.commission({ qrPairingCode: payload });
+        ref = await dut.commission(target);
     } catch (e) {
-        cx.recorder.check({ type: "response", verdict: "fail", detail: `commissioning by payload failed: ${e}` });
+        cx.recorder.check({
+            type: "response",
+            verdict: "fail",
+            detail: `commissioning from ${describeTarget(target)} failed: ${e}`,
+        });
         throw e;
     }
     commissioned.set("dut", ref);

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -274,7 +274,18 @@ export class CommissioningRefusals {
             ),
         );
 
-        record(cx, await expectRejection(`commissioning from ${describeTarget(target)}`, attempt, timeoutMs), what);
+        record(
+            cx,
+            await expectRejection(
+                `commissioning from ${describeTarget(target)}`,
+                attempt,
+                timeoutMs,
+                // A payload refusal would mean the code never reached discovery, so the step proved
+                // nothing about a commissionee that is not there
+                error => !isPayloadRefusal(error),
+            ),
+            what,
+        );
     }
 
     /**
@@ -323,6 +334,10 @@ export class CommissioningRefusals {
     }
 }
 
+function describeTarget(target: CommissioningTarget): string {
+    return target.qrPairingCode ?? target.manualPairingCode ?? JSON.stringify(target);
+}
+
 /**
  * Whether `error` is a controller refusing the onboarding payload rather than failing for some other
  * reason. Both adapters mark that refusal where it happens, because neither controller's own error
@@ -331,10 +346,6 @@ export class CommissioningRefusals {
  * invalid CSR response, for one). Either would let a commissioner that took a forbidden code and only
  * then failed be recorded as having refused it.
  */
-function describeTarget(target: CommissioningTarget): string {
-    return target.qrPairingCode ?? target.manualPairingCode ?? JSON.stringify(target);
-}
-
 function isPayloadRefusal(error: unknown): boolean {
     return error instanceof OnboardingPayloadRefusedError;
 }
@@ -350,17 +361,24 @@ export async function thManualPairingCode(
     cx: CertStepContext,
     overrides: Partial<ManualPairingCodeParts> = {},
 ): Promise<string> {
+    return manualPairingCode({ ...(await thCodeParts(cx)), ...overrides });
+}
+
+/**
+ * What the TH's own setup code puts into a 21-digit manual code. Read once by a step that builds
+ * several, so a dozen substitutions do not become a dozen concurrent requests to the DUT.
+ */
+export async function thCodeParts(cx: CertStepContext): Promise<ManualPairingCodeParts> {
     const th = cx.devices.th;
     const { vendorId, productId } = await cx.controllers.dut.parseQrPayload(await thQrPayload(th));
 
-    return manualPairingCode({
+    return {
         vidPidPresent: true,
         discriminator: th.commissioning.discriminator,
         passcode: th.commissioning.passcode,
         vendorId,
         productId,
-        ...overrides,
-    });
+    };
 }
 
 /**
@@ -408,6 +426,48 @@ export async function recordCommissionable(
     what = "TH advertising as commissionable",
 ): Promise<void> {
     record(cx, await expectMdns(cx.devices.th, { commissionable: true }, { timeoutMs: MDNS_TIMEOUT_MS }), what);
+}
+
+/**
+ * Records what the DUT made of a code whose vendor id is not the TH's, where the plan accepts either
+ * outcome: terminating commissioning, or onboarding anyway with the user aware of the risk.
+ *
+ * The two controllers genuinely differ. chip-tool matches a code's vendor and product id against the
+ * device it discovered (`SetUpCodePairer::NodeMatchesCurrentFilter`) and finds nothing; matter.js
+ * discovers on the discriminator alone and onboards. A fabric that results is removed here rather
+ * than left for the step's own cleanup, so it cannot collide with the ref the step keeps.
+ */
+export async function recordVendorMismatchOutcome(
+    cx: CertStepContext,
+    manualPairingCode: string,
+    what: string,
+    timeoutMs: number,
+): Promise<void> {
+    const dut = cx.controllers.dut;
+    const attempt = dut.commission({ manualPairingCode, giveUpAfterMs: timeoutMs });
+
+    const outcome = await expectRejection(`commissioning from ${manualPairingCode}`, attempt, timeoutMs + 30_000);
+    if (outcome.verdict === "pass") {
+        record(cx, { ...outcome, detail: `DUT terminated commissioning: ${outcome.detail}` }, what);
+        return;
+    }
+
+    const ref = await attempt;
+    try {
+        record(
+            cx,
+            {
+                type: "response",
+                verdict: "pass",
+                detail:
+                    `DUT onboarded the TH as node ${ref} despite the code naming another vendor, which the ` +
+                    `plan allows where the user accepts the risk`,
+            },
+            what,
+        );
+    } finally {
+        await dut.node(ref).decommission();
+    }
 }
 
 /** {@link commissionByQr} for a manual pairing code, which discovers by the short discriminator. */
@@ -483,6 +543,17 @@ async function commissionByTarget(
     );
 }
 
+/**
+ * A part that does not fit its field would be written as extra digits or roll into its neighbour,
+ * putting a code nobody asked for into the evidence — the same trap `writeBits` guards for a QR
+ * payload.
+ */
+function assertFits(value: number, max: number, what: string): void {
+    if (!Number.isInteger(value) || value < 0 || value > max) {
+        throw new InternalError(`${what} ${value} does not fit a manual pairing code`);
+    }
+}
+
 /** First digit CHIP and matter.js both read as "a format this implementation does not know". */
 const FUTURE_FORMAT_DIGIT = 8;
 
@@ -528,6 +599,12 @@ export function manualPairingCode(parts: ManualPairingCodeParts): string {
     const chunk1 = futureFormat ? FUTURE_FORMAT_DIGIT : (vidPidPresent ? 1 << 2 : 0) | (discriminator >> 10);
     const chunk2 = (((discriminator & 0x300) << 6) | (passcode & 0x3fff)).toString().padStart(5, "0");
     const chunk3 = (passcode >>> 14).toString().padStart(4, "0");
+
+    assertFits(discriminator, 0xfff, "discriminator");
+    assertFits(passcode, 0x7ffffff, "passcode");
+    assertFits(vendorId ?? 0, 0xffff, "vendorId");
+    assertFits(productId ?? 0, 0xffff, "productId");
+    assertFits(checkDigit ?? 0, 9, "checkDigit");
 
     if ((vendorId === undefined) !== (productId === undefined)) {
         throw new InternalError("A manual pairing code carries a vendor and a product id together or not at all");


### PR DESCRIPTION
Certification case TC-DD-3.17: a commissioner given a device's 21-digit manual pairing code recognises the ways it can be wrong and does not commission from them.

Builds on #4258, which added the two refusals matter.js was missing for this.

## What the case checks

| Plan step | Substitution | Outcome |
| --- | --- | --- |
| 1 | none | the commissioner reports what it read |
| 2 | a version marking a format after v1 | refused |
| 3 | a header disagreeing with the code's length | refused |
| 4 | a discriminator naming a device that is not there | no device commissioned |
| 5 | each of the twelve trivial passcodes | refused, all twelve |
| 6 | each test vendor identifier | see below |
| 7 | a product identifier of zero | refused |
| 8 | a wrong check digit | refused |

All four runs pass — matter.js and chip-tool as the commissioner, each against a matter.js harness device and a real chip application.

## The codes are the specification's own

No harness device publishes a 21-digit code: one on the standard commissioning flow prints the 11-digit form, and the longer form is what these cases test. The case renders the device's own identity in the longer form, which is what the plan's preconditions describe.

The harness devices happen to share the identity the plan uses in its worked examples, so every code the case generates comes out byte-identical to the code the plan prints — the reserved-version marker, the header mismatch, the changed discriminator, all twelve passcodes, all four vendors, the zero product identifier and the wrong check digit. A unit test asserts all twenty-two of them. The run therefore checks matter.js against the specification's own arithmetic rather than against numbers this implementation produced.

The digits are laid out directly rather than encoded, because every value these cases substitute is one the encoder refuses to write. Two of the plan's printed codes corrected the first attempt at that: a reserved version is a first digit of 8 rather than a bit set beside the other fields, since a decimal digit cannot hold both; and the bit announcing a vendor and product has to be settable independently of whether those digits follow, because a code where the two disagree is exactly what step 3 tests.

## Step 6 records a disagreement between the two commissioners

The obvious reading is that a manual code's vendor identifier is informational and no commissioner checks it against the device it found. **That is false**, and a failing run is what showed it: chip-tool's `SetUpCodePairer` skips a discovered device whose advertised vendor or product identifier disagrees with the code's, so a code naming another vendor finds nothing and it gives up. matter.js discovers on the discriminator alone and onboards.

The plan's expected outcome admits both — terminate commissioning, "unless the user is made fully aware of the security risks" — so the step records which happened rather than asserting one. Both appear in the evidence, one per commissioner.

That difference is worth someone's attention on its own: as this harness drives it, matter.js does not check an onboarding code's vendor or product identifier against the device it discovered, where the reference implementation does. Raised separately rather than changed here.

## Two claims, two checks

"Terminates the commissioning process" turns out to mean different things in different steps. Most hand over a code the commissioner must refuse to read, and only a refusal of the code itself counts. Step 4 hands over a perfectly good code naming a device that is not on the network, where the commissioner instead fails to find anything — there any other failure is acceptable and only a success is not.

The two checks are exclusive by construction: the second refuses a payload refusal as evidence. Without that a malformed generated code would satisfy step 4 in about a millisecond, having never reached discovery, and the step would assert nothing. A review caught it.

Step 4 also needed a way to say how long to look. A commissioner otherwise waits out the specification's three-minute minimum commissioning window, so a commissioning target can now bound it; matter.js honours the bound and chip-tool says it cannot and stops on its own after thirty seconds.

## Reading a manual code through the commissioner

`ControllerAdapter` gains `parseManualPairingCode`, separate from the QR equivalent because the forms carry different fields — a manual code states only four bits of the discriminator, names no discovery capabilities, and identifies a vendor and product only in its longer form. Both drivers implement it, and chip-tool's reports the identity as absent for the shorter form rather than passing on the zeroes it prints.

## Verification

- Clean build, format check, lint and the full test suite green from the repository root
- `test/cert-framework` 444/444, including 27 in the manual-code suite
- TC-DD-3.17 passes on all four commissioner × device combinations
- Each change mutation-tested with compiling mutations: removing the discovery bound, the exclusivity predicate, either range guard, or the code writer's field arithmetic each fails the test that covers it

## What the reviews changed

Three things, each of which a green run had hidden:

- The vendor-identifier step substituted the harness device's *own* identifier, which reproduces step 1's code exactly, so it commissioned from an unmodified code while claiming to test a substitution.
- Fixing that turned the chip-tool runs red, which is how the vendor-matching behaviour above surfaced.
- Removing the stray fabric directly left a chip application out of commissioning mode, because it does not return there when its last fabric goes — a trap this suite had already recorded and this change walked into anyway. It now uses the helper that opens a window before removing the fabric that can open it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)