### PR TITLE
fix(protocol): set the mDNS cache-flush bit on the records this node owns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,8 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Attribute, event and connection-state log lines are recognized by the web UI again, so node tiles and device values update; event lines name the peer and render their timestamp according to the wire variant the device sent
 
 - @matter/protocol
+    - Fix: mDNS advertisements set the cache-flush bit on the SRV, TXT and address records unique to the node
+    - Fix: mDNS known-answer suppression compares what identifies a record rather than its wire framing, and honors RFC 6762 §7.1's remaining-lifetime rule
     - Deprecation: The legacy `DecodedDataReport` / `Decoded{Attribute,Event}Report*` types and the `normalize*` / `normalizeAndDecode*` helpers now announce removal in 0.19 instead of 0.18
     - Deprecation: The legacy `ClusterType` command request surface (`Invoke.LegacyCommandRequest`, `Specifier.ClusterTypeCommand`) and `SessionManager.owner` are scheduled for removal in 0.19
     - Enhancement: Network profiles accept a separate `bdxAdditionalMrpDelay` for bulk transfer, defaulting to the profile's messaging margin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,8 +107,10 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/protocol
     - Fix: mDNS advertisements set the cache-flush bit on the SRV, TXT and address records unique to the node
-    - Fix: mDNS known-answer suppression compares what identifies a record, and honors RFC 6762 §7.1's remaining-lifetime rule
-    - Fix: an mDNS response drops the cache-flush bit where it no longer carries the whole record set, and where it is sent by unicast
+    - Fix: mDNS known-answer suppression compares what identifies a record
+    - Fix: mDNS known-answer suppression only applies while more than half the known answer's lifetime remains
+    - Fix: an mDNS response drops the cache-flush bit where it no longer carries the whole record set
+    - Fix: a unicast mDNS response does not carry the cache-flush bit
     - Deprecation: The legacy `DecodedDataReport` / `Decoded{Attribute,Event}Report*` types and the `normalize*` / `normalizeAndDecode*` helpers now announce removal in 0.19 instead of 0.18
     - Deprecation: The legacy `ClusterType` command request surface (`Invoke.LegacyCommandRequest`, `Specifier.ClusterTypeCommand`) and `SessionManager.owner` are scheduled for removal in 0.19
     - Enhancement: Network profiles accept a separate `bdxAdditionalMrpDelay` for bulk transfer, defaulting to the profile's messaging margin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,11 +106,6 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: Attribute, event and connection-state log lines are recognized by the web UI again, so node tiles and device values update; event lines name the peer and render their timestamp according to the wire variant the device sent
 
 - @matter/protocol
-    - Fix: mDNS advertisements set the cache-flush bit on the SRV, TXT and address records unique to the node
-    - Fix: mDNS known-answer suppression compares what identifies a record
-    - Fix: mDNS known-answer suppression only applies while more than half the known answer's lifetime remains
-    - Fix: an mDNS response drops the cache-flush bit where it no longer carries the whole record set
-    - Fix: a unicast mDNS response does not carry the cache-flush bit
     - Deprecation: The legacy `DecodedDataReport` / `Decoded{Attribute,Event}Report*` types and the `normalize*` / `normalizeAndDecode*` helpers now announce removal in 0.19 instead of 0.18
     - Deprecation: The legacy `ClusterType` command request surface (`Invoke.LegacyCommandRequest`, `Specifier.ClusterTypeCommand`) and `SessionManager.owner` are scheduled for removal in 0.19
     - Enhancement: Network profiles accept a separate `bdxAdditionalMrpDelay` for bulk transfer, defaulting to the profile's messaging margin
@@ -118,6 +113,11 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: Commissioning accepts `caseConnectionTimeout`, bounding how long it waits for the operational CASE connection that follows it; defaults to the previous fixed 4m15s
     - Fix: Cancelling BLE commissioning aborts the in-flight channel open
     - Fix: A subscription's `maxIntervalCeiling` is transmitted exactly as requested; jitter now applies only when we derive the ceiling ourselves
