### PR TITLE
fix(general): honor a DNS-SD goodbye that follows a re-announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 ## __WORK IN PROGRESS__
 
 - @matter/general
-    - Breaking: `DnssdNames.Context.goodbyeProtectionWindow` and `DnssdNames.defaults.goodbyeProtectionWindow` are now `goodbyeDelay`, and `DnssdName.deleteRecord` no longer takes an `ifOlderThan` argument
+    - Breaking: `DnssdNames.Context.goodbyeProtectionWindow` and `DnssdNames.defaults.goodbyeProtectionWindow` are now `evictionDelay`, and `DnssdName.deleteRecord` no longer takes an `ifOlderThan` argument
     - Enhancement: New `MatterAggregateError.settleSeries()` runs tasks in order, continuing past a failure, and reports the accumulated errors
     - Enhancement: A storage driver states how long a consumer may buffer dirty values via `StorageDriver.writeCoalescingInterval`, defaulting to 20 minutes; `MemoryStorageDriver` reports `Instant`
     - Fix: Opening a namespace whose `driver.json` names an unregistered storage driver now throws `NoProviderError` instead of silently opening the existing data with a mismatched driver

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ The main work (all changes without a GitHub username in brackets in the below li
 ## __WORK IN PROGRESS__
 
 - @matter/general
+    - Breaking: `DnssdNames.Context.goodbyeProtectionWindow` and `DnssdNames.defaults.goodbyeProtectionWindow` are now `goodbyeDelay`, and `DnssdName.deleteRecord` no longer takes an `ifOlderThan` argument
     - Enhancement: New `MatterAggregateError.settleSeries()` runs tasks in order, continuing past a failure, and reports the accumulated errors
     - Enhancement: A storage driver states how long a consumer may buffer dirty values via `StorageDriver.writeCoalescingInterval`, defaulting to 20 minutes; `MemoryStorageDriver` reports `Instant`
     - Fix: Opening a namespace whose `driver.json` names an unregistered storage driver now throws `NoProviderError` instead of silently opening the existing data with a mismatched driver
     - Fix: DNS-SD ignores SRV records with port 0, an empty target or an out-of-range port
+    - Fix: DNS-SD honors a goodbye that arrives shortly after the same record was re-announced
     - Fix: DNS-SD resolution queries A/AAAA for the SRV target host instead of the service instance name
     - Fix: The `Symbol.metadata` polyfill no longer conflicts with `lib.esnext.decorators` in the published declarations
 

--- a/packages/general/src/net/dns-sd/DnssdName.ts
+++ b/packages/general/src/net/dns-sd/DnssdName.ts
@@ -7,8 +7,9 @@
 import { DnsRecord, DnsRecordType, SrvRecordValue } from "#codec/DnsCodec.js";
 import { Diagnostic } from "#log/Diagnostic.js";
 import { Logger } from "#log/Logger.js";
+import type { Duration } from "#time/Duration.js";
 import { Time } from "#time/Time.js";
-import type { Timestamp } from "#time/Timestamp.js";
+import { Timestamp } from "#time/Timestamp.js";
 import { Millis } from "#time/TimeUnit.js";
 import { Bytes } from "#util/Bytes.js";
 import { AsyncObserver, BasicObservable } from "#util/Observable.js";
@@ -173,22 +174,49 @@ export class DnssdName extends BasicObservable<[changes: DnssdName.Changes], May
         return true;
     }
 
