### PR TITLE
Report a concrete subscription path only when that attribute changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: New `CertificateAuthority.erase()` discards the authority's key material, persisted and in memory
     - Enhancement: Commissioning accepts `caseConnectionTimeout`, bounding how long it waits for the operational CASE connection that follows it; defaults to the previous fixed 4m15s
     - Fix: Cancelling BLE commissioning aborts the in-flight channel open
+    - Fix: A concrete subscription path is reported only when that attribute changed; it was previously reported whenever any other attribute of the same cluster changed
     - Fix: A subscription's `maxIntervalCeiling` is transmitted exactly as requested; jitter now applies only when we derive the ceiling ourselves
     - Fix: mDNS advertisements set the cache-flush bit on the SRV, TXT and address records unique to the node
     - Fix: mDNS known-answer suppression compares what identifies a record

--- a/packages/node/test/endpoint/server/ProtocolServiceTest.ts
+++ b/packages/node/test/endpoint/server/ProtocolServiceTest.ts
@@ -204,28 +204,26 @@ describe("ProtocolServiceTest", () => {
             maxIntervalCeilingSeconds: 2,
         });
 
-        // Handle an updated report
-        const fabricAdded = interaction.receiveData(node, 3, 0);
+        // NOCs carries the "changes omitted" quality, so its subscription path stays silent
+        const fabricAdded = interaction.receiveData(node, 2, 0);
 
         // Create another fabric so we can capture subscription messages
         const fabric2 = await node.addFabric();
         let report = await MockTime.resolve(fabricAdded);
-        expect(report.attributes.length).equals(3);
+        expect(report.attributes.map(({ attributeData }) => attributeData?.path)).deep.equals([
+            FABRICS_PATH,
+            COMMISSIONED_FABRICS_PATH,
+        ]);
         expect(report.events.length).equals(0);
 
         const fabricsReport = report.attributes[0]?.attributeData;
-        expect(fabricsReport?.path).deep.equals(FABRICS_PATH);
         const decodedFabrics =
             fabricsReport?.data && TlvOfModel(OperationalCredentials.attributes.fabrics).decodeTlv(fabricsReport?.data);
         expect((decodedFabrics as { fabricIndex: number }[])?.map(({ fabricIndex }) => fabricIndex)).deep.equals([
             1, 2,
         ]);
 
-        const nocsReport = report.attributes[1]?.attributeData;
-        expect(nocsReport?.path).deep.equals(NOCS_PATH);
-
-        const commissionedFabricsReport = report.attributes[2]?.attributeData;
-        expect(commissionedFabricsReport?.path).deep.equals(COMMISSIONED_FABRICS_PATH);
+        const commissionedFabricsReport = report.attributes[1]?.attributeData;
 
         const commissionedFabricCount =
             commissionedFabricsReport?.data &&