+    - Fix: mDNS advertisements set the cache-flush bit on the SRV, TXT and address records unique to the node
+    - Fix: mDNS known-answer suppression compares what identifies a record
+    - Fix: mDNS known-answer suppression only applies while more than half the known answer's lifetime remains
+    - Fix: an mDNS response drops the cache-flush bit where it no longer carries the whole record set
+    - Fix: a unicast mDNS response does not carry the cache-flush bit
 
 - @matter/react-native
     - Fix: The `storage.clear` variable now clears the storage on start as it does on Node.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,8 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/protocol
     - Fix: mDNS advertisements set the cache-flush bit on the SRV, TXT and address records unique to the node
-    - Fix: mDNS known-answer suppression compares what identifies a record rather than its wire framing, and honors RFC 6762 §7.1's remaining-lifetime rule
+    - Fix: mDNS known-answer suppression compares what identifies a record, and honors RFC 6762 §7.1's remaining-lifetime rule
+    - Fix: an mDNS response drops the cache-flush bit where it no longer carries the whole record set, and where it is sent by unicast
     - Deprecation: The legacy `DecodedDataReport` / `Decoded{Attribute,Event}Report*` types and the `normalize*` / `normalizeAndDecode*` helpers now announce removal in 0.19 instead of 0.18
     - Deprecation: The legacy `ClusterType` command request surface (`Invoke.LegacyCommandRequest`, `Specifier.ClusterTypeCommand`) and `SessionManager.owner` are scheduled for removal in 0.19
     - Enhancement: Network profiles accept a separate `bdxAdditionalMrpDelay` for bulk transfer, defaulting to the profile's messaging margin

--- a/packages/protocol/src/advertisement/mdns/MdnsAdvertisement.ts
+++ b/packages/protocol/src/advertisement/mdns/MdnsAdvertisement.ts
@@ -14,9 +14,9 @@ import {
     AAAARecord,
     ARecord,
     DnsRecord,
+    DnsRecordType,
     Duration,
     Logger,
-    isUniqueRecordType,
     NetworkInterfaceDetails,
     ServerAddress,
     SrvRecord,
@@ -178,10 +178,10 @@ export abstract class MdnsAdvertisement<T extends ServiceDescription = ServiceDe
             records.push(ip.includes(":") ? AAAARecord(hostname, ip) : ARecord(hostname, ip));
         }
 
-        // Records this node owns outright carry the cache-flush bit so peers replace their copies rather than hold
-        // both until the old one expires (RFC 6762 §10.2)
+        // We claim these names without probing for a conflict first (RFC 6762 §8.1), which Matter's 64-bit instance
+        // names and MAC-derived hostnames make an acceptable trade for not implementing §9 conflict resolution
         return records.map(record =>
-            isUniqueRecordType(record.recordType) ? { ...record, flushCache: true } : record,
+            DnsRecordType.isUnique(record.recordType) ? { ...record, flushCache: true } : record,
         );
     }
 

--- a/packages/protocol/src/advertisement/mdns/MdnsAdvertisement.ts
+++ b/packages/protocol/src/advertisement/mdns/MdnsAdvertisement.ts
@@ -16,6 +16,7 @@ import {
     DnsRecord,
     Duration,
     Logger,
+    isUniqueRecordType,
     NetworkInterfaceDetails,
     ServerAddress,
     SrvRecord,
@@ -177,7 +178,11 @@ export abstract class MdnsAdvertisement<T extends ServiceDescription = ServiceDe
             records.push(ip.includes(":") ? AAAARecord(hostname, ip) : ARecord(hostname, ip));
         }
 
-        return records;
+        // Records this node owns outright carry the cache-flush bit so peers replace their copies rather than hold
+        // both until the old one expires (RFC 6762 §10.2)
+        return records.map(record =>
+            isUniqueRecordType(record.recordType) ? { ...record, flushCache: true } : record,
+        );
     }
 
     get #txtValues() {

--- a/packages/protocol/src/mdns/MdnsServer.ts
+++ b/packages/protocol/src/mdns/MdnsServer.ts
@@ -143,11 +143,6 @@ export class MdnsServer {
                         );
                     }
                 }