-    deleteRecord(record: DnsRecord, ifOlderThan?: Timestamp) {
+    /**
+     * The record installed under {@link record}'s key, with that key, or undefined if we hold none.
+     */
+    #installedFor(record: DnsRecord): [key: string, record: DnssdName.Record] | undefined {
         const key = keyOf(record);
-        if (key === undefined) {
-            this.#deleteIfUnused();
+        if (key !== undefined) {
+            const installed = this.#records.get(key);
+            if (installed !== undefined) {
+                return [key, installed];
+            }
+        }
+
+        this.#deleteIfUnused();
+    }
+
+    /**
+     * Shorten a record's remaining lifetime to {@link delay}.  Never extends it.
+     */
+    expireRecord(record: DnsRecord, delay: Duration) {
+        const installed = this.#installedFor(record);
+        if (installed === undefined) {
             return;
         }
 
-        const recordWithExpire = this.#records?.get(key);
-        if (!recordWithExpire) {
-            this.#deleteIfUnused();
+        const [key, current] = installed;
+        const expiresAt = Timestamp(Time.nowMs + delay);
+        if (current.expiresAt <= expiresAt) {
             return;
         }
 
-        if (ifOlderThan !== undefined && recordWithExpire.installedAt >= ifOlderThan) {
+        const expiring = { ...current, ttl: delay, expiresAt };
+        this.#context.registerForExpiration(expiring);
+        this.#context.unregisterForExpiration(current);
+        this.#records.set(key, expiring);
+    }
+
+    deleteRecord(record: DnsRecord) {
+        const installed = this.#installedFor(record);
+        if (installed === undefined) {
             return;
         }
+
+        const [key, recordWithExpire] = installed;
 
         this.#records.delete(key);
         this.#recordCount--;

--- a/packages/general/src/net/dns-sd/DnssdNames.ts
+++ b/packages/general/src/net/dns-sd/DnssdNames.ts
@@ -43,7 +43,7 @@ export class DnssdNames {
     readonly #names = new Map<string, DnssdName>();
     readonly #expiration: Scheduler<DnssdName.Record>;
     readonly #discovered = new Observable<[name: DnssdName]>();
-    readonly #goodbyeProtectionWindow: Duration;
+    readonly #goodbyeDelay: Duration;
     readonly #minTtl: Duration;
     readonly #ttlGraceFactor: number;
 
@@ -63,7 +63,7 @@ export class DnssdNames {
         entropy,
         filter,
         filterNames,
-        goodbyeProtectionWindow,
+        goodbyeDelay,
         minTtl,
         ttlGraceFactor,
     }: DnssdNames.Context) {
@@ -74,7 +74,7 @@ export class DnssdNames {
             this.#addFilter(filter, filterNames);
         }
         this.#solicitor = new QueryMulticaster(this);
-        this.#goodbyeProtectionWindow = goodbyeProtectionWindow ?? DnssdNames.defaults.goodbyeProtectionWindow;
+        this.#goodbyeDelay = goodbyeDelay ?? DnssdNames.defaults.goodbyeDelay;
         this.#minTtl = minTtl ?? DnssdNames.defaults.minTtl;
         const effectiveGraceFactor = ttlGraceFactor ?? DEFAULT_TTL_GRACE_FACTOR;
         if (!(effectiveGraceFactor >= 1)) {
@@ -156,7 +156,6 @@ export class DnssdNames {
             this.#currentBatch = undefined;
         }
 
-        // Same-message goodbyes may have reverted discovery
         for (const name of newlyDiscovered ?? []) {
             if (name.isDiscovered) {
                 this.#discovered.emit(name);
@@ -168,7 +167,6 @@ export class DnssdNames {
         const records = [...message.answers, ...message.additionalRecords];
         const filtered = new Set(records);
         const sourceIntf = message.sourceIntf;
-        let goodbyesBefore: undefined | Timestamp;
 
         // Collect newly discovered names so we can emit after all records in the message are processed.  This ensures
         // that observers see the complete record set (e.g. both SRV and TXT) rather than partial state mid-message.
@@ -199,10 +197,9 @@ export class DnssdNames {
                 }
             } else {
                 packetRelevant = true;
-                if (goodbyesBefore === undefined) {
-                    goodbyesBefore = Timestamp(Time.nowMs - this.#goodbyeProtectionWindow);
-                }
-                name.deleteRecord(record, goodbyesBefore);
+                // A goodbye takes effect a second out so a host that reboots and re-announces immediately keeps its
+                // records (RFC 6762 §10.1)
+                name.expireRecord(record, this.#goodbyeDelay);
             }
         };
 
@@ -327,8 +324,8 @@ export class DnssdNames {
                 this.#stagedIpRecords.delete(key);
                 const now = Time.nowMs;
                 for (const { record, receivedAt, sourceIntf } of staged) {
-                    // Preserve original TTL and receivedAt so expiry math and goodbye-protection recovery both
-                    // reference the real discovery time rather than the replay moment
+                    // Preserve original TTL and receivedAt so expiry references the real discovery time rather
+                    // than the replay moment
                     if (now - receivedAt < record.ttl * this.#ttlGraceFactor) {
                         name.installRecord(record, { sourceIntf, installedAt: receivedAt });
                     }
@@ -498,12 +495,9 @@ export namespace DnssdNames {
         filterNames?: Iterable<string> | "all";
 
         /**
-         * The interval after discovering a record for which we ignore goodbyes.
-         *
-         * This serves as protection for out-of-order messages when a device expires then broadcasts the same record
-         * in a very short amount of time.
+         * How long a record survives a goodbye (RFC 6762 §10.1).
          */
-        goodbyeProtectionWindow?: Duration;
+        goodbyeDelay?: Duration;
 
         /**
          * Minimum TTL for PTR records.
@@ -538,7 +532,7 @@ export namespace DnssdNames {
     }
 
     export const defaults = {
-        goodbyeProtectionWindow: Seconds(1),
+        goodbyeDelay: Seconds(1),
         minTtl: Seconds(15), // This is the value that Apple uses
     };
 }

--- a/packages/general/src/net/dns-sd/DnssdNames.ts
+++ b/packages/general/src/net/dns-sd/DnssdNames.ts
@@ -43,7 +43,7 @@ export class DnssdNames {
     readonly #names = new Map<string, DnssdName>();
     readonly #expiration: Scheduler<DnssdName.Record>;
     readonly #discovered = new Observable<[name: DnssdName]>();
-    readonly #goodbyeDelay: Duration;
+    readonly #evictionDelay: Duration;
     readonly #minTtl: Duration;
     readonly #ttlGraceFactor: number;
 
@@ -63,7 +63,7 @@ export class DnssdNames {
         entropy,
         filter,
         filterNames,
-        goodbyeDelay,
+        evictionDelay,
         minTtl,
         ttlGraceFactor,
     }: DnssdNames.Context) {
@@ -74,7 +74,7 @@ export class DnssdNames {
             this.#addFilter(filter, filterNames);
         }
         this.#solicitor = new QueryMulticaster(this);
-        this.#goodbyeDelay = goodbyeDelay ?? DnssdNames.defaults.goodbyeDelay;
+        this.#evictionDelay = evictionDelay ?? DnssdNames.defaults.evictionDelay;
         this.#minTtl = minTtl ?? DnssdNames.defaults.minTtl;
         const effectiveGraceFactor = ttlGraceFactor ?? DEFAULT_TTL_GRACE_FACTOR;
         if (!(effectiveGraceFactor >= 1)) {
@@ -199,7 +199,7 @@ export class DnssdNames {
                 packetRelevant = true;
                 // A goodbye takes effect a second out so a host that reboots and re-announces immediately keeps its
                 // records (RFC 6762 §10.1)
-                name.expireRecord(record, this.#goodbyeDelay);
+                name.expireRecord(record, this.#evictionDelay);
             }
         };
 
@@ -495,9 +495,9 @@ export namespace DnssdNames {
         filterNames?: Iterable<string> | "all";
 
         /**
-         * How long a record survives a goodbye (RFC 6762 §10.1).
+         * How long a record survives once something supersedes it rather than replaces it (RFC 6762 §10.1).
          */
-        goodbyeDelay?: Duration;
+        evictionDelay?: Duration;
 
         /**
          * Minimum TTL for PTR records.
@@ -532,7 +532,7 @@ export namespace DnssdNames {
     }
 
     export const defaults = {
-        goodbyeDelay: Seconds(1),
+        evictionDelay: Seconds(1),
         minTtl: Seconds(15), // This is the value that Apple uses
     };
 }

--- a/packages/general/test/net/dns-sd/DnssdNamesTest.ts
+++ b/packages/general/test/net/dns-sd/DnssdNamesTest.ts
@@ -806,9 +806,6 @@ describe("DnssdNames", () => {
                 ["b", "2"],
             ]);
 
-            // Past goodbye-protection window so the deleteRecord is honoured
-            await MockTime.advance(Seconds(2));
-
             await server.mdns.send({
                 messageType: DnsMessageType.Response,
                 answers: [
@@ -822,7 +819,7 @@ describe("DnssdNames", () => {
                 ],
                 additionalRecords: [],
             });
-            await MockTime.advance(10);
+            await MockTime.advance(Seconds(2));
 
             expect([...client.names.get(qname).parameters]).deep.equals([]);
         });
@@ -870,9 +867,6 @@ describe("DnssdNames", () => {
                 ["b", "2"],
             ]);
 
-            // Past goodbye-protection window
-            await MockTime.advance(Seconds(2));
-
             // Goodbye the original TXT, then send a new TXT that omits key "a"
             await server.mdns.send({
                 messageType: DnsMessageType.Response,
@@ -894,7 +888,7 @@ describe("DnssdNames", () => {
                 ],
                 additionalRecords: [],
             });
-            await MockTime.advance(10);
+            await MockTime.advance(Seconds(2));
 
             expect([...client.names.get(qname).parameters]).deep.equals([["b", "3"]]);
         });
@@ -1120,6 +1114,57 @@ describe("DnssdNames", () => {
             expect(parameters.get("yy")).equal("");
             expect(parameters.has("flag")).true;
             expect(parameters.get("flag")).equal("");
+        });
+    });
+
+    describe("goodbyes", () => {
+        it("removes a record whose goodbye follows a re-announcement", async () => {
+            await using site = new MockSite();
+            const { client, server } = await site.addPair();
+
+            const qname = qnameOf(1);
+
+            const discovered = new Promise<void>(resolve => {
+                client.names.discovered.once(() => resolve());
+            });
+            await server.broadcast(1, Hours(1));
+            await MockTime.resolve(discovered);
+
+            // An advertisement re-announces on its own schedule, then the host departs
+            await MockTime.advance(Minutes(1));
+            await server.broadcast(1, Hours(1));
+            await MockTime.advance(Millis(100));
+
+            await server.broadcast(1, 0);
+            await MockTime.advance(Seconds(1));
+            await MockTime.advance(10);
+
+            expect(client.names.has(qname)).false;
+        });
+
+        it("keeps a record re-announced within the goodbye delay", async () => {
+            await using site = new MockSite();
+            const { client, server } = await site.addPair();
+
+            const qname = qnameOf(1);
+
+            const discovered = new Promise<void>(resolve => {
+                client.names.discovered.once(() => resolve());
+            });
+            await server.broadcast(1, Hours(1));
+            await MockTime.resolve(discovered);
+
+            await MockTime.advance(Minutes(1));
+            await server.broadcast(1, 0);
+            await MockTime.advance(Millis(100));
+
+            expect(client.names.has(qname)).true;
+
+            await server.broadcast(1, Hours(1));
+            await MockTime.advance(Seconds(1));
+            await MockTime.advance(10);
+
+            expect(client.names.has(qname)).true;
         });
     });
 

--- a/packages/protocol/test/mdns/CommissionableMdnsScannerTest.ts
+++ b/packages/protocol/test/mdns/CommissionableMdnsScannerTest.ts
@@ -249,7 +249,7 @@ describe("CommissionableMdnsScanner", () => {
         }
     });
 
-    it("accepts TTL=0 goodbye after protection window", async () => {
+    it("removes a device whose goodbye follows a re-announcement", async () => {
         const simulator = new NetworkSimulator();
         const serverNetwork = new MockNetwork(simulator, SERVER_MAC, [SERVER_IPv4, SERVER_IPv6]);
         const clientNetwork = new MockNetwork(simulator, CLIENT_MAC, [CLIENT_IPv4, CLIENT_IPv6]);
@@ -261,7 +261,7 @@ describe("CommissionableMdnsScanner", () => {
 
         try {
             const instanceQname = `${INSTANCE_ID}._matterc._udp.local`;
-            await serverSocket.send({
+            const announcement = {
                 messageType: DnsMessageType.Response,
                 answers: [
                     {
@@ -287,15 +287,16 @@ describe("CommissionableMdnsScanner", () => {
                     },
                 ],
                 additionalRecords: [],
-            });
+            };
+            await serverSocket.send(announcement);
 
             await MockTime.advance(10);
             expect(scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 3840 }).length).equals(1);
 
-            // Advance past the 1-second goodbye protection window
-            await MockTime.advance(Millis(1100));
+            await MockTime.advance(Minutes(1));
+            await serverSocket.send(announcement);
+            await MockTime.advance(10);
 
-            // Send TTL=0 (goodbye) — now outside the protection window
             await serverSocket.send({
                 messageType: DnsMessageType.Response,
                 answers: [
@@ -316,9 +317,9 @@ describe("CommissionableMdnsScanner", () => {
                 ],
                 additionalRecords: [],
             });
+            await MockTime.advance(Seconds(1));
             await MockTime.advance(10);
 
-            // Device should be removed — goodbye was accepted
             expect(scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 3840 }).length).equals(0);
         } finally {
             await scanner.close();

--- a/packages/protocol/test/mdns/CommissionableMdnsScannerTest.ts
+++ b/packages/protocol/test/mdns/CommissionableMdnsScannerTest.ts
@@ -249,7 +249,7 @@ describe("CommissionableMdnsScanner", () => {
         }
     });
 
-    it("removes a device whose goodbye follows a re-announcement", async () => {
+    it("removes a device whose goodbye follows a re-announcement, and finds it again when it returns", async () => {
         const simulator = new NetworkSimulator();
         const serverNetwork = new MockNetwork(simulator, SERVER_MAC, [SERVER_IPv4, SERVER_IPv6]);
         const clientNetwork = new MockNetwork(simulator, CLIENT_MAC, [CLIENT_IPv4, CLIENT_IPv6]);
@@ -321,6 +321,11 @@ describe("CommissionableMdnsScanner", () => {
             await MockTime.advance(10);
 
             expect(scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 3840 }).length).equals(0);
+
+            await serverSocket.send(announcement);
+            await MockTime.advance(10);
+
+            expect(scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 3840 }).length).equals(1);
         } finally {
             await scanner.close();
             await clientNames.close();


### PR DESCRIPTION
## What a goodbye is, and what went wrong

A DNS-SD responder that stops advertising sends a *goodbye* — the same record with a time-to-live of zero — so listeners drop it at once instead of holding it until it would have expired on its own.

matter.js ignored a goodbye whenever the record had been announced again in the preceding second.

The guard existed to survive out-of-order delivery: a host that departs and immediately re-announces can have the two messages arrive in the wrong order, and honoring the goodbye would then throw away a record that is still valid. But the timestamp it compared against is refreshed by *every* ordinary re-announcement, so it also swallowed correctly ordered announce-then-depart pairs. That is the common case rather than the exception, because a departing matter.js device waits for its in-flight announcement to finish before sending the goodbye — the two are milliseconds apart by construction.

The record then lived out its full time-to-live, up to two minutes, naming a device that had gone.

## Why it matters

A controller that has seen a device keeps offering it for commissioning after the device stops advertising.

It also produced an intermittent certification failure on `main`. `TC-DD-3.17` step 4.b hands the commissioner a pairing code naming a device the network does not carry and asserts that nothing is commissioned; roughly one run in sixteen it commissioned one anyway, in under a second. The advertisement it matched was left behind by an earlier test in the same process — an enhanced commissioning window whose randomly chosen discriminator happened to share its short form with the deliberately wrong code. The device had gone, its goodbye had been dropped, and the address in the stale record still reached a live device.

## The fix

A goodbye now shortens the record's remaining lifetime to one second instead of deleting it under a guard, which is what RFC 6762 section 10.1 prescribes. A re-announcement inside that second reinstalls the record with its own time-to-live and so revives it — the same out-of-order protection, keyed on a later announcement actually arriving rather than on how much time has passed.

`DnssdName.expireRecord(record, delay)` is a general shortening primitive that never extends a lifetime; the goodbye rationale lives at its one call site.

## Breaking

- `DnssdNames.Context.goodbyeProtectionWindow` and `DnssdNames.defaults.goodbyeProtectionWindow` are now `goodbyeDelay`
- `DnssdName.deleteRecord` no longer takes an `ifOlderThan` argument

Both are published API (`@matter/general` re-exports them), shipped in 0.16.8. No caller in this repository passed either.

## Tests

Two new tests in `DnssdNamesTest` and one in `CommissionableMdnsScannerTest`, each verified to fail against the unmodified baseline:

- a record whose goodbye follows a re-announcement is removed (previously it survived its full TTL)
- a record re-announced within the delay is kept, and is still present 100 ms after its goodbye — which is where the old code had already deleted it
- at scanner level, a commissionable device whose goodbye follows a re-announcement stops being discovered

Two existing TXT tests were updated because removal is now deferred by a second. Those document the behaviour change; they are not evidence for the fix.

## Known adjacent gap, not addressed here

`flushCache` is decoded onto every record and honored nowhere. RFC 6762 section 10.2 asks for exactly the primitive this change introduces. Being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)