### PR TITLE
Bound the wait for a commissioning either outcome satisfies

### DIFF
--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -17,8 +17,9 @@ import {
     ON_NETWORK_ONLY,
     qrPayloadWith,
     qrPayloadWithPrefix,
+    recordVendorOutcome,
 } from "../cert/tc-dd-support.js";
-import { CertCheckFailedError, CertCleanupError } from "../cert/tc-support.js";
+import { CertCheckFailedError, CertCleanupError, CommissionedRefs } from "../cert/tc-support.js";
 
 /**
  * `devicediscovery.adoc`'s own example payload for TC-DD-3.14: vendor id 0xFFF1, product id 0x8001,
@@ -97,58 +98,59 @@ describe("qrPayloadWithPrefix", () => {
     });
 });
 
+/** A step context whose DUT controller answers commissioning as the test says, and nothing else. */
+function contextWith(
+    commission: () => Promise<CertNodeRef>,
+    decommission: (ref: CertNodeRef) => Promise<void> = async () => {},
+): CertStepContext {
+    const unused = () => Promise.reject(new InternalError("not used by these tests"));
+    const noLines = async function* (): AsyncGenerator<string> {};
+
+    const nodeFor = (ref: CertNodeRef) =>
+        ({
+            invoke: unused,
+            invokeBatch: unused,
+            readAttribute: unused,
+            readAttributes: unused,
+            writeAttribute: unused,
+            writeAttributes: unused,
+            subscribe: unused,
+            readEvents: unused,
+            subscribeEvents: unused,
+            openCommissioningWindow: unused,
+            operationalMdnsInstanceName: unused,
+            decommission: () => decommission(ref),
+        }) satisfies CertNodeApi;
+
+    const dut = {
+        id: "dut",
+        log: new LogFollower(noLines(), "dut"),
+        async start() {},
+        async close() {},
+        commission,
+        parseQrPayload: unused,
+        parseManualPairingCode: unused,
+        node: nodeFor,
+    } satisfies ControllerAdapter;
+
+    return {
+        controllers: { dut },
+        devices: {},
+        recorder: {
+            beginStep() {},
+            check() {},
+            endStep() {
+                return [];
+            },
+            async flush() {
+                return "";
+            },
+        },
+    };
+}
+
 describe("CommissioningRefusals", () => {
     const BUDGETS = { refusalTimeoutMs: 100, settleTimeoutMs: 100 };
-
-    function contextWith(
-        commission: () => Promise<CertNodeRef>,
-        decommission: (ref: CertNodeRef) => Promise<void> = async () => {},
-    ): CertStepContext {
-        const unused = () => Promise.reject(new InternalError("not used by these tests"));
-        const noLines = async function* (): AsyncGenerator<string> {};
-
-        const nodeFor = (ref: CertNodeRef) =>
-            ({
-                invoke: unused,
-                invokeBatch: unused,
-                readAttribute: unused,
-                readAttributes: unused,
-                writeAttribute: unused,
-                writeAttributes: unused,
-                subscribe: unused,
-                readEvents: unused,
-                subscribeEvents: unused,
-                openCommissioningWindow: unused,
-                operationalMdnsInstanceName: unused,
-                decommission: () => decommission(ref),
-            }) satisfies CertNodeApi;
-
-        const dut = {
-            id: "dut",
-            log: new LogFollower(noLines(), "dut"),
-            async start() {},
-            async close() {},
-            commission,
-            parseQrPayload: unused,
-            parseManualPairingCode: unused,
-            node: nodeFor,
-        } satisfies ControllerAdapter;
-
-        return {
-            controllers: { dut },
-            devices: {},
-            recorder: {
-                beginStep() {},
-                check() {},
-                endStep() {
-                    return [];
-                },
-                async flush() {
-                    return "";
-                },
-            },
-        };
-    }
 
     it("does not accept a bare UnexpectedDataError, which commissioning raises after taking the payload", async () => {
         const cx = contextWith(() => Promise.reject(new UnexpectedDataError("Invalid response from device")));
@@ -273,6 +275,52 @@ describe("CommissioningRefusals", () => {
         await expect(refusals.requireRefusal(cx, { qrPairingCode: "MT:whatever" }, "must be refused")).rejected;
 
         await expect(refusals.settle(cx)).rejectedWith(CertCleanupError, /still running/);
+    });
+});
+
+describe("recordVendorOutcome", () => {
+    const CODE = "34970112332";
+
+    it("fails, and leaves cleanup owning the attempt, when the DUT neither onboards nor gives up", async () => {
+        const refusals = new CommissioningRefusals({ refusalTimeoutMs: 50, settleTimeoutMs: 50 });
+        const cx = contextWith(() => new Promise<CertNodeRef>(() => {}));
+
+        await expect(
+            recordVendorOutcome(cx, CODE, new CommissionedRefs(), refusals, "vendor outcome", 50),
+        ).rejectedWith(/neither onboarded the TH nor gave up/);
+
+        await expect(refusals.settle(cx)).rejectedWith(/still running/);
+    });
+
+    it("records the DUT onboarding the TH, which the plan also allows", async () => {
+        const refusals = new CommissioningRefusals({ refusalTimeoutMs: 50, settleTimeoutMs: 50 });
+        const decommissioned = new Array<CertNodeRef>();
+        const cx = contextWith(
+            async () => "peer1" as CertNodeRef,
+            async ref => {
+                decommissioned.push(ref);
+            },
+        );
+        const commissioned = new CommissionedRefs();
+
+        await recordVendorOutcome(cx, CODE, commissioned, refusals, "vendor outcome", 50);
+
+        expect(commissioned.get("dut")).equal("peer1");
+        await refusals.settle(cx);
+        expect(decommissioned).deep.equal(["peer1"]);
+    });
+
+    it("records the DUT terminating commissioning", async () => {
+        const refusals = new CommissioningRefusals({ refusalTimeoutMs: 50, settleTimeoutMs: 50 });
+        const cx = contextWith(async () => {
+            throw new InternalError("code names a vendor this network does not carry");
+        });
+        const commissioned = new CommissionedRefs();
+
+        await recordVendorOutcome(cx, CODE, commissioned, refusals, "vendor outcome", 50);
+
+        expect(commissioned.get("dut")).equal(undefined);
+        await refusals.settle(cx);
     });
 });
 

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -292,7 +292,7 @@ describe("recordVendorOutcome", () => {
         await expect(refusals.settle(cx)).rejectedWith(/still running/);
     });
 
-    it("records the DUT onboarding the TH, which the plan also allows", async () => {
+    it("records the DUT onboarding the TH, leaving the fabric to the step that owns it", async () => {
         const refusals = new CommissioningRefusals({ refusalTimeoutMs: 50, settleTimeoutMs: 50 });
         const decommissioned = new Array<CertNodeRef>();
         const cx = contextWith(
@@ -306,8 +306,11 @@ describe("recordVendorOutcome", () => {
         await recordVendorOutcome(cx, CODE, commissioned, refusals, "vendor outcome", 50);
 
         expect(commissioned.get("dut")).equal("peer1");
+
+        // Cleanup must not remove it as well: the ref above is what removes it, and a second removal
+        // of the same fabric fails
         await refusals.settle(cx);
-        expect(decommissioned).deep.equal(["peer1"]);
+        expect(decommissioned).deep.equal([]);
     });
 
     it("records the DUT terminating commissioning", async () => {

--- a/support/chip-testing/test/cert/TC-DD-3.17.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.17.test.ts
@@ -254,6 +254,7 @@ certTest("TC-DD-3.17", {
                     cx,
                     manualPairingCode({ ...parts, vendorId }),
                     commissioned,
+                    refusals,
                     `Code naming vendor 0x${vendorId.toString(16)}`,
                     VENDOR_OUTCOME_TIMEOUT_MS,
                 );

--- a/support/chip-testing/test/cert/TC-SC-3.5.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-3.5.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Duration, InternalError, Millis, Time } from "@matter/main";
+import { Duration, InternalError, Millis } from "@matter/main";
 import type { CertStepContext, CertStepDefinition, PromptHandler, StepVerdict, Subject } from "@matter/testing";
 import {
     chip,
@@ -15,6 +15,7 @@ import {
 } from "@matter/testing";
 import { join } from "node:path";
 import { env } from "node:process";
+import { settleWithin } from "./tc-support.js";
 
 // setup_class's th_server_discriminator — fixed for every OpenCommissioningWindow call in the script.
 // The passcode is NOT fixed the same way: only the initial precondition commission (TH_CLIENT pairing
@@ -62,15 +63,6 @@ function extractPasscode(promptText: string): number {
 // DUT that hangs instead of rejecting must not stall this step for the full mocha timeout.
 const COMMISSION_TIMEOUT_MS = 60_000;
 
-type SettleOutcome = { kind: "resolved"; ref: string } | { kind: "rejected"; error: unknown } | { kind: "timeout" };
-
-function settled(promise: Promise<string>): Promise<SettleOutcome> {
-    return promise.then(
-        (ref): SettleOutcome => ({ kind: "resolved", ref }),
-        (error: unknown): SettleOutcome => ({ kind: "rejected", error }),
-    );
-}
-
 /**
  * Handles every "Manual Pairing Code" prompt `TC_SC_3_5.py` prints — steps 1b, 2c, 3c, 4c, 5c (4c is
  * skipped, and never prompts, if DUT has no ICAC in its NOC chain; see the script's `setup_class`/
@@ -101,26 +93,18 @@ function manualPairingCodeHandler(state: { attempts: number }): PromptHandler {
             };
             cx.recorder.beginStep(stepDef);
 
-            const timeout = Time.sleep("TC-SC-3.5 commission timeout", Millis(COMMISSION_TIMEOUT_MS));
-            let outcome: SettleOutcome;
-            try {
-                outcome = await Promise.race([
-                    settled(
-                        dut.commission({
-                            passcode,
-                            discriminator: TH_SERVER_DISCRIMINATOR,
-                            // The script arms each fault for one handshake only, so a commissioner that retries gets a
-                            // clean one and commissions successfully. Step 1b injects no fault and must be free to
-                            // recover like any healthy commissioning.
-                            singleHandshakeAttempt: !expectSuccess,
-                        }),
-                    ),
-                    timeout.then((): SettleOutcome => ({ kind: "timeout" })),
-                ]);
-            } finally {
-                // A lost race leaves the sleep armed for its full duration, keeping the process alive past teardown
-                timeout.cancel();
-            }
+            const outcome = await settleWithin(
+                `TC-SC-3.5 commissioning attempt ${attempt}`,
+                dut.commission({
+                    passcode,
+                    discriminator: TH_SERVER_DISCRIMINATOR,
+                    // The script arms each fault for one handshake only, so a commissioner that retries gets a
+                    // clean one and commissions successfully. Step 1b injects no fault and must be free to
+                    // recover like any healthy commissioning.
+                    singleHandshakeAttempt: !expectSuccess,
+                }),
+                COMMISSION_TIMEOUT_MS,
+            );
 
             let verdict: StepVerdict;
             let failure: Error | undefined;
@@ -131,11 +115,11 @@ function manualPairingCodeHandler(state: { attempts: number }): PromptHandler {
                     cx.recorder.check({
                         type: "response",
                         verdict,
-                        detail: `commission() resolved on attempt ${attempt} (ref ${outcome.ref})`,
+                        detail: `commission() resolved on attempt ${attempt} (ref ${outcome.value})`,
                     });
                     if (!expectSuccess) {
                         await dut
-                            .node(outcome.ref)
+                            .node(outcome.value)
                             .decommission()
                             .catch(e =>
                                 console.warn(`Failed to decommission unexpectedly-successful attempt ${attempt}:`, e),

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -10,7 +10,14 @@ import type { CertNodeRef, CertStepContext, CommissioningTarget } from "@matter/
 import type { CertDevice } from "@matter/testing";
 import { expectMdns } from "../../src/cert/mdns-check.js";
 import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload.js";
-import { CertCleanupError, CommissionedRefs, expectRejection, expectSequence, record } from "./tc-support.js";
+import {
+    CertCleanupError,
+    CommissionedRefs,
+    expectRejection,
+    expectSequence,
+    record,
+    settleWithin,
+} from "./tc-support.js";
 
 export const LOG_TIMEOUT_MS = 30_000;
 export const MDNS_TIMEOUT_MS = 30_000;
@@ -225,6 +232,11 @@ export class CommissioningRefusals {
         this.#settleTimeoutMs = budgets?.settleTimeoutMs ?? REFUSAL_SETTLE_TIMEOUT_MS;
     }
 
+    /** How long {@link settle} waits, for a step that needs the same slack for its own wait. */
+    get settleBudgetMs(): number {
+        return this.#settleTimeoutMs;
+    }
+
     /**
      * Records that the DUT refuses to commission from `payload`, which is how the negative plans
      * phrase "the DUT terminates the commissioning process in a DUT-specific manner".
@@ -233,16 +245,23 @@ export class CommissioningRefusals {
      * rejection would let the step pass on a controller that died, timed out or was never asked —
      * outcomes that say nothing about what the DUT made of the code.
      */
-    async requireRefusal(cx: CertStepContext, target: CommissioningTarget, what: string): Promise<void> {
-        const attempt = cx.controllers.dut.commission(target);
-        // Kept as a settled outcome so an attempt nobody awaits again cannot surface as an unhandled
-        // rejection, and so settle() can collect the ref of one that succeeded after its budget
+    /**
+     * Hands `attempt` to {@link settle}, which is what a step that may stop waiting for a
+     * commissioning owes the run: one that succeeds late leaves a fabric on the TH. Kept as a settled
+     * outcome so an attempt nobody awaits again cannot surface as an unhandled rejection.
+     */
+    track(attempt: Promise<CertNodeRef>): void {
         this.#attempts.push(
             attempt.then(
                 ref => ref,
                 () => undefined,
             ),
         );
+    }
+
+    async requireRefusal(cx: CertStepContext, target: CommissioningTarget, what: string): Promise<void> {
+        const attempt = cx.controllers.dut.commission(target);
+        this.track(attempt);
 
         record(
             cx,
@@ -268,12 +287,7 @@ export class CommissioningRefusals {
         timeoutMs: number,
     ): Promise<void> {
         const attempt = cx.controllers.dut.commission(target);
-        this.#attempts.push(
-            attempt.then(
-                ref => ref,
-                () => undefined,
-            ),
-        );
+        this.track(attempt);
 
         record(
             cx,
@@ -442,31 +456,64 @@ export async function recordVendorOutcome(
     cx: CertStepContext,
     manualPairingCode: string,
     commissioned: CommissionedRefs,
+    refusals: CommissioningRefusals,
     what: string,
     timeoutMs: number,
 ): Promise<void> {
     await restoreCommissioningMode(cx, commissioned);
 
-    const dut = cx.controllers.dut;
-    const attempt = dut.commission({ manualPairingCode, giveUpAfterMs: timeoutMs });
+    const label = `commissioning from ${manualPairingCode}`;
+    const attempt = cx.controllers.dut.commission({ manualPairingCode, giveUpAfterMs: timeoutMs });
 
-    const outcome = await expectRejection(`commissioning from ${manualPairingCode}`, attempt, timeoutMs + 30_000);
-    if (outcome.verdict === "pass") {
-        record(cx, { ...outcome, detail: `DUT terminated commissioning: ${outcome.detail}` }, what);
-        return;
+    // The plan accepts either outcome, so the attempt is tracked rather than required to fail: one
+    // that neither onboards nor gives up inside the budget is the step's failure, and cleanup — not
+    // another unbounded wait here — is what owns it afterwards.
+    refusals.track(attempt);
+
+    const outcome = await settleWithin(label, attempt, timeoutMs + refusals.settleBudgetMs);
+
+    switch (outcome.kind) {
+        case "rejected": {
+            const { error } = outcome;
+            const message = error instanceof Error ? `${error.constructor.name}: ${error.message}` : String(error);
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: "pass",
+                    detail: `DUT terminated commissioning after ${outcome.elapsed}: ${message}`,
+                },
+                what,
+            );
+            return;
+        }
+
+        case "resolved": {
+            const ref = outcome.value;
+            commissioned.set("dut", ref);
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: "pass",
+                    detail: `DUT onboarded the TH as node ${ref}, which the plan allows where the user accepts the risk`,
+                },
+                what,
+            );
+            return;
+        }
+
+        case "timeout":
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: "fail",
+                    detail: `${label} neither onboarded the TH nor gave up within ${outcome.elapsed}`,
+                },
+                what,
+            );
     }
-
-    const ref = await attempt;
-    commissioned.set("dut", ref);
-    record(
-        cx,
-        {
-            type: "response",
-            verdict: "pass",
-            detail: `DUT onboarded the TH as node ${ref}, which the plan allows where the user accepts the risk`,
-        },
-        what,
-    );
 }
 
 /**

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -238,17 +238,11 @@ export class CommissioningRefusals {
     }
 
     /**
-     * Records that the DUT refuses to commission from `payload`, which is how the negative plans
-     * phrase "the DUT terminates the commissioning process in a DUT-specific manner".
-     *
-     * Only a refusal of the payload itself counts (see {@link isPayloadRefusal}). Accepting any
-     * rejection would let the step pass on a controller that died, timed out or was never asked —
-     * outcomes that say nothing about what the DUT made of the code.
-     */
-    /**
-     * Hands `attempt` to {@link settle}, which is what a step that may stop waiting for a
-     * commissioning owes the run: one that succeeds late leaves a fabric on the TH. Kept as a settled
-     * outcome so an attempt nobody awaits again cannot surface as an unhandled rejection.
+     * Hands `attempt` to {@link settle}, which is what a step that stops waiting for a commissioning
+     * owes the run: one that succeeds afterwards leaves a fabric on the TH that nothing else will
+     * remove. An attempt whose outcome the step *did* see is owned by the step, and handing that one
+     * over as well would have its fabric removed twice. Kept as a settled outcome so an attempt nobody
+     * awaits again cannot surface as an unhandled rejection.
      */
     track(attempt: Promise<CertNodeRef>): void {
         this.#attempts.push(
@@ -259,6 +253,14 @@ export class CommissioningRefusals {
         );
     }
 
+    /**
+     * Records that the DUT refuses to commission from `payload`, which is how the negative plans
+     * phrase "the DUT terminates the commissioning process in a DUT-specific manner".
+     *
+     * Only a refusal of the payload itself counts (see {@link isPayloadRefusal}). Accepting any
+     * rejection would let the step pass on a controller that died, timed out or was never asked —
+     * outcomes that say nothing about what the DUT made of the code.
+     */
     async requireRefusal(cx: CertStepContext, target: CommissioningTarget, what: string): Promise<void> {
         const attempt = cx.controllers.dut.commission(target);
         this.track(attempt);
@@ -342,8 +344,8 @@ export class CommissioningRefusals {
         }
         if (failures.length) {
             throw new CertCleanupError(
-                `The DUT commissioned the TH from a payload it was asked to refuse and the fabric could not be ` +
-                    `removed: ${failures.join("; ")}`,
+                `A commissioning attempt this run stopped waiting for onboarded the TH after all, and the fabric ` +
+                    `could not be removed: ${failures.join("; ")}`,
             );
         }
     }
@@ -464,12 +466,6 @@ export async function recordVendorOutcome(
 
     const label = `commissioning from ${manualPairingCode}`;
     const attempt = cx.controllers.dut.commission({ manualPairingCode, giveUpAfterMs: timeoutMs });
-
-    // The plan accepts either outcome, so the attempt is tracked rather than required to fail: one
-    // that neither onboards nor gives up inside the budget is the step's failure, and cleanup — not
-    // another unbounded wait here — is what owns it afterwards.
-    refusals.track(attempt);
-
     const outcome = await settleWithin(label, attempt, timeoutMs + refusals.settleBudgetMs);
 
     switch (outcome.kind) {
@@ -504,6 +500,10 @@ export async function recordVendorOutcome(
         }
 
         case "timeout":
+            // Only now does cleanup own the attempt: an outcome this step saw is already owned, by
+            // `commissioned` for one that onboarded, and handing it over as well would have the fabric
+            // removed twice.
+            refusals.track(attempt);
             record(
                 cx,
                 {

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -1018,13 +1018,44 @@ export async function expectReportAck(
     }
 }
 
-type SettleOutcome = { kind: "resolved" } | { kind: "rejected"; error: unknown } | { kind: "timeout" };
+/**
+ * How an operation a step was waiting for ended, and how long it took, formatted for the evidence.
+ * A `"timeout"` says only that the wait ended: the operation itself is still running.
+ */
+export type SettleReport<T = unknown> = { elapsed: string } & (
+    | { kind: "resolved"; value: T }
+    | { kind: "rejected"; error: unknown }
+    | { kind: "timeout" }
+);
 
-function settled(promise: Promise<unknown>): Promise<SettleOutcome> {
-    return promise.then(
-        (): SettleOutcome => ({ kind: "resolved" }),
-        (error: unknown): SettleOutcome => ({ kind: "rejected", error }),
-    );
+/**
+ * Waits for `op` to settle, bounded by `timeoutMs` so an implementation that neither answers nor
+ * gives up cannot hang the step for the whole mocha timeout. Reports which way it went, for a step
+ * that has something to record either way; {@link expectRejection} is the form for a step that
+ * demands a refusal.
+ *
+ * A step that stops waiting is still responsible for what the operation does afterwards — a
+ * commissioning that succeeds late leaves a fabric on the device.
+ */
+export async function settleWithin<T>(label: string, op: Promise<T>, timeoutMs: number): Promise<SettleReport<T>> {
+    // nowUs is the monotonic clock despite the name; nowMs tracks UTC and a step of it would put a
+    // negative elapsed into the evidence
+    const start = Time.nowUs;
+    const elapsed = () => Duration.format(Millis(Time.nowUs - start));
+    const timeout = Time.sleep(`${label} settle timeout`, Millis(timeoutMs));
+
+    try {
+        return await Promise.race([
+            op.then(
+                (value): SettleReport<T> => ({ kind: "resolved", value, elapsed: elapsed() }),
+                (error: unknown): SettleReport<T> => ({ kind: "rejected", error, elapsed: elapsed() }),
+            ),
+            timeout.then((): SettleReport<T> => ({ kind: "timeout", elapsed: elapsed() })),
+        ]);
+    } finally {
+        // A lost race leaves the sleep armed for its full duration, keeping the process alive past teardown
+        timeout.cancel();
+    }
 }
 
 /**
@@ -1043,18 +1074,8 @@ export async function expectRejection(
     timeoutMs: number,
     accept?: (error: unknown) => boolean,
 ): Promise<CheckRecord> {
-    // nowUs is the monotonic clock despite the name; nowMs tracks UTC and a step of it would put a
-    // negative elapsed into the evidence
-    const start = Time.nowUs;
-    const timeout = Time.sleep(`${label} rejection timeout`, Millis(timeoutMs));
-    let outcome: SettleOutcome;
-    try {
-        outcome = await Promise.race([settled(op), timeout.then((): SettleOutcome => ({ kind: "timeout" }))]);
-    } finally {
-        // A lost race leaves the sleep armed for its full duration, keeping the process alive past teardown
-        timeout.cancel();
-    }
-    const elapsed = Duration.format(Millis(Time.nowUs - start));
+    const outcome = await settleWithin(label, op, timeoutMs);
+    const { elapsed } = outcome;
 
     switch (outcome.kind) {
         case "resolved":


### PR DESCRIPTION
Stacked on #4277. Review this diff alone (five files); rebase onto main once the three below it land.

Fourth batch from the certification-suite review, and the sharpest item it found in the shared
helpers.

## The defect

Where a plan accepts either outcome — the DUT onboards the TH, or it terminates commissioning —
`recordVendorOutcome` judged the attempt with `expectRejection`, which reports `fail` for two
different things: the attempt *resolved*, and the attempt *never settled inside the budget*. Only the
first was handled. So a commissioning that neither onboarded nor gave up:

- had its failing check dropped — never given to `record()`, so it reached neither the evidence nor
  the step's verdict;
- was then awaited again with **no bound**, so a chip-tool commissioning stuck in its own three-minute
  budget held the step well past the budget the caller gave it;
- and if it eventually resolved, the step recorded a `pass` for a check that had already judged `fail`.

## The fix

One shared bounded wait, `settleWithin`, reports which way an operation went and how long it took.
`expectRejection` is now built on it, unchanged in behaviour, and `recordVendorOutcome` handles all
three outcomes: onboarded (recorded, ref kept for cleanup), terminated (recorded), or neither inside
the budget — which is the step's failure.

An attempt the step stops waiting for is handed to `CommissioningRefusals`, which already owns waiting
out a late success and removing the fabric it created. That ownership handoff is now one `track()`
method rather than the same five lines in each of three places.

TC-SC-3.5 had copied the three-way outcome type, the race and the cancel-in-`finally` verbatim; it
uses the shared helper now, which is also why the helper carries the resolved value.

## Testing

`build`, `format-verify`, `lint` and the cert framework suite (464 tests) are green. Three new unit
tests cover the three outcomes, with injectable budgets so they run in milliseconds; the timeout one
also asserts that cleanup ends up owning the still-running attempt. Mutation-tested: with the timeout
branch's record removed, that test fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
