### PR TITLE
Let a PICS override survive a key chip declares twice

### DIFF
--- a/packages/testing/src/chip/matter-js-pics.properties
+++ b/packages/testing/src/chip/matter-js-pics.properties
@@ -104,8 +104,13 @@ CGEN.S.F00=0
 # We disabled the Frequency attributes in LevelControl cluster
 LVL.S.A0004..6=0
 
-# We do support Oven Mode cluster
+# We do support Oven Mode cluster.  Chip's ci-pics-values declares the cluster and its elements a second time with
+# everything disabled, so state the elements too or the test runs with every step skipped
 OTCCM.S=1
+OTCCM.S.A0000=1
+OTCCM.S.A0001=1
+OTCCM.S.C00.Rsp=1
+OTCCM.S.C01.Tx=1
 
 # We do support Water Heater Mode cluster
 WHM.S=1

--- a/packages/testing/src/chip/pics/file.ts
+++ b/packages/testing/src/chip/pics/file.ts
@@ -69,7 +69,11 @@ export class PicsFile {
     }
 
     patch(other: PicsFile) {
-        const newValues = { ...other.values };
+        const newValues = other.values;
+
+        // Chip's PICS files declare some keys more than once and the last declaration is the effective one, so an
+        // override must replace every occurrence or the file's own later value wins
+        const unapplied = { ...newValues };
 
         const newLines = new Array<string>();
         for (const line of this.lines) {
@@ -83,15 +87,15 @@ export class PicsFile {
                 const newValue = newValues[key];
                 if (newValue !== undefined) {
                     newLines.push(`${key}=${newValue}`);
-                    delete newValues[key];
+                    delete unapplied[key];
                 } else {
                     newLines.push(`${key}=${lineValues[key]}`);
                 }
             }
         }
 
-        for (const key in newValues) {
-            newLines.push(`${key}=${newValues[key]}`);
+        for (const key in unapplied) {
+            newLines.push(`${key}=${unapplied[key]}`);
         }
 
         this.#values = undefined;

--- a/support/chip-testing/test/cert-framework/pics.test.ts
+++ b/support/chip-testing/test/cert-framework/pics.test.ts
@@ -30,16 +30,15 @@ describe("PicsFile", () => {
             expect(base.values).deep.equal({ PICS_A: 1 });
         });
 
-        // Characterization of a known defect, not desired behaviour: only the first occurrence of a repeated key is
-        // overridden, and since the last occurrence is what `values` resolves to, such an override has no effect.
-        // Changing this shifts how every composed PICS file resolves, so it needs the affected suites run.
-        it("overrides only the first occurrence of a key the base file repeats", () => {
+        // Chip's files repeat keys and `values` resolves to the last one, so an override that stops at the first
+        // occurrence has no effect at all
+        it("overrides every occurrence of a key the base file repeats", () => {
             const base = new PicsFile(["PICS_A=1", "PICS_B=1", "PICS_A=1"]);
 
             const patched = base.with({ PICS_A: 0 });
 
-            expect(patched.lines).deep.equal(["PICS_A=0", "PICS_B=1", "PICS_A=1"]);
-            expect(patched.values.PICS_A).equal(1);
+            expect(patched.lines).deep.equal(["PICS_A=0", "PICS_B=1", "PICS_A=0"]);
+            expect(patched.values.PICS_A).equal(0);
         });
 
         it("keeps the base file's comments", () => {


### PR DESCRIPTION
Follow-up to #4272.

## The problem

Chip's `ci-pics-values` declares 36 of its 2547 keys more than once. Seven carry conflicting values — all Oven Mode, enabled in one block and disabled in a later one:

```
OTCCM.S=1                              … later …   OTCCM.S=0
OTCCM.S.A0000=1                                    OTCCM.S.A0000=0
OTCCM.S.A0001=1                                    OTCCM.S.A0001=0
OTCCM.S.C00.Rsp=1                                  OTCCM.S.C00.Rsp=0
OTCCM.S.C01.Tx=1                                   OTCCM.S.C01.Tx=0
OTCCM.S.M.CAN_TEST_MODE_FAILURE=1                  …=0
OTCCM.S.M.CAN_MANUALLY_CONTROLLED=1                …=0  (twice)
```

The remaining 29 duplicates repeat the same value.

Both readers take the last declaration — chip's `matter_yamltests/pics_checker.py::__parse` assigns `pics[key] = …` per line with no duplicate check, and ours matched that. But `PicsFile.patch()` rewrote only the **first** occurrence of an overridden key and then dropped it from its pending set, so the file's own later line won and our override silently evaporated.

Two of our overrides were affected, measured by running the real `PicsFile` over the real files:

| key | we declare | was effective | now |
|---|---|---|---|
| `OTCCM.S` | 1 | **0** | 1 |
| `DRLK.S.M.DetectLockJammed` | 0 | **1** | 0 |

`DetectLockJammed` was lost even though chip's two declarations agree — the first-occurrence bug alone was enough.

The `OTCCM.S=0` meant the Oven Mode tests were filtered out entirely: TC-OTCCM-2.1 has reported as passing in every leg while asserting nothing, so the oven's Oven Mode has never actually been exercised.

## The change

`patch()` now replaces every occurrence of an overridden key. The "append what wasn't in the file" pass tracks a separate set, so a key absent from the target is still appended exactly once.

Fixing that alone would select TC-OTCCM-2.1 but leave every step gated off, because its element keys are duplicated the same way and we don't name them. Our oven implements all four, so the override file now claims them:

- `OTCCM.S.A0000`, `OTCCM.S.A0001` — SupportedModes, CurrentMode
- `OTCCM.S.C00.Rsp`, `OTCCM.S.C01.Tx` — ChangeToMode and its response

Steps 2–4 of TC-OTCCM-2.1 therefore run for real: SupportedModes with the `minLength: 2` constraint (the oven cavity offers Grill and Bake), CurrentMode, and `ChangeToMode(current) → 0x00`. The two `OTCCM.S.M.*` capability keys stay off — we have no way to make an oven mode transition fail on demand.

## Verification

`npm run build`, `npm run format-verify`, `npm run lint` and `npm test` all pass. The effective-value delta was measured before and after against chip's real file: the six keys above change and nothing else.

Because this is the first run in which TC-OTCCM-2.1 asserts anything, CI is the real test of it.

## Upstream

The duplicate keys are chip's, and a repeated declaration silently deciding a test's fate is worth fixing there — deduplicate the file, and have the parser reject (or at least warn about) a duplicate key. Tracked for filing as a connectedhomeip issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
