### PR TITLE
Gate certification checks through one helper, and never a plain Error

### DIFF
--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -174,16 +174,19 @@ certTest("TC-XXX-0.0", { plan: "n/a" | "<plan doc id>", pics: [], app: "all-clus
         const dut = cx.controllers.dut; // ControllerAdapter
         const th = cx.devices.th; // CertDevice
         // ...
-        cx.recorder.check({ type: "...", verdict: "pass" | "fail", detail: "..." });
-        if (/* not actually pass */) {
-            throw new Error("...");
-        }
+        record(cx, { type: "...", verdict: "pass" | "fail", detail: "..." }, "what this check is");
     });
 ```
 
 - `cx.recorder.check(...)` only records evidence; it does **not** fail the step. A step fails by
-  throwing from `run`. Always follow a check with an explicit `if (result.verdict !== "pass") throw
-  ...` if the check result should gate the step.
+  throwing from `run`. So a check that should gate the step goes through `record(cx, check, what)`
+  (`tc-support.ts`), which records it and throws `CertCheckFailedError` on `"fail"` — hand-rolling
+  the `if (verdict === "fail") throw` after a `check()` is how one such gate came to be missing.
+  `"unverified"` passes through: that is what a log check reports on a flavor nobody wrote a pattern
+  for. Use `cx.recorder.check` directly only for a record that is provenance rather than a gate — the
+  unconditional "this is what the DUT answered" line beside an `await` that would have thrown.
+- Never throw a plain `Error` from a step: `CertCheckFailedError` is the step-assertion type, and
+  `InternalError` is for a harness invariant that cannot hold.
 - `certTest` registers the mocha `it()` immediately; `.step()` calls append to it and may continue
   after `certTest()` returns (see `cert-dsl.ts`'s `certTest`/`defineCertTest`).
 - Role names: `cx.controllers.dut` / `cx.devices.th` are the defaults (`controllers: { dut: "dut" }`,

--- a/support/chip-testing/test/cert/TC-ACT-3.2.test.ts
+++ b/support/chip-testing/test/cert/TC-ACT-3.2.test.ts
@@ -9,7 +9,7 @@ import { Matter } from "@matter/model";
 import type { CertStepContext, DeviceFlavor } from "@matter/testing";
 import { certTest } from "@matter/testing";
 import type { CommandFieldValue } from "./tc-support.js";
-import { CommissionedRefs, expectCommandInvoke, requireId } from "./tc-support.js";
+import { CommissionedRefs, expectCommandInvoke, record, requireId } from "./tc-support.js";
 
 const ACTIONS = Matter.clusters.require("Actions");
 
@@ -105,12 +105,7 @@ async function invokeAndCheck(
         from,
         15_000,
     );
-    cx.recorder.check(logCheck);
-    if (logCheck.verdict === "fail") {
-        throw new Error(
-            `CommandDataIB log check failed for step ${step} (${commandName}): ${JSON.stringify(logCheck)}`,
-        );
-    }
+    record(cx, logCheck, `CommandDataIB log for step ${step} (${commandName})`);
 }
 
 const EXPECTED_ACTION_ID_AND_INVOKE_ID =

--- a/support/chip-testing/test/cert/TC-CADMIN-1.17.test.ts
+++ b/support/chip-testing/test/cert/TC-CADMIN-1.17.test.ts
@@ -17,7 +17,7 @@ import type {
 } from "@matter/testing";
 import { CertLogClosedError, CertLogTimeoutError, certTest } from "@matter/testing";
 import { expectMdns } from "../../src/cert/mdns-check.js";
-import { CommissionedRefs, expectRejection, PendingPairingCode } from "./tc-support.js";
+import { CertCheckFailedError, CommissionedRefs, expectRejection, PendingPairingCode, record } from "./tc-support.js";
 
 const BASIC_INFORMATION = Matter.clusters.require("BasicInformation");
 const VENDOR_ID = BASIC_INFORMATION.attributes.require("vendorId");
@@ -174,7 +174,9 @@ async function checkCommissioned(
         detail: `${who} read VendorID = ${vendorId}`,
     });
     if (!pass) {
-        throw new Error(`${who}: expected VendorID 0xfff1 after commissioning, got ${JSON.stringify(vendorId)}`);
+        throw new CertCheckFailedError(
+            `${who}: expected VendorID 0xfff1 after commissioning, got ${JSON.stringify(vendorId)}`,
+        );
     }
 
     const { check } = await expectDeviceLog(
@@ -184,10 +186,7 @@ async function checkCommissioned(
         logFrom,
         15_000,
     );
-    cx.recorder.check(check);
-    if (check.verdict === "fail") {
-        throw new Error(`Commissioning-complete log check failed for ${who}: ${JSON.stringify(check)}`);
-    }
+    record(cx, check, `Commissioning-complete log for ${who}`);
 }
 
 /** DUT_CR1 opens an enhanced commissioning window and stashes the manual pairing code for the next step. */
@@ -211,10 +210,7 @@ async function openWindowAndCheck(cx: CertStepContext): Promise<void> {
     });
 
     const { check } = await expectDeviceLog(th.log, th.flavor, { chip: WINDOW_OPEN_PATTERN }, from, 15_000);
-    cx.recorder.check(check);
-    if (check.verdict === "fail") {
-        throw new Error(`Commissioning-window-open log check failed: ${JSON.stringify(check)}`);
-    }
+    record(cx, check, "Commissioning-window-open log");
 }
 
 certTest("TC-CADMIN-1.17", {
@@ -292,7 +288,7 @@ certTest("TC-CADMIN-1.17", {
             const fabrics = await readFabrics(dut.node(dutRef));
             cr2FabricIndex = await readOwnFabricIndex(cx.controllers.th_cr2.node(commissioned.require("th_cr2")));
             if (!fabrics.some(entry => entry.fabricIndex === cr2FabricIndex)) {
-                throw new Error(
+                throw new CertCheckFailedError(
                     `TH_CR2 reports fabric index ${cr2FabricIndex}, absent from DUT_CR1's own read: ` +
                         describeFabrics(fabrics),
                 );
