### PR TITLE
Make a certification step that generates a code prove what it generated

### DIFF
--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -4,19 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InternalError, UnexpectedDataError } from "@matter/main";
-import type { CertNodeApi, CertNodeRef, CertStepContext, ControllerAdapter } from "@matter/testing";
+import { ImplementationError, InternalError, Millis, UnexpectedDataError } from "@matter/main";
+import type { CertNodeApi, CertNodeRef, CertStepContext, CheckRecord, ControllerAdapter } from "@matter/testing";
 import { LogFollower } from "@matter/testing";
 import { expect } from "chai";
 import { ChipToolCommandError } from "../../src/cert/ChipToolControllerAdapter.js";
 import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload.js";
 import type { ManualPairingCodeParts } from "../cert/tc-dd-support.js";
 import {
+    checkGeneratedManualCode,
+    checkGeneratedPayload,
     CommissioningRefusals,
     manualPairingCode,
+    manualPairingCodeDigits,
     ON_NETWORK_ONLY,
+    qrPayloadFields,
     qrPayloadWith,
     qrPayloadWithPrefix,
+    recordGeneratedManualCode,
+    recordGeneratedPayload,
     recordVendorOutcome,
 } from "../cert/tc-dd-support.js";
 import { CertCheckFailedError, CertCleanupError, CommissionedRefs } from "../cert/tc-support.js";
