### PR TITLE
Make three certification log checks prove what they claim

### DIFF
--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -21,7 +21,9 @@ import {
     Seconds,
     ServerNode,
     Time,
+    UnexpectedDataError,
 } from "@matter/main";
+import { OperationalCredentialsClient } from "@matter/main/behaviors/operational-credentials";
 import { GeneralCommissioning, OperationalCredentials } from "@matter/main/clusters";
 import {
     ClientRead,
@@ -383,12 +385,14 @@ class InProcessCertNodeApi implements CertNodeApi {
             // the whole point of this call is the one request, and a step proving how a device answers
             // a batch would silently prove nothing. This reads the same value the interaction's own
             // exchange provider does.
-            const maxPathsPerInvoke = this.#protocolPeer?.sessionParameters.maxPathsPerInvoke ?? 1;
-            if (commands.length > maxPathsPerInvoke) {
+            const advertised = this.#protocolPeer?.sessionParameters.maxPathsPerInvoke;
+            if (commands.length > (advertised ?? 1)) {
                 throw new ImplementationError(
-                    `invokeBatch of ${commands.length} commands, but node ${this.#nodeId} accepts ` +
-                        `${maxPathsPerInvoke} path(s) per invoke; the request would be split into separate ` +
-                        "interactions",
+                    `invokeBatch of ${commands.length} commands, but ` +
+                        (advertised === undefined
+                            ? `node ${this.#nodeId} has no protocol peer yet, so its limit is unknown and taken as 1`
+                            : `node ${this.#nodeId} accepts ${advertised} path(s) per invoke`) +
+                        "; the request would be split into separate interactions",
                 );
             }
 
@@ -404,9 +408,10 @@ class InProcessCertNodeApi implements CertNodeApi {
                 for (const entry of chunk) {
                     const index = entry.commandRef === undefined ? undefined : entry.commandRef - 1;
                     if (index === undefined || index < 0 || index >= commands.length) {
-                        throw new InternalError(
+                        throw new UnexpectedDataError(
                             `Invoke response carries commandRef ${entry.commandRef}, which belongs to no command of ` +
-                                `this ${commands.length}-command request`,
+                                `this ${commands.length}-command request; ${results.length} result(s) had arrived ` +
+                                `first: ${JSON.stringify(results)}`,
                         );
                     }
 
@@ -644,18 +649,16 @@ class InProcessCertNodeApi implements CertNodeApi {
     decommission(): Promise<void> {
         return runTagged(this.#adapterId, async () => {
             const peer = this.#peer;
-            try {
-                await peer.decommission();
-                return;
-            } catch (e) {
-                // Decommissioning acts through the peer's OperationalCredentials behavior, which exists only once a
-                // report has carried that cluster. A peer whose structure read aborted holds no such behavior.
-                if (!peer.lifecycle.isCommissioned) {
-                    throw e;
-                }
-                logger.info(`Decommissioning ${peer.id} failed, reading its credentials and retrying:`, e);
+
+            // Decommissioning acts through the peer's OperationalCredentials behavior, which exists only
+            // once a report has carried that cluster; a peer whose structure read aborted holds none. The
+            // read is what installs it — so it happens before the attempt rather than as a retry, which
+            // would answer every other failure the same way, including a refusal a step means to assert.
+            if (peer.lifecycle.isCommissioned && !peer.behaviors.has(OperationalCredentialsClient)) {
+                logger.info(`Reading ${peer.id}'s credentials, which decommissioning it needs`);
+                await this.readAttribute({ endpoint: 0, cluster: OperationalCredentials.id });
             }
-            await this.readAttribute({ endpoint: 0, cluster: OperationalCredentials.id });
+
             await peer.decommission();
         });
     }
@@ -842,7 +845,16 @@ export class InProcessControllerAdapter implements ControllerAdapter {
                 timeout: target.giveUpAfterMs === undefined ? undefined : Millis(target.giveUpAfterMs),
                 regulatoryLocation: GeneralCommissioning.RegulatoryLocationType.IndoorOutdoor,
                 regulatoryCountryCode: "XX",
-                onAttestationFailure: () => true,
+                onAttestationFailure: findings => {
+                    // Accepting is what lets a test device commission at all; the evidence still has
+                    // to say what was accepted, or a step asserting a clean attestation proves nothing
+                    logger.notice(
+                        `Accepting device attestation findings: ${findings
+                            .map(({ level, type, message }) => `${level} ${type}: ${message}`)
+                            .join("; ")}`,
+                    );
+                    return true;
+                },
             });
             const address = peer.peerAddress;
             if (address === undefined) {

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -8,6 +8,7 @@ import {
     Boot,
     ClientNode,
     ControllerBehavior,
+    Diagnostic,
     Duration,
     Environment,
     ImplementationError,
@@ -411,7 +412,7 @@ class InProcessCertNodeApi implements CertNodeApi {
                         throw new UnexpectedDataError(
                             `Invoke response carries commandRef ${entry.commandRef}, which belongs to no command of ` +
                                 `this ${commands.length}-command request; ${results.length} result(s) had arrived ` +
-                                `first: ${JSON.stringify(results)}`,
+                                `first: ${Diagnostic.json(results)}`,
                         );
                     }
 
@@ -650,10 +651,10 @@ class InProcessCertNodeApi implements CertNodeApi {
         return runTagged(this.#adapterId, async () => {
             const peer = this.#peer;
 
-            // Decommissioning acts through the peer's OperationalCredentials behavior, which exists only
-            // once a report has carried that cluster; a peer whose structure read aborted holds none. The
-            // read is what installs it — so it happens before the attempt rather than as a retry, which
-            // would answer every other failure the same way, including a refusal a step means to assert.
+            // Decommissioning acts through the peer's OperationalCredentials behavior, which the first
+            // report carrying that cluster installs; a peer whose structure read aborted has none, and
+            // reading it here is what installs it. Only that condition may be pre-empted: any other
+            // failure is the step's outcome, including a refusal a step means to assert.
             if (peer.lifecycle.isCommissioned && !peer.behaviors.has(OperationalCredentialsClient)) {
                 logger.info(`Reading ${peer.id}'s credentials, which decommissioning it needs`);
                 await this.readAttribute({ endpoint: 0, cluster: OperationalCredentials.id });

--- a/support/chip-testing/test/cert-framework/controller-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/controller-adapter.test.ts
@@ -484,9 +484,8 @@ describe("InProcessControllerAdapter", () => {
         await node.decommission();
     });
 
-    // Characterization: matter.js's own Write action enforces § 8.9.2.8.1, so the adapter needs no guard
-    // of its own. Pinned because a review proposed adding one, on the premise that nothing below the
-    // adapter validated it.
+    // Characterization: § 8.9.2.8.1 is enforced by matter.js's own write action, not by this adapter, so
+    // a guard added here would be dead code.
     it("refuses a data version on a wildcard endpoint path, which the specification forbids", async function () {
         this.timeout(30_000);
 

--- a/support/chip-testing/test/cert-framework/controller-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/controller-adapter.test.ts
@@ -484,6 +484,28 @@ describe("InProcessControllerAdapter", () => {
         await node.decommission();
     });
 
+    // Characterization: matter.js's own Write action enforces § 8.9.2.8.1, so the adapter needs no guard
+    // of its own. Pinned because a review proposed adding one, on the premise that nothing below the
+    // adapter validated it.
+    it("refuses a data version on a wildcard endpoint path, which the specification forbids", async function () {
+        this.timeout(30_000);
+
+        const ref = await adapter.commission({ passcode: 20202021, discriminator: 3840 });
+        const node = adapter.node(ref);
+
+        await expect(
+            node.writeAttributes([
+                {
+                    path: { cluster: BASIC_INFORMATION.id, attribute: NODE_LABEL_ATTRIBUTE.id },
+                    value: "wildcard",
+                    dataVersion: 1,
+                },
+            ]),
+        ).rejectedWith(/must target a concrete endpoint/);
+
+        await node.decommission();
+    });
+
     it("throws when constructing a second adapter with an id already registered", () => {
         expect(() => new InProcessControllerAdapter("dut")).to.throw(InternalError, /already registered/);
     });

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -17,8 +17,9 @@ import {
     ON_NETWORK_ONLY,
     qrPayloadWith,
     qrPayloadWithPrefix,
+    recordVendorOutcome,
 } from "../cert/tc-dd-support.js";
-import { CertCheckFailedError, CertCleanupError } from "../cert/tc-support.js";
+import { CertCheckFailedError, CertCleanupError, CommissionedRefs } from "../cert/tc-support.js";
 
 /**
  * `devicediscovery.adoc`'s own example payload for TC-DD-3.14: vendor id 0xFFF1, product id 0x8001,
@@ -97,58 +98,59 @@ describe("qrPayloadWithPrefix", () => {
     });
 });
 
+/** A step context whose DUT controller answers commissioning as the test says, and nothing else. */
+function contextWith(
+    commission: () => Promise<CertNodeRef>,
+    decommission: (ref: CertNodeRef) => Promise<void> = async () => {},
+): CertStepContext {
+    const unused = () => Promise.reject(new InternalError("not used by these tests"));
+    const noLines = async function* (): AsyncGenerator<string> {};
+
+    const nodeFor = (ref: CertNodeRef) =>
+        ({
+            invoke: unused,
+            invokeBatch: unused,
+            readAttribute: unused,
+            readAttributes: unused,
+            writeAttribute: unused,
+            writeAttributes: unused,
+            subscribe: unused,
+            readEvents: unused,
+            subscribeEvents: unused,
+            openCommissioningWindow: unused,
+            operationalMdnsInstanceName: unused,
+            decommission: () => decommission(ref),
+        }) satisfies CertNodeApi;
+
+    const dut = {
+        id: "dut",
+        log: new LogFollower(noLines(), "dut"),
+        async start() {},
+        async close() {},
+        commission,
+        parseQrPayload: unused,
+        parseManualPairingCode: unused,
+        node: nodeFor,
+    } satisfies ControllerAdapter;
+
+    return {
+        controllers: { dut },
+        devices: {},
+        recorder: {
+            beginStep() {},
+            check() {},
+            endStep() {
+                return [];
+            },
+            async flush() {
+                return "";
+            },
+        },
+    };
+}
+
 describe("CommissioningRefusals", () => {
     const BUDGETS = { refusalTimeoutMs: 100, settleTimeoutMs: 100 };
-
-    function contextWith(
-        commission: () => Promise<CertNodeRef>,
-        decommission: (ref: CertNodeRef) => Promise<void> = async () => {},
-    ): CertStepContext {
-        const unused = () => Promise.reject(new InternalError("not used by these tests"));
-        const noLines = async function* (): AsyncGenerator<string> {};
-
-        const nodeFor = (ref: CertNodeRef) =>
-            ({
-                invoke: unused,
-                invokeBatch: unused,
-                readAttribute: unused,
-                readAttributes: unused,
-                writeAttribute: unused,
-                writeAttributes: unused,
-                subscribe: unused,
-                readEvents: unused,
-                subscribeEvents: unused,
-                openCommissioningWindow: unused,
-                operationalMdnsInstanceName: unused,
-                decommission: () => decommission(ref),
-            }) satisfies CertNodeApi;
-
-        const dut = {
-            id: "dut",
-            log: new LogFollower(noLines(), "dut"),
-            async start() {},
-            async close() {},
-            commission,
-            parseQrPayload: unused,
-            parseManualPairingCode: unused,
-            node: nodeFor,
-        } satisfies ControllerAdapter;
-
-        return {
-            controllers: { dut },
-            devices: {},
-            recorder: {
-                beginStep() {},
-                check() {},
-                endStep() {
-                    return [];
-                },
-                async flush() {
-                    return "";
-                },
-            },
-        };
-    }
 
     it("does not accept a bare UnexpectedDataError, which commissioning raises after taking the payload", async () => {
         const cx = contextWith(() => Promise.reject(new UnexpectedDataError("Invalid response from device")));
@@ -273,6 +275,52 @@ describe("CommissioningRefusals", () => {
         await expect(refusals.requireRefusal(cx, { qrPairingCode: "MT:whatever" }, "must be refused")).rejected;
 
         await expect(refusals.settle(cx)).rejectedWith(CertCleanupError, /still running/);
+    });
+});
+
+describe("recordVendorOutcome", () => {
+    const CODE = "34970112332";
+
+    it("fails, and leaves cleanup owning the attempt, when the DUT neither onboards nor gives up", async () => {
+        const refusals = new CommissioningRefusals({ refusalTimeoutMs: 50, settleTimeoutMs: 50 });
+        const cx = contextWith(() => new Promise<CertNodeRef>(() => {}));
+
+        await expect(
+            recordVendorOutcome(cx, CODE, new CommissionedRefs(), refusals, "vendor outcome", 50),
+        ).rejectedWith(/neither onboarded the TH nor gave up/);
+
+        await expect(refusals.settle(cx)).rejectedWith(/still running/);
+    });
+
+    it("records the DUT onboarding the TH, which the plan also allows", async () => {
+        const refusals = new CommissioningRefusals({ refusalTimeoutMs: 50, settleTimeoutMs: 50 });
+        const decommissioned = new Array<CertNodeRef>();
+        const cx = contextWith(
+            async () => "peer1" as CertNodeRef,
+            async ref => {
+                decommissioned.push(ref);
+            },
+        );
+        const commissioned = new CommissionedRefs();
+
+        await recordVendorOutcome(cx, CODE, commissioned, refusals, "vendor outcome", 50);
+
+        expect(commissioned.get("dut")).equal("peer1");
+        await refusals.settle(cx);
+        expect(decommissioned).deep.equal(["peer1"]);
+    });
+
+    it("records the DUT terminating commissioning", async () => {
+        const refusals = new CommissioningRefusals({ refusalTimeoutMs: 50, settleTimeoutMs: 50 });
+        const cx = contextWith(async () => {
+            throw new InternalError("code names a vendor this network does not carry");
+        });
+        const commissioned = new CommissionedRefs();
+
+        await recordVendorOutcome(cx, CODE, commissioned, refusals, "vendor outcome", 50);
+
+        expect(commissioned.get("dut")).equal(undefined);
+        await refusals.settle(cx);
     });
 });
 

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -292,7 +292,7 @@ describe("recordVendorOutcome", () => {
         await expect(refusals.settle(cx)).rejectedWith(/still running/);
     });
 
-    it("records the DUT onboarding the TH, which the plan also allows", async () => {
+    it("records the DUT onboarding the TH, leaving the fabric to the step that owns it", async () => {
         const refusals = new CommissioningRefusals({ refusalTimeoutMs: 50, settleTimeoutMs: 50 });
         const decommissioned = new Array<CertNodeRef>();
         const cx = contextWith(
@@ -306,8 +306,11 @@ describe("recordVendorOutcome", () => {
         await recordVendorOutcome(cx, CODE, commissioned, refusals, "vendor outcome", 50);
 
         expect(commissioned.get("dut")).equal("peer1");
+
+        // Cleanup must not remove it as well: the ref above is what removes it, and a second removal
+        // of the same fabric fails
         await refusals.settle(cx);
-        expect(decommissioned).deep.equal(["peer1"]);
+        expect(decommissioned).deep.equal([]);
     });
 
     it("records the DUT terminating commissioning", async () => {

--- a/support/chip-testing/test/cert-framework/tc-idm-1.3-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-1.3-support.test.ts
@@ -270,6 +270,15 @@ describe("expectBatchRequestPaths", () => {
         expect(check.verdict).equal("pass");
     });
 
+    it("fails when two separate requests carried one command each instead of one batch", async () => {
+        const check = await withBufferedFollower(
+            [...batchRequestLines([PATHS[0]]), ...batchRequestLines([PATHS[1]])],
+            follower => expectBatchRequestPaths(follower, "chip-local", PATHS, 0, 500),
+        );
+
+        expect(check.verdict).equal("fail");
+    });
+
     it("is unverified for a matterjs device", async () => {
         const check = await withFollower(batchRequestLines(PATHS), follower =>
             expectBatchRequestPaths(follower, "matterjs", PATHS, 0, 200),

--- a/support/chip-testing/test/cert-framework/tc-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-support.test.ts
@@ -159,6 +159,13 @@ describe("expectChunkedTransfer", () => {
         expect(record.detail).contains(`Exchange ${EXCHANGE}`);
     });
 
+    it("fails when two one-chunk reads, each acked on its own exchange, look like a chunked one", async () => {
+        const record = await check([...chunkLines(), ackLine(), ...chunkLines(EXCHANGE + 1), ackLine(EXCHANGE + 1)]);
+
+        expect(record.verdict).equal("fail");
+        expect(record.detail).match(/belongs to another read/);
+    });
+
     it("fails when a chunk has no outbound trace line to take an exchange from", async () => {
         const record = await check([CHUNK, ackLine(), ...chunkLines(), ackLine(), ...chunkLines(), NOISE]);
 

--- a/support/chip-testing/test/cert-framework/tc-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-support.test.ts
@@ -29,9 +29,19 @@ import {
     WRITE_REQUEST_MESSAGE,
 } from "../cert/tc-support.js";
 
+const EXCHANGE = 26481;
 const CHUNK = "[DMG] ReportDataMessage =";
-const ACK = "[EM] <<< [E:1r S:2 M:3] (S) Msg RX from 1:0000000000000001 [1234] --- Type 0001:01 (IM:StatusResponse)";
 const NOISE = "[DMG] AttributeReportIBs =";
+
+// chip prints the outbound trace line, then the chunk's decode dump; the DUT's ack arrives on the
+// same Exchange, on a different Session. Shapes verified against a real chip-all-clusters-app log.
+const sentLine = (exchange = EXCHANGE) =>
+    `[DMG] >> to UDP:[fe80::1%eth0]:58253 | 92720281 | [Interaction Model  (1) / Report Data (0x05) / Session = 56179 / Exchange = ${exchange}]`;
+const ackLine = (exchange = EXCHANGE) =>
+    `[DMG] << from UDP:[fe80::1%eth0]:58253 | 208635799 | [Interaction Model  (1) / Status Response (0x01) / Session = 13606 / Exchange = ${exchange}]`;
+
+/** One chunk as chip logs it: its own trace line, then the decode dump the check matches. */
+const chunkLines = (exchange = EXCHANGE) => [sentLine(exchange), CHUNK];
 
 /**
  * A log source the test feeds by hand and never ends — a source that finishes closes the follower,
@@ -106,35 +116,69 @@ async function check(lines: string[], flavor = "chip-docker", endSource = false)
 
 describe("expectChunkedTransfer", () => {
     it("passes when every chunk but the last is acked", async () => {
-        const record = await check([CHUNK, NOISE, ACK, CHUNK, ACK, CHUNK, NOISE]);
+        const record = await check([
+            ...chunkLines(),
+            NOISE,
+            ackLine(),
+            ...chunkLines(),
+            ackLine(),
+            ...chunkLines(),
+            NOISE,
+        ]);
 
         expect(record.verdict).equal("pass");
         expect(record.detail).equal("3 report chunks, each but the last followed by a StatusResponse");
     });
 
     it("fails when a later chunk pair has no StatusResponse between it", async () => {
-        const record = await check([CHUNK, ACK, CHUNK, NOISE, CHUNK, ACK]);
+        const record = await check([...chunkLines(), ackLine(), ...chunkLines(), NOISE, ...chunkLines(), ackLine()]);
 
         expect(record.verdict).equal("fail");
         expect(record.detail).match(/chunk 2 of 3 went unacked/);
     });
 
     it("fails when the first chunk pair has no StatusResponse between it", async () => {
-        const record = await check([CHUNK, CHUNK, ACK, CHUNK, ACK]);
+        const record = await check([...chunkLines(), ...chunkLines(), ackLine(), ...chunkLines(), ackLine()]);
 
         expect(record.verdict).equal("fail");
         expect(record.detail).match(/chunk 1 of 3 went unacked/);
     });
 
+    it("fails when the only StatusResponse between two chunks answered another exchange", async () => {
+        const record = await check([
+            ...chunkLines(),
+            ackLine(EXCHANGE + 1),
+            ...chunkLines(),
+            ackLine(),
+            ...chunkLines(),
+            NOISE,
+        ]);
+
+        expect(record.verdict).equal("fail");
+        expect(record.detail).match(/chunk 1 of 3 went unacked/);
+        expect(record.detail).contains(`Exchange ${EXCHANGE}`);
+    });
+
+    it("fails when a chunk has no outbound trace line to take an exchange from", async () => {
+        const record = await check([CHUNK, ackLine(), ...chunkLines(), ackLine(), ...chunkLines(), NOISE]);
+
+        expect(record.verdict).equal("fail");
+        expect(record.detail).match(/No outbound Report Data trace line/);
+    });
+
     it("fails when the read never chunked", async () => {
-        const record = await check([CHUNK, ACK]);
+        const record = await check([...chunkLines(), ackLine()]);
 
         expect(record.verdict).equal("fail");
         expect(record.detail).match(/did not chunk/);
     });
 
     it("treats a log source that ends mid-transfer as the end of the transfer", async () => {
-        const record = await check([CHUNK, ACK, CHUNK, ACK, CHUNK], "chip-docker", true);
+        const record = await check(
+            [...chunkLines(), ackLine(), ...chunkLines(), ackLine(), ...chunkLines()],
+            "chip-docker",
+            true,
+        );
 
         expect(record.verdict).equal("pass");
         expect(record.detail).equal("3 report chunks, each but the last followed by a StatusResponse");

--- a/support/chip-testing/test/cert/TC-DD-3.17.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.17.test.ts
@@ -254,6 +254,7 @@ certTest("TC-DD-3.17", {
                     cx,
                     manualPairingCode({ ...parts, vendorId }),
                     commissioned,
+                    refusals,
                     `Code naming vendor 0x${vendorId.toString(16)}`,
                     VENDOR_OUTCOME_TIMEOUT_MS,
                 );

--- a/support/chip-testing/test/cert/TC-SC-3.5.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-3.5.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Duration, InternalError, Millis, Time } from "@matter/main";
+import { Duration, InternalError, Millis } from "@matter/main";
 import type { CertStepContext, CertStepDefinition, PromptHandler, StepVerdict, Subject } from "@matter/testing";
 import {
     chip,
@@ -15,6 +15,7 @@ import {
 } from "@matter/testing";
 import { join } from "node:path";
 import { env } from "node:process";
+import { settleWithin } from "./tc-support.js";
 
 // setup_class's th_server_discriminator — fixed for every OpenCommissioningWindow call in the script.
 // The passcode is NOT fixed the same way: only the initial precondition commission (TH_CLIENT pairing
@@ -62,15 +63,6 @@ function extractPasscode(promptText: string): number {
 // DUT that hangs instead of rejecting must not stall this step for the full mocha timeout.
 const COMMISSION_TIMEOUT_MS = 60_000;
 
-type SettleOutcome = { kind: "resolved"; ref: string } | { kind: "rejected"; error: unknown } | { kind: "timeout" };
-
-function settled(promise: Promise<string>): Promise<SettleOutcome> {
-    return promise.then(
-        (ref): SettleOutcome => ({ kind: "resolved", ref }),
-        (error: unknown): SettleOutcome => ({ kind: "rejected", error }),
-    );
-}
-
 /**
  * Handles every "Manual Pairing Code" prompt `TC_SC_3_5.py` prints — steps 1b, 2c, 3c, 4c, 5c (4c is
  * skipped, and never prompts, if DUT has no ICAC in its NOC chain; see the script's `setup_class`/
@@ -101,26 +93,18 @@ function manualPairingCodeHandler(state: { attempts: number }): PromptHandler {
             };
             cx.recorder.beginStep(stepDef);
 
-            const timeout = Time.sleep("TC-SC-3.5 commission timeout", Millis(COMMISSION_TIMEOUT_MS));
-            let outcome: SettleOutcome;
-            try {
-                outcome = await Promise.race([
-                    settled(
-                        dut.commission({
-                            passcode,
-                            discriminator: TH_SERVER_DISCRIMINATOR,
-                            // The script arms each fault for one handshake only, so a commissioner that retries gets a
-                            // clean one and commissions successfully. Step 1b injects no fault and must be free to
-                            // recover like any healthy commissioning.
-                            singleHandshakeAttempt: !expectSuccess,
-                        }),
-                    ),
-                    timeout.then((): SettleOutcome => ({ kind: "timeout" })),
-                ]);
-            } finally {
-                // A lost race leaves the sleep armed for its full duration, keeping the process alive past teardown
-                timeout.cancel();
-            }
+            const outcome = await settleWithin(
+                `TC-SC-3.5 commissioning attempt ${attempt}`,
+                dut.commission({
+                    passcode,
+                    discriminator: TH_SERVER_DISCRIMINATOR,
+                    // The script arms each fault for one handshake only, so a commissioner that retries gets a
+                    // clean one and commissions successfully. Step 1b injects no fault and must be free to
+                    // recover like any healthy commissioning.
+                    singleHandshakeAttempt: !expectSuccess,
+                }),
+                COMMISSION_TIMEOUT_MS,
+            );
 
             let verdict: StepVerdict;
             let failure: Error | undefined;
@@ -131,11 +115,11 @@ function manualPairingCodeHandler(state: { attempts: number }): PromptHandler {
                     cx.recorder.check({
                         type: "response",
                         verdict,
-                        detail: `commission() resolved on attempt ${attempt} (ref ${outcome.ref})`,
+                        detail: `commission() resolved on attempt ${attempt} (ref ${outcome.value})`,
                     });
                     if (!expectSuccess) {
                         await dut
-                            .node(outcome.ref)
+                            .node(outcome.value)
                             .decommission()
                             .catch(e =>
                                 console.warn(`Failed to decommission unexpectedly-successful attempt ${attempt}:`, e),

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -10,7 +10,14 @@ import type { CertNodeRef, CertStepContext, CommissioningTarget } from "@matter/
 import type { CertDevice } from "@matter/testing";
 import { expectMdns } from "../../src/cert/mdns-check.js";
 import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload.js";
-import { CertCleanupError, CommissionedRefs, expectRejection, expectSequence, record } from "./tc-support.js";
+import {
+    CertCleanupError,
+    CommissionedRefs,
+    expectRejection,
+    expectSequence,
+    record,
+    settleWithin,
+} from "./tc-support.js";
 
 export const LOG_TIMEOUT_MS = 30_000;
 export const MDNS_TIMEOUT_MS = 30_000;
@@ -225,6 +232,11 @@ export class CommissioningRefusals {
         this.#settleTimeoutMs = budgets?.settleTimeoutMs ?? REFUSAL_SETTLE_TIMEOUT_MS;
     }
 
+    /** How long {@link settle} waits, for a step that needs the same slack for its own wait. */
+    get settleBudgetMs(): number {
+        return this.#settleTimeoutMs;
+    }
+
     /**
      * Records that the DUT refuses to commission from `payload`, which is how the negative plans
      * phrase "the DUT terminates the commissioning process in a DUT-specific manner".
@@ -233,16 +245,23 @@ export class CommissioningRefusals {
      * rejection would let the step pass on a controller that died, timed out or was never asked —
      * outcomes that say nothing about what the DUT made of the code.
      */
-    async requireRefusal(cx: CertStepContext, target: CommissioningTarget, what: string): Promise<void> {
-        const attempt = cx.controllers.dut.commission(target);
-        // Kept as a settled outcome so an attempt nobody awaits again cannot surface as an unhandled
-        // rejection, and so settle() can collect the ref of one that succeeded after its budget
+    /**
+     * Hands `attempt` to {@link settle}, which is what a step that may stop waiting for a
+     * commissioning owes the run: one that succeeds late leaves a fabric on the TH. Kept as a settled
+     * outcome so an attempt nobody awaits again cannot surface as an unhandled rejection.
+     */
+    track(attempt: Promise<CertNodeRef>): void {
         this.#attempts.push(
             attempt.then(
                 ref => ref,
                 () => undefined,
             ),
         );
+    }
+
+    async requireRefusal(cx: CertStepContext, target: CommissioningTarget, what: string): Promise<void> {
+        const attempt = cx.controllers.dut.commission(target);
+        this.track(attempt);
 
         record(
             cx,
@@ -268,12 +287,7 @@ export class CommissioningRefusals {
         timeoutMs: number,
     ): Promise<void> {
         const attempt = cx.controllers.dut.commission(target);
-        this.#attempts.push(
-            attempt.then(
-                ref => ref,
-                () => undefined,
-            ),
-        );
+        this.track(attempt);
 
         record(
             cx,
@@ -442,31 +456,64 @@ export async function recordVendorOutcome(
     cx: CertStepContext,
     manualPairingCode: string,
     commissioned: CommissionedRefs,
+    refusals: CommissioningRefusals,
     what: string,
     timeoutMs: number,
 ): Promise<void> {
     await restoreCommissioningMode(cx, commissioned);
 
-    const dut = cx.controllers.dut;
-    const attempt = dut.commission({ manualPairingCode, giveUpAfterMs: timeoutMs });
+    const label = `commissioning from ${manualPairingCode}`;
+    const attempt = cx.controllers.dut.commission({ manualPairingCode, giveUpAfterMs: timeoutMs });
 
-    const outcome = await expectRejection(`commissioning from ${manualPairingCode}`, attempt, timeoutMs + 30_000);
-    if (outcome.verdict === "pass") {
-        record(cx, { ...outcome, detail: `DUT terminated commissioning: ${outcome.detail}` }, what);
-        return;
+    // The plan accepts either outcome, so the attempt is tracked rather than required to fail: one
+    // that neither onboards nor gives up inside the budget is the step's failure, and cleanup — not
+    // another unbounded wait here — is what owns it afterwards.
+    refusals.track(attempt);
+
+    const outcome = await settleWithin(label, attempt, timeoutMs + refusals.settleBudgetMs);
+
+    switch (outcome.kind) {
+        case "rejected": {
+            const { error } = outcome;
+            const message = error instanceof Error ? `${error.constructor.name}: ${error.message}` : String(error);
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: "pass",
+                    detail: `DUT terminated commissioning after ${outcome.elapsed}: ${message}`,
+                },
+                what,
+            );
+            return;
+        }
+
+        case "resolved": {
+            const ref = outcome.value;
+            commissioned.set("dut", ref);
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: "pass",
+                    detail: `DUT onboarded the TH as node ${ref}, which the plan allows where the user accepts the risk`,
+                },
+                what,
+            );
+            return;
+        }
+
+        case "timeout":
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: "fail",
+                    detail: `${label} neither onboarded the TH nor gave up within ${outcome.elapsed}`,
+                },
+                what,
+            );
     }
-
-    const ref = await attempt;
-    commissioned.set("dut", ref);
-    record(
-        cx,
-        {
-            type: "response",
-            verdict: "pass",
-            detail: `DUT onboarded the TH as node ${ref}, which the plan allows where the user accepts the risk`,
-        },
-        what,
-    );
 }
 
 /**

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -238,17 +238,11 @@ export class CommissioningRefusals {
     }
 
     /**
-     * Records that the DUT refuses to commission from `payload`, which is how the negative plans
-     * phrase "the DUT terminates the commissioning process in a DUT-specific manner".
-     *
-     * Only a refusal of the payload itself counts (see {@link isPayloadRefusal}). Accepting any
-     * rejection would let the step pass on a controller that died, timed out or was never asked —
-     * outcomes that say nothing about what the DUT made of the code.
-     */
-    /**
-     * Hands `attempt` to {@link settle}, which is what a step that may stop waiting for a
-     * commissioning owes the run: one that succeeds late leaves a fabric on the TH. Kept as a settled
-     * outcome so an attempt nobody awaits again cannot surface as an unhandled rejection.
+     * Hands `attempt` to {@link settle}, which is what a step that stops waiting for a commissioning
+     * owes the run: one that succeeds afterwards leaves a fabric on the TH that nothing else will
+     * remove. An attempt whose outcome the step *did* see is owned by the step, and handing that one
+     * over as well would have its fabric removed twice. Kept as a settled outcome so an attempt nobody
+     * awaits again cannot surface as an unhandled rejection.
      */
     track(attempt: Promise<CertNodeRef>): void {
         this.#attempts.push(
@@ -259,6 +253,14 @@ export class CommissioningRefusals {
         );
     }
 
+    /**
+     * Records that the DUT refuses to commission from `payload`, which is how the negative plans
+     * phrase "the DUT terminates the commissioning process in a DUT-specific manner".
+     *
+     * Only a refusal of the payload itself counts (see {@link isPayloadRefusal}). Accepting any
+     * rejection would let the step pass on a controller that died, timed out or was never asked —
+     * outcomes that say nothing about what the DUT made of the code.
+     */
     async requireRefusal(cx: CertStepContext, target: CommissioningTarget, what: string): Promise<void> {
         const attempt = cx.controllers.dut.commission(target);
         this.track(attempt);
@@ -342,8 +344,8 @@ export class CommissioningRefusals {
         }
         if (failures.length) {
             throw new CertCleanupError(
-                `The DUT commissioned the TH from a payload it was asked to refuse and the fabric could not be ` +
-                    `removed: ${failures.join("; ")}`,
+                `A commissioning attempt this run stopped waiting for onboarded the TH after all, and the fabric ` +
+                    `could not be removed: ${failures.join("; ")}`,
             );
         }
     }
@@ -464,12 +466,6 @@ export async function recordVendorOutcome(
 
     const label = `commissioning from ${manualPairingCode}`;
     const attempt = cx.controllers.dut.commission({ manualPairingCode, giveUpAfterMs: timeoutMs });
-
-    // The plan accepts either outcome, so the attempt is tracked rather than required to fail: one
-    // that neither onboards nor gives up inside the budget is the step's failure, and cleanup — not
-    // another unbounded wait here — is what owns it afterwards.
-    refusals.track(attempt);
-
     const outcome = await settleWithin(label, attempt, timeoutMs + refusals.settleBudgetMs);
 
     switch (outcome.kind) {
@@ -504,6 +500,10 @@ export async function recordVendorOutcome(
         }
 
         case "timeout":
+            // Only now does cleanup own the attempt: an outcome this step saw is already owned, by
+            // `commissioned` for one that onboarded, and handing it over as well would have the fabric
+            // removed twice.
+            refusals.track(attempt);
             record(
                 cx,
                 {

--- a/support/chip-testing/test/cert/tc-idm-1.3-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-1.3-support.ts
@@ -161,6 +161,17 @@ export async function expectBatchRequestPaths(
             return { type: "device-log", verdict: "unverified" };
         }
 
+        // The matched message's own closing line is located first, because it is what bounds
+        // everything below: a path or a command found past it belongs to a later request, which is
+        // the case this check exists to tell apart from one batch carrying them all.
+        const end = await log.expect(
+            { chip: INTERACTION_MODEL_REVISION },
+            { flavor, timeoutMs, from: envelope.last.index + 1 },
+        );
+        if (end.verdict === "unverified") {
+            return { type: "device-log", verdict: "unverified" };
+        }
+
         let last = envelope.last;
         for (const { endpoint, cluster, command } of paths) {
             const block = await expectAdjacentLines(
@@ -173,12 +184,18 @@ export async function expectBatchRequestPaths(
             if (block.verdict === "unverified") {
                 return { type: "device-log", verdict: "unverified" };
             }
+            if (block.last.index > end.matched.index) {
+                return {
+                    type: "device-log",
+                    verdict: "fail",
+                    pattern: label,
+                    detail:
+                        `endpoint ${endpoint} cluster ${cluster} command ${command} appears only after the ` +
+                        "request ended, so a later request carried it",
+                    logLine: block.last.index,
+                };
+            }
             last = block.last;
-        }
-
-        const end = await log.expect({ chip: INTERACTION_MODEL_REVISION }, { flavor, timeoutMs, from: last.index + 1 });
-        if (end.verdict === "unverified") {
-            return { type: "device-log", verdict: "unverified" };
         }
 
         const commands =

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -1018,13 +1018,44 @@ export async function expectReportAck(
     }
 }
 
-type SettleOutcome = { kind: "resolved" } | { kind: "rejected"; error: unknown } | { kind: "timeout" };
+/**
+ * How an operation a step was waiting for ended, and how long it took, formatted for the evidence.
+ * A `"timeout"` says only that the wait ended: the operation itself is still running.
+ */
+export type SettleReport<T = unknown> = { elapsed: string } & (
+    | { kind: "resolved"; value: T }
+    | { kind: "rejected"; error: unknown }
+    | { kind: "timeout" }
+);
 
-function settled(promise: Promise<unknown>): Promise<SettleOutcome> {
-    return promise.then(
-        (): SettleOutcome => ({ kind: "resolved" }),
-        (error: unknown): SettleOutcome => ({ kind: "rejected", error }),
-    );
+/**
+ * Waits for `op` to settle, bounded by `timeoutMs` so an implementation that neither answers nor
+ * gives up cannot hang the step for the whole mocha timeout. Reports which way it went, for a step
+ * that has something to record either way; {@link expectRejection} is the form for a step that
+ * demands a refusal.
+ *
+ * A step that stops waiting is still responsible for what the operation does afterwards — a
+ * commissioning that succeeds late leaves a fabric on the device.
+ */
+export async function settleWithin<T>(label: string, op: Promise<T>, timeoutMs: number): Promise<SettleReport<T>> {
+    // nowUs is the monotonic clock despite the name; nowMs tracks UTC and a step of it would put a
+    // negative elapsed into the evidence
+    const start = Time.nowUs;
+    const elapsed = () => Duration.format(Millis(Time.nowUs - start));
+    const timeout = Time.sleep(`${label} settle timeout`, Millis(timeoutMs));
+
+    try {
+        return await Promise.race([
+            op.then(
+                (value): SettleReport<T> => ({ kind: "resolved", value, elapsed: elapsed() }),
+                (error: unknown): SettleReport<T> => ({ kind: "rejected", error, elapsed: elapsed() }),
+            ),
+            timeout.then((): SettleReport<T> => ({ kind: "timeout", elapsed: elapsed() })),
+        ]);
+    } finally {
+        // A lost race leaves the sleep armed for its full duration, keeping the process alive past teardown
+        timeout.cancel();
+    }
 }
 
 /**
@@ -1043,18 +1074,8 @@ export async function expectRejection(
     timeoutMs: number,
     accept?: (error: unknown) => boolean,
 ): Promise<CheckRecord> {
-    // nowUs is the monotonic clock despite the name; nowMs tracks UTC and a step of it would put a
-    // negative elapsed into the evidence
-    const start = Time.nowUs;
-    const timeout = Time.sleep(`${label} rejection timeout`, Millis(timeoutMs));
-    let outcome: SettleOutcome;
-    try {
-        outcome = await Promise.race([settled(op), timeout.then((): SettleOutcome => ({ kind: "timeout" }))]);
-    } finally {
-        // A lost race leaves the sleep armed for its full duration, keeping the process alive past teardown
-        timeout.cancel();
-    }
-    const elapsed = Duration.format(Millis(Time.nowUs - start));
+    const outcome = await settleWithin(label, op, timeoutMs);
+    const { elapsed } = outcome;
 
     switch (outcome.kind) {
         case "resolved":

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -163,7 +163,6 @@ export async function expectAdjacentLines(
 // pairs). matter.js has no equivalent log line, so this is chip-only; see AGENTS.md's flavor-pattern
 // policy for the matterjs "unverified" fallback.
 export const REPORT_DATA_MESSAGE = /\[DMG\] ReportDataMessage =\s*$/;
-const STATUS_RESPONSE_RECEIVED = /Msg RX from.*\(IM:StatusResponse\)/;
 
 // A subscription's own reports and its SubscribeResponse both carry the id the TH minted for it,
 // printed as the block's first field in chip's own unpadded lowercase hex — captured verbatim in
@@ -461,13 +460,18 @@ export async function expectCommandInvoke(
     let cursor = from;
     let last: { index: number; text: string } | undefined;
 
+    // One deadline for the whole check, not one per wait: a per-wait budget makes the worst case
+    // timeoutMs × (1 + fields.length), where the caller asked for timeoutMs
+    const deadline = Time.nowMs + timeoutMs;
+    const remaining = () => Math.max(1, deadline - Time.nowMs);
+
     try {
         const block = await expectAdjacentLines(
             log,
             flavor,
             commandPathIBSequence(endpoint, cluster, command),
             from,
-            timeoutMs,
+            remaining(),
         );
         if (block.verdict === "unverified") {
             return { type: "device-log", verdict: "unverified" };
@@ -480,7 +484,7 @@ export async function expectCommandInvoke(
             // chip's decode dump appends the TLV type name after the value (verified against a real
             // chip-bridge-app capture).
             const pattern = new RegExp(`0x${id.toString(16)} = ${value} \\(unsigned\\),\\s*$`);
-            const result = await log.expect({ chip: pattern }, { flavor, timeoutMs, from: cursor });
+            const result = await log.expect({ chip: pattern }, { flavor, timeoutMs: remaining(), from: cursor });
             if (result.verdict === "unverified") {
                 return { type: "device-log", verdict: "unverified" };
             }
@@ -585,17 +589,33 @@ export async function expectChunkedTransfer(
 
     const lines = log.lines;
     for (let i = 1; i < chunks.length; i++) {
+        // Matched by Exchange id, like expectReportAck: the node's own subscription stays live during
+        // these runs, so an unrelated report's ack can land between two chunks of this read.
+        const exchange = exchangeIdBefore(log, chunks[i - 1].index);
+        if (exchange === undefined) {
+            return {
+                type: "device-log",
+                verdict: "fail",
+                pattern: String(REPORT_SENT_LINE),
+                detail:
+                    "No outbound Report Data trace line (carrying an Exchange id) found before the report " +
+                    `chunk at log line ${chunks[i - 1].index}`,
+                logLine: chunks[i - 1].index,
+            };
+        }
+
+        const ackPattern = reportAckedOnExchange(exchange);
         const acked = lines
             .slice(chunks[i - 1].index + 1, chunks[i].index)
-            .some(line => !line.synthetic && STATUS_RESPONSE_RECEIVED.test(line.text));
+            .some(line => !line.synthetic && ackPattern.test(line.text));
         if (!acked) {
             return {
                 type: "device-log",
                 verdict: "fail",
-                pattern: String(STATUS_RESPONSE_RECEIVED),
+                pattern: String(ackPattern),
                 detail:
-                    `No StatusResponse between the report chunks at log lines ${chunks[i - 1].index} and ` +
-                    `${chunks[i].index} (chunk ${i} of ${chunks.length} went unacked)`,
+                    `No StatusResponse on Exchange ${exchange} between the report chunks at log lines ` +
+                    `${chunks[i - 1].index} and ${chunks[i].index} (chunk ${i} of ${chunks.length} went unacked)`,
                 logLine: chunks[i].index,
             };
         }
@@ -604,7 +624,7 @@ export async function expectChunkedTransfer(
     return {
         type: "device-log",
         verdict: "pass",
-        pattern: "ReportDataMessage, StatusResponse between every adjacent pair",
+        pattern: "ReportDataMessage, StatusResponse on the same Exchange between every adjacent pair",
         detail: `${chunks.length} report chunks, each but the last followed by a StatusResponse`,
         matched: chunks[chunks.length - 1].text,
         logLine: chunks[chunks.length - 1].index,

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -587,24 +587,41 @@ export async function expectChunkedTransfer(
         };
     }
 
-    const lines = log.lines;
-    for (let i = 1; i < chunks.length; i++) {
-        // Matched by Exchange id, like expectReportAck: the node's own subscription stays live during
-        // these runs, so an unrelated report's ack can land between two chunks of this read.
-        const exchange = exchangeIdBefore(log, chunks[i - 1].index);
-        if (exchange === undefined) {
+    // One transfer stays on one exchange, so this is what makes the chunks *one* read's rather than
+    // several reads' — and, like expectReportAck, what tells this read's acks from those of the node's
+    // own subscription, which stays live during these runs.
+    const exchange = exchangeIdBefore(log, chunks[0].index);
+    if (exchange === undefined) {
+        return {
+            type: "device-log",
+            verdict: "fail",
+            pattern: String(REPORT_SENT_LINE),
+            detail:
+                "No outbound Report Data trace line (carrying an Exchange id) found before the report " +
+                `chunk at log line ${chunks[0].index}`,
+            logLine: chunks[0].index,
+        };
+    }
+
+    for (const [i, chunk] of chunks.entries()) {
+        const chunkExchange = exchangeIdBefore(log, chunk.index);
+        if (chunkExchange !== exchange) {
             return {
                 type: "device-log",
                 verdict: "fail",
                 pattern: String(REPORT_SENT_LINE),
                 detail:
-                    "No outbound Report Data trace line (carrying an Exchange id) found before the report " +
-                    `chunk at log line ${chunks[i - 1].index}`,
-                logLine: chunks[i - 1].index,
+                    `The report chunk at log line ${chunk.index} went out on Exchange ` +
+                    `${chunkExchange ?? "(none)"}, not ${exchange}, so chunk ${i + 1} of ${chunks.length} ` +
+                    "belongs to another read",
+                logLine: chunk.index,
             };
         }
+    }
 
-        const ackPattern = reportAckedOnExchange(exchange);
+    const ackPattern = reportAckedOnExchange(exchange);
+    const lines = log.lines;
+    for (let i = 1; i < chunks.length; i++) {
         const acked = lines
             .slice(chunks[i - 1].index + 1, chunks[i].index)
             .some(line => !line.synthetic && ackPattern.test(line.text));


### PR DESCRIPTION
Stacked on #4275 — that branch is the base, so review this diff alone (four files). Rebase onto main
once #4275 lands.

A review of the certification suite found three shared log checks that can report a pass on evidence
that does not support it. Each fix here is proved by a test that fails against the unmodified check.

## A batched invoke was indistinguishable from two separate ones

The check looked for each expected command path in turn, then counted the commands between the message
it matched and the next closing line it could find — which need not belong to that message. Two
separate requests carrying one command each therefore satisfied a check whose whole purpose is telling
a batch apart from exactly that. A test written before the fix recorded `pass` for that log; with the
fix it fails, which is what the new test asserts.

The message's own closing line is now located first, and a path or a command found past it fails the
check with a detail naming which path arrived late.

## A chunked read's acknowledgements were not tied to the read

The check accepted any inbound status response between two chunks as the earlier chunk's
acknowledgement. Per this suite's own notes the device's subscription stays live during these runs, so
an unrelated report's acknowledgement could stand in for one that never arrived. It is now matched on
the exchange the chunk went out on, the way the subscription report check already does.

Provenance, since this replaces a loose match with a strict one: the two trace line shapes and the
assumption that one transfer stays on one exchange were checked against a real chip log, pulled from
the evidence bundle of a passing certification run — outbound `Report Data (0x05)` and inbound
`Status Response (0x01)` alternating, all on one exchange, on different sessions in each direction.
The unit test fixtures were rewritten to that shape, so they now also document it.

## An invoked command's check could take four times its budget

Every wait got the caller's full timeout, so a command with three fields could run to
`timeout × (1 + fields)` — a minute against a documented fifteen seconds. They now share one deadline,
as every other check in that module does.

## Testing

`build`, `format-verify`, `lint`, the full root suite and the cert framework suite (457 tests) are
green. Two of the three fixes are covered by tests that were red before the change: the two-requests
case, and a status response between two chunks that answers a different exchange. The shared deadline
is not covered — asserting it means asserting wall-clock time, and a timing test in this suite would
trade a real defect for a flaky one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