@@ -305,7 +301,7 @@ certTest("TC-CADMIN-1.17", {
                 detail: `${fabrics.length} fabrics; th_cr2 fabricIndex=${cr2FabricIndex}`,
             });
             if (!pass) {
-                throw new Error(`Expected 3 fabrics (dut, th_cr2, th_cr3), got ${fabrics.length}`);
+                throw new CertCheckFailedError(`Expected 3 fabrics (dut, th_cr2, th_cr3), got ${fabrics.length}`);
             }
         },
         { pics: "OPCREDS.C.A0001", expected: "Verify TH_CE receives and processes the command successfully" },
@@ -329,7 +325,7 @@ certTest("TC-CADMIN-1.17", {
                 detail: `th_cr2 fabricIndex=${fabricIndex} (plan assumes ${EXPECTED_CR2_FABRIC_INDEX} for a dut→th_cr2→th_cr3 commissioning order)`,
             });
             if (fabricIndex !== EXPECTED_CR2_FABRIC_INDEX) {
-                throw new Error(
+                throw new CertCheckFailedError(
                     `th_cr2's fabricIndex was ${fabricIndex}, not the plan's assumed ${EXPECTED_CR2_FABRIC_INDEX}`,
                 );
             }
@@ -344,17 +340,11 @@ certTest("TC-CADMIN-1.17", {
                 from,
                 15_000,
             );
-            cx.recorder.check(removed.check);
-            if (removed.check.verdict === "fail") {
-                throw new Error(`RemoveFabric-successful log check failed: ${JSON.stringify(removed.check)}`);
-            }
+            record(cx, removed.check, "RemoveFabric-successful log");
 
             const expiringPattern = new RegExp(`Expiring all sessions for fabric 0x${fabricIndex.toString(16)}!!`);
             const expiring = await expectDeviceLog(th.log, th.flavor, { chip: expiringPattern }, removed.from, 15_000);
-            cx.recorder.check(expiring.check);
-            if (expiring.check.verdict === "fail") {
-                throw new Error(`"Expiring all sessions" log check failed: ${JSON.stringify(expiring.check)}`);
-            }
+            record(cx, expiring.check, '"Expiring all sessions" log');
 
             // Only surrender th_cr2 to step 8 once both checks above confirm TH_CE actually removed
             // it — invoke() resolving only means the peer accepted the interaction, not that
@@ -396,7 +386,7 @@ certTest("TC-CADMIN-1.17", {
             if (writeCheck.verdict !== "pass" || readCheck.verdict !== "pass") {
                 // A call that succeeded proves the fabric outlived RemoveFabric, so cleanup owns it again.
                 commissioned.set("th_cr2", removedCr2Ref);
-                throw new Error(
+                throw new CertCheckFailedError(
                     `Expected both write and read to fail post-removal: ${JSON.stringify({ writeCheck, readCheck })}`,
                 );
             }
@@ -424,7 +414,7 @@ certTest("TC-CADMIN-1.17", {
                     fabrics.map(entry => entry.fabricIndex).join(", "),
             });
             if (!pass) {
-                throw new Error(
+                throw new CertCheckFailedError(
                     `Expected 2 fabrics with index ${cr2FabricIndex} (TH_CR2) removed, got ` + describeFabrics(fabrics),
                 );
             }
@@ -451,12 +441,7 @@ certTest("TC-CADMIN-1.17", {
                 { operationalRecords: 2 },
                 { timeoutMs: 20_000, operationalInstanceName: [dutInstanceName, cr3InstanceName] },
             );
-            cx.recorder.check(result);
-            if (result.verdict !== "pass") {
-                throw new Error(
-                    `Expected exactly 2 operational mDNS records (dut + th_cr3), got ${JSON.stringify(result)}`,
-                );
-            }
+            record(cx, result, "Exactly 2 operational mDNS records (dut + th_cr3)");
         },
         {
             expected:
@@ -503,7 +488,9 @@ certTest("TC-CADMIN-1.17", {
                 detail: `${fabrics.length} fabrics: ${fabrics.map(entry => `${entry.label}#${entry.fabricIndex}`).join(", ")}`,
             });
             if (!pass) {
-                throw new Error(`Expected 3 fabrics after th_cr2 re-commissioned, got ${fabrics.length}`);
+                throw new CertCheckFailedError(
+                    `Expected 3 fabrics after th_cr2 re-commissioned, got ${fabrics.length}`,
+                );
             }
         },
         { pics: "OPCREDS.C.A0001", expected: "Verify TH_CE receives and processes the command successfully" },

--- a/support/chip-testing/test/cert/TC-IDM-1.1.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-1.1.test.ts
@@ -7,7 +7,7 @@
 import { Matter } from "@matter/model";
 import type { CertNodeRef, CertStepContext, CheckRecord } from "@matter/testing";
 import { certTest } from "@matter/testing";
-import { CommissionedRefs, expectCommandInvoke, requireId } from "./tc-support.js";
+import { CommissionedRefs, expectCommandInvoke, record, requireId } from "./tc-support.js";
 
 const ON_OFF = Matter.clusters.require("OnOff");
 const ON_OFF_ID = requireId(ON_OFF.id, "OnOff cluster");
@@ -35,10 +35,7 @@ async function invokeOnOffAndCheck(
     cx.recorder.check({ type: "response", verdict: "pass", detail: "status=Success" });
 
     const logCheck = await expectCommandInvoke(th.log, th.flavor, ENDPOINT, ON_OFF_ID, commandId, [], from, 15_000);
-    cx.recorder.check(logCheck);
-    if (logCheck.verdict === "fail") {
-        throw new Error(`CommandDataIB log check failed for OnOff.${commandName}: ${JSON.stringify(logCheck)}`);
-    }
+    record(cx, logCheck, `CommandDataIB log for OnOff.${commandName}`);
     return logCheck;
 }
 

--- a/support/chip-testing/test/cert/TC-IDM-2.1.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-2.1.test.ts
@@ -8,7 +8,13 @@ import { InternalError } from "@matter/main";
 import { Matter } from "@matter/model";
 import type { AttributePathSpec, CertStepContext, CheckRecord } from "@matter/testing";
 import { certTest } from "@matter/testing";
-import { CommissionedRefs, expectAttributePathIB, expectChunkedTransfer } from "./tc-support.js";
+import {
+    CertCheckFailedError,
+    CommissionedRefs,
+    expectAttributePathIB,
+    expectChunkedTransfer,
+    record,
+} from "./tc-support.js";
 
 const BASIC_INFORMATION = Matter.clusters.require("BasicInformation");
 const ON_OFF = Matter.clusters.require("OnOff");
@@ -95,10 +101,7 @@ async function readAndCheckLog(
 }
 
 function recordLogCheck(cx: CertStepContext, logCheck: CheckRecord): void {
-    cx.recorder.check(logCheck);
-    if (logCheck.verdict === "fail") {
-        throw new Error(`AttributePathIB log check failed: ${JSON.stringify(logCheck)}`);
-    }
+    record(cx, logCheck, "AttributePathIB log");
 }
 
 const commissioned = new CommissionedRefs();
@@ -128,7 +131,7 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
             const pass = value === 0xfff1;
             cx.recorder.check({ type: "response", verdict: pass ? "pass" : "fail", detail: `VendorID = ${value}` });
             if (!pass) {
-                throw new Error(`Expected VendorID 0xfff1, got ${JSON.stringify(value)}`);
+                throw new CertCheckFailedError(`Expected VendorID 0xfff1, got ${JSON.stringify(value)}`);
             }
         },
         { expected: "Verify that the TH receives the right Read Request Message." },
@@ -153,7 +156,7 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `${entries.length} attributes, all BasicInformation@0: ${allBasicInformationAt0}, vendorId=${vendorIdEntry?.value}`,
             });
             if (!pass) {
-                throw new Error(`Unexpected cluster-wildcard read result: ${JSON.stringify(entries)}`);
+                throw new CertCheckFailedError(`Unexpected cluster-wildcard read result: ${JSON.stringify(entries)}`);
             }
         }),
         { expected: "Verify that the TH receives the right Read Request Message." },
@@ -180,7 +183,7 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `${entries.length} attributes total, vendorId marker=${marker?.value}`,
             });
             if (!pass) {
-                throw new Error(`Unexpected full-wildcard read result: ${entries.length} entries`);
+                throw new CertCheckFailedError(`Unexpected full-wildcard read result: ${entries.length} entries`);
             }
         }),
         { expected: "Verify that the TH receives the right Read Request Message." },
