### PR TITLE
Let a cert step factory reset a device, and stop the suite passing on evidence it lacks

### DIFF
--- a/packages/testing/src/chip/cert/cert-context.ts
+++ b/packages/testing/src/chip/cert/cert-context.ts
@@ -35,6 +35,13 @@ export interface DeviceExitInfo {
 export interface CertDevice extends Subject {
     readonly log: LogFollower;
     readonly flavor: DeviceFlavor;
+
+    /**
+     * Settles when the device's backing process or container ends without the harness having asked
+     * it to — and only then, so a `stop()` or a restart a step drives itself is not an exit in this
+     * sense. One latch therefore covers the device's whole life, and a run that restarts a device
+     * keeps the crash detection it armed before the first step.
+     */
     readonly exit: Promise<DeviceExitInfo>;
 
     /** The app variant this device actually runs, absent for a device whose flavor has no binary to vary. */

--- a/packages/testing/src/chip/cert/cert-dsl.ts
+++ b/packages/testing/src/chip/cert/cert-dsl.ts
@@ -489,11 +489,19 @@ class WiredCertTest extends CertTest {
             await super.invoke(subject, step, args, uncommissioned);
         } finally {
             this.#cx = undefined;
+
+            // The base tears down inside its own run, and does so for every path it can reach. This
+            // is the backstop for the ones it cannot — a throw before that run begins would otherwise
+            // leave this run's controllers open for the next test in the process. Idempotent, so the
+            // ordinary path closes nothing twice.
+            await this.teardown();
         }
     }
 
     protected override async teardown(): Promise<unknown[]> {
-        return this.#teardown(this.#openControllers);
+        const controllers = this.#openControllers;
+        this.#openControllers = {};
+        return this.#teardown(controllers);
     }
 
     protected override flavorFor(): DeviceFlavor {
@@ -601,7 +609,6 @@ class WiredCertTest extends CertTest {
 
     /** Closes everything this run opened, returning what refused to close rather than deciding for the caller. */
     async #teardown(controllers: Record<string, ControllerAdapter>): Promise<unknown[]> {
-        this.#openControllers = {};
         const errors = new Array<unknown>();
 
         for (const controller of Object.values(controllers)) {

--- a/packages/testing/src/chip/cert/cert-dsl.ts
+++ b/packages/testing/src/chip/cert/cert-dsl.ts
@@ -350,11 +350,20 @@ let matterJsCommitPromise: Promise<string> | undefined;
 function matterJsCommit(): Promise<string> {
     matterJsCommitPromise ??= execFileAsync("git", ["rev-parse", "HEAD"])
         .then(({ stdout }) => stdout.trim())
-        .catch(() => "(unknown)");
+        .catch(e => {
+            // Degraded provenance is not a failed run, but silence here is how a bundle comes to say
+            // "(unknown)" for a reason nobody can reconstruct afterwards
+            console.warn("Cert test cannot determine the matter.js commit:", e);
+            return "(unknown)";
+        });
     return matterJsCommitPromise;
 }
 
-/** Best-effort: a missing image/marker/label means no chip ref is available, not a test failure. */
+/**
+ * A missing image, marker or label means no chip ref is available, not a test failure — but anything
+ * else that stops us reading one is reported, or a bundle silently loses the provenance that is half
+ * its purpose.
+ */
 async function chipRefFor(flavor: DeviceFlavor, app: string): Promise<string | undefined> {
     try {
         switch (flavor) {
@@ -365,7 +374,8 @@ async function chipRefFor(flavor: DeviceFlavor, app: string): Promise<string | u
             case "matterjs":
                 return undefined;
         }
-    } catch {
+    } catch (e) {
+        console.warn(`Cert test cannot determine the chip ref for ${flavor} app "${app}":`, e);
         return undefined;
     }
 }
@@ -374,12 +384,23 @@ async function chipDockerImageRevision(app: string): Promise<string | undefined>
     const docker = new Docker();
     const image = Image(docker, `${chipImageBase()}-${app}:latest`);
     const info = await image.inspect();
-    return info.Config.Labels?.["org.opencontainers.image.revision"];
+    return info.Config?.Labels?.["org.opencontainers.image.revision"];
 }
 
 async function chipLocalMarkerRevision(): Promise<string | undefined> {
     const dir = await resolveChipLocalAppDir();
-    const text = await readFile(join(dir, "CHIP_REF"), "utf-8");
+
+    let text: string;
+    try {
+        text = await readFile(join(dir, "CHIP_REF"), "utf-8");
+    } catch (e) {
+        // A tree that did not come from an extraction carries no marker, which is not a fault
+        if (e instanceof Error && "code" in e && e.code === "ENOENT") {
+            return undefined;
+        }
+        throw e;
+    }
+
     const trimmed = text.trim();
     return trimmed === "" ? undefined : trimmed;
 }
@@ -399,7 +420,8 @@ async function chipToolRefFor(implementation: ControllerImplementation): Promise
     }
     try {
         return await chipLocalMarkerRevision();
-    } catch {
+    } catch (e) {
+        console.warn("Cert test cannot determine the chip-tool ref:", e);
         return undefined;
     }
 }
@@ -461,12 +483,39 @@ class WiredCertTest extends CertTest {
     ): Promise<void> {
         const cx = await this.#buildContext(subject);
         this.#cx = cx;
+
+        let failure: unknown;
+        let failed = false;
         try {
             await super.invoke(subject, step, args, uncommissioned);
+        } catch (e) {
+            failed = true;
+            failure = e;
         } finally {
             this.#cx = undefined;
-            await this.#teardown(cx.controllers);
+            const teardownErrors = await this.#teardown(cx.controllers);
+
+            // A controller that would not close has left a fabric, a session or a live subscription on
+            // the TH for the next test in this process to inherit, so the run cannot report success.
+            // The run's own failure keeps precedence. The evidence bundle is written before this, on
+            // purpose (see the finalization bound in cert-test.ts), so it is the run's outcome rather
+            // than the bundle that carries this.
+            if (teardownErrors.length > 0 && !failed) {
+                failed = true;
+                failure = new AggregateError(
+                    teardownErrors,
+                    `Cert test ${this.definition.tc}: ${teardownErrors.length} controller/device(s) failed to close`,
+                );
+            }
         }
+
+        if (failed) {
+            throw failure;
+        }
+    }
+
+    protected override flavorFor(): DeviceFlavor {
+        return this.#flavor;
     }
 
     protected override contextFor(_subject: Subject): CertStepContext {
@@ -567,7 +616,8 @@ class WiredCertTest extends CertTest {
         }
     }
 
-    async #teardown(controllers: Record<string, ControllerAdapter>): Promise<void> {
+    /** Closes everything this run opened, returning what refused to close rather than deciding for the caller. */
+    async #teardown(controllers: Record<string, ControllerAdapter>): Promise<unknown[]> {
         const errors = new Array<unknown>();
 
         for (const controller of Object.values(controllers)) {
@@ -591,5 +641,7 @@ class WiredCertTest extends CertTest {
         for (const error of errors) {
             console.warn("Error tearing down cert-test controller/device:", error);
         }
+
+        return errors;
     }
 }

--- a/packages/testing/src/chip/cert/cert-dsl.ts
+++ b/packages/testing/src/chip/cert/cert-dsl.ts
@@ -456,6 +456,8 @@ class WiredCertTest extends CertTest {
     #controllerRoles: Record<string, "dut" | "helper">;
     #deviceRoles: Record<string, string>;
     #cx?: CertStepContext;
+    /** Held apart from {@link #cx} so teardown does not depend on how long the context lives. */
+    #openControllers: Record<string, ControllerAdapter> = {};
     #extraDevices = new Array<CertDevice>();
     #recorder?: EvidenceRecorder;
 
@@ -483,35 +485,15 @@ class WiredCertTest extends CertTest {
     ): Promise<void> {
         const cx = await this.#buildContext(subject);
         this.#cx = cx;
-
-        let failure: unknown;
-        let failed = false;
         try {
             await super.invoke(subject, step, args, uncommissioned);
-        } catch (e) {
-            failed = true;
-            failure = e;
         } finally {
             this.#cx = undefined;
-            const teardownErrors = await this.#teardown(cx.controllers);
-
-            // A controller that would not close has left a fabric, a session or a live subscription on
-            // the TH for the next test in this process to inherit, so the run cannot report success.
-            // The run's own failure keeps precedence. The evidence bundle is written before this, on
-            // purpose (see the finalization bound in cert-test.ts), so it is the run's outcome rather
-            // than the bundle that carries this.
-            if (teardownErrors.length > 0 && !failed) {
-                failed = true;
-                failure = new AggregateError(
-                    teardownErrors,
-                    `Cert test ${this.definition.tc}: ${teardownErrors.length} controller/device(s) failed to close`,
-                );
-            }
         }
+    }
 
-        if (failed) {
-            throw failure;
-        }
+    protected override async teardown(): Promise<unknown[]> {
+        return this.#teardown(this.#openControllers);
     }
 
     protected override flavorFor(): DeviceFlavor {
@@ -563,6 +545,7 @@ class WiredCertTest extends CertTest {
             for (const name of Object.keys(this.#controllerRoles)) {
                 const controller = createControllerAdapter(name);
                 controllers[name] = controller;
+                this.#openControllers = controllers;
                 await controller.start();
             }
 
@@ -618,6 +601,7 @@ class WiredCertTest extends CertTest {
 
     /** Closes everything this run opened, returning what refused to close rather than deciding for the caller. */
     async #teardown(controllers: Record<string, ControllerAdapter>): Promise<unknown[]> {
+        this.#openControllers = {};
         const errors = new Array<unknown>();
 
         for (const controller of Object.values(controllers)) {

--- a/packages/testing/src/chip/cert/cert-test.ts
+++ b/packages/testing/src/chip/cert/cert-test.ts
@@ -207,30 +207,35 @@ export class CertTest extends BaseTest {
                 }
             }
 
-            deviceExitWatch.disarm();
-
             // After the flush, so a bundle exists even for a teardown that hangs against an
             // unreachable TH: it is the run's outcome, not the bundle, that carries a close failure.
             const teardownErrors = await this.teardown();
-            if (teardownErrors.length > 0 && !failed) {
-                failed = true;
-                failure = new AggregateError(
-                    teardownErrors,
-                    `Cert test ${tc}: ${teardownErrors.length} controller/device(s) failed to close, leaving state ` +
-                        "behind for whatever runs next",
-                );
+
+            const exited = deviceExitWatch.observed;
+            deviceExitWatch.disarm();
+
+            // In order: what the run itself hit, then a device that died under it — an exit settling
+            // too late for any step's race is still the run's own outcome — and only then cleanup.
+            if (!failed) {
+                if (exited !== undefined) {
+                    failed = true;
+                    failure = new Error(
+                        `A cert-test device exited unexpectedly (code ${exited.code}, signal ${exited.signal}) ` +
+                            "during the run",
+                    );
+                } else if (teardownErrors.length > 0) {
+                    failed = true;
+                    failure = new AggregateError(
+                        teardownErrors,
+                        `Cert test ${tc}: ${teardownErrors.length} controller/device(s) failed to close, leaving ` +
+                            "state behind for whatever runs next",
+                    );
+                }
             }
         }
 
         if (failed) {
             throw failure;
-        }
-
-        const exited = deviceExitWatch.observed;
-        if (exited !== undefined) {
-            throw new Error(
-                `A cert-test device exited unexpectedly (code ${exited.code}, signal ${exited.signal}) during the run`,
-            );
         }
     }
 

--- a/packages/testing/src/chip/cert/cert-test.ts
+++ b/packages/testing/src/chip/cert/cert-test.ts
@@ -66,7 +66,6 @@ export class CertTest extends BaseTest {
     ): Promise<void> {
         const cx = this.contextFor(subject);
         const { recorder, devices } = cx;
-        const picsFile = resolvePicsFile(subject)?.with(controllerPicsOverridesFor(resolveControllerImplementation()));
         const deviceExitWatch = watchDeviceExits(devices, recorder);
         const flavor = this.flavorFor(devices);
         const tc = this.#definition.tc;
@@ -92,6 +91,12 @@ export class CertTest extends BaseTest {
         };
 
         try {
+            // Inside the try: reading the subject's PICS, and resolving what the controller declares,
+            // can both throw, and everything this run opened is closed by the teardown below.
+            const picsFile = resolvePicsFile(subject)?.with(
+                controllerPicsOverridesFor(resolveControllerImplementation()),
+            );
+
             // Provenance reporting must never be why a run that would otherwise pass its steps
             // aborts before running any of them.
             try {

--- a/packages/testing/src/chip/cert/cert-test.ts
+++ b/packages/testing/src/chip/cert/cert-test.ts
@@ -208,6 +208,18 @@ export class CertTest extends BaseTest {
             }
 
             deviceExitWatch.disarm();
+
+            // After the flush, so a bundle exists even for a teardown that hangs against an
+            // unreachable TH: it is the run's outcome, not the bundle, that carries a close failure.
+            const teardownErrors = await this.teardown();
+            if (teardownErrors.length > 0 && !failed) {
+                failed = true;
+                failure = new AggregateError(
+                    teardownErrors,
+                    `Cert test ${tc}: ${teardownErrors.length} controller/device(s) failed to close, leaving state ` +
+                        "behind for whatever runs next",
+                );
+            }
         }
 
         if (failed) {
@@ -220,6 +232,15 @@ export class CertTest extends BaseTest {
                 `A cert-test device exited unexpectedly (code ${exited.code}, signal ${exited.signal}) during the run`,
             );
         }
+    }
+
+    /**
+     * Closes whatever this run opened, returning what refused to close. A close failure means state is
+     * left on the TH for the next run in this process, so {@link invoke} fails the run over it — unless
+     * the run failed on its own account, which keeps precedence.
+     */
+    protected async teardown(): Promise<unknown[]> {
+        return [];
     }
 
     /**

--- a/packages/testing/src/chip/cert/cert-test.ts
+++ b/packages/testing/src/chip/cert/cert-test.ts
@@ -68,7 +68,7 @@ export class CertTest extends BaseTest {
         const { recorder, devices } = cx;
         const picsFile = resolvePicsFile(subject)?.with(controllerPicsOverridesFor(resolveControllerImplementation()));
         const deviceExitWatch = watchDeviceExits(devices, recorder);
-        const flavor = currentFlavor(devices);
+        const flavor = this.flavorFor(devices);
         const tc = this.#definition.tc;
 
         let aborted = false;
@@ -113,8 +113,17 @@ export class CertTest extends BaseTest {
                 }
 
                 try {
-                    if (stepDef.flavors && flavor !== undefined && !stepDef.flavors.includes(flavor)) {
-                        report(stepDef, "skipped", `unsupported on device flavor "${flavor}"`);
+                    // A step that declares flavors never runs on an unknown one: taking silence for
+                    // consent would run it wherever the flavor could not be determined, which is the
+                    // one case its declaration cannot speak for.
+                    if (stepDef.flavors !== undefined && (flavor === undefined || !stepDef.flavors.includes(flavor))) {
+                        report(
+                            stepDef,
+                            "skipped",
+                            flavor === undefined
+                                ? `device flavor unknown, and this step declares ${stepDef.flavors.join("/")}`
+                                : `unsupported on device flavor "${flavor}"`,
+                        );
                         continue;
                     }
 
@@ -211,6 +220,14 @@ export class CertTest extends BaseTest {
                 `A cert-test device exited unexpectedly (code ${exited.code}, signal ${exited.signal}) during the run`,
             );
         }
+    }
+
+    /**
+     * The flavor this run's steps gate on. Derived from the devices by default; a run that knows its
+     * own flavor overrides this, since the devices are only as authoritative as whatever built them.
+     */
+    protected flavorFor(devices: Record<string, CertDevice>): DeviceFlavor | undefined {
+        return currentFlavor(devices);
     }
 
     /**

--- a/packages/testing/src/chip/cert/cert-test.ts
+++ b/packages/testing/src/chip/cert/cert-test.ts
@@ -75,6 +75,21 @@ export class CertTest extends BaseTest {
         let failure: unknown;
         let failed = false;
         let controllerUnsupportedSkips = 0;
+        let reportingFailure: unknown;
+
+        // Ends a step and announces its outcome. A throw here must not become the step's outcome —
+        // the step's own error takes precedence — but a run whose evidence could not be written must
+        // not report success either, so the first such failure is kept and applied below.
+        const report = (stepDef: CertStepDefinition, verdict: StepVerdict, skipReason?: string) => {
+            try {
+                announceStepEnd(cx, tc, stepDef, verdict, recorder.endStep(stepDef, verdict, skipReason));
+            } catch (e) {
+                if (reportingFailure === undefined) {
+                    reportingFailure = e;
+                }
+                console.warn(`Cert test ${tc} step ${stepDef.number}: reporting the ${verdict} outcome failed:`, e);
+            }
+        };
 
         try {
             // Provenance reporting must never be why a run that would otherwise pass its steps
@@ -88,41 +103,23 @@ export class CertTest extends BaseTest {
             for (const stepDef of this.#definition.steps) {
                 // A step that can never execute keeps its declared reason; "aborted by step N" loses it.
                 if (stepDef.notApplicable !== undefined) {
-                    announceStepEnd(
-                        cx,
-                        tc,
-                        stepDef,
-                        "skipped",
-                        recorder.endStep(stepDef, "skipped", stepDef.notApplicable),
-                    );
+                    report(stepDef, "skipped", stepDef.notApplicable);
                     continue;
                 }
 
                 if (aborted) {
-                    announceStepEnd(cx, tc, stepDef, "aborted", recorder.endStep(stepDef, "aborted"));
+                    report(stepDef, "aborted");
                     continue;
                 }
 
                 try {
                     if (stepDef.flavors && flavor !== undefined && !stepDef.flavors.includes(flavor)) {
-                        announceStepEnd(
-                            cx,
-                            tc,
-                            stepDef,
-                            "skipped",
-                            recorder.endStep(stepDef, "skipped", `unsupported on device flavor "${flavor}"`),
-                        );
+                        report(stepDef, "skipped", `unsupported on device flavor "${flavor}"`);
                         continue;
                     }
 
                     if (!stepPicsMet(stepDef, picsFile)) {
-                        announceStepEnd(
-                            cx,
-                            tc,
-                            stepDef,
-                            "skipped",
-                            recorder.endStep(stepDef, "skipped", `PICS "${stepDef.pics}" not met`),
-                        );
+                        report(stepDef, "skipped", `PICS "${stepDef.pics}" not met`);
                         continue;
                     }
 
@@ -134,18 +131,24 @@ export class CertTest extends BaseTest {
                 } catch (e) {
                     if (e instanceof UnsupportedByControllerError) {
                         controllerUnsupportedSkips++;
-                        announceStepEnd(cx, tc, stepDef, "skipped", recorder.endStep(stepDef, "skipped", e.message));
+                        report(stepDef, "skipped", e.message);
                         continue;
                     }
 
-                    announceStepEnd(cx, tc, stepDef, "fail", recorder.endStep(stepDef, "fail"));
                     aborted = true;
                     failed = true;
                     failure = e;
+
+                    report(stepDef, "fail");
                     continue;
                 }
 
-                announceStepEnd(cx, tc, stepDef, "pass", recorder.endStep(stepDef, "pass"));
+                report(stepDef, "pass");
+            }
+
+            if (!failed && reportingFailure !== undefined) {
+                failed = true;
+                failure = reportingFailure;
             }
 
             // Every remaining step in a run can skip as controller-unsupported without ever failing
@@ -374,12 +377,23 @@ function announceFinalizationFailure(cx: CertStepContext, tc: string, e: unknown
     announceStep(cx, [STEP_BANNER_RULE, `${tc} — Finalization: FAIL`, errorText(e), STEP_BANNER_RULE]);
 }
 
-/** One evidence line for `check`: a device-log check names its pattern/match, others their own detail. */
+/**
+ * One evidence line for `check`. The verdict leads, since a reader of the log excerpt has nothing
+ * else to tell a failed check from a passing one; a device-log check names its pattern and match, and
+ * every check that carries a detail says it — that is where a failed log check puts its reason.
+ */
 function formatCheckLine(check: CheckRecord): string {
+    const parts = new Array<string>();
+
     if (check.type === "device-log") {
-        return `pattern=${check.pattern ?? "(none)"} matched=${check.matched ?? "(none)"}`;
+        parts.push(`pattern=${check.pattern ?? "(none)"}`, `matched=${check.matched ?? "(none)"}`);
     }
-    return check.detail ?? "(no detail)";
+
+    if (check.detail !== undefined) {
+        parts.push(check.detail);
+    }
+
+    return `${check.verdict}: ${parts.length === 0 ? "(no detail)" : parts.join(" ")}`;
 }
 
 function announceStepEnd(
@@ -424,9 +438,8 @@ interface DeviceExitWatch {
 
 /**
  * Races every device's {@link CertDevice.exit} against the run and reports the first one that
- * settles to `recorder`. A device's own controlled `stop()`/`close()` (normal test teardown) always
- * runs after {@link CertTest.invoke} has already returned, so a resolution here during the run means
- * the device crashed independently of anything the test asked it to do.
+ * settles to `recorder`. {@link CertDevice.exit} settles only for an exit the harness did not ask
+ * for, so a resolution here means the device died independently of anything the test asked it to do.
  */
 function watchDeviceExits(devices: Record<string, CertDevice>, recorder: StepRecorder): DeviceExitWatch {
     let observed: DeviceExitInfo | undefined;

--- a/packages/testing/src/chip/cert/chip-app-subject.ts
+++ b/packages/testing/src/chip/cert/chip-app-subject.ts
@@ -97,6 +97,8 @@ interface DockerGeneration extends Generation {
     composition: CompositionHandle;
     /** Absent until the app container has been added, which `start()` may fail before. */
     container?: Container;
+    /** Set when this generation never came up, so a later `start()` replaces it rather than joining it. */
+    startFailed?: boolean;
 }
 
 function newGeneration(pumps: Promise<void>[]): Generation {
@@ -531,11 +533,12 @@ export class ChipDockerDevice implements CertDevice {
     async #launch(): Promise<void> {
         const previous = this.#generation;
         if (previous !== undefined) {
-            if (!previous.exited) {
+            // A generation that is up is joined; one that ended, or never came up at all, is replaced —
+            // reaping whatever it did manage to create, since a container it left behind is ours
+            if (!previous.exited && previous.startFailed !== true) {
                 return;
             }
-            this.#generation = undefined;
-            await this.#drain(previous);
+            await this.stop();
         }
 
         this.#assertNoVariant();
@@ -577,26 +580,33 @@ export class ChipDockerDevice implements CertDevice {
             ...this.#appArgs,
         ];
 
-        const container = await composition.add({
-            name: "app",
-            image: appImage,
-            recreate: true,
-            binds: { [volumeName]: "/run/dbus" },
-            command: args,
-        });
+        try {
+            const container = await composition.add({
+                name: "app",
+                image: appImage,
+                recreate: true,
+                binds: { [volumeName]: "/run/dbus" },
+                command: args,
+            });
 
-        generation.container = container;
+            generation.container = container;
 
-        // Deliberately not awaited — it runs for the container's whole lifetime and only settles this
-        // generation's latches, which stop() awaits separately. Its own try/catch means nothing is
-        // swallowed. Must stay ahead of anything that can throw below, so a start() that fails later
-        // still leaves stop() a latch that settles.
-        void this.#trackExit(generation, container);
+            // Deliberately not awaited — it runs for the container's whole lifetime and only settles
+            // this generation's latches, which stop() awaits separately. Its own try/catch means
+            // nothing is swallowed. Must stay ahead of anything that can throw below, so a start()
+            // that fails later still leaves stop() a latch that settles.
+            void this.#trackExit(generation, container);
 
-        // Attaching immediately after the container starts still risks losing whatever it printed in
-        // that gap — Docker doesn't let us attach before start.
-        const terminal = await container.attach(Terminal.Line);
-        generation.pumps.push(this.#hub.pump(terminal));
+            // Attaching immediately after the container starts still risks losing whatever it printed
+            // in that gap — Docker doesn't let us attach before start.
+            const terminal = await container.attach(Terminal.Line);
+            generation.pumps.push(this.#hub.pump(terminal));
+        } catch (e) {
+            // Marked rather than dropped: stop() still has to reap what this attempt created, and a
+            // later start() must not take this generation for a device that came up.
+            generation.startFailed = true;
+            throw e;
+        }
     }
 
     async #trackExit(generation: DockerGeneration, container: Container): Promise<void> {

--- a/packages/testing/src/chip/cert/chip-app-subject.ts
+++ b/packages/testing/src/chip/cert/chip-app-subject.ts
@@ -600,20 +600,27 @@ export class ChipDockerDevice implements CertDevice {
     }
 
     async #trackExit(generation: DockerGeneration, container: Container): Promise<void> {
-        let info: DeviceExitInfo;
         try {
             await container.wait();
-            info = { code: 0, signal: null };
+            this.#ended(generation, { code: 0, signal: null });
         } catch (e) {
             if (e instanceof NonZeroExitError) {
-                info = { code: e.code, signal: null };
-            } else {
-                console.warn(`Error waiting for cert device container ${this.id}:`, e);
-                info = { code: null, signal: null };
+                this.#ended(generation, { code: e.code, signal: null });
+                return;
             }
-        }
 
-        this.#ended(generation, info);
+            // The daemon did not tell us the container stopped, so we do not know that it did: the
+            // run can no longer trust the device, but the container stays a candidate for stop()'s
+            // kill, which composition.close() does not perform.
+            console.warn(`Error waiting for cert device container ${this.id}:`, e);
+            this.#report(generation, { code: null, signal: null });
+        }
+    }
+
+    /** {@link #report}s an end the daemon confirmed, which stop() then has nothing left to kill for. */
+    #ended(generation: DockerGeneration, info: DeviceExitInfo): void {
+        generation.exited = true;
+        this.#report(generation, info);
     }
 
     /**
@@ -621,8 +628,7 @@ export class ChipDockerDevice implements CertDevice {
      * for. The crash latch spans the device's whole life, so a run that restarts a device keeps the
      * detection it armed before its first step.
      */
-    #ended(generation: DockerGeneration, info: DeviceExitInfo): void {
-        generation.exited = true;
+    #report(generation: DockerGeneration, info: DeviceExitInfo): void {
         generation.terminated.resolve(info);
 
         if (!generation.stopping) {

--- a/packages/testing/src/chip/cert/chip-app-subject.ts
+++ b/packages/testing/src/chip/cert/chip-app-subject.ts
@@ -9,10 +9,11 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { env, platform as hostPlatform } from "node:process";
+import type { BackchannelCommand } from "../../device/backchannel.js";
 import type { Subject } from "../../device/subject.js";
 import type { Container } from "../../docker/container.js";
 import { Docker } from "../../docker/docker.js";
-import { NonZeroExitError } from "../../docker/errors.js";
+import { DockerError, NonZeroExitError } from "../../docker/errors.js";
 import { Terminal } from "../../docker/terminal.js";
 import { Volume } from "../../docker/volume.js";
 import { delay, LineQueue } from "../../util/async.js";
@@ -31,6 +32,11 @@ export { HARNESS_DBUS_CONTAINER };
 const DEFAULT_DISCRIMINATOR = 3840;
 const DEFAULT_PASSCODE = 20202021;
 const STOP_TIMEOUT_MS = 5_000;
+const DRAIN_TIMEOUT_MS = 5_000;
+
+// Killing a container and seeing it gone goes through the Docker daemon, so it is nothing like as
+// prompt as a SIGTERM to a local child.
+const CONTAINER_STOP_TIMEOUT_MS = 30_000;
 
 // Without these, a chip binary logs only its terse progress categories (EM/IN/SC) — the structured
 // `CHIP:DMG: ReadRequestMessage = { AttributePathIB = ... }` decode dumps cert-test log checks match
@@ -66,6 +72,35 @@ function throwUnsupported(flavor: DeviceFlavor, capability: string): never {
 interface ExitDeferred {
     promise: Promise<DeviceExitInfo>;
     resolve: (info: DeviceExitInfo) => void;
+}
+
+/**
+ * One run of a device's backing process or container. A cert step can restart a device, so every
+ * latch and every output pump belongs to the generation that created it: a handler still attached to
+ * a process that has gone must not be able to settle its successor's.
+ */
+interface Generation {
+    /** Settles when this generation ends, however it ended; `stop()` awaits this. */
+    terminated: ExitDeferred;
+    pumps: Promise<void>[];
+    /** Set once this generation has ended, so `start()` knows to replace it. */
+    exited: boolean;
+    /** Set while the harness is terminating this generation, which is not the crash `exit` reports. */
+    stopping: boolean;
+}
+
+interface LocalGeneration extends Generation {
+    child: ChildProcess;
+}
+
+interface DockerGeneration extends Generation {
+    composition: CompositionHandle;
+    /** Absent until the app container has been added, which `start()` may fail before. */
+    container?: Container;
+}
+
+function newGeneration(pumps: Promise<void>[]): Generation {
+    return { terminated: createExitDeferred(), pumps, exited: false, stopping: false };
 }
 
 function createExitDeferred(): ExitDeferred {
@@ -124,9 +159,9 @@ class ChipLocalDevice implements CertDevice {
     #appArgs: string[];
     #hub = new LineQueue();
     #storageDir?: string;
-    #child?: ChildProcess;
+    #generation?: LocalGeneration;
+    #starting?: Promise<void>;
     #exit: ExitDeferred = createExitDeferred();
-    #pumps = new Array<Promise<void>>();
 
     constructor(app: string, domain: string, options?: Subject.Options, appVariant?: string) {
         this.app = app;
@@ -151,8 +186,19 @@ class ChipLocalDevice implements CertDevice {
     }
 
     async start(): Promise<void> {
-        if (this.#child) {
-            return;
+        // One process per device, even when two callers start it at once
+        this.#starting ??= this.#spawn().finally(() => (this.#starting = undefined));
+        return this.#starting;
+    }
+
+    async #spawn(): Promise<void> {
+        const previous = this.#generation;
+        if (previous !== undefined) {
+            if (!previous.exited) {
+                return;
+            }
+            this.#generation = undefined;
+            await this.#drain(previous);
         }
 
         const dir = await resolveChipLocalAppDir();
@@ -178,52 +224,144 @@ class ChipLocalDevice implements CertDevice {
             throw new Error("Spawned process has no stdout/stderr streams");
         }
 
-        this.#child = child;
-        this.#exit = createExitDeferred();
-        this.#pumps = [this.#hub.pump(asyncLinesOf(stdout)), this.#hub.pump(asyncLinesOf(stderr))];
+        const generation: LocalGeneration = {
+            child,
+            ...newGeneration([this.#hub.pump(asyncLinesOf(stdout)), this.#hub.pump(asyncLinesOf(stderr))]),
+        };
+        this.#generation = generation;
+
+        let failSpawn: ((error: Error) => void) | undefined;
+        const spawned = new Promise<void>((resolve, reject) => {
+            failSpawn = reject;
+            child.once("spawn", () => {
+                failSpawn = undefined;
+                resolve();
+            });
+        });
 
         child.once("exit", (code, signal) => {
-            this.#exit.resolve({ code, signal });
+            // A process that never ran has already been reported through start()'s own rejection
+            if (failSpawn === undefined) {
+                this.#ended(generation, { code, signal });
+            }
         });
 
         child.once("error", error => {
-            // spawn() failures (e.g. ENOENT) surface via "error", not "exit" — the exit promise
-            // still needs to settle so a caller awaiting it doesn't hang.
-            this.#exit.resolve({ code: null, signal: null });
+            // spawn() failures (e.g. ENOENT) surface via "error", not "exit". The process never ran,
+            // so this is start()'s own failure rather than a device that died on its own.
+            if (failSpawn !== undefined) {
+                generation.exited = true;
+                generation.terminated.resolve({ code: null, signal: null });
+                if (this.#generation === generation) {
+                    this.#generation = undefined;
+                }
+                failSpawn(error);
+                return;
+            }
+
             console.warn(`Error running ${binPath}:`, error);
+            this.#ended(generation, { code: null, signal: null });
         });
+
+        try {
+            await spawned;
+        } catch (e) {
+            await this.#drain(generation);
+            throw e;
+        }
     }
 
-    async stop(): Promise<void> {
-        const child = this.#child;
-        if (!child) {
+    /**
+     * Settles `generation`'s own latch, and the device's crash latch only for an end nobody asked
+     * for. The crash latch spans the device's whole life, so a run that restarts a device keeps the
+     * detection it armed before its first step.
+     */
+    #ended(generation: Generation, info: DeviceExitInfo): void {
+        generation.exited = true;
+        generation.terminated.resolve(info);
+
+        if (!generation.stopping) {
+            this.#exit.resolve(info);
+        }
+    }
+
+    /**
+     * Awaits `generation`'s output pumps, bounded: a stream something else still holds open would
+     * otherwise stall a restart with nothing said about why.
+     */
+    async #drain(generation: Generation): Promise<void> {
+        const pumps = generation.pumps;
+        generation.pumps = [];
+        if (pumps.length === 0) {
             return;
         }
 
-        child.kill("SIGTERM");
-
-        const timer = delay(STOP_TIMEOUT_MS);
+        const timer = delay(DRAIN_TIMEOUT_MS);
         try {
-            const outcome = await Promise.race([this.#exit.promise.then((): "exited" => "exited"), timer.promise]);
+            const outcome = await Promise.race([
+                Promise.allSettled(pumps).then((results): "drained" => {
+                    for (const result of results) {
+                        if (result.status === "rejected") {
+                            console.warn("Error reading device output:", result.reason);
+                        }
+                    }
+                    return "drained";
+                }),
+                timer.promise,
+            ]);
+
             if (outcome === "timeout") {
-                child.kill("SIGKILL");
-                await this.#exit.promise;
+                console.warn(
+                    `Cert device ${this.id}: output pumps did not finish within ${DRAIN_TIMEOUT_MS}ms; ` +
+                        "continuing without them",
+                );
+                for (const pump of pumps) {
+                    void pump.catch(e => console.warn("Error reading device output:", e));
+                }
             }
         } finally {
             timer.cancel();
-            this.#child = undefined;
+        }
+    }
+
+    async stop(): Promise<void> {
+        const generation = this.#generation;
+        if (generation === undefined) {
+            return;
+        }
+
+        this.#generation = undefined;
+        generation.stopping = true;
+
+        try {
+            if (generation.exited) {
+                return;
+            }
+
+            const { child } = generation;
+            child.kill("SIGTERM");
+
+            const timer = delay(STOP_TIMEOUT_MS);
+            try {
+                const outcome = await Promise.race([
+                    generation.terminated.promise.then((): "exited" => "exited"),
+                    timer.promise,
+                ]);
+                if (outcome === "timeout") {
+                    child.kill("SIGKILL");
+                    await generation.terminated.promise;
+                }
+            } finally {
+                timer.cancel();
+            }
+        } finally {
+            await this.#drain(generation);
         }
     }
 
     async close(): Promise<void> {
         await this.stop();
 
-        const results = await Promise.allSettled(this.#pumps);
-        for (const result of results) {
-            if (result.status === "rejected") {
-                console.warn("Error reading device output:", result.reason);
-            }
-        }
         this.#hub.close();
 
         if (this.#storageDir) {
@@ -240,8 +378,37 @@ class ChipLocalDevice implements CertDevice {
         throwUnsupported(this.flavor, "snapshot/restore");
     }
 
-    async backchannel(): Promise<void> {
-        throwUnsupported(this.flavor, "backchannel simulation");
+    async backchannel(command: BackchannelCommand): Promise<void> {
+        switch (command.name) {
+            case "factoryReset":
+                await this.stop();
+
+                // A chip app is factory-new only once its key-value store is gone. Dropping the
+                // whole storage directory keeps this independent of the file layout the app's KVS
+                // implementation chooses; start() creates a fresh one.
+                if (this.#storageDir !== undefined) {
+                    await rm(this.#storageDir, { recursive: true, force: true });
+                    this.#storageDir = undefined;
+                }
+                await this.start();
+                break;
+
+            case "reboot":
+                await this.stop();
+                await this.start();
+                break;
+
+            case "stop":
+                await this.stop();
+                break;
+
+            case "start":
+                await this.start();
+                break;
+
+            default:
+                throwUnsupported(this.flavor, `the "${command.name}" backchannel command`);
+        }
     }
 }
 
@@ -309,10 +476,9 @@ export class ChipDockerDevice implements CertDevice {
     #appArgs: string[];
     #hub = new LineQueue();
     #docker: DockerHandle;
-    #composition?: CompositionHandle;
-    #container?: Container;
+    #generation?: DockerGeneration;
+    #starting?: Promise<void>;
     #exit: ExitDeferred = createExitDeferred();
-    #pump?: Promise<void>;
 
     constructor(
         app: string,
@@ -357,8 +523,19 @@ export class ChipDockerDevice implements CertDevice {
     }
 
     async start(): Promise<void> {
-        if (this.#container) {
-            return;
+        // One container per device, even when two callers start it at once
+        this.#starting ??= this.#launch().finally(() => (this.#starting = undefined));
+        return this.#starting;
+    }
+
+    async #launch(): Promise<void> {
+        const previous = this.#generation;
+        if (previous !== undefined) {
+            if (!previous.exited) {
+                return;
+            }
+            this.#generation = undefined;
+            await this.#drain(previous);
         }
 
         this.#assertNoVariant();
@@ -380,12 +557,16 @@ export class ChipDockerDevice implements CertDevice {
 
         await this.#docker.ensureVolume(volumeName);
 
+        // Installed before the container is added: a failing add() otherwise leaves the composition
+        // (and its network) behind with nothing holding a reference to close it.
         const composition = this.#docker.compose(`cert-${this.app}-${this.id}`, {
             platform,
             binds: { [volumeName]: "/run/dbus" },
             network: "host",
             autoRemove: true,
         });
+        const generation: DockerGeneration = { composition, ...newGeneration([]) };
+        this.#generation = generation;
 
         const args = [
             "--discriminator",
@@ -404,62 +585,138 @@ export class ChipDockerDevice implements CertDevice {
             command: args,
         });
 
-        this.#composition = composition;
-        this.#container = container;
-        this.#exit = createExitDeferred();
+        generation.container = container;
 
-        // Deliberately not awaited — it runs for the container's whole lifetime and only settles
-        // #exit, which stop()/close() await separately. Its own try/catch means nothing is swallowed.
-        // Must stay ahead of anything that can throw below: #container/#exit are already installed,
-        // so a start() that fails later still leaves stop() an #exit that settles.
-        void this.#trackExit(container);
+        // Deliberately not awaited — it runs for the container's whole lifetime and only settles this
+        // generation's latches, which stop() awaits separately. Its own try/catch means nothing is
+        // swallowed. Must stay ahead of anything that can throw below, so a start() that fails later
+        // still leaves stop() a latch that settles.
+        void this.#trackExit(generation, container);
 
-        // Attaching immediately after the container starts still risks losing whatever it printed
-        // in that gap — Docker doesn't let us attach before start. Acceptable for now; Task 6 smoke-
-        // tests this flavor end to end.
+        // Attaching immediately after the container starts still risks losing whatever it printed in
+        // that gap — Docker doesn't let us attach before start.
         const terminal = await container.attach(Terminal.Line);
-        this.#pump = this.#hub.pump(terminal);
+        generation.pumps.push(this.#hub.pump(terminal));
     }
 
-    async #trackExit(container: Container): Promise<void> {
+    async #trackExit(generation: DockerGeneration, container: Container): Promise<void> {
+        let info: DeviceExitInfo;
         try {
             await container.wait();
-            this.#exit.resolve({ code: 0, signal: null });
+            info = { code: 0, signal: null };
         } catch (e) {
             if (e instanceof NonZeroExitError) {
-                this.#exit.resolve({ code: e.code, signal: null });
+                info = { code: e.code, signal: null };
             } else {
                 console.warn(`Error waiting for cert device container ${this.id}:`, e);
-                this.#exit.resolve({ code: null, signal: null });
+                info = { code: null, signal: null };
             }
+        }
+
+        this.#ended(generation, info);
+    }
+
+    /**
+     * Settles `generation`'s own latch, and the device's crash latch only for an end nobody asked
+     * for. The crash latch spans the device's whole life, so a run that restarts a device keeps the
+     * detection it armed before its first step.
+     */
+    #ended(generation: DockerGeneration, info: DeviceExitInfo): void {
+        generation.exited = true;
+        generation.terminated.resolve(info);
+
+        if (!generation.stopping) {
+            this.#exit.resolve(info);
+        }
+    }
+
+    /**
+     * Awaits `generation`'s output pump, bounded: a terminal something else still holds open would
+     * otherwise stall a restart with nothing said about why.
+     */
+    async #drain(generation: DockerGeneration): Promise<void> {
+        const pumps = generation.pumps;
+        generation.pumps = [];
+        if (pumps.length === 0) {
+            return;
+        }
+
+        const timer = delay(DRAIN_TIMEOUT_MS);
+        try {
+            const outcome = await Promise.race([
+                Promise.allSettled(pumps).then((results): "drained" => {
+                    for (const result of results) {
+                        if (result.status === "rejected") {
+                            console.warn("Error reading device output:", result.reason);
+                        }
+                    }
+                    return "drained";
+                }),
+                timer.promise,
+            ]);
+
+            if (outcome === "timeout") {
+                console.warn(
+                    `Cert device ${this.id}: output pump did not finish within ${DRAIN_TIMEOUT_MS}ms; ` +
+                        "continuing without it",
+                );
+                for (const pump of pumps) {
+                    void pump.catch(e => console.warn("Error reading device output:", e));
+                }
+            }
+        } finally {
+            timer.cancel();
         }
     }
 
     async stop(): Promise<void> {
-        const container = this.#container;
-        if (!container) {
+        const generation = this.#generation;
+        if (generation === undefined) {
             return;
         }
 
-        try {
-            await container.kill();
-        } catch {
-            // Already stopped/removed (e.g. crashed) — nothing left to stop.
-        }
-        await this.#exit.promise;
+        this.#generation = undefined;
+        generation.stopping = true;
 
-        await this.#composition?.close();
-        this.#composition = undefined;
-        this.#container = undefined;
+        try {
+            const { container } = generation;
+            if (container !== undefined && !generation.exited) {
+                try {
+                    await container.kill();
+                } catch (e) {
+                    // A container that has already gone has nothing left to kill; every other cause
+                    // leaves it running, which the wait below then reports.
+                    DockerError.accept(e, 404, 409);
+                }
+
+                const timer = delay(CONTAINER_STOP_TIMEOUT_MS);
+                try {
+                    const outcome = await Promise.race([
+                        generation.terminated.promise.then((): "exited" => "exited"),
+                        timer.promise,
+                    ]);
+                    if (outcome === "timeout") {
+                        throw new Error(
+                            `Cert device container ${this.id} did not exit within ${CONTAINER_STOP_TIMEOUT_MS}ms`,
+                        );
+                    }
+                } finally {
+                    timer.cancel();
+                }
+            }
+        } finally {
+            // A container that would not die must still release the composition and its network
+            try {
+                await generation.composition.close();
+            } finally {
+                await this.#drain(generation);
+            }
+        }
     }
 
     async close(): Promise<void> {
         await this.stop();
 
-        if (this.#pump) {
-            await this.#pump.catch(e => console.warn("Error reading device output:", e));
-            this.#pump = undefined;
-        }
         this.#hub.close();
     }
 
@@ -471,8 +728,34 @@ export class ChipDockerDevice implements CertDevice {
         throwUnsupported(this.flavor, "snapshot/restore");
     }
 
-    async backchannel(): Promise<void> {
-        throwUnsupported(this.flavor, "backchannel simulation");
+    async backchannel(command: BackchannelCommand): Promise<void> {
+        switch (command.name) {
+            case "factoryReset":
+                // The app's key-value store lives in the container's own filesystem, which the
+                // composition discards when it stops, so a fresh container is a factory-new device.
+                await this.stop();
+                await this.start();
+                break;
+
+            case "reboot":
+                throwUnsupported(
+                    this.flavor,
+                    "rebooting with its key-value store intact: the store lives in the container's " +
+                        "filesystem, which is discarded when the container stops, so a restart here is a " +
+                        "factory reset. Restrict the test to the chip-local flavor",
+                );
+
+            case "stop":
+                await this.stop();
+                break;
+
+            case "start":
+                await this.start();
+                break;
+
+            default:
+                throwUnsupported(this.flavor, `the "${command.name}" backchannel command`);
+        }
     }
 }
 

--- a/packages/testing/src/chip/state.ts
+++ b/packages/testing/src/chip/state.ts
@@ -163,8 +163,9 @@ export const State = {
 
             const image = await State.container.image;
             const info = await image.inspect();
-            const chipCommit = formatSha(info.Config.Labels["org.opencontainers.image.revision"] ?? "(unknown)");
-            const imageVersion = info.Config.Labels["org.opencontainers.image.version"] ?? "(unknown)";
+            const labels = info.Config?.Labels;
+            const chipCommit = formatSha(labels?.["org.opencontainers.image.revision"] ?? "(unknown)");
+            const imageVersion = labels?.["org.opencontainers.image.version"] ?? "(unknown)";
             const arch = info.Architecture;
 
             progress.success(

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -21,7 +21,9 @@ import {
     Seconds,
     ServerNode,
     Time,
+    UnexpectedDataError,
 } from "@matter/main";
+import { OperationalCredentialsClient } from "@matter/main/behaviors/operational-credentials";
 import { GeneralCommissioning, OperationalCredentials } from "@matter/main/clusters";
 import {
     ClientRead,
@@ -383,12 +385,14 @@ class InProcessCertNodeApi implements CertNodeApi {
             // the whole point of this call is the one request, and a step proving how a device answers
             // a batch would silently prove nothing. This reads the same value the interaction's own
             // exchange provider does.
-            const maxPathsPerInvoke = this.#protocolPeer?.sessionParameters.maxPathsPerInvoke ?? 1;
-            if (commands.length > maxPathsPerInvoke) {
+            const advertised = this.#protocolPeer?.sessionParameters.maxPathsPerInvoke;
+            if (commands.length > (advertised ?? 1)) {
                 throw new ImplementationError(
-                    `invokeBatch of ${commands.length} commands, but node ${this.#nodeId} accepts ` +
-                        `${maxPathsPerInvoke} path(s) per invoke; the request would be split into separate ` +
-                        "interactions",
+                    `invokeBatch of ${commands.length} commands, but ` +
+                        (advertised === undefined
+                            ? `node ${this.#nodeId} has no protocol peer yet, so its limit is unknown and taken as 1`
+                            : `node ${this.#nodeId} accepts ${advertised} path(s) per invoke`) +
+                        "; the request would be split into separate interactions",
                 );
             }
 
@@ -404,9 +408,10 @@ class InProcessCertNodeApi implements CertNodeApi {
                 for (const entry of chunk) {
                     const index = entry.commandRef === undefined ? undefined : entry.commandRef - 1;
                     if (index === undefined || index < 0 || index >= commands.length) {
-                        throw new InternalError(
+                        throw new UnexpectedDataError(
                             `Invoke response carries commandRef ${entry.commandRef}, which belongs to no command of ` +
-                                `this ${commands.length}-command request`,
+                                `this ${commands.length}-command request; ${results.length} result(s) had arrived ` +
+                                `first: ${JSON.stringify(results)}`,
                         );
                     }
 
@@ -644,18 +649,16 @@ class InProcessCertNodeApi implements CertNodeApi {
     decommission(): Promise<void> {
         return runTagged(this.#adapterId, async () => {
             const peer = this.#peer;
-            try {
-                await peer.decommission();
-                return;
-            } catch (e) {
-                // Decommissioning acts through the peer's OperationalCredentials behavior, which exists only once a
-                // report has carried that cluster. A peer whose structure read aborted holds no such behavior.
-                if (!peer.lifecycle.isCommissioned) {
-                    throw e;
-                }
-                logger.info(`Decommissioning ${peer.id} failed, reading its credentials and retrying:`, e);
+
+            // Decommissioning acts through the peer's OperationalCredentials behavior, which exists only
+            // once a report has carried that cluster; a peer whose structure read aborted holds none. The
+            // read is what installs it — so it happens before the attempt rather than as a retry, which
+            // would answer every other failure the same way, including a refusal a step means to assert.
+            if (peer.lifecycle.isCommissioned && !peer.behaviors.has(OperationalCredentialsClient)) {
+                logger.info(`Reading ${peer.id}'s credentials, which decommissioning it needs`);
+                await this.readAttribute({ endpoint: 0, cluster: OperationalCredentials.id });
             }
-            await this.readAttribute({ endpoint: 0, cluster: OperationalCredentials.id });
+
             await peer.decommission();
         });
     }
@@ -842,7 +845,16 @@ export class InProcessControllerAdapter implements ControllerAdapter {
                 timeout: target.giveUpAfterMs === undefined ? undefined : Millis(target.giveUpAfterMs),
                 regulatoryLocation: GeneralCommissioning.RegulatoryLocationType.IndoorOutdoor,
                 regulatoryCountryCode: "XX",
-                onAttestationFailure: () => true,
+                onAttestationFailure: findings => {
+                    // Accepting is what lets a test device commission at all; the evidence still has
+                    // to say what was accepted, or a step asserting a clean attestation proves nothing
+                    logger.notice(
+                        `Accepting device attestation findings: ${findings
+                            .map(({ level, type, message }) => `${level} ${type}: ${message}`)
+                            .join("; ")}`,
+                    );
+                    return true;
+                },
             });
             const address = peer.peerAddress;
             if (address === undefined) {

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -8,6 +8,7 @@ import {
     Boot,
     ClientNode,
     ControllerBehavior,
+    Diagnostic,
     Duration,
     Environment,
     ImplementationError,
@@ -411,7 +412,7 @@ class InProcessCertNodeApi implements CertNodeApi {
                         throw new UnexpectedDataError(
                             `Invoke response carries commandRef ${entry.commandRef}, which belongs to no command of ` +
                                 `this ${commands.length}-command request; ${results.length} result(s) had arrived ` +
-                                `first: ${JSON.stringify(results)}`,
+                                `first: ${Diagnostic.json(results)}`,
                         );
                     }
 
@@ -650,10 +651,10 @@ class InProcessCertNodeApi implements CertNodeApi {
         return runTagged(this.#adapterId, async () => {
             const peer = this.#peer;
 
-            // Decommissioning acts through the peer's OperationalCredentials behavior, which exists only
-            // once a report has carried that cluster; a peer whose structure read aborted holds none. The
-            // read is what installs it — so it happens before the attempt rather than as a retry, which
-            // would answer every other failure the same way, including a refusal a step means to assert.
+            // Decommissioning acts through the peer's OperationalCredentials behavior, which the first
+            // report carrying that cluster installs; a peer whose structure read aborted has none, and
+            // reading it here is what installs it. Only that condition may be pre-empted: any other
+            // failure is the step's outcome, including a refusal a step means to assert.
             if (peer.lifecycle.isCommissioned && !peer.behaviors.has(OperationalCredentialsClient)) {
                 logger.info(`Reading ${peer.id}'s credentials, which decommissioning it needs`);
                 await this.readAttribute({ endpoint: 0, cluster: OperationalCredentials.id });

--- a/support/chip-testing/src/cert/index.ts
+++ b/support/chip-testing/src/cert/index.ts
@@ -140,7 +140,7 @@ class MatterJsCertDevice implements CertDevice {
     }
 
     backchannel(command: BackchannelCommand) {
-        return this.#inner.backchannel(command);
+        return runTaggedForDevice(this.#id, () => this.#inner.backchannel(command));
     }
 }
 

--- a/support/chip-testing/test/cert-framework/cert-test.test.ts
+++ b/support/chip-testing/test/cert-framework/cert-test.test.ts
@@ -1475,6 +1475,38 @@ describe("CertTest", () => {
         );
     });
 
+    it("fails the run when reporting a passing step's outcome throws", async () => {
+        const definition: CertTestDefinition = {
+            tc: "TC-IDM-1.3",
+            plan: "interactiondatamodel.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [
+                {
+                    number: 1,
+                    text: "Step one text",
+                    run: async () => {},
+                },
+            ],
+        };
+
+        const cx: CertStepContext = {
+            controllers: {},
+            devices: {},
+            recorder: stubRecorder({
+                endStep() {
+                    throw new Error("reporting exploded");
+                },
+            }),
+        };
+
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
+
+        await expect(test.invoke(stubSubject(new PicsFile([])), () => {}, [], false)).rejectedWith(
+            "reporting exploded",
+        );
+    });
+
     it("records a step that throws UnsupportedByControllerError as skipped with a reason naming the operation and controller, and still runs later steps", async () => {
         let step2Ran = false;
 

--- a/support/chip-testing/test/cert-framework/cert-test.test.ts
+++ b/support/chip-testing/test/cert-framework/cert-test.test.ts
@@ -193,7 +193,10 @@ class TestCertTest extends CertTest {
         this.#teardownErrors = teardownErrors;
     }
 
+    teardownCalls = 0;
+
     protected override async teardown(): Promise<unknown[]> {
+        this.teardownCalls++;
         return this.#teardownErrors;
     }
 
@@ -1276,6 +1279,25 @@ describe("CertTest", () => {
         expect(endStepVerdicts).deep.equal([{ number: 1, verdict: "pass" }]);
         expect(deviceExitedCalls).deep.equal([{ code: 1, signal: null }]);
         expect(flushed).equal(true);
+    });
+
+    it("closes what the run opened even when reading the subject's PICS throws", async () => {
+        const definition: CertTestDefinition = {
+            tc: "TC-CADMIN-1.17",
+            plan: "multiplefabrics.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [{ number: 1, text: "A step that never runs", run: async () => {} }],
+        };
+
+        const cx: CertStepContext = { controllers: {}, devices: {}, recorder: stubRecorder() };
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
+
+        await expect(
+            test.invoke(stubSubjectWithThrowingPics(new Error("PICS accessor exploded")), () => {}, [], false),
+        ).rejectedWith("PICS accessor exploded");
+
+        expect(test.teardownCalls).equal(1);
     });
 
     it("reports a device that died rather than a controller that would not close", async () => {

--- a/support/chip-testing/test/cert-framework/cert-test.test.ts
+++ b/support/chip-testing/test/cert-framework/cert-test.test.ts
@@ -620,6 +620,52 @@ describe("CertTest", () => {
         ]);
     });
 
+    it("skips a flavor-restricted step when the run's flavor cannot be determined", async () => {
+        let ran = false;
+
+        const definition: CertTestDefinition = {
+            tc: "TC-CADMIN-1.17",
+            plan: "multiplefabrics.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [
+                {
+                    number: 1,
+                    text: "Step restricted to chip flavors",
+                    flavors: ["chip-docker", "chip-local"],
+                    run: async () => {
+                        ran = true;
+                    },
+                },
+            ],
+        };
+
+        const endStepCalls = new Array<{ number: number | string; verdict: StepVerdict; skipReason?: string }>();
+        const cx: CertStepContext = {
+            controllers: {},
+            devices: {},
+            recorder: stubRecorder({
+                endStep(step, verdict, skipReason) {
+                    endStepCalls.push({ number: step.number, verdict, skipReason });
+                    return [];
+                },
+            }),
+        };
+
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
+
+        await test.invoke(stubSubject(new PicsFile([])), () => {}, [], false);
+
+        expect(ran).equal(false);
+        expect(endStepCalls).deep.equal([
+            {
+                number: 1,
+                verdict: "skipped",
+                skipReason: "device flavor unknown, and this step declares chip-docker/chip-local",
+            },
+        ]);
+    });
+
     it("never runs a step declared not applicable, and records the reason ahead of any flavor or PICS gate", async () => {
         let step1Ran = false;
         let step2Ran = false;

--- a/support/chip-testing/test/cert-framework/cert-test.test.ts
+++ b/support/chip-testing/test/cert-framework/cert-test.test.ts
@@ -1278,6 +1278,42 @@ describe("CertTest", () => {
         expect(flushed).equal(true);
     });
 
+    it("reports a device that died rather than a controller that would not close", async () => {
+        let exitDevice!: (info: DeviceExitInfo) => void;
+        const exitPromise = new Promise<DeviceExitInfo>(resolve => {
+            exitDevice = resolve;
+        });
+
+        const definition: CertTestDefinition = {
+            tc: "TC-CADMIN-1.17",
+            plan: "multiplefabrics.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [{ number: 1, text: "A step that passes", run: async () => {} }],
+        };
+
+        const cx: CertStepContext = {
+            controllers: {},
+            devices: { th: stubCertDevice(exitPromise) },
+            recorder: stubRecorder({
+                async flush() {
+                    // The device dies while the evidence is being written, too late for any step race
+                    exitDevice({ code: 1, signal: null });
+                    await new Promise(resolve => setTimeout(resolve, 20));
+                    return "";
+                },
+            }),
+        };
+
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx, undefined, [
+            new Error("controller would not close"),
+        ]);
+
+        await expect(test.invoke(stubSubject(new PicsFile([])), () => {}, [], false)).rejectedWith(
+            "exited unexpectedly (code 1, signal null) during the run",
+        );
+    });
+
     it("disarms the device-exit watch once invoke() finishes, so a later exit isn't reported to a finished run's recorder", async () => {
         let exitDevice!: (info: DeviceExitInfo) => void;
         const exitPromise = new Promise<DeviceExitInfo>(resolve => {

--- a/support/chip-testing/test/cert-framework/cert-test.test.ts
+++ b/support/chip-testing/test/cert-framework/cert-test.test.ts
@@ -1346,7 +1346,7 @@ describe("CertTest", () => {
             "-".repeat(70),
             "-".repeat(70),
             "TC-CADMIN-1.17 — Test Step 1: PASS",
-            "single check detail",
+            "pass: single check detail",
             "-".repeat(70),
         ]);
     });
@@ -1394,10 +1394,85 @@ describe("CertTest", () => {
             "-".repeat(70),
             "-".repeat(70),
             "TC-CADMIN-1.17 — Test Step 1: PASS",
-            "0: pattern=AttributePathIB {} matched=raw log line",
-            "1: second check detail",
+            "0: pass: pattern=AttributePathIB {} matched=raw log line",
+            "1: pass: second check detail",
             "-".repeat(70),
         ]);
+    });
+
+    it("names the verdict and the reason of a failing device-log check in the banner", async () => {
+        const definition: CertTestDefinition = {
+            tc: "TC-IDM-1.3",
+            plan: "interactiondatamodel.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [
+                {
+                    number: 1,
+                    text: "Step one text",
+                    run: async cx => {
+                        cx.recorder.check({
+                            type: "device-log",
+                            verdict: "fail",
+                            pattern: "two commands",
+                            detail: "Timed out waiting for two commands",
+                            logLine: 7,
+                        });
+                        throw new Error("step failed on its log check");
+                    },
+                },
+            ],
+        };
+
+        const deviceLog = new LogFollower(noLines(), "device");
+        const cx: CertStepContext = {
+            controllers: {},
+            devices: { th: { ...stubCertDevice(new Promise<DeviceExitInfo>(() => {})), log: deviceLog } },
+            recorder: recordingRecorder(),
+        };
+
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
+
+        await expect(test.invoke(stubSubject(new PicsFile([])), () => {}, [], false)).rejectedWith(
+            "step failed on its log check",
+        );
+
+        const banners = deviceLog.lines.filter(line => line.synthetic).map(line => line.text);
+        expect(banners).includes("fail: pattern=two commands matched=(none) Timed out waiting for two commands");
+    });
+
+    it("keeps the step's own error when reporting its failure throws", async () => {
+        const definition: CertTestDefinition = {
+            tc: "TC-IDM-1.3",
+            plan: "interactiondatamodel.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [
+                {
+                    number: 1,
+                    text: "Step one text",
+                    run: async () => {
+                        throw new Error("the step's own failure");
+                    },
+                },
+            ],
+        };
+
+        const cx: CertStepContext = {
+            controllers: {},
+            devices: {},
+            recorder: stubRecorder({
+                endStep() {
+                    throw new Error("reporting exploded");
+                },
+            }),
+        };
+
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
+
+        await expect(test.invoke(stubSubject(new PicsFile([])), () => {}, [], false)).rejectedWith(
+            "the step's own failure",
+        );
     });
 
     it("records a step that throws UnsupportedByControllerError as skipped with a reason naming the operation and controller, and still runs later steps", async () => {
@@ -1587,7 +1662,7 @@ describe("CertTest", () => {
             "-".repeat(70),
             "-".repeat(70),
             "TC-CADMIN-1.17 — Test Step 1: SKIPPED",
-            "read the data version",
+            "pass: read the data version",
             "-".repeat(70),
             "-".repeat(70),
             "TC-CADMIN-1.17 — 1 step skipped as unsupported by the controller",

--- a/support/chip-testing/test/cert-framework/cert-test.test.ts
+++ b/support/chip-testing/test/cert-framework/cert-test.test.ts
@@ -177,6 +177,7 @@ function stubSubjectWithoutPics(): Subject {
 class TestCertTest extends CertTest {
     #cx: CertStepContext;
     #finalizationTimeoutMs?: number;
+    #teardownErrors: unknown[];
 
     constructor(
         definition: CertTestDefinition,
@@ -184,10 +185,16 @@ class TestCertTest extends CertTest {
         container: Container,
         cx: CertStepContext,
         finalizationTimeoutMs?: number,
+        teardownErrors: unknown[] = [],
     ) {
         super(definition, descriptor, container);
         this.#cx = cx;
         this.#finalizationTimeoutMs = finalizationTimeoutMs;
+        this.#teardownErrors = teardownErrors;
+    }
+
+    protected override async teardown(): Promise<unknown[]> {
+        return this.#teardownErrors;
     }
 
     protected override contextFor(_subject: Subject): CertStepContext {
@@ -1515,6 +1522,50 @@ describe("CertTest", () => {
         };
 
         const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
+
+        await expect(test.invoke(stubSubject(new PicsFile([])), () => {}, [], false)).rejectedWith(
+            "the step's own failure",
+        );
+    });
+
+    it("fails a run whose controller would not close", async () => {
+        const definition: CertTestDefinition = {
+            tc: "TC-CADMIN-1.17",
+            plan: "multiplefabrics.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [{ number: 1, text: "A step that passes", run: async () => {} }],
+        };
+
+        const cx: CertStepContext = { controllers: {}, devices: {}, recorder: stubRecorder() };
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx, undefined, [
+            new Error("controller would not close"),
+        ]);
+
+        await expect(test.invoke(stubSubject(new PicsFile([])), () => {}, [], false)).rejectedWith(/failed to close/);
+    });
+
+    it("keeps a step's failure ahead of a controller that would not close", async () => {
+        const definition: CertTestDefinition = {
+            tc: "TC-CADMIN-1.17",
+            plan: "multiplefabrics.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [
+                {
+                    number: 1,
+                    text: "A step that fails",
+                    run: async () => {
+                        throw new Error("the step's own failure");
+                    },
+                },
+            ],
+        };
+
+        const cx: CertStepContext = { controllers: {}, devices: {}, recorder: stubRecorder() };
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx, undefined, [
+            new Error("controller would not close"),
+        ]);
 
         await expect(test.invoke(stubSubject(new PicsFile([])), () => {}, [], false)).rejectedWith(
             "the step's own failure",

--- a/support/chip-testing/test/cert-framework/chip-app-subject.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-app-subject.test.ts
@@ -528,13 +528,65 @@ describe("ChipDockerSubject", () => {
         expect(closed).equal(1);
     });
 
-    it("still reaps the container when attach() fails, so a later close() completes", async function () {
+    it("kills a container whose exit the daemon never confirmed", async function () {
         this.timeout(5_000);
 
+        let killed = false;
+        let closed = 0;
+        const container = fakeContainer({
+            kill: async () => {
+                killed = true;
+            },
+            wait: async () => {
+                throw new Error("daemon went away");
+            },
+        });
+
+        const composition: CompositionHandle = {
+            async add() {
+                return container;
+            },
+            async close() {
+                closed++;
+            },
+        };
+
+        const docker: DockerHandle = {
+            async ensureVolume() {},
+            compose() {
+                return composition;
+            },
+            async containerStatus() {
+                return { isRunning: true };
+            },
+        };
+
+        const device = new ChipDockerDevice("test", "cert", undefined, docker);
+
+        await device.start();
+        await device.close();
+
+        expect(killed).equal(true);
+        expect(closed).equal(1);
+    });
+
+    it("still kills and reaps a running container when attach() fails", async function () {
+        this.timeout(5_000);
+
+        let killed = false;
+        let ended!: () => void;
         const container = fakeContainer({
             attach: async () => {
                 throw new Error("attach exploded");
             },
+            kill: async () => {
+                killed = true;
+                ended();
+            },
+            wait: () =>
+                new Promise<void>(resolve => {
+                    ended = resolve;
+                }),
         });
 
         let closed = 0;
@@ -563,6 +615,7 @@ describe("ChipDockerSubject", () => {
 
         await device.close();
 
+        expect(killed).equal(true);
         expect(closed).equal(1);
     });
 });

--- a/support/chip-testing/test/cert-framework/chip-app-subject.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-app-subject.test.ts
@@ -6,7 +6,8 @@
 
 import type { CertDevice, CompositionHandle, Container, DockerHandle, Subject } from "@matter/testing";
 import { ChipDockerDevice, ChipDockerSubject, ChipLocalSubject, HARNESS_DBUS_CONTAINER } from "@matter/testing";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { env } from "node:process";
@@ -61,6 +62,21 @@ function fakeContainer(overrides: Partial<Container> = {}): Container {
     } as unknown as Container;
 }
 
+/** Resolves to `true` if `promise` is still pending after `ms`, which is what a non-exit looks like. */
+async function stillPending(promise: Promise<unknown>, ms: number): Promise<boolean> {
+    let timer!: NodeJS.Timeout;
+    try {
+        return await Promise.race([
+            promise.then(() => false),
+            new Promise<true>(resolve => {
+                timer = setTimeout(() => resolve(true), ms);
+            }),
+        ]);
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
 function isCertDevice(subject: Subject): subject is CertDevice {
     return "flavor" in subject && "log" in subject && "exit" in subject;
 }
@@ -97,6 +113,46 @@ async function collectLines(source: AsyncIterable<string>, count: number, timeou
     return lines;
 }
 
+/** Reads the next `kvs <path> <generations>` line the test app prints for the store it was started with. */
+async function nextStore(
+    source: AsyncIterable<string>,
+    timeoutMs: number,
+): Promise<{ path: string; generations: number }> {
+    const seen = new Array<string>();
+    const iterator = source[Symbol.asyncIterator]();
+    const deadline = Date.now() + timeoutMs;
+
+    for (;;) {
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) {
+            throw new Error(`No store line in ${JSON.stringify(seen)}`);
+        }
+
+        let timer!: NodeJS.Timeout;
+        let result;
+        try {
+            result = await Promise.race([
+                iterator.next(),
+                new Promise<never>((_, reject) => {
+                    timer = setTimeout(() => reject(new Error(`No store line in ${JSON.stringify(seen)}`)), remaining);
+                }),
+            ]);
+        } finally {
+            clearTimeout(timer);
+        }
+
+        if (result.done) {
+            throw new Error(`Log ended before a store line; saw ${JSON.stringify(seen)}`);
+        }
+
+        seen.push(result.value);
+        if (result.value.startsWith("kvs ")) {
+            const [, path, generations] = result.value.split(" ");
+            return { path, generations: Number(generations) };
+        }
+    }
+}
+
 describe("ChipLocalSubject", () => {
     const app = "test";
 
@@ -108,10 +164,27 @@ describe("ChipLocalSubject", () => {
         const scriptPath = join(appDir, `chip-${app}-app`);
 
         // `exec` replaces the shell with `sleep` so SIGTERM lands on the actual sleeping process,
-        // not a shell that could leave it orphaned.
-        await writeFile(scriptPath, "#!/bin/sh\necho known-line-one\necho known-line-two\nexec sleep 300\n", {
-            mode: 0o755,
-        });
+        // not a shell that could leave it orphaned. The store line stands in for the app's own
+        // key-value store: its path and its accumulated generations are what a factory reset and a
+        // reboot have to differ on.
+        await writeFile(
+            scriptPath,
+            [
+                "#!/bin/sh",
+                "echo known-line-one",
+                "echo known-line-two",
+                'kvs=""',
+                "while [ $# -gt 0 ]; do",
+                '    if [ "$1" = "--KVS" ]; then kvs="$2"; fi',
+                "    shift",
+                "done",
+                'echo generation >> "$kvs"',
+                'echo "kvs $kvs $(wc -l < "$kvs" | tr -d " ")"',
+                "exec sleep 300",
+                "",
+            ].join("\n"),
+            { mode: 0o755 },
+        );
 
         env.MATTER_CERT_APP_DIR = appDir;
     });
@@ -140,10 +213,175 @@ describe("ChipLocalSubject", () => {
             const lines = await collectLines(device.log.follow(), 2, 5_000);
             expect(lines).deep.equal(["known-line-one", "known-line-two"]);
 
+            // stop() only returns once the process is gone, and a stop the harness asked for is not
+            // the crash `exit` reports.
             await device.stop();
+            expect(await stillPending(device.exit, 250)).equal(true);
+        } finally {
+            await device.close();
+        }
+    });
 
-            const exitInfo = await device.exit;
-            expect(exitInfo.signal).equal("SIGTERM");
+    it("reports a process that exits on its own as an exit", async function () {
+        this.timeout(15_000);
+
+        await writeFile(join(appDir, `chip-${app}-app`), "#!/bin/sh\necho known-line-one\nexit 3\n", {
+            mode: 0o755,
+        });
+
+        const device = ChipLocalSubject(app)("cert");
+        if (!isCertDevice(device)) {
+            throw new Error("Expected a CertDevice");
+        }
+
+        await device.initialize();
+        await device.start();
+
+        try {
+            expect(await device.exit).deep.equal({ code: 3, signal: null });
+        } finally {
+            await device.close();
+        }
+    });
+
+    it("does not report a restarted device as crashed by the process it replaced", async function () {
+        this.timeout(15_000);
+
+        const device = ChipLocalSubject(app)("cert");
+        if (!isCertDevice(device)) {
+            throw new Error("Expected a CertDevice");
+        }
+
+        await device.initialize();
+        await device.start();
+
+        try {
+            const follow = device.log.follow();
+            await nextStore(follow, 5_000);
+
+            await device.stop();
+            await device.start();
+
+            await nextStore(follow, 5_000);
+            expect(await stillPending(device.exit, 250)).equal(true);
+        } finally {
+            await device.close();
+        }
+    });
+
+    it("starts a fresh process after one that exited on its own", async function () {
+        this.timeout(15_000);
+
+        const binary = join(appDir, `chip-${app}-app`);
+        const sleeper = await readFile(binary, "utf8");
+        await writeFile(binary, "#!/bin/sh\necho known-line-one\nexit 3\n", { mode: 0o755 });
+
+        const device = ChipLocalSubject(app)("cert");
+        if (!isCertDevice(device)) {
+            throw new Error("Expected a CertDevice");
+        }
+
+        await device.initialize();
+        await device.start();
+
+        try {
+            expect(await device.exit).deep.equal({ code: 3, signal: null });
+
+            await writeFile(binary, sleeper, { mode: 0o755 });
+            await device.start();
+
+            expect((await nextStore(device.log.follow(), 5_000)).generations).equal(1);
+        } finally {
+            await device.close();
+        }
+    });
+
+    it("spawns one process for two overlapping start() calls", async function () {
+        this.timeout(15_000);
+
+        const device = ChipLocalSubject(app)("cert");
+        if (!isCertDevice(device)) {
+            throw new Error("Expected a CertDevice");
+        }
+
+        await device.initialize();
+        await Promise.all([device.start(), device.start()]);
+
+        try {
+            expect((await nextStore(device.log.follow(), 5_000)).generations).equal(1);
+        } finally {
+            await device.close();
+        }
+    });
+
+    it("rejects start() when the binary is missing, rather than reporting a device that never ran as crashed", async function () {
+        this.timeout(15_000);
+
+        await rm(join(appDir, `chip-${app}-app`));
+
+        const device = ChipLocalSubject(app)("cert");
+        if (!isCertDevice(device)) {
+            throw new Error("Expected a CertDevice");
+        }
+
+        await device.initialize();
+
+        try {
+            await expect(device.start()).rejectedWith("ENOENT");
+            expect(await stillPending(device.exit, 250)).equal(true);
+        } finally {
+            await device.close();
+        }
+    });
+
+    it("discards the key-value store on a factoryReset backchannel command", async function () {
+        this.timeout(15_000);
+
+        const device = ChipLocalSubject(app)("cert");
+        if (!isCertDevice(device)) {
+            throw new Error("Expected a CertDevice");
+        }
+
+        await device.initialize();
+        await device.start();
+
+        try {
+            const follow = device.log.follow();
+            const first = await nextStore(follow, 5_000);
+            expect(first.generations).equal(1);
+
+            await device.backchannel({ name: "factoryReset" });
+
+            const second = await nextStore(follow, 5_000);
+            expect(second.generations).equal(1);
+            expect(second.path).not.equal(first.path);
+            expect(existsSync(first.path)).equal(false);
+            expect(await stillPending(device.exit, 250)).equal(true);
+        } finally {
+            await device.close();
+        }
+    });
+
+    it("keeps the key-value store on a reboot backchannel command", async function () {
+        this.timeout(15_000);
+
+        const device = ChipLocalSubject(app)("cert");
+        if (!isCertDevice(device)) {
+            throw new Error("Expected a CertDevice");
+        }
+
+        await device.initialize();
+        await device.start();
+
+        try {
+            const follow = device.log.follow();
+            const first = await nextStore(follow, 5_000);
+
+            await device.backchannel({ name: "reboot" });
+
+            const second = await nextStore(follow, 5_000);
+            expect(second.path).equal(first.path);
+            expect(second.generations).equal(first.generations + 1);
         } finally {
             await device.close();
         }
@@ -213,7 +451,18 @@ describe("ChipDockerSubject", () => {
     it("reuses the harness's dbus/mdns pair and starts only the app container", async () => {
         const statusChecks = new Array<string>();
         const addedParts = new Array<string>();
-        const container = fakeContainer();
+        let killed = false;
+        let ended!: () => void;
+        const container = fakeContainer({
+            kill: async () => {
+                killed = true;
+                ended();
+            },
+            wait: () =>
+                new Promise<void>(resolve => {
+                    ended = resolve;
+                }),
+        });
 
         const composition: CompositionHandle = {
             async add(config) {
@@ -243,26 +492,59 @@ describe("ChipDockerSubject", () => {
         } finally {
             await device.close();
         }
+
+        expect(killed).equal(true);
+        expect(await stillPending(device.exit, 100)).equal(true);
     });
 
-    it("settles the exit promise when attach() fails, so a later stop() completes", async function () {
+    it("closes the composition when adding the app container fails", async function () {
         this.timeout(5_000);
 
-        let killed = false;
+        let closed = 0;
+        const composition: CompositionHandle = {
+            async add() {
+                throw new Error("add exploded");
+            },
+            async close() {
+                closed++;
+            },
+        };
+
+        const docker: DockerHandle = {
+            async ensureVolume() {},
+            compose() {
+                return composition;
+            },
+            async containerStatus() {
+                return { isRunning: true };
+            },
+        };
+
+        const device = new ChipDockerDevice("test", "cert", undefined, docker);
+
+        await expect(device.start()).rejectedWith("add exploded");
+        await device.close();
+
+        expect(closed).equal(1);
+    });
+
+    it("still reaps the container when attach() fails, so a later close() completes", async function () {
+        this.timeout(5_000);
+
         const container = fakeContainer({
             attach: async () => {
                 throw new Error("attach exploded");
             },
-            kill: async () => {
-                killed = true;
-            },
         });
 
+        let closed = 0;
         const composition: CompositionHandle = {
             async add() {
                 return container;
             },
-            async close() {},
+            async close() {
+                closed++;
+            },
         };
 
         const docker: DockerHandle = {
@@ -281,7 +563,6 @@ describe("ChipDockerSubject", () => {
 
         await device.close();
 
-        expect(killed).equal(true);
-        expect(await device.exit).deep.equal({ code: 0, signal: null });
+        expect(closed).equal(1);
     });
 });

--- a/support/chip-testing/test/cert-framework/chip-app-subject.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-app-subject.test.ts
@@ -528,6 +528,49 @@ describe("ChipDockerSubject", () => {
         expect(closed).equal(1);
     });
 
+    it("starts for real after a launch that failed, rather than reporting the failed one as up", async function () {
+        this.timeout(5_000);
+
+        let closed = 0;
+        const added = new Array<string>();
+        const composition: CompositionHandle = {
+            async add(config) {
+                added.push(config.name);
+                if (added.length === 1) {
+                    throw new Error("add exploded");
+                }
+                return fakeContainer();
+            },
+            async close() {
+                closed++;
+            },
+        };
+
+        const docker: DockerHandle = {
+            async ensureVolume() {},
+            compose() {
+                return composition;
+            },
+            async containerStatus() {
+                return { isRunning: true };
+            },
+        };
+
+        const device = new ChipDockerDevice("test", "cert", undefined, docker);
+
+        await expect(device.start()).rejectedWith("add exploded");
+
+        // Without replacing the failed generation this resolves having started nothing
+        await device.start();
+        expect(added).deep.equal(["app", "app"]);
+
+        // The composition of the failed attempt is reaped before the second one runs
+        expect(closed).equal(1);
+
+        await device.close();
+        expect(closed).equal(2);
+    });
+
     it("kills a container whose exit the daemon never confirmed", async function () {
         this.timeout(5_000);
 

--- a/support/chip-testing/test/cert-framework/controller-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/controller-adapter.test.ts
@@ -484,9 +484,8 @@ describe("InProcessControllerAdapter", () => {
         await node.decommission();
     });
 
-    // Characterization: matter.js's own Write action enforces § 8.9.2.8.1, so the adapter needs no guard
-    // of its own. Pinned because a review proposed adding one, on the premise that nothing below the
-    // adapter validated it.
+    // Characterization: § 8.9.2.8.1 is enforced by matter.js's own write action, not by this adapter, so
+    // a guard added here would be dead code.
     it("refuses a data version on a wildcard endpoint path, which the specification forbids", async function () {
         this.timeout(30_000);
 

--- a/support/chip-testing/test/cert-framework/controller-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/controller-adapter.test.ts
@@ -484,6 +484,28 @@ describe("InProcessControllerAdapter", () => {
         await node.decommission();
     });
 
+    // Characterization: matter.js's own Write action enforces § 8.9.2.8.1, so the adapter needs no guard
+    // of its own. Pinned because a review proposed adding one, on the premise that nothing below the
+    // adapter validated it.
+    it("refuses a data version on a wildcard endpoint path, which the specification forbids", async function () {
+        this.timeout(30_000);
+
+        const ref = await adapter.commission({ passcode: 20202021, discriminator: 3840 });
+        const node = adapter.node(ref);
+
+        await expect(
+            node.writeAttributes([
+                {
+                    path: { cluster: BASIC_INFORMATION.id, attribute: NODE_LABEL_ATTRIBUTE.id },
+                    value: "wildcard",
+                    dataVersion: 1,
+                },
+            ]),
+        ).rejectedWith(/must target a concrete endpoint/);
+
+        await node.decommission();
+    });
+
     it("throws when constructing a second adapter with an id already registered", () => {
         expect(() => new InProcessControllerAdapter("dut")).to.throw(InternalError, /already registered/);
     });

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -17,8 +17,9 @@ import {
     ON_NETWORK_ONLY,
     qrPayloadWith,
     qrPayloadWithPrefix,
+    recordVendorOutcome,
 } from "../cert/tc-dd-support.js";
-import { CertCheckFailedError, CertCleanupError } from "../cert/tc-support.js";
+import { CertCheckFailedError, CertCleanupError, CommissionedRefs } from "../cert/tc-support.js";
 
 /**
  * `devicediscovery.adoc`'s own example payload for TC-DD-3.14: vendor id 0xFFF1, product id 0x8001,
@@ -97,58 +98,59 @@ describe("qrPayloadWithPrefix", () => {
     });
 });
 
+/** A step context whose DUT controller answers commissioning as the test says, and nothing else. */
+function contextWith(
+    commission: () => Promise<CertNodeRef>,
+    decommission: (ref: CertNodeRef) => Promise<void> = async () => {},
+): CertStepContext {
+    const unused = () => Promise.reject(new InternalError("not used by these tests"));
+    const noLines = async function* (): AsyncGenerator<string> {};
+
+    const nodeFor = (ref: CertNodeRef) =>
+        ({
+            invoke: unused,
+            invokeBatch: unused,
+            readAttribute: unused,
+            readAttributes: unused,
+            writeAttribute: unused,
+            writeAttributes: unused,
+            subscribe: unused,
+            readEvents: unused,
+            subscribeEvents: unused,
+            openCommissioningWindow: unused,
+            operationalMdnsInstanceName: unused,
+            decommission: () => decommission(ref),
+        }) satisfies CertNodeApi;
+
+    const dut = {
+        id: "dut",
+        log: new LogFollower(noLines(), "dut"),
+        async start() {},
+        async close() {},
+        commission,
+        parseQrPayload: unused,
+        parseManualPairingCode: unused,
+        node: nodeFor,
+    } satisfies ControllerAdapter;
+
+    return {
+        controllers: { dut },
+        devices: {},
+        recorder: {
+            beginStep() {},
+            check() {},
+            endStep() {
+                return [];
+            },
+            async flush() {
+                return "";
+            },
+        },
+    };
+}
+
 describe("CommissioningRefusals", () => {
     const BUDGETS = { refusalTimeoutMs: 100, settleTimeoutMs: 100 };
-
-    function contextWith(
-        commission: () => Promise<CertNodeRef>,
-        decommission: (ref: CertNodeRef) => Promise<void> = async () => {},
-    ): CertStepContext {
-        const unused = () => Promise.reject(new InternalError("not used by these tests"));
-        const noLines = async function* (): AsyncGenerator<string> {};
-
-        const nodeFor = (ref: CertNodeRef) =>
-            ({
-                invoke: unused,
-                invokeBatch: unused,
-                readAttribute: unused,
-                readAttributes: unused,
-                writeAttribute: unused,
-                writeAttributes: unused,
-                subscribe: unused,
-                readEvents: unused,
-                subscribeEvents: unused,
-                openCommissioningWindow: unused,
-                operationalMdnsInstanceName: unused,
-                decommission: () => decommission(ref),
-            }) satisfies CertNodeApi;
-
-        const dut = {
-            id: "dut",
-            log: new LogFollower(noLines(), "dut"),
-            async start() {},
-            async close() {},
-            commission,
-            parseQrPayload: unused,
-            parseManualPairingCode: unused,
-            node: nodeFor,
-        } satisfies ControllerAdapter;
-
-        return {
-            controllers: { dut },
-            devices: {},
-            recorder: {
-                beginStep() {},
-                check() {},
-                endStep() {
-                    return [];
-                },
-                async flush() {
-                    return "";
-                },
-            },
-        };
-    }
 
     it("does not accept a bare UnexpectedDataError, which commissioning raises after taking the payload", async () => {
         const cx = contextWith(() => Promise.reject(new UnexpectedDataError("Invalid response from device")));
@@ -273,6 +275,52 @@ describe("CommissioningRefusals", () => {
         await expect(refusals.requireRefusal(cx, { qrPairingCode: "MT:whatever" }, "must be refused")).rejected;
 
         await expect(refusals.settle(cx)).rejectedWith(CertCleanupError, /still running/);
+    });
+});
+
+describe("recordVendorOutcome", () => {
+    const CODE = "34970112332";
+
+    it("fails, and leaves cleanup owning the attempt, when the DUT neither onboards nor gives up", async () => {
+        const refusals = new CommissioningRefusals({ refusalTimeoutMs: 50, settleTimeoutMs: 50 });
+        const cx = contextWith(() => new Promise<CertNodeRef>(() => {}));
+
+        await expect(
+            recordVendorOutcome(cx, CODE, new CommissionedRefs(), refusals, "vendor outcome", 50),
+        ).rejectedWith(/neither onboarded the TH nor gave up/);
+
+        await expect(refusals.settle(cx)).rejectedWith(/still running/);
+    });
+
+    it("records the DUT onboarding the TH, which the plan also allows", async () => {
+        const refusals = new CommissioningRefusals({ refusalTimeoutMs: 50, settleTimeoutMs: 50 });
+        const decommissioned = new Array<CertNodeRef>();
+        const cx = contextWith(
+            async () => "peer1" as CertNodeRef,
+            async ref => {
+                decommissioned.push(ref);
+            },
+        );
+        const commissioned = new CommissionedRefs();
+
+        await recordVendorOutcome(cx, CODE, commissioned, refusals, "vendor outcome", 50);
+
+        expect(commissioned.get("dut")).equal("peer1");
+        await refusals.settle(cx);
+        expect(decommissioned).deep.equal(["peer1"]);
+    });
+
+    it("records the DUT terminating commissioning", async () => {
+        const refusals = new CommissioningRefusals({ refusalTimeoutMs: 50, settleTimeoutMs: 50 });
+        const cx = contextWith(async () => {
+            throw new InternalError("code names a vendor this network does not carry");
+        });
+        const commissioned = new CommissionedRefs();
+
+        await recordVendorOutcome(cx, CODE, commissioned, refusals, "vendor outcome", 50);
+
+        expect(commissioned.get("dut")).equal(undefined);
+        await refusals.settle(cx);
     });
 });
 

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -292,7 +292,7 @@ describe("recordVendorOutcome", () => {
         await expect(refusals.settle(cx)).rejectedWith(/still running/);
     });
 
-    it("records the DUT onboarding the TH, which the plan also allows", async () => {
+    it("records the DUT onboarding the TH, leaving the fabric to the step that owns it", async () => {
         const refusals = new CommissioningRefusals({ refusalTimeoutMs: 50, settleTimeoutMs: 50 });
         const decommissioned = new Array<CertNodeRef>();
         const cx = contextWith(
@@ -306,8 +306,11 @@ describe("recordVendorOutcome", () => {
         await recordVendorOutcome(cx, CODE, commissioned, refusals, "vendor outcome", 50);
 
         expect(commissioned.get("dut")).equal("peer1");
+
+        // Cleanup must not remove it as well: the ref above is what removes it, and a second removal
+        // of the same fabric fails
         await refusals.settle(cx);
-        expect(decommissioned).deep.equal(["peer1"]);
+        expect(decommissioned).deep.equal([]);
     });
 
     it("records the DUT terminating commissioning", async () => {

--- a/support/chip-testing/test/cert-framework/tc-idm-1.3-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-1.3-support.test.ts
@@ -270,6 +270,15 @@ describe("expectBatchRequestPaths", () => {
         expect(check.verdict).equal("pass");
     });
 
+    it("fails when two separate requests carried one command each instead of one batch", async () => {
+        const check = await withBufferedFollower(
+            [...batchRequestLines([PATHS[0]]), ...batchRequestLines([PATHS[1]])],
+            follower => expectBatchRequestPaths(follower, "chip-local", PATHS, 0, 500),
+        );
+
+        expect(check.verdict).equal("fail");
+    });
+
     it("is unverified for a matterjs device", async () => {
         const check = await withFollower(batchRequestLines(PATHS), follower =>
             expectBatchRequestPaths(follower, "matterjs", PATHS, 0, 200),

--- a/support/chip-testing/test/cert-framework/tc-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-support.test.ts
@@ -159,6 +159,13 @@ describe("expectChunkedTransfer", () => {
         expect(record.detail).contains(`Exchange ${EXCHANGE}`);
     });
 
+    it("fails when two one-chunk reads, each acked on its own exchange, look like a chunked one", async () => {
+        const record = await check([...chunkLines(), ackLine(), ...chunkLines(EXCHANGE + 1), ackLine(EXCHANGE + 1)]);
+
+        expect(record.verdict).equal("fail");
+        expect(record.detail).match(/belongs to another read/);
+    });
+
     it("fails when a chunk has no outbound trace line to take an exchange from", async () => {
         const record = await check([CHUNK, ackLine(), ...chunkLines(), ackLine(), ...chunkLines(), NOISE]);
 

--- a/support/chip-testing/test/cert-framework/tc-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-support.test.ts
@@ -29,9 +29,19 @@ import {
     WRITE_REQUEST_MESSAGE,
 } from "../cert/tc-support.js";
 
+const EXCHANGE = 26481;
 const CHUNK = "[DMG] ReportDataMessage =";
-const ACK = "[EM] <<< [E:1r S:2 M:3] (S) Msg RX from 1:0000000000000001 [1234] --- Type 0001:01 (IM:StatusResponse)";
 const NOISE = "[DMG] AttributeReportIBs =";
+
+// chip prints the outbound trace line, then the chunk's decode dump; the DUT's ack arrives on the
+// same Exchange, on a different Session. Shapes verified against a real chip-all-clusters-app log.
+const sentLine = (exchange = EXCHANGE) =>
+    `[DMG] >> to UDP:[fe80::1%eth0]:58253 | 92720281 | [Interaction Model  (1) / Report Data (0x05) / Session = 56179 / Exchange = ${exchange}]`;
+const ackLine = (exchange = EXCHANGE) =>
+    `[DMG] << from UDP:[fe80::1%eth0]:58253 | 208635799 | [Interaction Model  (1) / Status Response (0x01) / Session = 13606 / Exchange = ${exchange}]`;
+
+/** One chunk as chip logs it: its own trace line, then the decode dump the check matches. */
+const chunkLines = (exchange = EXCHANGE) => [sentLine(exchange), CHUNK];
 
 /**
  * A log source the test feeds by hand and never ends — a source that finishes closes the follower,
@@ -106,35 +116,69 @@ async function check(lines: string[], flavor = "chip-docker", endSource = false)
 
 describe("expectChunkedTransfer", () => {
     it("passes when every chunk but the last is acked", async () => {
-        const record = await check([CHUNK, NOISE, ACK, CHUNK, ACK, CHUNK, NOISE]);
+        const record = await check([
+            ...chunkLines(),
+            NOISE,
+            ackLine(),
+            ...chunkLines(),
+            ackLine(),
+            ...chunkLines(),
+            NOISE,
+        ]);
 
         expect(record.verdict).equal("pass");
         expect(record.detail).equal("3 report chunks, each but the last followed by a StatusResponse");
     });
 
     it("fails when a later chunk pair has no StatusResponse between it", async () => {
-        const record = await check([CHUNK, ACK, CHUNK, NOISE, CHUNK, ACK]);
+        const record = await check([...chunkLines(), ackLine(), ...chunkLines(), NOISE, ...chunkLines(), ackLine()]);
 
         expect(record.verdict).equal("fail");
         expect(record.detail).match(/chunk 2 of 3 went unacked/);
     });
 
     it("fails when the first chunk pair has no StatusResponse between it", async () => {
-        const record = await check([CHUNK, CHUNK, ACK, CHUNK, ACK]);
+        const record = await check([...chunkLines(), ...chunkLines(), ackLine(), ...chunkLines(), ackLine()]);
 
         expect(record.verdict).equal("fail");
         expect(record.detail).match(/chunk 1 of 3 went unacked/);
     });
 
+    it("fails when the only StatusResponse between two chunks answered another exchange", async () => {
+        const record = await check([
+            ...chunkLines(),
+            ackLine(EXCHANGE + 1),
+            ...chunkLines(),
+            ackLine(),
+            ...chunkLines(),
+            NOISE,
+        ]);
+
+        expect(record.verdict).equal("fail");
+        expect(record.detail).match(/chunk 1 of 3 went unacked/);
+        expect(record.detail).contains(`Exchange ${EXCHANGE}`);
+    });
+
+    it("fails when a chunk has no outbound trace line to take an exchange from", async () => {
+        const record = await check([CHUNK, ackLine(), ...chunkLines(), ackLine(), ...chunkLines(), NOISE]);
+
+        expect(record.verdict).equal("fail");
+        expect(record.detail).match(/No outbound Report Data trace line/);
+    });
+
     it("fails when the read never chunked", async () => {
-        const record = await check([CHUNK, ACK]);
+        const record = await check([...chunkLines(), ackLine()]);
 
         expect(record.verdict).equal("fail");
         expect(record.detail).match(/did not chunk/);
     });
 
     it("treats a log source that ends mid-transfer as the end of the transfer", async () => {
-        const record = await check([CHUNK, ACK, CHUNK, ACK, CHUNK], "chip-docker", true);
+        const record = await check(
+            [...chunkLines(), ackLine(), ...chunkLines(), ackLine(), ...chunkLines()],
+            "chip-docker",
+            true,
+        );
 
         expect(record.verdict).equal("pass");
         expect(record.detail).equal("3 report chunks, each but the last followed by a StatusResponse");

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1232,26 +1232,49 @@ all, which is what lets `Test_TC_DD_1_8.yaml`'s own (older, larger) 1000-byte TL
 The TC asserts the length it built rather than trusting the arithmetic, since a filler byte count that
 misses lands on a payload the plan did not ask for.
 
-**Onboarding the same TH twice: open a basic window before removing the fabric.** A chip TH does not
-return to commissioning mode when its last fabric goes — after `RemoveFabric succeeds` its log stops
-there, and the next commissioning fails as `No device could be commissioned (1 of 1 started attempt(s)
-failed, 1 discovered)` against a stale advertisement. Spec-wise the plans cover this with a
-precondition ("place the TH back into commissioning mode using the TH manufacturer's means"), which for
-a TC that drives everything itself means opening the window before the fabric it needs to open it is
-gone. It must be a **basic** window (`openCommissioningWindow({ enhanced: false })`): its PASE verifier
-is the device's own setup code, so the TH's own onboarding payload still pairs, where an enhanced
-window would mint a fresh discriminator and passcode instead (see "Pairing-code commissioning" above).
+**Onboarding the same TH twice: factory reset it between attempts.** A chip TH does not return to
+commissioning mode when its last fabric goes — after `RemoveFabric succeeds` its log stops there, and
+the next commissioning fails as `No device could be commissioned (1 of 1 started attempt(s) failed, 1
+discovered)` against a stale advertisement. The plans cover this with a precondition ("place the TH
+back into commissioning mode using the TH manufacturer's means"), and for a TC that drives everything
+itself that means asking the device for a factory reset:
 
-A restart would satisfy the same precondition, and TC-DD-3.20 asks for one explicitly — but a step
-cannot stop a device today: `raceAgainstDeviceExit` (`cert-test.ts`) treats any device exit during a
-step as the run's failure. Deliberate-restart support is the framework piece that block still needs.
+```ts
+await cx.controllers.dut.node(ref).decommission();
+if (th.flavor !== "matterjs") {
+    const from = th.log.mark();
+    await th.backchannel({ name: "factoryReset" });
+    // wait for the restarted app's own SetupQRCode line before any mDNS check
+}
+```
 
-**A factory reset is not the same operation on both flavors.** Removing the last fabric leaves a chip
-app's KVS in place; the storage has to be deleted and the app restarted for it to come up factory-new,
-which is also why it stays out of commissioning mode above. matter.js returns to commissioning mode on
-its own instead. The specification allows either, so a TC whose precondition is a factory-reset TH must
-ask the device for one — per flavor, `ChipLocalDevice`'s own storage directory versus a matterjs
-subject's storage — rather than assume `RemoveFabric` delivered it.
+Three things about that shape are load-bearing. The fabric comes off first, so the controller never
+holds a peer for a fabric the device has forgotten — a later `decommissionAll` against a wiped device
+fails. The matterjs leg is excluded because it is already back in commissioning mode, and erasing it
+would restart a TH that needs nothing. And the wait for the restarted app matters because
+`ChipLocalDevice.start()` returns when the *process* is up, not when the app is, while
+`checkCommissionable` primes from the DNS-SD names already cached — so without it the check can be
+answered by an advertisement the generation that just died had published.
+
+Earlier revisions instead opened a *basic* commissioning window and then removed the fabric, which
+works on paper but publishes `_matterc._udp` twice inside about 15 ms; avahi calls that a name
+collision and withdraws the service, so the TH ends up advertising nothing. That was an intermittent
+failure of this helper on the own-built leg, root-caused from the TH's own log in the evidence bundle
+and filed upstream.
+
+**A factory reset is not the same operation on every flavor**, which is why it is the *device* that
+implements it, behind one `BackchannelCommand`:
+
+| Flavor | `factoryReset` | `reboot` |
+| --- | --- | --- |
+| `chip-local` | stop, drop the storage directory holding `chip_kvs`, start | stop, start (store kept) |
+| `chip-docker` | stop, start — the store lives in the container's own filesystem, which the composition discards | refused: it cannot keep the store, so a caller wanting one must use `chip-local` |
+| `matterjs` | `Node.erase()`, which goes offline, resets storage and comes back | close, reinitialize, start |
+
+**A stop the harness asked for is not a crash.** `CertDevice.exit` settles only for an exit nobody
+asked for, so `cert-test.ts`'s exit watch survives a step restarting a device and still fails the run
+if the device does not come back. This is what makes a restart from inside a step possible at all;
+TC-DD-3.20's "manufacturer's means" precondition needs nothing further.
 
 **On a developer host, limit mDNS to one interface.** With VPN tunnels up (`utun*`), a local run of the
 whole cert suite floods `UDP send timeout`/`EMSGSIZE` on every extra interface, stretches a 1m 40s run to

--- a/support/chip-testing/test/cert/TC-DD-3.17.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.17.test.ts
@@ -254,6 +254,7 @@ certTest("TC-DD-3.17", {
                     cx,
                     manualPairingCode({ ...parts, vendorId }),
                     commissioned,
+                    refusals,
                     `Code naming vendor 0x${vendorId.toString(16)}`,
                     VENDOR_OUTCOME_TIMEOUT_MS,
                 );

--- a/support/chip-testing/test/cert/TC-IDM-3.1.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-3.1.test.ts
@@ -8,7 +8,7 @@ import { Status } from "@matter/main/types";
 import { Matter } from "@matter/model";
 import type { AttributePathSpec, CertNodeApi, CertNodeRef, CertStepContext, DeviceFlavor } from "@matter/testing";
 import { certTest } from "@matter/testing";
-import { CommissionedRefs, expectMessageWithPath, requireId, WRITE_REQUEST_MESSAGE } from "./tc-support.js";
+import { CommissionedRefs, expectMessageWithPath, record, requireId, WRITE_REQUEST_MESSAGE } from "./tc-support.js";
 
 const LEVEL_CONTROL = Matter.clusters.require("LevelControl");
 const BASIC_INFORMATION = Matter.clusters.require("BasicInformation");
@@ -157,12 +157,16 @@ certTest("TC-IDM-3.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 const value = await dut
                     .node(ref)
                     .readAttribute({ endpoint, cluster: IDENTIFY_ID, attribute: IDENTIFY_TIME.id });
-                cx.recorder.check({
-                    type: "response",
-                    // identifyTime counts down from the written value, so the device may already report less
-                    verdict: typeof value === "number" ? "pass" : "fail",
-                    detail: `endpoint ${endpoint} reports identifyTime=${JSON.stringify(value)}`,
-                });
+                record(
+                    cx,
+                    {
+                        type: "response",
+                        // identifyTime counts down from the written value, so the device may already report less
+                        verdict: typeof value === "number" ? "pass" : "fail",
+                        detail: `endpoint ${endpoint} reports identifyTime=${JSON.stringify(value)}`,
+                    },
+                    `endpoint ${endpoint} identifyTime`,
+                );
             }
         }),
         {

--- a/support/chip-testing/test/cert/TC-SC-3.5.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-3.5.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Duration, InternalError, Millis, Time } from "@matter/main";
+import { Duration, InternalError, Millis } from "@matter/main";
 import type { CertStepContext, CertStepDefinition, PromptHandler, StepVerdict, Subject } from "@matter/testing";
 import {
     chip,
@@ -15,6 +15,7 @@ import {
 } from "@matter/testing";
 import { join } from "node:path";
 import { env } from "node:process";
+import { settleWithin } from "./tc-support.js";
 
 // setup_class's th_server_discriminator — fixed for every OpenCommissioningWindow call in the script.
 // The passcode is NOT fixed the same way: only the initial precondition commission (TH_CLIENT pairing
@@ -62,15 +63,6 @@ function extractPasscode(promptText: string): number {
 // DUT that hangs instead of rejecting must not stall this step for the full mocha timeout.
 const COMMISSION_TIMEOUT_MS = 60_000;
 
-type SettleOutcome = { kind: "resolved"; ref: string } | { kind: "rejected"; error: unknown } | { kind: "timeout" };
-
-function settled(promise: Promise<string>): Promise<SettleOutcome> {
-    return promise.then(
-        (ref): SettleOutcome => ({ kind: "resolved", ref }),
-        (error: unknown): SettleOutcome => ({ kind: "rejected", error }),
-    );
-}
-
 /**
  * Handles every "Manual Pairing Code" prompt `TC_SC_3_5.py` prints — steps 1b, 2c, 3c, 4c, 5c (4c is
  * skipped, and never prompts, if DUT has no ICAC in its NOC chain; see the script's `setup_class`/
@@ -101,26 +93,18 @@ function manualPairingCodeHandler(state: { attempts: number }): PromptHandler {
             };
             cx.recorder.beginStep(stepDef);
 
-            const timeout = Time.sleep("TC-SC-3.5 commission timeout", Millis(COMMISSION_TIMEOUT_MS));
-            let outcome: SettleOutcome;
-            try {
-                outcome = await Promise.race([
-                    settled(
-                        dut.commission({
-                            passcode,
-                            discriminator: TH_SERVER_DISCRIMINATOR,
-                            // The script arms each fault for one handshake only, so a commissioner that retries gets a
-                            // clean one and commissions successfully. Step 1b injects no fault and must be free to
-                            // recover like any healthy commissioning.
-                            singleHandshakeAttempt: !expectSuccess,
-                        }),
-                    ),
-                    timeout.then((): SettleOutcome => ({ kind: "timeout" })),
-                ]);
-            } finally {
-                // A lost race leaves the sleep armed for its full duration, keeping the process alive past teardown
-                timeout.cancel();
-            }
+            const outcome = await settleWithin(
+                `TC-SC-3.5 commissioning attempt ${attempt}`,
+                dut.commission({
+                    passcode,
+                    discriminator: TH_SERVER_DISCRIMINATOR,
+                    // The script arms each fault for one handshake only, so a commissioner that retries gets a
+                    // clean one and commissions successfully. Step 1b injects no fault and must be free to
+                    // recover like any healthy commissioning.
+                    singleHandshakeAttempt: !expectSuccess,
+                }),
+                COMMISSION_TIMEOUT_MS,
+            );
 
             let verdict: StepVerdict;
             let failure: Error | undefined;
@@ -131,11 +115,11 @@ function manualPairingCodeHandler(state: { attempts: number }): PromptHandler {
                     cx.recorder.check({
                         type: "response",
                         verdict,
-                        detail: `commission() resolved on attempt ${attempt} (ref ${outcome.ref})`,
+                        detail: `commission() resolved on attempt ${attempt} (ref ${outcome.value})`,
                     });
                     if (!expectSuccess) {
                         await dut
-                            .node(outcome.ref)
+                            .node(outcome.value)
                             .decommission()
                             .catch(e =>
                                 console.warn(`Failed to decommission unexpectedly-successful attempt ${attempt}:`, e),

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -30,9 +30,6 @@ export const REFUSAL_TIMEOUT_MS = 15_000;
  */
 export const REFUSAL_SETTLE_TIMEOUT_MS = 30_000;
 
-/** Outlives the rest of a run, so a later step never pairs against a window that closed on its own. */
-const WINDOW_TIMEOUT_SECONDS = 300;
-
 /** Both device flavors print the payload they publish on this line; chip prints one per commissioning flow. */
 const SETUP_QR_CODE = /SetupQRCode: \[(MT:[^\]]+)\]/;
 
@@ -156,6 +153,10 @@ function writeBits(data: Uint8Array, { offset, length }: { offset: number; lengt
         // The bitwise operators below coerce a fraction and NaN silently, which would put a payload
         // nobody asked for into the evidence
         throw new InternalError(`${value} does not fit the ${length} bits at offset ${offset}`);
+    }
+    if (data.length * 8 < offset + length) {
+        // Writing past the end of a Uint8Array is silently dropped, for the same result
+        throw new InternalError(`The ${length} bits at offset ${offset} do not fit a payload of ${data.length} bytes`);
     }
     for (let i = 0; i < length; i++) {
         const bit = offset + i;
@@ -435,8 +436,7 @@ export async function recordCommissionable(
  * The two controllers genuinely differ. chip-tool matches a code's vendor and product id against the
  * device it discovered (`SetUpCodePairer::NodeMatchesCurrentFilter`) and finds nothing; matter.js
  * discovers on the discriminator alone and onboards. A fabric that results is handed to
- * `commissioned`, whose next {@link commissionByManualCode} takes it off the TH the only way a chip
- * TH survives — opening a window before the fabric that opens it is gone.
+ * `commissioned`, whose next {@link commissionByManualCode} takes it off the TH again.
  */
 export async function recordVendorOutcome(
     cx: CertStepContext,
@@ -470,11 +470,13 @@ export async function recordVendorOutcome(
 }
 
 /**
- * Puts the TH back into commissioning mode if a fabric from an earlier onboarding is still on it.
+ * Returns the TH to a factory-new state if a fabric from an earlier onboarding is still on it, which
+ * is what a plan means by commissioning the same device again.
  *
- * A chip TH does not return there when its last fabric goes, so the window is opened while the fabric
- * that can open it is still present. It is a basic one: that is the window whose PASE verifier is the
- * device's own setup code, which is what an onboarding code carries.
+ * The fabric comes off first, so the controller never holds a peer for a fabric the device has
+ * forgotten. A chip TH then needs a factory reset, which is what actually puts it back into
+ * commissioning mode — removing its last fabric does not. A matter.js device is already there, and
+ * erasing it would restart a TH that needs nothing.
  */
 async function restoreCommissioningMode(cx: CertStepContext, commissioned: CommissionedRefs): Promise<void> {
     const previous = commissioned.get("dut");
@@ -482,14 +484,26 @@ async function restoreCommissioningMode(cx: CertStepContext, commissioned: Commi
         return;
     }
 
-    const dut = cx.controllers.dut;
-    await dut.node(previous).openCommissioningWindow({ timeout: WINDOW_TIMEOUT_SECONDS, enhanced: false });
-    await dut.node(previous).decommission();
+    const th = cx.devices.th;
+    await cx.controllers.dut.node(previous).decommission();
     commissioned.clear("dut");
 
-    // Removing the fabric returns as soon as the TH answers; the TH advertises itself commissionable
-    // again on its own schedule, and a discovery started before that finds only the devices this run
-    // is not looking for.
+    if (th.flavor !== "matterjs") {
+        const from = th.log.mark();
+        await th.backchannel({ name: "factoryReset" });
+
+        // A chip app's start() returns when the process is up, not when the app is; without waiting
+        // for the new generation to reach its own onboarding print, the check below can be answered
+        // by a cached advertisement from the generation that just went down.
+        record(
+            cx,
+            await expectSequence(th.log, th.flavor, "TH restarted", [SETUP_QR_CODE], from, LOG_TIMEOUT_MS),
+            "TH factory reset",
+        );
+    }
+
+    // The TH advertises itself commissionable on its own schedule, and a discovery started before
+    // that finds only the devices this run is not looking for.
     await recordCommissionable(cx, "TH back in commissioning mode");
 }
 
@@ -503,11 +517,8 @@ export async function commissionByManualCode(
 }
 
 /**
- * Onboards the TH from `payload`, first taking off a fabric an earlier step commissioned.
- *
- * A chip TH does not return to commissioning mode when its last fabric goes, so the window is opened
- * while the fabric is still there. It is a basic one: that is the window whose PASE verifier is the
- * device's own setup code, which is what an onboarding payload carries.
+ * Onboards the TH from `payload`, first returning it to a factory-new state if an earlier step
+ * commissioned it (see {@link restoreCommissioningMode}).
  */
 export async function commissionByQr(
     cx: CertStepContext,

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -10,7 +10,14 @@ import type { CertNodeRef, CertStepContext, CommissioningTarget } from "@matter/
 import type { CertDevice } from "@matter/testing";
 import { expectMdns } from "../../src/cert/mdns-check.js";
 import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload.js";
-import { CertCleanupError, CommissionedRefs, expectRejection, expectSequence, record } from "./tc-support.js";
+import {
+    CertCleanupError,
+    CommissionedRefs,
+    expectRejection,
+    expectSequence,
+    record,
+    settleWithin,
+} from "./tc-support.js";
 
 export const LOG_TIMEOUT_MS = 30_000;
 export const MDNS_TIMEOUT_MS = 30_000;
@@ -225,6 +232,11 @@ export class CommissioningRefusals {
         this.#settleTimeoutMs = budgets?.settleTimeoutMs ?? REFUSAL_SETTLE_TIMEOUT_MS;
     }
 
+    /** How long {@link settle} waits, for a step that needs the same slack for its own wait. */
+    get settleBudgetMs(): number {
+        return this.#settleTimeoutMs;
+    }
+
     /**
      * Records that the DUT refuses to commission from `payload`, which is how the negative plans
      * phrase "the DUT terminates the commissioning process in a DUT-specific manner".
@@ -233,16 +245,23 @@ export class CommissioningRefusals {
      * rejection would let the step pass on a controller that died, timed out or was never asked —
      * outcomes that say nothing about what the DUT made of the code.
      */
-    async requireRefusal(cx: CertStepContext, target: CommissioningTarget, what: string): Promise<void> {
-        const attempt = cx.controllers.dut.commission(target);
-        // Kept as a settled outcome so an attempt nobody awaits again cannot surface as an unhandled
-        // rejection, and so settle() can collect the ref of one that succeeded after its budget
+    /**
+     * Hands `attempt` to {@link settle}, which is what a step that may stop waiting for a
+     * commissioning owes the run: one that succeeds late leaves a fabric on the TH. Kept as a settled
+     * outcome so an attempt nobody awaits again cannot surface as an unhandled rejection.
+     */
+    track(attempt: Promise<CertNodeRef>): void {
         this.#attempts.push(
             attempt.then(
                 ref => ref,
                 () => undefined,
             ),
         );
+    }
+
+    async requireRefusal(cx: CertStepContext, target: CommissioningTarget, what: string): Promise<void> {
+        const attempt = cx.controllers.dut.commission(target);
+        this.track(attempt);
 
         record(
             cx,
@@ -268,12 +287,7 @@ export class CommissioningRefusals {
         timeoutMs: number,
     ): Promise<void> {
         const attempt = cx.controllers.dut.commission(target);
-        this.#attempts.push(
-            attempt.then(
-                ref => ref,
-                () => undefined,
-            ),
-        );
+        this.track(attempt);
 
         record(
             cx,
@@ -442,31 +456,64 @@ export async function recordVendorOutcome(
     cx: CertStepContext,
     manualPairingCode: string,
     commissioned: CommissionedRefs,
+    refusals: CommissioningRefusals,
     what: string,
     timeoutMs: number,
 ): Promise<void> {
     await restoreCommissioningMode(cx, commissioned);
 
-    const dut = cx.controllers.dut;
-    const attempt = dut.commission({ manualPairingCode, giveUpAfterMs: timeoutMs });
+    const label = `commissioning from ${manualPairingCode}`;
+    const attempt = cx.controllers.dut.commission({ manualPairingCode, giveUpAfterMs: timeoutMs });
 
-    const outcome = await expectRejection(`commissioning from ${manualPairingCode}`, attempt, timeoutMs + 30_000);
-    if (outcome.verdict === "pass") {
-        record(cx, { ...outcome, detail: `DUT terminated commissioning: ${outcome.detail}` }, what);
-        return;
+    // The plan accepts either outcome, so the attempt is tracked rather than required to fail: one
+    // that neither onboards nor gives up inside the budget is the step's failure, and cleanup — not
+    // another unbounded wait here — is what owns it afterwards.
+    refusals.track(attempt);
+
+    const outcome = await settleWithin(label, attempt, timeoutMs + refusals.settleBudgetMs);
+
+    switch (outcome.kind) {
+        case "rejected": {
+            const { error } = outcome;
+            const message = error instanceof Error ? `${error.constructor.name}: ${error.message}` : String(error);
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: "pass",
+                    detail: `DUT terminated commissioning after ${outcome.elapsed}: ${message}`,
+                },
+                what,
+            );
+            return;
+        }
+
+        case "resolved": {
+            const ref = outcome.value;
+            commissioned.set("dut", ref);
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: "pass",
+                    detail: `DUT onboarded the TH as node ${ref}, which the plan allows where the user accepts the risk`,
+                },
+                what,
+            );
+            return;
+        }
+
+        case "timeout":
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: "fail",
+                    detail: `${label} neither onboarded the TH nor gave up within ${outcome.elapsed}`,
+                },
+                what,
+            );
     }
-
-    const ref = await attempt;
-    commissioned.set("dut", ref);
-    record(
-        cx,
-        {
-            type: "response",
-            verdict: "pass",
-            detail: `DUT onboarded the TH as node ${ref}, which the plan allows where the user accepts the risk`,
-        },
-        what,
-    );
 }
 
 /**

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -238,17 +238,11 @@ export class CommissioningRefusals {
     }
 
     /**
-     * Records that the DUT refuses to commission from `payload`, which is how the negative plans
-     * phrase "the DUT terminates the commissioning process in a DUT-specific manner".
-     *
-     * Only a refusal of the payload itself counts (see {@link isPayloadRefusal}). Accepting any
-     * rejection would let the step pass on a controller that died, timed out or was never asked —
-     * outcomes that say nothing about what the DUT made of the code.
-     */
-    /**
-     * Hands `attempt` to {@link settle}, which is what a step that may stop waiting for a
-     * commissioning owes the run: one that succeeds late leaves a fabric on the TH. Kept as a settled
-     * outcome so an attempt nobody awaits again cannot surface as an unhandled rejection.
+     * Hands `attempt` to {@link settle}, which is what a step that stops waiting for a commissioning
+     * owes the run: one that succeeds afterwards leaves a fabric on the TH that nothing else will
+     * remove. An attempt whose outcome the step *did* see is owned by the step, and handing that one
+     * over as well would have its fabric removed twice. Kept as a settled outcome so an attempt nobody
+     * awaits again cannot surface as an unhandled rejection.
      */
     track(attempt: Promise<CertNodeRef>): void {
         this.#attempts.push(
@@ -259,6 +253,14 @@ export class CommissioningRefusals {
         );
     }
 
+    /**
+     * Records that the DUT refuses to commission from `payload`, which is how the negative plans
+     * phrase "the DUT terminates the commissioning process in a DUT-specific manner".
+     *
+     * Only a refusal of the payload itself counts (see {@link isPayloadRefusal}). Accepting any
+     * rejection would let the step pass on a controller that died, timed out or was never asked —
+     * outcomes that say nothing about what the DUT made of the code.
+     */
     async requireRefusal(cx: CertStepContext, target: CommissioningTarget, what: string): Promise<void> {
         const attempt = cx.controllers.dut.commission(target);
         this.track(attempt);
@@ -342,8 +344,8 @@ export class CommissioningRefusals {
         }
         if (failures.length) {
             throw new CertCleanupError(
-                `The DUT commissioned the TH from a payload it was asked to refuse and the fabric could not be ` +
-                    `removed: ${failures.join("; ")}`,
+                `A commissioning attempt this run stopped waiting for onboarded the TH after all, and the fabric ` +
+                    `could not be removed: ${failures.join("; ")}`,
             );
         }
     }
@@ -464,12 +466,6 @@ export async function recordVendorOutcome(
 
     const label = `commissioning from ${manualPairingCode}`;
     const attempt = cx.controllers.dut.commission({ manualPairingCode, giveUpAfterMs: timeoutMs });
-
-    // The plan accepts either outcome, so the attempt is tracked rather than required to fail: one
-    // that neither onboards nor gives up inside the budget is the step's failure, and cleanup — not
-    // another unbounded wait here — is what owns it afterwards.
-    refusals.track(attempt);
-
     const outcome = await settleWithin(label, attempt, timeoutMs + refusals.settleBudgetMs);
 
     switch (outcome.kind) {
@@ -504,6 +500,10 @@ export async function recordVendorOutcome(
         }
 
         case "timeout":
+            // Only now does cleanup own the attempt: an outcome this step saw is already owned, by
+            // `commissioned` for one that onboarded, and handing it over as well would have the fabric
+            // removed twice.
+            refusals.track(attempt);
             record(
                 cx,
                 {

--- a/support/chip-testing/test/cert/tc-idm-1.3-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-1.3-support.ts
@@ -161,6 +161,17 @@ export async function expectBatchRequestPaths(
             return { type: "device-log", verdict: "unverified" };
         }
 
+        // The matched message's own closing line is located first, because it is what bounds
+        // everything below: a path or a command found past it belongs to a later request, which is
+        // the case this check exists to tell apart from one batch carrying them all.
+        const end = await log.expect(
+            { chip: INTERACTION_MODEL_REVISION },
+            { flavor, timeoutMs, from: envelope.last.index + 1 },
+        );
+        if (end.verdict === "unverified") {
+            return { type: "device-log", verdict: "unverified" };
+        }
+
         let last = envelope.last;
         for (const { endpoint, cluster, command } of paths) {
             const block = await expectAdjacentLines(
@@ -173,12 +184,18 @@ export async function expectBatchRequestPaths(
             if (block.verdict === "unverified") {
                 return { type: "device-log", verdict: "unverified" };
             }
+            if (block.last.index > end.matched.index) {
+                return {
+                    type: "device-log",
+                    verdict: "fail",
+                    pattern: label,
+                    detail:
+                        `endpoint ${endpoint} cluster ${cluster} command ${command} appears only after the ` +
+                        "request ended, so a later request carried it",
+                    logLine: block.last.index,
+                };
+            }
             last = block.last;
-        }
-
-        const end = await log.expect({ chip: INTERACTION_MODEL_REVISION }, { flavor, timeoutMs, from: last.index + 1 });
-        if (end.verdict === "unverified") {
-            return { type: "device-log", verdict: "unverified" };
         }
 
         const commands =

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -1018,13 +1018,44 @@ export async function expectReportAck(
     }
 }
 
-type SettleOutcome = { kind: "resolved" } | { kind: "rejected"; error: unknown } | { kind: "timeout" };
+/**
+ * How an operation a step was waiting for ended, and how long it took, formatted for the evidence.
+ * A `"timeout"` says only that the wait ended: the operation itself is still running.
+ */
+export type SettleReport<T = unknown> = { elapsed: string } & (
+    | { kind: "resolved"; value: T }
+    | { kind: "rejected"; error: unknown }
+    | { kind: "timeout" }
+);
 
-function settled(promise: Promise<unknown>): Promise<SettleOutcome> {
-    return promise.then(
-        (): SettleOutcome => ({ kind: "resolved" }),
-        (error: unknown): SettleOutcome => ({ kind: "rejected", error }),
-    );
+/**
+ * Waits for `op` to settle, bounded by `timeoutMs` so an implementation that neither answers nor
+ * gives up cannot hang the step for the whole mocha timeout. Reports which way it went, for a step
+ * that has something to record either way; {@link expectRejection} is the form for a step that
+ * demands a refusal.
+ *
+ * A step that stops waiting is still responsible for what the operation does afterwards — a
+ * commissioning that succeeds late leaves a fabric on the device.
+ */
+export async function settleWithin<T>(label: string, op: Promise<T>, timeoutMs: number): Promise<SettleReport<T>> {
+    // nowUs is the monotonic clock despite the name; nowMs tracks UTC and a step of it would put a
+    // negative elapsed into the evidence
+    const start = Time.nowUs;
+    const elapsed = () => Duration.format(Millis(Time.nowUs - start));
+    const timeout = Time.sleep(`${label} settle timeout`, Millis(timeoutMs));
+
+    try {
+        return await Promise.race([
+            op.then(
+                (value): SettleReport<T> => ({ kind: "resolved", value, elapsed: elapsed() }),
+                (error: unknown): SettleReport<T> => ({ kind: "rejected", error, elapsed: elapsed() }),
+            ),
+            timeout.then((): SettleReport<T> => ({ kind: "timeout", elapsed: elapsed() })),
+        ]);
+    } finally {
+        // A lost race leaves the sleep armed for its full duration, keeping the process alive past teardown
+        timeout.cancel();
+    }
 }
 
 /**
@@ -1043,18 +1074,8 @@ export async function expectRejection(
     timeoutMs: number,
     accept?: (error: unknown) => boolean,
 ): Promise<CheckRecord> {
-    // nowUs is the monotonic clock despite the name; nowMs tracks UTC and a step of it would put a
-    // negative elapsed into the evidence
-    const start = Time.nowUs;
-    const timeout = Time.sleep(`${label} rejection timeout`, Millis(timeoutMs));
-    let outcome: SettleOutcome;
-    try {
-        outcome = await Promise.race([settled(op), timeout.then((): SettleOutcome => ({ kind: "timeout" }))]);
-    } finally {
-        // A lost race leaves the sleep armed for its full duration, keeping the process alive past teardown
-        timeout.cancel();
-    }
-    const elapsed = Duration.format(Millis(Time.nowUs - start));
+    const outcome = await settleWithin(label, op, timeoutMs);
+    const { elapsed } = outcome;
 
     switch (outcome.kind) {
         case "resolved":

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -163,7 +163,6 @@ export async function expectAdjacentLines(
 // pairs). matter.js has no equivalent log line, so this is chip-only; see AGENTS.md's flavor-pattern
 // policy for the matterjs "unverified" fallback.
 export const REPORT_DATA_MESSAGE = /\[DMG\] ReportDataMessage =\s*$/;
-const STATUS_RESPONSE_RECEIVED = /Msg RX from.*\(IM:StatusResponse\)/;
 
 // A subscription's own reports and its SubscribeResponse both carry the id the TH minted for it,
 // printed as the block's first field in chip's own unpadded lowercase hex — captured verbatim in
@@ -461,13 +460,18 @@ export async function expectCommandInvoke(
     let cursor = from;
     let last: { index: number; text: string } | undefined;
 
+    // One deadline for the whole check, not one per wait: a per-wait budget makes the worst case
+    // timeoutMs × (1 + fields.length), where the caller asked for timeoutMs
+    const deadline = Time.nowMs + timeoutMs;
+    const remaining = () => Math.max(1, deadline - Time.nowMs);
+
     try {
         const block = await expectAdjacentLines(
             log,
             flavor,
             commandPathIBSequence(endpoint, cluster, command),
             from,
-            timeoutMs,
+            remaining(),
         );
         if (block.verdict === "unverified") {
             return { type: "device-log", verdict: "unverified" };
@@ -480,7 +484,7 @@ export async function expectCommandInvoke(
             // chip's decode dump appends the TLV type name after the value (verified against a real
             // chip-bridge-app capture).
             const pattern = new RegExp(`0x${id.toString(16)} = ${value} \\(unsigned\\),\\s*$`);
-            const result = await log.expect({ chip: pattern }, { flavor, timeoutMs, from: cursor });
+            const result = await log.expect({ chip: pattern }, { flavor, timeoutMs: remaining(), from: cursor });
             if (result.verdict === "unverified") {
                 return { type: "device-log", verdict: "unverified" };
             }
@@ -585,17 +589,33 @@ export async function expectChunkedTransfer(
 
     const lines = log.lines;
     for (let i = 1; i < chunks.length; i++) {
+        // Matched by Exchange id, like expectReportAck: the node's own subscription stays live during
+        // these runs, so an unrelated report's ack can land between two chunks of this read.
+        const exchange = exchangeIdBefore(log, chunks[i - 1].index);
+        if (exchange === undefined) {
+            return {
+                type: "device-log",
+                verdict: "fail",
+                pattern: String(REPORT_SENT_LINE),
+                detail:
+                    "No outbound Report Data trace line (carrying an Exchange id) found before the report " +
+                    `chunk at log line ${chunks[i - 1].index}`,
+                logLine: chunks[i - 1].index,
+            };
+        }
+
+        const ackPattern = reportAckedOnExchange(exchange);
         const acked = lines
             .slice(chunks[i - 1].index + 1, chunks[i].index)
-            .some(line => !line.synthetic && STATUS_RESPONSE_RECEIVED.test(line.text));
+            .some(line => !line.synthetic && ackPattern.test(line.text));
         if (!acked) {
             return {
                 type: "device-log",
                 verdict: "fail",
-                pattern: String(STATUS_RESPONSE_RECEIVED),
+                pattern: String(ackPattern),
                 detail:
-                    `No StatusResponse between the report chunks at log lines ${chunks[i - 1].index} and ` +
-                    `${chunks[i].index} (chunk ${i} of ${chunks.length} went unacked)`,
+                    `No StatusResponse on Exchange ${exchange} between the report chunks at log lines ` +
+                    `${chunks[i - 1].index} and ${chunks[i].index} (chunk ${i} of ${chunks.length} went unacked)`,
                 logLine: chunks[i].index,
             };
         }
@@ -604,7 +624,7 @@ export async function expectChunkedTransfer(
     return {
         type: "device-log",
         verdict: "pass",
-        pattern: "ReportDataMessage, StatusResponse between every adjacent pair",
+        pattern: "ReportDataMessage, StatusResponse on the same Exchange between every adjacent pair",
         detail: `${chunks.length} report chunks, each but the last followed by a StatusResponse`,
         matched: chunks[chunks.length - 1].text,
         logLine: chunks[chunks.length - 1].index,

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -587,24 +587,41 @@ export async function expectChunkedTransfer(
         };
     }
 
-    const lines = log.lines;
-    for (let i = 1; i < chunks.length; i++) {
-        // Matched by Exchange id, like expectReportAck: the node's own subscription stays live during
-        // these runs, so an unrelated report's ack can land between two chunks of this read.
-        const exchange = exchangeIdBefore(log, chunks[i - 1].index);
-        if (exchange === undefined) {
+    // One transfer stays on one exchange, so this is what makes the chunks *one* read's rather than
+    // several reads' — and, like expectReportAck, what tells this read's acks from those of the node's
+    // own subscription, which stays live during these runs.
+    const exchange = exchangeIdBefore(log, chunks[0].index);
+    if (exchange === undefined) {
+        return {
+            type: "device-log",
+            verdict: "fail",
+            pattern: String(REPORT_SENT_LINE),
+            detail:
+                "No outbound Report Data trace line (carrying an Exchange id) found before the report " +
+                `chunk at log line ${chunks[0].index}`,
+            logLine: chunks[0].index,
+        };
+    }
+
+    for (const [i, chunk] of chunks.entries()) {
+        const chunkExchange = exchangeIdBefore(log, chunk.index);
+        if (chunkExchange !== exchange) {
             return {
                 type: "device-log",
                 verdict: "fail",
                 pattern: String(REPORT_SENT_LINE),
                 detail:
-                    "No outbound Report Data trace line (carrying an Exchange id) found before the report " +
-                    `chunk at log line ${chunks[i - 1].index}`,
-                logLine: chunks[i - 1].index,
+                    `The report chunk at log line ${chunk.index} went out on Exchange ` +
+                    `${chunkExchange ?? "(none)"}, not ${exchange}, so chunk ${i + 1} of ${chunks.length} ` +
+                    "belongs to another read",
+                logLine: chunk.index,
             };
         }
+    }
 
-        const ackPattern = reportAckedOnExchange(exchange);
+    const ackPattern = reportAckedOnExchange(exchange);
+    const lines = log.lines;
+    for (let i = 1; i < chunks.length; i++) {
         const acked = lines
             .slice(chunks[i - 1].index + 1, chunks[i].index)
             .some(line => !line.synthetic && ackPattern.test(line.text));


### PR DESCRIPTION
Five pieces of work on the certification harness. The first is the feature; the rest come from the
first full review of the suite, which had never had one.

## A step can factory reset the device under test

A chip test device is only factory-new once its key-value store is deleted and it restarts, and the
harness could not do that: any device exit during a step counted as a crash and failed the run. So the
commissioning-flow cases took the only route left — open a commissioning window on the device, then
remove the fabric — and that ordering makes CHIP publish the same mDNS instance twice within about
15 ms. Avahi calls that a name collision and withdraws the service, leaving the device advertising
nothing. That was an intermittent failure on the own-built leg, root-caused from the device's own log
in a run's evidence bundle and reported upstream; matter.js was not at fault on either side.

A device's exit now means only "it died without being asked to" — it was documented that way already,
but was true only by accident of timing. Each process or container run owns its own exit latches and
output pumps, and the device keeps one crash latch for its whole life, so a step can restart a device
while the run keeps the crash detection it armed beforehand. Factory reset and reboot arrive through
the backchannel commands matter.js devices already implement, one behaviour per flavour: a locally
spawned chip app drops the directory holding its store and restarts, a containerised one restarts
because its store dies with the container, and that flavour refuses a plain reboot since it cannot keep
the store. The deliberate-restart precondition TC-DD-3.20 asks for needs nothing further.

Everything a restart makes reachable came with it: overlapping starts raise one process rather than
two, starting again after a device died on its own actually starts it, a spawn failure is reported as
the start's own failure naming the real error, the waits for a container to go away and for its output
to finish are bounded, a container that could not be reaped still releases the composition and its
network, and a container whose exit the daemon never confirmed is still killed rather than assumed
gone.

## Three log checks now prove what they claim

- The batched-invoke check counted commands past its own message's closing line, so two separate
  single-command invokes satisfied a check whose whole purpose is telling a batch apart from that.
- The chunked-read check accepted any inbound status response as a chunk's acknowledgement, though the
  device's own subscription stays live during these runs. It is now matched on the exchange the chunk
  went out on, and required to stay on one exchange — two one-chunk reads, each properly acknowledged,
  used to pass as a chunked transfer of two.
- An invoked command's check gave every wait the caller's full timeout, so three fields could take four
  times the budget.

The exchange correlation was checked against a real chip log pulled from a passing run's evidence
bundle, not reasoned about.

## The in-process controller stops retrying every decommissioning failure

It caught whatever went wrong and, if the peer still looked commissioned, read its credentials and
tried again. Only one cause was ever meant — the operational-credentials behaviour is installed by the
first report carrying that cluster — and everything else was retried the same way, which is how a step
asserting a refusal could record a success. The read now happens before the attempt and only when the
behaviour is absent. Across a whole passing matrix the old retry fired exactly once, in TC-ACT-3.2, on
`Unsupported behavior`, which is thrown precisely when the behaviour is not in the peer's supported
set: the condition now checked up front.

Also here: an invoke response naming a command the request never carried is reported as the device's
answer being wrong rather than as our own invariant, and serialized with a bigint-aware serializer so
the error cannot itself throw; the batch-size refusal says whether the limit came from the device or
from our own assumption; and attestation findings are logged rather than accepted in silence.

## A wait that either outcome satisfies is bounded

Where a plan accepts either outcome — the device onboards, or it terminates commissioning — the step
judged its commissioning with the helper that demands a refusal, which reports failure for two
different things and only handled one. A commissioning that neither onboarded nor gave up had its
failing check dropped, was then awaited again with no bound, and could record a pass for a check
already judged failed. There is now one shared bounded wait reporting which way an operation went, all
three outcomes are recorded, and an attempt the step stops waiting for is handed to the cleanup that
already owns removing a fabric created late. TC-SC-3.5's copy of that race is gone.

## A run reports the failures it was hiding

- A controller that failed to close was collected, logged and forgotten, so a run that left a fabric, a
  session or a live subscription on the device — for the next test in the same process to inherit —
  still reported success. Closing failures now decide the outcome, behind the run's own failure and
  behind a device that died under it. The evidence bundle is deliberately written first, so that one
  exists even when cleanup hangs, which is why the run's outcome rather than the bundle carries this.
- Provenance came from three catch-and-ignore blocks, so a broken `git`, a stopped Docker daemon and a
  permissions error all produced the same silent `"(unknown)"` in the part of the harness whose whole
  job is saying what was tested. Only the genuinely expected case stays quiet now.
- A step declaring which device flavours it supports ran anyway wherever the flavour could not be
  determined — the one case its declaration cannot speak for. The gate fails closed and says why.
- Reading the subject's PICS happens inside the region whose cleanup closes the run's controllers, so a
  run that fails before its first step no longer leaves them open for the next one.

Plus, from the same review: every evidence check line names its verdict and a failing device-log check
keeps its reason, which it used to drop entirely; a failure while writing the evidence no longer
replaces the step's own error; one certification case recorded a failed check inside a passing step and
now fails; and `writeBits` refuses a payload too short for the field it is given.

## Two review findings were refuted, and say so

- The claim that the `*-by-id` handler family's missing model conversion breaks every non-scalar
  attribute on every chip-tool leg: that handler is matter.js impersonating chip-tool's server for the
  YAML runner, while the certification adapter drives the real binary through its own codec. TC-IDM-2.1
  reads a list of octet strings through that path and asserts `Uint8Array` entries. The handler defect
  is real but latent, and is written up as such.
- A guard against a data version on a wildcard write path: matter.js's own write action already
  enforces § 8.9.2.8.1. The guard was written, then a mutation test showed the covering test still
  passed without it. The guard is gone; the test stays as a characterization.

## Testing

`build-clean`, `format-verify`, `lint`, the full root suite and the certification framework suite (469
tests) are green, and the certification matrix passed on this branch.

Every production change was mutation-tested separately: with the change reverted, the covering test
fails. Where a mutation only compiled after a fix, that is called out as proving nothing until it did.
Deliberately uncovered, and stated rather than implied: the container stop timeout and the output-drain
bound (both need a wall-clock wait), the provenance classification (needs `git` and Docker stubs), and
the commissioning-flow helper itself, which the matrix exercises.

Unrelated: the harness now tolerates an image that reports no labels. Docker 29 returns none for the
multi-architecture chip image, which stopped every local chip test in container setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