-
-                // The cache-flush bit tells the receiver to drop everything else it holds for the name and type, so a
-                // set we have pruned must not carry it (RFC 6762 §10.2)
-                answers = withoutPartialFlush(answers, portRecords);
-                additionalRecords = withoutPartialFlush(additionalRecords, portRecords);
             }
 
             const now = Time.nowMs;
@@ -190,8 +185,8 @@ export class MdnsServer {
                     {
                         messageType: DnsMessageType.Response,
                         transactionId,
-                        answers,
-                        additionalRecords,
+                        answers: sendable(answers, portRecords, uniCastResponse),
+                        additionalRecords: sendable(additionalRecords, portRecords, uniCastResponse),
                     },
                     sourceIntf,
                     uniCastResponse ? sourceIp : undefined,
@@ -314,17 +309,19 @@ export class MdnsServer {
     /**
      * Whether a querier's known answer already carries {@link record}.
      *
-     * Compares what identifies the record, not how it was framed: the cache-flush bit is meaningful only in a
-     * response, so a querier's copy never carries it and comparing it would suppress nothing.  Per RFC 6762 §7.1 a
-     * known answer only suppresses while more than half its lifetime remains.
+     * A record is identified by its name, type, class and value; the cache-flush bit is framing, meaningful only in a
+     * response.  A known answer suppresses only while more than half its lifetime remains.
+     *
+     * @see {@link https://www.rfc-editor.org/rfc/rfc6762#section-7.1} RFC 6762 §7.1
      */
     #suppressedByKnownAnswer(record: DnsRecord<any>, knownAnswer: DnsRecord<any>): boolean {
+        // Cheapest discriminators first: this runs once per (answer, known answer) pair on every inbound query
         return (
             record.recordType === knownAnswer.recordType &&
             record.recordClass === knownAnswer.recordClass &&
-            record.name.toLowerCase() === knownAnswer.name.toLowerCase() &&
-            isDeepEqual(record.value, knownAnswer.value) &&
-            knownAnswer.ttl >= record.ttl / 2
+            knownAnswer.ttl >= record.ttl / 2 &&
+            sameName(record.name, knownAnswer.name) &&
+            isDeepEqual(record.value, knownAnswer.value)
         );
     }
 
@@ -471,20 +468,50 @@ export namespace MdnsServer {
 }
 
 /**
- * Clears the cache-flush bit on records whose name and type are no longer completely represented in {@link sent}.
+ * Prepares records for the wire, clearing the cache-flush bit wherever we cannot honor what it claims.
+ *
+ * The bit says the receiver may drop everything else it holds for the name and type, which is only true if this
+ * response carries that whole set — suppression and rate limiting both remove records before we get here.  A legacy
+ * resolver, which we cannot distinguish because the source port does not reach us, must never see the bit at all, so
+ * a unicast response omits it.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc6762#section-10.2} RFC 6762 §10.2
+ * @see {@link https://www.rfc-editor.org/rfc/rfc6762#section-6.7} RFC 6762 §6.7
  */
-function withoutPartialFlush(sent: DnsRecord<any>[], complete: DnsRecord<any>[]) {
-    const countOf = (records: DnsRecord<any>[], of: DnsRecord<any>) =>
-        records.filter(
-            record =>
-                record.recordType === of.recordType &&
-                record.recordClass === of.recordClass &&
-                record.name.toLowerCase() === of.name.toLowerCase(),
-        ).length;
+function sendable(sent: DnsRecord<any>[], complete: DnsRecord<any>[], isUnicast: boolean) {
+    if (isUnicast) {
+        return sent.map(record => (record.flushCache ? { ...record, flushCache: false } : record));
+    }
+
+    if (!sent.some(record => record.flushCache)) {
+        return sent;
+    }
+
+    const sentSizes = setSizes(sent);
+    const completeSizes = setSizes(complete);
 
     return sent.map(record =>
-        record.flushCache && countOf(sent, record) !== countOf(complete, record)
+        record.flushCache && (sentSizes.get(setKeyOf(record)) ?? 0) < (completeSizes.get(setKeyOf(record)) ?? 0)
             ? { ...record, flushCache: false }
             : record,
     );
+}
+
+/** Identifies the record set a record belongs to: RFC 6762 scopes the cache-flush bit to one name, type and class. */
+function setKeyOf(record: DnsRecord<any>) {
+    return `${record.recordType}-${record.recordClass}-${record.name.toLowerCase()}`;
+}
+
+function setSizes(records: DnsRecord<any>[]) {
+    const sizes = new Map<string, number>();
+    for (const record of records) {
+        const key = setKeyOf(record);
+        sizes.set(key, (sizes.get(key) ?? 0) + 1);
+    }
+    return sizes;
+}
+
+/** DNS names are case-insensitive (RFC 6762 §16), but they rarely differ in case, so try the cheap comparison first. */
+function sameName(a: string, b: string) {
+    return a === b || a.toLowerCase() === b.toLowerCase();
 }

--- a/packages/protocol/src/mdns/MdnsServer.ts
+++ b/packages/protocol/src/mdns/MdnsServer.ts
@@ -319,7 +319,7 @@ export class MdnsServer {
         return (
             record.recordType === knownAnswer.recordType &&
             record.recordClass === knownAnswer.recordClass &&
-            knownAnswer.ttl >= record.ttl / 2 &&
+            knownAnswer.ttl > record.ttl / 2 &&
             sameName(record.name, knownAnswer.name) &&
             isDeepEqual(record.value, knownAnswer.value)
         );

--- a/packages/protocol/src/mdns/MdnsServer.ts
+++ b/packages/protocol/src/mdns/MdnsServer.ts
@@ -143,6 +143,11 @@ export class MdnsServer {
                         );
                     }
                 }
+
+                // The cache-flush bit tells the receiver to drop everything else it holds for the name and type, so a
+                // set we have pruned must not carry it (RFC 6762 §10.2)
+                answers = withoutPartialFlush(answers, portRecords);
+                additionalRecords = withoutPartialFlush(additionalRecords, portRecords);
             }
 
             const now = Time.nowMs;