@@ -204,7 +207,7 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `${entries.length} entries across ${distinctClusters.length} clusters, ${distinctEndpoints.length} endpoints`,
             });
             if (!pass) {
-                throw new Error(
+                throw new CertCheckFailedError(
                     `Unexpected attribute-wildcard read result: ${JSON.stringify({ distinctClusters, distinctEndpoints })}`,
                 );
             }
@@ -229,7 +232,7 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `${entries.length} Descriptor attributes across endpoints ${distinctEndpoints.join(",")}`,
             });
             if (!pass) {
-                throw new Error(
+                throw new CertCheckFailedError(
                     `Unexpected cluster-wildcard-across-endpoints result: ${JSON.stringify(distinctEndpoints)}`,
                 );
             }
@@ -257,7 +260,9 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `ServerList read at endpoints ${distinctEndpoints.join(",")}`,
             });
             if (!pass) {
-                throw new Error(`Unexpected cluster+attribute-wildcard result: ${JSON.stringify(entries)}`);
+                throw new CertCheckFailedError(
+                    `Unexpected cluster+attribute-wildcard result: ${JSON.stringify(entries)}`,
+                );
             }
         }),
         { expected: "Verify that the TH receives the right Read Request Message." },
@@ -280,7 +285,9 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `${entries.length} attributes across ${distinctClusters.length} clusters at endpoint 1`,
             });
             if (!pass) {
-                throw new Error(`Unexpected endpoint-wildcard result: ${distinctClusters.length} clusters`);
+                throw new CertCheckFailedError(
+                    `Unexpected endpoint-wildcard result: ${distinctClusters.length} clusters`,
+                );
             }
         }),
         { expected: "Verify that the TH receives the right Read Request Message." },
