### PR TITLE
Stop a certification cleanup failure disappearing, and make a failed log lookup impossible to ignore

### DIFF
--- a/support/chip-testing/test/cert-framework/tc-idm-5.1-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-5.1-support.test.ts
@@ -100,7 +100,8 @@ describe("expectTimedRequest", () => {
         );
 
         expect(result.check.verdict).equal("pass");
-        expect(result.line?.text).contains("TimeoutMs = 0xc8,");
+        expect(result.outcome).equal("found");
+        expect(result.outcome === "found" ? result.line.text : "").contains("TimeoutMs = 0xc8,");
     });
 
     it("fails when the device was asked for a different timeout", async () => {
@@ -109,7 +110,7 @@ describe("expectTimedRequest", () => {
         );
 
         expect(result.check.verdict).equal("fail");
-        expect(result.line).equal(undefined);
+        expect(result.outcome).equal("failed");
     });
 
     it("reports unverified for a flavor with no pattern for the message", async () => {
@@ -154,10 +155,21 @@ describe("expectUnicastReceipt", () => {
         expect(check.detail).contains("No receive line");
     });
 
-    it("reports unverified when the timed request itself was not located", () => {
-        expect(expectUnicastReceipt({ check: { type: "device-log", verdict: "unverified" } }).verdict).equal(
-            "unverified",
-        );
+    it("reports unverified for a flavor whose log names no timed request", () => {
+        expect(
+            expectUnicastReceipt({ outcome: "unnamed", check: { type: "device-log", verdict: "unverified" } }).verdict,
+        ).equal("unverified");
+    });
+
+    it("hands a failed search's own reason to the consumer, not a bare unverified", () => {
+        // Callers gate on `check` before getting here, so this is the guard for one that forgets
+        const check = expectUnicastReceipt({
+            outcome: "failed",
+            check: { type: "device-log", verdict: "fail", detail: "no TimedRequestMessage arrived" },
+        });
+
+        expect(check.verdict).equal("fail");
+        expect(check.detail).equal("no TimedRequestMessage arrived");
     });
 });
 
@@ -206,19 +218,38 @@ describe("expectTimedFollowUp", () => {
         expect(check.detail).contains("carries no timedRequest flag");
     });
 
-    it("reports unverified when the timed request itself was not located", async () => {
+    it("reports unverified for a flavor whose log names no timed request", async () => {
         const check = await withFollower([], follower =>
             expectTimedFollowUp(
                 follower,
                 "chip-local",
                 INVOKE_REQUEST_MESSAGE,
-                { check: { type: "device-log", verdict: "unverified" } },
+                { outcome: "unnamed", check: { type: "device-log", verdict: "unverified" } },
                 TIMEOUT,
                 Millis(500),
             ),
         );
 
         expect(check.verdict).equal("unverified");
+    });
+
+    it("hands a failed search's own reason to the follow-up check, not a bare unverified", async () => {
+        const check = await withFollower([], follower =>
+            expectTimedFollowUp(
+                follower,
+                "chip-local",
+                INVOKE_REQUEST_MESSAGE,
+                {
+                    outcome: "failed",
+                    check: { type: "device-log", verdict: "fail", detail: "no TimedRequestMessage arrived" },
+                },
+                TIMEOUT,
+                Millis(500),
+            ),
+        );
+
+        expect(check.verdict).equal("fail");
+        expect(check.detail).equal("no TimedRequestMessage arrived");
     });
 
     it("skips an interaction on another exchange and reports the one this request opened", async () => {

--- a/support/chip-testing/test/cert-framework/tc-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-support.test.ts
@@ -406,9 +406,18 @@ describe("expectSubscriptionId and expectReportAck against a matter.js TH", () =
         "acked: 05ab904b reqAck size: 8 payload: 1524000024ff0c18";
 
     async function ack(lines: string[], subscriptionId = 0x54c99e7e) {
-        return withFollower(lines, follower => expectReportAck(follower, "matterjs", subscriptionId, 0, Millis(200)), {
-            endSource: true,
-        });
+        return withFollower(
+            lines,
+            follower =>
+                expectReportAck(
+                    follower,
+                    "matterjs",
+                    { outcome: "found", subscriptionId, check: { type: "device-log", verdict: "pass" } },
+                    0,
+                    Millis(200),
+                ),
+            { endSource: true },
+        );
     }
 
     it("reads the id the TH minted", async () => {
@@ -416,8 +425,48 @@ describe("expectSubscriptionId and expectReportAck against a matter.js TH", () =
             expectSubscriptionId(follower, "matterjs", 0, Millis(200)),
         );
 
-        expect(lookup.subscriptionId).equal(0x54c99e7e);
+        expect(lookup.outcome).equal("found");
+        expect(lookup.outcome === "found" && lookup.subscriptionId).equal(0x54c99e7e);
         expect(lookup.check.verdict).equal("pass");
+    });
+
+    it("hands a failed lookup's own reason to the ack check, not a bare unverified", async () => {
+        // Callers gate on `check` before getting here, so this is the guard for one that forgets
+        const record = await withFollower(
+            [],
+            follower =>
+                expectReportAck(
+                    follower,
+                    "matterjs",
+                    {
+                        outcome: "failed",
+                        check: { type: "device-log", verdict: "fail", detail: "no SubscribeResponse arrived" },
+                    },
+                    0,
+                    Millis(200),
+                ),
+            { endSource: true },
+        );
+
+        expect(record.verdict).equal("fail");
+        expect(record.detail).equal("no SubscribeResponse arrived");
+    });
+
+    it("reports unverified for a flavor whose log names no subscription", async () => {
+        const record = await withFollower(
+            [],
+            follower =>
+                expectReportAck(
+                    follower,
+                    "matterjs",
+                    { outcome: "unnamed", check: { type: "device-log", verdict: "unverified" } },
+                    0,
+                    Millis(200),
+                ),
+            { endSource: true },
+        );
+
+        expect(record.verdict).equal("unverified");
     });
 
     it("passes when the DUT acked this report with Success", async () => {

--- a/support/chip-testing/test/cert/TC-IDM-4.1.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-4.1.test.ts
@@ -160,13 +160,7 @@ certTest("TC-IDM-4.1", {
             const idLookup = await expectSubscriptionId(th.log, th.flavor, established, LOG_TIMEOUT);
             record(cx, idLookup.check, "Subscription-id lookup");
 
-            const logCheck = await expectReportAck(
-                th.log,
-                th.flavor,
-                idLookup.subscriptionId,
-                established,
-                LOG_TIMEOUT,
-            );
+            const logCheck = await expectReportAck(th.log, th.flavor, idLookup, established, LOG_TIMEOUT);
             record(cx, logCheck, "Priming-report status");
         }),
         {

--- a/support/chip-testing/test/cert/TC-IDM-6.4.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-6.4.test.ts
@@ -135,7 +135,7 @@ certTest("TC-IDM-6.4", {
             const idLookup = await expectSubscriptionId(th.log, th.flavor, from, LOG_TIMEOUT);
             record(cx, idLookup.check, "SubscribeResponseMessage");
 
-            const ackCheck = await expectReportAck(th.log, th.flavor, idLookup.subscriptionId, from, LOG_TIMEOUT);
+            const ackCheck = await expectReportAck(th.log, th.flavor, idLookup, from, LOG_TIMEOUT);
             record(cx, ackCheck, "Report ack");
         }),
         { expected: "Verify that the DUT sends Status Response Action with a success Status Code." },

--- a/support/chip-testing/test/cert/TC-SC-3.5.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-3.5.test.ts
@@ -15,7 +15,7 @@ import {
 } from "@matter/testing";
 import { join } from "node:path";
 import { env } from "node:process";
-import { settleWithin } from "./tc-support.js";
+import { CertCleanupError, settleWithin } from "./tc-support.js";
 
 // setup_class's th_server_discriminator — fixed for every OpenCommissioningWindow call in the script.
 // The passcode is NOT fixed the same way: only the initial precondition commission (TH_CLIENT pairing
@@ -118,12 +118,15 @@ function manualPairingCodeHandler(state: { attempts: number }): PromptHandler {
                         detail: `commission() resolved on attempt ${attempt} (ref ${outcome.value})`,
                     });
                     if (!expectSuccess) {
-                        await dut
-                            .node(outcome.value)
-                            .decommission()
-                            .catch(e =>
-                                console.warn(`Failed to decommission unexpectedly-successful attempt ${attempt}:`, e),
-                            );
+                        try {
+                            await dut.node(outcome.value).decommission();
+                        } catch (e) {
+                            // Both: whether a fabric was left on TH_SERVER decides whether the *next*
+                            // run can be trusted, and the bundle carrying it may itself never be written
+                            const detail = `attempt ${attempt}'s fabric could not be removed, so it may remain on TH_SERVER: ${e}`;
+                            console.warn(`TC-SC-3.5: ${detail}`);
+                            cx.recorder.check({ type: "response", verdict: "fail", detail });
+                        }
                         failure = new Error(
                             `DUT commissioning unexpectedly succeeded on attempt ${attempt} against a ` +
                                 "Sigma2-fault-injected TH_SERVER, so either it accepted a corrupted Sigma2 or it " +
@@ -223,6 +226,8 @@ describe("TC-SC-3.5", () => {
         this.timeout(10 * 60_000);
 
         const state = { attempts: 0 };
+        let flushFailure: unknown;
+        let closeFailure: unknown;
         const dut = createControllerAdapter("dut");
 
         const recorder = new EvidenceRecorder(evidenceOutDir(), {
@@ -254,12 +259,34 @@ describe("TC-SC-3.5", () => {
         } finally {
             recorder.attachLog("controller-dut", dut.log.lines);
             recorder.attachLog("device-python", test.logLines);
-            await recorder.flush().catch(e => console.warn("Failed to flush TC-SC-3.5 evidence:", e));
+
+            // Warned as well as kept: the throw below is unreachable when the body itself threw, and a
+            // cleanup failure is likeliest exactly then — so the console carries it in the one case the
+            // bundle cannot.
+            try {
+                await recorder.flush();
+            } catch (e) {
+                console.warn("TC-SC-3.5 could not write its evidence bundle:", e);
+                flushFailure = e;
+            }
             try {
                 await dut.close();
             } catch (e) {
-                console.warn("Failed to close TC-SC-3.5 dut adapter:", e);
+                console.warn("TC-SC-3.5 could not close its dut adapter:", e);
+                closeFailure = e;
             }
+        }
+
+        // Reached only when the steps themselves succeeded, which is what makes these the run's own
+        // outcome. Flush first, as `cert-test.ts` orders it: a run with no bundle proves nothing, where
+        // a controller that would not close is state left for whatever runs next.
+        if (flushFailure !== undefined) {
+            throw flushFailure;
+        }
+        if (closeFailure !== undefined) {
+            throw new CertCleanupError(
+                `TC-SC-3.5's dut adapter would not close, so its fabric may remain on TH_SERVER: ${closeFailure}`,
+            );
         }
     });
 });

--- a/support/chip-testing/test/cert/tc-idm-4.1-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-4.1-support.ts
@@ -12,6 +12,7 @@ import {
     expectReportAck,
     expectSubscriptionId,
     LOG_TIMEOUT,
+    record,
     SUBSCRIBE_REQUEST_MESSAGE,
 } from "./tc-support.js";
 
@@ -140,12 +141,7 @@ export async function subscribeAndModify<Value>(
         from,
         establish,
     );
-    cx.recorder.check(subscribeCheck);
-    if (subscribeCheck.verdict === "fail") {
-        throw new CertCheckFailedError(
-            `SubscribeRequestMessage log check failed for step ${step}: ${JSON.stringify(subscribeCheck)}`,
-        );
-    }
+    record(cx, subscribeCheck, `SubscribeRequestMessage log for step ${step}`);
 
     // The follower pumps the device stream asynchronously, so a previous step's SubscribeResponse
     // can surface after this step marked — reading the id out of that one pins every later check to
@@ -153,12 +149,7 @@ export async function subscribeAndModify<Value>(
     const established = subscribeCheck.logLine !== undefined ? subscribeCheck.logLine + 1 : from;
 
     const idLookup = await expectSubscriptionId(th.log, th.flavor, established, establish);
-    cx.recorder.check(idLookup.check);
-    if (idLookup.check.verdict === "fail") {
-        throw new CertCheckFailedError(
-            `Subscription-id lookup failed for step ${step}: ${JSON.stringify(idLookup.check)}`,
-        );
-    }
+    record(cx, idLookup.check, `Subscription-id lookup for step ${step}`);
 
     // Every flavor names its subscriptions in its own log. One that does not cannot show the TH's own
     // side of what this step claims, and the controller's callbacks are no substitute for it — chip-tool
@@ -171,12 +162,7 @@ export async function subscribeAndModify<Value>(
     }
 
     const primingAckCheck = await expectReportAck(th.log, th.flavor, idLookup, established, establish);
-    cx.recorder.check(primingAckCheck);
-    if (primingAckCheck.verdict === "fail") {
-        throw new CertCheckFailedError(
-            `Priming-report status check failed for step ${step}: ${JSON.stringify(primingAckCheck)}`,
-        );
-    }
+    record(cx, primingAckCheck, `Priming-report status for step ${step}`);
 
     let ackCursor = primingAckCheck.logLine !== undefined ? primingAckCheck.logLine + 1 : th.log.mark();
     for (let i = 0; i < values.length; i++) {
@@ -192,6 +178,8 @@ export async function subscribeAndModify<Value>(
         }
 
         const ackCheck = await expectReportAck(th.log, th.flavor, idLookup, Math.max(ackCursor, writeFrom), report);
+        // Not `record()`: this demands a pass, where that lets "unverified" through. A flavor whose log
+        // cannot show the ack cannot show what this step claims, so it fails rather than proving less.
         cx.recorder.check(ackCheck);
         if (ackCheck.verdict !== "pass") {
             throw new CertCheckFailedError(

--- a/support/chip-testing/test/cert/tc-idm-4.1-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-4.1-support.ts
@@ -163,14 +163,14 @@ export async function subscribeAndModify<Value>(
     // Every flavor names its subscriptions in its own log. One that does not cannot show the TH's own
     // side of what this step claims, and the controller's callbacks are no substitute for it — chip-tool
     // drops reports its device coalesced (see AGENTS.md) — so the step says so rather than proving less.
-    if (idLookup.subscriptionId === undefined) {
+    if (idLookup.outcome !== "found") {
         throw new CertCheckFailedError(
             `Step ${step} cannot read a subscription id from a ${th.flavor} TH's log, so the reports this step ` +
-                "writes for cannot be attributed to its own subscription",
+                `writes for cannot be attributed to its own subscription: ${JSON.stringify(idLookup.check)}`,
         );
     }
 
-    const primingAckCheck = await expectReportAck(th.log, th.flavor, idLookup.subscriptionId, established, establish);
+    const primingAckCheck = await expectReportAck(th.log, th.flavor, idLookup, established, establish);
     cx.recorder.check(primingAckCheck);
     if (primingAckCheck.verdict === "fail") {
         throw new CertCheckFailedError(
@@ -191,13 +191,7 @@ export async function subscribeAndModify<Value>(
             throw e;
         }
 
-        const ackCheck = await expectReportAck(
-            th.log,
-            th.flavor,
-            idLookup.subscriptionId,
-            Math.max(ackCursor, writeFrom),
-            report,
-        );
+        const ackCheck = await expectReportAck(th.log, th.flavor, idLookup, Math.max(ackCursor, writeFrom), report);
         cx.recorder.check(ackCheck);
         if (ackCheck.verdict !== "pass") {
             throw new CertCheckFailedError(
@@ -240,7 +234,7 @@ export async function subscribeAndModify<Value>(
         });
     }
 
-    const idText = idLookup.subscriptionId === undefined ? "(none)" : `0x${idLookup.subscriptionId.toString(16)}`;
+    const idText = `0x${idLookup.subscriptionId.toString(16)}`;
     cx.recorder.check({
         type: "response",
         verdict: "pass",

--- a/support/chip-testing/test/cert/tc-idm-5.1-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-5.1-support.ts
@@ -82,13 +82,19 @@ function receiptBefore(log: LogFollower, index: number): Receipt | undefined {
     return { index: line.index, text: line.text, exchange: match[1], category: match[2] as Receipt["category"] };
 }
 
-export interface TimedRequestLookup {
-    check: CheckRecord;
-    /** Absent when the lookup failed, and for the matterjs flavor. */
-    line?: LogLine;
-    /** Absent when the lookup failed, and when the log carries no receive line for the message. */
-    receipt?: Receipt;
-}
+/**
+ * What looking for a `TimedRequestMessage` produced, as three outcomes rather than one optional line —
+ * `SubscriptionIdLookup` keeps its own the same way, and for the same reason. Unlike that one,
+ * `unnamed` here is reachable: this search asks for a chip pattern whatever the flavor, so a matterjs
+ * TH produces it.
+ */
+export type TimedRequestLookup =
+    /** The message was found; `receipt` is absent when no receive line precedes it, which is a failure. */
+    | { outcome: "found"; line: LogLine; receipt?: Receipt; check: CheckRecord }
+    /** This flavor's log names no timed request (see AGENTS.md's flavor-pattern policy). */
+    | { outcome: "unnamed"; check: CheckRecord }
+    /** The search itself failed; `check` carries why. */
+    | { outcome: "failed"; check: CheckRecord };
 
 /**
  * Confirms the device received a `TimedRequestMessage` asking for `timeout` at or after `from`, and
@@ -105,9 +111,10 @@ export async function expectTimedRequest(
     try {
         const result = await expectAdjacentLines(log, flavor, timedRequestSequence(timeout), from, wait);
         if (result.verdict === "unverified") {
-            return { check: { type: "device-log", verdict: "unverified" } };
+            return { outcome: "unnamed", check: { type: "device-log", verdict: "unverified" } };
         }
         return {
+            outcome: "found",
             line: result.last,
             receipt: receiptBefore(log, result.last.index),
             check: {
@@ -120,7 +127,10 @@ export async function expectTimedRequest(
         };
     } catch (e) {
         if (e instanceof CertLogTimeoutError || e instanceof CertLogClosedError) {
-            return { check: { type: "device-log", verdict: "fail", pattern, detail: e.message, logLine: from } };
+            return {
+                outcome: "failed",
+                check: { type: "device-log", verdict: "fail", pattern, detail: e.message, logLine: from },
+            };
         }
         throw e;
     }
@@ -128,8 +138,10 @@ export async function expectTimedRequest(
 
 /** Confirms the session the timed request arrived on was unicast. */
 export function expectUnicastReceipt(timed: TimedRequestLookup): CheckRecord {
-    if (timed.line === undefined) {
-        return { type: "device-log", verdict: "unverified" };
+    // A failed search keeps its own reason rather than arriving here as an unverified. Callers gate
+    // on `check` first, so this is the second line of defence.
+    if (timed.outcome !== "found") {
+        return timed.check;
     }
 
     const { receipt } = timed;
@@ -177,10 +189,10 @@ export async function expectTimedFollowUp(
     budget: Duration,
     wait: Duration,
 ): Promise<CheckRecord> {
-    const { line: timedLine, receipt } = timed;
-    if (timedLine === undefined) {
-        return { type: "device-log", verdict: "unverified" };
+    if (timed.outcome !== "found") {
+        return timed.check;
     }
+    const { line: timedLine, receipt } = timed;
 
     const pattern = `${message.source} with ${TIMED_REQUEST_FLAG.source} within ${budget}ms`;
     if (receipt === undefined) {

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -660,7 +660,7 @@ export async function expectChunkedTransfer(
 
 /**
  * What reading a subscription id off a TH's log produced, as three outcomes rather than one optional
- * field. Every caller today records `check` through {@link record} first, so a failed lookup fails the
+ * field. Every caller gates on `check` before using the result, so a failed lookup already fails the
  * step before any consumer sees it; the union is what keeps that true if one ever forgets, since a
  * consumer cannot then treat a failure as a flavor that had nothing to say.
  */

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -658,12 +658,22 @@ export async function expectChunkedTransfer(
     };
 }
 
-/** What the TH's own SubscribeResponse says about the subscription a step just established. */
-export interface SubscriptionIdLookup {
-    check: CheckRecord;
-    /** Absent when the lookup failed, or for a flavor whose log names no subscription. */
-    subscriptionId?: number;
-}
+/**
+ * What reading a subscription id off a TH's log produced, as three outcomes rather than one optional
+ * field. Every caller today records `check` through {@link record} first, so a failed lookup fails the
+ * step before any consumer sees it; the union is what keeps that true if one ever forgets, since a
+ * consumer cannot then treat a failure as a flavor that had nothing to say.
+ */
+export type SubscriptionIdLookup =
+    /** The TH named it. */
+    | { outcome: "found"; subscriptionId: number; check: CheckRecord }
+    /**
+     * No pattern for this flavor. Unreachable while the flavors are chip and matterjs — both name
+     * their subscriptions — and the handling exists for a flavor added without a pattern.
+     */
+    | { outcome: "unnamed"; check: CheckRecord }
+    /** The lookup itself failed; `check` carries why. */
+    | { outcome: "failed"; check: CheckRecord };
 
 async function matterjsSubscriptionId(
     log: LogFollower,
@@ -677,17 +687,21 @@ async function matterjsSubscriptionId(
         response = await log.expect({ matterjs: MATTERJS_SUBSCRIBE_RESPONSE }, { flavor, timeoutMs: timeout, from });
     } catch (e) {
         if (e instanceof CertLogTimeoutError || e instanceof CertLogClosedError) {
-            return { check: { type: "device-log", verdict: "fail", pattern, detail: e.message, logLine: from } };
+            return {
+                outcome: "failed",
+                check: { type: "device-log", verdict: "fail", pattern, detail: e.message, logLine: from },
+            };
         }
         throw e;
     }
     if (response.verdict === "unverified") {
-        return { check: { type: "device-log", verdict: "unverified" } };
+        return { outcome: "unnamed", check: { type: "device-log", verdict: "unverified" } };
     }
 
     const id = MATTERJS_SUBSCRIBE_RESPONSE.exec(response.matched.text)?.[1];
     if (id === undefined) {
         return {
+            outcome: "failed",
             check: {
                 type: "device-log",
                 verdict: "fail",
@@ -699,6 +713,7 @@ async function matterjsSubscriptionId(
     }
 
     return {
+        outcome: "found",
         subscriptionId: parseInt(id, 16),
         check: {
             type: "device-log",
@@ -731,12 +746,13 @@ export async function expectSubscriptionId(
     try {
         const result = await expectAdjacentLines(log, flavor, sequence, from, timeout);
         if (result.verdict === "unverified") {
-            return { check: { type: "device-log", verdict: "unverified" } };
+            return { outcome: "unnamed", check: { type: "device-log", verdict: "unverified" } };
         }
 
         const id = SUBSCRIPTION_ID_LINE.exec(result.last.text)?.[1];
         if (id === undefined) {
             return {
+                outcome: "failed",
                 check: {
                     type: "device-log",
                     verdict: "fail",
@@ -748,6 +764,7 @@ export async function expectSubscriptionId(
         }
 
         return {
+            outcome: "found",
             subscriptionId: parseInt(id, 16),
             check: {
                 type: "device-log",
@@ -760,6 +777,7 @@ export async function expectSubscriptionId(
     } catch (e) {
         if (e instanceof CertLogTimeoutError || e instanceof CertLogClosedError) {
             return {
+                outcome: "failed",
                 check: {
                     type: "device-log",
                     verdict: "fail",
@@ -904,13 +922,16 @@ async function matterjsReportAck(
 export async function expectReportAck(
     log: LogFollower,
     flavor: string,
-    subscriptionId: number | undefined,
+    subscription: SubscriptionIdLookup,
     from: number,
     timeout: Duration,
 ): Promise<CheckRecord> {
-    if (subscriptionId === undefined) {
-        return { type: "device-log", verdict: "unverified" };
+    // Takes the lookup rather than its id so a failure cannot arrive here as an unverified nobody can
+    // explain. Callers gate on `check` first, so this is the second line of defence, not the first.
+    if (subscription.outcome !== "found") {
+        return subscription.check;
     }
+    const { subscriptionId } = subscription;
 
     if (flavor === "matterjs") {
         return matterjsReportAck(log, flavor, subscriptionId, from, timeout);


### PR DESCRIPTION
Two changes. They are not of equal weight, and the second is smaller than it looks — see below.

## A cleanup failure no longer disappears

TC-SC-3.5 ends by writing its evidence bundle and closing its controller. Both failures were a `console.warn` and nothing else, so a run whose bundle was never written reported the same pass as one whose bundle is complete, and a controller that would not close — leaving a fabric on TH_SERVER for whatever runs next — did too.

Both now fail the test, with the precedence the framework already keeps: only when the steps themselves passed, because a step failure is what explains the run. That has a consequence worth stating, since an earlier revision of this branch got it wrong: when the body throws, the check after `try/finally` is unreachable, and that is exactly when cleanup is most likely to fail as well. So both failures are **also** still written to the console — dropping the warns, as that revision did, was a strict regression on the path that matters most.

The two are kept apart the way `cert-test.ts` keeps them: a bundle that could not be written is the run's own failure and is rethrown as it arrived; a controller that would not close is `CertCleanupError`, the type whose doc describes exactly that. The same reasoning applies to the fabric of a commissioning that unexpectedly succeeded — whether it could be removed decides whether the next run can be trusted, so it now goes to the console as well as into the bundle that may never be written.

## A failed log lookup is no longer shaped like a lookup with nothing to say

`SubscriptionIdLookup` and `TimedRequestLookup` each reported three outcomes through one optional field: the TH named it, this flavor's log names none, and the search failed. A consumer could not distinguish the last two, and a failed search's reason was discarded on the way. Both are discriminated unions now, and `expectReportAck` / `expectUnicastReceipt` / `expectTimedFollowUp` take the whole lookup rather than a field off it, so a failure's own check reaches the step.

**What this is worth, stated plainly:** every caller already runs `record(cx, lookup.check, …)` before the consumer, and `record()` throws on a `"fail"` verdict — so a failed lookup never reached a consumer, and no certification run was reporting a wrong verdict because of this. An earlier version of this description claimed otherwise; a review traced the call sites and showed the claim was false. The union is type hardening: it keeps the property true if a future caller forgets to gate, and it lets one caller drop a third error path it had hand-written to work around the ambiguity. `unnamed` is unreachable for the subscription lookup while the flavors are chip and matterjs (both name their subscriptions) and the doc says so; it is genuinely reachable for the timed-request one, which asks for a chip pattern whatever the flavor.

## Verification

`build-clean`, `lint`, `format-verify`, and the package's own `test-cert-framework` script: **ESM 521/521**, no crash.

Three mutations, each compiled and each turning the suite red — one per consumer returning a bare `unverified` instead of the failed lookup's own check. A fourth (treating a found lookup as not found) will not compile, because the narrowing removes the field it would need; that is the union working, and it is not counted as a kill.

**TC-SC-3.5's own cleanup path is not unit-tested.** The test is gated on the python harness binary and skips locally, and its `finally` cannot be exercised without extracting it into an exported helper purely for testability. Verified by reading; the cert matrix leg is what runs it. A mutation confirming this — reverting the throw — survives for that reason, and is reported rather than hidden.

## Unrelated, found while gating

Two `matter-test -p support/chip-testing` runs cannot share a machine: the harness containers are named (`matter.js-chip`), not per-run, so a second run recreates the container the first is still waiting on and that wait rejects with SIGKILL, surfacing as `✗ Test suite crash → Process exited with error code 137` with no spec having failed. Container memory was 5 MiB of 7.7 GiB, so it is not the memory pressure I had assumed when I filed this earlier. Not addressed here; naming the containers per run would turn a sibling-kill into a clear error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
