### PR TITLE
Let a certification run report the failures it was hiding

### DIFF
--- a/packages/testing/src/chip/cert/cert-dsl.ts
+++ b/packages/testing/src/chip/cert/cert-dsl.ts
@@ -489,11 +489,19 @@ class WiredCertTest extends CertTest {
             await super.invoke(subject, step, args, uncommissioned);
         } finally {
             this.#cx = undefined;
+
+            // The base tears down inside its own run, and does so for every path it can reach. This
+            // is the backstop for the ones it cannot — a throw before that run begins would otherwise
+            // leave this run's controllers open for the next test in the process. Idempotent, so the
+            // ordinary path closes nothing twice.
+            await this.teardown();
         }
     }
 
     protected override async teardown(): Promise<unknown[]> {
-        return this.#teardown(this.#openControllers);
+        const controllers = this.#openControllers;
+        this.#openControllers = {};
+        return this.#teardown(controllers);
     }
 
     protected override flavorFor(): DeviceFlavor {
@@ -601,7 +609,6 @@ class WiredCertTest extends CertTest {
 
     /** Closes everything this run opened, returning what refused to close rather than deciding for the caller. */
     async #teardown(controllers: Record<string, ControllerAdapter>): Promise<unknown[]> {
-        this.#openControllers = {};
         const errors = new Array<unknown>();
 
         for (const controller of Object.values(controllers)) {

--- a/packages/testing/src/chip/cert/cert-dsl.ts
+++ b/packages/testing/src/chip/cert/cert-dsl.ts
@@ -350,11 +350,20 @@ let matterJsCommitPromise: Promise<string> | undefined;
 function matterJsCommit(): Promise<string> {
     matterJsCommitPromise ??= execFileAsync("git", ["rev-parse", "HEAD"])
         .then(({ stdout }) => stdout.trim())
-        .catch(() => "(unknown)");
+        .catch(e => {
+            // Degraded provenance is not a failed run, but silence here is how a bundle comes to say
+            // "(unknown)" for a reason nobody can reconstruct afterwards
+            console.warn("Cert test cannot determine the matter.js commit:", e);
+            return "(unknown)";
+        });
     return matterJsCommitPromise;
 }
 
-/** Best-effort: a missing image/marker/label means no chip ref is available, not a test failure. */
+/**
+ * A missing image, marker or label means no chip ref is available, not a test failure — but anything
+ * else that stops us reading one is reported, or a bundle silently loses the provenance that is half
+ * its purpose.
+ */
 async function chipRefFor(flavor: DeviceFlavor, app: string): Promise<string | undefined> {
     try {
         switch (flavor) {
@@ -365,7 +374,8 @@ async function chipRefFor(flavor: DeviceFlavor, app: string): Promise<string | u
             case "matterjs":
                 return undefined;
         }
-    } catch {
+    } catch (e) {
+        console.warn(`Cert test cannot determine the chip ref for ${flavor} app "${app}":`, e);
         return undefined;
     }
 }
@@ -374,12 +384,23 @@ async function chipDockerImageRevision(app: string): Promise<string | undefined>
     const docker = new Docker();
     const image = Image(docker, `${chipImageBase()}-${app}:latest`);
     const info = await image.inspect();
-    return info.Config.Labels?.["org.opencontainers.image.revision"];
+    return info.Config?.Labels?.["org.opencontainers.image.revision"];
 }
 
 async function chipLocalMarkerRevision(): Promise<string | undefined> {
     const dir = await resolveChipLocalAppDir();
-    const text = await readFile(join(dir, "CHIP_REF"), "utf-8");
+
+    let text: string;
+    try {
+        text = await readFile(join(dir, "CHIP_REF"), "utf-8");
+    } catch (e) {
+        // A tree that did not come from an extraction carries no marker, which is not a fault
+        if (e instanceof Error && "code" in e && e.code === "ENOENT") {
+            return undefined;
+        }
+        throw e;
+    }
+
     const trimmed = text.trim();
     return trimmed === "" ? undefined : trimmed;
 }
@@ -399,7 +420,8 @@ async function chipToolRefFor(implementation: ControllerImplementation): Promise
     }
     try {
         return await chipLocalMarkerRevision();
-    } catch {
+    } catch (e) {
+        console.warn("Cert test cannot determine the chip-tool ref:", e);
         return undefined;
     }
 }