@@ -233,7 +231,7 @@ describe("ProtocolServiceTest", () => {
         expect(commissionedFabricCount).deep.equals(2);
 
         // Remove the second fabric so we can capture the leave event notification
-        const fabricRemoved = interaction.receiveData(node, 3, 1);
+        const fabricRemoved = interaction.receiveData(node, 2, 1);
 
         await MockTime.resolve(fabric2.leave());
 

--- a/packages/node/test/node/AttributeSubscriptionResponseTest.ts
+++ b/packages/node/test/node/AttributeSubscriptionResponseTest.ts
@@ -13,7 +13,7 @@ import { countAttrs } from "./read-helpers.js";
 import INTERACTION_MODEL_REVISION = Specification.INTERACTION_MODEL_REVISION;
 
 describe("AttributeSubscriptionResponse", () => {
-    it("reads concrete attribute when in filter", async () => {
+    it("reads wildcard endpoint attribute when in filter", async () => {
         const response = await readAttrSub(
             await MockServerNode.createOnline(),
             { [EndpointNumber(0)]: { [ClusterId(40)]: new Set([AttributeId(1)]) } },
@@ -41,7 +41,7 @@ describe("AttributeSubscriptionResponse", () => {
         expect(response.counts).deep.equals({ status: 0, success: 1, existent: 1 });
     });
 
-    it("reads no concrete attribute when not in filter", async () => {
+    it("reads no wildcard endpoint attribute when not in filter", async () => {
         const response = await readAttrSub(
             await MockServerNode.createOnline(),
             { [EndpointNumber(0)]: { [ClusterId(40)]: new Set([AttributeId(2)]) } },
@@ -53,6 +53,103 @@ describe("AttributeSubscriptionResponse", () => {
 
         expect(response.data).deep.equals([]);
         expect(response.counts).deep.equals({ status: 0, success: 0, existent: 0 });
+    });
+
+    it("reads concrete path when attribute is dirty", async () => {
+        const node = await MockServerNode.createOnline();
+        const response = await readAttrSub(
+            node,
+            { [EndpointNumber(0)]: { [ClusterId(40)]: new Set([AttributeId(1)]) } },
+            Read.Attribute({
+                endpoint: node,
+                cluster: BasicInformation,
+                attributes: "vendorName",
+            }),
+        );
+
+        expect(response.data).deep.equals([
+            [
+                {
+                    kind: "attr-value",
+                    path: {
+                        attributeId: 1,
+                        clusterId: 40,
+                        endpointId: 0,
+                    },
+                    tlv: {},
+                    value: "Matter.js Test Vendor",
+                    version: 0x80808081,
+                },
+            ],
+        ]);
+        expect(response.counts).deep.equals({ status: 0, success: 1, existent: 1 });
+    });
+
+    it("ignores concrete path when only a sibling attribute of the same cluster is dirty", async () => {
+        const node = await MockServerNode.createOnline();
+        const response = await readAttrSub(
+            node,
+            { [EndpointNumber(0)]: { [ClusterId(40)]: new Set([AttributeId(2)]) } },
+            Read.Attribute({
+                endpoint: node,
+                cluster: BasicInformation,
+                attributes: "vendorName",
+            }),
+        );
+
+        expect(response.data).deep.equals([]);
+        expect(response.counts).deep.equals({ status: 0, success: 0, existent: 0 });
+    });
+
+    it("ignores concrete path when the cluster has no dirty attributes", async () => {
+        const node = await MockServerNode.createOnline();
+        const response = await readAttrSub(
+            node,
+            { [EndpointNumber(0)]: { [ClusterId(41)]: new Set([AttributeId(1)]) } },
+            Read.Attribute({
+                endpoint: node,
+                cluster: BasicInformation,
+                attributes: "vendorName",
+            }),
+        );
+
+        expect(response.data).deep.equals([]);
+        expect(response.counts).deep.equals({ status: 0, success: 0, existent: 0 });
+    });
+
+    it("reads only the dirty attributes of a cluster with several concrete paths", async () => {
+        const node = await MockServerNode.createOnline();
+        const response = await readAttrSub(
+            node,
+            { [EndpointNumber(0)]: { [ClusterId(40)]: new Set([AttributeId(3)]) } },
+            Read.Attribute({
+                endpoint: node,
+                cluster: BasicInformation,
+                attributes: "vendorName",
+            }),
+            Read.Attribute({
+                endpoint: node,
+                cluster: BasicInformation,
+                attributes: "productName",
+            }),
+        );
+
+        expect(response.data).deep.equals([
+            [
+                {
+                    kind: "attr-value",
+                    path: {
+                        attributeId: 3,
+                        clusterId: 40,
+                        endpointId: 0,
+                    },
+                    tlv: {},
+                    value: "Matter.js Test Product",
+                    version: 0x80808081,
+                },
+            ],
+        ]);
+        expect(response.counts).deep.equals({ status: 0, success: 1, existent: 1 });
     });
 
     it("reads wildcard endpoint & attributes with 5 in Filter", async () => {

--- a/packages/node/test/node/ServerSubscriptionTest.ts
+++ b/packages/node/test/node/ServerSubscriptionTest.ts
@@ -8,6 +8,7 @@ import { IcdManagementServer } from "#behaviors/icd-management";
 import { InteractionServer } from "#node/server/InteractionServer.js";
 import { ServerSubscription, ServerSubscriptionConfig } from "#node/server/ServerSubscription.js";
 import { DataReadQueue, Lifetime, Millis, NoResponseTimeoutError, Seconds } from "@matter/general";
+import { Specification } from "@matter/model";
 import {
     ExchangeManager,
     InteractionServerMessenger,
@@ -22,6 +23,7 @@ import { BasicInformation } from "@matter/types/clusters/basic-information";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { LIT_CONFIG } from "./icd-helpers.js";
 import { MockServerNode } from "./mock-server-node.js";
+import { interaction } from "./node-helpers.js";
 
 function activeSpanNames(lifetime: Lifetime): string[] {
     const names = new Array<string>();
@@ -304,6 +306,41 @@ describe("ServerSubscription", () => {
         await MockTime.resolve(flushingClose!);
 
         expect([...session.subscriptions]).is.empty;
+
+        await MockTime.resolve(node.close());
+    });
+
+    it("reports only the changed attribute when several attributes of one cluster are subscribed", async () => {
+        const node = await MockServerNode.createOnline();
+        const fabric = await node.addFabric();
+
+        const nodeLabelPath = {
+            endpointId: EndpointNumber(0),
+            clusterId: ClusterId(BasicInformation.id),
+            attributeId: AttributeId(BasicInformation.attributes.nodeLabel.id),
+        };
+        const locationPath = {
+            endpointId: EndpointNumber(0),
+            clusterId: ClusterId(BasicInformation.id),
+            attributeId: AttributeId(BasicInformation.attributes.location.id),
+        };
+
+        await interaction.subscribe(node, fabric, {
+            interactionModelRevision: Specification.INTERACTION_MODEL_REVISION,
+            isFabricFiltered: false,
+            attributeRequests: [nodeLabelPath, locationPath],
+            keepSubscriptions: true,
+            minIntervalFloorSeconds: 0,
+            maxIntervalCeilingSeconds: 2,
+        });
+
+        const reported = interaction.receiveData(node, 1, 0);
+
+        await MockTime.resolve(node.set({ basicInformation: { nodeLabel: "relabeled" } }));
+
+        const report = await MockTime.resolve(reported);
+
+        expect(report.attributes.map(({ attributeData }) => attributeData?.path)).deep.equals([nodeLabelPath]);
 
         await MockTime.resolve(node.close());
     });

--- a/packages/protocol/src/action/server/AttributeSubscriptionResponse.ts
+++ b/packages/protocol/src/action/server/AttributeSubscriptionResponse.ts
@@ -59,7 +59,7 @@ export class AttributeSubscriptionResponse<
 
     protected override addConcrete(path: ReadResult.ConcreteAttributePath) {
         const { endpointId, clusterId, attributeId } = path;
-        if (this.#dirty[endpointId]?.[clusterId]?.has(attributeId) === undefined) {
+        if (!this.#dirty[endpointId]?.[clusterId]?.has(attributeId)) {
             return;
         }
         super.addConcrete(path);


### PR DESCRIPTION
## What was wrong

A subscription report is built from a "dirty" set — for each endpoint and cluster, the ids of the attributes that changed since the last report. The filter that decides whether a **fully-concrete** request path (endpoint, cluster and attribute all named, as opposed to a wildcard) belongs in the report tested that set like this:

```ts
if (this.#dirty[endpointId]?.[clusterId]?.has(attributeId) === undefined) {
    return;
}
```

`Set.prototype.has()` returns a boolean and never `undefined`. So the early return only fired when the optional chain itself short-circuited — that is, when the cluster had no dirty attribute at all. As soon as *any one* attribute of that cluster was dirty, `has()` returned a real `false` for the unchanged ones, `false !== undefined`, and the path was reported anyway.

Net effect on the wire: a controller subscribed to one attribute got a report for it every time *any sibling attribute in the same cluster* changed, repeating the unchanged value. The wildcard paths in the same class already used the correct per-attribute test, so only concrete paths were affected.

It also defeated the **"changes omitted" quality** (Matter core specification quality `C`), whose whole purpose is that the attribute is never reported on change. `OperationalCredentials.nocs` and `trustedRootCertificates` both carry it, and both went out on the wire whenever `fabrics` changed.

## The fix

One predicate:

```ts
if (!this.#dirty[endpointId]?.[clusterId]?.has(attributeId)) {
    return;
}
```

## When it was introduced

Introduced in #2000 (10 May 2025) — the commit that replaced the legacy subscription implementation, so the new code path went live in the same change. The legacy implementation it replaced was correct: it gated on `Map.get() === undefined`, where `undefined` is a legitimate result.

Live since **0.14.0**, so **every release from 0.14.0 through 0.17.9** carries it.

## How it was found

Reported by @luligu, chasing a failing CHIP `TC_FAN_3_2.py` run against Matterbridge's `FanControl` server with five individually-subscribed attributes. Writing `SpeedSetting` 1→10 genuinely changes `FanMode` only 3 times, at the Low/Medium/High boundaries, but a paced subscriber saw 10 `FanMode` reports, 7 of them repeating the previous value. The report traced it to this predicate and confirmed the fix against a running container.

## Why the defect survived the existing tests

`AttributeSubscriptionResponseTest` had two cases named "reads concrete attribute…", but they build their request with `Read.Attribute({ cluster, attributes })` and no `endpoint`. `Read()` only sets `endpointId` when an endpoint is given, and `AttributeReadResponse.process()` routes a path with any missing id to the wildcard branch. So both cases exercised the wildcard filter, which was already strict, and `addConcrete` had no coverage at all. They are renamed here to say what they actually cover.

## Tests

Four unit cases in `AttributeSubscriptionResponseTest` and one end-to-end case in `ServerSubscriptionTest` that subscribes to `nodeLabel` and `location`, changes only `nodeLabel`, and decodes the resulting report off a mock exchange.

Each was mutation-tested against the reverted production hunk:

- `ignores concrete path when only a sibling attribute of the same cluster is dirty` — unfixed: reports `vendorName` although only `vendorID` is dirty.
- `reads only the dirty attributes of a cluster with several concrete paths` — unfixed: `expected [ {…attributeId: 1}, {…attributeId: 3} ] to deeply equal [ {…attributeId: 3} ]`.
- `reports only the changed attribute when several attributes of one cluster are subscribed` — unfixed: `expected [ {…attributeId: 5}, {…attributeId: 6} ] to deeply equal [ {…attributeId: 5} ]`, i.e. the unchanged `location` rides along.

The other two new cases (attribute is dirty; cluster has no dirty attributes) pass either way — they are boundary coverage for the branch that did work, not evidence for the change.

`ProtocolServiceTest` was asserting the old behaviour: it expected three attribute reports after adding a fabric, where only `fabrics` and `commissionedFabrics` actually change. The third was `nocs`, quality `C`. Its path stays in the subscribe request so the test now proves that attribute is *not* reported.

## Scope check

An audit of the surrounding read and subscribe code found no other instance of this predicate shape — comparing a `has()`, `includes()`, `indexOf()` or `.size` result against `undefined` — anywhere in `packages/protocol/src`, `packages/node/src` or `packages/matter.js/src`.

## Known separate defect this makes visible

`Thermostat.Presets` (attribute 0x50) is now never reported to any subscriber. It is a virtual property (`ThermostatServer.ts`, via `[Val.properties]`) backed by the non-schema state field `persistedPresets`. `RootSupervisor.propertyNamesAndIds` is built from schema members only, so `ProtocolService.handleChange` maps `persistedPresets` to `undefined` and drops it — attribute 0x50 never enters the dirty set. Wildcard subscribers were already affected; concrete-path subscribers used to receive it incidentally, whenever another Thermostat attribute changed. That accidental coverage is gone.

This needs a fix in the behavior/datasource layer (broadcast the `presets` attribute name when `persistedPresets` changes, as the quiet-event hook already does for `remainingTime`), not in the subscription filter, so it is deliberately not in this PR. Filing separately.

## Gates

`npm run build`, `npm run format-verify`, `npm run lint`, `npm test` — full suite, all packages, ESM + CJS + Web, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
