### PR TITLE
test(chip-testing): certification checks that pass only when they proved something (TC-DD-3.17, TC-DD-3.14, TC-IDM-2.1)

### DIFF
--- a/packages/testing/src/chip/cert/controller-adapter.ts
+++ b/packages/testing/src/chip/cert/controller-adapter.ts
@@ -269,6 +269,9 @@ export interface CertNodeApi {
      * A step needing the data versions of two clusters (TC-IDM-3.1 step 15) must obtain them from a
      * single `ReadRequest`, which is what the plan's procedure describes; issuing one read per cluster
      * would exercise a different interaction.
+     *
+     * A concrete path the device answers with a status **rejects**, matching {@link readAttribute}; a
+     * wildcard path's statuses are per-item results of the expansion and are dropped.
      */
     readAttributes(paths: AttributePathSpec[], options?: ReadAttributeOptions): Promise<AttributeReadEntry[]>;
     writeAttribute(path: AttributePathSpec, value: unknown, options?: TimedInteractionOptions): Promise<void>;

--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -579,6 +579,28 @@ function statusFor(statuses: ChipPathStatus[], path: { endpoint?: number; cluste
     );
 }
 
+/**
+ * {@link statusFor} for the concrete attribute paths of a request. A status on one of those is that
+ * path's read having failed, where a wildcard path's statuses are per-item results of the expansion.
+ */
+function attributeStatusFor(statuses: ChipPathStatus[], paths: AttributePathSpec[]) {
+    for (const path of paths) {
+        if (path.endpoint === undefined || path.cluster === undefined || path.attribute === undefined) {
+            continue;
+        }
+        const status = statuses.find(
+            entry =>
+                entry.endpoint === path.endpoint &&
+                entry.cluster === path.cluster &&
+                entry.attribute === path.attribute,
+        );
+        if (status !== undefined) {
+            return { path, status };
+        }
+    }
+    return undefined;
+}
+
 /** {@link statusFor} for the concrete event paths of a request; a wildcard path's statuses are per-item. */
 function eventStatusFor(statuses: ChipPathStatus[], paths: EventPathSpec[]) {
     for (const path of paths) {
@@ -779,6 +801,16 @@ class ChipToolCertNodeApi implements CertNodeApi {
 
         const reply = await this.#read(paths, options);
         assertNoFailure(reply, `read ${JSON.stringify(paths)}`);
+
+        const refused = attributeStatusFor(reply.statuses, paths);
+        if (refused !== undefined) {
+            throw new StatusResponseError(
+                `readAttributes ${JSON.stringify(refused.path)} failed`,
+                codeOf(refused.status.status, "readAttributes"),
+                refused.status.clusterStatus,
+            );
+        }
+
         return toReadEntries(reply.values);
     }
 

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -204,11 +204,44 @@ function eventFiltersFor(options?: ReadEventOptions) {
 }
 
 /**
+ * A concrete path the device answered with a status is a failed read of that path, the same way
+ * {@link CertNodeApi.readAttribute}'s is: the step asked for that attribute and got none, so reporting
+ * the read as successful would have it read as "the device has no value for it".
+ *
+ * A wildcard path's statuses are per-item results of the expansion instead (UNSUPPORTED_ATTRIBUTE for
+ * a path the expansion reached but that does not apply there), so those are dropped.
+ */
+function assertNoConcreteAttributeStatus(
+    paths: AttributePathSpec[],
+    statuses: ReadResult.AttributeStatus[],
+    operation: string,
+) {
+    for (const status of statuses) {
+        const { endpointId, clusterId, attributeId } = status.path;
+        const requested = paths.some(
+            path =>
+                isConcretePath(path) &&
+                path.endpoint === endpointId &&
+                path.cluster === clusterId &&
+                path.attribute === attributeId,
+        );
+        if (requested) {
+            throw new StatusResponseError(
+                `${operation} ${JSON.stringify({ endpoint: endpointId, cluster: clusterId, attribute: attributeId })} failed`,
+                status.status,
+                status.clusterStatus,
+            );
+        }
+    }
+}
+
+/**
  * A status for a path the step named concretely means it will never see that event; per-path statuses
  * of a wildcard expansion are results of the expansion instead (see {@link CertNodeApi.readEvents}).
  *
- * Reads only. A subscription the device refuses is already rejected by the interaction itself, before
- * its priming report reaches us.
+ * A subscribe whose every path the device refuses is rejected by the interaction itself, but one that
+ * also carries a path the device serves is established, and only the priming report's status says the
+ * other path went unanswered.
  */
 function assertNoConcreteEventStatus(paths: EventPathSpec[], statuses: ReadResult.EventStatus[], operation: string) {
     for (const status of statuses) {
@@ -482,6 +515,7 @@ class InProcessCertNodeApi implements CertNodeApi {
                 throw new ImplementationError("readAttributes requires at least one path");
             }
             const values = new Array<ReadResult.AttributeValue>();
+            const statuses = new Array<ReadResult.AttributeStatus>();
             const request: ClientRead = {
                 ...Read({ attributes: paths.map(toIds), fabricFilter: options?.fabricFiltered }),
                 includeKnownVersions: true,
@@ -490,9 +524,12 @@ class InProcessCertNodeApi implements CertNodeApi {
                 for await (const report of chunk) {
                     if (report.kind === "attr-value") {
                         values.push(report);
+                    } else if (report.kind === "attr-status") {
+                        statuses.push(report);
                     }
                 }
             }
+            assertNoConcreteAttributeStatus(paths, statuses, "readAttributes");
             return toWireValues(values);
         });
     }
@@ -613,7 +650,11 @@ class InProcessCertNodeApi implements CertNodeApi {
                 throw new ImplementationError("subscribeEvents requires at least one path");
             }
             const seed = new Array<ReadResult.EventValue>();
-            let seeding = true;
+            const seedStatuses = new Array<ReadResult.EventStatus>();
+            // A subscription this rejects stays established on the device and nothing here can revoke
+            // it; dropping its reports is what keeps them away from the `onUpdate` of a step that has
+            // already failed on the rejection, which is what the chip-tool adapter does too.
+            let phase: "seeding" | "live" | "refused" = "seeding";
             const request = Subscribe({
                 events: paths.map(toEventIds),
                 eventFilters: eventFiltersFor(opts),
@@ -625,10 +666,19 @@ class InProcessCertNodeApi implements CertNodeApi {
             request.updated = async data => {
                 for await (const chunk of data) {
                     for await (const report of chunk) {
+                        if (phase === "refused") {
+                            continue;
+                        }
+                        if (report.kind === "event-status") {
+                            if (phase === "seeding") {
+                                seedStatuses.push(report);
+                            }
+                            continue;
+                        }
                         if (report.kind !== "event-value") {
                             continue;
                         }
-                        if (seeding) {
+                        if (phase === "seeding") {
                             seed.push(report);
                         } else {
                             opts.onUpdate?.(toWireEvents([report])[0]);
@@ -637,7 +687,13 @@ class InProcessCertNodeApi implements CertNodeApi {
                 }
             };
             await this.#peer.interaction.subscribe(request);
-            seeding = false;
+            try {
+                assertNoConcreteEventStatus(paths, seedStatuses, "subscribeEvents");
+            } catch (e) {
+                phase = "refused";
+                throw e;
+            }
+            phase = "live";
             return toWireEvents(seed);
         });
     }

--- a/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
@@ -608,6 +608,65 @@ describe("ChipToolControllerAdapter", function () {
         expect(fake.commands).deep.equal([`any read-by-id 0x28,0x8 0x5,0x11 ${ref} 0,1`]);
     });
 
+    it("rejects a multi-path read whose concrete path chip-tool answered with a status", async () => {
+        const { node } = await commissioned();
+
+        fake.reply = () => ({
+            results: [
+                {
+                    clusterId: BASIC_INFORMATION.id,
+                    endpointId: 0,
+                    attributeId: requireId(NODE_LABEL.id, "nodeLabel"),
+                    dataVersion: 11,
+                    value: "a-label",
+                },
+                {
+                    clusterId: LEVEL_CONTROL.id,
+                    endpointId: 1,
+                    attributeId: requireId(ON_LEVEL.id, "onLevel"),
+                    error: Status.UnsupportedAttribute,
+                },
+            ],
+            status: 1,
+        });
+
+        const rejection = await rejectionOf(
+            node.readAttributes([
+                { endpoint: 0, cluster: BASIC_INFORMATION.id, attribute: NODE_LABEL.id },
+                { endpoint: 1, cluster: LEVEL_CONTROL.id, attribute: ON_LEVEL.id },
+            ]),
+        );
+        expect(rejection).instanceOf(StatusResponseError);
+        expect(StatusResponseError.of(rejection)?.code).equal(Status.UnsupportedAttribute);
+    });
+
+    it("reads a wildcard path's own status as a per-item result of the expansion", async () => {
+        const { node } = await commissioned();
+
+        fake.reply = () => ({
+            results: [
+                {
+                    clusterId: LEVEL_CONTROL.id,
+                    endpointId: 2,
+                    attributeId: requireId(ON_LEVEL.id, "onLevel"),
+                    error: Status.UnsupportedAttribute,
+                },
+                {
+                    clusterId: LEVEL_CONTROL.id,
+                    endpointId: 1,
+                    attributeId: requireId(ON_LEVEL.id, "onLevel"),
+                    dataVersion: 12,
+                    value: 3,
+                },
+            ],
+            status: 1,
+        });
+
+        expect(await node.readAttributes([{ cluster: LEVEL_CONTROL.id, attribute: ON_LEVEL.id }])).deep.equal([
+            { endpoint: 1, cluster: LEVEL_CONTROL.id, attribute: ON_LEVEL.id, value: 3, version: 12 },
+        ]);
+    });
+
     it("reports a read of more paths than chip-tool accepts as unsupported, without issuing it", async () => {
         const { node } = await commissioned();
 

--- a/support/chip-testing/test/cert-framework/controller-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/controller-adapter.test.ts
@@ -393,6 +393,53 @@ describe("InProcessControllerAdapter", () => {
         await node.decommission();
     });
 
+    it("rejects a multi-path read whose concrete path the device refused", async function () {
+        this.timeout(30_000);
+
+        const ref = await adapter.commission({ passcode: 20202021, discriminator: 3840 });
+        const node = adapter.node(ref);
+
+        // The first path the device answers, so the read as a whole succeeds and only this one's status
+        // says the second went unanswered — endpoint 1 has no BasicInformation
+        const rejection = await rejectionOf(
+            node.readAttributes([
+                { endpoint: 1, cluster: ON_OFF.id, attribute: ON_OFF_ATTRIBUTE.id },
+                { endpoint: 1, cluster: BASIC_INFORMATION.id, attribute: VENDOR_ID_ATTRIBUTE.id },
+            ]),
+        );
+        expect(rejection).to.be.instanceOf(StatusResponseError);
+        expect(StatusResponseError.of(rejection)?.code).equal(Status.UnsupportedCluster);
+
+        await node.decommission();
+    });
+
+    it("rejects a multi-path event subscribe whose concrete path the device refused", async function () {
+        this.timeout(30_000);
+
+        const ref = await adapter.commission({ passcode: 20202021, discriminator: 3840 });
+        const node = adapter.node(ref);
+
+        // The subscription the device did establish cannot be revoked, so its reports must not reach the
+        // step that already failed on this rejection — which is what chip-tool does as well
+        const updates = new Array<EventReadEntry>();
+        const rejection = await rejectionOf(
+            node.subscribeEvents(
+                [
+                    { endpoint: 1, cluster: BOOLEAN_STATE.id, event: STATE_CHANGE_EVENT.id },
+                    { endpoint: 1, cluster: BASIC_INFORMATION.id, event: START_UP_EVENT.id },
+                ],
+                { minIntervalFloorSeconds: 0, maxIntervalCeilingSeconds: 10, onUpdate: event => updates.push(event) },
+            ),
+        );
+        expect(rejection).to.be.instanceOf(StatusResponseError);
+
+        await device.backchannel({ name: "setBooleanState", endpointId: 1, newState: true });
+        await new Promise(resolve => setTimeout(resolve, 1_000));
+        expect(updates).to.be.empty;
+
+        await node.decommission();
+    });
+
     it("rejects a concrete-path event subscribe the device refused", async function () {
         this.timeout(30_000);
 

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -4,7 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ImplementationError, InternalError, Millis, UnexpectedDataError } from "@matter/main";
+import {
+    DiscoveryAggregateError,
+    DiscoveryError,
+    ImplementationError,
+    InternalError,
+    Millis,
+    UnexpectedDataError,
+} from "@matter/main";
 import type { CertNodeApi, CertNodeRef, CertStepContext, CheckRecord, ControllerAdapter } from "@matter/testing";
 import { LogFollower } from "@matter/testing";
 import { expect } from "chai";
@@ -21,6 +28,7 @@ import {
     qrPayloadFields,
     qrPayloadWith,
     qrPayloadWithPrefix,
+    recordDiscoveryCapabilityAbsent,
     recordGeneratedManualCode,
     recordGeneratedPayload,
     recordVendorOutcome,
@@ -104,6 +112,13 @@ describe("qrPayloadWithPrefix", () => {
     });
 });
 
+/** What each context recorded, for a test judging the evidence rather than only the outcome. */
+const recordedChecks = new WeakMap<CertStepContext, CheckRecord[]>();
+
+function checksOf(cx: CertStepContext): CheckRecord[] {
+    return recordedChecks.get(cx) ?? [];
+}
+
 /** A step context whose DUT controller answers commissioning as the test says, and nothing else. */
 function contextWith(
     commission: () => Promise<CertNodeRef>,
@@ -139,12 +154,15 @@ function contextWith(
         node: nodeFor,
     } satisfies ControllerAdapter;
 
-    return {
+    const checks = new Array<CheckRecord>();
+    const cx: CertStepContext = {
         controllers: { dut },
         devices: {},
         recorder: {
             beginStep() {},
-            check() {},
+            check(record) {
+                checks.push(record);
+            },
             endStep() {
                 return [];
             },
@@ -153,6 +171,9 @@ function contextWith(
             },
         },
     };
+    recordedChecks.set(cx, checks);
+
+    return cx;
 }
 
 describe("CommissioningRefusals", () => {
@@ -284,22 +305,91 @@ describe("CommissioningRefusals", () => {
     });
 });
 
+describe("recordDiscoveryCapabilityAbsent", () => {
+    /** A DUT that reads a payload the way both real controllers do. */
+    function contextWithParser(): CertStepContext {
+        const cx = contextWith(() => Promise.reject(new InternalError("not used by these tests")));
+        cx.controllers.dut.parseQrPayload = async payload => {
+            const { version, vendorId, productId, flowType, discoveryCapabilities, discriminator, passcode } =
+                qrPayloadFields(payload);
+            return { version, vendorId, productId, flowType, discoveryCapabilities, discriminator, passcode };
+        };
+        return cx;
+    }
+
+    // chip-all-clusters-app's own payload, whose bitmask is BLE alone — the plan's own example payload
+    // is already OnNetwork-only, so substituting the capabilities into it changes nothing and the check
+    // would hold however the field were compared
+    const BLE_PAYLOAD = "MT:-24J042C00KA0648G00";
+
+    it("passes for a payload that changed nothing but the capabilities", async () => {
+        const cx = contextWithParser();
+
+        await recordDiscoveryCapabilityAbsent(
+            cx,
+            qrPayloadWith(BLE_PAYLOAD, { discoveryCapabilities: ON_NETWORK_ONLY }),
+            "ble",
+            "no BLE",
+            BLE_PAYLOAD,
+        );
+
+        expect(checksOf(cx).map(({ verdict }) => verdict)).deep.equal(["pass", "pass"]);
+    });
+
+    it("fails when the derivation moved a field the plan told it to keep", async () => {
+        const cx = contextWithParser();
+
+        await expect(
+            recordDiscoveryCapabilityAbsent(
+                cx,
+                qrPayloadWith(BLE_PAYLOAD, { discoveryCapabilities: ON_NETWORK_ONLY, passcode: 12345678 }),
+                "ble",
+                "no BLE",
+                BLE_PAYLOAD,
+            ),
+        ).rejectedWith(CertCheckFailedError, /passcode=20202021/);
+    });
+
+    it("fails when the payload still offers the capability", async () => {
+        const cx = contextWithParser();
+
+        await expect(recordDiscoveryCapabilityAbsent(cx, BLE_PAYLOAD, "ble", "no BLE", BLE_PAYLOAD)).rejectedWith(
+            CertCheckFailedError,
+            /ble is offered/,
+        );
+    });
+});
+
 describe("recordVendorOutcome", () => {
     const CODE = "34970112332";
+    const IDS = { vendorId: 0xfff2, thVendorId: 0xfff1 };
+    const BUDGET = { refusalTimeout: Millis(50), settleTimeout: Millis(50) };
+
+    /** The advertisement check the real helper makes, which these tests have no mDNS to answer. */
+    const observed = async () => {};
 
     it("fails, and leaves cleanup owning the attempt, when the DUT neither onboards nor gives up", async () => {
-        const refusals = new CommissioningRefusals({ refusalTimeout: Millis(50), settleTimeout: Millis(50) });
+        const refusals = new CommissioningRefusals(BUDGET);
         const cx = contextWith(() => new Promise<CertNodeRef>(() => {}));
 
         await expect(
-            recordVendorOutcome(cx, CODE, new CommissionedRefs(), refusals, "vendor outcome", Millis(50)),
+            recordVendorOutcome(
+                cx,
+                CODE,
+                new CommissionedRefs(),
+                refusals,
+                "vendor outcome",
+                Millis(50),
+                IDS,
+                observed,
+            ),
         ).rejectedWith(/neither onboarded the TH nor gave up/);
 
         await expect(refusals.settle(cx)).rejectedWith(/still running/);
     });
 
     it("records the DUT onboarding the TH, leaving the fabric to the step that owns it", async () => {
-        const refusals = new CommissioningRefusals({ refusalTimeout: Millis(50), settleTimeout: Millis(50) });
+        const refusals = new CommissioningRefusals(BUDGET);
         const decommissioned = new Array<CertNodeRef>();
         const cx = contextWith(
             async () => "peer1" as CertNodeRef,
@@ -309,7 +399,7 @@ describe("recordVendorOutcome", () => {
         );
         const commissioned = new CommissionedRefs();
 
-        await recordVendorOutcome(cx, CODE, commissioned, refusals, "vendor outcome", Millis(50));
+        await recordVendorOutcome(cx, CODE, commissioned, refusals, "vendor outcome", Millis(50), IDS, observed);
 
         expect(commissioned.get("dut")).equal("peer1");
 
@@ -319,16 +409,153 @@ describe("recordVendorOutcome", () => {
         expect(decommissioned).deep.equal([]);
     });
 
-    it("records the DUT terminating commissioning", async () => {
-        const refusals = new CommissioningRefusals({ refusalTimeout: Millis(50), settleTimeout: Millis(50) });
+    it("records the DUT giving up on the code, and which vendor id the code named", async () => {
+        const refusals = new CommissioningRefusals(BUDGET);
         const cx = contextWith(async () => {
-            throw new InternalError("code names a vendor this network does not carry");
+            throw new DiscoveryError("No commissionable device was discovered");
         });
         const commissioned = new CommissionedRefs();
 
-        await recordVendorOutcome(cx, CODE, commissioned, refusals, "vendor outcome", Millis(50));
+        await recordVendorOutcome(cx, CODE, commissioned, refusals, "vendor outcome", Millis(50), IDS, observed);
 
         expect(commissioned.get("dut")).equal(undefined);
+        const detail = checksOf(cx).at(-1)?.detail ?? "";
+        expect(detail).contains("DUT terminated commissioning");
+        expect(detail).contains("the code names vendor 0xfff2 where the TH's own payload names 0xfff1");
+        await refusals.settle(cx);
+    });
+
+    it("accepts a give-up that tried a candidate and failed on it", async () => {
+        const refusals = new CommissioningRefusals(BUDGET);
+        const cx = contextWith(async () => {
+            throw new DiscoveryAggregateError(
+                [new UnexpectedDataError("PASE failed for a candidate that matched the short discriminator")],
+                "discovery of node with discriminator 15 failed",
+            );
+        });
+
+        await recordVendorOutcome(
+            cx,
+            CODE,
+            new CommissionedRefs(),
+            refusals,
+            "vendor outcome",
+            Millis(50),
+            IDS,
+            observed,
+        );
+
+        expect(checksOf(cx).at(-1)?.detail).contains("DUT terminated commissioning");
+        await refusals.settle(cx);
+    });
+
+    it("does not accept a rejection that says nothing about the code", async () => {
+        const refusals = new CommissioningRefusals(BUDGET);
+        const cx = contextWith(async () => {
+            throw new InternalError("the controller would not start");
+        });
+
+        await expect(
+            recordVendorOutcome(
+                cx,
+                CODE,
+                new CommissionedRefs(),
+                refusals,
+                "vendor outcome",
+                Millis(50),
+                IDS,
+                observed,
+            ),
+        ).rejectedWith(CertCheckFailedError, /says nothing about the code/);
+
+        await refusals.settle(cx);
+    });
+
+    it("does not accept a payload refusal, which happens before the controller looks for the TH", async () => {
+        const refusals = new CommissioningRefusals(BUDGET);
+        const cx = contextWith(async () => {
+            throw new OnboardingPayloadRefusedError(`Refused manual pairing code ${CODE}`);
+        });
+
+        await expect(
+            recordVendorOutcome(
+                cx,
+                CODE,
+                new CommissionedRefs(),
+                refusals,
+                "vendor outcome",
+                Millis(50),
+                IDS,
+                observed,
+            ),
+        ).rejectedWith(CertCheckFailedError, /says nothing about the code/);
+
+        await refusals.settle(cx);
+    });
+
+    it("accepts chip-tool's own give-up, which its output cannot qualify", async () => {
+        const refusals = new CommissioningRefusals(BUDGET);
+        const cx = contextWith(async () => {
+            throw new ChipToolCommandError("chip-tool commissioning of node 4113 failed");
+        });
+
+        await recordVendorOutcome(
+            cx,
+            CODE,
+            new CommissionedRefs(),
+            refusals,
+            "vendor outcome",
+            Millis(50),
+            IDS,
+            observed,
+        );
+
+        await refusals.settle(cx);
+    });
+
+    it("does not drive the attempt when the TH was not observed advertising", async () => {
+        const refusals = new CommissioningRefusals(BUDGET);
+        let commissionCalled = false;
+        const cx = contextWith(async () => {
+            commissionCalled = true;
+            return "peer1" as CertNodeRef;
+        });
+
+        await expect(
+            recordVendorOutcome(
+                cx,
+                CODE,
+                new CommissionedRefs(),
+                refusals,
+                "vendor outcome",
+                Millis(50),
+                IDS,
+                async () => {
+                    throw new CertCheckFailedError("TH advertising before the attempt check failed");
+                },
+            ),
+        ).rejectedWith(CertCheckFailedError, /TH advertising before the attempt/);
+
+        expect(commissionCalled).equal(false);
+        await refusals.settle(cx);
+    });
+
+    it("says so when the code names the vendor the TH itself advertises", async () => {
+        const refusals = new CommissioningRefusals(BUDGET);
+        const cx = contextWith(async () => "peer1" as CertNodeRef);
+
+        await recordVendorOutcome(
+            cx,
+            CODE,
+            new CommissionedRefs(),
+            refusals,
+            "vendor outcome",
+            Millis(50),
+            { vendorId: 0xfff1, thVendorId: 0xfff1 },
+            observed,
+        );
+
+        expect(checksOf(cx).at(-1)?.detail).contains("substitutes nothing");
         await refusals.settle(cx);
     });
 });

--- a/support/chip-testing/test/cert-framework/tc-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-support.test.ts
@@ -30,7 +30,9 @@ import {
     matterjsSubscribeTiming,
     READ_REQUEST_MESSAGE,
     recordAll,
+    CertCleanupErrors,
     requireId,
+    runCleanups,
     WRITE_REQUEST_MESSAGE,
 } from "../cert/tc-support.js";
 
@@ -45,8 +47,20 @@ const sentLine = (exchange = EXCHANGE) =>
 const ackLine = (exchange = EXCHANGE) =>
     `[DMG] << from UDP:[fe80::1%eth0]:58253 | 208635799 | [Interaction Model  (1) / Status Response (0x01) / Session = 13606 / Exchange = ${exchange}]`;
 
-/** One chunk as chip logs it: its own trace line, then the decode dump the check matches. */
-const chunkLines = (exchange = EXCHANGE) => [sentLine(exchange), CHUNK];
+// A report's own flags, which chip prints as fields of its decode dump: every chunk but the last says
+// there is more to come, the last one says the requester must not answer it.
+const MORE_CHUNKS = "[DMG] \tMoreChunkedMessages = true,";
+const SUPPRESSED = "[DMG] \tSuppressResponse = true,";
+
+/**
+ * One chunk as chip logs it: its own trace line, the decode dump the check matches, and the flag that
+ * says whether the transfer ends here.
+ */
+const chunkLines = (exchange = EXCHANGE, finality: "more" | "final" = "more") => [
+    sentLine(exchange),
+    CHUNK,
+    finality === "final" ? SUPPRESSED : MORE_CHUNKS,
+];
 
 /**
  * A log source the test feeds by hand and never ends — a source that finishes closes the follower,
@@ -127,12 +141,14 @@ describe("expectChunkedTransfer", () => {
             ackLine(),
             ...chunkLines(),
             ackLine(),
-            ...chunkLines(),
+            ...chunkLines(EXCHANGE, "final"),
             NOISE,
         ]);
 
         expect(record.verdict).equal("pass");
-        expect(record.detail).equal("3 report chunks, each but the last followed by a StatusResponse");
+        expect(record.detail).equal(
+            "3 report chunks, each but the last followed by a StatusResponse, and none after the last",
+        );
     });
 
     it("fails when a later chunk pair has no StatusResponse between it", async () => {
@@ -185,6 +201,25 @@ describe("expectChunkedTransfer", () => {
         expect(record.detail).match(/did not chunk/);
     });
 
+    it("fails when the DUT acked the final chunk as well, which a read suppresses", async () => {
+        const record = await check([...chunkLines(), ackLine(), ...chunkLines(EXCHANGE, "final"), ackLine(), NOISE]);
+
+        expect(record.verdict).equal("fail");
+        expect(record.detail).match(/after the final one of 2 report chunks/);
+    });
+
+    it("ignores an ack of another exchange after the final chunk", async () => {
+        const record = await check([
+            ...chunkLines(),
+            ackLine(),
+            ...chunkLines(EXCHANGE, "final"),
+            ackLine(EXCHANGE + 1),
+        ]);
+
+        expect(record.verdict).equal("pass");
+        expect(record.detail).match(/none after the last/);
+    });
+
     it("treats a log source that ends mid-transfer as the end of the transfer", async () => {
         const record = await check(
             [...chunkLines(), ackLine(), ...chunkLines(), ackLine(), ...chunkLines()],
@@ -193,7 +228,16 @@ describe("expectChunkedTransfer", () => {
         );
 
         expect(record.verdict).equal("pass");
-        expect(record.detail).equal("3 report chunks, each but the last followed by a StatusResponse");
+        expect(record.detail).match(/3 report chunks, each but the last followed by a StatusResponse; the log stops/);
+    });
+
+    it("does not read a truncated transfer's trailing ack as an answer to a final chunk", async () => {
+        // A log cut inside a transfer ends on an acked chunk by construction — the ack of chunk N
+        // precedes chunk N+1 — so this must not be the same finding as an answered final chunk
+        const record = await check([...chunkLines(), ackLine(), ...chunkLines(), ackLine()], "chip-docker", true);
+
+        expect(record.verdict).equal("pass");
+        expect(record.detail).match(/the log stops inside the transfer/);
     });
 
     it("records a fail instead of throwing when no report chunk ever appears", async () => {
@@ -532,8 +576,10 @@ describe("expectChunkedTransfer against a matter.js TH", () => {
     // matter.js names the exchange on the report line itself (`⇵<exchange>✉<counter>`), so a chunk
     // carries its own attribution. Lines captured from a matterjs-vs-matterjs run's device log.
     const MATTERJS_EXCHANGE = "50c9";
-    const mjsChunk = (exchange = MATTERJS_EXCHANGE) =>
-        `2026-08-22 16:54:44.382 DEBUG MessageChannel Message » for: I/ReportData moreChunkedMessages attr: 36 backOff: 371ms id: @1:f8b164969e6633a1•678b⇵${exchange}✉02ca1953 type: 0x1/0x5 acked: 0fcef3be reqAck size: 1139 payload: 1536`;
+    const mjsChunk = (exchange = MATTERJS_EXCHANGE, finality: "more" | "final" = "more") =>
+        `2026-08-22 16:54:44.382 DEBUG MessageChannel Message » for: I/ReportData ` +
+        `${finality === "final" ? "suppressResponse" : "moreChunkedMessages"} attr: 36 backOff: 371ms ` +
+        `id: @1:f8b164969e6633a1•678b⇵${exchange}✉02ca1953 type: 0x1/0x5 acked: 0fcef3be reqAck size: 1139 payload: 1536`;
     const mjsAck = (exchange = MATTERJS_EXCHANGE) =>
         `2026-08-22 16:54:44.385 DEBUG MessageExchange Message « for: I/StatusResponse id: @1:f8b164969e6633a1•678b⇵${exchange}✉0fcef3bf type: 0x1/0x1 acked: 02ca1953 reqAck size: 8 payload: 0000000000000000`;
 
@@ -542,10 +588,18 @@ describe("expectChunkedTransfer against a matter.js TH", () => {
     }
 
     it("passes when every chunk but the last is acked", async () => {
-        const record = await transfer([mjsChunk(), mjsAck(), mjsChunk(), mjsAck(), mjsChunk()]);
+        const record = await transfer([
+            mjsChunk(),
+            mjsAck(),
+            mjsChunk(),
+            mjsAck(),
+            mjsChunk(MATTERJS_EXCHANGE, "final"),
+        ]);
 
         expect(record.verdict).equal("pass");
-        expect(record.detail).equal("3 report chunks, each but the last followed by a StatusResponse");
+        expect(record.detail).equal(
+            "3 report chunks, each but the last followed by a StatusResponse, and none after the last",
+        );
     });
 
     it("fails when a chunk pair has no StatusResponse between it", async () => {
@@ -574,6 +628,20 @@ describe("expectChunkedTransfer against a matter.js TH", () => {
 
         expect(record.verdict).equal("fail");
         expect(record.detail).match(/did not chunk/);
+    });
+
+    it("fails when the DUT acked the final chunk as well", async () => {
+        const record = await transfer([mjsChunk(), mjsAck(), mjsChunk(MATTERJS_EXCHANGE, "final"), mjsAck()]);
+
+        expect(record.verdict).equal("fail");
+        expect(record.detail).match(/after the final one of 2 report chunks/);
+    });
+
+    it("does not claim the final message was unanswered where the log stops inside the transfer", async () => {
+        const record = await transfer([mjsChunk(), mjsAck(), mjsChunk(), mjsAck()]);
+
+        expect(record.verdict).equal("pass");
+        expect(record.detail).match(/the log stops inside the transfer/);
     });
 });
 
@@ -974,6 +1042,62 @@ describe("expectCommandInvoke", () => {
         );
 
         expect(record.verdict).equal("unverified");
+    });
+});
+
+describe("runCleanups", () => {
+    it("runs every cleanup even after one fails, and reports both failures", async () => {
+        const ran = new Array<string>();
+
+        const failure = await expect(
+            runCleanups(
+                async () => {
+                    ran.push("settle");
+                    throw new CertCleanupError("an attempt is still running");
+                },
+                async () => {
+                    ran.push("decommission");
+                    throw new CertCleanupError("the fabric is still on the TH");
+                },
+            ),
+        ).rejectedWith(CertCleanupErrors);
+
+        expect(ran).deep.equal(["settle", "decommission"]);
+        // The engine records a finalization failure as the message alone, so both have to be named there
+        expect(failure.message).contains("an attempt is still running");
+        expect(failure.message).contains("the fabric is still on the TH");
+        expect(failure.errors.map((e: Error) => e.message)).deep.equal([
+            "an attempt is still running",
+            "the fabric is still on the TH",
+        ]);
+    });
+
+    it("rethrows a lone failure as it arrived, so its own type survives", async () => {
+        class OwnError extends CertCleanupError {}
+
+        await expect(
+            runCleanups(
+                async () => {
+                    throw new OwnError("only this one failed");
+                },
+                async () => {},
+            ),
+        ).rejectedWith(OwnError, /only this one failed/);
+    });
+
+    it("resolves when every cleanup does", async () => {
+        const ran = new Array<string>();
+
+        await runCleanups(
+            async () => {
+                ran.push("first");
+            },
+            async () => {
+                ran.push("second");
+            },
+        );
+
+        expect(ran).deep.equal(["first", "second"]);
     });
 });
 

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -305,6 +305,16 @@ displace an earlier step failure — that stays the run's outcome, with the clea
 it in the evidence. A cleanup failure this suite swallowed into a `console.warn` once already went
 unnoticed across passing runs, which is why it is loud now.
 
+**A TC owing more than one cleanup uses `runCleanups`, not a `try`/`finally`.** `finally` runs both
+but reports only the last one's failure, and the two name different state the next run inherits — an
+outstanding commissioning attempt is not a substitute for a fabric left on the TH. `runCleanups` runs
+each in order, rethrows a lone failure unchanged so its own type survives, and joins several into one
+`CertCleanupError`:
+
+```ts
+    .finalize(cx => runCleanups(() => refusals.settle(cx), () => commissioned.decommissionAll(cx)));
+```
+
 `CommissionedRefs.withRef(role, run)` only requires the role's ref up front and threads it in; the
 old `guarded()` wrapper, which decommissioned on a step's own failure, is gone — the finalizer covers
 that case, and a cleanup failure raised from inside a step's `catch` would have masked the step's own
@@ -1501,16 +1511,24 @@ it did until `CommissioningTarget.giveUpAfterMs` was added. matter.js maps it to
 timeout; chip-tool cannot be bounded and says so, stopping on its own after ~30s, so the step's own
 budget has to outlast chip-tool rather than matter.js.
 
-**Step 6 records a real disagreement between the two controllers, and this one cost a review round.**
-The obvious reading — "a manual code's vendor id is informational, no commissioner matches it against
-the device it found" — is **false for chip-tool**:
-`SetUpCodePairer::NodeMatchesCurrentFilter` (`src/controller/SetUpCodePairer.cpp`) skips a discovered
-device whose advertised vendor or product id disagrees with the code's, so a code naming another
-vendor finds nothing and chip-tool gives up after its 30s discovery budget. matter.js discovers on
-the discriminator alone (`resolveCommissioningTarget` passes only `shortDiscriminator`/`passcode`)
-and onboards. **The plan's expected outcome admits both** — terminate, "unless the user is made fully
-aware of the security risks" — so the step records which happened instead of asserting one. Both
-outcomes appear in the evidence, one per controller.
+**Step 6: a manual code's vendor id is not informational, and both controllers act on it.** The
+obvious reading — "no commissioner matches a code's vendor id against the device it found" — is false
+for chip-tool: `SetUpCodePairer::NodeMatchesCurrentFilter` (`src/controller/SetUpCodePairer.cpp`)
+skips a discovered device whose advertised vendor or product id disagrees with the code's, so a code
+naming another vendor finds nothing and chip-tool gives up after its 30s discovery budget. It is
+false for matter.js too: `resolveCommissioningTarget` hands the code's `vendorId`/`productId` to
+`peers.commission`, whose discovery passes over a device whose advertisement disagrees, and the attempt
+ends in `DiscoveryError` after `giveUpAfterMs`. **The plan's expected outcome admits both
+outcomes** — terminate, "unless the user is made fully aware of the security risks" — so the step
+records which happened instead of asserting one.
+
+Two things the step's evidence has to say, and did not until it was made to. A `DiscoveryError` or a
+chip-tool command failure is what termination looks like, but so is a TH that stopped advertising, so
+`recordVendorOutcome` proves the TH is advertising commissionable immediately before each attempt (the
+`restoreCommissioningMode` that precedes it only does so for a code that follows an onboarding). And
+one of `TEST_VENDOR_IDS` is the vendor id a harness TH advertises for itself, so that code is step 1's
+code and its outcome says nothing about a substituted id — the detail now says which of the two the
+attempt was.
 
 **All four codes go to the DUT, which needs the TH restored between them.** The plan says "provide
 each", and an attempt that onboards leaves the TH out of commissioning mode for the next one — so

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -309,7 +309,8 @@ unnoticed across passing runs, which is why it is loud now.
 but reports only the last one's failure, and the two name different state the next run inherits — an
 outstanding commissioning attempt is not a substitute for a fabric left on the TH. `runCleanups` runs
 each in order, rethrows a lone failure unchanged so its own type survives, and joins several into one
-`CertCleanupError`:
+`CertCleanupErrors` — a `MatterAggregateError` whose message names every failure, because the message
+is all the engine keeps of a finalization failure, with the originals as its causes:
 
 ```ts
     .finalize(cx => runCleanups(() => refusals.settle(cx), () => commissioned.decommissionAll(cx)));

--- a/support/chip-testing/test/cert/TC-DD-3.14.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.14.test.ts
@@ -18,7 +18,7 @@ import {
     recordParse,
     thQrPayload,
 } from "./tc-dd-support.js";
-import { CommissionedRefs, recordAll } from "./tc-support.js";
+import { CommissionedRefs, recordAll, runCleanups } from "./tc-support.js";
 
 /** The plan's own substitute for the specification's `000`; any non-zero 3-bit value works. */
 const INVALID_VERSION = 0b010;
@@ -75,7 +75,13 @@ certTest("TC-DD-3.14", {
         "Using the QR code from Step 1, ensure the TH's Discovery Capability bit string is NOT set to BLE for " +
             "discovery (i.e. set to OnNetwork discovery capability)",
         async cx =>
-            recordDiscoveryCapabilityAbsent(cx, await onNetworkOnlyPayload(cx), "ble", "Payload does not offer BLE"),
+            recordDiscoveryCapabilityAbsent(
+                cx,
+                await onNetworkOnlyPayload(cx),
+                "ble",
+                "Payload does not offer BLE",
+                await thQrPayload(cx.devices.th),
+            ),
         {
             pics: "MCORE.DD.DISCOVERY_BLE",
             expected: "User has a QR code generated to pass into DUT.",
@@ -104,6 +110,7 @@ certTest("TC-DD-3.14", {
                 await onNetworkOnlyPayload(cx),
                 "wifiPublicActionFrame",
                 "Payload does not offer Wi-Fi PAF",
+                await thQrPayload(cx.devices.th),
             ),
         {
             pics: "MCORE.DD.DISCOVERY_PAF",
@@ -198,10 +205,9 @@ certTest("TC-DD-3.14", {
                 "commissioning process in a DUT-specific manner according to the DUT manufacturer's instructions.",
         },
     )
-    .finalize(async cx => {
-        try {
-            await refusals.settle(cx);
-        } finally {
-            await commissioned.decommissionAll(cx);
-        }
-    });
+    .finalize(cx =>
+        runCleanups(
+            () => refusals.settle(cx),
+            () => commissioned.decommissionAll(cx),
+        ),
+    );

--- a/support/chip-testing/test/cert/TC-DD-3.17.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.17.test.ts
@@ -20,7 +20,7 @@ import {
     thCodeParts,
     thManualPairingCode,
 } from "./tc-dd-support.js";
-import { CommissionedRefs, recordAll } from "./tc-support.js";
+import { CertCheckFailedError, CommissionedRefs, recordAll, runCleanups } from "./tc-support.js";
 
 /**
  * Flips a bit the plan requires to change: § 5.1.4.1 Table 62 carries only the discriminator's 4 most
@@ -246,19 +246,35 @@ certTest("TC-DD-3.17", {
             "supported by the DUT",
         async cx => {
             // The plan's own "unless" branch: a cert harness commissions uncertified devices on
-            // purpose, and its operator is the user the clause speaks of. A code naming a vendor the TH
-            // is not is where the two commissioners part: chip-tool refuses to pair with a device whose
-            // advertisement disagrees, matter.js discovers on the discriminator alone. Both are outcomes
-            // the plan admits, so the step records which happened for each of the four codes.
+            // purpose, and its operator is the user the clause speaks of. Both controllers pass over a
+            // device whose advertised vendor id the code does not name, and one of the four codes names
+            // the TH's own, so the step records which outcome each code produced rather than asserting
+            // one (see recordVendorOutcome).
             const parts = await thCodeParts(cx);
+            const failures = new Array<CertCheckFailedError>();
             for (const vendorId of TEST_VENDOR_IDS) {
-                await recordVendorOutcome(
-                    cx,
-                    manualPairingCode({ ...parts, vendorId }),
-                    commissioned,
-                    refusals,
-                    `Code naming vendor 0x${vendorId.toString(16)}`,
-                    VENDOR_OUTCOME_TIMEOUT,
+                try {
+                    await recordVendorOutcome(
+                        cx,
+                        manualPairingCode({ ...parts, vendorId }),
+                        commissioned,
+                        refusals,
+                        `Code naming vendor 0x${vendorId.toString(16)}`,
+                        VENDOR_OUTCOME_TIMEOUT,
+                        { vendorId, thVendorId: parts.vendorId },
+                    );
+                } catch (e) {
+                    // The plan hands over every code, so one the DUT answered unexpectedly must not
+                    // leave the rest unrecorded — the step fails once, after all four are in the bundle
+                    if (!(e instanceof CertCheckFailedError)) {
+                        throw e;
+                    }
+                    failures.push(e);
+                }
+            }
+            if (failures.length) {
+                throw new CertCheckFailedError(
+                    `${failures.length} of ${TEST_VENDOR_IDS.length} codes: ${failures.map(e => e.message).join("; ")}`,
                 );
             }
         },
@@ -326,13 +342,12 @@ certTest("TC-DD-3.17", {
                 "DUT-specific manner according to the DUT manufacturer's instructions.",
         },
     )
-    .finalize(async cx => {
-        try {
-            await refusals.settle(cx);
-        } finally {
-            await commissioned.decommissionAll(cx);
-        }
-    });
+    .finalize(cx =>
+        runCleanups(
+            () => refusals.settle(cx),
+            () => commissioned.decommissionAll(cx),
+        ),
+    );
 
 async function checkDigitCodes(cx: CertStepContext): Promise<{ correct: string; wrong: string }> {
     const parts = await thCodeParts(cx);

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -4,10 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, Duration, ImplementationError, InternalError, Millis, Seconds, Time, Verhoeff } from "@matter/main";
+import {
+    Bytes,
+    DiscoveryAggregateError,
+    DiscoveryError,
+    Duration,
+    ImplementationError,
+    InternalError,
+    Millis,
+    Seconds,
+    Time,
+    Verhoeff,
+} from "@matter/main";
 import { Base38, DiscoveryCapabilitiesBitmap, DiscoveryCapabilitiesSchema } from "@matter/main/types";
 import type { CertNodeRef, CertStepContext, CheckRecord, CommissioningTarget } from "@matter/testing";
 import type { CertDevice } from "@matter/testing";
+import { ChipToolCommandError } from "../../src/cert/ChipToolControllerAdapter.js";
 import { expectMdns } from "../../src/cert/mdns-check.js";
 import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload.js";
 import {
@@ -136,13 +148,27 @@ export async function onNetworkOnlyPayload(cx: CertStepContext): Promise<string>
 /**
  * Records that `payload` does not offer `capability`, read back through the DUT so a controller that
  * cannot report a bitmask fails here rather than silently proving nothing.
+ *
+ * `unchangedFrom` is the payload the plan derived this one from ("using the QR code from Step 1"), and
+ * is what holds the derivation to changing only the discovery capabilities: a helper that also moved
+ * the discriminator or the passcode still offers no BLE, so the capability check alone cannot tell the
+ * plan's payload from a different device's. Required for that reason — a guard against a
+ * self-satisfying comparison is one an optional parameter loses by accident.
  */
 export async function recordDiscoveryCapabilityAbsent(
     cx: CertStepContext,
     payload: string,
     capability: keyof typeof DiscoveryCapabilitiesBitmap,
     what: string,
+    unchangedFrom: string,
 ): Promise<void> {
+    // Every field of the source but the capabilities, which is the one this derivation changes and the
+    // one the check below judges. Stating them from the source rather than through `unchangedFrom` is
+    // what keeps the capabilities out of the comparison without asserting the payload's own value
+    // against itself.
+    const { discoveryCapabilities: _capabilities, ...unchanged } = qrPayloadFields(unchangedFrom);
+    record(cx, checkGeneratedPayload(payload, unchanged), `${what}: derived from step 1's payload`);
+
     const parsed = await cx.controllers.dut.parseQrPayload(payload);
     const offered = DiscoveryCapabilitiesSchema.decode(parsed.discoveryCapabilities);
     const names = Object.entries(offered)
@@ -548,8 +574,14 @@ export async function thManualPairingCode(
 /**
  * What the TH's own setup code puts into a 21-digit manual code. Read once by a step that builds
  * several, so a dozen substitutions do not become a dozen concurrent requests to the DUT.
+ *
+ * The two ids are optional on {@link ManualPairingCodeParts} — a step generating a code may leave them
+ * out — but a TH that names neither is refused below, so a caller comparing against the TH's own ids
+ * gets them without a check of its own.
  */
-export async function thCodeParts(cx: CertStepContext): Promise<ManualPairingCodeParts> {
+export async function thCodeParts(
+    cx: CertStepContext,
+): Promise<ManualPairingCodeParts & { vendorId: number; productId: number }> {
     const th = cx.devices.th;
     const { vendorId, productId } = await cx.controllers.dut.parseQrPayload(await thQrPayload(th));
     if (vendorId === undefined || productId === undefined) {
@@ -618,13 +650,51 @@ export async function recordCommissionable(
 }
 
 /**
- * Records what the DUT made of a code naming a given vendor, where the plan accepts either outcome:
- * terminating commissioning, or onboarding anyway with the user aware of the risk.
+ * Whether `error` is a commissioner giving up on a code it read successfully, which is what the
+ * negative vendor and product plans mean by "the DUT terminates the commissioning process".
+ *
+ * The two controllers say it differently. In-process, a code no advertisement satisfies ends as a
+ * {@link DiscoveryError}, or as a {@link DiscoveryAggregateError} where a candidate was tried and
+ * failed — a manual code carries only the discriminator's 4 most significant bits, so one device in
+ * sixteen on the network is a candidate the scanner hands on. chip-tool's output cannot separate one
+ * command failure from another, so its give-up arrives as a {@link ChipToolCommandError} — on those
+ * legs this excludes a controller that would not start, and the probe the caller makes first excludes
+ * a TH that was not there.
+ *
+ * An {@link OnboardingPayloadRefusedError} is the opposite outcome — the controller rejected the code
+ * before it looked for anything, and these steps generate a well-formed one. It is not a subclass of
+ * either accepted error today, and the guard is what keeps that true if it becomes one.
+ */
+export function isCommissioningGiveUp(error: unknown): boolean {
+    if (error instanceof OnboardingPayloadRefusedError) {
+        return false;
+    }
+    return (
+        error instanceof DiscoveryError ||
+        error instanceof DiscoveryAggregateError ||
+        error instanceof ChipToolCommandError
+    );
+}
+
+/**
+ * Records what the DUT made of a code naming `vendorId` where the TH's own payload names `thVendorId`,
+ * and the plan accepts either outcome: terminating commissioning, or onboarding anyway with the user
+ * aware of the risk.
  *
  * The two controllers genuinely differ. chip-tool matches a code's vendor and product id against the
  * device it discovered (`SetUpCodePairer::NodeMatchesCurrentFilter`) and finds nothing; matter.js
- * discovers on the discriminator alone and onboards. A fabric that results is handed to
- * `commissioned`, whose next {@link commissionByManualCode} takes it off the TH again.
+ * filters its own discovery on the ids the code carries and finds nothing either. A fabric that
+ * results is handed to `commissioned`, whose next {@link commissionByManualCode} takes it off the TH
+ * again.
+ *
+ * Two things the evidence has to carry, because the verdict is `pass` either way:
+ *
+ * - Only a give-up counts as termination ({@link isCommissioningGiveUp}), and the TH has to be
+ *   observed advertising first: accepting any rejection would pass the step on a controller that would
+ *   not start, and on a TH that stopped advertising. The restore this runs first probes only for a code
+ *   that follows an onboarding, so a code after a refusal needs its own probe.
+ * - A code naming the vendor the TH itself advertises is step 1's code, so what the DUT did with it
+ *   says nothing about a substituted id. The detail says which of the two happened.
  */
 export async function recordVendorOutcome(
     cx: CertStepContext,
@@ -633,8 +703,25 @@ export async function recordVendorOutcome(
     refusals: CommissioningRefusals,
     what: string,
     timeout: Duration,
+    ids: { vendorId: number; thVendorId: number },
+    /** Overridden by the unit tests, which have no advertisement to observe. */
+    probeCommissionable: (cx: CertStepContext, what: string) => Promise<void> = recordCommissionable,
 ): Promise<void> {
-    await restoreCommissioningMode(cx, commissioned);
+    const restored = await restoreCommissioningMode(cx, commissioned);
+
+    // A rejection is evidence about the code only if the TH was there to be found; without this the
+    // step passes on a TH that stopped advertising after an earlier attempt. A restore that ran has
+    // just proven the same thing.
+    if (!restored) {
+        await probeCommissionable(cx, `${what}: TH advertising before the attempt`);
+    }
+
+    const substitution =
+        ids.vendorId === ids.thVendorId
+            ? `the code names the TH's own vendor 0x${ids.thVendorId.toString(16)}, so it is step 1's code and ` +
+              "substitutes nothing"
+            : `the code names vendor 0x${ids.vendorId.toString(16)} where the TH's own payload names ` +
+              `0x${ids.thVendorId.toString(16)}`;
 
     const label = `commissioning from ${code}`;
     const attempt = cx.controllers.dut.commission({ manualPairingCode: code, giveUpAfterMs: timeout });
@@ -644,12 +731,16 @@ export async function recordVendorOutcome(
         case "rejected": {
             const { error } = outcome;
             const message = error instanceof Error ? `${error.constructor.name}: ${error.message}` : String(error);
+            const gaveUp = isCommissioningGiveUp(error);
             record(
                 cx,
                 {
                     type: "response",
-                    verdict: "pass",
-                    detail: `DUT terminated commissioning after ${outcome.elapsed}: ${message}`,
+                    verdict: gaveUp ? "pass" : "fail",
+                    detail: gaveUp
+                        ? `DUT terminated commissioning after ${outcome.elapsed} (${substitution}): ${message}`
+                        : `${label} failed after ${outcome.elapsed} for a reason that says nothing about the code ` +
+                          `(${substitution}): ${message}`,
                 },
                 what,
             );
@@ -664,7 +755,9 @@ export async function recordVendorOutcome(
                 {
                     type: "response",
                     verdict: "pass",
-                    detail: `DUT onboarded the TH as node ${ref}, which the plan allows where the user accepts the risk`,
+                    detail:
+                        `DUT onboarded the TH as node ${ref} (${substitution}), which the plan allows where the ` +
+                        "user accepts the risk",
                 },
                 what,
             );
@@ -697,10 +790,10 @@ export async function recordVendorOutcome(
  * commissioning mode — removing its last fabric does not. A matter.js device is already there, and
  * erasing it would restart a TH that needs nothing.
  */
-async function restoreCommissioningMode(cx: CertStepContext, commissioned: CommissionedRefs): Promise<void> {
+async function restoreCommissioningMode(cx: CertStepContext, commissioned: CommissionedRefs): Promise<boolean> {
     const previous = commissioned.get("dut");
     if (previous === undefined) {
-        return;
+        return false;
     }
 
     const th = cx.devices.th;
@@ -731,6 +824,7 @@ async function restoreCommissioningMode(cx: CertStepContext, commissioned: Commi
     // The TH advertises itself commissionable on its own schedule, and a discovery started before
     // that finds only the devices this run is not looking for.
     await recordCommissionable(cx, "TH back in commissioning mode");
+    return true;
 }
 
 /** {@link commissionByQr} for a manual pairing code, which discovers by the short discriminator. */

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -4,7 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { camelize, Duration, InternalError, MatterError, Millis, Seconds, Time } from "@matter/main";
+import {
+    camelize,
+    Duration,
+    InternalError,
+    MatterAggregateError,
+    MatterError,
+    Millis,
+    Seconds,
+    Time,
+} from "@matter/main";
 import { Matter } from "@matter/model";
 import type {
     AttributePathSpec,
@@ -65,6 +74,50 @@ export function recordAll(cx: CertStepContext, checks: readonly { check: () => C
     if (failed.length) {
         throw new CertCheckFailedError(`${failed.length} of ${checks.length} checks failed: ${failed.join("; ")}`);
     }
+}
+
+/**
+ * Several cleanups of one TC's finalizer having failed. The engine records a finalization failure as
+ * the error's `message` alone, so every failure has to be named there; the causes travel along for a
+ * reader who also has the console output.
+ */
+export class CertCleanupErrors extends MatterAggregateError {
+    constructor(causes: unknown[]) {
+        super(causes, causes.map(cause => describeError(cause)).join("; "));
+    }
+}
+
+/**
+ * Runs every cleanup a TC owes, in order, whatever any of them does.
+ *
+ * A `try { a() } finally { b() }` runs both but reports only `b`'s failure, and each of a TC's
+ * cleanups names different state the next run inherits — an outstanding commissioning attempt and a
+ * fabric on the TH are not substitutes for one another. A lone failure is rethrown as it arrived so
+ * its own type survives; several become one {@link CertCleanupErrors}.
+ *
+ * {@link MatterAggregateError.settleSeries} runs a series the same way but names it with a fixed
+ * message, and the message is all the evidence bundle keeps.
+ */
+export async function runCleanups(...cleanups: (() => Promise<void>)[]): Promise<void> {
+    const failures = new Array<unknown>();
+    for (const cleanup of cleanups) {
+        try {
+            await cleanup();
+        } catch (e) {
+            failures.push(e);
+        }
+    }
+
+    if (failures.length === 1) {
+        throw failures[0];
+    }
+    if (failures.length) {
+        throw new CertCleanupErrors(failures);
+    }
+}
+
+function describeError(e: unknown): string {
+    return e instanceof Error ? `${e.constructor.name}: ${e.message}` : String(e);
 }
 
 /**
@@ -885,6 +938,14 @@ interface ChunkedTransferDialect {
     /** An outbound report chunk. */
     chunk: RegExp;
 
+    /**
+     * Whether `chunk` is the transfer's own last message — `"unknown"` where the log stops before
+     * saying. A read's last report sets `SuppressResponse` and every earlier one
+     * `MoreChunkedMessages` (Matter Core § 8.4.3.3, § 10.7.3), so this is what tells the end of a
+     * transfer from a log that was cut inside one.
+     */
+    finality(log: LogFollower, chunk: LogLine): "final" | "more" | "unknown";
+
     /** The exchange `chunk` went out on, or `undefined` where the log does not say. */
     exchangeOf(log: LogFollower, chunk: LogLine): string | undefined;
 
@@ -899,10 +960,14 @@ interface ChunkedTransferDialect {
 }
 
 /**
- * Confirms a chunked read actually chunked and that the DUT acked every chunk but the last: at least
- * two report chunks, all on one exchange, with a `StatusResponse` received between every adjacent
- * pair. Missing evidence comes back as a `"fail"` record rather than a thrown timeout, so the step's
- * own reporting carries it.
+ * Confirms a chunked read actually chunked and that the DUT acked every chunk but the last, and only
+ * those: at least two report chunks, all on one exchange, with a `StatusResponse` received between
+ * every adjacent pair and none after the transfer's final message. A log that stops inside the transfer
+ * carries the first claim but not the second, and says so rather than failing. Missing evidence comes
+ * back as a `"fail"` record rather than a thrown timeout, so the step's own reporting carries it.
+ *
+ * A read only. A subscription's reports are answered including the last, so pointing this at one would
+ * fail a conforming device.
  *
  * Both flavors name the same three things, in different places — {@link ChunkedTransferDialect}.
  */
@@ -1001,13 +1066,47 @@ export async function expectChunkedTransfer(
         }
     }
 
+    // A read's report carries SuppressResponse (Matter Core § 8.4.3.3), which the wire encoding
+    // overrides to false only while MoreChunkedMessages is set (§ 10.7.3) — so the transfer's own last
+    // message is the one chunk the requester must not answer. A log that stops inside a transfer ends on
+    // an acked chunk by construction, so the search below is only evidence where the log says this chunk
+    // was the last; the loop above already waited CHUNK_QUIET past it, so the window an ack would have
+    // landed in is in the log by now.
+    const last = chunks[chunks.length - 1];
+    if (dialect.finality(log, last) !== "final") {
+        return {
+            type: "device-log",
+            verdict: "pass",
+            pattern: "ReportDataMessage, StatusResponse on the same Exchange between every adjacent pair",
+            detail:
+                `${chunks.length} report chunks, each but the last followed by a StatusResponse; the log stops ` +
+                "inside the transfer, so whether the DUT answered its final message is not claimed",
+            matched: last.text,
+            logLine: last.index,
+        };
+    }
+
+    const lateAck = lines.slice(last.index + 1).find(line => !line.synthetic && ackPattern.test(line.text));
+    if (lateAck !== undefined) {
+        return {
+            type: "device-log",
+            verdict: "fail",
+            pattern: String(ackPattern),
+            detail:
+                `The DUT sent a StatusResponse on Exchange ${exchange} after the final one of ${chunks.length} ` +
+                `report chunks (log line ${lateAck.index}), which a read's last chunk suppresses`,
+            logLine: lateAck.index,
+        };
+    }
+
     return {
         type: "device-log",
         verdict: "pass",
-        pattern: "ReportDataMessage, StatusResponse on the same Exchange between every adjacent pair",
-        detail: `${chunks.length} report chunks, each but the last followed by a StatusResponse`,
-        matched: chunks[chunks.length - 1].text,
-        logLine: chunks[chunks.length - 1].index,
+        pattern:
+            "ReportDataMessage, StatusResponse on the same Exchange between every adjacent pair and none after the last",
+        detail: `${chunks.length} report chunks, each but the last followed by a StatusResponse, and none after the last`,
+        matched: last.text,
+        logLine: last.index,
     };
 }
 
@@ -1192,9 +1291,37 @@ function exchangeIdBefore(log: LogFollower, beforeIndex: number): string | undef
 // chip's decode dump does not, and its exchange comes off the trace line preceding it.
 const MATTERJS_REPORT_CHUNK = /Message » for: I\/ReportData .*⇵([0-9a-f]+)✉/;
 
+// Both implementations say on which message a transfer ends, in their own place: matter.js renders the
+// report's own flags on the report line, chip prints them inside that message's decode dump.
+const MATTERJS_MORE_CHUNKS = /Message » for: I\/ReportData [^⇵]*\bmoreChunkedMessages\b/;
+const MATTERJS_SUPPRESSED_RESPONSE = /Message » for: I\/ReportData [^⇵]*\bsuppressResponse\b/;
+const CHIP_MORE_CHUNKS = /\[DMG\]\s+MoreChunkedMessages = true,\s*$/;
+const CHIP_SUPPRESSED_RESPONSE = /\[DMG\]\s+SuppressResponse = true,\s*$/;
+
+/**
+ * Which of the two flags chip printed first at or after `chunk`. They are fields of the message's own
+ * decode dump, so the first of either after the chunk line belongs to that chunk; a log cut inside the
+ * dump has neither.
+ */
+function chipChunkFinality(log: LogFollower, chunk: LogLine): "final" | "more" | "unknown" {
+    for (const line of log.lines.slice(chunk.index + 1)) {
+        if (line.synthetic) {
+            continue;
+        }
+        if (CHIP_SUPPRESSED_RESPONSE.test(line.text)) {
+            return "final";
+        }
+        if (CHIP_MORE_CHUNKS.test(line.text)) {
+            return "more";
+        }
+    }
+    return "unknown";
+}
+
 const CHUNKED_TRANSFER_DIALECTS: { chip: ChunkedTransferDialect; matterjs: ChunkedTransferDialect } = {
     chip: {
         chunk: REPORT_DATA_MESSAGE,
+        finality: (log, chunk) => chipChunkFinality(log, chunk),
         exchangeOf: (log, chunk) => exchangeIdBefore(log, chunk.index),
         ack: reportAckedOnExchange,
         attribution: String(REPORT_SENT_LINE),
@@ -1203,6 +1330,12 @@ const CHUNKED_TRANSFER_DIALECTS: { chip: ChunkedTransferDialect; matterjs: Chunk
 
     matterjs: {
         chunk: MATTERJS_REPORT_CHUNK,
+        finality: (_log, chunk) =>
+            MATTERJS_SUPPRESSED_RESPONSE.test(chunk.text)
+                ? "final"
+                : MATTERJS_MORE_CHUNKS.test(chunk.text)
+                  ? "more"
+                  : "unknown",
         exchangeOf: (_log, chunk) => MATTERJS_REPORT_CHUNK.exec(chunk.text)?.[1],
         ack: exchange => new RegExp(`Message « for: I/StatusResponse .*⇵${exchange}✉`),
         attribution: String(MATTERJS_REPORT_CHUNK),


### PR DESCRIPTION
Four places in the certification harness where a check could report a pass without having proven what
the step claims, and one where a real failure went unreported. Test-only; no library behavior changes.

## A read the device refused on one path looked like a read that found nothing

Both controllers answered a read of several attribute paths by returning whatever data came back and
dropping the device's per-path statuses. A path the device refused therefore reached the test as "no
value reported": TC-IDM-3.1 turns that into "TH reported no data version", which names the wrong
problem, and a step could pass having proven nothing about the path it asked for. A concrete path the
device answered with a status now fails the read — the way a read of one path already did — while a
wildcard path's statuses stay per-item results of the expansion and are still dropped. The adapter
interface documented that rule already; only the single-path read implemented it.

The in-process controller did the same to the priming report of an event subscription, where the
chip-tool controller already rejected. Since the two controllers have to agree — a step that fails
under one and passes under the other is supposed to mean an interoperability finding — the in-process
one now rejects too, and drops every later report of the subscription it cannot revoke, so those
reports cannot reach a step that already failed on the rejection.

## A chunked read's last message was never checked for the answer it must not get

TC-IDM-2.1 step 20 states two things about a read too large for one message: the controller answers
every chunk but the last, and does not answer the last. Only the first was checked, while the pass
detail read as if both were. A read's final report tells the receiver not to answer it (Matter Core
§ 8.4.3.3, § 10.7.3), and both implementations say on which message a transfer ends, so the absence of
that answer is now proven as well. Where the log stops inside a transfer the check says so rather than
claiming it: such a log ends on an answered chunk by construction, so failing there would fail a
conforming device.

## A cleanup failure hid the one before it

A test case that owes two cleanups ran them as `try`/`finally`, which reports only the second one's
failure. An outstanding commissioning attempt and a fabric left behind on the test device are
different state for the next run to inherit, so both are named now — in the message, which is all the
evidence bundle keeps of a cleanup failure, with the original errors kept as its causes.

## TC-DD-3.17 step 6.b passed on any failure at all

The step hands the device four pairing codes naming test vendor ids and accepts either outcome the
plan admits: onboarding the device anyway, or giving up on the code. It recorded a pass for any
rejection, so a controller that would not start, or a test device that had stopped advertising itself,
passed as if the device had made a decision. It now accepts only a commissioner giving up — each
controller's own error class for that, taken from a captured run of all six certification
configurations — and proves the test device is advertising itself commissionable immediately before
each attempt, which the restore between attempts only did for a code following an onboarding.

Two things the evidence now says out loud. The list of vendor ids the plan calls invalid includes the
one the harness device advertises for itself, so that code is the unmodified code of step 1 and what
the device did with it says nothing about a substitution. And a code the device answers unexpectedly
no longer ends the step before the remaining codes are recorded.

## TC-DD-3.14 steps 3.a/4.a claimed more than they checked

Both claim a payload derived from step 1's with only the discovery capabilities changed, but checked
the capabilities alone — a derivation that also moved the discriminator or the passcode would have
passed. Every other field is held to the source now, and the source is a required argument, because a
guard against a self-satisfying comparison is one an optional parameter loses by accident.

## The authoring guide was wrong about matter.js discovery

It said matter.js discovers on the discriminator alone and onboards whatever it finds. matter.js has
passed the code's vendor and product ids to discovery since "pass over a device the onboarding code
does not name", and a captured run shows the attempt ending in a discovery failure, so the guide and a
test comment repeating it are corrected.

## Evidence

- `build-clean`, `format-verify`, `lint` green. Full suite green; two later full runs each flaked one
  different `@matter/node` mock-time test, and that package alone passes 1776/1776 in ESM and CJS.
- `test-cert-framework` green, including 37 new tests. Each production change is covered by a test
  that goes red when the change is reverted — among them the two the review found: dropping the
  end-of-transfer gate reddens both truncated-log tests, and keeping a refused subscription live
  delivers an event the step must never see.
- Certification runs against a matter.js device on this branch: TC-DD-3.17, TC-DD-3.14, TC-IDM-2.1
  (`24 report chunks, each but the last followed by a StatusResponse, and none after the last`) and
  TC-IDM-3.1 all pass, with no unverified checks beyond the one TC-IDM-2.1 already had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