@@ -461,12 +483,39 @@ class WiredCertTest extends CertTest {
     ): Promise<void> {
         const cx = await this.#buildContext(subject);
         this.#cx = cx;
+
+        let failure: unknown;
+        let failed = false;
         try {
             await super.invoke(subject, step, args, uncommissioned);
+        } catch (e) {
+            failed = true;
+            failure = e;
         } finally {
             this.#cx = undefined;
-            await this.#teardown(cx.controllers);
+            const teardownErrors = await this.#teardown(cx.controllers);
+
+            // A controller that would not close has left a fabric, a session or a live subscription on
+            // the TH for the next test in this process to inherit, so the run cannot report success.
+            // The run's own failure keeps precedence. The evidence bundle is written before this, on
+            // purpose (see the finalization bound in cert-test.ts), so it is the run's outcome rather
+            // than the bundle that carries this.
+            if (teardownErrors.length > 0 && !failed) {
+                failed = true;
+                failure = new AggregateError(
+                    teardownErrors,
+                    `Cert test ${this.definition.tc}: ${teardownErrors.length} controller/device(s) failed to close`,
+                );
+            }
         }
+
+        if (failed) {
+            throw failure;
+        }
+    }
+
+    protected override flavorFor(): DeviceFlavor {
+        return this.#flavor;
     }
 
     protected override contextFor(_subject: Subject): CertStepContext {
@@ -567,7 +616,8 @@ class WiredCertTest extends CertTest {
         }
     }
 
-    async #teardown(controllers: Record<string, ControllerAdapter>): Promise<void> {
+    /** Closes everything this run opened, returning what refused to close rather than deciding for the caller. */
+    async #teardown(controllers: Record<string, ControllerAdapter>): Promise<unknown[]> {
         const errors = new Array<unknown>();
 
         for (const controller of Object.values(controllers)) {
@@ -591,5 +641,7 @@ class WiredCertTest extends CertTest {
         for (const error of errors) {
             console.warn("Error tearing down cert-test controller/device:", error);
         }
+
+        return errors;
     }
 }

