### PR TITLE
test(chip-testing): the YAML shim no longer answers success for something the device never did

### DIFF
--- a/support/chip-testing/src/ChipToolWebSocketHandler.ts
+++ b/support/chip-testing/src/ChipToolWebSocketHandler.ts
@@ -58,7 +58,7 @@ import {
 import { NodeNotConnectedError } from "@project-chip/matter.js/device";
 import { WebSocketServer } from "ws";
 import { log } from "./GenericTestApp.js";
-import { AttributeResponseData, EventResponseData } from "./handler/CommandHandler.js";
+import { AttributeResponseData, DiscoveryResponse, EventResponseData } from "./handler/CommandHandler.js";
 import { LegacyControllerCommandHandler } from "./handler/LegacyControllerCommandHandler.js";
 
 const logger = new Logger("ChipToolWebSocketHandler");
@@ -161,6 +161,64 @@ function toChipJson(object: object, spaces?: number): string {
     }
 
     return result;
+}
+
+/**
+ * A discovery command's answer.
+ *
+ * `{results: []}` is the runner's success shape, and every `DiscoveryCommands` step of the corpus
+ * exists to prove a device was found, so a discovery that found nothing has to fail them instead.
+ */
+export function discoveryResponseFor(results: DiscoveryResponse, command: string): ChipWebSocketCommandResponse {
+    if (results.length === 0) {
+        logger.error(`Discovery for "${command}" found no device`);
+        return { results: [{ error: "FAILURE" }] };
+    }
+    return { results };
+}
+
+/**
+ * A write payload the step handed over, as the value to write.
+ *
+ * A payload nothing can read is refused rather than answered: `{results: []}` is the runner's success
+ * shape, so returning it would record a write the device never saw as one it accepted.
+ */
+export function parseWritePayload(value: string, what: string): unknown {
+    try {
+        return JSON.parse(value);
+    } catch (error) {
+        throw new ImplementationError(`Cannot read the payload of ${what}: ${(error as Error).message}`);
+    }
+}
+
+/**
+ * Whether `error` can only be a fault of this shim or of the step that drove it, rather than an answer
+ * from the device: our own invariant, API misuse or unimplemented path (`NotImplementedError` extends
+ * {@link InternalError}), a JavaScript type error from a path the request never fit, or a `SyntaxError`
+ * from reading a step's own argument — `JSON.parse` in {@link parseChipJSON} and `BigInt` in
+ * {@link parseNumber} both raise one, and both run inside a command handler's `try`.
+ *
+ * The device cannot produce any of those, so reporting them as the failure the device gave lets a step
+ * that expects one pass on our bug. `RangeError` is deliberately absent: `DataReader` clamps its offset
+ * rather than failing, so a truncated device message reaches `DataView` and raises one.
+ *
+ * Cause chains are followed, as {@link StatusResponseError.of} and {@link causedBy} do for the two
+ * classifications beside this one — a wrapped {@link ImplementationError} is still ours.
+ */
+export function isOwnFailure(error: unknown) {
+    return causedBy(error, ImplementationError, InternalError, TypeError, SyntaxError);
+}
+
+/**
+ * How this shim reports a failure of its own to the runner.
+ *
+ * The message is never empty: the runner drops a trailing `FAILURE` from a multi-entry result and reads
+ * a falsy error as no error at all, so an error carrying no message would be recorded as a command that
+ * succeeded.
+ */
+export function ownFailureResponse(error: unknown): ChipWebSocketCommandResponse {
+    const message = error instanceof Error ? `${error.constructor.name}: ${error.message}` : String(error);
+    return { results: [{ error: `Test harness failure — ${message || "no message"}` }, { error: "FAILURE" }] };
 }
 
 /**
@@ -842,13 +900,9 @@ export class ChipToolWebSocketHandler {
             throw new ImplementationError("Missing attribute name or value");
         }
 
-        let parsedValue: any = value;
-        try {
-            parsedValue = JSON.parse(value);
-        } catch (err) {
-            logger.error("Error parsing data for write-by-id", err);
-            return { results: [] };
-        }
+        // `{results: []}` is the runner's success shape, so answering it for a payload nothing can read
+        // records a write the device never saw as one it accepted
+        const parsedValue = parseWritePayload(value, "write-by-id");
 
         const nodeId = NodeId(parseNumber(destinationId));
         try {
@@ -943,7 +997,7 @@ export class ChipToolWebSocketHandler {
             ).handleDiscovery({
                 findBy,
             });
-            return { results };
+            return discoveryResponseFor(results, command);
         } catch (error) {
             logger.error("Error on discovery", error);
             return { results: [{ error: "FAILURE" }] };
@@ -1206,17 +1260,12 @@ export class ChipToolWebSocketHandler {
             throw new ImplementationError("Missing attribute name or value");
         }
         const attributeModel = clusterData.attributes[attributeName.toLowerCase()] ?? GlobalAttributes[attributeName];
-        let parsedValue: any = value;
+        let parsedValue: unknown = value;
         if (
             typeof value === "string" &&
             ((value.startsWith("[") && value.endsWith("]")) || (value.startsWith("{") && value.endsWith("}")))
         ) {
-            try {
-                parsedValue = JSON.parse(value);
-            } catch (err) {
-                logger.error("Error on parsing value for write", err);
-                return { results: [] };
-            }
+            parsedValue = parseWritePayload(value, `write of ${cluster}.${commandSpecifier}`);
         }
         const matterValue = convertWebsocketDataToMatter(parsedValue, attributeModel);
         const nodeId = NodeId(parseNumber(destinationId));
@@ -1322,6 +1371,11 @@ export class ChipToolWebSocketHandler {
             `Error for command "${command}" and cluster "${cluster}" and specifier "${commandSpecifier}"`,
             error,
         );
+        if (isOwnFailure(error)) {
+            // A step that expects a bare FAILURE would otherwise pass on a bug of this shim, on evidence
+            // the device never produced
+            return ownFailureResponse(error);
+        }
         return { results: [{ error: "FAILURE" }] };
     }
 

--- a/support/chip-testing/src/ChipToolWebSocketHandler.ts
+++ b/support/chip-testing/src/ChipToolWebSocketHandler.ts
@@ -187,7 +187,7 @@ export function parseWritePayload(value: string, what: string): unknown {
     try {
         return JSON.parse(value);
     } catch (error) {
-        throw new ImplementationError(`Cannot read the payload of ${what}: ${(error as Error).message}`);
+        throw new ImplementationError(`Cannot read the payload of ${what}`, { cause: error });
     }
 }
 
@@ -207,6 +207,18 @@ export function parseWritePayload(value: string, what: string): unknown {
  */
 export function isOwnFailure(error: unknown) {
     return causedBy(error, ImplementationError, InternalError, TypeError, SyntaxError);
+}
+
+/**
+ * How this shim answers a command that failed.
+ *
+ * A device that refuses gives a bare `FAILURE`, which steps of the corpus expect; a failure of this
+ * shim's own must not be spelled the same way (see {@link isOwnFailure}) or those steps pass on our bug.
+ * Every catch that answers a failure goes through here, so a handler cannot answer one way while
+ * another answers the other.
+ */
+export function failureResponseFor(error: unknown): ChipWebSocketCommandResponse {
+    return isOwnFailure(error) ? ownFailureResponse(error) : { results: [{ error: "FAILURE" }] };
 }
 
 /**
@@ -625,7 +637,7 @@ export class ChipToolWebSocketHandler {
                             return { results: [] };
                         } catch (error) {
                             logger.error("Error commissioning node", error);
-                            return { results: [{ error: "FAILURE" }] };
+                            return failureResponseFor(error);
                         }
                     default:
                         throw new NotImplementedError(`Pairing text command ${commandData[1]}`);
@@ -725,7 +737,7 @@ export class ChipToolWebSocketHandler {
                     return { results: [] };
                 } catch (error) {
                     logger.error("Error commissioning node", error);
-                    return { results: [{ error: "FAILURE" }] };
+                    return failureResponseFor(error);
                 }
             }
             case "code-paseonly": {
@@ -738,7 +750,7 @@ export class ChipToolWebSocketHandler {
                     return { results: [] };
                 } catch (error) {
                     logger.error("Error connecting to node via PASE", error);
-                    return { results: [{ error: "FAILURE" }] };
+                    return failureResponseFor(error);
                 }
             }
             case "get-commissioner-node-id":
@@ -1000,7 +1012,7 @@ export class ChipToolWebSocketHandler {
             return discoveryResponseFor(results, command);
         } catch (error) {
             logger.error("Error on discovery", error);
-            return { results: [{ error: "FAILURE" }] };
+            return failureResponseFor(error);
         }
     }
 
@@ -1371,12 +1383,7 @@ export class ChipToolWebSocketHandler {
             `Error for command "${command}" and cluster "${cluster}" and specifier "${commandSpecifier}"`,
             error,
         );
-        if (isOwnFailure(error)) {
-            // A step that expects a bare FAILURE would otherwise pass on a bug of this shim, on evidence
-            // the device never produced
-            return ownFailureResponse(error);
-        }
-        return { results: [{ error: "FAILURE" }] };
+        return failureResponseFor(error);
     }
 
     close() {

--- a/support/chip-testing/test/cert-framework/chip-tool-websocket-handler.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-websocket-handler.test.ts
@@ -11,6 +11,7 @@ import { expect } from "chai";
 import {
     convertWebsocketDataToMatter,
     discoveryResponseFor,
+    failureResponseFor,
     isOwnFailure,
     ownFailureResponse,
     parseWritePayload,
@@ -86,8 +87,18 @@ describe("parseWritePayload", () => {
         expect(parseWritePayload('{"a":1}', "write of x.y")).deep.equal({ a: 1 });
     });
 
-    it("refuses a payload it cannot read rather than answering the success shape", () => {
-        expect(() => parseWritePayload("{not json", "write of x.y")).throw(ImplementationError, /write of x\.y/);
+    it("refuses a payload it cannot read rather than answering the success shape, keeping the cause", () => {
+        let raised: unknown;
+        try {
+            parseWritePayload("{not json", "write of x.y");
+        } catch (e) {
+            raised = e;
+        }
+        if (!(raised instanceof ImplementationError)) {
+            throw new InternalError(`Expected an ImplementationError, got ${raised}`);
+        }
+        expect(raised.message).contains("write of x.y");
+        expect(raised.cause).instanceOf(SyntaxError);
     });
 });
 
@@ -123,6 +134,20 @@ describe("isOwnFailure", () => {
 
     it("leaves a RangeError alone, which a truncated device message raises through DataReader", () => {
         expect(isOwnFailure(new RangeError("Offset is outside the bounds of the DataView"))).equal(false);
+    });
+});
+
+describe("failureResponseFor", () => {
+    it("gives the bare failure a refusing device gives, which the corpus expects", () => {
+        expect(failureResponseFor(new UnexpectedDataError("the device answered something else"))).deep.equal({
+            results: [{ error: "FAILURE" }],
+        });
+    });
+
+    it("does not spell a fault of this shim the same way", () => {
+        expect(failureResponseFor(new ImplementationError("missing argument")).results[0].error).contains(
+            "Test harness failure",
+        );
     });
 });
 

--- a/support/chip-testing/test/cert-framework/chip-tool-websocket-handler.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-websocket-handler.test.ts
@@ -4,10 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes } from "@matter/main";
+import { Bytes, ImplementationError, InternalError, NotImplementedError, UnexpectedDataError } from "@matter/main";
+import { Status, StatusResponseError } from "@matter/main/types";
 import { Matter } from "@matter/model";
 import { expect } from "chai";
-import { convertWebsocketDataToMatter } from "../../src/ChipToolWebSocketHandler.js";
+import {
+    convertWebsocketDataToMatter,
+    discoveryResponseFor,
+    isOwnFailure,
+    ownFailureResponse,
+    parseWritePayload,
+} from "../../src/ChipToolWebSocketHandler.js";
 
 const NETWORK_COMMISSIONING = Matter.clusters.require("NetworkCommissioning");
 const LAST_NETWORK_ID_ATTRIBUTE = NETWORK_COMMISSIONING.attributes.require("lastNetworkID");
@@ -33,5 +40,105 @@ describe("ChipToolWebSocketHandler convertWebsocketDataToMatter octet strings", 
     it("leaves a non-empty unprefixed string unchanged", () => {
         const decoded = convertWebsocketDataToMatter("not-a-prefix-abcd", LAST_NETWORK_ID_ATTRIBUTE);
         expect(decoded).to.equal("not-a-prefix-abcd");
+    });
+});
+
+describe("discoveryResponseFor", () => {
+    // One entry of the shape `LegacyControllerCommandHandler.handleDiscovery` builds; the values are this
+    // test's own
+    const device = {
+        value: {
+            commissioningMode: 1,
+            deviceName: "",
+            deviceType: 0,
+            hostName: "B0FFFF00FF00",
+            instanceName: "0123456789ABCDEF",
+            longDiscriminator: 3840,
+            numIPs: 1,
+            pairingHint: -1,
+            pairingInstruction: "",
+            port: 5540,
+            productId: 32769,
+            rotatingId: "",
+            rotatingIdLen: 0,
+            shortDiscriminator: 15,
+            vendorId: 65521,
+            supportsTcpServer: false,
+            supportsTcpClient: false,
+        },
+    };
+
+    it("hands the runner what discovery found", () => {
+        expect(discoveryResponseFor([device], "find-commissionable-by-long-discriminator")).deep.equal({
+            results: [device],
+        });
+    });
+
+    it("fails the command when discovery found nothing, which the empty result would report as success", () => {
+        expect(discoveryResponseFor([], "find-commissionable-by-long-discriminator")).deep.equal({
+            results: [{ error: "FAILURE" }],
+        });
+    });
+});
+
+describe("parseWritePayload", () => {
+    it("reads the payload a step handed over", () => {
+        expect(parseWritePayload('{"a":1}', "write of x.y")).deep.equal({ a: 1 });
+    });
+
+    it("refuses a payload it cannot read rather than answering the success shape", () => {
+        expect(() => parseWritePayload("{not json", "write of x.y")).throw(ImplementationError, /write of x\.y/);
+    });
+});
+
+describe("isOwnFailure", () => {
+    it("claims this shim's own faults", () => {
+        expect(isOwnFailure(new ImplementationError("missing argument"))).equal(true);
+        expect(isOwnFailure(new InternalError("cannot happen"))).equal(true);
+        expect(isOwnFailure(new NotImplementedError("no handler for this command"))).equal(true);
+        expect(isOwnFailure(new TypeError("cluster is undefined"))).equal(true);
+    });
+
+    it("claims a SyntaxError, which is how a step's own malformed argument arrives", () => {
+        // JSON.parse in parseChipJSON and BigInt in parseNumber both raise one inside a handler's try
+        let raised: unknown;
+        try {
+            JSON.parse("{not json");
+        } catch (e) {
+            raised = e;
+        }
+        expect(isOwnFailure(raised)).equal(true);
+    });
+
+    it("claims one of ours that arrived wrapped", () => {
+        expect(isOwnFailure(new Error("while writing", { cause: new ImplementationError("missing argument") }))).equal(
+            true,
+        );
+    });
+
+    it("leaves an answer the device gave, or a device it could not reach, to the FAILURE the runner expects", () => {
+        expect(isOwnFailure(new StatusResponseError("refused", Status.UnsupportedAttribute))).equal(false);
+        expect(isOwnFailure(new UnexpectedDataError("the device answered something else"))).equal(false);
+    });
+
+    it("leaves a RangeError alone, which a truncated device message raises through DataReader", () => {
+        expect(isOwnFailure(new RangeError("Offset is outside the bounds of the DataView"))).equal(false);
+    });
+});
+
+describe("ownFailureResponse", () => {
+    it("names the failure and fails the command", () => {
+        expect(ownFailureResponse(new ImplementationError("missing argument"))).deep.equal({
+            results: [{ error: "Test harness failure — ImplementationError: missing argument" }, { error: "FAILURE" }],
+        });
+    });
+
+    it("names an error even where the failure carries no text of its own", () => {
+        // A falsy error entry is no error at all to the runner, so neither an Error without a message nor
+        // a thrown empty string may produce one
+        expect(ownFailureResponse(new InternalError("")).results[0].error).equal(
+            "Test harness failure — InternalError: ",
+        );
+        expect(ownFailureResponse("").results[0].error).equal("Test harness failure — no message");
     });
 });


### PR DESCRIPTION
The YAML shim stands in for `chip-tool`'s interactive server: CHIP's own test runner connects to it
over a websocket, and it turns each command into matter.js controller calls and answers in chip-tool's
JSON shape. The runner reads `{results: []}` as "the command succeeded", and three paths answered that
without the device having answered anything. Test-only; no library behavior changes.

## A discovery that found nothing was reported as a successful discovery

Five steps of `TestDiscovery` exist to prove the device advertises its commissioning subtypes — `_L`,
`_S`, `_CM`, `_V`, `_T`. None of them states an expected response, so the runner's parser fills in an
empty expectation that any success shape satisfies, and the steps passed against a discovery that came
back with nothing at all. An empty discovery now fails the command.

## A write payload the shim could not read was reported as a write the device accepted

The parse failure was logged and answered with the success shape. Both write paths refuse it now. No
step in the corpus reaches this today — the runner happens to quote the values it sends — so this is
the answer shape being wrong rather than a step currently passing wrongly.

## The shim's own faults were reported as the failure the device gave

Every command handler ends in one error path, and it answered the bare failure a device gives for
anything it did not recognise. 40 steps across 14 files of the corpus expect exactly that failure, so a
broken invariant of ours, a wrong argument, or a step argument we could not read passed them on
evidence the device never produced. Those now answer a failure that names itself.

Only classes the device cannot produce count as ours: our own invariant and API-misuse errors, a
JavaScript type error from a path the request never fit, and the syntax error raised by reading a step's
own malformed argument. Cause chains are followed, matching the two classifications beside it. A
`RangeError` is deliberately left as the device's, because the reader clamps its offset rather than
failing, so a truncated message from the device is what raises one.

## Evidence

- The shim's unit suite is 15 tests, 11 of them new; each new branch was checked by disabling it and
  confirming exactly the intended test goes red.
- `TestDiscovery` runs green through the shim locally (`MATTER_LOCAL_CONTROLLER=1`).
- Root `build`, `format-verify`, `lint` clean; full suite 19,933 tests green.
- The rest of the corpus cannot run on this machine: those suites pair from inside the container, whose
  chip-tool cannot discover a host device here. I confirmed that fails identically without this change,
  so CI is the arbiter for them.

## Not in this change

- The three decisions are covered as functions, but nothing proves the call sites use them — deleting
  the error branch or reverting the discovery call leaves the tests green. Closing that needs a fake
  runner-side websocket client, which belongs in its own change.
- `hostName` is still a fabricated constant, and a subtype check still cannot fail, because the
  identifier the scanner takes carries no hostname and every query set also asks the unfiltered service
  type. Both need a small addition to `@matter/protocol` rather than a change here.
- `rotatingIdLen` reports the hex string's length rather than the byte count, and no step constrains it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