@@ -306,10 +311,21 @@ export class MdnsServer {
         return netInterface === undefined ? this.network.getNetInterfaces() : [{ name: netInterface }];
     }
 
+    /**
+     * Whether a querier's known answer already carries {@link record}.
+     *
+     * Compares what identifies the record, not how it was framed: the cache-flush bit is meaningful only in a
+     * response, so a querier's copy never carries it and comparing it would suppress nothing.  Per RFC 6762 §7.1 a
+     * known answer only suppresses while more than half its lifetime remains.
+     */
     #suppressedByKnownAnswer(record: DnsRecord<any>, knownAnswer: DnsRecord<any>): boolean {
-        const lcName = knownAnswer.name.toLowerCase();
-        if (record.name.toLowerCase() !== lcName) return false;
-        return isDeepEqual({ ...record, name: lcName }, { ...knownAnswer, name: lcName }, true);
+        return (
+            record.recordType === knownAnswer.recordType &&
+            record.recordClass === knownAnswer.recordClass &&
+            record.name.toLowerCase() === knownAnswer.name.toLowerCase() &&
+            isDeepEqual(record.value, knownAnswer.value) &&
+            knownAnswer.ttl >= record.ttl / 2
+        );
     }
 
     #queryRecords({ name, recordType }: { name: string; recordType: DnsRecordType }, records: DnsRecord<any>[]) {
@@ -452,4 +468,23 @@ export namespace MdnsServer {
         /** Lower-cased names of records we own on this interface - used to fast-reject unrelated LAN queries. */
         ownedNames: Set<string>;
     }
+}
+
+/**
+ * Clears the cache-flush bit on records whose name and type are no longer completely represented in {@link sent}.
+ */
+function withoutPartialFlush(sent: DnsRecord<any>[], complete: DnsRecord<any>[]) {
+    const countOf = (records: DnsRecord<any>[], of: DnsRecord<any>) =>
+        records.filter(
+            record =>
+                record.recordType === of.recordType &&
+                record.recordClass === of.recordClass &&
+                record.name.toLowerCase() === of.name.toLowerCase(),
+        ).length;
+
+    return sent.map(record =>
+        record.flushCache && countOf(sent, record) !== countOf(complete, record)
+            ? { ...record, flushCache: false }
+            : record,
+    );
 }