@@ -150,7 +156,7 @@ function contextWith(
 }
 
 describe("CommissioningRefusals", () => {
-    const BUDGETS = { refusalTimeoutMs: 100, settleTimeoutMs: 100 };
+    const BUDGETS = { refusalTimeout: Millis(100), settleTimeout: Millis(100) };
 
     it("does not accept a bare UnexpectedDataError, which commissioning raises after taking the payload", async () => {
         const cx = contextWith(() => Promise.reject(new UnexpectedDataError("Invalid response from device")));
@@ -198,7 +204,7 @@ describe("CommissioningRefusals", () => {
         const refusals = new CommissioningRefusals(BUDGETS);
 
         await expect(
-            refusals.requireNoCommissioning(cx, { manualPairingCode: "749" }, "nothing commissioned", 100),
+            refusals.requireNoCommissioning(cx, { manualPairingCode: "749" }, "nothing commissioned", Millis(100)),
         ).rejectedWith(CertCheckFailedError, /unrelated reason/);
     });
 
@@ -207,7 +213,7 @@ describe("CommissioningRefusals", () => {
         const cx = contextWith(() => Promise.reject(new ChipToolCommandError("chip-tool commissioning failed")));
         const refusals = new CommissioningRefusals(BUDGETS);
 
-        await refusals.requireNoCommissioning(cx, { manualPairingCode: "749" }, "nothing commissioned", 100);
+        await refusals.requireNoCommissioning(cx, { manualPairingCode: "749" }, "nothing commissioned", Millis(100));
         await refusals.settle(cx);
     });
 
@@ -222,7 +228,7 @@ describe("CommissioningRefusals", () => {
         const refusals = new CommissioningRefusals(BUDGETS);
 
         await expect(
-            refusals.requireNoCommissioning(cx, { manualPairingCode: "749" }, "nothing commissioned", 100),
+            refusals.requireNoCommissioning(cx, { manualPairingCode: "749" }, "nothing commissioned", Millis(100)),
         ).rejectedWith(CertCheckFailedError);
 
         await refusals.settle(cx);
@@ -282,18 +288,18 @@ describe("recordVendorOutcome", () => {
     const CODE = "34970112332";
 
     it("fails, and leaves cleanup owning the attempt, when the DUT neither onboards nor gives up", async () => {
-        const refusals = new CommissioningRefusals({ refusalTimeoutMs: 50, settleTimeoutMs: 50 });
+        const refusals = new CommissioningRefusals({ refusalTimeout: Millis(50), settleTimeout: Millis(50) });
         const cx = contextWith(() => new Promise<CertNodeRef>(() => {}));
 
         await expect(
-            recordVendorOutcome(cx, CODE, new CommissionedRefs(), refusals, "vendor outcome", 50),
+            recordVendorOutcome(cx, CODE, new CommissionedRefs(), refusals, "vendor outcome", Millis(50)),
         ).rejectedWith(/neither onboarded the TH nor gave up/);
 
         await expect(refusals.settle(cx)).rejectedWith(/still running/);
     });
 
     it("records the DUT onboarding the TH, leaving the fabric to the step that owns it", async () => {
-        const refusals = new CommissioningRefusals({ refusalTimeoutMs: 50, settleTimeoutMs: 50 });
+        const refusals = new CommissioningRefusals({ refusalTimeout: Millis(50), settleTimeout: Millis(50) });
         const decommissioned = new Array<CertNodeRef>();
         const cx = contextWith(
             async () => "peer1" as CertNodeRef,
@@ -303,7 +309,7 @@ describe("recordVendorOutcome", () => {
         );
         const commissioned = new CommissionedRefs();
 
-        await recordVendorOutcome(cx, CODE, commissioned, refusals, "vendor outcome", 50);
+        await recordVendorOutcome(cx, CODE, commissioned, refusals, "vendor outcome", Millis(50));
 
         expect(commissioned.get("dut")).equal("peer1");
 
@@ -314,13 +320,13 @@ describe("recordVendorOutcome", () => {
     });
 
     it("records the DUT terminating commissioning", async () => {
-        const refusals = new CommissioningRefusals({ refusalTimeoutMs: 50, settleTimeoutMs: 50 });
+        const refusals = new CommissioningRefusals({ refusalTimeout: Millis(50), settleTimeout: Millis(50) });
         const cx = contextWith(async () => {
             throw new InternalError("code names a vendor this network does not carry");
         });
         const commissioned = new CommissionedRefs();
 
-        await recordVendorOutcome(cx, CODE, commissioned, refusals, "vendor outcome", 50);
+        await recordVendorOutcome(cx, CODE, commissioned, refusals, "vendor outcome", Millis(50));
 
         expect(commissioned.get("dut")).equal(undefined);
         await refusals.settle(cx);
@@ -391,5 +397,302 @@ describe("manualPairingCode", () => {
 
     it("refuses one id without the other", () => {
         expect(() => manualPairingCode({ ...PLAN_DEVICE, productId: undefined })).throw(InternalError);
+    });
+});
+
+describe("qrPayloadFields", () => {
+    it("reads back the plan's own example payload", () => {
+        expect(qrPayloadFields(PLAN_PAYLOAD)).deep.equal({
+            prefix: "MT:",
+            version: 0,
+            vendorId: 0xfff1,
+            productId: 0x8001,
+            flowType: 2,
+            discoveryCapabilities: ON_NETWORK_ONLY,
+            discriminator: 0xf00,
+            passcode: 20202021,
+            tlv: "",
+        });
+    });
+
+    it("reads back the TLV a payload appends, which no substitution may disturb", () => {
+        const withTlv = "MT:-24J029Q00KA064IJ3P0IXZB0DK5N1K8SQ1RYCU1-A40";
+
+        expect(qrPayloadFields(withTlv).tlv).not.equal("");
+        expect(qrPayloadFields(withTlv).tlv).equal(qrPayloadFields(qrPayloadWith(withTlv, { passcode: 12345678 })).tlv);
+    });
+
+    it("reads back each substitution the plan makes", () => {
+        expect(qrPayloadFields("MT:034J029Q00KA0648G00").version, "version").equal(0b010);
+
+        for (const [passcode, payload] of PLAN_INVALID_PASSCODE_PAYLOADS) {
+            expect(qrPayloadFields(payload).passcode, `passcode ${passcode}`).equal(passcode);
+        }
+    });
+
+    it("reads a payload behind a substituted prefix", () => {
+        const fields = qrPayloadFields(qrPayloadWithPrefix(PLAN_PAYLOAD, "AB:"));
+
+        expect(fields.prefix).equal("AB:");
+        expect(fields.passcode).equal(20202021);
+    });
+
+    it("reads back a payload carrying appended TLV data", () => {
+        expect(qrPayloadFields("MT:-24J029Q00KA064IJ3P0IXZB0DK5N1K8SQ1RYCU1-A40").passcode).equal(20202021);
+    });
+
+    it("refuses a code carrying no prefix at all", () => {
+        expect(() => qrPayloadFields("34970112336552132769")).throw(InternalError);
+    });
+});
+
+describe("manualPairingCodeDigits", () => {
+    it("reads back the plan's own example code", () => {
+        expect(manualPairingCodeDigits("749701123365521327694")).deep.equal({
+            length: 21,
+            futureFormat: false,
+            vidPidPresent: true,
+            shortDiscriminator: 0xf,
+            passcode: 20202021,
+            vendorId: 0xfff1,
+            productId: 0x8001,
+            checkDigit: 4,
+            checkDigitCorrect: true,
+        });
+    });
+
+    it("reads back each substitution the plan makes", () => {
+        expect(manualPairingCodeDigits("849701123365521327693").futureFormat, "version").equal(true);
+        expect(manualPairingCodeDigits("349701123365521327696").vidPidPresent, "VID_PID_PRESENT").equal(false);
+        expect(manualPairingCodeDigits("733317123365521327692").shortDiscriminator, "discriminator").equal(0xe);
+        expect(manualPairingCodeDigits("749701123365521000006").productId, "product id").equal(0);
+        expect(manualPairingCodeDigits("749701123365522327692").vendorId, "vendor id").equal(0xfff2);
+        expect(manualPairingCodeDigits("749152000065521327698").passcode, "passcode").equal(0);
+    });
+
+    it("reports a check digit that is not the one the digits produce", () => {
+        const digits = manualPairingCodeDigits("749701123365521327693");
+
+        expect(digits.checkDigit).equal(3);
+        expect(digits.checkDigitCorrect).equal(false);
+    });
+
+    it("reads back an 11-digit code", () => {
+        const code = manualPairingCode({ vidPidPresent: false, discriminator: 0xf00, passcode: 20202021 });
+
+        expect(manualPairingCodeDigits(code)).deep.contain({
+            length: 11,
+            vidPidPresent: false,
+            shortDiscriminator: 0xf,
+            passcode: 20202021,
+            vendorId: undefined,
+            productId: undefined,
+        });
+    });
+
+    it("ignores the separators a tester may type", () => {
+        expect(manualPairingCodeDigits("7497-011.233 65521327694").passcode).equal(20202021);
+    });
+
+    it("refuses a digit count no manual pairing code has", () => {
+        expect(() => manualPairingCodeDigits("7497011233655213276")).throw(InternalError);
+    });
+});
+
+function recordingContext() {
+    const checks = new Array<CheckRecord>();
+    const cx = contextWith(() => Promise.reject(new InternalError("not used by these tests")));
+
+    return { checks, cx: { ...cx, recorder: { ...cx.recorder, check: (check: CheckRecord) => checks.push(check) } } };
+}
+
+describe("recordGeneratedPayload", () => {
+    it("records the fields the payload carries", () => {
+        const { checks, cx } = recordingContext();
+
+        recordGeneratedPayload(cx, PLAN_PAYLOAD, { passcode: 20202021 }, "plan payload");
+
+        expect(checks).length(1);
+        expect(checks[0].verdict).equal("pass");
+        expect(checks[0].detail).contain("passcode=20202021");
+    });
+
+    it("fails the step when the payload does not carry what the step asked for", () => {
+        const { checks, cx } = recordingContext();
+
+        expect(() => recordGeneratedPayload(cx, PLAN_PAYLOAD, { passcode: 12345678 }, "plan payload")).throw(
+            CertCheckFailedError,
+        );
+        expect(checks[0].verdict).equal("fail");
+        expect(checks[0].detail).contain("expected passcode=12345678");
+    });
+
+    it("fails the step on a prefix the step did not ask for", () => {
+        const { cx } = recordingContext();
+
+        expect(() => recordGeneratedPayload(cx, PLAN_PAYLOAD, { prefix: "AB:" }, "plan payload")).throw(
+            CertCheckFailedError,
+        );
+    });
+});
+
+describe("recordGeneratedManualCode", () => {
+    const PLAN_CODE = "749701123365521327694";
+
+    it("records the digits the code carries", () => {
+        const { checks, cx } = recordingContext();
+
+        recordGeneratedManualCode(cx, PLAN_CODE, { vendorId: 0xfff1 }, "plan code");
+
+        expect(checks).length(1);
+        expect(checks[0].verdict).equal("pass");
+        expect(checks[0].detail).contain("checkDigit=4 (correct)");
+    });
+
+    it("fails the step when the code does not carry what the step asked for", () => {
+        const { checks, cx } = recordingContext();
+
+        expect(() => recordGeneratedManualCode(cx, PLAN_CODE, { productId: 0 }, "plan code")).throw(
+            CertCheckFailedError,
+        );
+        expect(checks[0].detail).contain("expected productId=0");
+    });
+
+    it("asserts the Verhoeff digit no step names, which every step's expected outcome demands", () => {
+        const { checks, cx } = recordingContext();
+
+        expect(() => recordGeneratedManualCode(cx, "749701123365521327693", { vendorId: 0xfff1 }, "plan code")).throw(
+            CertCheckFailedError,
+        );
+        expect(checks[0].detail).contain("expected checkDigitCorrect=true");
+    });
+
+    it("accepts the wrong check digit the step that asks for one generates", () => {
+        const { checks, cx } = recordingContext();
+
+        recordGeneratedManualCode(cx, "749701123365521327693", { checkDigitCorrect: false }, "wrong check digit");
+
+        expect(checks[0].verdict).equal("pass");
+        expect(checks[0].detail).contain("not the Verhoeff digit");
+    });
+
+    it("fails the step when the code does not differ from the one it must differ from", () => {
+        const { checks, cx } = recordingContext();
+
+        expect(() => recordGeneratedManualCode(cx, PLAN_CODE, { differsFrom: PLAN_CODE }, "plan code")).throw(
+            CertCheckFailedError,
+        );
+        expect(checks[0].detail).contain(`expected a code other than ${PLAN_CODE}`);
+    });
+});
+
+describe("checkGeneratedManualCode", () => {
+    const PLAN_CODE = "749701123365521327694";
+
+    it("asserts a field a caller states as undefined rather than silently skipping it", () => {
+        // `Partial<T>` accepts an accidental `undefined` from an optional source field, and treating
+        // that as "not asserted" is how a step would claim something it never checked
+        expect(checkGeneratedManualCode(PLAN_CODE, { productId: undefined }).verdict).equal("fail");
+    });
+
+    it("asserts an absent field, which the 11-digit form has", () => {
+        const short = manualPairingCode({ vidPidPresent: false, discriminator: 0xf00, passcode: 20202021 });
+
+        expect(checkGeneratedManualCode(short, { vendorId: undefined, productId: undefined }).verdict).equal("pass");
+        expect(checkGeneratedManualCode(PLAN_CODE, { vendorId: undefined }).verdict).equal("fail");
+    });
+
+    it("asserts a field whose expected value is falsy", () => {
+        expect(checkGeneratedManualCode("749701123365521000006", { productId: 0 }).verdict).equal("pass");
+        expect(checkGeneratedManualCode(PLAN_CODE, { productId: 0 }).verdict).equal("fail");
+        expect(checkGeneratedManualCode("349701123365521327696", { vidPidPresent: false }).verdict).equal("pass");
+        expect(checkGeneratedManualCode(PLAN_CODE, { vidPidPresent: false }).verdict).equal("fail");
+    });
+});
+
+describe("checkGeneratedPayload", () => {
+    it("asserts a field a caller states as undefined rather than silently skipping it", () => {
+        expect(checkGeneratedPayload(PLAN_PAYLOAD, { passcode: undefined }).verdict).equal("fail");
+    });
+
+    it("asserts a version of 0, which is the value the specification requires", () => {
+        expect(checkGeneratedPayload(PLAN_PAYLOAD, { version: 0 }).verdict).equal("pass");
+        expect(checkGeneratedPayload(qrPayloadWith(PLAN_PAYLOAD, { version: 2 }), { version: 0 }).verdict).equal(
+            "fail",
+        );
+    });
+});
+
+describe("unchangedFrom", () => {
+    const PLAN_CODE = "749701123365521327694";
+
+    it("fails a payload whose vendor, product, flow or discriminator moved", () => {
+        // The four fields the reader gained: comparing only the substituted one left a generator
+        // free to corrupt any of them
+        const source = qrPayloadFields(PLAN_PAYLOAD);
+        for (const field of ["vendorId", "productId", "flowType", "discriminator"] as const) {
+            const moved = { ...source, [field]: source[field] + 1 };
+            expect(checkGeneratedPayload(PLAN_PAYLOAD, { ...moved, unchangedFrom: PLAN_PAYLOAD }).verdict, field).equal(
+                "fail",
+            );
+        }
+    });
+
+    it("fails a payload whose other fields moved, which the substituted field alone cannot show", () => {
+        const clobbered = qrPayloadWith(PLAN_PAYLOAD, { passcode: 12345678, discoveryCapabilities: 0b010 });
+
+        expect(checkGeneratedPayload(clobbered, { passcode: 12345678 }).verdict, "the substituted field alone").equal(
+            "pass",
+        );
+        expect(
+            checkGeneratedPayload(clobbered, { passcode: 12345678, unchangedFrom: PLAN_PAYLOAD }).verdict,
+            "against the source payload",
+        ).equal("fail");
+    });
+
+    it("passes a payload where only the substituted field moved", () => {
+        expect(
+            checkGeneratedPayload(qrPayloadWith(PLAN_PAYLOAD, { passcode: 12345678 }), {
+                passcode: 12345678,
+                unchangedFrom: PLAN_PAYLOAD,
+            }).verdict,
+        ).equal("pass");
+    });
+
+    it("fails a code whose other digits moved", () => {
+        const parts = { vidPidPresent: true, discriminator: 0xf00, passcode: 20202021, productId: 0x8001 };
+        const clobbered = manualPairingCode({ ...parts, vendorId: 0xfff2, discriminator: 0xe00 });
+
+        expect(checkGeneratedManualCode(clobbered, { vendorId: 0xfff2 }).verdict, "the vendor alone").equal("pass");
+        expect(
+            checkGeneratedManualCode(clobbered, { vendorId: 0xfff2, unchangedFrom: PLAN_CODE }).verdict,
+            "against the source code",
+        ).equal("fail");
+    });
+
+    it("passes a code where only the substituted digits moved, check digit aside", () => {
+        expect(
+            checkGeneratedManualCode("749701123365522327692", { vendorId: 0xfff2, unchangedFrom: PLAN_CODE }).verdict,
+        ).equal("pass");
+    });
+
+    it("refuses a code field that is there but undefined, rather than dropping the assertion", () => {
+        expect(() => checkGeneratedManualCode(PLAN_CODE, { unchangedFrom: undefined }), "unchangedFrom").throw(
+            ImplementationError,
+        );
+        expect(() => checkGeneratedManualCode(PLAN_CODE, { differsFrom: undefined }), "differsFrom").throw(
+            ImplementationError,
+        );
+        expect(() => checkGeneratedPayload(PLAN_PAYLOAD, { unchangedFrom: undefined }), "payload").throw(
+            ImplementationError,
+        );
+    });
+
+    it("does not demand the check digit, which every substitution changes", () => {
+        // The source's own check digit is 4 and the substituted code's is 2; naming it would make
+        // every `unchangedFrom` expectation self-contradictory
+        expect(
+            checkGeneratedManualCode("749701123365522327692", { vendorId: 0xfff2, unchangedFrom: PLAN_CODE }).detail,
+        ).contain("checkDigit=2 (correct)");
     });
 });

--- a/support/chip-testing/test/cert-framework/tc-idm-1.3-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-1.3-support.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Millis } from "@matter/main";
 import { LineQueue, LogFollower } from "@matter/testing";
 import { expect } from "chai";
 import { ChipFault } from "../cert/fault-injection.js";
@@ -136,7 +137,7 @@ describe("injectedFaultSequence", () => {
 describe("expectInjectedFault", () => {
     it("records the fault the TH announced", async () => {
         const check = await withFollower(faultLines(ChipFault.imInvokeSkipSecondResponse), follower =>
-            expectInjectedFault(follower, "chip-local", ChipFault.imInvokeSkipSecondResponse, 0, 500),
+            expectInjectedFault(follower, "chip-local", ChipFault.imInvokeSkipSecondResponse, 0, Millis(500)),
         );
 
         expect(check.verdict).equal("pass");
@@ -145,7 +146,7 @@ describe("expectInjectedFault", () => {
 
     it("fails when a different fault fired", async () => {
         const check = await withFollower(faultLines(ChipFault.imInvokeSeparateResponses), follower =>
-            expectInjectedFault(follower, "chip-local", ChipFault.imInvokeSkipSecondResponse, 0, 200),
+            expectInjectedFault(follower, "chip-local", ChipFault.imInvokeSkipSecondResponse, 0, Millis(200)),
         );
 
         expect(check.verdict).equal("fail");
@@ -153,7 +154,7 @@ describe("expectInjectedFault", () => {
 
     it("is unverified for a matterjs device", async () => {
         const check = await withFollower([], follower =>
-            expectInjectedFault(follower, "matterjs", ChipFault.imInvokeSeparateResponses, 0, 200),
+            expectInjectedFault(follower, "matterjs", ChipFault.imInvokeSeparateResponses, 0, Millis(200)),
         );
 
         expect(check.verdict).equal("unverified");
@@ -227,7 +228,7 @@ describe("expectInvokeCount", () => {
 describe("expectBatchRequestPaths", () => {
     it("records both command paths of the request", async () => {
         const check = await withFollower(batchRequestLines(PATHS), follower =>
-            expectBatchRequestPaths(follower, "chip-local", PATHS, 0, 500),
+            expectBatchRequestPaths(follower, "chip-local", PATHS, 0, Millis(500)),
         );
 
         expect(check.verdict).equal("pass");
@@ -236,7 +237,7 @@ describe("expectBatchRequestPaths", () => {
 
     it("fails when the paths arrived in the other order", async () => {
         const check = await withFollower(batchRequestLines([PATHS[1], PATHS[0]]), follower =>
-            expectBatchRequestPaths(follower, "chip-local", PATHS, 0, 200),
+            expectBatchRequestPaths(follower, "chip-local", PATHS, 0, Millis(200)),
         );
 
         expect(check.verdict).equal("fail");
@@ -244,7 +245,7 @@ describe("expectBatchRequestPaths", () => {
 
     it("fails when a requested path is absent", async () => {
         const check = await withFollower(batchRequestLines([PATHS[0]]), follower =>
-            expectBatchRequestPaths(follower, "chip-local", PATHS, 0, 200),
+            expectBatchRequestPaths(follower, "chip-local", PATHS, 0, Millis(200)),
         );
 
         expect(check.verdict).equal("fail");
@@ -253,7 +254,7 @@ describe("expectBatchRequestPaths", () => {
     it("fails when the request carried a command beside the expected ones", async () => {
         const extra: BatchPath = { endpoint: 1, cluster: ON_OFF, command: 0x2 };
         const check = await withFollower([...batchRequestLines([PATHS[0], extra, PATHS[1]])], follower =>
-            expectBatchRequestPaths(follower, "chip-local", PATHS, 0, 500),
+            expectBatchRequestPaths(follower, "chip-local", PATHS, 0, Millis(500)),
         );
 
         expect(check.verdict).equal("fail");
@@ -264,7 +265,7 @@ describe("expectBatchRequestPaths", () => {
         // Buffered, so a later request's commands are actually in reach of the count being bounded.
         const check = await withBufferedFollower(
             [...batchRequestLines(PATHS), ...batchRequestLines([PATHS[0]])],
-            follower => expectBatchRequestPaths(follower, "chip-local", PATHS, 0, 500),
+            follower => expectBatchRequestPaths(follower, "chip-local", PATHS, 0, Millis(500)),
         );
 
         expect(check.verdict).equal("pass");
@@ -273,7 +274,7 @@ describe("expectBatchRequestPaths", () => {
     it("fails when two separate requests carried one command each instead of one batch", async () => {
         const check = await withBufferedFollower(
             [...batchRequestLines([PATHS[0]]), ...batchRequestLines([PATHS[1]])],
-            follower => expectBatchRequestPaths(follower, "chip-local", PATHS, 0, 500),
+            follower => expectBatchRequestPaths(follower, "chip-local", PATHS, 0, Millis(500)),
         );
 
         expect(check.verdict).equal("fail");
@@ -281,7 +282,7 @@ describe("expectBatchRequestPaths", () => {
 
     it("is unverified for a matterjs device", async () => {
         const check = await withFollower(batchRequestLines(PATHS), follower =>
-            expectBatchRequestPaths(follower, "matterjs", PATHS, 0, 200),
+            expectBatchRequestPaths(follower, "matterjs", PATHS, 0, Millis(200)),
         );
 
         expect(check.verdict).equal("unverified");

--- a/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InternalError } from "@matter/main";
+import { InternalError, Millis, Seconds } from "@matter/main";
 import type {
     CertDevice,
     CertNodeApi,
@@ -31,11 +31,11 @@ const ACKED_SIBLING_ID = 0x77;
 const PATH = { endpoint: 0, cluster: 0x28, attribute: 0x10 };
 const VALUES = [true, false, true];
 
-const TIMEOUTS: SubscribeAndModifyTimeouts = { establishMs: 5_000, reportMs: 5_000 };
+const TIMEOUTS: SubscribeAndModifyTimeouts = { establish: Seconds(5), report: Seconds(5) };
 
 // Only for the cases that assert a wait giving up: long enough for the follower's async pump, short
 // enough that the failure lands inside a normal mocha timeout.
-const IMPATIENT: SubscribeAndModifyTimeouts = { establishMs: 5_000, reportMs: 400 };
+const IMPATIENT: SubscribeAndModifyTimeouts = { establish: Seconds(5), report: Millis(400) };
 
 function subscribeRequestLines(path: { endpoint: number; cluster: number; attribute: number }): string[] {
     const attribute = path.attribute.toString(16).toUpperCase().padStart(8, "0");

--- a/support/chip-testing/test/cert-framework/tc-idm-5.1-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-5.1-support.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Millis } from "@matter/main";
 import { LineQueue, LogFollower } from "@matter/testing";
 import {
     expectTimedFollowUp,
@@ -14,7 +15,7 @@ import {
 } from "../cert/tc-idm-5.1-support.js";
 import { INVOKE_REQUEST_MESSAGE, WRITE_REQUEST_MESSAGE } from "../cert/tc-support.js";
 
-const TIMEOUT_MS = 200;
+const TIMEOUT = Millis(200);
 
 /** One chip log line: its own timestamp prefix, then the module tag the matchers anchor on. */
 function line(atMs: number, text: string) {
@@ -37,7 +38,7 @@ function timedRequestLines(atMs: number, category: "S" | "U" | "G" = "S") {
         receipt(atMs, category, "0a (IM:TimedRequest)"),
         line(atMs, "[DMG] TimedRequestMessage ="),
         line(atMs, "[DMG] {"),
-        line(atMs, `[DMG] \tTimeoutMs = 0x${TIMEOUT_MS.toString(16)},`),
+        line(atMs, `[DMG] \tTimeoutMs = 0x${TIMEOUT.toString(16)},`),
         line(atMs, "[DMG] }"),
     ];
 }
@@ -84,7 +85,7 @@ describe("timestampMsOf", () => {
 
 describe("timedRequestSequence", () => {
     it("asks for the timeout in chip's own bare lowercase hex", () => {
-        const sequence = timedRequestSequence(200);
+        const sequence = timedRequestSequence(Millis(200));
 
         expect(sequence).to.have.lengthOf(3);
         expect(sequence[2].test("[DMG] \tTimeoutMs = 0xc8,")).equal(true);
@@ -95,7 +96,7 @@ describe("timedRequestSequence", () => {
 describe("expectTimedRequest", () => {
     it("matches the block and returns the line it matched", async () => {
         const result = await withFollower(timedRequestLines(T0), follower =>
-            expectTimedRequest(follower, "chip-local", TIMEOUT_MS, 0, 500),
+            expectTimedRequest(follower, "chip-local", TIMEOUT, 0, Millis(500)),
         );
 
         expect(result.check.verdict).equal("pass");
@@ -104,7 +105,7 @@ describe("expectTimedRequest", () => {
 
     it("fails when the device was asked for a different timeout", async () => {
         const result = await withFollower(timedRequestLines(T0), follower =>
-            expectTimedRequest(follower, "chip-local", 300, 0, 200),
+            expectTimedRequest(follower, "chip-local", Millis(300), 0, Millis(200)),
         );
 
         expect(result.check.verdict).equal("fail");
@@ -113,7 +114,7 @@ describe("expectTimedRequest", () => {
 
     it("reports unverified for a flavor with no pattern for the message", async () => {
         const result = await withFollower(timedRequestLines(T0), follower =>
-            expectTimedRequest(follower, "matterjs", TIMEOUT_MS, 0, 500),
+            expectTimedRequest(follower, "matterjs", TIMEOUT, 0, Millis(500)),
         );
 
         expect(result.check.verdict).equal("unverified");
@@ -123,7 +124,7 @@ describe("expectTimedRequest", () => {
 describe("expectUnicastReceipt", () => {
     async function categoryVerdict(category: "S" | "U" | "G") {
         return withFollower(timedRequestLines(T0, category), async follower => {
-            const timed = await expectTimedRequest(follower, "chip-local", TIMEOUT_MS, 0, 500);
+            const timed = await expectTimedRequest(follower, "chip-local", TIMEOUT, 0, Millis(500));
             return expectUnicastReceipt(timed);
         });
     }
@@ -145,7 +146,7 @@ describe("expectUnicastReceipt", () => {
 
     it("fails when no receive line precedes the message", async () => {
         const check = await withFollower(timedRequestLines(T0).slice(1), async follower => {
-            const timed = await expectTimedRequest(follower, "chip-local", TIMEOUT_MS, 0, 500);
+            const timed = await expectTimedRequest(follower, "chip-local", TIMEOUT, 0, Millis(500));
             return expectUnicastReceipt(timed);
         });
 
@@ -163,8 +164,8 @@ describe("expectUnicastReceipt", () => {
 describe("expectTimedFollowUp", () => {
     async function followUp(lines: string[], message = INVOKE_REQUEST_MESSAGE) {
         return withFollower(lines, async follower => {
-            const timed = await expectTimedRequest(follower, "chip-local", TIMEOUT_MS, 0, 500);
-            return expectTimedFollowUp(follower, "chip-local", message, timed, TIMEOUT_MS, 500);
+            const timed = await expectTimedRequest(follower, "chip-local", TIMEOUT, 0, Millis(500));
+            return expectTimedFollowUp(follower, "chip-local", message, timed, TIMEOUT, Millis(500));
         });
     }
 
@@ -188,7 +189,7 @@ describe("expectTimedFollowUp", () => {
     });
 
     it("fails when the message arrives after the window it was promised", async () => {
-        const check = await followUp([...timedRequestLines(T0), ...invokeLines(T0 + TIMEOUT_MS + 1)]);
+        const check = await followUp([...timedRequestLines(T0), ...invokeLines(T0 + TIMEOUT + 1)]);
 
         expect(check.verdict).equal("fail");
         expect(check.detail).contains("201.0ms");
@@ -212,8 +213,8 @@ describe("expectTimedFollowUp", () => {
                 "chip-local",
                 INVOKE_REQUEST_MESSAGE,
                 { check: { type: "device-log", verdict: "unverified" } },
-                TIMEOUT_MS,
-                500,
+                TIMEOUT,
+                Millis(500),
             ),
         );
 

--- a/support/chip-testing/test/cert-framework/tc-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-support.test.ts
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InternalError, Time } from "@matter/main";
-import type { CertNodeApi, CertStepContext, ControllerAdapter } from "@matter/testing";
+import { InternalError, Millis, Time, Seconds } from "@matter/main";
+import type { CertNodeApi, CertStepContext, CheckRecord, ControllerAdapter } from "@matter/testing";
 import { LogFollower } from "@matter/testing";
 import {
     attributePathIBSequence,
+    CertCheckFailedError,
     CertCleanupError,
     CommissionedRefs,
     commandPathIBSequence,
@@ -24,6 +25,7 @@ import {
     expectSubscriptionId,
     fabricFilteredPattern,
     READ_REQUEST_MESSAGE,
+    recordAll,
     requireId,
     STATUS_RESPONSE_SUCCESS,
     WRITE_REQUEST_MESSAGE,
@@ -111,7 +113,7 @@ async function withFollower<T>(
 }
 
 async function check(lines: string[], flavor = "chip-docker", endSource = false) {
-    return withFollower(lines, follower => expectChunkedTransfer(follower, flavor, 0, 1_000), { endSource });
+    return withFollower(lines, follower => expectChunkedTransfer(follower, flavor, 0, Seconds(1)), { endSource });
 }
 
 describe("expectChunkedTransfer", () => {
@@ -284,7 +286,7 @@ describe("expectSequence", () => {
 
     it("passes on the consecutive read-request-with-event-path run", async () => {
         const record = await withFollower(READ_EVENT_LINES, follower =>
-            expectSequence(follower, "chip-local", "read event path", SEQUENCE, 0, 1_000),
+            expectSequence(follower, "chip-local", "read event path", SEQUENCE, 0, Seconds(1)),
         );
 
         expect(record.verdict).equal("pass");
@@ -293,7 +295,7 @@ describe("expectSequence", () => {
 
     it("finds isFabricFiltered after the path block, which is not adjacent to it", async () => {
         const record = await withFollower(READ_EVENT_LINES, async follower => {
-            const block = await expectSequence(follower, "chip-local", "read event path", SEQUENCE, 0, 1_000);
+            const block = await expectSequence(follower, "chip-local", "read event path", SEQUENCE, 0, Seconds(1));
             expect(block.logLine).equal(9);
             return expectSequence(
                 follower,
@@ -301,7 +303,7 @@ describe("expectSequence", () => {
                 "isFabricFiltered",
                 [fabricFilteredPattern(true)],
                 block.logLine! + 1,
-                1_000,
+                Seconds(1),
             );
         });
 
@@ -310,7 +312,7 @@ describe("expectSequence", () => {
 
     it("fails, rather than throwing, when the sequence never arrives", async () => {
         const record = await withFollower(["[DMG] ReadRequestMessage ="], follower =>
-            expectSequence(follower, "chip-local", "read event path", SEQUENCE, 0, 200),
+            expectSequence(follower, "chip-local", "read event path", SEQUENCE, 0, Millis(200)),
         );
 
         expect(record.verdict).equal("fail");
@@ -319,7 +321,7 @@ describe("expectSequence", () => {
 
     it("reports unverified for a flavor with no pattern for the sequence", async () => {
         const record = await withFollower(READ_EVENT_LINES, follower =>
-            expectSequence(follower, "matterjs", "read event path", SEQUENCE, 0, 1_000),
+            expectSequence(follower, "matterjs", "read event path", SEQUENCE, 0, Seconds(1)),
         );
 
         expect(record.verdict).equal("unverified");
@@ -340,7 +342,7 @@ describe("expectMessageWithPath", () => {
 
     it("passes when the path block follows the message", async () => {
         const record = await withFollower([WRITE, ...PATH], follower =>
-            expectMessageWithPath(follower, "chip-local", WRITE_REQUEST_MESSAGE, FIELDS, 0, 1_000),
+            expectMessageWithPath(follower, "chip-local", WRITE_REQUEST_MESSAGE, FIELDS, 0, Seconds(1)),
         );
 
         expect(record.verdict).equal("pass");
@@ -348,7 +350,7 @@ describe("expectMessageWithPath", () => {
 
     it("fails at the message stage when the path block appears without the message", async () => {
         const record = await withFollower([...PATH], follower =>
-            expectMessageWithPath(follower, "chip-local", WRITE_REQUEST_MESSAGE, FIELDS, 0, 1_000),
+            expectMessageWithPath(follower, "chip-local", WRITE_REQUEST_MESSAGE, FIELDS, 0, Seconds(1)),
         );
 
         expect(record.verdict).equal("fail");
@@ -357,7 +359,7 @@ describe("expectMessageWithPath", () => {
 
     it("fails at the path stage when a path block appears before the message but not after", async () => {
         const record = await withFollower([...PATH, WRITE], follower =>
-            expectMessageWithPath(follower, "chip-local", WRITE_REQUEST_MESSAGE, FIELDS, 0, 1_000),
+            expectMessageWithPath(follower, "chip-local", WRITE_REQUEST_MESSAGE, FIELDS, 0, Seconds(1)),
         );
 
         expect(record.verdict).equal("fail");
@@ -366,28 +368,28 @@ describe("expectMessageWithPath", () => {
 
     it("reports unverified for a flavor with no pattern for the message", async () => {
         const record = await withFollower([WRITE, ...PATH], follower =>
-            expectMessageWithPath(follower, "matterjs", WRITE_REQUEST_MESSAGE, FIELDS, 0, 1_000),
+            expectMessageWithPath(follower, "matterjs", WRITE_REQUEST_MESSAGE, FIELDS, 0, Seconds(1)),
         );
 
         expect(record.verdict).equal("unverified");
     });
 
-    it("gives up within roughly one timeoutMs budget when the path block never arrives, not two", async () => {
+    it("gives up within roughly one timeout budget when the path block never arrives, not two", async () => {
         // The message must arrive partway through the budget, not be already buffered — otherwise
-        // stage 1 costs ~0ms and remaining() is indistinguishable from a fresh timeoutMs, hiding a
+        // stage 1 costs ~0ms and remaining() is indistinguishable from a fresh timeout, hiding a
         // shared-vs-fresh-budget regression in stage 2 instead of catching it.
-        const timeoutMs = 600;
+        const timeout = Millis(600);
         const source = new OpenSource();
         const follower = new LogFollower(source, "th");
         setTimeout(() => source.push(WRITE), 300);
 
         const start = Date.now();
-        const record = await expectMessageWithPath(follower, "chip-local", WRITE_REQUEST_MESSAGE, FIELDS, 0, timeoutMs);
+        const record = await expectMessageWithPath(follower, "chip-local", WRITE_REQUEST_MESSAGE, FIELDS, 0, timeout);
         const elapsed = Date.now() - start;
         await follower.close();
 
         expect(record.verdict).equal("fail");
-        expect(elapsed).lessThan(timeoutMs * 1.25);
+        expect(elapsed).lessThan(timeout * 1.25);
     });
 });
 
@@ -406,14 +408,14 @@ describe("expectSubscriptionId and expectReportAck against a matter.js TH", () =
         "acked: 05ab904b reqAck size: 8 payload: 1524000024ff0c18";
 
     async function ack(lines: string[], subscriptionId = 0x54c99e7e) {
-        return withFollower(lines, follower => expectReportAck(follower, "matterjs", subscriptionId, 0, 200), {
+        return withFollower(lines, follower => expectReportAck(follower, "matterjs", subscriptionId, 0, Millis(200)), {
             endSource: true,
         });
     }
 
     it("reads the id the TH minted", async () => {
         const lookup = await withFollower([SUBSCRIBE_RESPONSE], follower =>
-            expectSubscriptionId(follower, "matterjs", 0, 200),
+            expectSubscriptionId(follower, "matterjs", 0, Millis(200)),
         );
 
         expect(lookup.subscriptionId).equal(0x54c99e7e);
@@ -512,7 +514,7 @@ describe("expectCommandInvoke", () => {
 
     it("passes when the path block matches and every field line follows in order", async () => {
         const record = await withFollower([...PATH, FIELD], follower =>
-            expectCommandInvoke(follower, "chip-local", 1, 0x6, 0x1, [{ id: 0, value: 4097 }], 0, 1_000),
+            expectCommandInvoke(follower, "chip-local", 1, 0x6, 0x1, [{ id: 0, value: 4097 }], 0, Seconds(1)),
         );
 
         expect(record.verdict).equal("pass");
@@ -520,7 +522,7 @@ describe("expectCommandInvoke", () => {
 
     it("fails when a field line never appears", async () => {
         const record = await withFollower([...PATH], follower =>
-            expectCommandInvoke(follower, "chip-local", 1, 0x6, 0x1, [{ id: 0, value: 4097 }], 0, 1_000),
+            expectCommandInvoke(follower, "chip-local", 1, 0x6, 0x1, [{ id: 0, value: 4097 }], 0, Seconds(1)),
         );
 
         expect(record.verdict).equal("fail");
@@ -528,7 +530,7 @@ describe("expectCommandInvoke", () => {
 
     it("passes with no field checks when fields is empty", async () => {
         const record = await withFollower([...PATH], follower =>
-            expectCommandInvoke(follower, "chip-local", 1, 0x6, 0x1, [], 0, 1_000),
+            expectCommandInvoke(follower, "chip-local", 1, 0x6, 0x1, [], 0, Seconds(1)),
         );
 
         expect(record.verdict).equal("pass");
@@ -536,7 +538,7 @@ describe("expectCommandInvoke", () => {
 
     it("reports unverified for a flavor with no pattern", async () => {
         const record = await withFollower([...PATH], follower =>
-            expectCommandInvoke(follower, "matterjs", 1, 0x6, 0x1, [], 0, 1_000),
+            expectCommandInvoke(follower, "matterjs", 1, 0x6, 0x1, [], 0, Seconds(1)),
         );
 
         expect(record.verdict).equal("unverified");
@@ -696,24 +698,24 @@ describe("CommissionedRefs", () => {
 });
 
 describe("expectRejection", () => {
-    const BUDGET_MS = 200;
+    const BUDGET = Millis(200);
 
     it("passes on a rejection and reports what it rejected with", async () => {
-        const check = await expectRejection("op", Promise.reject(new Error("refused")), BUDGET_MS);
+        const check = await expectRejection("op", Promise.reject(new Error("refused")), BUDGET);
 
         expect(check.verdict).equal("pass");
         expect(check.detail).match(/^op rejected after .*: refused$/);
     });
 
     it("fails on an unexpected success", async () => {
-        const check = await expectRejection("op", Promise.resolve("commissioned"), BUDGET_MS);
+        const check = await expectRejection("op", Promise.resolve("commissioned"), BUDGET);
 
         expect(check.verdict).equal("fail");
         expect(check.detail).match(/^op unexpectedly succeeded after /);
     });
 
     it("fails once the budget expires rather than waiting for the call", async () => {
-        const check = await expectRejection("op", new Promise(() => {}), BUDGET_MS);
+        const check = await expectRejection("op", new Promise(() => {}), BUDGET);
 
         expect(check.verdict).equal("fail");
         expect(check.detail).match(/^op neither resolved nor rejected within /);
@@ -723,7 +725,7 @@ describe("expectRejection", () => {
         const check = await expectRejection(
             "op",
             Promise.reject(new InternalError("the process died")),
-            BUDGET_MS,
+            BUDGET,
             error => error instanceof TypeError,
         );
 
@@ -735,7 +737,7 @@ describe("expectRejection", () => {
         const check = await expectRejection(
             "op",
             Promise.reject(new InternalError("refused")),
-            BUDGET_MS,
+            BUDGET,
             error => error instanceof InternalError,
         );
 
@@ -746,8 +748,99 @@ describe("expectRejection", () => {
         // A budget nothing waits out would otherwise hold the process open past teardown
         const before = Time.timers.size;
 
-        await expectRejection("op", Promise.reject(new Error("refused")), 60_000);
+        await expectRejection("op", Promise.reject(new Error("refused")), Seconds(60));
 
         expect(Time.timers.size).equal(before);
+    });
+});
+
+describe("recordAll", () => {
+    function recordingContext() {
+        const checks = new Array<CheckRecord>();
+        const cx = {
+            controllers: {},
+            devices: {},
+            recorder: {
+                beginStep() {},
+                check(check: CheckRecord) {
+                    checks.push(check);
+                },
+                endStep() {
+                    return [];
+                },
+                async flush() {
+                    return "";
+                },
+            },
+        } satisfies CertStepContext;
+
+        return { checks, cx };
+    }
+
+    const pass = (detail: string): CheckRecord => ({ type: "response", verdict: "pass", detail });
+    const fail = (detail: string): CheckRecord => ({ type: "response", verdict: "fail", detail });
+
+    it("records every check when they all pass", () => {
+        const { checks, cx } = recordingContext();
+
+        recordAll(cx, [
+            { check: () => pass("first"), what: "one" },
+            { check: () => pass("second"), what: "two" },
+        ]);
+
+        expect(checks.map(check => check.detail)).deep.equal(["first", "second"]);
+    });
+
+    it("records the checks after a failing one rather than stopping at it", () => {
+        const { checks, cx } = recordingContext();
+
+        expect(() =>
+            recordAll(cx, [
+                { check: () => fail("first"), what: "one" },
+                { check: () => pass("second"), what: "two" },
+                { check: () => fail("third"), what: "three" },
+            ]),
+        ).throw(CertCheckFailedError, /2 of 3 checks failed/);
+
+        expect(checks.map(check => check.detail)).deep.equal(["first", "second", "third"]);
+    });
+
+    it("names every failure in the error it throws", () => {
+        const { cx } = recordingContext();
+
+        expect(() =>
+            recordAll(cx, [
+                { check: () => fail("first"), what: "one" },
+                { check: () => fail("third"), what: "three" },
+            ]),
+        ).throw(CertCheckFailedError, /one:.*three:/);
+    });
+
+    it("keeps the checks recorded before a builder threw", () => {
+        const { checks, cx } = recordingContext();
+
+        expect(() =>
+            recordAll(cx, [
+                { check: () => pass("first"), what: "one" },
+                {
+                    check: (): CheckRecord => {
+                        throw new InternalError("generator produced no artifact");
+                    },
+                    what: "two",
+                },
+            ]),
+        ).throw(InternalError);
+
+        expect(checks.map(check => check.detail)).deep.equal(["first"]);
+    });
+
+    it("passes an unverified check through, as record does", () => {
+        const { checks, cx } = recordingContext();
+
+        recordAll(cx, [
+            { check: () => ({ type: "device-log", verdict: "unverified" }), what: "matterjs has no pattern" },
+        ]);
+
+        expect(checks).length(1);
     });
 });

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -187,6 +187,24 @@ certTest("TC-XXX-0.0", { plan: "n/a" | "<plan doc id>", pics: [], app: "all-clus
   unconditional "this is what the DUT answered" line beside an `await` that would have thrown.
 - Never throw a plain `Error` from a step: `CertCheckFailedError` is the step-assertion type, and
   `InternalError` is for a harness invariant that cannot hold.
+- A budget in this directory is a `Duration` (`Seconds(15)`, not `15_000`). The framework underneath
+  takes plain numbers, since `@matter/testing` carries no dependency on the library; a `Duration` is
+  milliseconds, so it crosses that boundary as a value — `{ flavor, timeoutMs: timeout, from }`.
+- Two log budgets, and they are not interchangeable. `LOG_TIMEOUT` (`tc-support.ts`, 15 s) bounds a
+  wait for a line the step has already caused — the device writes it while answering the interaction
+  the step drove, so the budget only covers the write and the follower's pump. It absorbed
+  TC-IDM-4.1's old ack budget, which had the same value and the same argument.
+  `COMMISSIONING_LOG_TIMEOUT` (`tc-dd-support.ts`, 30 s) bounds a line a device prints as it comes
+  up or is commissioned, with discovery, PASE, CASE and the commissioning exchanges in between.
+- A step whose only job is to produce something the next step consumes — a substituted QR payload, a
+  manual pairing code — still has a checkable claim: that the artifact carries the substitution the
+  plan asked for. Read it back (`checkGeneratedPayload`/`checkGeneratedManualCode` in
+  `tc-dd-support.ts`) instead of recording a hard-coded `"pass"` whose `detail` asserts a property
+  nobody looked at. Know what this is worth: the artifact is produced and read back in-process, so
+  the check catches a wiring or generator bug in the step, **not** anything the DUT or the TH did —
+  it is not interop evidence, and the `.b` step that feeds the artifact to the DUT is what carries
+  that. A step generating several artifacts records them through `recordAll` (`tc-support.ts`), which
+  puts every one in the evidence before failing; `record` in a loop stops at the first bad one.
 - `certTest` registers the mocha `it()` immediately; `.step()` calls append to it and may continue
   after `certTest()` returns (see `cert-dsl.ts`'s `certTest`/`defineCertTest`).
 - Role names: `cx.controllers.dut` / `cx.devices.th` are the defaults (`controllers: { dut: "dut" }`,
@@ -1017,8 +1035,8 @@ the YAML captures (whose event blocks date from 2022):
 
 ## Promoting the subscription-id and report-ack checks (`TC-IDM-6.4`)
 
-`expectSubscriptionId`/`expectReportAck` (with `ACK_WAIT_TIMEOUT_MS` and their private exchange-id
-helpers) were TC-IDM-4.1-local until TC-IDM-6.4 needed the same "did the DUT ack *this* subscription's
+`expectSubscriptionId`/`expectReportAck` (with their private exchange-id helpers, and with an ack
+budget of their own that is now the shared `LOG_TIMEOUT`) were TC-IDM-4.1-local until TC-IDM-6.4 needed the same "did the DUT ack *this* subscription's
 report" evidence for an event subscription, so they moved to `tc-support.ts` unchanged — same trigger
 as `attributePathIBSequence`'s and `commandPathIBSequence`'s own promotions. `expectSequence` (record
 an `expectAdjacentLines` result as a `CheckRecord`, turning a timeout into a recorded `"fail"`) came

--- a/support/chip-testing/test/cert/TC-ACT-3.2.test.ts
+++ b/support/chip-testing/test/cert/TC-ACT-3.2.test.ts
@@ -9,7 +9,7 @@ import { Matter } from "@matter/model";
 import type { CertStepContext, DeviceFlavor } from "@matter/testing";
 import { certTest } from "@matter/testing";
 import type { CommandFieldValue } from "./tc-support.js";
-import { CommissionedRefs, expectCommandInvoke, record, requireId } from "./tc-support.js";
+import { CommissionedRefs, expectCommandInvoke, LOG_TIMEOUT, record, requireId } from "./tc-support.js";
 
 const ACTIONS = Matter.clusters.require("Actions");
 
@@ -103,7 +103,7 @@ async function invokeAndCheck(
         commandId,
         fieldValues,
         from,
-        15_000,
+        LOG_TIMEOUT,
     );
     record(cx, logCheck, `CommandDataIB log for step ${step} (${commandName})`);
 }

--- a/support/chip-testing/test/cert/TC-CADMIN-1.17.test.ts
+++ b/support/chip-testing/test/cert/TC-CADMIN-1.17.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InternalError } from "@matter/main";
+import { Duration, InternalError, Seconds } from "@matter/main";
 import { Matter } from "@matter/model";
 import type {
     CertNodeApi,
@@ -17,7 +17,14 @@ import type {
 } from "@matter/testing";
 import { CertLogClosedError, CertLogTimeoutError, certTest } from "@matter/testing";
 import { expectMdns } from "../../src/cert/mdns-check.js";
-import { CertCheckFailedError, CommissionedRefs, expectRejection, PendingPairingCode, record } from "./tc-support.js";
+import {
+    CertCheckFailedError,
+    CommissionedRefs,
+    expectRejection,
+    LOG_TIMEOUT,
+    PendingPairingCode,
+    record,
+} from "./tc-support.js";
 
 const BASIC_INFORMATION = Matter.clusters.require("BasicInformation");
 const VENDOR_ID = BASIC_INFORMATION.attributes.require("vendorId");
@@ -33,7 +40,7 @@ const EXPECTED_CR2_FABRIC_INDEX = 2;
 // failing the command, which is longer than its 20s ModelCommand wait because the wait starts after
 // resolution. A budget under that reports "neither resolved nor rejected" for a controller that was
 // about to reject.
-const POST_REMOVAL_TIMEOUT_MS = 60_000;
+const POST_REMOVAL_TIMEOUT = Seconds(60);
 
 const WINDOW_OPEN_PATTERN = /Commissioning window is now open/;
 const COMMISSIONING_COMPLETE_PATTERN = /Commissioning completed successfully/;
@@ -126,10 +133,10 @@ async function expectDeviceLog(
     flavor: string,
     patterns: LogExpectPatterns,
     from: number,
-    timeoutMs: number,
+    timeout: Duration,
 ): Promise<DeviceLogCheck> {
     try {
-        const result = await log.expect(patterns, { flavor, timeoutMs, from });
+        const result = await log.expect(patterns, { flavor, timeoutMs: timeout, from });
         if (result.verdict === "unverified") {
             return { check: { type: "device-log", verdict: "unverified" }, from };
         }
@@ -184,7 +191,7 @@ async function checkCommissioned(
         th.flavor,
         { chip: COMMISSIONING_COMPLETE_PATTERN },
         logFrom,
-        15_000,
+        LOG_TIMEOUT,
     );
     record(cx, check, `Commissioning-complete log for ${who}`);
 }
@@ -209,7 +216,7 @@ async function openWindowAndCheck(cx: CertStepContext): Promise<void> {
         detail: `manualPairingCode length=${manualPairingCode.length}`,
     });
 
-    const { check } = await expectDeviceLog(th.log, th.flavor, { chip: WINDOW_OPEN_PATTERN }, from, 15_000);
+    const { check } = await expectDeviceLog(th.log, th.flavor, { chip: WINDOW_OPEN_PATTERN }, from, LOG_TIMEOUT);
     record(cx, check, "Commissioning-window-open log");
 }
 
@@ -338,12 +345,18 @@ certTest("TC-CADMIN-1.17", {
                 th.flavor,
                 { chip: REMOVE_FABRIC_SUCCESS_PATTERN },
                 from,
-                15_000,
+                LOG_TIMEOUT,
             );
             record(cx, removed.check, "RemoveFabric-successful log");
 
             const expiringPattern = new RegExp(`Expiring all sessions for fabric 0x${fabricIndex.toString(16)}!!`);
-            const expiring = await expectDeviceLog(th.log, th.flavor, { chip: expiringPattern }, removed.from, 15_000);
+            const expiring = await expectDeviceLog(
+                th.log,
+                th.flavor,
+                { chip: expiringPattern },
+                removed.from,
+                LOG_TIMEOUT,
+            );
             record(cx, expiring.check, '"Expiring all sessions" log');
 
             // Only surrender th_cr2 to step 8 once both checks above confirm TH_CE actually removed
@@ -372,14 +385,14 @@ certTest("TC-CADMIN-1.17", {
             const writeCheck = await expectRejection(
                 "writeAttribute(NodeLabel)",
                 node.writeAttribute(path, "post-removal"),
-                POST_REMOVAL_TIMEOUT_MS,
+                POST_REMOVAL_TIMEOUT,
             );
             cx.recorder.check(writeCheck);
 
             const readCheck = await expectRejection(
                 "readAttribute(NodeLabel)",
                 node.readAttribute(path),
-                POST_REMOVAL_TIMEOUT_MS,
+                POST_REMOVAL_TIMEOUT,
             );
             cx.recorder.check(readCheck);
 
@@ -403,19 +416,23 @@ certTest("TC-CADMIN-1.17", {
             const dut = cx.controllers.dut;
             const dutRef = commissioned.require("dut");
 
+            if (cr2FabricIndex === undefined) {
+                throw new InternalError("Step ran before TH_CR2's own fabric index was read");
+            }
+            const removedIndex = cr2FabricIndex;
+
             const fabrics = await readFabrics(dut.node(dutRef));
-            const stillHasCr2 = fabrics.some(entry => entry.fabricIndex === cr2FabricIndex);
-            const pass = fabrics.length === 2 && !stillHasCr2;
+            const pass = fabrics.length === 2 && !fabrics.some(entry => entry.fabricIndex === removedIndex);
             cx.recorder.check({
                 type: "response",
                 verdict: pass ? "pass" : "fail",
                 detail:
-                    `${fabrics.length} fabrics after removing index ${cr2FabricIndex}: ` +
+                    `${fabrics.length} fabrics after removing index ${removedIndex}: ` +
                     fabrics.map(entry => entry.fabricIndex).join(", "),
             });
             if (!pass) {
                 throw new CertCheckFailedError(
-                    `Expected 2 fabrics with index ${cr2FabricIndex} (TH_CR2) removed, got ` + describeFabrics(fabrics),
+                    `Expected 2 fabrics with index ${removedIndex} (TH_CR2) removed, got ` + describeFabrics(fabrics),
                 );
             }
         },

--- a/support/chip-testing/test/cert/TC-DD-3.14.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.14.test.ts
@@ -6,30 +6,25 @@
 
 import { certTest } from "@matter/testing";
 import {
+    checkGeneratedPayload,
     CommissioningRefusals,
     commissionByQr,
+    INVALID_PASSCODES,
+    onNetworkOnlyPayload,
     qrPayloadWith,
     qrPayloadWithPrefix,
-    onNetworkOnlyPayload,
     recordDiscoveryCapabilityAbsent,
+    recordGeneratedPayload,
     recordParse,
     thQrPayload,
 } from "./tc-dd-support.js";
-import { CommissionedRefs, record } from "./tc-support.js";
+import { CommissionedRefs, recordAll } from "./tc-support.js";
 
 /** The plan's own substitute for the specification's `000`; any non-zero 3-bit value works. */
 const INVALID_VERSION = 0b010;
 
 /** The plan's own substitute for `MT:`. */
 const INVALID_PREFIX = "AB:";
-
-/**
- * The trivial passcodes § 5.1.7.1 forbids, transcribed from the plan's step 5.a rather than taken
- * from matter.js's own list, so a divergence between the two shows up as a failing step.
- */
-const INVALID_PASSCODES = [
-    0, 11111111, 22222222, 33333333, 44444444, 55555555, 66666666, 77777777, 88888888, 99999999, 12345678, 87654321,
-];
 
 const commissioned = new CommissionedRefs();
 const refusals = new CommissioningRefusals();
@@ -52,14 +47,11 @@ certTest("TC-DD-3.14", {
         "Version String: Using the QR code from Step 1, generate a new QR code but substituting out the current " +
             "Version String with an invalid Version String (i.e. '010' or any non-zero 3-bit value)",
         async cx => {
-            const payload = qrPayloadWith(await thQrPayload(cx.devices.th), { version: INVALID_VERSION });
-            record(
+            const source = await thQrPayload(cx.devices.th);
+            recordGeneratedPayload(
                 cx,
-                {
-                    type: "response",
-                    verdict: "pass",
-                    detail: `Generated ${payload} carrying version ${INVALID_VERSION}`,
-                },
+                qrPayloadWith(source, { version: INVALID_VERSION }),
+                { version: INVALID_VERSION, unchangedFrom: source },
                 "Invalid-version payload",
             );
         },
@@ -140,18 +132,17 @@ certTest("TC-DD-3.14", {
             "Payload components and one Passcode from the list: 00000000, 11111111, 22222222, 33333333, 44444444, " +
             "55555555, 66666666, 77777777, 88888888, 99999999, 12345678, 87654321",
         async cx => {
-            const th = await thQrPayload(cx.devices.th);
-            const payloads = INVALID_PASSCODES.map(passcode => qrPayloadWith(th, { passcode }));
-            record(
+            const source = await thQrPayload(cx.devices.th);
+            recordAll(
                 cx,
-                {
-                    type: "response",
-                    verdict: "pass",
-                    detail: `Generated ${payloads.length} payloads: ${payloads
-                        .map((payload, i) => `${payload} (${INVALID_PASSCODES[i]})`)
-                        .join(", ")}`,
-                },
-                "Invalid-passcode payloads",
+                INVALID_PASSCODES.map(passcode => ({
+                    check: () =>
+                        checkGeneratedPayload(qrPayloadWith(source, { passcode }), {
+                            passcode,
+                            unchangedFrom: source,
+                        }),
+                    what: `Payload carrying passcode ${passcode}`,
+                })),
             );
         },
         {
@@ -184,8 +175,13 @@ certTest("TC-DD-3.14", {
         "Prefix: Using the QR code from Step 1, generate a new QR code but substituting out the current Prefix " +
             "with an invalid Prefix that is not 'MT:' (i.e. Prefix='AB:')",
         async cx => {
-            const payload = qrPayloadWithPrefix(await thQrPayload(cx.devices.th), INVALID_PREFIX);
-            record(cx, { type: "response", verdict: "pass", detail: `Generated ${payload}` }, "Invalid-prefix payload");
+            const source = await thQrPayload(cx.devices.th);
+            recordGeneratedPayload(
+                cx,
+                qrPayloadWithPrefix(source, INVALID_PREFIX),
+                { prefix: INVALID_PREFIX, unchangedFrom: source },
+                "Invalid-prefix payload",
+            );
         },
         { expected: "User has a QR code generated to pass into DUT." },
     )

--- a/support/chip-testing/test/cert/TC-DD-3.17.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.17.test.ts
@@ -4,27 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Seconds } from "@matter/main";
+import type { CertStepContext } from "@matter/testing";
 import { certTest } from "@matter/testing";
 import {
+    checkGeneratedManualCode,
     CommissioningRefusals,
+    INVALID_PASSCODES,
     manualPairingCode,
+    recordGeneratedManualCode,
     recordManualParse,
     recordVendorOutcome,
+    SHORT_DISCRIMINATOR_SHIFT,
+    TEST_VENDOR_IDS,
     thCodeParts,
     thManualPairingCode,
 } from "./tc-dd-support.js";
-import { CommissionedRefs, record } from "./tc-support.js";
-
-/**
- * The trivial passcodes § 5.1.7.1 forbids, transcribed from the plan's step 5.a rather than taken
- * from matter.js's own list, so a divergence between the two shows up as a failing step.
- */
-const INVALID_PASSCODES = [
-    0, 11111111, 22222222, 33333333, 44444444, 55555555, 66666666, 77777777, 88888888, 99999999, 12345678, 87654321,
-];
-
-/** The test vendor identifiers the plan's step 6.a substitutes. */
-const TEST_VENDOR_IDS = [0xfff1, 0xfff2, 0xfff3, 0xfff4];
+import { CommissionedRefs, recordAll } from "./tc-support.js";
 
 /**
  * Flips a bit the plan requires to change: § 5.1.4.1 Table 62 carries only the discriminator's 4 most
@@ -37,11 +33,11 @@ const DISCRIMINATOR_MSB = 0x100;
  * the specification's 3-minute minimum commissioning window; chip-tool cannot be bounded and stops
  * on its own after roughly 45 seconds, so the step's own budget has to outlast that.
  */
-const GIVE_UP_AFTER_MS = 20_000;
+const GIVE_UP_AFTER = Seconds(20);
 
 /** Step 6's per-vendor attempt, bounded the same way step 4's absent device is. */
-const VENDOR_OUTCOME_TIMEOUT_MS = 20_000;
-const NO_COMMISSIONEE_TIMEOUT_MS = 90_000;
+const VENDOR_OUTCOME_TIMEOUT = Seconds(20);
+const NO_COMMISSIONEE_TIMEOUT = Seconds(90);
 
 /** The plan repeats this in the expected outcome of every step that generates a code. */
 const GUIDELINES =
@@ -69,10 +65,19 @@ certTest("TC-DD-3.17", {
         "VERSION: Using the manual code from Step 1, generate a new manual code but substituting out the current " +
             "VERSION with an invalid VERSION: 2",
         async cx => {
-            const code = await thManualPairingCode(cx, { futureFormat: true });
-            record(
+            // The marker occupies the whole first digit (§ 5.1.4.1.2), so VID_PID_PRESENT and the
+            // discriminator's two MSBs cannot survive alongside it; the passcode has to, or step 2.b
+            // would be refusing the code for the wrong reason
+            const parts = await thCodeParts(cx);
+            recordGeneratedManualCode(
                 cx,
-                { type: "response", verdict: "pass", detail: `Generated ${code}, which marks a format after v1` },
+                manualPairingCode({ ...parts, futureFormat: true }),
+                {
+                    futureFormat: true,
+                    vidPidPresent: false,
+                    shortDiscriminator: (parts.discriminator >> SHORT_DISCRIMINATOR_SHIFT) & 0x03,
+                    unchangedFrom: manualPairingCode(parts),
+                },
                 "Reserved-version code",
             );
         },
@@ -82,8 +87,8 @@ certTest("TC-DD-3.17", {
         "2.b",
         "Provide the Manual Pairing Code, generated in the previous step, to the DUT in any format supported by the DUT",
         async cx => {
-            const manualPairingCode = await thManualPairingCode(cx, { futureFormat: true });
-            await refusals.requireRefusal(cx, { manualPairingCode }, "Reserved-version code refused");
+            const code = await thManualPairingCode(cx, { futureFormat: true });
+            await refusals.requireRefusal(cx, { manualPairingCode: code }, "Reserved-version code refused");
         },
         {
             expected:
@@ -96,14 +101,11 @@ certTest("TC-DD-3.17", {
         "VID_PID_PRESENT: Using the manual code from Step 1, generate a new manual code but substituting out the " +
             "current VID_PID_PRESENT with an invalid VID_PID_PRESENT set to 0",
         async cx => {
-            const code = await thManualPairingCode(cx, { vidPidPresent: false });
-            record(
+            const parts = await thCodeParts(cx);
+            recordGeneratedManualCode(
                 cx,
-                {
-                    type: "response",
-                    verdict: "pass",
-                    detail: `Generated ${code}, whose header disagrees with its ${code.length} digits`,
-                },
+                manualPairingCode({ ...parts, vidPidPresent: false }),
+                { vidPidPresent: false, unchangedFrom: manualPairingCode(parts) },
                 "Header/length mismatch code",
             );
         },
@@ -113,8 +115,8 @@ certTest("TC-DD-3.17", {
         "3.b",
         "Provide the Manual Pairing Code, generated in the previous step, to the DUT in any format supported by the DUT",
         async cx => {
-            const manualPairingCode = await thManualPairingCode(cx, { vidPidPresent: false });
-            await refusals.requireRefusal(cx, { manualPairingCode }, "Header/length mismatch refused");
+            const code = await thManualPairingCode(cx, { vidPidPresent: false });
+            await refusals.requireRefusal(cx, { manualPairingCode: code }, "Header/length mismatch refused");
         },
         {
             expected:
@@ -130,15 +132,15 @@ certTest("TC-DD-3.17", {
             "most-significant bits of Step 1's 12-bit discriminator value and adheres to rules of section 5.1.1.5. " +
             '"Discriminator value")',
         async cx => {
-            const code = await thManualPairingCode(cx, {
-                discriminator: cx.devices.th.commissioning.discriminator ^ DISCRIMINATOR_MSB,
-            });
-            record(
+            const parts = await thCodeParts(cx);
+            const discriminator = parts.discriminator ^ DISCRIMINATOR_MSB;
+            recordGeneratedManualCode(
                 cx,
+                manualPairingCode({ ...parts, discriminator }),
                 {
-                    type: "response",
-                    verdict: "pass",
-                    detail: `Generated ${code}, naming a device this network does not carry`,
+                    shortDiscriminator: discriminator >> SHORT_DISCRIMINATOR_SHIFT,
+                    differsFrom: manualPairingCode(parts),
+                    unchangedFrom: manualPairingCode(parts),
                 },
                 "Wrong-discriminator code",
             );
@@ -149,14 +151,14 @@ certTest("TC-DD-3.17", {
         "4.b",
         "Provide the Manual Pairing Code, generated in the previous step, to the DUT in any format supported by the DUT",
         async cx => {
-            const manualPairingCode = await thManualPairingCode(cx, {
+            const code = await thManualPairingCode(cx, {
                 discriminator: cx.devices.th.commissioning.discriminator ^ DISCRIMINATOR_MSB,
             });
             await refusals.requireNoCommissioning(
                 cx,
-                { manualPairingCode, giveUpAfterMs: GIVE_UP_AFTER_MS },
+                { manualPairingCode: code, giveUpAfterMs: GIVE_UP_AFTER },
                 "No device commissioned from the wrong discriminator",
-                NO_COMMISSIONEE_TIMEOUT_MS,
+                NO_COMMISSIONEE_TIMEOUT,
             );
         },
         {
@@ -173,17 +175,17 @@ certTest("TC-DD-3.17", {
             "33333333, 44444444, 55555555, 66666666, 77777777, 88888888, 99999999, 12345678, 87654321",
         async cx => {
             const parts = await thCodeParts(cx);
-            const codes = INVALID_PASSCODES.map(passcode => manualPairingCode({ ...parts, passcode }));
-            record(
+            const source = manualPairingCode(parts);
+            recordAll(
                 cx,
-                {
-                    type: "response",
-                    verdict: "pass",
-                    detail: `Generated ${codes.length} codes: ${codes
-                        .map((code, i) => `${code} (${INVALID_PASSCODES[i]})`)
-                        .join(", ")}`,
-                },
-                "Invalid-passcode codes",
+                INVALID_PASSCODES.map(passcode => ({
+                    check: () =>
+                        checkGeneratedManualCode(manualPairingCode({ ...parts, passcode }), {
+                            passcode,
+                            unchangedFrom: source,
+                        }),
+                    what: `Code carrying passcode ${passcode}`,
+                })),
             );
         },
         {
@@ -219,17 +221,17 @@ certTest("TC-DD-3.17", {
             "VENDOR_ID component to one of the invalid Test VENDOR_IDs: 0xFFF1, 0xFFF2, 0xFFF3, 0xFFF4",
         async cx => {
             const parts = await thCodeParts(cx);
-            const codes = TEST_VENDOR_IDS.map(vendorId => manualPairingCode({ ...parts, vendorId }));
-            record(
+            const source = manualPairingCode(parts);
+            recordAll(
                 cx,
-                {
-                    type: "response",
-                    verdict: "pass",
-                    detail: `Generated ${codes.length} codes: ${codes
-                        .map((code, i) => `${code} (0x${TEST_VENDOR_IDS[i].toString(16)})`)
-                        .join(", ")}`,
-                },
-                "Test-vendor codes",
+                TEST_VENDOR_IDS.map(vendorId => ({
+                    check: () =>
+                        checkGeneratedManualCode(manualPairingCode({ ...parts, vendorId }), {
+                            vendorId,
+                            unchangedFrom: source,
+                        }),
+                    what: `Code naming vendor 0x${vendorId.toString(16)}`,
+                })),
             );
         },
         {
@@ -256,7 +258,7 @@ certTest("TC-DD-3.17", {
                     commissioned,
                     refusals,
                     `Code naming vendor 0x${vendorId.toString(16)}`,
-                    VENDOR_OUTCOME_TIMEOUT_MS,
+                    VENDOR_OUTCOME_TIMEOUT,
                 );
             }
         },
@@ -273,10 +275,11 @@ certTest("TC-DD-3.17", {
         "PRODUCT_ID: Using the manual code from Step 1, generate a new manual code but substituting out the " +
             "current PRODUCT_ID with an invalid PRODUCT_ID of 0x0000",
         async cx => {
-            const code = await thManualPairingCode(cx, { productId: 0 });
-            record(
+            const parts = await thCodeParts(cx);
+            recordGeneratedManualCode(
                 cx,
-                { type: "response", verdict: "pass", detail: `Generated ${code}, naming product id 0` },
+                manualPairingCode({ ...parts, productId: 0 }),
+                { productId: 0, unchangedFrom: manualPairingCode(parts) },
                 "Product-id-0 code",
             );
         },
@@ -286,8 +289,8 @@ certTest("TC-DD-3.17", {
         "7.b",
         "Provide the Manual Pairing Code, generated in the previous step, to the DUT in any format supported by the DUT",
         async cx => {
-            const manualPairingCode = await thManualPairingCode(cx, { productId: 0 });
-            await refusals.requireRefusal(cx, { manualPairingCode }, "Product-id-0 code refused");
+            const code = await thManualPairingCode(cx, { productId: 0 });
+            await refusals.requireRefusal(cx, { manualPairingCode: code }, "Product-id-0 code refused");
         },
         {
             expected:
@@ -300,10 +303,11 @@ certTest("TC-DD-3.17", {
         "Check Digit: Using the manual code from Step 1, generate a new manual code but substituting out the " +
             "current CHECK_DIGIT with an invalid CHECK_DIGIT",
         async cx => {
-            const code = await wrongCheckDigitCode(cx);
-            record(
+            const { correct, wrong } = await checkDigitCodes(cx);
+            recordGeneratedManualCode(
                 cx,
-                { type: "response", verdict: "pass", detail: `Generated ${code}, whose check digit is wrong` },
+                wrong,
+                { checkDigitCorrect: false, differsFrom: correct, unchangedFrom: correct },
                 "Wrong-check-digit code",
             );
         },
@@ -313,11 +317,8 @@ certTest("TC-DD-3.17", {
         "8.b",
         "Provide the Manual Pairing Code, generated in the previous step, to the DUT in any format supported by the DUT",
         async cx => {
-            await refusals.requireRefusal(
-                cx,
-                { manualPairingCode: await wrongCheckDigitCode(cx) },
-                "Wrong-check-digit code refused",
-            );
+            const { wrong } = await checkDigitCodes(cx);
+            await refusals.requireRefusal(cx, { manualPairingCode: wrong }, "Wrong-check-digit code refused");
         },
         {
             expected:
@@ -333,9 +334,10 @@ certTest("TC-DD-3.17", {
         }
     });
 
-/** The TH's own code with a check digit that is not the one its digits produce. */
-async function wrongCheckDigitCode(cx: Parameters<typeof thManualPairingCode>[0]) {
-    const correct = await thManualPairingCode(cx);
+async function checkDigitCodes(cx: CertStepContext): Promise<{ correct: string; wrong: string }> {
+    const parts = await thCodeParts(cx);
+    const correct = manualPairingCode(parts);
     const digit = Number(correct.slice(-1));
-    return thManualPairingCode(cx, { checkDigit: (digit + 1) % 10 });
+
+    return { correct, wrong: manualPairingCode({ ...parts, checkDigit: (digit + 1) % 10 }) };
 }

--- a/support/chip-testing/test/cert/TC-DD-3.21.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.21.test.ts
@@ -8,7 +8,13 @@ import { InternalError } from "@matter/main";
 import { Matter } from "@matter/model";
 import type { CertNodeRef, CertStepContext } from "@matter/testing";
 import { certTest } from "@matter/testing";
-import { commissionByQr, LOG_TIMEOUT_MS, recordCommissionable, recordParse, thQrPayload } from "./tc-dd-support.js";
+import {
+    commissionByQr,
+    COMMISSIONING_LOG_TIMEOUT,
+    recordCommissionable,
+    recordParse,
+    thQrPayload,
+} from "./tc-dd-support.js";
 import { CommissionedRefs, expectCommandInvoke, record, requireId } from "./tc-support.js";
 
 const DESCRIPTOR = Matter.clusters.require("Descriptor");
@@ -128,7 +134,16 @@ certTest("TC-DD-3.21", {
                 await cx.controllers.dut.node(ref).invoke("OnOff", "on", {}, endpoint);
                 record(
                     cx,
-                    await expectCommandInvoke(th.log, th.flavor, endpoint, ON_OFF_ID, ON, [], from, LOG_TIMEOUT_MS),
+                    await expectCommandInvoke(
+                        th.log,
+                        th.flavor,
+                        endpoint,
+                        ON_OFF_ID,
+                        ON,
+                        [],
+                        from,
+                        COMMISSIONING_LOG_TIMEOUT,
+                    ),
                     `OnOff.on reached endpoint ${endpoint}`,
                 );
 

--- a/support/chip-testing/test/cert/TC-IDM-1.1.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-1.1.test.ts
@@ -7,7 +7,7 @@
 import { Matter } from "@matter/model";
 import type { CertNodeRef, CertStepContext, CheckRecord } from "@matter/testing";
 import { certTest } from "@matter/testing";
-import { CommissionedRefs, expectCommandInvoke, record, requireId } from "./tc-support.js";
+import { CommissionedRefs, expectCommandInvoke, LOG_TIMEOUT, record, requireId } from "./tc-support.js";
 
 const ON_OFF = Matter.clusters.require("OnOff");
 const ON_OFF_ID = requireId(ON_OFF.id, "OnOff cluster");
@@ -34,7 +34,16 @@ async function invokeOnOffAndCheck(
     }
     cx.recorder.check({ type: "response", verdict: "pass", detail: "status=Success" });
 
-    const logCheck = await expectCommandInvoke(th.log, th.flavor, ENDPOINT, ON_OFF_ID, commandId, [], from, 15_000);
+    const logCheck = await expectCommandInvoke(
+        th.log,
+        th.flavor,
+        ENDPOINT,
+        ON_OFF_ID,
+        commandId,
+        [],
+        from,
+        LOG_TIMEOUT,
+    );
     record(cx, logCheck, `CommandDataIB log for OnOff.${commandName}`);
     return logCheck;
 }

--- a/support/chip-testing/test/cert/TC-IDM-1.3.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-1.3.test.ts
@@ -18,7 +18,7 @@ import {
     expectInvokeCount,
     expectNoInjectedFault,
 } from "./tc-idm-1.3-support.js";
-import { CommissionedRefs, record, requireId } from "./tc-support.js";
+import { CommissionedRefs, LOG_TIMEOUT, record, requireId } from "./tc-support.js";
 
 const ON_OFF = Matter.clusters.require("OnOff");
 const ON_OFF_ID = requireId(ON_OFF.id, "OnOff cluster");
@@ -54,8 +54,6 @@ const BATCH_PATHS: BatchPath[] = [
  */
 const FLAVORS: DeviceFlavor[] = ["chip-local"];
 
-const LOG_TIMEOUT_MS = 15_000;
-
 const CW_TIMEOUT_SECONDS = 180;
 
 const commissioned = new CommissionedRefs<"dut" | "th_client">();
@@ -85,7 +83,7 @@ function recordResults(
 
 async function recordBatchRequest(cx: CertStepContext, from: number, paths: BatchPath[]) {
     const th = cx.devices.th;
-    record(cx, await expectBatchRequestPaths(th.log, th.flavor, paths, from, LOG_TIMEOUT_MS), "Invoke request paths");
+    record(cx, await expectBatchRequestPaths(th.log, th.flavor, paths, from, LOG_TIMEOUT), "Invoke request paths");
     record(cx, expectInvokeCount(th.log, th.flavor, from, 1), "Invoke request count");
 }
 
@@ -214,7 +212,7 @@ certTest("TC-IDM-1.3", {
             await recordBatchRequest(cx, from, BATCH_PATHS);
             record(
                 cx,
-                await expectInjectedFault(th.log, th.flavor, ChipFault.imInvokeSeparateResponses, from, LOG_TIMEOUT_MS),
+                await expectInjectedFault(th.log, th.flavor, ChipFault.imInvokeSeparateResponses, from, LOG_TIMEOUT),
                 "Separate response messages",
             );
         },
@@ -247,7 +245,7 @@ certTest("TC-IDM-1.3", {
                     th.flavor,
                     ChipFault.imInvokeSeparateResponsesInvertResponseOrder,
                     from,
-                    LOG_TIMEOUT_MS,
+                    LOG_TIMEOUT,
                 ),
                 "Inverted response order",
             );
@@ -275,13 +273,7 @@ certTest("TC-IDM-1.3", {
             await recordBatchRequest(cx, from, BATCH_PATHS);
             record(
                 cx,
-                await expectInjectedFault(
-                    th.log,
-                    th.flavor,
-                    ChipFault.imInvokeSkipSecondResponse,
-                    from,
-                    LOG_TIMEOUT_MS,
-                ),
+                await expectInjectedFault(th.log, th.flavor, ChipFault.imInvokeSkipSecondResponse, from, LOG_TIMEOUT),
                 "Dropped second response",
             );
         },

--- a/support/chip-testing/test/cert/TC-IDM-2.1.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-2.1.test.ts
@@ -13,6 +13,7 @@ import {
     CommissionedRefs,
     expectAttributePathIB,
     expectChunkedTransfer,
+    LOG_TIMEOUT,
     record,
 } from "./tc-support.js";
 
@@ -96,12 +97,55 @@ async function readAndCheckLog(
     const dut = cx.controllers.dut;
     const from = th.log.mark();
     const value = await dut.node(ref).readAttribute(spec);
-    const logCheck = await expectAttributePathIB(th.log, th.flavor, spec, from, 15_000);
+    const logCheck = await expectAttributePathIB(th.log, th.flavor, spec, from, LOG_TIMEOUT);
     return { value, logCheck };
 }
 
 function recordLogCheck(cx: CertStepContext, logCheck: CheckRecord): void {
     record(cx, logCheck, "AttributePathIB log");
+}
+
+const INT16_MIN = -32768;
+const INT16_MAX = 32767;
+
+/**
+ * Records a numeric read against the data type its step names.
+ *
+ * A step repointed at another attribute fails here rather than testing a data type nobody asked for:
+ * `declaredType` is checked against the model's `effectiveType`, which resolves the inheritance a raw
+ * `type` leaves undefined on a derived element. Where `carries` is absent the value itself narrows
+ * nothing, and the detail says so rather than implying the type was read off the value.
+ */
+function recordNumericRead(
+    cx: CertStepContext,
+    attribute: { effectiveType?: string },
+    declaredType: string,
+    value: unknown,
+    what: string,
+    carries?: (value: number) => boolean,
+): void {
+    const wrong = new Array<string>();
+    if (attribute.effectiveType !== declaredType) {
+        wrong.push(`the model declares the attribute as ${attribute.effectiveType}, not ${declaredType}`);
+    }
+    if (value !== null && typeof value !== "number") {
+        wrong.push("the value is not a number");
+    } else if (carries !== undefined && value !== null && !carries(value)) {
+        wrong.push(`the value is outside what a ${declaredType} carries`);
+    }
+
+    record(
+        cx,
+        {
+            type: "response",
+            verdict: wrong.length ? "fail" : "pass",
+            detail:
+                `${what} = ${JSON.stringify(value)}; the model declares ${declaredType}` +
+                (carries === undefined ? ", which the value itself cannot narrow further here" : "") +
+                (wrong.length ? `; ${wrong.join("; ")}` : ""),
+        },
+        `${declaredType} read`,
+    );
 }
 
 const commissioned = new CommissionedRefs();
@@ -412,15 +456,14 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
             const { value, logCheck } = await readAndCheckLog(cx, ref, spec);
             recordLogCheck(cx, logCheck);
 
-            const pass = value === null || typeof value === "number";
-            cx.recorder.check({
-                type: "response",
-                verdict: pass ? "pass" : "fail",
-                detail: `PressureMeasurement.MeasuredValue = ${JSON.stringify(value)}`,
-            });
-            if (!pass) {
-                throw new CertCheckFailedError(`Expected an int16 value, got ${JSON.stringify(value)}`);
-            }
+            recordNumericRead(
+                cx,
+                PRESSURE_MEASURED_VALUE,
+                "int16",
+                value,
+                "PressureMeasurement.MeasuredValue",
+                value => Number.isInteger(value) && value >= INT16_MIN && value <= INT16_MAX,
+            );
         }),
         {
             pics: "MCORE.IDM.C.ReadRequest.Attribute.DataType_SignedInteger",
@@ -439,15 +482,16 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
             const { value, logCheck } = await readAndCheckLog(cx, ref, spec);
             recordLogCheck(cx, logCheck);
 
-            const pass = value === null || typeof value === "number";
-            cx.recorder.check({
-                type: "response",
-                verdict: pass ? "pass" : "fail",
-                detail: `CarbonDioxideConcentrationMeasurement.MeasuredValue = ${JSON.stringify(value)}`,
-            });
-            if (!pass) {
-                throw new CertCheckFailedError(`Expected a floating-point value, got ${JSON.stringify(value)}`);
-            }
+            // Both adapters hand the value over as a JSON number, which a single and a double reach
+            // identically, so no value predicate can tell them apart; the type claim rests on the
+            // model's declaration and on the AttributePathIB the TH logged
+            recordNumericRead(
+                cx,
+                CO2_MEASURED_VALUE,
+                "single",
+                value,
+                "CarbonDioxideConcentrationMeasurement.MeasuredValue",
+            );
         }),
         {
             pics: "MCORE.IDM.C.ReadRequest.Attribute.DataType_FloatingPoint",
@@ -649,7 +693,7 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 );
             }
 
-            const chunkCheck = await expectChunkedTransfer(th.log, th.flavor, from, 15_000);
+            const chunkCheck = await expectChunkedTransfer(th.log, th.flavor, from, LOG_TIMEOUT);
             record(cx, chunkCheck, "Chunked-transfer log");
         }),
         {

--- a/support/chip-testing/test/cert/TC-IDM-3.1.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-3.1.test.ts
@@ -12,6 +12,7 @@ import {
     CertCheckFailedError,
     CommissionedRefs,
     expectMessageWithPath,
+    LOG_TIMEOUT,
     record,
     requireId,
     WRITE_REQUEST_MESSAGE,
@@ -78,7 +79,7 @@ async function writeAndCheck(
         detail: `wrote ${JSON.stringify(value)} to ${JSON.stringify(path)}`,
     });
 
-    const logCheck = await expectMessageWithPath(th.log, th.flavor, WRITE_REQUEST_MESSAGE, path, from, 15_000);
+    const logCheck = await expectMessageWithPath(th.log, th.flavor, WRITE_REQUEST_MESSAGE, path, from, LOG_TIMEOUT);
     record(cx, logCheck, `WriteRequestMessage log for step ${label}`);
 }
 
@@ -155,7 +156,14 @@ certTest("TC-IDM-3.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 );
             }
 
-            const logCheck = await expectMessageWithPath(th.log, th.flavor, WRITE_REQUEST_MESSAGE, path, from, 15_000);
+            const logCheck = await expectMessageWithPath(
+                th.log,
+                th.flavor,
+                WRITE_REQUEST_MESSAGE,
+                path,
+                from,
+                LOG_TIMEOUT,
+            );
             record(cx, logCheck, "WriteRequestMessage log for step 2");
 
             for (const { endpoint } of written) {
@@ -365,7 +373,7 @@ certTest("TC-IDM-3.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                 WRITE_REQUEST_MESSAGE,
                 labelPath,
                 from,
-                15_000,
+                LOG_TIMEOUT,
             );
             record(cx, logCheck, "WriteRequestMessage log for step 15");
 

--- a/support/chip-testing/test/cert/TC-IDM-4.1.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-4.1.test.ts
@@ -9,12 +9,12 @@ import type { AttributePathSpec } from "@matter/testing";
 import { certTest } from "@matter/testing";
 import { MAX_INTERVAL_CEILING_SECONDS, MIN_INTERVAL_FLOOR_SECONDS, subscribeAndModify } from "./tc-idm-4.1-support.js";
 import {
-    ACK_WAIT_TIMEOUT_MS,
     CommissionedRefs,
     expectMessageWithPath,
     expectReportAck,
     expectSequence,
     expectSubscriptionId,
+    LOG_TIMEOUT,
     record,
     requireId,
     SUBSCRIBE_REQUEST_MESSAGE,
@@ -103,7 +103,7 @@ certTest("TC-IDM-4.1", {
                 SUBSCRIBE_REQUEST_MESSAGE,
                 path,
                 from,
-                15_000,
+                LOG_TIMEOUT,
             );
             record(cx, pathCheck, "SubscribeRequestMessage log");
 
@@ -113,7 +113,7 @@ certTest("TC-IDM-4.1", {
                 SUBSCRIBE_ENVELOPE_LABEL,
                 SUBSCRIBE_ENVELOPE_SEQUENCE,
                 from,
-                15_000,
+                LOG_TIMEOUT,
             );
             record(cx, envelopeCheck, "SubscribeRequestMessage envelope");
         },
@@ -149,7 +149,7 @@ certTest("TC-IDM-4.1", {
                 SUBSCRIBE_REQUEST_MESSAGE,
                 path,
                 from,
-                15_000,
+                LOG_TIMEOUT,
             );
             record(cx, requestCheck, "SubscribeRequestMessage log");
 
@@ -157,7 +157,7 @@ certTest("TC-IDM-4.1", {
             // SubscribeResponses apart (see subscribeAndModify).
             const established = requestCheck.logLine !== undefined ? requestCheck.logLine + 1 : from;
 
-            const idLookup = await expectSubscriptionId(th.log, th.flavor, established, ACK_WAIT_TIMEOUT_MS);
+            const idLookup = await expectSubscriptionId(th.log, th.flavor, established, LOG_TIMEOUT);
             record(cx, idLookup.check, "Subscription-id lookup");
 
             const logCheck = await expectReportAck(
@@ -165,7 +165,7 @@ certTest("TC-IDM-4.1", {
                 th.flavor,
                 idLookup.subscriptionId,
                 established,
-                ACK_WAIT_TIMEOUT_MS,
+                LOG_TIMEOUT,
             );
             record(cx, logCheck, "Priming-report status");
         }),

--- a/support/chip-testing/test/cert/TC-IDM-5.1.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-5.1.test.ts
@@ -4,11 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Millis } from "@matter/main";
 import { Matter } from "@matter/model";
 import type { CertStepContext } from "@matter/testing";
 import { certTest } from "@matter/testing";
 import { expectTimedFollowUp, expectTimedRequest, expectUnicastReceipt } from "./tc-idm-5.1-support.js";
-import { CommissionedRefs, INVOKE_REQUEST_MESSAGE, record, requireId, WRITE_REQUEST_MESSAGE } from "./tc-support.js";
+import {
+    CommissionedRefs,
+    INVOKE_REQUEST_MESSAGE,
+    LOG_TIMEOUT,
+    record,
+    requireId,
+    WRITE_REQUEST_MESSAGE,
+} from "./tc-support.js";
 
 const ON_OFF = Matter.clusters.require("OnOff");
 const ON_OFF_ID = requireId(ON_OFF.id, "OnOff cluster");
@@ -18,16 +26,14 @@ const ENDPOINT_1 = 1;
 
 // The timeout Test_TC_IDM_5_1.yaml's own captures ask for, which the plan quotes as its example. The
 // device enforces it, so a late follow-up fails on the device's own answer as well as on the check below.
-const TIMED_INTERACTION_TIMEOUT_MS = 200;
-
-const LOG_TIMEOUT_MS = 15_000;
+const TIMED_INTERACTION_TIMEOUT = Millis(200);
 
 const commissioned = new CommissionedRefs();
 
 async function recordTimedInteraction(cx: CertStepContext, message: RegExp, from: number): Promise<void> {
     const th = cx.devices.th;
 
-    const timed = await expectTimedRequest(th.log, th.flavor, TIMED_INTERACTION_TIMEOUT_MS, from, LOG_TIMEOUT_MS);
+    const timed = await expectTimedRequest(th.log, th.flavor, TIMED_INTERACTION_TIMEOUT, from, LOG_TIMEOUT);
     record(cx, timed.check, "TimedRequestMessage");
 
     record(cx, expectUnicastReceipt(timed), "Timed request session");
@@ -37,8 +43,8 @@ async function recordTimedInteraction(cx: CertStepContext, message: RegExp, from
         th.flavor,
         message,
         timed,
-        TIMED_INTERACTION_TIMEOUT_MS,
-        LOG_TIMEOUT_MS,
+        TIMED_INTERACTION_TIMEOUT,
+        LOG_TIMEOUT,
     );
     record(cx, followUp, "Timed follow-up");
 }
@@ -61,7 +67,7 @@ certTest("TC-IDM-5.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C"
 
             const from = th.log.mark();
             await dut.node(ref).invoke(ON_OFF_ID, "on", undefined, ENDPOINT_1, {
-                timedInteractionTimeoutMs: TIMED_INTERACTION_TIMEOUT_MS,
+                timedInteractionTimeoutMs: TIMED_INTERACTION_TIMEOUT,
             });
             cx.recorder.check({
                 type: "response",
@@ -91,7 +97,7 @@ certTest("TC-IDM-5.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C"
             await cx.controllers.dut
                 .node(ref)
                 .writeAttribute({ endpoint: ENDPOINT_1, cluster: ON_OFF_ID, attribute: ON_TIME }, 2, {
-                    timedInteractionTimeoutMs: TIMED_INTERACTION_TIMEOUT_MS,
+                    timedInteractionTimeoutMs: TIMED_INTERACTION_TIMEOUT,
                 });
             cx.recorder.check({
                 type: "response",

--- a/support/chip-testing/test/cert/TC-IDM-6.3.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-6.3.test.ts
@@ -14,6 +14,7 @@ import {
     eventPathIBSequence,
     expectSequence,
     fabricFilteredPattern,
+    LOG_TIMEOUT,
     READ_REQUEST_MESSAGE,
     record,
     requireId,
@@ -24,7 +25,6 @@ const BASIC_INFORMATION_ID = requireId(BASIC_INFORMATION.id, "BasicInformation c
 const START_UP_EVENT = requireId(BASIC_INFORMATION.events.require("startUp").id, "BasicInformation.startUp");
 
 const ENDPOINT_0 = 0;
-const LOG_TIMEOUT_MS = 15_000;
 
 // Test_TC_IDM_6_3.yaml's own capture reads every event of every cluster, whose EventPathIB is empty
 // and so carries nothing to verify field by field. This is the concrete path Test_TC_IDM_6_4.yaml
@@ -90,7 +90,7 @@ certTest("TC-IDM-6.3", {
                 `ReadRequestMessage EventPathIBs ${JSON.stringify(EVENT_PATH)}`,
                 READ_EVENT_SEQUENCE,
                 from,
-                LOG_TIMEOUT_MS,
+                LOG_TIMEOUT,
             );
             record(cx, pathCheck, "ReadRequestMessage event path");
 
@@ -102,7 +102,7 @@ certTest("TC-IDM-6.3", {
                 "ReadRequestMessage isFabricFiltered",
                 [fabricFilteredPattern(true)],
                 pathCheck.logLine === undefined ? from : pathCheck.logLine + 1,
-                LOG_TIMEOUT_MS,
+                LOG_TIMEOUT,
             );
             record(cx, fabricFilteredCheck, "ReadRequestMessage isFabricFiltered");
         },

--- a/support/chip-testing/test/cert/TC-IDM-6.4.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-6.4.test.ts
@@ -8,7 +8,6 @@ import { Matter } from "@matter/model";
 import type { EventPathSpec } from "@matter/testing";
 import { certTest } from "@matter/testing";
 import {
-    ACK_WAIT_TIMEOUT_MS,
     CommissionedRefs,
     EVENT_PATH_IBS_SEQUENCE,
     eventPathIBSequence,
@@ -16,6 +15,7 @@ import {
     expectSequence,
     expectSubscriptionId,
     fabricFilteredPattern,
+    LOG_TIMEOUT,
     record,
     requireId,
     SUBSCRIBE_REQUEST_MESSAGE,
@@ -26,7 +26,6 @@ const BASIC_INFORMATION_ID = requireId(BASIC_INFORMATION.id, "BasicInformation c
 const START_UP_EVENT = requireId(BASIC_INFORMATION.events.require("startUp").id, "BasicInformation.startUp");
 
 const ENDPOINT_0 = 0;
-const LOG_TIMEOUT_MS = 15_000;
 
 const EVENT_PATH: EventPathSpec = { endpoint: ENDPOINT_0, cluster: BASIC_INFORMATION_ID, event: START_UP_EVENT };
 
@@ -88,7 +87,7 @@ certTest("TC-IDM-6.4", {
                     `MaxIntervalCeilingSeconds, EventPathIBs ${JSON.stringify(EVENT_PATH)})`,
                 subscribeEnvelopeSequence(STEP_1_MIN_INTERVAL, STEP_1_MAX_INTERVAL),
                 from,
-                LOG_TIMEOUT_MS,
+                LOG_TIMEOUT,
             );
             record(cx, envelopeCheck, "SubscribeRequestMessage envelope");
 
@@ -98,7 +97,7 @@ certTest("TC-IDM-6.4", {
                 "SubscribeRequestMessage isFabricFiltered",
                 [fabricFilteredPattern(true)],
                 envelopeCheck.logLine === undefined ? from : envelopeCheck.logLine + 1,
-                LOG_TIMEOUT_MS,
+                LOG_TIMEOUT,
             );
             record(cx, fabricFilteredCheck, "SubscribeRequestMessage isFabricFiltered");
         },
@@ -133,16 +132,10 @@ certTest("TC-IDM-6.4", {
             // Several subscriptions of this run report concurrently (step 1's is still live, as is the
             // controller's own node-level one), so the ack this step needs is identified by the
             // subscription the TH just minted, not by position in the log.
-            const idLookup = await expectSubscriptionId(th.log, th.flavor, from, ACK_WAIT_TIMEOUT_MS);
+            const idLookup = await expectSubscriptionId(th.log, th.flavor, from, LOG_TIMEOUT);
             record(cx, idLookup.check, "SubscribeResponseMessage");
 
-            const ackCheck = await expectReportAck(
-                th.log,
-                th.flavor,
-                idLookup.subscriptionId,
-                from,
-                ACK_WAIT_TIMEOUT_MS,
-            );
+            const ackCheck = await expectReportAck(th.log, th.flavor, idLookup.subscriptionId, from, LOG_TIMEOUT);
             record(cx, ackCheck, "Report ack");
         }),
         { expected: "Verify that the DUT sends Status Response Action with a success Status Code." },

--- a/support/chip-testing/test/cert/TC-SC-3.5.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-3.5.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Duration, InternalError, Millis } from "@matter/main";
+import { Duration, InternalError, Seconds } from "@matter/main";
 import type { CertStepContext, CertStepDefinition, PromptHandler, StepVerdict, Subject } from "@matter/testing";
 import {
     chip,
@@ -61,7 +61,7 @@ function extractPasscode(promptText: string): number {
 
 // Corrupted-Sigma2 commissioning failures should surface promptly (an aborted CASE handshake), but a
 // DUT that hangs instead of rejecting must not stall this step for the full mocha timeout.
-const COMMISSION_TIMEOUT_MS = 60_000;
+const COMMISSION_TIMEOUT = Seconds(60);
 
 /**
  * Handles every "Manual Pairing Code" prompt `TC_SC_3_5.py` prints — steps 1b, 2c, 3c, 4c, 5c (4c is
@@ -103,7 +103,7 @@ function manualPairingCodeHandler(state: { attempts: number }): PromptHandler {
                     // recover like any healthy commissioning.
                     singleHandshakeAttempt: !expectSuccess,
                 }),
-                COMMISSION_TIMEOUT_MS,
+                COMMISSION_TIMEOUT,
             );
 
             let verdict: StepVerdict;
@@ -155,7 +155,7 @@ function manualPairingCodeHandler(state: { attempts: number }): PromptHandler {
                         verdict,
                         detail:
                             `commission() neither resolved nor rejected on attempt ${attempt} within ` +
-                            Duration.format(Millis(COMMISSION_TIMEOUT_MS)),
+                            Duration.format(COMMISSION_TIMEOUT),
                     });
                     failure = new Error(`DUT commissioning attempt ${attempt} timed out`);
                     break;

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, Duration, InternalError, Millis, Time, Verhoeff } from "@matter/main";
+import { Bytes, Duration, ImplementationError, InternalError, Millis, Seconds, Time, Verhoeff } from "@matter/main";
 import { Base38, DiscoveryCapabilitiesBitmap, DiscoveryCapabilitiesSchema } from "@matter/main/types";
-import type { CertNodeRef, CertStepContext, CommissioningTarget } from "@matter/testing";
+import type { CertNodeRef, CertStepContext, CheckRecord, CommissioningTarget } from "@matter/testing";
 import type { CertDevice } from "@matter/testing";
 import { expectMdns } from "../../src/cert/mdns-check.js";
 import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload.js";
@@ -19,23 +19,35 @@ import {
     settleWithin,
 } from "./tc-support.js";
 
-export const LOG_TIMEOUT_MS = 30_000;
-export const MDNS_TIMEOUT_MS = 30_000;
+/** Bounds a wait for a line a device prints as it comes up, with a whole commissioning flow ahead of it. */
+export const COMMISSIONING_LOG_TIMEOUT = Seconds(30);
+export const MDNS_TIMEOUT = Seconds(30);
 
 /**
  * Bounds a "the DUT must refuse this" commissioning attempt. Both controllers read the payload
  * before they touch the network, so a refusal lands in milliseconds; the budget is what keeps a
  * controller that instead went looking for the commissionee from hanging the step.
  */
-export const REFUSAL_TIMEOUT_MS = 15_000;
+export const REFUSAL_TIMEOUT = Seconds(15);
 
 /**
- * Bounds the cleanup's wait for an attempt that outlived {@link REFUSAL_TIMEOUT_MS}. A commissioning
+ * Bounds the cleanup's wait for an attempt that outlived {@link REFUSAL_TIMEOUT}. A commissioning
  * that is going to succeed does so in seconds; what this cannot outwait is a chip-tool command stuck
  * in its own 3-minute budget, and that is deliberate — `CertTest`'s whole finalizer gets 2 minutes,
  * and a controller stuck that long has left the TH in a state this run cannot report on anyway.
  */
-export const REFUSAL_SETTLE_TIMEOUT_MS = 30_000;
+export const REFUSAL_SETTLE_TIMEOUT = Seconds(30);
+
+/**
+ * The trivial passcodes § 5.1.7.1 forbids, transcribed from the plans' own step 5.a rather than taken
+ * from matter.js's own list, so a divergence between the two shows up as a failing step.
+ */
+export const INVALID_PASSCODES: readonly number[] = [
+    0, 11111111, 22222222, 33333333, 44444444, 55555555, 66666666, 77777777, 88888888, 99999999, 12345678, 87654321,
+];
+
+/** The test vendor identifiers § 2.5.2 reserves, which TC-DD-3.17's own step 6.a substitutes. */
+export const TEST_VENDOR_IDS: readonly number[] = [0xfff1, 0xfff2, 0xfff3, 0xfff4];
 
 /** Both device flavors print the payload they publish on this line; chip prints one per commissioning flow. */
 const SETUP_QR_CODE = /SetupQRCode: \[(MT:[^\]]+)\]/;
@@ -55,7 +67,7 @@ export async function thQrPayload(th: CertDevice): Promise<string> {
 
     const result = await th.log.expect(
         { chip: SETUP_QR_CODE, matterjs: SETUP_QR_CODE },
-        { flavor: th.flavor, from: 0, timeoutMs: LOG_TIMEOUT_MS },
+        { flavor: th.flavor, from: 0, timeoutMs: COMMISSIONING_LOG_TIMEOUT },
     );
     if (result.verdict === "unverified") {
         throw new InternalError(`${th.flavor} devices neither report nor print an onboarding payload`);
@@ -152,8 +164,15 @@ export async function recordDiscoveryCapabilityAbsent(
 
 /** Bit offset and length of § 5.1.3.1 Table 59's fields inside the payload's fixed structure. */
 const VERSION_BITS = { offset: 0, length: 3 };
-const PASSCODE_BITS = { offset: 57, length: 27 };
+const VENDOR_ID_BITS = { offset: 3, length: 16 };
+const PRODUCT_ID_BITS = { offset: 19, length: 16 };
+const FLOW_TYPE_BITS = { offset: 35, length: 2 };
 const DISCOVERY_BITS = { offset: 37, length: 8 };
+const DISCRIMINATOR_BITS = { offset: 45, length: 12 };
+const PASSCODE_BITS = { offset: 57, length: 27 };
+
+/** § 5.1.3.1's fixed structure is 11 bytes; § 5.1.5's optional TLV follows it. */
+const FIXED_PAYLOAD_BYTES = 11;
 
 function writeBits(data: Uint8Array, { offset, length }: { offset: number; length: number }, value: number): void {
     if (!Number.isInteger(value) || value < 0 || value >= 2 ** length) {
@@ -174,6 +193,20 @@ function writeBits(data: Uint8Array, { offset, length }: { offset: number; lengt
             data[bit >> 3] &= ~mask;
         }
     }
+}
+
+function readBits(data: Uint8Array, { offset, length }: { offset: number; length: number }): number {
+    if (data.length * 8 < offset + length) {
+        throw new InternalError(`The ${length} bits at offset ${offset} do not fit a payload of ${data.length} bytes`);
+    }
+    let value = 0;
+    for (let i = 0; i < length; i++) {
+        const bit = offset + i;
+        if (data[bit >> 3] & (1 << (bit % 8))) {
+            value |= 1 << i;
+        }
+    }
+    return value;
 }
 
 /**
@@ -215,6 +248,136 @@ export function qrPayloadWithPrefix(payload: string, prefix: string): string {
 }
 
 /**
+ * Names each of `names` that `expected` states and `actual` does not carry. A field `expected` omits
+ * is not asserted — keyed on the property being present, so a caller can assert an absent field, and
+ * so one that passes an accidental `undefined` gets an assertion rather than silence.
+ */
+function statedMismatches<T extends object>(actual: T, expected: Partial<T>, names: readonly (keyof T)[]): string[] {
+    const wrong = new Array<string>();
+    for (const name of names) {
+        if (Object.hasOwn(expected, name) && actual[name] !== expected[name]) {
+            wrong.push(`${String(name)}=${String(expected[name])}`);
+        }
+    }
+    return wrong;
+}
+
+/**
+ * Every field § 5.1.3.1 Table 59's fixed structure carries, plus § 5.1.5's optional tail.
+ *
+ * All of them, not only the ones the negative plans substitute: an expectation that a substitution
+ * left the rest of the payload alone is only as strong as the set of fields it can compare.
+ */
+export interface QrPayloadFields {
+    /** § 5.1.3's `MT:`, or whatever a step put in its place. */
+    prefix: string;
+
+    version: number;
+    vendorId: number;
+    productId: number;
+
+    /** 0 standard, 1 user intent, 2 custom (Table 59). */
+    flowType: number;
+
+    /** § 5.1.3.1 Table 60's bitmask, as it appears on the wire. */
+    discoveryCapabilities: number;
+
+    discriminator: number;
+    passcode: number;
+
+    /** § 5.1.5's TLV as hex, `""` where the payload carries none. */
+    tlv: string;
+}
+
+/**
+ * {@link qrPayloadWith}'s reader, and not a codec for the same reason it is not one.
+ *
+ * Base38 carries no colon, so the first one ends the prefix.
+ */
+export function qrPayloadFields(payload: string): QrPayloadFields {
+    const prefixEnd = payload.indexOf(":");
+    if (prefixEnd < 0) {
+        throw new InternalError(`Cannot read fields out of "${payload}", which carries no onboarding payload prefix`);
+    }
+
+    const prefix = payload.slice(0, prefixEnd + 1);
+    const data = Uint8Array.from(Bytes.of(Base38.decode(payload.slice(prefix.length))));
+
+    return {
+        prefix,
+        version: readBits(data, VERSION_BITS),
+        vendorId: readBits(data, VENDOR_ID_BITS),
+        productId: readBits(data, PRODUCT_ID_BITS),
+        flowType: readBits(data, FLOW_TYPE_BITS),
+        discoveryCapabilities: readBits(data, DISCOVERY_BITS),
+        discriminator: readBits(data, DISCRIMINATOR_BITS),
+        passcode: readBits(data, PASSCODE_BITS),
+        tlv: Bytes.toHex(data.slice(FIXED_PAYLOAD_BYTES)),
+    };
+}
+
+/** What a generating step claims about the payload it produced. */
+export interface ExpectedQrPayloadFields extends Partial<QrPayloadFields> {
+    /**
+     * The payload every field `expected` does not name must still match. The plans ask for "the same
+     * Onboarding Payload components except for" one, and without this the expectation and the
+     * substitution are the same value, which no generator bug can violate.
+     */
+    unchangedFrom?: string;
+}
+
+/**
+ * Judges a generated `payload` against the fields `expected` names; one it omits is not asserted
+ * unless {@link ExpectedQrPayloadFields.unchangedFrom} supplies it.
+ *
+ * This is a claim about the artifact a step produced, not about the DUT or the TH: a generating step
+ * has no interaction of its own to record, and what it can be held to is that the code it made
+ * carries the substitution the plan asked for and nothing else.
+ */
+export function checkGeneratedPayload(payload: string, expected: ExpectedQrPayloadFields): CheckRecord {
+    const { unchangedFrom, ...stated } = expected;
+    const unchanged = namedCode(expected, "unchangedFrom", unchangedFrom);
+    const fields = qrPayloadFields(payload);
+    const wrong = statedMismatches(
+        fields,
+        { ...(unchanged === undefined ? {} : qrPayloadFields(unchanged)), ...stated },
+        [
+            "prefix",
+            "version",
+            "vendorId",
+            "productId",
+            "flowType",
+            "discoveryCapabilities",
+            "discriminator",
+            "passcode",
+            "tlv",
+        ],
+    );
+
+    return {
+        type: "response",
+        verdict: wrong.length ? "fail" : "pass",
+        detail:
+            `Generated ${payload}, carrying prefix ${fields.prefix} version=${fields.version} ` +
+            `vendorId=${fields.vendorId} productId=${fields.productId} flowType=${fields.flowType} ` +
+            `discoveryCapabilities=0b${fields.discoveryCapabilities.toString(2).padStart(8, "0")} ` +
+            `discriminator=${fields.discriminator} passcode=${fields.passcode}` +
+            (fields.tlv ? ` tlv=${fields.tlv}` : "") +
+            (wrong.length ? `; expected ${wrong.join(", ")}` : ""),
+    };
+}
+
+/** {@link checkGeneratedPayload} for the one-artifact case; use {@link recordAll} for a step generating several. */
+export function recordGeneratedPayload(
+    cx: CertStepContext,
+    payload: string,
+    expected: ExpectedQrPayloadFields,
+    what: string,
+): void {
+    record(cx, checkGeneratedPayload(payload, expected), what);
+}
+
+/**
  * The commissioning attempts a TC has told the DUT to refuse.
  *
  * A TC's `finalize` must {@link settle} this. An attempt outlives the check that judged it —
@@ -223,18 +386,18 @@ export function qrPayloadWithPrefix(payload: string, prefix: string): string {
  */
 export class CommissioningRefusals {
     #attempts = new Array<Promise<CertNodeRef | undefined>>();
-    #refusalTimeoutMs: number;
-    #settleTimeoutMs: number;
+    #refusalTimeout: Duration;
+    #settleTimeout: Duration;
 
     /** Budgets are injectable because the unit tests cannot wait out the real ones. */
-    constructor(budgets?: { refusalTimeoutMs?: number; settleTimeoutMs?: number }) {
-        this.#refusalTimeoutMs = budgets?.refusalTimeoutMs ?? REFUSAL_TIMEOUT_MS;
-        this.#settleTimeoutMs = budgets?.settleTimeoutMs ?? REFUSAL_SETTLE_TIMEOUT_MS;
+    constructor(budgets?: { refusalTimeout?: Duration; settleTimeout?: Duration }) {
+        this.#refusalTimeout = budgets?.refusalTimeout ?? REFUSAL_TIMEOUT;
+        this.#settleTimeout = budgets?.settleTimeout ?? REFUSAL_SETTLE_TIMEOUT;
     }
 
     /** How long {@link settle} waits, for a step that needs the same slack for its own wait. */
-    get settleBudgetMs(): number {
-        return this.#settleTimeoutMs;
+    get settleBudget(): number {
+        return this.#settleTimeout;
     }
 
     /**
@@ -270,7 +433,7 @@ export class CommissioningRefusals {
             await expectRejection(
                 `commissioning from ${describeTarget(target)}`,
                 attempt,
-                this.#refusalTimeoutMs,
+                this.#refusalTimeout,
                 isPayloadRefusal,
             ),
             what,
@@ -286,7 +449,7 @@ export class CommissioningRefusals {
         cx: CertStepContext,
         target: CommissioningTarget,
         what: string,
-        timeoutMs: number,
+        timeout: Duration,
     ): Promise<void> {
         const attempt = cx.controllers.dut.commission(target);
         this.track(attempt);
@@ -296,7 +459,7 @@ export class CommissioningRefusals {
             await expectRejection(
                 `commissioning from ${describeTarget(target)}`,
                 attempt,
-                timeoutMs,
+                timeout,
                 // A payload refusal would mean the code never reached discovery, so the step proved
                 // nothing about a commissionee that is not there
                 error => !isPayloadRefusal(error),
@@ -316,7 +479,7 @@ export class CommissioningRefusals {
             return;
         }
 
-        const timeout = Time.sleep("outstanding refused commissionings", Millis(this.#settleTimeoutMs));
+        const timeout = Time.sleep("outstanding refused commissionings", this.#settleTimeout);
         let refs;
         try {
             refs = await Promise.race([Promise.all(attempts), timeout.then(() => undefined)]);
@@ -327,7 +490,7 @@ export class CommissioningRefusals {
         if (refs === undefined) {
             throw new CertCleanupError(
                 `${attempts.length} commissioning attempt(s) the DUT was asked to refuse are still running after ` +
-                    `${Duration.format(Millis(this.#settleTimeoutMs))}; one that succeeds now cannot be cleaned up`,
+                    `${Duration.format(this.#settleTimeout)}; one that succeeds now cannot be cleaned up`,
             );
         }
 
@@ -388,6 +551,14 @@ export async function thManualPairingCode(
 export async function thCodeParts(cx: CertStepContext): Promise<ManualPairingCodeParts> {
     const th = cx.devices.th;
     const { vendorId, productId } = await cx.controllers.dut.parseQrPayload(await thQrPayload(th));
+    if (vendorId === undefined || productId === undefined) {
+        // parseQrPayload reports § 2.5.2/§ 2.5.3's "unspecified" as absent, and Table 64's 21-digit
+        // form has nowhere to put an absent one — a TH publishing neither cannot host these plans
+        throw new InternalError(
+            `The TH's onboarding payload names vendor ${vendorId} and product ${productId}; a 21-digit ` +
+                "manual pairing code carries both",
+        );
+    }
 
     return {
         vidPidPresent: true,
@@ -432,7 +603,7 @@ export async function recordManualParse(cx: CertStepContext, code: string): Prom
 }
 
 /** § 5.1.4.1 Table 62 carries only the discriminator's 4 most significant bits. */
-const SHORT_DISCRIMINATOR_SHIFT = 8;
+export const SHORT_DISCRIMINATOR_SHIFT = 8;
 
 /**
  * Records that the TH is discoverable as a commissionable device, which every commissioning-flow plan
@@ -442,7 +613,7 @@ export async function recordCommissionable(
     cx: CertStepContext,
     what = "TH advertising as commissionable",
 ): Promise<void> {
-    record(cx, await expectMdns(cx.devices.th, { commissionable: true }, { timeoutMs: MDNS_TIMEOUT_MS }), what);
+    record(cx, await expectMdns(cx.devices.th, { commissionable: true }, { timeoutMs: MDNS_TIMEOUT }), what);
 }
 
 /**
@@ -456,17 +627,17 @@ export async function recordCommissionable(
  */
 export async function recordVendorOutcome(
     cx: CertStepContext,
-    manualPairingCode: string,
+    code: string,
     commissioned: CommissionedRefs,
     refusals: CommissioningRefusals,
     what: string,
-    timeoutMs: number,
+    timeout: Duration,
 ): Promise<void> {
     await restoreCommissioningMode(cx, commissioned);
 
-    const label = `commissioning from ${manualPairingCode}`;
-    const attempt = cx.controllers.dut.commission({ manualPairingCode, giveUpAfterMs: timeoutMs });
-    const outcome = await settleWithin(label, attempt, timeoutMs + refusals.settleBudgetMs);
+    const label = `commissioning from ${code}`;
+    const attempt = cx.controllers.dut.commission({ manualPairingCode: code, giveUpAfterMs: timeout });
+    const outcome = await settleWithin(label, attempt, Millis(timeout + refusals.settleBudget));
 
     switch (outcome.kind) {
         case "rejected": {
@@ -544,7 +715,7 @@ async function restoreCommissioningMode(cx: CertStepContext, commissioned: Commi
         // by a cached advertisement from the generation that just went down.
         record(
             cx,
-            await expectSequence(th.log, th.flavor, "TH restarted", [SETUP_QR_CODE], from, LOG_TIMEOUT_MS),
+            await expectSequence(th.log, th.flavor, "TH restarted", [SETUP_QR_CODE], from, COMMISSIONING_LOG_TIMEOUT),
             "TH factory reset",
         );
     }
@@ -557,10 +728,10 @@ async function restoreCommissioningMode(cx: CertStepContext, commissioned: Commi
 /** {@link commissionByQr} for a manual pairing code, which discovers by the short discriminator. */
 export async function commissionByManualCode(
     cx: CertStepContext,
-    manualPairingCode: string,
+    code: string,
     commissioned: CommissionedRefs,
 ): Promise<void> {
-    await commissionByTarget(cx, { manualPairingCode }, commissioned);
+    await commissionByTarget(cx, { manualPairingCode: code }, commissioned);
 }
 
 /**
@@ -608,7 +779,7 @@ async function commissionByTarget(
             "commissioning complete",
             [COMMISSIONING_COMPLETE],
             from,
-            LOG_TIMEOUT_MS,
+            COMMISSIONING_LOG_TIMEOUT,
         ),
         "TH commissioning",
     );
@@ -687,4 +858,149 @@ export function manualPairingCode(parts: ManualPairingCodeParts): string {
     }
 
     return digits + (checkDigit ?? new Verhoeff().computeChecksum(digits));
+}
+
+/** § 5.1.4.1 Table 62/64's two lengths. */
+const MANUAL_CODE_SHORT_LENGTH = 11;
+const MANUAL_CODE_LONG_LENGTH = 21;
+
+/** What § 5.1.4.1 Table 62's digits say, read back without judging any of it. */
+export interface ManualPairingCodeDigits {
+    /** Table 62's 11 or Table 64's 21. */
+    length: number;
+
+    /** § 5.1.4.1.2's "a format after v1", which a first digit of 8 or 9 marks. */
+    futureFormat: boolean;
+
+    /** The `VID_PID_PRESENT` bit, which {@link length} states a second time and may disagree with. */
+    vidPidPresent: boolean;
+
+    /** Table 62's 4-bit form. Says nothing about a {@link futureFormat} code, whose marker displaces it. */
+    shortDiscriminator: number;
+
+    passcode: number;
+
+    /**
+     * The digits the 21-digit form carries, whatever `VID_PID_PRESENT` says. Reported as 0 where the
+     * codecs would normalise § 2.5.3's unspecified identifier to absent, so a step can assert the 0 it
+     * substituted.
+     */
+    vendorId?: number;
+    productId?: number;
+
+    checkDigit: number;
+
+    /** Whether {@link checkDigit} is § 5.1.4.1's Verhoeff digit over every digit before it. */
+    checkDigitCorrect: boolean;
+}
+
+/** {@link manualPairingCode}'s reader, and not a codec for the same reason it is not one. */
+export function manualPairingCodeDigits(code: string): ManualPairingCodeDigits {
+    const digits = code.replace(/\D/g, "");
+    if (digits.length !== MANUAL_CODE_SHORT_LENGTH && digits.length !== MANUAL_CODE_LONG_LENGTH) {
+        throw new InternalError(`"${code}" is ${digits.length} digits, which is no manual pairing code length`);
+    }
+
+    const header = Number(digits[0]);
+    const carriesIdentity = digits.length === MANUAL_CODE_LONG_LENGTH;
+    const checkDigit = Number(digits.slice(-1));
+
+    return {
+        length: digits.length,
+        futureFormat: header >= FUTURE_FORMAT_DIGIT,
+        vidPidPresent: !!(header & (1 << 2)),
+        shortDiscriminator: ((header & 0x03) << 2) | ((Number(digits.slice(1, 6)) >> 14) & 0x03),
+        passcode: (Number(digits.slice(1, 6)) & 0x3fff) | (Number(digits.slice(6, 10)) << 14),
+        vendorId: carriesIdentity ? Number(digits.slice(10, 15)) : undefined,
+        productId: carriesIdentity ? Number(digits.slice(15, 20)) : undefined,
+        checkDigit,
+        checkDigitCorrect: new Verhoeff().computeChecksum(digits.slice(0, -1)) === checkDigit,
+    };
+}
+
+/** What a generating step claims about the manual code it produced. */
+export interface ExpectedManualCodeDigits extends Partial<ManualPairingCodeDigits> {
+    /** The plan requires the generated code to differ from step 1's. */
+    differsFrom?: string;
+
+    /**
+     * The code every field `expected` does not name must still match, the check digit aside — every
+     * substitution changes that one. See {@link ExpectedQrPayloadFields.unchangedFrom} for why an
+     * expectation naming only the substituted field asserts nothing.
+     */
+    unchangedFrom?: string;
+}
+
+/**
+ * {@link checkGeneratedPayload} for a manual pairing code, and a claim about the artifact for the
+ * same reason.
+ *
+ * The check digit is asserted whether or not `expected` names it, because every generating step's
+ * expected outcome demands the Verhoeff digit of § 5.1.4.1; the step asking for a wrong one states
+ * `checkDigitCorrect: false`.
+ */
+export function checkGeneratedManualCode(code: string, expected: ExpectedManualCodeDigits): CheckRecord {
+    const { differsFrom, unchangedFrom, ...stated } = expected;
+    const differs = namedCode(expected, "differsFrom", differsFrom);
+    const unchanged = unchangedDigits(namedCode(expected, "unchangedFrom", unchangedFrom));
+    const digits = manualPairingCodeDigits(code);
+    const wrong = statedMismatches(digits, { checkDigitCorrect: true, ...unchanged, ...stated }, [
+        "length",
+        "futureFormat",
+        "vidPidPresent",
+        "shortDiscriminator",
+        "passcode",
+        "vendorId",
+        "productId",
+        "checkDigit",
+        "checkDigitCorrect",
+    ]);
+    if (differs !== undefined && code === differs) {
+        wrong.push(`a code other than ${differs}`);
+    }
+
+    return {
+        type: "response",
+        verdict: wrong.length ? "fail" : "pass",
+        detail:
+            `Generated ${code}, carrying ${digits.length} digits futureFormat=${digits.futureFormat} ` +
+            `vidPidPresent=${digits.vidPidPresent} shortDiscriminator=${digits.shortDiscriminator} ` +
+            `passcode=${digits.passcode} vendorId=${digits.vendorId} productId=${digits.productId} ` +
+            `checkDigit=${digits.checkDigit} (${digits.checkDigitCorrect ? "correct" : "not the Verhoeff digit"})` +
+            (wrong.length ? `; expected ${wrong.join(", ")}` : ""),
+    };
+}
+
+/** Every digit field a substitution leaves alone, which is all of them but the check digit. */
+function unchangedDigits(code?: string): Partial<ManualPairingCodeDigits> {
+    if (code === undefined) {
+        return {};
+    }
+    const { checkDigit, ...unchanged } = manualPairingCodeDigits(code);
+    return unchanged;
+}
+
+/**
+ * The code an expectation names under `key`, holding to the presence rule {@link statedMismatches}
+ * follows: a property that is there but undefined is a caller threading an optional value in, which
+ * would otherwise drop the assertion silently.
+ */
+function namedCode(expected: object, key: string, code: string | undefined): string | undefined {
+    if (!Object.hasOwn(expected, key)) {
+        return undefined;
+    }
+    if (code === undefined) {
+        throw new ImplementationError(`${key} names a code to compare against; omit it when there is none`);
+    }
+    return code;
+}
+
+/** {@link checkGeneratedManualCode} for the one-code case; use {@link recordAll} for a step generating several. */
+export function recordGeneratedManualCode(
+    cx: CertStepContext,
+    code: string,
+    expected: ExpectedManualCodeDigits,
+    what: string,
+): void {
+    record(cx, checkGeneratedManualCode(code, expected), what);
 }

--- a/support/chip-testing/test/cert/tc-idm-1.3-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-1.3-support.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ImplementationError } from "@matter/main";
+import { Duration, ImplementationError } from "@matter/main";
 import type { CheckRecord, LogFollower } from "@matter/testing";
 import { CertLogClosedError, CertLogTimeoutError } from "@matter/testing";
 import { ChipFault } from "./fault-injection.js";
@@ -80,9 +80,9 @@ export function expectInjectedFault(
     flavor: string,
     fault: number,
     from: number,
-    timeoutMs: number,
+    timeout: Duration,
 ): Promise<CheckRecord> {
-    return expectSequence(log, flavor, `fault ${fault} injected`, injectedFaultSequence(fault), from, timeoutMs);
+    return expectSequence(log, flavor, `fault ${fault} injected`, injectedFaultSequence(fault), from, timeout);
 }
 
 /**
@@ -151,12 +151,12 @@ export async function expectBatchRequestPaths(
     flavor: string,
     paths: BatchPath[],
     from: number,
-    timeoutMs: number,
+    timeout: Duration,
 ): Promise<CheckRecord> {
     const label = `InvokeRequestMessage with paths ${JSON.stringify(paths)}`;
 
     try {
-        const envelope = await expectAdjacentLines(log, flavor, [INVOKE_REQUEST_MESSAGE], from, timeoutMs);
+        const envelope = await expectAdjacentLines(log, flavor, [INVOKE_REQUEST_MESSAGE], from, timeout);
         if (envelope.verdict === "unverified") {
             return { type: "device-log", verdict: "unverified" };
         }
@@ -166,7 +166,7 @@ export async function expectBatchRequestPaths(
         // the case this check exists to tell apart from one batch carrying them all.
         const end = await log.expect(
             { chip: INTERACTION_MODEL_REVISION },
-            { flavor, timeoutMs, from: envelope.last.index + 1 },
+            { flavor, timeoutMs: timeout, from: envelope.last.index + 1 },
         );
         if (end.verdict === "unverified") {
             return { type: "device-log", verdict: "unverified" };
@@ -179,7 +179,7 @@ export async function expectBatchRequestPaths(
                 flavor,
                 commandPathIBSequence(endpoint, cluster, command),
                 last.index + 1,
-                timeoutMs,
+                timeout,
             );
             if (block.verdict === "unverified") {
                 return { type: "device-log", verdict: "unverified" };

--- a/support/chip-testing/test/cert/tc-idm-4.1-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-4.1-support.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Millis, Time } from "@matter/main";
+import { Duration, Millis, Seconds, Time } from "@matter/main";
 import type { AttributePathSpec, CertNodeRef, CertStepContext } from "@matter/testing";
 import {
-    ACK_WAIT_TIMEOUT_MS,
     CertCheckFailedError,
     expectMessageWithPath,
     expectReportAck,
     expectSubscriptionId,
+    LOG_TIMEOUT,
     SUBSCRIBE_REQUEST_MESSAGE,
 } from "./tc-support.js";
 
@@ -30,19 +30,19 @@ export const MAX_INTERVAL_CEILING_SECONDS = 80;
 // elapsed since the last report is coalesced into the next one, not reported on its own. Each write
 // in subscribeAndModify waits for its own report before the next write is issued, so this bounds
 // that wait (floor plus slack for scheduling/CI jitter), not the write itself.
-const REPORT_WAIT_TIMEOUT_MS = (MIN_INTERVAL_FLOOR_SECONDS + 20) * 1000;
+const REPORT_WAIT_TIMEOUT = Seconds(MIN_INTERVAL_FLOOR_SECONDS + 20);
 
 /**
- * Waits until `satisfied()` holds or `timeoutMs` elapses, woken by `setNotify`'s callback rather than
+ * Waits until `satisfied()` holds or `timeout` elapses, woken by `setNotify`'s callback rather than
  * polling. A wake that leaves `satisfied()` false waits again on the remaining budget, so a report
  * that isn't the awaited one can wake this without ending it, and no timer outlives the wait.
  */
 async function waitForReport(
     satisfied: () => boolean,
     setNotify: (fn: (() => void) | undefined) => void,
-    timeoutMs: number,
+    timeout: Duration,
 ): Promise<boolean> {
-    const deadline = Time.nowMs + timeoutMs;
+    const deadline = Time.nowMs + timeout;
     while (!satisfied()) {
         const remaining = deadline - Time.nowMs;
         if (remaining <= 0) {
@@ -63,9 +63,9 @@ async function waitForReport(
 /** Per-wait budgets {@link subscribeAndModify} uses; a test supplies shorter ones than a real run needs. */
 export interface SubscribeAndModifyTimeouts {
     /** Bounds each establishment check (SubscribeRequest shape, subscription id, priming-report ack). */
-    establishMs?: number;
+    establish?: Duration;
     /** Bounds the wait for one write's own report; must cover MinIntervalFloor's debounce. */
-    reportMs?: number;
+    report?: Duration;
 }
 
 /**
@@ -103,8 +103,8 @@ export async function subscribeAndModify<Value>(
 ): Promise<void> {
     const th = cx.devices.th;
     const node = cx.controllers.dut.node(ref);
-    const establishMs = timeouts.establishMs ?? ACK_WAIT_TIMEOUT_MS;
-    const reportMs = timeouts.reportMs ?? REPORT_WAIT_TIMEOUT_MS;
+    const establish = timeouts.establish ?? LOG_TIMEOUT;
+    const report = timeouts.report ?? REPORT_WAIT_TIMEOUT;
     const from = th.log.mark();
 
     const failResponse = (detail: string): never => {
@@ -138,7 +138,7 @@ export async function subscribeAndModify<Value>(
         SUBSCRIBE_REQUEST_MESSAGE,
         path,
         from,
-        establishMs,
+        establish,
     );
     cx.recorder.check(subscribeCheck);
     if (subscribeCheck.verdict === "fail") {
@@ -152,7 +152,7 @@ export async function subscribeAndModify<Value>(
     // the wrong subscription.
     const established = subscribeCheck.logLine !== undefined ? subscribeCheck.logLine + 1 : from;
 
-    const idLookup = await expectSubscriptionId(th.log, th.flavor, established, establishMs);
+    const idLookup = await expectSubscriptionId(th.log, th.flavor, established, establish);
     cx.recorder.check(idLookup.check);
     if (idLookup.check.verdict === "fail") {
         throw new CertCheckFailedError(
@@ -170,7 +170,7 @@ export async function subscribeAndModify<Value>(
         );
     }
 
-    const primingAckCheck = await expectReportAck(th.log, th.flavor, idLookup.subscriptionId, established, establishMs);
+    const primingAckCheck = await expectReportAck(th.log, th.flavor, idLookup.subscriptionId, established, establish);
     cx.recorder.check(primingAckCheck);
     if (primingAckCheck.verdict === "fail") {
         throw new CertCheckFailedError(
@@ -196,7 +196,7 @@ export async function subscribeAndModify<Value>(
             th.flavor,
             idLookup.subscriptionId,
             Math.max(ackCursor, writeFrom),
-            reportMs,
+            report,
         );
         cx.recorder.check(ackCheck);
         if (ackCheck.verdict !== "pass") {
@@ -218,7 +218,7 @@ export async function subscribeAndModify<Value>(
     const allReported = await waitForReport(
         () => matched >= values.length,
         fn => (notify = fn),
-        reportMs,
+        report,
     );
     if (mismatch !== undefined) {
         failResponse(`step ${step}: ${mismatch}`);

--- a/support/chip-testing/test/cert/tc-idm-5.1-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-5.1-support.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Time } from "@matter/main";
+import { Duration, Millis, Seconds, Time } from "@matter/main";
 import type { CheckRecord, LogFollower, LogLine } from "@matter/testing";
 import { CertLogClosedError, CertLogTimeoutError } from "@matter/testing";
 import { expectAdjacentLines } from "./tc-support.js";
@@ -16,8 +16,8 @@ import { expectAdjacentLines } from "./tc-support.js";
 export const TIMED_REQUEST_MESSAGE = /\[DMG\] TimedRequestMessage =\s*$/;
 
 /** `TimedRequestMessage::Parser::PrettyPrint` — one field, printed as bare lowercase hex. */
-export function timedRequestSequence(timeoutMs: number): RegExp[] {
-    return [TIMED_REQUEST_MESSAGE, /\{\s*$/, new RegExp(`TimeoutMs = 0x${timeoutMs.toString(16)},\\s*$`)];
+export function timedRequestSequence(timeout: Duration): RegExp[] {
+    return [TIMED_REQUEST_MESSAGE, /\{\s*$/, new RegExp(`TimeoutMs = 0x${timeout.toString(16)},\\s*$`)];
 }
 
 const TIMED_REQUEST_FLAG = /timedRequest = true,\s*$/;
@@ -42,7 +42,7 @@ const FLAG_WITHIN_LINES = 2;
  * this covers the follower's pump lag only — bounding it is what turns a message that simply carries
  * no flag into that finding rather than into a generic timeout at the end of the step's whole budget.
  */
-const FLAG_WAIT_MS = 2_000;
+const FLAG_WAIT = Seconds(2);
 
 /**
  * chip prefixes every line with its own timestamp, `[<seconds>.<fraction>]`, whose fraction is
@@ -94,19 +94,19 @@ export interface TimedRequestLookup {
 }
 
 /**
- * Confirms the device received a `TimedRequestMessage` asking for `timeoutMs` at or after `from`, and
+ * Confirms the device received a `TimedRequestMessage` asking for `timeout` at or after `from`, and
  * returns what a follow-up check needs to attribute the interaction that follows to this request.
  */
 export async function expectTimedRequest(
     log: LogFollower,
     flavor: string,
-    timeoutMs: number,
+    timeout: Duration,
     from: number,
-    waitMs: number,
+    wait: Duration,
 ): Promise<TimedRequestLookup> {
-    const pattern = `TimedRequestMessage(TimeoutMs = 0x${timeoutMs.toString(16)})`;
+    const pattern = `TimedRequestMessage(TimeoutMs = 0x${timeout.toString(16)})`;
     try {
-        const result = await expectAdjacentLines(log, flavor, timedRequestSequence(timeoutMs), from, waitMs);
+        const result = await expectAdjacentLines(log, flavor, timedRequestSequence(timeout), from, wait);
         if (result.verdict === "unverified") {
             return { check: { type: "device-log", verdict: "unverified" } };
         }
@@ -177,15 +177,15 @@ export async function expectTimedFollowUp(
     flavor: string,
     message: RegExp,
     timed: TimedRequestLookup,
-    budgetMs: number,
-    waitMs: number,
+    budget: Duration,
+    wait: Duration,
 ): Promise<CheckRecord> {
     const { line: timedLine, receipt } = timed;
     if (timedLine === undefined) {
         return { type: "device-log", verdict: "unverified" };
     }
 
-    const pattern = `${message.source} with ${TIMED_REQUEST_FLAG.source} within ${budgetMs}ms`;
+    const pattern = `${message.source} with ${TIMED_REQUEST_FLAG.source} within ${budget}ms`;
     if (receipt === undefined) {
         return {
             type: "device-log",
@@ -196,8 +196,8 @@ export async function expectTimedFollowUp(
         };
     }
 
-    const deadline = Time.nowMs + waitMs;
-    const remaining = () => Math.max(1, deadline - Time.nowMs);
+    const deadline = Time.nowMs + wait;
+    const remaining = () => Millis(Math.max(1, deadline - Time.nowMs));
     let cursor = timedLine.index + 1;
 
     try {
@@ -249,9 +249,9 @@ export async function expectTimedFollowUp(
             const elapsed = arrived - started;
             return {
                 type: "device-log",
-                verdict: elapsed >= 0 && elapsed <= budgetMs ? "pass" : "fail",
+                verdict: elapsed >= 0 && elapsed <= budget ? "pass" : "fail",
                 pattern,
-                detail: `arrived ${elapsed.toFixed(1)}ms after the timed request (budget ${budgetMs}ms)`,
+                detail: `arrived ${elapsed.toFixed(1)}ms after the timed request (budget ${budget}ms)`,
                 matched: messageLine.text,
                 logLine: messageLine.index,
             };
@@ -265,19 +265,19 @@ export async function expectTimedFollowUp(
 }
 
 /**
- * Whether the flag arrives within {@link FLAG_WAIT_MS} of a message whose own buffered lines did not
+ * Whether the flag arrives within {@link FLAG_WAIT} of a message whose own buffered lines did not
  * carry it yet, and close enough to still be that message's own.
  */
 async function waitForLaggingFlag(
     log: LogFollower,
     flavor: string,
     braceIndex: number,
-    remainingMs: number,
+    remaining: Duration,
 ): Promise<boolean | "unverified"> {
     try {
         const flag = await log.expect(
             { chip: TIMED_REQUEST_FLAG },
-            { flavor, timeoutMs: Math.min(FLAG_WAIT_MS, remainingMs), from: braceIndex + 1 },
+            { flavor, timeoutMs: Duration.min(FLAG_WAIT, remaining), from: braceIndex + 1 },
         );
         if (flag.verdict === "unverified") {
             return "unverified";

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Duration, InternalError, MatterError, Millis, Time } from "@matter/main";
+import { Duration, InternalError, MatterError, Millis, Seconds, Time } from "@matter/main";
 import type {
     AttributePathSpec,
     CertNodeRef,
@@ -16,6 +16,12 @@ import type {
     LogLine,
 } from "@matter/testing";
 import { CertLogClosedError, CertLogTimeoutError } from "@matter/testing";
+
+/**
+ * Bounds a device-log check's wait for a line the step has already caused — one the device writes
+ * while answering the interaction the step drove, not one it writes after work of its own.
+ */
+export const LOG_TIMEOUT = Seconds(15);
 
 /** A cert run left a fabric (and whatever it carries) behind on the TH. */
 export class CertCleanupError extends MatterError {}
@@ -33,6 +39,28 @@ export function record(cx: CertStepContext, check: CheckRecord, what: string) {
     cx.recorder.check(check);
     if (check.verdict === "fail") {
         throw new CertCheckFailedError(`${what} check failed: ${JSON.stringify(check)}`);
+    }
+}
+
+/**
+ * Records every check and fails the step once at the end, so a step asserting several artifacts puts
+ * all of them in the evidence — {@link record} in a loop stops at the first failure and leaves the
+ * rest of the step's own claim unrecorded.
+ *
+ * Each check is built on demand rather than taken as a list, so a builder that throws on the fifth
+ * artifact leaves the first four recorded; its error carries the step, as {@link record}'s does.
+ */
+export function recordAll(cx: CertStepContext, checks: readonly { check: () => CheckRecord; what: string }[]): void {
+    const failed = new Array<string>();
+    for (const { check, what } of checks) {
+        const record = check();
+        cx.recorder.check(record);
+        if (record.verdict === "fail") {
+            failed.push(`${what}: ${JSON.stringify(record)}`);
+        }
+    }
+    if (failed.length) {
+        throw new CertCheckFailedError(`${failed.length} of ${checks.length} checks failed: ${failed.join("; ")}`);
     }
 }
 
@@ -114,17 +142,17 @@ export class CommissionedRefs<Role extends string = "dut"> {
  * earlier step — the follower pumps the device stream asynchronously, so a previous step's response
  * can surface after this step's `mark()`). Such a candidate is skipped and the search resumes at
  * the next one; genuine absence of the block surfaces as `log.expect`'s own timeout error. The
- * whole search shares one `timeoutMs` budget.
+ * whole search shares one `timeout` budget.
  */
 export async function expectAdjacentLines(
     log: LogFollower,
     flavor: string,
     sequence: RegExp[],
     from: number,
-    timeoutMs: number,
+    timeout: Duration,
 ): Promise<{ verdict: "unverified" } | { verdict: "pass"; last: LogLine }> {
-    const deadline = Time.nowMs + timeoutMs;
-    const remaining = () => Math.max(1, deadline - Time.nowMs);
+    const deadline = Time.nowMs + timeout;
+    const remaining = () => Millis(Math.max(1, deadline - Time.nowMs));
 
     let cursor = from;
     for (;;) {
@@ -299,10 +327,10 @@ export async function expectSequence(
     label: string,
     sequence: RegExp[],
     from: number,
-    timeoutMs: number,
+    timeout: Duration,
 ): Promise<CheckRecord> {
     try {
-        const result = await expectAdjacentLines(log, flavor, sequence, from, timeoutMs);
+        const result = await expectAdjacentLines(log, flavor, sequence, from, timeout);
         if (result.verdict === "unverified") {
             return { type: "device-log", verdict: "unverified" };
         }
@@ -333,9 +361,9 @@ export async function expectAttributePathIB(
     flavor: string,
     fields: AttributePathSpec,
     from: number,
-    timeoutMs: number,
+    timeout: Duration,
 ): Promise<CheckRecord> {
-    const result = await expectAdjacentLines(log, flavor, attributePathIBSequence(fields), from, timeoutMs);
+    const result = await expectAdjacentLines(log, flavor, attributePathIBSequence(fields), from, timeout);
     if (result.verdict === "unverified") {
         return { type: "device-log", verdict: "unverified" };
     }
@@ -356,7 +384,7 @@ export async function expectAttributePathIB(
  * `AttributePathIB` block for `fields` follows it at or after that point (see
  * {@link expectAttributePathIB}). Anchoring on the request-message name first, not just the path
  * block on its own, rules out a differently-typed request landing at the same log position. Both
- * waits share `timeoutMs`'s deadline; a timeout or closed source from either stage is recorded as a
+ * waits share `timeout`'s deadline; a timeout or closed source from either stage is recorded as a
  * `"fail"` rather than propagating uncaught.
  */
 export async function expectMessageWithPath(
@@ -365,10 +393,10 @@ export async function expectMessageWithPath(
     message: RegExp,
     fields: AttributePathSpec,
     from: number,
-    timeoutMs: number,
+    timeout: Duration,
 ): Promise<CheckRecord> {
-    const deadline = Time.nowMs + timeoutMs;
-    const remaining = () => Math.max(1, deadline - Time.nowMs);
+    const deadline = Time.nowMs + timeout;
+    const remaining = () => Millis(Math.max(1, deadline - Time.nowMs));
 
     let anchor: LogExpectResult;
     try {
@@ -455,15 +483,15 @@ export async function expectCommandInvoke(
     command: number,
     fields: CommandFieldValue[],
     from: number,
-    timeoutMs: number,
+    timeout: Duration,
 ): Promise<CheckRecord> {
     let cursor = from;
     let last: { index: number; text: string } | undefined;
 
     // One deadline for the whole check, not one per wait: a per-wait budget makes the worst case
-    // timeoutMs × (1 + fields.length), where the caller asked for timeoutMs
-    const deadline = Time.nowMs + timeoutMs;
-    const remaining = () => Math.max(1, deadline - Time.nowMs);
+    // timeout × (1 + fields.length), where the caller asked for timeout
+    const deadline = Time.nowMs + timeout;
+    const remaining = () => Millis(Math.max(1, deadline - Time.nowMs));
 
     try {
         const block = await expectAdjacentLines(
@@ -534,7 +562,7 @@ export function countMatches(log: LogFollower, _flavor: string, pattern: RegExp,
 
 // How long a further report chunk may take to surface before the transfer counts as finished. The
 // read has already returned by the time a step checks, so this covers the follower's pump lag only.
-const CHUNK_QUIET_MS = 2_000;
+const CHUNK_QUIET = Seconds(2);
 
 /**
  * Confirms a chunked read actually chunked and that the DUT acked every chunk but the last: at least
@@ -547,16 +575,16 @@ export async function expectChunkedTransfer(
     log: LogFollower,
     flavor: string,
     from: number,
-    timeoutMs: number,
+    timeout: Duration,
 ): Promise<CheckRecord> {
-    const deadline = Time.nowMs + timeoutMs;
-    const remaining = () => Math.max(1, deadline - Time.nowMs);
+    const deadline = Time.nowMs + timeout;
+    const remaining = () => Millis(Math.max(1, deadline - Time.nowMs));
 
     const chunks = new Array<LogLine>();
     for (;;) {
         // The second chunk is what proves the read chunked at all, so it gets the whole remaining
         // budget; every later one only has to outlast pump lag, and its absence ends the transfer.
-        const timeout = chunks.length > 1 ? Math.min(CHUNK_QUIET_MS, remaining()) : remaining();
+        const timeout = chunks.length > 1 ? Duration.min(CHUNK_QUIET, remaining()) : remaining();
         let next: LogExpectResult;
         try {
             next = await log.expect(
@@ -648,11 +676,6 @@ export async function expectChunkedTransfer(
     };
 }
 
-// Bounds waiting for a StatusResponseMessage that should already have been sent by the time this
-// wait starts (the controller's own report-processing acks a report as part of handling it) — this
-// only needs to cover the log follower's own pump lag, not any protocol-level delay.
-export const ACK_WAIT_TIMEOUT_MS = 15_000;
-
 /** What the TH's own SubscribeResponse says about the subscription a step just established. */
 export interface SubscriptionIdLookup {
     check: CheckRecord;
@@ -664,12 +687,12 @@ async function matterjsSubscriptionId(
     log: LogFollower,
     flavor: string,
     from: number,
-    timeoutMs: number,
+    timeout: Duration,
 ): Promise<SubscriptionIdLookup> {
     const pattern = String(MATTERJS_SUBSCRIBE_RESPONSE);
     let response: LogExpectResult;
     try {
-        response = await log.expect({ matterjs: MATTERJS_SUBSCRIBE_RESPONSE }, { flavor, timeoutMs, from });
+        response = await log.expect({ matterjs: MATTERJS_SUBSCRIBE_RESPONSE }, { flavor, timeoutMs: timeout, from });
     } catch (e) {
         if (e instanceof CertLogTimeoutError || e instanceof CertLogClosedError) {
             return { check: { type: "device-log", verdict: "fail", pattern, detail: e.message, logLine: from } };
@@ -716,15 +739,15 @@ export async function expectSubscriptionId(
     log: LogFollower,
     flavor: string,
     from: number,
-    timeoutMs: number,
+    timeout: Duration,
 ): Promise<SubscriptionIdLookup> {
     if (flavor === "matterjs") {
-        return matterjsSubscriptionId(log, flavor, from, timeoutMs);
+        return matterjsSubscriptionId(log, flavor, from, timeout);
     }
 
     const sequence = [SUBSCRIBE_RESPONSE_MESSAGE, /\{\s*$/, SUBSCRIPTION_ID_LINE];
     try {
-        const result = await expectAdjacentLines(log, flavor, sequence, from, timeoutMs);
+        const result = await expectAdjacentLines(log, flavor, sequence, from, timeout);
         if (result.verdict === "unverified") {
             return { check: { type: "device-log", verdict: "unverified" } };
         }
@@ -830,10 +853,10 @@ async function matterjsReportAck(
     flavor: string,
     subscriptionId: number,
     from: number,
-    timeoutMs: number,
+    timeout: Duration,
 ): Promise<CheckRecord> {
-    const deadline = Time.nowMs + timeoutMs;
-    const remaining = () => Math.max(1, deadline - Time.nowMs);
+    const deadline = Time.nowMs + timeout;
+    const remaining = () => Millis(Math.max(1, deadline - Time.nowMs));
     const reportPattern = matterjsReportPattern(subscriptionId);
     const pattern = `${reportPattern} then its own Success StatusResponse`;
 
@@ -909,18 +932,18 @@ export async function expectReportAck(
     flavor: string,
     subscriptionId: number | undefined,
     from: number,
-    timeoutMs: number,
+    timeout: Duration,
 ): Promise<CheckRecord> {
     if (subscriptionId === undefined) {
         return { type: "device-log", verdict: "unverified" };
     }
 
     if (flavor === "matterjs") {
-        return matterjsReportAck(log, flavor, subscriptionId, from, timeoutMs);
+        return matterjsReportAck(log, flavor, subscriptionId, from, timeout);
     }
 
-    const deadline = Time.nowMs + timeoutMs;
-    const remaining = () => Math.max(1, deadline - Time.nowMs);
+    const deadline = Time.nowMs + timeout;
+    const remaining = () => Millis(Math.max(1, deadline - Time.nowMs));
     const pattern = `ReportDataMessage(SubscriptionId = 0x${subscriptionId.toString(16)}) then its own ${STATUS_RESPONSE_SUCCESS} (matched by Exchange id)`;
 
     try {
@@ -1029,7 +1052,7 @@ export type SettleReport<T = unknown> = { elapsed: string } & (
 );
 
 /**
- * Waits for `op` to settle, bounded by `timeoutMs` so an implementation that neither answers nor
+ * Waits for `op` to settle, bounded by `timeout` so an implementation that neither answers nor
  * gives up cannot hang the step for the whole mocha timeout. Reports which way it went, for a step
  * that has something to record either way; {@link expectRejection} is the form for a step that
  * demands a refusal.
@@ -1037,12 +1060,12 @@ export type SettleReport<T = unknown> = { elapsed: string } & (
  * A step that stops waiting is still responsible for what the operation does afterwards — a
  * commissioning that succeeds late leaves a fabric on the device.
  */
-export async function settleWithin<T>(label: string, op: Promise<T>, timeoutMs: number): Promise<SettleReport<T>> {
+export async function settleWithin<T>(label: string, op: Promise<T>, timeout: Duration): Promise<SettleReport<T>> {
     // nowUs is the monotonic clock despite the name; nowMs tracks UTC and a step of it would put a
     // negative elapsed into the evidence
     const start = Time.nowUs;
     const elapsed = () => Duration.format(Millis(Time.nowUs - start));
-    const timeout = Time.sleep(`${label} settle timeout`, Millis(timeoutMs));
+    const timer = Time.sleep(`${label} settle timeout`, timeout);
 
     try {
         return await Promise.race([
@@ -1050,16 +1073,16 @@ export async function settleWithin<T>(label: string, op: Promise<T>, timeoutMs: 
                 (value): SettleReport<T> => ({ kind: "resolved", value, elapsed: elapsed() }),
                 (error: unknown): SettleReport<T> => ({ kind: "rejected", error, elapsed: elapsed() }),
             ),
-            timeout.then((): SettleReport<T> => ({ kind: "timeout", elapsed: elapsed() })),
+            timer.then((): SettleReport<T> => ({ kind: "timeout", elapsed: elapsed() })),
         ]);
     } finally {
         // A lost race leaves the sleep armed for its full duration, keeping the process alive past teardown
-        timeout.cancel();
+        timer.cancel();
     }
 }
 
 /**
- * Asserts `op` rejects rather than resolves, bounded by `timeoutMs` so an implementation that
+ * Asserts `op` rejects rather than resolves, bounded by `timeout` so an implementation that
  * neither errors nor gives up cannot hang the step for the whole mocha timeout — which is useless as
  * either evidence or a fast local failure. A timeout is reported `"fail"`, same as an unexpected
  * success, and the elapsed time reaches the evidence either way.
@@ -1071,10 +1094,10 @@ export async function settleWithin<T>(label: string, op: Promise<T>, timeoutMs: 
 export async function expectRejection(
     label: string,
     op: Promise<unknown>,
-    timeoutMs: number,
+    timeout: Duration,
     accept?: (error: unknown) => boolean,
 ): Promise<CheckRecord> {
-    const outcome = await settleWithin(label, op, timeoutMs);
+    const outcome = await settleWithin(label, op, timeout);
     const { elapsed } = outcome;
 
     switch (outcome.kind) {
@@ -1084,7 +1107,7 @@ export async function expectRejection(
             return {
                 type: "response",
                 verdict: "fail",
-                detail: `${label} neither resolved nor rejected within ${Duration.format(Millis(timeoutMs))}`,
+                detail: `${label} neither resolved nor rejected within ${Duration.format(timeout)}`,
             };
         case "rejected": {
             const { error } = outcome;


### PR DESCRIPTION
Rebased onto `main` after #4282 squash-merged; one commit, no duplicate.

## Steps that record more than they verified

Eight steps across TC-DD-3.14 and TC-DD-3.17 exist only to produce something for the step after them: a QR payload or a 21-digit manual pairing code with one field replaced by a value the specification forbids. Each recorded a hard-coded pass whose text asserted a property nobody had looked at — "whose check digit is wrong", "naming a device this network does not carry". The generator could have stopped substituting anything and every one of them would still have passed.

They now read the artifact back and judge it. Two readers do that, one for the bit layout of a QR payload and one for the digits of a manual code, deliberately not the production codecs — those refuse to read exactly the malformed codes these plans call for, which is the reason the writers next to them are hand-rolled too.

The claim each step makes is the plan's own wording, *"all the same Onboarding Payload components except for the Passcode"*: every field the step does not name must still match the code it started from. Naming only the substituted field would assert nothing, because the same value feeds the generator and the expectation — an early revision of this branch did exactly that and a reviewer caught it. The QR reader therefore covers all of Table 59 — version, vendor, product, flow type, discovery capabilities, discriminator, passcode — plus § 5.1.5's optional TLV tail, since the guarantee is only as strong as the set of fields it can compare. Every generated manual code also has its Verhoeff check digit verified, which the plan demands in all eight expected outcomes, and the one step that asks for a wrong check digit states that.

A step producing twelve codes records twelve findings and fails once at the end, so the evidence bundle carries every code rather than stopping at the first bad one.

## Two read steps claimed a type they never checked

TC-IDM-2.1 steps 12 and 13 verify "signed integer" and "floating point" with the same expression, so neither could fail where the other passed. The signed one now checks whole numbers in range. Both check the type the data model declares for the attribute they read, so a step pointed at a differently typed attribute fails instead of quietly testing something nobody asked for.

A floating-point value cannot be told from a whole number after either controller hands it over as JSON. The step says so rather than implying otherwise — an earlier attempt here used a single-precision round-trip test, which would have failed a conforming device reporting `0.1`.

## Reading the fabric list after a removal

TC-CADMIN-1.17 step 9 compared against a value that is undefined when the step reading it was skipped, making the comparison always false and reducing the step to counting fabrics. It now requires the value, as step 7 already did.

## One budget, one name

A timeout had five declarations and two different values, plus thirteen more places spelling the number inline. There is one now. The differently valued one is named for what it bounds: a line a device prints while starting up or being commissioned, which has a whole commissioning flow ahead of it, rather than a request that was already answered. **Every call site keeps the budget it had** — an intermediate revision halved one and that is reverted.

Timeouts are `Duration`s throughout these tests rather than numbers named after their unit, which removed some millisecond arithmetic. The framework underneath keeps plain numbers on purpose, since it carries no dependency on the main library; a `Duration` is milliseconds, so the boundary is a value and needs no conversion.

## Verification

`build-clean`, `format-verify`, `lint` and the full suite pass. Twenty-one new unit tests, anchored on the payloads and codes the test plan prints for its own example device, so the readers are checked against something outside this repository.

Every production change was mutation-tested: twenty-one mutations, each compiled and each turning the suite red, including one per bit offset the QR reader gained. Two are reported as not proven rather than as kills — one phrasing TypeScript rejects three ways, and a survivor that showed an earlier "consistency" fix was inert, which is why a code field that is present but undefined is now an error instead of silence.

## Known limits, deliberately not fixed here

- A `.b` step still rebuilds its artifact instead of taking the one `.a` vouched for. Generation is deterministic so the artifacts are equal, but they are not the same object; the handoff is filed.
- TC-CADMIN-1.17 step 8 has no predicate narrowing *which* rejection counts. Adding one is filed rather than done: both controllers raise the same error type after a completed round trip as they do for a harness fault, so the obvious predicate would report a legitimate failure as a passing step and then leave cleanup chasing a fabric that no longer exists. Pinning it needs a captured run.
- The new artifact checks are made and read back in one process. They catch a mistake in the step, not anything a device did, and the notes in the directory now say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