@@ -305,7 +312,9 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `ClusterRevision read from ${distinctClusters.length} clusters at endpoint 1`,
             });
             if (!pass) {
-                throw new Error(`Unexpected endpoint+attribute-wildcard result: ${distinctClusters.length} clusters`);
+                throw new CertCheckFailedError(
+                    `Unexpected endpoint+attribute-wildcard result: ${distinctClusters.length} clusters`,
+                );
             }
         }),
         { expected: "Verify that the TH receives the right Read Request Message." },
@@ -329,7 +338,7 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `OnOff = ${JSON.stringify(value)}`,
             });
             if (!pass) {
-                throw new Error(`Expected a bool value, got ${JSON.stringify(value)}`);
+                throw new CertCheckFailedError(`Expected a bool value, got ${JSON.stringify(value)}`);
             }
         }),
         {
@@ -356,7 +365,7 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `ModeSelect.Description = ${JSON.stringify(value)}`,
             });
             if (!pass) {
-                throw new Error(`Expected a string value, got ${JSON.stringify(value)}`);
+                throw new CertCheckFailedError(`Expected a string value, got ${JSON.stringify(value)}`);
             }
         }),
         {
@@ -383,7 +392,7 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `LevelControl.CurrentLevel = ${JSON.stringify(value)}`,
             });
             if (!pass) {
-                throw new Error(`Expected a uint8 value, got ${JSON.stringify(value)}`);
+                throw new CertCheckFailedError(`Expected a uint8 value, got ${JSON.stringify(value)}`);
             }
         }),
         {
@@ -410,7 +419,7 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `PressureMeasurement.MeasuredValue = ${JSON.stringify(value)}`,
             });
             if (!pass) {
-                throw new Error(`Expected an int16 value, got ${JSON.stringify(value)}`);
+                throw new CertCheckFailedError(`Expected an int16 value, got ${JSON.stringify(value)}`);
             }
         }),
         {
@@ -437,7 +446,7 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `CarbonDioxideConcentrationMeasurement.MeasuredValue = ${JSON.stringify(value)}`,
             });
             if (!pass) {
-                throw new Error(`Expected a floating-point value, got ${JSON.stringify(value)}`);
+                throw new CertCheckFailedError(`Expected a floating-point value, got ${JSON.stringify(value)}`);
             }
         }),
         {
@@ -464,7 +473,9 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `TrustedRootCertificates: ${Array.isArray(value) ? `${value.length} entries` : JSON.stringify(value)}`,
             });
             if (!pass) {
-                throw new Error(`Expected a non-empty list of octet strings, got ${JSON.stringify(value)}`);
+                throw new CertCheckFailedError(
+                    `Expected a non-empty list of octet strings, got ${JSON.stringify(value)}`,
+                );
             }
         }),
         {
@@ -495,7 +506,9 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `BasicCommissioningInfo = ${JSON.stringify(value)}`,
             });
             if (!pass) {
-                throw new Error(`Expected a BasicCommissioningInfo struct, got ${JSON.stringify(value)}`);
+                throw new CertCheckFailedError(
+                    `Expected a BasicCommissioningInfo struct, got ${JSON.stringify(value)}`,
+                );
             }
         }),
         {
@@ -522,7 +535,7 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `ModeSelect.SupportedModes: ${Array.isArray(value) ? `${value.length} entries` : JSON.stringify(value)}`,
             });
             if (!pass) {
-                throw new Error(`Expected a non-empty list, got ${JSON.stringify(value)}`);
+                throw new CertCheckFailedError(`Expected a non-empty list, got ${JSON.stringify(value)}`);
             }
         }),
         {
@@ -549,7 +562,7 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `OccupancySensing.OccupancySensorType = ${JSON.stringify(value)}`,
             });
             if (!pass) {
-                throw new Error(`Expected an enum (number) value, got ${JSON.stringify(value)}`);
+                throw new CertCheckFailedError(`Expected an enum (number) value, got ${JSON.stringify(value)}`);
             }
         }),
         {
@@ -572,7 +585,7 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `LevelControl.Options = ${JSON.stringify(value)}`,
             });
             if (!pass) {
-                throw new Error(`Expected a bitmap value, got ${JSON.stringify(value)}`);
+                throw new CertCheckFailedError(`Expected a bitmap value, got ${JSON.stringify(value)}`);
             }
         }),
         {
@@ -605,7 +618,7 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `3 reads: ${JSON.stringify(values)}`,
             });
             if (!pass) {
-                throw new Error(`Expected 3 identical bool reads, got ${JSON.stringify(values)}`);
+                throw new CertCheckFailedError(`Expected 3 identical bool reads, got ${JSON.stringify(values)}`);
             }
         }),
         { expected: "On the TH verify the received Read Request message is same for all the 3 times." },
