### PR TITLE
Stop the certification harness reporting work it did as work it skipped

### DIFF
--- a/packages/testing/src/chip/cert/cert-test.ts
+++ b/packages/testing/src/chip/cert/cert-test.ts
@@ -65,7 +65,37 @@ export class CertTest extends BaseTest {
         _uncommissioned: boolean,
     ): Promise<void> {
         const cx = this.contextFor(subject);
-        const { recorder, devices } = cx;
+        const { devices } = cx;
+
+        // A step's own checks are how the suite defines "something was observed" — AGENTS.md requires
+        // a response check on essentially every step. Counting them is what lets a controller refusal
+        // discovered *after* the step acted be told apart from one discovered before it acted.
+        let observedThisStep = 0;
+        const recorded = cx.recorder;
+
+        // A StepRecorder may be a class instance, whose members live on its prototype — so each is
+        // forwarded by name.
+        const recorder: StepRecorder = {
+            beginStep: step => {
+                observedThisStep = 0;
+                recorded.beginStep(step);
+            },
+            check: record => {
+                observedThisStep++;
+                recorded.check(record);
+            },
+            endStep: (step, verdict, skipReason) => recorded.endStep(step, verdict, skipReason),
+            deviceExited: recorded.deviceExited === undefined ? undefined : info => recorded.deviceExited?.(info),
+            finalizationFailed:
+                recorded.finalizationFailed === undefined ? undefined : detail => recorded.finalizationFailed?.(detail),
+            runHeaderLines: recorded.runHeaderLines === undefined ? undefined : () => recorded.runHeaderLines?.() ?? [],
+            recordControllerUnsupportedSkips:
+                recorded.recordControllerUnsupportedSkips === undefined
+                    ? undefined
+                    : count => recorded.recordControllerUnsupportedSkips?.(count),
+            flush: () => recorded.flush(),
+        };
+        cx.recorder = recorder;
         const deviceExitWatch = watchDeviceExits(devices, recorder);
         const flavor = this.flavorFor(devices);
         const tc = this.#definition.tc;
@@ -144,8 +174,25 @@ export class CertTest extends BaseTest {
                     await raceAgainstDeviceExit(stepDef.run(cx), deviceExitWatch.exit, tc, stepDef.number);
                 } catch (e) {
                     if (e instanceof UnsupportedByControllerError) {
-                        controllerUnsupportedSkips++;
-                        report(stepDef, "skipped", e.message);
+                        // "skipped" claims nothing was evaluated. A step that already recorded
+                        // evidence did act, so every later step would rest on a device state nobody
+                        // declared — that is the run's outcome, not a skip.
+                        if (observedThisStep === 0) {
+                            controllerUnsupportedSkips++;
+                            report(stepDef, "skipped", e.message);
+                            continue;
+                        }
+
+                        aborted = true;
+                        failed = true;
+                        failure = new Error(
+                            `Cert test ${tc} step ${stepDef.number}: the controller refused "${e.operation}" after ` +
+                                `the step had already recorded ${observedThisStep} check(s), so the device is in a ` +
+                                `state this run cannot describe. Declare the limitation in the controller's own ` +
+                                `PICS so the step is skipped before it acts. Refusal: ${e.message}`,
+                        );
+
+                        report(stepDef, "fail");
                         continue;
                     }
 

--- a/packages/testing/src/chip/cert/controller-adapter.ts
+++ b/packages/testing/src/chip/cert/controller-adapter.ts
@@ -343,12 +343,17 @@ export interface CertNodeApi {
 /**
  * Thrown by a {@link ControllerAdapter} (or a {@link CertNodeApi} it returns) whose underlying
  * controller cannot express the requested operation — e.g. a {@link CertNodeApi.writeAttributes}
- * request chip-tool has no single command for. The step runner records such a step `skipped`
- * rather than failing the run; every other thrown value still fails and aborts it.
+ * request chip-tool has no single command for.
  *
  * Raise this before the operation has any observable effect (a commission, a write, a recorded
- * check). Raising it after a step already recorded evidence discards that evidence under a
- * `skipped` verdict instead of a `fail`.
+ * check). The step runner enforces that: a refusal reaching it before the step recorded anything is
+ * a `skipped` step, counted as a coverage gap in the run summary; a refusal arriving after the step
+ * recorded evidence fails and aborts the run, because the step did act and no later step can rest on
+ * a device state the bundle cannot describe.
+ *
+ * A controller that cannot do something at all should say so in its own PICS
+ * (see {@link controllerPicsOverridesFor}), which gates the step before it runs and keeps the rest of
+ * the run's coverage.
  */
 export class UnsupportedByControllerError extends Error {
     constructor(

--- a/packages/testing/src/chip/cert/log-follower.ts
+++ b/packages/testing/src/chip/cert/log-follower.ts
@@ -141,10 +141,82 @@ export class LogFollower implements LogSource {
 
     /**
      * Every line seen so far, in arrival order. A fresh copy on each access — callers cannot
-     * mutate the follower's own buffer through it.
+     * mutate the follower's own buffer through it. Prefer {@link count} and {@link lastMatchBefore}
+     * for scanning: they read the buffer directly, where this copies all of it per access.
      */
     get lines(): LogLine[] {
         return [...this.#lines];
+    }
+
+    /** The line at `index`, or `undefined` past the end. */
+    at(index: number): LogLine | undefined {
+        return this.#lines[index];
+    }
+
+    /**
+     * `count` lines starting at `from`, clamped to the buffer. Not named `slice`, whose second
+     * argument is an end index.
+     *
+     * Reads the buffer directly, where {@link lines} copies all of it: a caller scanning a fixed
+     * window inside a wait loop otherwise copies the whole log once per iteration.
+     */
+    window(from: number, count: number): LogLine[] {
+        const start = Math.max(0, from);
+        return this.#lines.slice(start, start + Math.max(0, count));
+    }
+
+    /**
+     * How many lines at or after `from` match `pattern` — for a "repeat N times, expect N
+     * successes" check. Skips synthetic lines, as {@link expect} does.
+     *
+     * `from` is required deliberately: {@link expect} defaults its cursor to the last {@link mark},
+     * and a count defaulting to the whole buffer instead would silently include every earlier step's
+     * lines.
+     */
+    count(pattern: RegExp, from: number): number {
+        const matchable = matchableCopy(pattern);
+        let matches = 0;
+        for (let i = Math.max(0, from); i < this.#lines.length; i++) {
+            const line = this.#lines[i];
+            if (!line.synthetic && matchable.test(line.text)) {
+                matches++;
+            }
+        }
+        return matches;
+    }
+
+    /**
+     * The nearest line before `before` matching `pattern`, searching back at most `within` lines,
+     * with the match it produced. Skips synthetic lines, as {@link expect} does.
+     *
+     * chip logs one message at a time, so the nearest preceding trace line belongs to the message
+     * whose decode dump starts at `before` — which is what makes scanning backward correct however
+     * many raw-frame lines that message's payload produced. `within` bounds it: unbounded, a search
+     * that finds nothing nearby keeps going and attributes a line from minutes earlier.
+     *
+     * The match comes back with the line so a caller reading capture groups does not re-`exec` the
+     * pattern it passed: this scans with a `g`/`y`-stripped copy, and a second `exec` of the
+     * caller's own pattern would not have that protection.
+     */
+    lastMatchBefore(
+        pattern: RegExp,
+        before: number,
+        within: number,
+    ): { line: LogLine; match: RegExpExecArray } | undefined {
+        const matchable = matchableCopy(pattern);
+        const end = Math.min(before, this.#lines.length);
+        const floor = Math.max(0, end - within);
+        for (let i = end - 1; i >= floor; i--) {
+            const line = this.#lines[i];
+            if (line.synthetic) {
+                continue;
+            }
+            const match = matchable.exec(line.text);
+            if (match !== null) {
+                return { line, match };
+            }
+        }
+        return undefined;
     }
 
     /**

--- a/packages/testing/src/chip/state.ts
+++ b/packages/testing/src/chip/state.ts
@@ -166,7 +166,7 @@ export const State = {
             const labels = info.Config?.Labels;
             const chipCommit = formatSha(labels?.["org.opencontainers.image.revision"] ?? "(unknown)");
             const imageVersion = labels?.["org.opencontainers.image.version"] ?? "(unknown)";
-            const arch = info.Architecture;
+            const arch = info.Architecture || "(unknown)";
 
             progress.success(
                 `Initialized CHIP ${ansi.bold(chipCommit)} image ${ansi.bold(imageVersion)} for ${ansi.bold(arch)}`,
@@ -430,14 +430,17 @@ async function initialize() {
 async function configureContainer() {
     const docker = new Docker();
 
-    let platform = Constants.platform;
+    let platform: string | undefined = Constants.platform;
 
     if (Values.pullBeforeTesting) {
         await docker.pull(Constants.imageName, platform);
     } else if (Constants.selectedPlatform === undefined) {
-        // Without pull, use whatever platform is available unless explicitly configured
+        // Without pull, use whatever platform is available unless explicitly configured. A multi-arch
+        // image reports no architecture of its own — Docker 29 answers `inspect` with an empty string
+        // — and `linux/` is not a platform specifier it will accept on create, so leave it unset and
+        // let the daemon pick.
         const arch = (await Image(docker, Constants.imageName).inspect()).Architecture;
-        platform = `linux/${arch}`;
+        platform = arch ? `linux/${arch}` : undefined;
     }
 
     // chip-cert-bins publishes linux/arm64 only (no amd64 manifest exists at any tag). Bind-mounting
@@ -445,11 +448,12 @@ async function configureContainer() {
     // confusing "cannot execute: required file not found" deep inside a test run, so fail fast here
     // instead, before spending time on extraction.
     const chipBinsSelected = resolveChipBinsSource() === "cert-bins";
-    if (chipBinsSelected && !chipBinsPlatformSupported(platform)) {
+    if (chipBinsSelected && (platform === undefined || !chipBinsPlatformSupported(platform))) {
         throw new Error(
             `MATTER_CHIP_BINS_SOURCE=cert-bins requires the harness "chip" container to run ` +
                 `${CERT_BINS_PLATFORM} (chip-cert-bins publishes no other platform), but it is configured for ` +
-                `${platform}. Set MATTER_CHIP_PLATFORM=${CERT_BINS_PLATFORM} and point MATTER_CHIP_IMAGE at an ` +
+                `${platform ?? "whichever the daemon picks"}. Set MATTER_CHIP_PLATFORM=${CERT_BINS_PLATFORM} and ` +
+                `point MATTER_CHIP_IMAGE at an ` +
                 `${CERT_BINS_PLATFORM} build of the harness image, or unset MATTER_CHIP_BINS_SOURCE.`,
         );
     }

--- a/packages/testing/src/cli.ts
+++ b/packages/testing/src/cli.ts
@@ -155,12 +155,32 @@ export async function main(argv = process.argv) {
             clear();
         }
 
+        const testable = new Array<Package>();
+        const optedOut = new Array<string>();
         for (const node of graph.nodes) {
-            if (!node.pkg.hasTests || node.pkg.json.nacho?.test === false) {
+            if (!node.pkg.hasTests) {
                 continue;
             }
+            if (node.pkg.json.nacho?.test === false) {
+                optedOut.push(node.pkg.json.name ?? node.pkg.path);
+                continue;
+            }
+            testable.push(node.pkg);
+        }
 
-            await test(node.pkg, true);
+        // Before the loop, not after: a package whose suite fails aborts this command
+        // (TestRunner.#run calls fatal()), so anything printed afterwards is exactly what a reader
+        // never sees. A run that silently omits packages otherwise reads as coverage it does not have.
+        // Plain text: --machine output carries no ANSI (see machine-reporter.ts).
+        if (optedOut.length && args._[0] !== "inspect" && args._[0] !== "manual") {
+            console.log(
+                `Not tested (opted out with nacho.test: false): ${optedOut.join(", ")}. ` +
+                    "Run each package's own test script for these.",
+            );
+        }
+
+        for (const pkg of testable) {
+            await test(pkg, true);
         }
     } else {
         const graph = await Graph.forProject(pkg.path);

--- a/support/chip-testing/test/cert-framework/cert-test.test.ts
+++ b/support/chip-testing/test/cert-framework/cert-test.test.ts
@@ -1812,7 +1812,7 @@ describe("CertTest", () => {
         ]);
     });
 
-    it("keeps a step's already-recorded checks, and the step's start banner, when it then throws UnsupportedByControllerError", async () => {
+    it("fails the run when a controller refusal arrives after the step already recorded evidence", async () => {
         const definition: CertTestDefinition = {
             tc: "TC-CADMIN-1.17",
             plan: "multiplefabrics.adoc",
@@ -1840,7 +1840,11 @@ describe("CertTest", () => {
         const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
         const subject = stubSubject(new PicsFile([]));
 
-        await test.invoke(subject, () => {}, [], false);
+        // The step did act, so "not evaluated" would misstate this run's coverage and leave every
+        // later step resting on a device state the bundle cannot describe
+        await expect(test.invoke(subject, () => {}, [], false)).rejectedWith(
+            /refused "writeAttributes" after the step had already recorded 1 check\(s\)/,
+        );
 
         const banners = deviceLog.lines.filter(line => line.synthetic).map(line => line.text);
         expect(banners).deep.equal([
@@ -1848,13 +1852,92 @@ describe("CertTest", () => {
             "TC-CADMIN-1.17 — Test Step 1: Step that records a check before hitting an unsupported operation",
             "-".repeat(70),
             "-".repeat(70),
-            "TC-CADMIN-1.17 — Test Step 1: SKIPPED",
+            "TC-CADMIN-1.17 — Test Step 1: FAIL",
             "pass: read the data version",
             "-".repeat(70),
-            "-".repeat(70),
-            "TC-CADMIN-1.17 — 1 step skipped as unsupported by the controller",
-            "-".repeat(70),
         ]);
+    });
+
+    it("judges each step on its own evidence, so an earlier step's checks cannot fail a later clean skip", async () => {
+        const definition: CertTestDefinition = {
+            tc: "TC-CADMIN-1.17",
+            plan: "multiplefabrics.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [
+                {
+                    number: 1,
+                    text: "Step that records evidence and passes",
+                    run: async cx => {
+                        cx.recorder.check({ type: "response", verdict: "pass", detail: "read the data version" });
+                    },
+                },
+                {
+                    number: 2,
+                    text: "Step whose first interaction is unsupported",
+                    run: async () => {
+                        throw new UnsupportedByControllerError("writeAttributes", "chip-tool");
+                    },
+                },
+            ],
+        };
+
+        const deviceLog = new LogFollower(noLines(), "device");
+        const cx: CertStepContext = {
+            controllers: {},
+            devices: { th: { ...stubCertDevice(new Promise<DeviceExitInfo>(() => {})), log: deviceLog } },
+            recorder: recordingRecorder(),
+        };
+
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
+
+        await test.invoke(stubSubject(new PicsFile([])), () => {}, [], false);
+
+        const banners = deviceLog.lines.filter(line => line.synthetic).map(line => line.text);
+        expect(banners).contain("TC-CADMIN-1.17 — Test Step 2: SKIPPED");
+    });
+
+    it("still skips, and keeps the run going, when the refusal arrives before the step recorded anything", async () => {
+        const definition: CertTestDefinition = {
+            tc: "TC-CADMIN-1.17",
+            plan: "multiplefabrics.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [
+                {
+                    number: 1,
+                    text: "Step whose first interaction is unsupported",
+                    run: async () => {
+                        throw new UnsupportedByControllerError("writeAttributes", "chip-tool");
+                    },
+                },
+                {
+                    number: 2,
+                    text: "Step that still runs",
+                    run: async cx => {
+                        cx.recorder.check({ type: "response", verdict: "pass", detail: "ran anyway" });
+                    },
+                },
+            ],
+        };
+
+        const deviceLog = new LogFollower(noLines(), "device");
+        const cx: CertStepContext = {
+            controllers: {},
+            devices: { th: { ...stubCertDevice(new Promise<DeviceExitInfo>(() => {})), log: deviceLog } },
+            recorder: recordingRecorder(),
+        };
+
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
+
+        await test.invoke(stubSubject(new PicsFile([])), () => {}, [], false);
+
+        const banners = deviceLog.lines.filter(line => line.synthetic).map(line => line.text);
+        expect(banners).contain("TC-CADMIN-1.17 — Test Step 1: SKIPPED");
+        expect(banners, "the coverage gap is still summarised").contain(
+            "TC-CADMIN-1.17 — 1 step skipped as unsupported by the controller",
+        );
+        expect(banners, "and the run continued").contain("TC-CADMIN-1.17 — Test Step 2: PASS");
     });
 
     it("injects only an end banner (SKIPPED) for a step the flavor gate skips before it starts", async () => {

--- a/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
@@ -25,7 +25,6 @@ import { registerCertCustomCluster } from "../../src/cert/custom-clusters.js";
 import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload.js";
 import { ChipToolExitError } from "../../src/chip-tool/chip-tool-client.js";
 import { FaultInjectionCluster } from "../cert/fault-injection.js";
-import { countMatches } from "../cert/tc-support.js";
 import { delay, FakeChipTool, waitFor, writeStandInBinary } from "./fake-chip-tool.js";
 
 const BASIC_INFORMATION = Matter.clusters.require("BasicInformation");
@@ -212,7 +211,7 @@ describe("ChipToolControllerAdapter", function () {
         await started.commission({ passcode: 20202021, discriminator: 3840 });
 
         await new Promise(resolve => setImmediate(resolve));
-        expect(countMatches(started.log, "chip-tool", /failed to send/, 0)).equal(0);
+        expect(started.log.count(/failed to send/, 0)).equal(0);
     });
 
     it("pairs from a QR onboarding payload, which chip-tool reads with the same command", async () => {

--- a/support/chip-testing/test/cert-framework/log-follower.test.ts
+++ b/support/chip-testing/test/cert-framework/log-follower.test.ts
@@ -393,4 +393,133 @@ describe("LogFollower", () => {
 
         await follower.close();
     });
+
+    /**
+     * A follower whose buffer holds exactly `lines`. Awaiting the last line's *index* rather than a
+     * pattern is what makes this exact: `expect` resolves on the first match, which for a repeated
+     * line is not the point at which every line has arrived.
+     */
+    async function bufferedFollower(...lines: string[]) {
+        const source = new TestSource();
+        const follower = new LogFollower(source, "test");
+        followers.push(follower);
+        for (const line of lines) {
+            source.push(line);
+        }
+        await follower.expect({ chip: /.*/ }, { flavor: "chip", timeoutMs: 2_000, from: lines.length - 1 });
+        return follower;
+    }
+
+    const followers = new Array<LogFollower>();
+    afterEach(async () => {
+        // The CI gate runs with MATTER_WTF=1, so a parked #consume left per test is a reported leak
+        while (followers.length) {
+            await followers.pop()?.close();
+        }
+    });
+
+    describe("count", () => {
+        it("counts matching lines at or after the cursor it was given", async () => {
+            const follower = await bufferedFollower("alpha", "beta", "alpha");
+
+            expect(follower.count(/alpha/, 0), "from the start").equal(2);
+            expect(follower.count(/alpha/, 1), "past the first").equal(1);
+            expect(follower.count(/gamma/, 0), "no match").equal(0);
+        });
+
+        it("skips the synthetic lines expect() skips, so a banner cannot be counted", async () => {
+            const follower = await bufferedFollower("alpha");
+            follower.annotate("alpha in a step banner");
+
+            expect(follower.count(/alpha/, 0)).equal(1);
+        });
+
+        it("does not let a caller's /g pattern skip matches through lastIndex", async () => {
+            const follower = await bufferedFollower("alpha", "alpha");
+            const global = /alpha/g;
+
+            expect(follower.count(global, 0), "first call").equal(2);
+            expect(follower.count(global, 0), "same pattern reused").equal(2);
+        });
+
+        it("clamps a negative cursor rather than counting from the end", async () => {
+            const follower = await bufferedFollower("alpha", "beta");
+
+            expect(follower.count(/alpha|beta/, -2)).equal(2);
+        });
+    });
+
+    describe("window", () => {
+        it("returns count lines from the start index, not up to it", async () => {
+            const follower = await bufferedFollower("a", "b", "c", "d");
+
+            expect(follower.window(1, 2).map(({ text }) => text)).deep.equal(["b", "c"]);
+        });
+
+        it("clamps to the buffer rather than padding", async () => {
+            const follower = await bufferedFollower("a", "b");
+
+            expect(follower.window(1, 10).map(({ text }) => text)).deep.equal(["b"]);
+            expect(
+                follower.window(-2, 1).map(({ text }) => text),
+                "negative start",
+            ).deep.equal(["a"]);
+            expect(follower.window(0, -1), "negative count").deep.equal([]);
+        });
+    });
+
+    describe("lastMatchBefore", () => {
+        it("finds the nearest preceding match, not the first, and returns its captures", async () => {
+            const follower = await bufferedFollower("trace 1", "noise", "trace 2", "dump");
+            const found = follower.lastMatchBefore(/trace (\d)/, 3, 10);
+
+            expect(found?.line.text).equal("trace 2");
+            expect(found?.match[1], "the capture the caller needs").equal("2");
+        });
+
+        it("stops at the lookback bound rather than attributing a far older line", async () => {
+            const follower = await bufferedFollower("trace 1", "a", "b", "c", "dump");
+
+            expect(follower.lastMatchBefore(/trace/, 4, 2), "within 2 lines").equal(undefined);
+            expect(follower.lastMatchBefore(/trace/, 4, 10)?.line.text, "within 10").equal("trace 1");
+        });
+
+        it("measures the bound from the buffer's end when the cursor is past it", async () => {
+            // Bounding from a raw out-of-range cursor would put the floor past every line there is
+            const follower = await bufferedFollower("trace 1", "dump");
+
+            expect(follower.lastMatchBefore(/trace/, 5_000, 10)?.line.text).equal("trace 1");
+        });
+
+        it("skips a synthetic banner sitting between the match and the cursor", async () => {
+            // The banner has to land *between* the match and the cursor: annotating after the fact
+            // puts it past the cursor, where a scanner ignoring the flag would still return the
+            // right line and the test would prove nothing
+            const source = new TestSource();
+            const follower = new LogFollower(source, "test");
+            followers.push(follower);
+            source.push("trace 1");
+            await follower.expect({ chip: /trace 1/ }, { flavor: "chip", timeoutMs: 2_000, from: 0 });
+            follower.annotate("trace 999 in a step banner");
+            source.push("dump");
+            await follower.expect({ chip: /dump/ }, { flavor: "chip", timeoutMs: 2_000, from: 2 });
+
+            expect(follower.at(1)?.synthetic, "the banner sits between them").equal(true);
+            expect(follower.lastMatchBefore(/trace/, 2, 10)?.line.text).equal("trace 1");
+        });
+
+        it("excludes the line at the cursor itself", async () => {
+            const follower = await bufferedFollower("trace 1", "trace 2");
+
+            expect(follower.lastMatchBefore(/trace/, 1, 10)?.line.text).equal("trace 1");
+        });
+
+        it("does not let a caller's /g pattern skip a match", async () => {
+            const follower = await bufferedFollower("trace 1", "dump");
+            const global = /trace/g;
+
+            expect(follower.lastMatchBefore(global, 1, 10)?.line.text, "first call").equal("trace 1");
+            expect(follower.lastMatchBefore(global, 1, 10)?.line.text, "reused").equal("trace 1");
+        });
+    });
 });

--- a/support/chip-testing/test/cert-framework/tc-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-support.test.ts
@@ -13,7 +13,6 @@ import {
     CertCleanupError,
     CommissionedRefs,
     commandPathIBSequence,
-    countMatches,
     EVENT_PATH_IBS_SEQUENCE,
     eventPathIBSequence,
     expectChunkedTransfer,
@@ -27,7 +26,6 @@ import {
     READ_REQUEST_MESSAGE,
     recordAll,
     requireId,
-    STATUS_RESPONSE_SUCCESS,
     WRITE_REQUEST_MESSAGE,
 } from "../cert/tc-support.js";
 
@@ -100,7 +98,7 @@ async function withFollower<T>(
     }
     if (drain) {
         // The follower buffers pushed lines through its own async pump; a caller that reads
-        // `.lines` synchronously (e.g. countMatches) instead of waiting via `.expect()` needs the
+        // the buffer synchronously (e.g. `count`) instead of waiting via `.expect()` needs the
         // pump to have drained them first. The pump chain is all microtasks, which the event loop
         // fully drains before running a macrotask callback, so one `setImmediate` tick suffices.
         await new Promise(resolve => setImmediate(resolve));
@@ -542,58 +540,6 @@ describe("expectCommandInvoke", () => {
         );
 
         expect(record.verdict).equal("unverified");
-    });
-});
-
-describe("countMatches", () => {
-    const SUCCESS = "[DMG] Status = 0x00 (SUCCESS),";
-
-    it("counts only lines at or after the cursor", async () => {
-        await withFollower(
-            [SUCCESS, "noise", SUCCESS],
-            follower => {
-                expect(countMatches(follower, "chip-local", STATUS_RESPONSE_SUCCESS, 0)).equal(2);
-                expect(countMatches(follower, "chip-local", STATUS_RESPONSE_SUCCESS, 1)).equal(1);
-                return Promise.resolve();
-            },
-            { drain: true },
-        );
-    });
-
-    it("returns 0 when nothing matches", async () => {
-        await withFollower(
-            ["noise", "more noise"],
-            follower => {
-                expect(countMatches(follower, "chip-local", STATUS_RESPONSE_SUCCESS, 0)).equal(0);
-                return Promise.resolve();
-            },
-            { drain: true },
-        );
-    });
-
-    it("skips synthetic lines the same way LogFollower.expect does", async () => {
-        await withFollower(
-            [SUCCESS],
-            follower => {
-                follower.annotate(SUCCESS);
-                expect(countMatches(follower, "chip-local", STATUS_RESPONSE_SUCCESS, 0)).equal(1);
-                return Promise.resolve();
-            },
-            { drain: true },
-        );
-    });
-
-    it("does not let a stateful /g pattern skip matches across repeated calls", async () => {
-        await withFollower(
-            [SUCCESS, SUCCESS, SUCCESS, SUCCESS],
-            follower => {
-                const stateful = new RegExp(STATUS_RESPONSE_SUCCESS.source, "g");
-                expect(countMatches(follower, "chip-local", stateful, 0)).equal(4);
-                expect(countMatches(follower, "chip-local", stateful, 0)).equal(4);
-                return Promise.resolve();
-            },
-            { drain: true },
-        );
     });
 });
 

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -138,7 +138,8 @@ them. A cert change therefore needs its own command:
 npm --prefix support/chip-testing run test-cert-framework -- --no-pull
 
 # one leg, for iteration
-npx matter-test esm -p support/chip-testing --spec "./test/cert-framework/*.test.ts"
+MATTER_TEST_SHUTDOWN_TIMEOUT_MS=15000 npx matter-test esm -p support/chip-testing \
+    --spec "./test/cert-framework/*.test.ts"
 ```
 
 `--prefix` rather than a `cd`, so a second command still resolves against the repository root.
@@ -148,6 +149,10 @@ flag.
 Docker is required either way, and no flag avoids it: the specs themselves use fakes, but
 `test/test.config.ts` awaits `chip.initialize()` at module scope, so every leg starts the harness
 containers before any spec runs.
+
+The second form sets `MATTER_TEST_SHUTDOWN_TIMEOUT_MS` by hand because it bypasses the npm script
+that would have set it — without it a run can end in exit 101 during normal cleanup (see
+"Resolved: exit-101 flake after decommission-of-self" below).
 
 What not to reach for: `npm test -- -p support/chip-testing` looks like the same thing and is not. The
 root script is `matter-test -w`, so `-w` arrives with it and queues web tests for a package that has

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -126,6 +126,42 @@ Two independent PICS mechanisms exist, and only one of them is live against toda
   actually does something, rather than assuming it's decorative everywhere just because it is on
   chip.
 
+## Running these tests locally
+
+The root `npm test` does **not** cover this package: `support/chip-testing/package.json` sets
+`nacho.test: false`, because the app legs need Docker and chip binaries, and the opt-out is per
+package rather than per spec. The hermetic tests under `test/cert-framework/**` are dropped with
+them. A cert change therefore needs its own command:
+
+```bash
+# what CI runs; needs a Docker that can start the harness container
+npm --prefix support/chip-testing run test-cert-framework -- --no-pull
+
+# the same specs on one leg, when that container will not start locally
+npx matter-test esm -p support/chip-testing --spec "./test/cert-framework/*.test.ts"
+```
+
+`--prefix` rather than a `cd`, so a second command still resolves against the repository root.
+`--no-pull` because `pull` defaults to true, and CI pulls the image once itself and passes the same
+flag.
+
+Neither flag makes the run independent of Docker. The specs themselves use fakes, but
+`test/test.config.ts` initializes chip state — which creates a container — before any of them run, so
+a machine whose Docker refuses that container cannot use the script form at all. The second command
+is the fallback, and is what a cert change should at minimum be gated on.
+
+What not to reach for: `npm test -- -p support/chip-testing` looks like the same thing and is not. The
+root script is `matter-test -w`, so `-w` arrives with it and queues web tests for a package that has
+none.
+
+CI runs these as the `test-cert-framework` gate that `test-cert` depends on
+(`.github/workflows/chip-cert-tests.yml`). Note what triggers that workflow: a daily schedule,
+`workflow_dispatch`, a release, and a **push** whose changed paths match its `prepare` filter (or
+whose head commit message carries `[execute-certtests]`) — there is no `pull_request` trigger, and
+`prepare` is gated on `github.repository == 'matter-js/matter.js'`. So an in-repo branch push runs
+it; a fork PR does not, and the paths filter diffs against `main` rather than the PR base. A
+root-level "suite green" says nothing about this directory either way.
+
 ## Evidence expectations
 
 Every run writes one `result.json` (`EvidenceRecorder.flush`, shape: `RunRecord` in `evidence.ts`)
@@ -884,7 +920,7 @@ design decision for the maintainer, not something to improvise from inside a ste
 
 ## Deterministic per-write report/ack evidence, not a snapshot count (`TC-IDM-4.1`)
 
-An early draft of `subscribeAndModify` took one `countMatches(STATUS_RESPONSE_SUCCESS, from)`
+An early draft of `subscribeAndModify` took one `log.count(STATUS_RESPONSE_SUCCESS, from)`
 snapshot after all of a step's writes had completed and asserted `>= values.length`. An
 independent review caught that this count is genuinely nondeterministic across otherwise-identical
 runs (it can read 2, 3, or 4 for three correct writes): whether the priming report's own ack falls

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -134,10 +134,10 @@ package rather than per spec. The hermetic tests under `test/cert-framework/**` 
 them. A cert change therefore needs its own command:
 
 ```bash
-# what CI runs; needs a Docker that can start the harness container
+# what CI runs (esm and cjs legs)
 npm --prefix support/chip-testing run test-cert-framework -- --no-pull
 
-# the same specs on one leg, when that container will not start locally
+# one leg, for iteration
 npx matter-test esm -p support/chip-testing --spec "./test/cert-framework/*.test.ts"
 ```
 
@@ -145,10 +145,9 @@ npx matter-test esm -p support/chip-testing --spec "./test/cert-framework/*.test
 `--no-pull` because `pull` defaults to true, and CI pulls the image once itself and passes the same
 flag.
 
-Neither flag makes the run independent of Docker. The specs themselves use fakes, but
-`test/test.config.ts` initializes chip state — which creates a container — before any of them run, so
-a machine whose Docker refuses that container cannot use the script form at all. The second command
-is the fallback, and is what a cert change should at minimum be gated on.
+Docker is required either way, and no flag avoids it: the specs themselves use fakes, but
+`test/test.config.ts` awaits `chip.initialize()` at module scope, so every leg starts the harness
+containers before any spec runs.
 
 What not to reach for: `npm test -- -p support/chip-testing` looks like the same thing and is not. The
 root script is `matter-test -w`, so `-w` arrives with it and queues web tests for a package that has

--- a/support/chip-testing/test/cert/tc-idm-1.3-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-1.3-support.ts
@@ -8,13 +8,7 @@ import { Duration, ImplementationError } from "@matter/main";
 import type { CheckRecord, LogFollower } from "@matter/testing";
 import { CertLogClosedError, CertLogTimeoutError } from "@matter/testing";
 import { ChipFault } from "./fault-injection.js";
-import {
-    commandPathIBSequence,
-    countMatches,
-    expectAdjacentLines,
-    expectSequence,
-    INVOKE_REQUEST_MESSAGE,
-} from "./tc-support.js";
+import { commandPathIBSequence, expectAdjacentLines, expectSequence, INVOKE_REQUEST_MESSAGE } from "./tc-support.js";
 
 /** A concrete command path of a batched invoke. */
 export interface BatchPath {
@@ -97,7 +91,7 @@ export function expectNoInjectedFault(log: LogFollower, flavor: string, from: nu
         return { type: "device-log", verdict: "unverified" };
     }
 
-    const count = countMatches(log, flavor, FAULT_INJECTED_LINE, from);
+    const count = log.count(FAULT_INJECTED_LINE, from);
     return {
         type: "device-log",
         verdict: count === 0 ? "pass" : "fail",
@@ -120,7 +114,7 @@ export function expectInvokeCount(log: LogFollower, flavor: string, from: number
         return { type: "device-log", verdict: "unverified" };
     }
 
-    const count = countMatches(log, flavor, INVOKE_REQUEST_MESSAGE, from);
+    const count = log.count(INVOKE_REQUEST_MESSAGE, from);
     return {
         type: "device-log",
         verdict: count === expected ? "pass" : "fail",
@@ -199,8 +193,7 @@ export async function expectBatchRequestPaths(
         }
 
         const commands =
-            countMatches(log, flavor, COMMAND_DATA_IB, envelope.last.index) -
-            countMatches(log, flavor, COMMAND_DATA_IB, end.matched.index);
+            log.count(COMMAND_DATA_IB, envelope.last.index) - log.count(COMMAND_DATA_IB, end.matched.index);
         if (commands !== paths.length) {
             return {
                 type: "device-log",

--- a/support/chip-testing/test/cert/tc-idm-5.1-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-5.1-support.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Duration, Millis, Seconds, Time } from "@matter/main";
+import { Duration, InternalError, Millis, Seconds, Time } from "@matter/main";
 import type { CheckRecord, LogFollower, LogLine } from "@matter/testing";
 import { CertLogClosedError, CertLogTimeoutError } from "@matter/testing";
 import { expectAdjacentLines } from "./tc-support.js";
@@ -28,6 +28,11 @@ const TIMED_REQUEST_FLAG = /timedRequest = true,\s*$/;
  * (`src/messaging/README.md`).
  */
 const RECEIPT_LINE = /\[E:(\d+[ir])[^\]]*\] \((S|U|G)\) Msg RX from/;
+
+// How far back from a message's decode dump its own receive line may sit. chip prints the two a
+// handful of lines apart; the bound is what stops a search that finds nothing nearby from
+// attributing a receipt logged minutes earlier to this message.
+const RECEIPT_LOOKBACK_LINES = 1000;
 
 /**
  * How many lines after a request message's opening brace its `timedRequest` flag may appear. chip
@@ -67,22 +72,14 @@ export interface Receipt {
     category: "S" | "U" | "G";
 }
 
-/**
- * The receive line for the message whose decode dump starts at `index`: the nearest one preceding it,
- * since chip logs one message at a time, so no other message's own receive line can land in between.
- */
-function receiptBefore(lines: readonly LogLine[], index: number): Receipt | undefined {
-    for (let i = index - 1; i >= 0; i--) {
-        const { text, synthetic } = lines[i];
-        if (synthetic) {
-            continue;
-        }
-        const match = RECEIPT_LINE.exec(text);
-        if (match !== null) {
-            return { index: i, text, exchange: match[1], category: match[2] as Receipt["category"] };
-        }
+/** The receive line for the message whose decode dump starts at `index`, as {@link LogFollower.lastMatchBefore} finds it. */
+function receiptBefore(log: LogFollower, index: number): Receipt | undefined {
+    const found = log.lastMatchBefore(RECEIPT_LINE, index, RECEIPT_LOOKBACK_LINES);
+    if (found === undefined) {
+        return undefined;
     }
-    return undefined;
+    const { line, match } = found;
+    return { index: line.index, text: line.text, exchange: match[1], category: match[2] as Receipt["category"] };
 }
 
 export interface TimedRequestLookup {
@@ -112,7 +109,7 @@ export async function expectTimedRequest(
         }
         return {
             line: result.last,
-            receipt: receiptBefore(log.lines, result.last.index),
+            receipt: receiptBefore(log, result.last.index),
             check: {
                 type: "device-log",
                 verdict: "pass",
@@ -208,15 +205,18 @@ export async function expectTimedFollowUp(
             }
             cursor = block.last.index + 1;
 
-            const lines = log.lines;
-            if (receiptBefore(lines, block.last.index)?.exchange !== receipt.exchange) {
+            if (receiptBefore(log, block.last.index)?.exchange !== receipt.exchange) {
                 continue;
             }
 
-            const messageLine = lines[block.last.index - 1];
+            // The matched block is [message, "{"], so the line before its last is the message's own
+            const messageLine = log.at(block.last.index - 1);
+            if (messageLine === undefined) {
+                throw new InternalError(`Matched a message block at line ${block.last.index} with no line before it`);
+            }
             const flagged =
-                lines
-                    .slice(block.last.index + 1, block.last.index + 1 + FLAG_WITHIN_LINES)
+                log
+                    .window(block.last.index + 1, FLAG_WITHIN_LINES)
                     .some(({ synthetic, text }) => !synthetic && TIMED_REQUEST_FLAG.test(text)) ||
                 (await waitForLaggingFlag(log, flavor, block.last.index, remaining()));
             if (flagged === "unverified") {

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -542,24 +542,6 @@ export async function expectCommandInvoke(
     };
 }
 
-// A caller-supplied /g or /y pattern keeps lastIndex between calls; reused as-is across the repeated
-// test() calls below, that state silently skips matches. Stripping once yields a pattern countMatches
-// can test() against every line safely (mirrors LogFollower.expect's own private copy of this fix).
-function matchableCopy(pattern: RegExp): RegExp {
-    return new RegExp(pattern.source, pattern.flags.replace(/[gy]/g, ""));
-}
-
-/**
- * Synchronous count of lines at or after `from` matching `pattern`, skipping
- * {@link LogLine.synthetic} lines the same way {@link LogFollower.expect} does — for a "repeat N
- * times, expect N successes" check. `flavor` is currently unused; every pattern this module exports
- * is chip-only.
- */
-export function countMatches(log: LogFollower, _flavor: string, pattern: RegExp, from: number): number {
-    const matchable = matchableCopy(pattern);
-    return log.lines.slice(from).filter(line => !line.synthetic && matchable.test(line.text)).length;
-}
-
 // How long a further report chunk may take to surface before the transfer counts as finished. The
 // read has already returned by the time a step checks, so this covers the follower's pump lag only.
 const CHUNK_QUIET = Seconds(2);
@@ -832,15 +814,7 @@ const EXCHANGE_LOOKBACK_LINES = 1000;
  * message's payload size.
  */
 function exchangeIdBefore(log: LogFollower, beforeIndex: number): string | undefined {
-    const floor = Math.max(0, beforeIndex - EXCHANGE_LOOKBACK_LINES);
-    const lines = log.lines;
-    for (let i = beforeIndex - 1; i >= floor; i--) {
-        const match = REPORT_SENT_LINE.exec(lines[i].text);
-        if (match) {
-            return match[1];
-        }
-    }
-    return undefined;
+    return log.lastMatchBefore(REPORT_SENT_LINE, beforeIndex, EXCHANGE_LOOKBACK_LINES)?.match[1];
 }
 
 /**


### PR DESCRIPTION
Three changes with one theme: the harness should not report work it did as work it skipped. None of them touch a test case's own logic.

## "skipped" has to mean "not evaluated"

A step can hit an operation the controller under test cannot perform. That was recorded as a **skipped** step whenever it happened — including after the step had already commissioned the device, opened a commissioning window, or written an attribute. Two consequences, one per reason the bundle exists:

- **Showing compliance:** the bundle called a step that *did* act "not evaluated", and every later step's result then rested on a device state nobody declared. It is not one wrong row; it is the rest of the run.
- **Catching regressions:** `skipped` is green, so a controller that regressed into refusing an operation converted real coverage into skips with nothing going red.

`UnsupportedByControllerError`'s own doc already stated the rule — *"Raise this before the operation has any observable effect… Raising it after a step already recorded evidence discards that evidence under a `skipped` verdict"*. Nothing enforced it. Now:

- A refusal arriving **before** the step recorded anything is still a skip. The run continues, and the run summary still counts it as a gap in what this run proved (that counting already existed).
- A refusal arriving **after** the step recorded evidence fails the run, naming the operation.
- A controller that cannot do something *at all* declares it in its own PICS, which skips the step before it starts and keeps the rest of the run's coverage. That already worked (`invokeBatch` is `MCORE.IDM.C.InvokeRequest.BatchCommands: 0`) and is unchanged — worth saying, because it is why the failing path should essentially never fire.

The criterion is "did the step record a check", which is this suite's own definition of having observed something: the authoring notes require a response check on essentially every step.

One existing test asserted the old behaviour and now pins the new contract, with two siblings: the honest case still skips and the run continues, and each step is judged on its **own** evidence — that last one exists because a surviving mutation showed a missing per-step reset would have wrongly failed a clean skip after any earlier step recorded anything.

## One log scanner instead of three

Scanning a device log was implemented three times:

- The helper counting matching lines was a copy of one `LogFollower` already had privately — including the fix for a caller's `/g` pattern remembering where it last matched, and including the comment saying it was a copy.
- Two more searched backwards for the line preceding a message, and had drifted apart **in opposite directions**: one stopped after a bounded distance but examined the step-banner lines the follower inserts; the other skipped banners but searched to index 0, so it could attribute a message received minutes earlier to the one being checked.

`LogFollower` now owns one bounded, banner-skipping backward search and one count. The search returns the match with the line, so a caller reading a capture group does not run its own pattern a second time without that `/g` protection. One caller was copying the whole log buffer once per iteration of a wait loop; it reads the window it needs instead. The dropped `flavor` parameter was documented as unused and had no consumer depending on it.

## A test run that omits packages says so

Running the tests from the repository root skipped two packages silently — a package can set `nacho.test: false`, and nothing reported that it had. Beyond `@matter/chip-testing`, this surfaced `@matter/integration-tests`, which I did not know was excluded.

The notice prints **before** the loop, because `TestRunner` calls `fatal()` on the first failing package and anything printed afterwards is exactly what a reader never sees. Plain text, since `--machine` output carries no ANSI, and suppressed for `inspect`/`manual` where nothing was tested at all.

## Corrections to the authoring notes

The section I added in #4285 about running these tests locally was wrong three ways, all fixed here: the workflow that gates them has **no `pull_request` trigger** (schedule / dispatch / release / **push**, path-filtered against `main`, and gated on the repository owner, so a fork PR never runs it); the framework job *does* pull the chip image and passes `--no-pull`; and `npm test -- -p support/chip-testing` inherits `-w` from the root script and queues browser tests for a package with none.

## Verification

`build-clean`, `lint`, `format-verify`, and 517 cert-framework specs pass. Five mutations, each compiled and each turning the suite red: the refusal-after-evidence rule, the check counter incrementing, the per-step reset, the backward search's bound measured from the clamped cursor, and the window's second argument being a count rather than an end index.

Two things stated rather than glossed. The prototype-loss bug this change had to avoid — spreading a class-instance recorder drops its methods — was caught by the full spec set while it was present (`recorder.flush is not a function`); two later attempts of mine to *re*-prove it by mutation were both ineffective, so that one rests on the direct evidence, not on a mutation. And single-spec mutation runs are unreliable in this package: `smoke.test.ts` alone passes even with that bug present, because its cert test needs device infrastructure and never reaches the recorder path in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
