### PR TITLE
fix(node): pass over a device the onboarding code does not name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Factory reset removes commissioned peers and the certificate authority's key material; a peer that cannot be torn down no longer blocks the reset
     - Fix: A client node's storage metadata no longer surfaces as state: a peer report that only bumps the data version emits no change notification, and `__version__` no longer appears among the changed properties or in cluster state
     - Fix: Commissioning passes over a discovered device whose advertised vendor or product ID disagrees with the onboarding payload's
+    - Breaking: A commissionable advertisement stating vendor or product ID 0 now reports it absent, matching the specification's "unspecified"
 
 - @matter/nodejs
     - Breaking: `FileStorageDriver`'s constructor no longer accepts a `clear` argument; clearing is handled by `StorageService`
@@ -112,6 +113,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: `Cluster.with()` rejects a feature the cluster does not define and returns one frozen namespace per selection
     - Fix: An onboarding payload carrying a vendor ID past the last test vendor, or a product ID of 0 beside a real vendor ID, is now rejected
     - Fix: A manual pairing code whose `VID_PID_PRESENT` bit disagrees with its length is now rejected
+    - Breaking: An onboarding payload's vendor and product ID are reported absent where it states none; the specification writes "unspecified" as 0, which callers had to know
 
 - @matter/testing
     - Enhancement: `certTest()` defines controller-side certification tests with per-step PICS gating, device-log expectations, and evidence recording; devices run as chip apps (docker or local binary) or matter.js test apps, selected via `MATTER_CERT_DEVICE`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A rejected write to an attribute served by dynamic properties restores the previous value instead of deleting the property, and a rejected write to a previously absent attribute leaves no slot behind instead of one holding `undefined`
     - Fix: Factory reset removes commissioned peers and the certificate authority's key material; a peer that cannot be torn down no longer blocks the reset
     - Fix: A client node's storage metadata no longer surfaces as state: a peer report that only bumps the data version emits no change notification, and `__version__` no longer appears among the changed properties or in cluster state
+    - Fix: Commissioning passes over a discovered device whose advertised vendor or product ID disagrees with the onboarding payload's
 
 - @matter/nodejs
     - Breaking: `FileStorageDriver`'s constructor no longer accepts a `clear` argument; clearing is handled by `StorageService`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Breaking: Provisional elements are no longer implemented by default; supply a state value or use `ClusterBehavior.enable()` to implement one
     - Breaking: `SoftwareUpdateManager.addUpdateConsent()` and `forceUpdate()` take the update as an object instead of three positional arguments, so it can carry per-update options
     - Breaking: Ensure that changing any attribute of a client node sends a write to the peer; an attribute the peer's cluster type cannot express, including the global attributes, is declined locally with `UnsupportedWrite` or `UnsupportedAttribute`
+    - Breaking: A commissionable advertisement stating vendor or product ID 0 now reports it absent (undefined)
     - Removed: `StructManager.assertDirectReadAuthorized()` and the direct-read authorization it backed, unused since the legacy cluster API was dropped
     - Deprecation: `ClientNodeInteraction.localStateFor()` is scheduled for removal in 0.19 together with the legacy controller API
     - Feature: Added `ServerNode.peers.commissioned` returning the commissioned `ClientNode`s
@@ -74,7 +75,6 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Factory reset removes commissioned peers and the certificate authority's key material; a peer that cannot be torn down no longer blocks the reset
     - Fix: A client node's storage metadata no longer surfaces as state: a peer report that only bumps the data version emits no change notification, and `__version__` no longer appears among the changed properties or in cluster state
     - Fix: Commissioning passes over a discovered device whose advertised vendor or product ID disagrees with the onboarding payload's
-    - Breaking: A commissionable advertisement stating vendor or product ID 0 now reports it absent, matching the specification's "unspecified"
 
 - @matter/nodejs
     - Breaking: `FileStorageDriver`'s constructor no longer accepts a `clear` argument; clearing is handled by `StorageService`
@@ -107,13 +107,13 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/types
     - Breaking: Provisional cluster elements are now typed as optional rather than always present
+    - Breaking: An onboarding payload's vendor and product ID are reported absent (undefined) where it states none instead of 0
     - Feature: Added the `ClusterLookup` namespace for cluster/attribute/command/event name↔id resolution (optional `MatterModel` for custom clusters)
     - Deprecation: The `ClusterType()` factory compat layer (`RetiredClusterType`, `RetiredElements`, the TLV `element` reverse mapping) is scheduled for removal in 0.19
     - Deprecation: The generated `Cluster`, `Complete` and `<Name>Cluster` aliases and the `ClusterType.WithCompat` `with()` shim are scheduled for removal in 0.19
     - Fix: `Cluster.with()` rejects a feature the cluster does not define and returns one frozen namespace per selection
     - Fix: An onboarding payload carrying a vendor ID past the last test vendor, or a product ID of 0 beside a real vendor ID, is now rejected
     - Fix: A manual pairing code whose `VID_PID_PRESENT` bit disagrees with its length is now rejected