--- a/packages/protocol/test/mdns/MdnsServerTest.ts
+++ b/packages/protocol/test/mdns/MdnsServerTest.ts
@@ -20,6 +20,7 @@ import {
     Network,
     NetworkSimulator,
     PtrRecord,
+    Seconds,
     SrvRecord,
     TxtRecord,
     UdpMulticastServer,
@@ -311,6 +312,103 @@ describe("MdnsServer", () => {
             await MockTime.yield3();
 
             expect(responses.flatMap(message => message?.answers ?? [])).deep.equals([PtrRecord(DUMMY_QNAME, "abcd")]);
+        });
+
+        it("suppresses only while more than half the known answer's lifetime remains", async () => {
+            for (const [remaining, expectSuppressed] of [
+                [Seconds(61), true],
+                [Seconds(59), false],
+            ] as const) {
+                await mdnsServer.setRecordsGenerator("foo", () => [PtrRecord(DUMMY_QNAME, "abcd"), flushed(DUMMY_SRV)]);
+                const responses = collectResponses();
+
+                send(
+                    DnsCodec.encode({
+                        messageType: DnsMessageType.Query,
+                        queries: [{ name: DUMMY_QNAME, recordClass: DnsRecordClass.IN, recordType: DnsRecordType.ANY }],
+                        answers: [
+                            SrvRecord(
+                                DUMMY_QNAME,
+                                { priority: 0, weight: 0, port: 1234, target: "abcd.local" },
+                                remaining,
+                            ),
+                        ],
+                    }),
+                    DUMMY_IP,
+                    INTERFACE_NAME,
+                );
+                await MockTime.yield3();
+
+                const sentSrv = responses
+                    .flatMap(message => message?.answers ?? [])
+                    .some(record => record.recordType === DnsRecordType.SRV);
+                expect(sentSrv).equals(!expectSuppressed);
+                await MockTime.advance(130_000);
+            }
+        });
+
+        it("drops the bit on an additional record whose set a known answer pruned", async () => {
+            const first = ARecord("abcd.local", DUMMY_IP);
+            const second = ARecord("abcd.local", "5.6.7.8");
+            await mdnsServer.setRecordsGenerator("foo", () => [
+                PtrRecord(DUMMY_QNAME, "abcd"),
+                flushed(first),
+                flushed(second),
+            ]);
+            const responses = collectResponses();
+
+            send(
+                DnsCodec.encode({
+                    messageType: DnsMessageType.Query,
+                    queries: [{ name: DUMMY_QNAME, recordClass: DnsRecordClass.IN, recordType: DnsRecordType.ANY }],
+                    answers: [first],
+                }),
+                DUMMY_IP,
+                INTERFACE_NAME,
+            );
+            await MockTime.yield3();
+
+            expect(responses.flatMap(message => message?.additionalRecords ?? [])).deep.equals([second]);
+        });
+
+        it("omits the bit from a unicast response", async () => {
+            await mdnsServer.setRecordsGenerator("foo", () => [PtrRecord(DUMMY_QNAME, "abcd"), flushed(DUMMY_SRV)]);
+
+            // A unicast request is answered by multicast unless the records went out as multicast recently, so
+            // establish that first
+            onResponse = async () => {};
+            send(
+                DnsCodec.encode({
+                    messageType: DnsMessageType.Query,
+                    queries: [{ name: DUMMY_QNAME, recordClass: DnsRecordClass.IN, recordType: DnsRecordType.ANY }],
+                }),
+                DUMMY_IP,
+                INTERFACE_NAME,
+            );
+            await MockTime.yield3();
+            await MockTime.advance(1000);
+
+            const responses = collectResponses();
+            send(
+                DnsCodec.encode({
+                    messageType: DnsMessageType.Query,
+                    queries: [
+                        {
+                            name: DUMMY_QNAME,
+                            recordClass: DnsRecordClass.IN,
+                            recordType: DnsRecordType.ANY,
+                            uniCastResponse: true,
+                        },
+                    ],
+                }),
+                DUMMY_IP,
+                INTERFACE_NAME,
+            );
+            await MockTime.yield3();
+
+            const sent = responses.flatMap(message => message?.answers ?? []);
+            expect(sent.length).greaterThan(0);
+            expect(sent.some(record => record.flushCache)).false;
         });
 
         it("drops the bit when a known answer leaves the record set incomplete", async () => {

--- a/packages/protocol/test/mdns/MdnsServerTest.ts
+++ b/packages/protocol/test/mdns/MdnsServerTest.ts
@@ -317,6 +317,7 @@ describe("MdnsServer", () => {
         it("suppresses only while more than half the known answer's lifetime remains", async () => {
             for (const [remaining, expectSuppressed] of [
                 [Seconds(61), true],
+                [Seconds(60), false],
                 [Seconds(59), false],
             ] as const) {
                 await mdnsServer.setRecordsGenerator("foo", () => [PtrRecord(DUMMY_QNAME, "abcd"), flushed(DUMMY_SRV)]);

--- a/packages/protocol/test/mdns/MdnsServerTest.ts
+++ b/packages/protocol/test/mdns/MdnsServerTest.ts
@@ -283,6 +283,76 @@ describe("MdnsServer", () => {
         });
     });
 
+    describe("Cache-flush bit", () => {
+        const DUMMY_SRV = SrvRecord(DUMMY_QNAME, { priority: 0, weight: 0, port: 1234, target: "abcd.local" });
+        const flushed = (record: DnsRecord<any>) => ({ ...record, flushCache: true });
+
+        function collectResponses() {
+            const responses = new Array<DnsMessage | undefined>();
+            onResponse = async (message: Bytes) => {
+                responses.push(DnsCodec.decode(message));
+            };
+            return responses;
+        }
+
+        it("suppresses a record the querier knows even though we flag it cache-flush", async () => {
+            await mdnsServer.setRecordsGenerator("foo", () => [PtrRecord(DUMMY_QNAME, "abcd"), flushed(DUMMY_SRV)]);
+            const responses = collectResponses();
+
+            send(
+                DnsCodec.encode({
+                    messageType: DnsMessageType.Query,
+                    queries: [{ name: DUMMY_QNAME, recordClass: DnsRecordClass.IN, recordType: DnsRecordType.ANY }],
+                    answers: [DUMMY_SRV],
+                }),
+                DUMMY_IP,
+                INTERFACE_NAME,
+            );
+            await MockTime.yield3();
+
+            expect(responses.flatMap(message => message?.answers ?? [])).deep.equals([PtrRecord(DUMMY_QNAME, "abcd")]);
+        });
+
+        it("drops the bit when a known answer leaves the record set incomplete", async () => {
+            const first = ARecord("abcd.local", DUMMY_IP);
+            const second = ARecord("abcd.local", "5.6.7.8");
+            await mdnsServer.setRecordsGenerator("foo", () => [flushed(first), flushed(second)]);
+            const responses = collectResponses();
+
+            send(
+                DnsCodec.encode({
+                    messageType: DnsMessageType.Query,
+                    queries: [{ name: "abcd.local", recordClass: DnsRecordClass.IN, recordType: DnsRecordType.A }],
+                    answers: [first],
+                }),
+                DUMMY_IP,
+                INTERFACE_NAME,
+            );
+            await MockTime.yield3();
+
+            expect(responses.flatMap(message => message?.answers ?? [])).deep.equals([second]);
+        });
+
+        it("keeps the bit when the whole record set is sent", async () => {
+            const first = ARecord("abcd.local", DUMMY_IP);
+            const second = ARecord("abcd.local", "5.6.7.8");
+            await mdnsServer.setRecordsGenerator("foo", () => [flushed(first), flushed(second)]);
+            const responses = collectResponses();
+
+            send(
+                DnsCodec.encode({
+                    messageType: DnsMessageType.Query,
+                    queries: [{ name: "abcd.local", recordClass: DnsRecordClass.IN, recordType: DnsRecordType.A }],
+                }),
+                DUMMY_IP,
+                INTERFACE_NAME,
+            );
+            await MockTime.yield3();
+
+            expect(responses.flatMap(message => message?.answers ?? [])).deep.equals([flushed(first), flushed(second)]);
+        });
+    });
+
     describe("Answer suppression", () => {
         it("suppress one answers in an ANY query", async () => {
             const responses = new Array<{ message?: DnsMessage; netInterface?: string; uniCastTarget?: string }>();

--- a/packages/protocol/test/mdns/MdnsTest.ts
+++ b/packages/protocol/test/mdns/MdnsTest.ts
@@ -67,7 +67,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
 
     const IPDnsRecords = [
         {
-            flushCache: false,
+            flushCache: true,
             name: "00B0D063C2260000.local",
             recordType: 28,
             recordClass: 1,
@@ -77,7 +77,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
     ];
     if (testIpv4Enabled && serverHasIpv4Addresses) {
         IPDnsRecords.push({
-            flushCache: false,
+            flushCache: true,
             name: "00B0D063C2260000.local",
             recordType: 1,
             recordClass: 1,
@@ -322,7 +322,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             value: "0000000000000018-0000000000000001._matter._tcp.local",
                         },
                         {
-                            flushCache: false,
+                            flushCache: true,
                             name: "0000000000000018-0000000000000001._matter._tcp.local",
                             recordType: 33,
                             recordClass: 1,
@@ -330,7 +330,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             value: { priority: 0, weight: 0, port: PORT, target: "00B0D063C2260000.local" },
                         },
                         {
-                            flushCache: false,
+                            flushCache: true,
                             name: "0000000000000018-0000000000000001._matter._tcp.local",
                             recordType: 16,
                             recordClass: 1,
@@ -389,7 +389,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             value: "0000000000000018-0000000000000001._matter._tcp.local",
                         },
                         {
-                            flushCache: false,
+                            flushCache: true,
                             name: "0000000000000018-0000000000000001._matter._tcp.local",
                             recordType: 33,
                             recordClass: 1,
@@ -397,7 +397,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             value: { priority: 0, weight: 0, port: PORT, target: "00B0D063C2260000.local" },
                         },
                         {
-                            flushCache: false,
+                            flushCache: true,
                             name: "0000000000000018-0000000000000001._matter._tcp.local",
                             recordType: 16,
                             recordClass: 1,
@@ -420,7 +420,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                     additionalRecords: [],
                     answers: [
                         {
-                            flushCache: false,
+                            flushCache: true,
                             name: "8080808080808080._matterc._udp.local",
                             recordClass: 1,
                             recordType: 33,
@@ -428,7 +428,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             value: { port: PORT, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
                         },
                         {
-                            flushCache: false,
+                            flushCache: true,
                             name: "8080808080808080._matterc._udp.local",
                             recordClass: 1,
                             recordType: 16,
@@ -559,7 +559,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                     additionalRecords: [],
                     answers: [
                         {
-                            flushCache: false,
+                            flushCache: true,
                             name: "8080808080808080._matterd._udp.local",
                             recordClass: 1,
                             recordType: 33,
@@ -567,7 +567,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             value: { port: PORT, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
                         },
                         {
-                            flushCache: false,
+                            flushCache: true,
                             name: "8080808080808080._matterd._udp.local",
                             recordClass: 1,
                             recordType: 16,
@@ -652,7 +652,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                     additionalRecords: [],
                     answers: [
                         {
-                            flushCache: false,
+                            flushCache: true,
                             name: "8080808080808080._matterd._udp.local",
                             recordClass: 1,
                             recordType: 33,
@@ -660,7 +660,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             value: { port: PORT, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
                         },
                         {
-                            flushCache: false,
+                            flushCache: true,
                             name: "8080808080808080._matterd._udp.local",
                             recordClass: 1,
                             recordType: 16,
@@ -766,7 +766,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             value: "0000000000000018-0000000000000001._matter._tcp.local",
                         },
                         {
-                            flushCache: false,
+                            flushCache: true,
                             name: "0000000000000018-0000000000000001._matter._tcp.local",
                             recordType: 33,
                             recordClass: 1,
@@ -774,7 +774,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             value: { priority: 0, weight: 0, port: PORT, target: "00B0D063C2260000.local" },
                         },
                         {
-                            flushCache: false,
+                            flushCache: true,
                             name: "0000000000000018-0000000000000001._matter._tcp.local",
                             recordType: 16,
                             recordClass: 1,
@@ -792,7 +792,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                     additionalRecords: [],
                     answers: [
                         {
-                            flushCache: false,
+                            flushCache: true,
                             name: "8080808080808080._matterc._udp.local",
                             recordClass: 1,
                             recordType: 33,
@@ -800,7 +800,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             value: { port: PORT2, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
                         },
                         {
-                            flushCache: false,
+                            flushCache: true,
                             name: "8080808080808080._matterc._udp.local",
                             recordClass: 1,
                             recordType: 16,
@@ -915,7 +915,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                     additionalRecords: [],
                     answers: [
                         {
-                            flushCache: false,
+                            flushCache: true,
                             name: "8080808080808080._matterd._udp.local",
                             recordClass: 1,
                             recordType: 33,
@@ -923,7 +923,7 @@ const COMMISSIONABLE_SERVICE = ServiceDescription.Commissionable({
                             value: { port: PORT3, priority: 0, target: "00B0D063C2260000.local", weight: 0 },
                         },
                         {
-                            flushCache: false,
+                            flushCache: true,
                             name: "8080808080808080._matterd._udp.local",
                             recordClass: 1,
                             recordType: 16,


### PR DESCRIPTION
Stacked on #4268 — based on that branch, so the diff here is only the send side. Retarget to `main` once #4268 merges.

**No human-facing review has run on this yet.** Opening it so review comments accumulate; treat it as draft-quality until that pass is done.

## What it does

A responder that owns a record set outright can tell listeners to replace their copies rather than hold both until the old one expires. matter.js never set that bit, so a peer that had seen this node kept its superseded SRV, TXT or address records for their full lifetime — up to two minutes after a commissioning window changed the discriminator, the commissioning mode, or the port.

The bit goes on SRV, TXT, A and AAAA, via the same `isUniqueRecordType` predicate the receive side uses. Never on the service pointer records: every commissionable device shares those, and a device claiming to own them would evict its neighbours from a listener's cache.

This goes further than CHIP, which sets the bit only on address records (`src/lib/dnssd/minimal_mdns/responders/IP.cpp`) and leaves SRV and TXT clear. That gap is filed separately for the SDK.

## Two responder defects had to be fixed first

Setting the bit is what exposes them, so they belong in the same change.

**Known-answer suppression compared the wire framing.** `#suppressedByKnownAnswer` used `isDeepEqual(…, true)`, whose third argument relaxes only the property *count* check — every shared property is still compared, `flushCache` included. A querier's copy never carries the bit, so once ours did, no record could ever match and we would have re-sent every record the querier had just told us it holds, on every query, forever. The comparison now looks at what identifies a record — name, type, class, value — and applies RFC 6762 §7.1's remaining-lifetime rule instead of demanding the querier echo our exact TTL.

`MdnsServerTest` could not have caught this: it installs its own generator built with the codec factories' `flushCache = false` default, so both sides of the comparison stayed `false` and all ten suppression tests kept passing.

**A pruned record set must not claim to be complete.** The bit promises the response carries the whole set for that name and type, and known-answer suppression removes individual records. A pruned set now goes out with the bit cleared. This could not fire before, because the suppression defect meant a record carrying the bit was never removed — fixing one arms the other.

I checked the other two places records are dropped before send: the 900 ms multicast filter keys on name and type without the value, so it is all-or-nothing per set and cannot split one; `#queryRecords` selects by type rather than pruning within a set.

## Tests

Three new cases in `MdnsServerTest`, each mutation-checked against the line it guards:

- restoring the `flushCache` comparison fails the suppression case
- pointing the completeness check at the pruned set instead of the generated one fails the partial-set case
- the complete-set case pins that we do not clear the bit unnecessarily

`MdnsTest` carries the wire expectations: 18 flip to `flushCache: true`, pointer records stay false. Reverting the advertisement change fails 15 of its 19 cases.

Full `npm test`, `format-verify` and `lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)