--- a/packages/testing/src/chip/cert/cert-dsl.ts
+++ b/packages/testing/src/chip/cert/cert-dsl.ts
@@ -456,6 +456,8 @@ class WiredCertTest extends CertTest {
     #controllerRoles: Record<string, "dut" | "helper">;
     #deviceRoles: Record<string, string>;
     #cx?: CertStepContext;
+    /** Held apart from {@link #cx} so teardown does not depend on how long the context lives. */
+    #openControllers: Record<string, ControllerAdapter> = {};
     #extraDevices = new Array<CertDevice>();
     #recorder?: EvidenceRecorder;
 
@@ -483,35 +485,15 @@ class WiredCertTest extends CertTest {
     ): Promise<void> {
         const cx = await this.#buildContext(subject);
         this.#cx = cx;
-
-        let failure: unknown;
-        let failed = false;
         try {
             await super.invoke(subject, step, args, uncommissioned);
-        } catch (e) {
-            failed = true;
-            failure = e;
         } finally {
             this.#cx = undefined;
-            const teardownErrors = await this.#teardown(cx.controllers);
-
-            // A controller that would not close has left a fabric, a session or a live subscription on
-            // the TH for the next test in this process to inherit, so the run cannot report success.
-            // The run's own failure keeps precedence. The evidence bundle is written before this, on
-            // purpose (see the finalization bound in cert-test.ts), so it is the run's outcome rather
-            // than the bundle that carries this.
-            if (teardownErrors.length > 0 && !failed) {
-                failed = true;
-                failure = new AggregateError(
-                    teardownErrors,
-                    `Cert test ${this.definition.tc}: ${teardownErrors.length} controller/device(s) failed to close`,
-                );
-            }
         }
+    }
 
-        if (failed) {
-            throw failure;
-        }
+    protected override async teardown(): Promise<unknown[]> {
+        return this.#teardown(this.#openControllers);
     }
 
     protected override flavorFor(): DeviceFlavor {
@@ -563,6 +545,7 @@ class WiredCertTest extends CertTest {
             for (const name of Object.keys(this.#controllerRoles)) {
                 const controller = createControllerAdapter(name);
                 controllers[name] = controller;
+                this.#openControllers = controllers;
                 await controller.start();
             }
 
@@ -618,6 +601,7 @@ class WiredCertTest extends CertTest {
 
     /** Closes everything this run opened, returning what refused to close rather than deciding for the caller. */
     async #teardown(controllers: Record<string, ControllerAdapter>): Promise<unknown[]> {
+        this.#openControllers = {};
         const errors = new Array<unknown>();
 
         for (const controller of Object.values(controllers)) {

--- a/packages/testing/src/chip/cert/cert-test.ts
+++ b/packages/testing/src/chip/cert/cert-test.ts
@@ -207,30 +207,35 @@ export class CertTest extends BaseTest {
                 }
             }
 
-            deviceExitWatch.disarm();
-
             // After the flush, so a bundle exists even for a teardown that hangs against an
             // unreachable TH: it is the run's outcome, not the bundle, that carries a close failure.
             const teardownErrors = await this.teardown();
-            if (teardownErrors.length > 0 && !failed) {
-                failed = true;
-                failure = new AggregateError(
-                    teardownErrors,
-                    `Cert test ${tc}: ${teardownErrors.length} controller/device(s) failed to close, leaving state ` +
-                        "behind for whatever runs next",
-                );
+
+            const exited = deviceExitWatch.observed;
+            deviceExitWatch.disarm();
+
+            // In order: what the run itself hit, then a device that died under it — an exit settling
+            // too late for any step's race is still the run's own outcome — and only then cleanup.
+            if (!failed) {
+                if (exited !== undefined) {
+                    failed = true;
+                    failure = new Error(
+                        `A cert-test device exited unexpectedly (code ${exited.code}, signal ${exited.signal}) ` +
+                            "during the run",
+                    );
+                } else if (teardownErrors.length > 0) {
+                    failed = true;
+                    failure = new AggregateError(
+                        teardownErrors,
+                        `Cert test ${tc}: ${teardownErrors.length} controller/device(s) failed to close, leaving ` +
+                            "state behind for whatever runs next",
+                    );
+                }
             }
         }
 
         if (failed) {
             throw failure;
-        }
-
-        const exited = deviceExitWatch.observed;
-        if (exited !== undefined) {
-            throw new Error(
-                `A cert-test device exited unexpectedly (code ${exited.code}, signal ${exited.signal}) during the run`,
-            );
         }
     }
 

--- a/packages/testing/src/chip/cert/cert-test.ts
+++ b/packages/testing/src/chip/cert/cert-test.ts
@@ -66,7 +66,6 @@ export class CertTest extends BaseTest {
     ): Promise<void> {
         const cx = this.contextFor(subject);
         const { recorder, devices } = cx;
-        const picsFile = resolvePicsFile(subject)?.with(controllerPicsOverridesFor(resolveControllerImplementation()));
         const deviceExitWatch = watchDeviceExits(devices, recorder);
         const flavor = this.flavorFor(devices);
         const tc = this.#definition.tc;
@@ -92,6 +91,12 @@ export class CertTest extends BaseTest {
         };
 
         try {
+            // Inside the try: reading the subject's PICS, and resolving what the controller declares,
+            // can both throw, and everything this run opened is closed by the teardown below.
+            const picsFile = resolvePicsFile(subject)?.with(
+                controllerPicsOverridesFor(resolveControllerImplementation()),
+            );
+
             // Provenance reporting must never be why a run that would otherwise pass its steps
             // aborts before running any of them.
             try {

--- a/packages/testing/src/chip/cert/cert-test.ts
+++ b/packages/testing/src/chip/cert/cert-test.ts
@@ -208,6 +208,18 @@ export class CertTest extends BaseTest {
             }
 
             deviceExitWatch.disarm();
+
+            // After the flush, so a bundle exists even for a teardown that hangs against an
+            // unreachable TH: it is the run's outcome, not the bundle, that carries a close failure.
+            const teardownErrors = await this.teardown();
+            if (teardownErrors.length > 0 && !failed) {
+                failed = true;
+                failure = new AggregateError(
+                    teardownErrors,
+                    `Cert test ${tc}: ${teardownErrors.length} controller/device(s) failed to close, leaving state ` +
+                        "behind for whatever runs next",
+                );
+            }
         }
 
         if (failed) {
@@ -220,6 +232,15 @@ export class CertTest extends BaseTest {
                 `A cert-test device exited unexpectedly (code ${exited.code}, signal ${exited.signal}) during the run`,
             );
         }
+    }
+
+    /**
+     * Closes whatever this run opened, returning what refused to close. A close failure means state is
+     * left on the TH for the next run in this process, so {@link invoke} fails the run over it — unless
+     * the run failed on its own account, which keeps precedence.
+     */
+    protected async teardown(): Promise<unknown[]> {
+        return [];
     }
 
     /**

--- a/packages/testing/src/chip/cert/cert-test.ts
+++ b/packages/testing/src/chip/cert/cert-test.ts
@@ -68,7 +68,7 @@ export class CertTest extends BaseTest {
         const { recorder, devices } = cx;
         const picsFile = resolvePicsFile(subject)?.with(controllerPicsOverridesFor(resolveControllerImplementation()));
         const deviceExitWatch = watchDeviceExits(devices, recorder);
-        const flavor = currentFlavor(devices);
+        const flavor = this.flavorFor(devices);
         const tc = this.#definition.tc;
 
         let aborted = false;
@@ -113,8 +113,17 @@ export class CertTest extends BaseTest {
                 }
 
                 try {
-                    if (stepDef.flavors && flavor !== undefined && !stepDef.flavors.includes(flavor)) {
-                        report(stepDef, "skipped", `unsupported on device flavor "${flavor}"`);
+                    // A step that declares flavors never runs on an unknown one: taking silence for
+                    // consent would run it wherever the flavor could not be determined, which is the
+                    // one case its declaration cannot speak for.
+                    if (stepDef.flavors !== undefined && (flavor === undefined || !stepDef.flavors.includes(flavor))) {
+                        report(
+                            stepDef,
+                            "skipped",
+                            flavor === undefined
+                                ? `device flavor unknown, and this step declares ${stepDef.flavors.join("/")}`
+                                : `unsupported on device flavor "${flavor}"`,
+                        );
                         continue;
                     }
 
@@ -211,6 +220,14 @@ export class CertTest extends BaseTest {
                 `A cert-test device exited unexpectedly (code ${exited.code}, signal ${exited.signal}) during the run`,
             );
         }
+    }
+
+    /**
+     * The flavor this run's steps gate on. Derived from the devices by default; a run that knows its
+     * own flavor overrides this, since the devices are only as authoritative as whatever built them.
+     */
+    protected flavorFor(devices: Record<string, CertDevice>): DeviceFlavor | undefined {
+        return currentFlavor(devices);
     }
 
     /**

--- a/support/chip-testing/test/cert-framework/cert-test.test.ts
+++ b/support/chip-testing/test/cert-framework/cert-test.test.ts
@@ -193,7 +193,10 @@ class TestCertTest extends CertTest {
         this.#teardownErrors = teardownErrors;
     }
 
+    teardownCalls = 0;
+
     protected override async teardown(): Promise<unknown[]> {
+        this.teardownCalls++;
         return this.#teardownErrors;
     }
 
@@ -1276,6 +1279,25 @@ describe("CertTest", () => {
         expect(endStepVerdicts).deep.equal([{ number: 1, verdict: "pass" }]);
         expect(deviceExitedCalls).deep.equal([{ code: 1, signal: null }]);
         expect(flushed).equal(true);
+    });
+
+    it("closes what the run opened even when reading the subject's PICS throws", async () => {
+        const definition: CertTestDefinition = {
+            tc: "TC-CADMIN-1.17",
+            plan: "multiplefabrics.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [{ number: 1, text: "A step that never runs", run: async () => {} }],
+        };
+
+        const cx: CertStepContext = { controllers: {}, devices: {}, recorder: stubRecorder() };
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
+
+        await expect(
+            test.invoke(stubSubjectWithThrowingPics(new Error("PICS accessor exploded")), () => {}, [], false),
+        ).rejectedWith("PICS accessor exploded");
+
+        expect(test.teardownCalls).equal(1);
     });
 
     it("reports a device that died rather than a controller that would not close", async () => {

--- a/support/chip-testing/test/cert-framework/cert-test.test.ts
+++ b/support/chip-testing/test/cert-framework/cert-test.test.ts
@@ -620,6 +620,52 @@ describe("CertTest", () => {
         ]);
     });
 
+    it("skips a flavor-restricted step when the run's flavor cannot be determined", async () => {
+        let ran = false;
+
+        const definition: CertTestDefinition = {
+            tc: "TC-CADMIN-1.17",
+            plan: "multiplefabrics.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [
+                {
+                    number: 1,
+                    text: "Step restricted to chip flavors",
+                    flavors: ["chip-docker", "chip-local"],
+                    run: async () => {
+                        ran = true;
+                    },
+                },
+            ],
+        };
+
+        const endStepCalls = new Array<{ number: number | string; verdict: StepVerdict; skipReason?: string }>();
+        const cx: CertStepContext = {
+            controllers: {},
+            devices: {},
+            recorder: stubRecorder({
+                endStep(step, verdict, skipReason) {
+                    endStepCalls.push({ number: step.number, verdict, skipReason });
+                    return [];
+                },
+            }),
+        };
+
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
+
+        await test.invoke(stubSubject(new PicsFile([])), () => {}, [], false);
+
+        expect(ran).equal(false);
+        expect(endStepCalls).deep.equal([
+            {
+                number: 1,
+                verdict: "skipped",
+                skipReason: "device flavor unknown, and this step declares chip-docker/chip-local",
+            },
+        ]);
+    });
+
     it("never runs a step declared not applicable, and records the reason ahead of any flavor or PICS gate", async () => {
         let step1Ran = false;
         let step2Ran = false;

--- a/support/chip-testing/test/cert-framework/cert-test.test.ts
+++ b/support/chip-testing/test/cert-framework/cert-test.test.ts
@@ -1278,6 +1278,42 @@ describe("CertTest", () => {
         expect(flushed).equal(true);
     });
 
+    it("reports a device that died rather than a controller that would not close", async () => {
+        let exitDevice!: (info: DeviceExitInfo) => void;
+        const exitPromise = new Promise<DeviceExitInfo>(resolve => {
+            exitDevice = resolve;
+        });
+
+        const definition: CertTestDefinition = {
+            tc: "TC-CADMIN-1.17",
+            plan: "multiplefabrics.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [{ number: 1, text: "A step that passes", run: async () => {} }],
+        };
+
+        const cx: CertStepContext = {
+            controllers: {},
+            devices: { th: stubCertDevice(exitPromise) },
+            recorder: stubRecorder({
+                async flush() {
+                    // The device dies while the evidence is being written, too late for any step race
+                    exitDevice({ code: 1, signal: null });
+                    await new Promise(resolve => setTimeout(resolve, 20));
+                    return "";
+                },
+            }),
+        };
+
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx, undefined, [
+            new Error("controller would not close"),
+        ]);
+
+        await expect(test.invoke(stubSubject(new PicsFile([])), () => {}, [], false)).rejectedWith(
+            "exited unexpectedly (code 1, signal null) during the run",
+        );
+    });
+
     it("disarms the device-exit watch once invoke() finishes, so a later exit isn't reported to a finished run's recorder", async () => {
         let exitDevice!: (info: DeviceExitInfo) => void;
         const exitPromise = new Promise<DeviceExitInfo>(resolve => {

--- a/support/chip-testing/test/cert-framework/cert-test.test.ts
+++ b/support/chip-testing/test/cert-framework/cert-test.test.ts
@@ -177,6 +177,7 @@ function stubSubjectWithoutPics(): Subject {
 class TestCertTest extends CertTest {
     #cx: CertStepContext;
     #finalizationTimeoutMs?: number;
+    #teardownErrors: unknown[];
 
     constructor(
         definition: CertTestDefinition,
@@ -184,10 +185,16 @@ class TestCertTest extends CertTest {
         container: Container,
         cx: CertStepContext,
         finalizationTimeoutMs?: number,
+        teardownErrors: unknown[] = [],
     ) {
         super(definition, descriptor, container);
         this.#cx = cx;
         this.#finalizationTimeoutMs = finalizationTimeoutMs;
+        this.#teardownErrors = teardownErrors;
+    }
+
+    protected override async teardown(): Promise<unknown[]> {
+        return this.#teardownErrors;
     }
 
     protected override contextFor(_subject: Subject): CertStepContext {
@@ -1515,6 +1522,50 @@ describe("CertTest", () => {
         };
 
         const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
+
+        await expect(test.invoke(stubSubject(new PicsFile([])), () => {}, [], false)).rejectedWith(
+            "the step's own failure",
+        );
+    });
+
+    it("fails a run whose controller would not close", async () => {
+        const definition: CertTestDefinition = {
+            tc: "TC-CADMIN-1.17",
+            plan: "multiplefabrics.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [{ number: 1, text: "A step that passes", run: async () => {} }],
+        };
+
+        const cx: CertStepContext = { controllers: {}, devices: {}, recorder: stubRecorder() };
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx, undefined, [
+            new Error("controller would not close"),
+        ]);
+
+        await expect(test.invoke(stubSubject(new PicsFile([])), () => {}, [], false)).rejectedWith(/failed to close/);
+    });
+
+    it("keeps a step's failure ahead of a controller that would not close", async () => {
+        const definition: CertTestDefinition = {
+            tc: "TC-CADMIN-1.17",
+            plan: "multiplefabrics.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [
+                {
+                    number: 1,
+                    text: "A step that fails",
+                    run: async () => {
+                        throw new Error("the step's own failure");
+                    },
+                },
+            ],
+        };
+
+        const cx: CertStepContext = { controllers: {}, devices: {}, recorder: stubRecorder() };
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx, undefined, [
+            new Error("controller would not close"),
+        ]);
 
         await expect(test.invoke(stubSubject(new PicsFile([])), () => {}, [], false)).rejectedWith(
             "the step's own failure",


### PR DESCRIPTION
Stacked on #4275. Review this diff alone (three files); rebase onto main once that lands.

Next batch from the certification-suite review: three ways a run could come back clean while something
had gone wrong.

## A controller that would not close was only warned about

`#teardown` collected close failures, logged them and dropped them. A controller that failed to close
has left a fabric, a session or a live subscription on the TH — for the next test in the same process
to inherit — and the run still reported success. Closing failures now decide the run's outcome, with
the run's own failure keeping precedence.

Deliberately *not* recorded in the evidence bundle: the bundle is written before teardown on purpose,
so that one exists even when cleanup hangs against an unreachable TH. Reordering that to get the
failure into `result.json` would trade a guarantee for a detail, so the run's outcome carries it and
the reason is in a comment.

## Provenance was gathered with three catch-and-ignore blocks

A broken `git`, a stopped Docker daemon and a permission error on the marker file all produced the same
silent `"(unknown)"` — in the part of the harness whose entire job is saying what was tested. The one
genuinely expected case, a source tree that carries no extraction marker, is now recognised as `ENOENT`
and stays quiet; everything else is reported. (`info.Config?.Labels` also gets the optional chain that
Docker 29's image inspect needs, matching the fix already in `state.ts`.)

## A flavor-restricted step ran where the flavor was unknown

`stepDef.flavors && flavor !== undefined && !includes(flavor)` runs the step whenever the flavor cannot
be determined — the one case a `flavors` declaration cannot speak for. The gate now fails closed and
says which flavors the step declared, and a run that knows its own flavor (`WiredCertTest` holds it)
no longer has it inferred from whichever device happens to be first in the map.

## Testing

`build`, `format-verify`, `lint`, the **full root `npm test` suite (zero failures)** and the cert
framework suite (467 tests) are all green, and the certification matrix passed on this branch.

Covered by tests that fail against the unmodified code, each verified by mutation:

- the flavor gate skipping where the flavor is unknown;
- a passing run rejecting when a controller refuses to close;
- a step's own failure keeping precedence over one.

The provenance classification has no unit coverage — it needs `git` and Docker stubs that do not exist
in this harness — so a certification run is its check. I would rather say that than imply otherwise.

## Review follow-up

The close-failure precedence first sat in the wired test class, where no test could reach it. It now
sits with the rest of the run's outcome policy, with the wired class supplying only what refused to
close, which is what made the two tests above possible. The controllers to close are also held in their
own field, set as each one starts, so teardown no longer depends on how long the step context lives —
and a controller that started before a later one failed is still closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