@@ -631,14 +644,13 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                     `high-level readAttribute does not expose per-chunk StatusResponse acking)`,
             });
             if (!pass) {
-                throw new Error(`Expected a large wildcard read (>100 attributes), got ${entries.length}`);
+                throw new CertCheckFailedError(
+                    `Expected a large wildcard read (>100 attributes), got ${entries.length}`,
+                );
             }
 
             const chunkCheck = await expectChunkedTransfer(th.log, th.flavor, from, 15_000);
-            cx.recorder.check(chunkCheck);
-            if (chunkCheck.verdict === "fail") {
-                throw new Error(`Chunked-transfer log check failed: ${JSON.stringify(chunkCheck)}`);
-            }
+            record(cx, chunkCheck, "Chunked-transfer log");
         }),
         {
             expected:
@@ -679,7 +691,7 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                         : "No manufacturer-specific cluster (>=0x10000) found in the wildcard read",
                 });
                 if (!sizePass || !msPass) {
-                    throw new Error(
+                    throw new CertCheckFailedError(
                         `Unexpected full-wildcard read result: ${entries.length} entries, MS clusters [${foundIds}]`,
                     );
                 }
@@ -690,7 +702,9 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                     detail: "matter.js all-clusters app defines no manufacturer-specific cluster",
                 });
                 if (!sizePass) {
-                    throw new Error(`Expected a large wildcard read (>100 attributes), got ${entries.length}`);
+                    throw new CertCheckFailedError(
+                        `Expected a large wildcard read (>100 attributes), got ${entries.length}`,
+                    );
                 }
             }
         }),

--- a/support/chip-testing/test/cert/TC-IDM-3.1.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-3.1.test.ts
@@ -8,7 +8,14 @@ import { Status } from "@matter/main/types";
 import { Matter } from "@matter/model";
 import type { AttributePathSpec, CertNodeApi, CertNodeRef, CertStepContext, DeviceFlavor } from "@matter/testing";
 import { certTest } from "@matter/testing";