-    - Breaking: An onboarding payload's vendor and product ID are reported absent where it states none; the specification writes "unspecified" as 0, which callers had to know
 
 - @matter/testing
     - Enhancement: `certTest()` defines controller-side certification tests with per-step PICS gating, device-log expectations, and evidence recording; devices run as chip apps (docker or local binary) or matter.js test apps, selected via `MATTER_CERT_DEVICE`

--- a/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
+++ b/packages/node/src/behavior/system/commissioning/CommissioningClient.ts
@@ -1170,6 +1170,19 @@ export namespace CommissioningClient {
          * The device's long discriminator.
          */
         discriminator?: number;
+
+        /**
+         * The vendor the onboarding payload names, if it names one.
+         *
+         * A commissionable advertisement may state its own vendor and product (§ 4.3.1's `VP` record).
+         * Where both the payload and the advertisement name one, a device that disagrees is not the
+         * device the payload describes and is passed over — otherwise a code for one device silently
+         * onboards another sharing its discriminator.
+         */
+        vendorId?: VendorId;
+
+        /** The product the onboarding payload names, matched as {@link vendorId} is. */
+        productId?: number;
     }
 
     export interface PairingCodeOptions extends BaseCommissioningOptions {

--- a/packages/node/src/behavior/system/commissioning/RemoteDescriptor.ts
+++ b/packages/node/src/behavior/system/commissioning/RemoteDescriptor.ts
@@ -185,8 +185,10 @@ export namespace RemoteDescriptor {
         if (VP !== undefined) {
             const [vendor, product] = VP.split("+").map(part => Number.parseInt(part, 10));
 
-            long.vendorId = Number.isFinite(vendor) ? VendorId(vendor, false) : undefined;
-            long.productId = Number.isFinite(product) ? product : undefined;
+            // § 2.5.2 / § 2.5.3 write "unspecified" as 0, which is an identity the device declines to
+            // state rather than one a caller can match against
+            long.vendorId = Number.isFinite(vendor) && vendor !== 0 ? VendorId(vendor, false) : undefined;
+            long.productId = Number.isFinite(product) && product !== 0 ? product : undefined;
         }
 
         // DNS-SD caps SII/SAI at 1 hour, so a value at the cap may be a clamped advertisement of a larger

--- a/packages/node/src/behavior/system/controller/discovery/CommissioningDiscovery.ts
+++ b/packages/node/src/behavior/system/controller/discovery/CommissioningDiscovery.ts
@@ -115,24 +115,27 @@ export namespace CommissioningDiscovery {
      * in its 11-digit form and the record is optional — and absence never rejects, so this only ever
      * refuses a device that positively advertises something else.
      *
-     * Zero is "not stated" on either side, not a value to match: a QR payload always carries both
-     * fields and says nothing by setting them to zero (§ 2.5.2, § 2.5.3), which is also the only form
-     * in which a payload may name a product of zero at all. Mirrors CHIP's
-     * `SetUpCodePairer::NodeMatchesCurrentFilter`, whose `kNotAvailable` is zero.
+     * Mirrors CHIP's `SetUpCodePairer::NodeMatchesCurrentFilter`. Both codecs already report § 2.5.2 /
+     * § 2.5.3's "unspecified" as an absent identifier, so nothing here has to know that it is 0 on the
+     * wire.
      */
     export function identityMismatch(payload: Identity, advertised: Identity) {
-        if (stated(payload.vendorId) && stated(advertised.vendorId) && payload.vendorId !== advertised.vendorId) {
+        if (
+            payload.vendorId !== undefined &&
+            advertised.vendorId !== undefined &&
+            payload.vendorId !== advertised.vendorId
+        ) {
             return `it advertises vendor ${advertised.vendorId} where the onboarding payload names ${payload.vendorId}`;
         }
 
-        if (stated(payload.productId) && stated(advertised.productId) && payload.productId !== advertised.productId) {
+        if (
+            payload.productId !== undefined &&
+            advertised.productId !== undefined &&
+            payload.productId !== advertised.productId
+        ) {
             return `it advertises product ${advertised.productId} where the onboarding payload names ${payload.productId}`;
         }
 
         return undefined;
-    }
-
-    function stated(id?: number): id is number {
-        return id !== undefined && id !== 0;
     }
 }

--- a/packages/node/src/behavior/system/controller/discovery/CommissioningDiscovery.ts
+++ b/packages/node/src/behavior/system/controller/discovery/CommissioningDiscovery.ts
@@ -7,9 +7,11 @@
 import { CommissioningClient } from "#behavior/system/commissioning/CommissioningClient.js";
 import type { ClientNode } from "#node/ClientNode.js";
 import type { ServerNode } from "#node/ServerNode.js";
-import { ChannelType, Minutes } from "@matter/general";
+import { ChannelType, Logger, Minutes } from "@matter/general";
 import { Discovery } from "./Discovery.js";
 import { ParallelPaseDiscovery } from "./ParallelPaseDiscovery.js";
+
+const logger = Logger.get("CommissioningDiscovery");
 
 /**
  * Discovers and commissions nodes.  All discovered candidates are commissioned in parallel; the first to establish
@@ -62,6 +64,10 @@ export class CommissioningDiscovery extends ParallelPaseDiscovery<ClientNode> {
     protected override onDiscovered(node: ClientNode) {
         if (this.paseWon) return;
 
+        if (!this.#namesThisDevice(node)) {
+            return;
+        }
+
         const peers = this.owner.peers;
         this.registerAttempt(
             winOnPase =>
@@ -77,8 +83,56 @@ export class CommissioningDiscovery extends ParallelPaseDiscovery<ClientNode> {
             () => node,
         );
     }
+
+    #namesThisDevice(node: ClientNode) {
+        const { vendorId, productId } = CommissioningClient.PasscodeOptions(this.#options);
+        const mismatch = CommissioningDiscovery.identityMismatch({ vendorId, productId }, node.state.commissioning);
+
+        if (mismatch !== undefined) {
+            logger.info(`Passing over ${node}: ${mismatch}`);
+            return false;
+        }
+
+        return true;
+    }
 }
 
 export namespace CommissioningDiscovery {
     export type Options = Discovery.InstanceOptions & CommissioningClient.CommissioningOptions;
+
+    /** What an onboarding payload and a commissionable advertisement each say about a device's identity. */
+    export interface Identity {
+        vendorId?: number;
+        productId?: number;
+    }
+
+    /**
+     * Why `advertised` is not the device `payload` names, or `undefined` if it may be.
+     *
+     * Discovery browses one DNS-SD sub-service, so a discriminator is all it can narrow by; the vendor
+     * and product a payload names are checked against what the device advertises (§ 4.3.1's `VP`
+     * record) once it is found. Either side may say nothing — a manual pairing code carries no identity
+     * in its 11-digit form and the record is optional — and absence never rejects, so this only ever
+     * refuses a device that positively advertises something else.
+     *
+     * Zero is "not stated" on either side, not a value to match: a QR payload always carries both
+     * fields and says nothing by setting them to zero (§ 2.5.2, § 2.5.3), which is also the only form
+     * in which a payload may name a product of zero at all. Mirrors CHIP's
+     * `SetUpCodePairer::NodeMatchesCurrentFilter`, whose `kNotAvailable` is zero.
+     */
+    export function identityMismatch(payload: Identity, advertised: Identity) {
+        if (stated(payload.vendorId) && stated(advertised.vendorId) && payload.vendorId !== advertised.vendorId) {
+            return `it advertises vendor ${advertised.vendorId} where the onboarding payload names ${payload.vendorId}`;
+        }
+
+        if (stated(payload.productId) && stated(advertised.productId) && payload.productId !== advertised.productId) {
+            return `it advertises product ${advertised.productId} where the onboarding payload names ${payload.productId}`;
+        }
+
+        return undefined;
+    }
+
+    function stated(id?: number): id is number {
+        return id !== undefined && id !== 0;
+    }
 }

--- a/packages/node/test/behavior/system/controller/discovery/CommissioningIdentityTest.ts
+++ b/packages/node/test/behavior/system/controller/discovery/CommissioningIdentityTest.ts
@@ -49,14 +49,10 @@ describe("CommissioningDiscovery.identityMismatch", () => {
         );
     });
 
-    it("reads 0 as unstated on either side", () => {
-        // A QR payload always carries both fields and says nothing by zeroing them, so matching on 0
-        // would refuse every device that does name a vendor
-        expect(identityMismatch({ vendorId: 0, productId: 0 }, { vendorId: 0xfff1, productId: 0x8001 })).equal(
-            undefined,
-        );
-        expect(identityMismatch({ vendorId: 0xfff1, productId: 0x8001 }, { vendorId: 0, productId: 0 })).equal(
-            undefined,
-        );
+    it("compares only what both sides state", () => {
+        // § 2.5.2 / § 2.5.3's "unspecified" is 0 on the wire, and the payload codecs and the
+        // advertisement parser both report it as absent, so it never arrives here as a value
+        expect(identityMismatch({}, {})).equal(undefined);
+        expect(identityMismatch({ productId: 0x8001 }, { productId: 0x8001 })).equal(undefined);
     });
 });

--- a/packages/node/test/behavior/system/controller/discovery/CommissioningIdentityTest.ts
+++ b/packages/node/test/behavior/system/controller/discovery/CommissioningIdentityTest.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CommissioningDiscovery } from "#behavior/system/controller/discovery/CommissioningDiscovery.js";
+
+const { identityMismatch } = CommissioningDiscovery;
+
+describe("CommissioningDiscovery.identityMismatch", () => {
+    it("accepts a device advertising what the payload names", () => {
+        expect(
+            identityMismatch({ vendorId: 0xfff1, productId: 0x8001 }, { vendorId: 0xfff1, productId: 0x8001 }),
+        ).equal(undefined);
+    });
+
+    it("refuses a device advertising another vendor", () => {
+        expect(identityMismatch({ vendorId: 0xfff1 }, { vendorId: 0xfff2 })).match(
+            /advertises vendor 65522 where the onboarding payload names 65521/,
+        );
+    });
+
+    it("refuses a device advertising another product", () => {
+        expect(
+            identityMismatch({ vendorId: 0xfff1, productId: 0x8001 }, { vendorId: 0xfff1, productId: 0x8002 }),
+        ).match(/advertises product 32770 where the onboarding payload names 32769/);
+    });
+
+    it("accepts when the payload names no identity", () => {
+        // An 11-digit manual pairing code carries neither
+        expect(identityMismatch({}, { vendorId: 0xfff1, productId: 0x8001 })).equal(undefined);
+    });
+
+    it("accepts when the advertisement states no identity", () => {
+        // The VP record is optional, so its absence cannot be read as disagreement
+        expect(identityMismatch({ vendorId: 0xfff1, productId: 0x8001 }, {})).equal(undefined);
+    });
+
+    it("judges each half on its own presence", () => {
+        expect(identityMismatch({ vendorId: 0xfff1, productId: 0x8001 }, { vendorId: 0xfff1 }), "product absent").equal(
+            undefined,
+        );
+        expect(identityMismatch({ productId: 0x8001 }, { vendorId: 0xfff2, productId: 0x8001 }), "vendor absent").equal(
+            undefined,
+        );
+        expect(identityMismatch({ vendorId: 0xfff1 }, { vendorId: 0xfff2, productId: 0x8001 }), "vendor differs").match(
+            /advertises vendor/,
+        );
+    });
+
+    it("reads 0 as unstated on either side", () => {
+        // A QR payload always carries both fields and says nothing by zeroing them, so matching on 0
+        // would refuse every device that does name a vendor
+        expect(identityMismatch({ vendorId: 0, productId: 0 }, { vendorId: 0xfff1, productId: 0x8001 })).equal(
+            undefined,
+        );
+        expect(identityMismatch({ vendorId: 0xfff1, productId: 0x8001 }, { vendorId: 0, productId: 0 })).equal(
+            undefined,
+        );
+    });
+});

--- a/packages/nodejs-shell/src/shell/cmd_commission.ts
+++ b/packages/nodejs-shell/src/shell/cmd_commission.ts
@@ -8,7 +8,14 @@ import { Diagnostic, ImplementationError, Logger, Seconds } from "@matter/genera
 import { ClientNode, CommissioningClient } from "@matter/node";
 import { BasicInformationClient } from "@matter/node/behaviors/basic-information";
 import { DescriptorClient } from "@matter/node/behaviors/descriptor";
-import { DiscoveryCapabilitiesSchema, ManualPairingCodeCodec, NodeId, QrCode, QrPairingCodeCodec } from "@matter/types";
+import {
+    DiscoveryCapabilitiesSchema,
+    ManualPairingCodeCodec,
+    NodeId,
+    QrCode,
+    QrPairingCodeCodec,
+    VendorId,
+} from "@matter/types";
 import { GeneralCommissioning } from "@matter/types/clusters";
 import type { Argv } from "yargs";
 import { MatterNode } from "../MatterNode.js";
@@ -100,6 +107,8 @@ export default function commands(theNode: MatterNode) {
                                 async argv => {
                                     const { pairingCode, qrCode, nodeId: nodeIdStr, port, ip, ble, instanceId } = argv;
                                     let { setupPinCode, discriminator, shortDiscriminator, qrCodeIndex } = argv;
+                                    let vendorId: VendorId | undefined;
+                                    let productId: number | undefined;
 
                                     if ((ip === undefined) !== (port === undefined)) {
                                         console.log(
@@ -109,11 +118,17 @@ export default function commands(theNode: MatterNode) {
                                     }
 
                                     if (typeof pairingCode === "string" && pairingCode.length > 0) {
-                                        const { shortDiscriminator: pairingCodeShortDiscriminator, passcode } =
-                                            ManualPairingCodeCodec.decode(pairingCode);
+                                        const {
+                                            shortDiscriminator: pairingCodeShortDiscriminator,
+                                            passcode,
+                                            vendorId: codeVendorId,
+                                            productId: codeProductId,
+                                        } = ManualPairingCodeCodec.decode(pairingCode);
                                         shortDiscriminator = pairingCodeShortDiscriminator;
                                         setupPinCode = passcode;
                                         discriminator = undefined;
+                                        vendorId = codeVendorId;
+                                        productId = codeProductId;
                                     } else if (typeof qrCode === "string" && qrCode.length > 0) {
                                         const pairingCodeCodec = QrPairingCodeCodec.decode(qrCode);
                                         if (typeof qrCodeIndex !== "number") {
@@ -141,6 +156,11 @@ export default function commands(theNode: MatterNode) {
                                         discriminator = qrResult.discriminator;
                                         shortDiscriminator = undefined;
                                         setupPinCode = qrResult.passcode;
+                                        vendorId =
+                                            qrResult.vendorId === undefined
+                                                ? undefined
+                                                : VendorId(qrResult.vendorId, false);
+                                        productId = qrResult.productId;
                                         if (
                                             DiscoveryCapabilitiesSchema.decode(qrResult.discoveryCapabilities).ble &&
                                             !ble
@@ -165,6 +185,9 @@ export default function commands(theNode: MatterNode) {
                                     const commissioningOptions: CommissioningClient.CommissioningOptions = {
                                         passcode: setupPinCode,
                                         discriminator,
+                                        // Carried from the code so a device advertising another identity is passed over
+                                        vendorId,
+                                        productId,
                                         nodeId,
                                         // The shell subscribes on demand via the `subscribe` command, not at commission.
                                         autoSubscribe: false,

--- a/packages/testing/src/chip/cert/controller-adapter.ts
+++ b/packages/testing/src/chip/cert/controller-adapter.ts
@@ -380,8 +380,10 @@ export interface ControllerAdapter {
  */
 export interface OnboardingPayloadFields {
     version: number;
-    vendorId: number;
-    productId: number;
+
+    /** Absent where the payload states nothing, which § 2.5.2 / § 2.5.3 write as 0. */
+    vendorId?: number;
+    productId?: number;
 
     /** 0 standard, 1 user intent, 2 custom (§ 5.1.3.1 Table 59). */
     flowType: number;

--- a/packages/types/src/schema/PairingCodeSchema.ts
+++ b/packages/types/src/schema/PairingCodeSchema.ts
@@ -98,7 +98,15 @@ const QrCodeDataSchema = ByteArrayBitmapSchema({
     passcode: BitField(57, 27),
 });
 
-export type QrCodeData = TypeFromBitmapSchema<typeof QrCodeDataSchema> & {
+/**
+ * § 2.5.2 and § 2.5.3 give 0 the meaning "unspecified" for a vendor and a product. A QR payload
+ * carries both fields whether or not it names anything, so the codec reports an unspecified one as
+ * absent rather than as a value a caller might compare against.
+ */
+export type QrCodeData = Omit<TypeFromBitmapSchema<typeof QrCodeDataSchema>, "vendorId" | "productId"> & {
+    vendorId?: number;
+    productId?: number;
+} & {
     /**
      * See {@link MatterSpecification.v16.Core} § 5.1.5
      * Variable length TLV data. Zero length if TLV is not included. This data is byte-aligned.
@@ -176,6 +184,14 @@ export function assertValidPasscode(passcode: number): void {
     }
 }
 
+/** § 2.5.2 / § 2.5.3's "unspecified", which the codecs report as an absent identifier. */
+const UNSPECIFIED_ID = 0;
+
+/** An identifier as a caller should see it: absent when the payload states nothing. */
+function stated(id: number | undefined) {
+    return id === undefined || id === UNSPECIFIED_ID ? undefined : id;
+}
+
 /** Inclusive upper bound of a product identifier, which § 5.1.3.1 Table 59 carries in 16 bits. */
 const PRODUCT_ID_MAX = 0xffff;
 
@@ -193,14 +209,14 @@ const PRODUCT_ID_MAX = 0xffff;
  * whose own code cannot be generated does not start at all. What a commissioner must refuse to *act*
  * on is a separate question from what a device may render.
  */
-export function assertValidPayloadIdentity(vendorId: number, productId: number): void {
-    if (!VendorId.isValid(vendorId)) {
+export function assertValidPayloadIdentity(vendorId?: number, productId?: number): void {
+    if (vendorId !== undefined && !VendorId.isValid(vendorId)) {
         throw new UnexpectedDataError(`Invalid vendor ID ${vendorId} in onboarding payload`);
     }
-    if (!Number.isInteger(productId) || productId < 0 || productId > PRODUCT_ID_MAX) {
+    if (productId !== undefined && (!Number.isInteger(productId) || productId < 0 || productId > PRODUCT_ID_MAX)) {
         throw new UnexpectedDataError(`Invalid product ID ${productId} in onboarding payload`);
     }
-    if (productId === 0 && vendorId !== 0) {
+    if (productId === undefined && vendorId !== undefined) {
         throw new UnexpectedDataError(`Product ID 0 is reserved and cannot accompany vendor ID ${vendorId}`);
     }
 }
@@ -279,10 +295,16 @@ class QrPairingCodeSchema extends Schema<QrCodeData[], string> {
             payloadData
                 .map(payloadData => {
                     const { tlvData } = payloadData;
+                    // The fields are always on the wire; "unspecified" is written as 0 (§ 2.5.2, § 2.5.3)
+                    const fields = {
+                        ...payloadData,
+                        vendorId: payloadData.vendorId ?? UNSPECIFIED_ID,
+                        productId: payloadData.productId ?? UNSPECIFIED_ID,
+                    };
                     const data =
                         tlvData !== undefined && tlvData.byteLength > 0
-                            ? Bytes.of(Bytes.concat(QrCodeDataSchema.encode(payloadData), tlvData))
-                            : QrCodeDataSchema.encode(payloadData);
+                            ? Bytes.of(Bytes.concat(QrCodeDataSchema.encode(fields), tlvData))
+                            : QrCodeDataSchema.encode(fields);
                     const result = Base38.encode(data);
                     const length = PREFIX.length + result.length;
                     if (length > MATTER_QR_CODE_SINGLE_PAYLOAD_MAX_LENGTH) {
@@ -308,8 +330,11 @@ class QrPairingCodeSchema extends Schema<QrCodeData[], string> {
             .split("*")
             .map(encodedData => {
                 const data = Bytes.of(Base38.decode(encodedData));
+                const { vendorId, productId, ...fields } = QrCodeDataSchema.decode(data.slice(0, 11));
                 return {
-                    ...QrCodeDataSchema.decode(data.slice(0, 11)),
+                    ...fields,
+                    vendorId: stated(vendorId),
+                    productId: stated(productId),
                     tlvData: data.length > 11 ? data.slice(11) : undefined, // TlvData (if any) is after the fixed-length data
                 };
             });
@@ -427,7 +452,7 @@ class ManualPairingCodeSchema extends Schema<ManualPairingData, string> {
     /** Adds the identity rules {@link assertValidPayloadIdentity} applies to a code being read. */
     override decode(encoded: string, validate = true): ManualPairingData {
         const data = super.decode(encoded, validate);
-        if (validate && data.vendorId !== undefined && data.productId !== undefined) {
+        if (validate) {
             assertValidPayloadIdentity(data.vendorId, data.productId);
         }
         return data;
@@ -460,8 +485,9 @@ class ManualPairingCodeSchema extends Schema<ManualPairingData, string> {
         let vendorId: VendorId | undefined;
         let productId: number | undefined;
         if (hasVendorProductIds) {
-            vendorId = VendorId(parseInt(encoded.slice(10, 15)));
-            productId = parseInt(encoded.slice(15, 20));
+            const stated1 = stated(parseInt(encoded.slice(10, 15)));
+            vendorId = stated1 === undefined ? undefined : VendorId(stated1);
+            productId = stated(parseInt(encoded.slice(15, 20)));
         }
         return { shortDiscriminator, passcode, vendorId, productId };
     }

--- a/packages/types/test/schema/PairingCodeSchemaTest.ts
+++ b/packages/types/test/schema/PairingCodeSchemaTest.ts
@@ -202,11 +202,17 @@ describe("QrPairingCodeCodec", () => {
             );
         });
 
-        it("accepts a product ID of 0 when the payload names no vendor either", () => {
+        it("reports an unspecified vendor and product as absent, not as 0", () => {
             const [decoded] = QrPairingCodeCodec.decode("MT:000004KP00KA0648G00");
 
-            expect(decoded.vendorId).equal(0);
-            expect(decoded.productId).equal(0);
+            expect(decoded.vendorId).equal(undefined);
+            expect(decoded.productId).equal(undefined);
+        });
+
+        it("writes an absent identifier back as the 0 the wire carries", () => {
+            const [decoded] = QrPairingCodeCodec.decode("MT:000004KP00KA0648G00");
+
+            expect(QrPairingCodeCodec.encode([decoded])).equal("MT:000004KP00KA0648G00");
         });
 
         it("rejects decoding a vendor ID past the last test vendor", () => {
@@ -214,7 +220,7 @@ describe("QrPairingCodeCodec", () => {
         });
 
         it("decodes either when validation is disabled", () => {
-            expect(QrPairingCodeCodec.decode("MT:Y.K904KP00KA0648G00", false)[0].productId).equal(0);
+            expect(QrPairingCodeCodec.decode("MT:Y.K904KP00KA0648G00", false)[0].productId).equal(undefined);
             expect(QrPairingCodeCodec.decode("MT:U34J029Q00KA0648G00", false)[0].vendorId).equal(65525);
         });
     });
@@ -447,7 +453,7 @@ describe("ManualPairingCodeCodec", () => {
         });
 
         it("decodes it when validation is disabled", () => {
-            expect(ManualPairingCodeCodec.decode("749701123365521000006", false).productId).equal(0);
+            expect(ManualPairingCodeCodec.decode("749701123365521000006", false).productId).equal(undefined);
         });
 
         it("rejects a product ID the field cannot hold", () => {

--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -86,6 +86,11 @@ const WILDCARD_ENDPOINT = 0xffff;
  */
 const MAX_PATHS_PER_COMMAND = 64;
 
+/** § 2.5.2 / § 2.5.3 write "unspecified" as 0; callers see an absent identifier instead. */
+function stated(id: number) {
+    return id === 0 ? undefined : id;
+}
+
 /** `chip::Crypto::kSpake2p_Min_PBKDF_Iterations`, the cheapest verifier chip-tool accepts. */
 const PBKDF_ITERATIONS = 1000;
 
@@ -1169,8 +1174,9 @@ export class ChipToolControllerAdapter implements ControllerAdapter {
 
         return {
             version: payloadField(logs, code, /Version:\s+(\d+)/),
-            vendorId: payloadField(logs, code, /VendorID:\s+(\d+)/),
-            productId: payloadField(logs, code, /ProductID:\s+(\d+)/),
+            // chip-tool prints 0 for an identifier the payload states nothing about
+            vendorId: stated(payloadField(logs, code, /VendorID:\s+(\d+)/)),
+            productId: stated(payloadField(logs, code, /ProductID:\s+(\d+)/)),
             flowType: payloadField(logs, code, /Custom flow:\s+(\d+)/),
             discoveryCapabilities: payloadField(logs, code, /Discovery Bitmask:\s+0x([0-9A-Fa-f]{2})/, 16),
             discriminator: payloadField(logs, code, /Long discriminator:\s+(\d+)/),

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -48,6 +48,7 @@ import {
     NodeId,
     Status,
     StatusResponseError,
+    VendorId,
 } from "@matter/main/types";
 import { AttributeModel } from "@matter/model";
 import type {
@@ -266,6 +267,10 @@ function inferAttributeModel(id: number, value: unknown): AttributeModel {
 interface ResolvedCommissioningTarget {
     identifierData: CommissionableDeviceIdentifiers;
     passcode: number;
+
+    /** What the payload names, so a device advertising another identity is passed over. */
+    vendorId?: VendorId;
+    productId?: number;
 }
 
 /**
@@ -280,19 +285,24 @@ interface ResolvedCommissioningTarget {
  */
 function resolveCommissioningTarget(target: CommissioningTarget): ResolvedCommissioningTarget {
     if (target.qrPairingCode) {
-        const { discriminator, passcode } = singleQrPayload(target.qrPairingCode);
-        return { identifierData: { longDiscriminator: discriminator }, passcode };
+        const { discriminator, passcode, vendorId, productId } = singleQrPayload(target.qrPairingCode);
+        return {
+            identifierData: { longDiscriminator: discriminator },
+            passcode,
+            vendorId: VendorId(vendorId, false),
+            productId,
+        };
     }
     if (target.manualPairingCode !== undefined) {
         const code = target.manualPairingCode;
-        const { shortDiscriminator, passcode } = refusalOf(
+        const { shortDiscriminator, passcode, vendorId, productId } = refusalOf(
             () => ManualPairingCodeCodec.decode(code),
             `manual pairing code ${code}`,
         );
         if (shortDiscriminator === undefined) {
             throw new ImplementationError("Manual pairing code did not decode to a short discriminator");
         }
-        return { identifierData: { shortDiscriminator }, passcode };
+        return { identifierData: { shortDiscriminator }, passcode, vendorId, productId };
     }
     if (target.passcode === undefined || target.discriminator === undefined) {
         throw new ImplementationError(
@@ -807,12 +817,14 @@ export class InProcessControllerAdapter implements ControllerAdapter {
 
     commission(target: CommissioningTarget): Promise<CertNodeRef> {
         return runTagged(this.id, async () => {
-            const { identifierData, passcode } = resolveCommissioningTarget(target);
+            const { identifierData, passcode, vendorId, productId } = resolveCommissioningTarget(target);
             // A commissioned peer holds the sustained wildcard subscription that bootstraps its own structure
             // read, so the standalone post-commissioning read is suppressed — one read, not two.
             const peer = await this.#startedController.peers.commission({
                 ...identifierData,
                 passcode,
+                vendorId,
+                productId,
                 autoStateInitialize: false,
                 caseConnectionTimeout: target.singleHandshakeAttempt ? SINGLE_HANDSHAKE_TIMEOUT : undefined,
                 regulatoryLocation: GeneralCommissioning.RegulatoryLocationType.IndoorOutdoor,

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -289,7 +289,7 @@ function resolveCommissioningTarget(target: CommissioningTarget): ResolvedCommis
         return {
             identifierData: { longDiscriminator: discriminator },
             passcode,
-            vendorId: VendorId(vendorId, false),
+            vendorId: vendorId === undefined ? undefined : VendorId(vendorId, false),
             productId,
         };
     }


### PR DESCRIPTION
An onboarding code names a vendor and a product, and a commissionable device advertises its own. matter.js ignored both and paired with whatever answered on the discriminator, so a code for one device could silently onboard another that happens to share it.

Found while building the manual pairing code certification case (#4259), where the two commissioners disagreed: chip-tool refused, matter.js did not.

## Where the check goes

Discovery cannot filter on it. A DNS-SD browse covers one sub-service, which is why `CommissionableDeviceIdentifiers` is a union and a discriminator is all discovery can narrow by. The reference implementation browses by discriminator and then checks the identity of what it found, in `SetUpCodePairer::NodeMatchesCurrentFilter`. This does the same, where a discovered device becomes a commissioning candidate.

matter.js already parsed the advertised identity onto the discovered node (`RemoteDescriptor`'s handling of the `VP` record), and already carried a manual pairing code's vendor and product into the commissioning options — nothing consumed either. So this is mostly wiring plus the comparison.

## Absence never rejects

Either side may say nothing: a manual pairing code carries no identity in its 11-digit form, and the advertisement record is optional. Reading absence as disagreement would refuse perfectly good devices, so only a device positively advertising something else is passed over. Vendor and product are judged separately on their own presence, matching the reference implementation.

## How it is tested

The comparison is a pure function and is unit-tested directly — matching, mismatched vendor, mismatched product, either side absent, each half judged independently.

The behaviour is also visible end to end. TC-DD-3.17 step 6 hands the commissioner a code naming a vendor the harness device is not, and records which of the two outcomes the test plan allows actually happened. On this branch the matter.js run changed from

```
DUT onboarded the TH as node 1 despite the code naming another vendor
```

to

```
DUT terminated commissioning: DiscoveryError: discovery of node with discriminator 15
failed: No commissionable device found
```

which is what chip-tool already did. The certification case stays green through the change because it accepts both branches — it validates the fix but deliberately does not gate it, which is why the unit test exists.

## Verification

- Clean build, format check, lint and the full test suite green from the repository root
- The whole certification suite re-run against a matter.js device: 12 cases, all pass, including every commissioning-flow case that pairs from a code
- Compiling mutations: dropping the presence gate fails the "advertisement states no identity" test, disabling the product half fails its own

🤖 Generated with [Claude Code](https://claude.com/claude-code)