-import { CommissionedRefs, expectMessageWithPath, record, requireId, WRITE_REQUEST_MESSAGE } from "./tc-support.js";
+import {
+    CertCheckFailedError,
+    CommissionedRefs,
+    expectMessageWithPath,
+    record,
+    requireId,
+    WRITE_REQUEST_MESSAGE,
+} from "./tc-support.js";
 
 const LEVEL_CONTROL = Matter.clusters.require("LevelControl");
 const BASIC_INFORMATION = Matter.clusters.require("BasicInformation");
@@ -72,10 +79,7 @@ async function writeAndCheck(
     });
 
     const logCheck = await expectMessageWithPath(th.log, th.flavor, WRITE_REQUEST_MESSAGE, path, from, 15_000);
-    cx.recorder.check(logCheck);
-    if (logCheck.verdict === "fail") {
-        throw new Error(`WriteRequestMessage log check failed for step ${label}: ${JSON.stringify(logCheck)}`);
-    }
+    record(cx, logCheck, `WriteRequestMessage log for step ${label}`);
 }
 
 /**
@@ -90,7 +94,9 @@ async function clusterVersions(node: CertNodeApi, paths: AttributePathSpec[]): P
             entry => entry.endpoint === endpoint && entry.cluster === cluster && entry.version !== undefined,
         )?.version;
         if (version === undefined) {
-            throw new Error(`TH reported no data version for cluster ${cluster} on endpoint ${endpoint}`);
+            throw new CertCheckFailedError(
+                `TH reported no data version for cluster ${cluster} on endpoint ${endpoint}`,
+            );
         }
         return version;
     });
@@ -144,14 +150,13 @@ certTest("TC-IDM-3.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                     JSON.stringify(statuses),
             });
             if (written.length <= 1) {
-                throw new Error(`A wildcard write must reach more than one endpoint, got ${JSON.stringify(statuses)}`);
+                throw new CertCheckFailedError(
+                    `A wildcard write must reach more than one endpoint, got ${JSON.stringify(statuses)}`,
+                );
             }
 
             const logCheck = await expectMessageWithPath(th.log, th.flavor, WRITE_REQUEST_MESSAGE, path, from, 15_000);
-            cx.recorder.check(logCheck);
-            if (logCheck.verdict === "fail") {
-                throw new Error(`WriteRequestMessage log check failed for step 2: ${JSON.stringify(logCheck)}`);
-            }
+            record(cx, logCheck, "WriteRequestMessage log for step 2");
 
             for (const { endpoint } of written) {
                 const value = await dut
@@ -351,7 +356,7 @@ certTest("TC-IDM-3.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `version-conditional write answered ${JSON.stringify(statuses)}`,
             });
             if (!allSucceeded) {
-                throw new Error(`Version-conditional write was rejected: ${JSON.stringify(statuses)}`);
+                throw new CertCheckFailedError(`Version-conditional write was rejected: ${JSON.stringify(statuses)}`);
             }
 
             const logCheck = await expectMessageWithPath(
@@ -362,10 +367,7 @@ certTest("TC-IDM-3.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 from,
                 15_000,
             );
-            cx.recorder.check(logCheck);
-            if (logCheck.verdict === "fail") {
-                throw new Error(`WriteRequestMessage log check failed for step 15: ${JSON.stringify(logCheck)}`);
-            }
+            record(cx, logCheck, "WriteRequestMessage log for step 15");
 
             const label = await node.readAttribute(labelPath);
             const level = await node.readAttribute(levelPath);
@@ -376,7 +378,7 @@ certTest("TC-IDM-3.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `read back nodeLabel=${JSON.stringify(label)}, onLevel=${JSON.stringify(level)}`,
             });
             if (!readBackOk) {
-                throw new Error(`Write did not take effect: nodeLabel=${label}, onLevel=${level}`);
+                throw new CertCheckFailedError(`Write did not take effect: nodeLabel=${label}, onLevel=${level}`);
             }
 
             // The plan stops at the successful write, which a device ignoring the version would also pass.
@@ -391,7 +393,7 @@ certTest("TC-IDM-3.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 detail: `write with the stale data version answered ${JSON.stringify(stale)}`,
             });
             if (!rejected) {
-                throw new Error(`A stale data version was accepted: ${JSON.stringify(stale)}`);
+                throw new CertCheckFailedError(`A stale data version was accepted: ${JSON.stringify(stale)}`);
             }
         }),
         {

--- a/support/chip-testing/test/cert/TC-IDM-4.1.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-4.1.test.ts
@@ -15,6 +15,7 @@ import {
     expectReportAck,
     expectSequence,
     expectSubscriptionId,
+    record,
     requireId,
     SUBSCRIBE_REQUEST_MESSAGE,
 } from "./tc-support.js";
@@ -104,10 +105,7 @@ certTest("TC-IDM-4.1", {
                 from,
                 15_000,
             );
-            cx.recorder.check(pathCheck);
-            if (pathCheck.verdict === "fail") {
-                throw new Error(`SubscribeRequestMessage log check failed: ${JSON.stringify(pathCheck)}`);
-            }
+            record(cx, pathCheck, "SubscribeRequestMessage log");
 
             const envelopeCheck = await expectSequence(
                 th.log,
@@ -117,10 +115,7 @@ certTest("TC-IDM-4.1", {
                 from,
                 15_000,
             );
-            cx.recorder.check(envelopeCheck);
-            if (envelopeCheck.verdict === "fail") {
-                throw new Error(`SubscribeRequestMessage envelope check failed: ${JSON.stringify(envelopeCheck)}`);
-            }
+            record(cx, envelopeCheck, "SubscribeRequestMessage envelope");
         },
         {
             pics: "MCORE.IDM.C.SubscribeRequest",
@@ -156,20 +151,14 @@ certTest("TC-IDM-4.1", {
                 from,
                 15_000,
             );
-            cx.recorder.check(requestCheck);
-            if (requestCheck.verdict === "fail") {
-                throw new Error(`SubscribeRequestMessage log check failed: ${JSON.stringify(requestCheck)}`);
-            }
+            record(cx, requestCheck, "SubscribeRequestMessage log");
 
             // Steps 1 and 2 subscribe to the same path, so only the request line tells their
             // SubscribeResponses apart (see subscribeAndModify).
             const established = requestCheck.logLine !== undefined ? requestCheck.logLine + 1 : from;
 
             const idLookup = await expectSubscriptionId(th.log, th.flavor, established, ACK_WAIT_TIMEOUT_MS);
-            cx.recorder.check(idLookup.check);
-            if (idLookup.check.verdict === "fail") {
-                throw new Error(`Subscription-id lookup failed: ${JSON.stringify(idLookup.check)}`);
-            }
+            record(cx, idLookup.check, "Subscription-id lookup");
 
             const logCheck = await expectReportAck(
                 th.log,
@@ -178,10 +167,7 @@ certTest("TC-IDM-4.1", {
                 established,
                 ACK_WAIT_TIMEOUT_MS,
             );
-            cx.recorder.check(logCheck);
-            if (logCheck.verdict === "fail") {
-                throw new Error(`Priming-report status check failed: ${JSON.stringify(logCheck)}`);
-            }
+            record(cx, logCheck, "Priming-report status");
         }),
         {
             pics: "MCORE.IDM.C.SubscribeRequest",

--- a/support/chip-testing/test/cert/TC-IDM-6.3.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-6.3.test.ts
@@ -15,6 +15,7 @@ import {
     expectSequence,
     fabricFilteredPattern,
     READ_REQUEST_MESSAGE,
+    record,
     requireId,
 } from "./tc-support.js";
 
@@ -91,12 +92,7 @@ certTest("TC-IDM-6.3", {
                 from,
                 LOG_TIMEOUT_MS,
             );
-            cx.recorder.check(pathCheck);
-            if (pathCheck.verdict === "fail") {
-                throw new CertCheckFailedError(
-                    `ReadRequestMessage event path check failed: ${JSON.stringify(pathCheck)}`,
-                );
-            }
+            record(cx, pathCheck, "ReadRequestMessage event path");
 
             // The plan's expected outcome names FabricFiltered alongside EventRequests; it sits after
             // the path list in the same message, separated from it by the list's own closing lines.
@@ -108,12 +104,7 @@ certTest("TC-IDM-6.3", {
                 pathCheck.logLine === undefined ? from : pathCheck.logLine + 1,
                 LOG_TIMEOUT_MS,
             );
-            cx.recorder.check(fabricFilteredCheck);
-            if (fabricFilteredCheck.verdict === "fail") {
-                throw new CertCheckFailedError(
-                    `ReadRequestMessage isFabricFiltered check failed: ${JSON.stringify(fabricFilteredCheck)}`,
-                );
-            }
+            record(cx, fabricFilteredCheck, "ReadRequestMessage isFabricFiltered");
         },
         {
             expected:

--- a/support/chip-testing/test/cert/TC-IDM-6.4.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-6.4.test.ts
@@ -9,7 +9,6 @@ import type { EventPathSpec } from "@matter/testing";
 import { certTest } from "@matter/testing";
 import {
     ACK_WAIT_TIMEOUT_MS,
-    CertCheckFailedError,
     CommissionedRefs,
     EVENT_PATH_IBS_SEQUENCE,
     eventPathIBSequence,
@@ -17,6 +16,7 @@ import {
     expectSequence,
     expectSubscriptionId,
     fabricFilteredPattern,
+    record,
     requireId,
     SUBSCRIBE_REQUEST_MESSAGE,
 } from "./tc-support.js";
@@ -90,12 +90,7 @@ certTest("TC-IDM-6.4", {
                 from,
                 LOG_TIMEOUT_MS,
             );
-            cx.recorder.check(envelopeCheck);
-            if (envelopeCheck.verdict === "fail") {
-                throw new CertCheckFailedError(
-                    `SubscribeRequestMessage envelope check failed: ${JSON.stringify(envelopeCheck)}`,
-                );
-            }
+            record(cx, envelopeCheck, "SubscribeRequestMessage envelope");
 
             const fabricFilteredCheck = await expectSequence(
                 th.log,
@@ -105,12 +100,7 @@ certTest("TC-IDM-6.4", {
                 envelopeCheck.logLine === undefined ? from : envelopeCheck.logLine + 1,
                 LOG_TIMEOUT_MS,
             );
-            cx.recorder.check(fabricFilteredCheck);
-            if (fabricFilteredCheck.verdict === "fail") {
-                throw new CertCheckFailedError(
-                    `SubscribeRequestMessage isFabricFiltered check failed: ${JSON.stringify(fabricFilteredCheck)}`,
-                );
-            }
+            record(cx, fabricFilteredCheck, "SubscribeRequestMessage isFabricFiltered");
         },
         {
             expected:
@@ -144,12 +134,7 @@ certTest("TC-IDM-6.4", {
             // controller's own node-level one), so the ack this step needs is identified by the
             // subscription the TH just minted, not by position in the log.
             const idLookup = await expectSubscriptionId(th.log, th.flavor, from, ACK_WAIT_TIMEOUT_MS);
-            cx.recorder.check(idLookup.check);
-            if (idLookup.check.verdict === "fail") {
-                throw new CertCheckFailedError(
-                    `SubscribeResponseMessage check failed: ${JSON.stringify(idLookup.check)}`,
-                );
-            }
+            record(cx, idLookup.check, "SubscribeResponseMessage");
 
             const ackCheck = await expectReportAck(
                 th.log,
@@ -158,10 +143,7 @@ certTest("TC-IDM-6.4", {
                 from,
                 ACK_WAIT_TIMEOUT_MS,
             );
-            cx.recorder.check(ackCheck);
-            if (ackCheck.verdict === "fail") {
-                throw new CertCheckFailedError(`Report ack check failed: ${JSON.stringify(ackCheck)}`);
-            }
+            record(cx, ackCheck, "Report ack");
         }),
         { expected: "Verify that the DUT sends Status Response Action with a success Status Code." },
     )


### PR DESCRIPTION
Off main, now that #4275 has landed. First of two batches over the certification cases themselves.

## One helper decides whether a check gates its step

Twenty-three places did this by hand:

```ts
cx.recorder.check(logCheck);
if (logCheck.verdict === "fail") {
    throw new Error(`… ${JSON.stringify(logCheck)}`);
}
```

That is `record(cx, check, what)`, whose own doc calls the guard "the single easiest thing to forget" —
and the one place where it *was* forgotten is how TC-IDM-3.1 came to record a failed check inside a
passing step (fixed in #4275). All twenty-three go through `record()` now, so the gate cannot be left
off, and the failure message is uniform.

One of them guarded on `!== "pass"` rather than `=== "fail"`. That is the same condition there:
`expectMdns` computes its verdict as pass-or-fail over the checks it ran and never reports
`"unverified"`. Checked before converting, because `record()` deliberately lets `"unverified"` through
— that is what a log check reports on a flavor nobody wrote a pattern for.

Unconditional records are left alone: a `check()` that states what the DUT answered, beside an `await`
that would have thrown, is provenance rather than a gate.

## No step throws a plain Error

Thirty-four remained; all are step assertions, so they become `CertCheckFailedError`, which the two
cases that already used it keep. The project rule is that a plain `Error` is never thrown, and these
were the last of them in this directory.

## The notes taught the pattern

This directory's `AGENTS.md` template showed the hand-rolled guard, which is how twenty-three copies
of it came to exist. It now shows `record()`, says when a bare `check()` is still right, and says
which error type a step throws.

## Testing

`build`, `format-verify`, `lint` and the certification framework suite (470 tests) are green. These
files have no unit coverage by nature — the certification matrix is what runs them — so a cert run on
this branch is the check, and I will dispatch one.

Behaviour is unchanged except where it was wrong: same checks, same verdicts, same gating, with the
failure text now uniform (`<what> check failed: <check>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
