### PR TITLE
test(chip-testing): a certification step that observed nothing no longer reports success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 ## __WORK IN PROGRESS__
 
 - @matter/testing
+    - Enhancement: A certification step whose check could not be evaluated ends `"unverified"` and fails the run, unless the check states why the claim cannot be observed
     - Fix: A certification run's `result.json` no longer reports a passing verdict for a run that failed
     - Fix: A failure to attach a certification run's device logs fails the run instead of only warning
 

--- a/packages/testing/src/chip/cert/cert-context.ts
+++ b/packages/testing/src/chip/cert/cert-context.ts
@@ -60,8 +60,14 @@ export interface CertDeviceFactory extends Subject.Factory {
 
 /**
  * Outcome of a single cert-test step.
+ *
+ * `"unverified"` means the step ran and nothing in it threw, but at least one of its checks could not
+ * be evaluated, so the step observed less than its claim needs. It fails the run — unlike `"skipped"`,
+ * which states the step never ran at all — because a gap in what was observed must not read as proof.
+ * A check whose claim the run genuinely cannot observe says so with {@link CheckRecord.accepted} and
+ * leaves the step at `"pass"`.
  */
-export type StepVerdict = "pass" | "fail" | "skipped" | "aborted";
+export type StepVerdict = "pass" | "fail" | "unverified" | "skipped" | "aborted";
 
 /**
  * A single piece of evidence a step recorded while running.
@@ -73,6 +79,13 @@ export interface CheckRecord {
     pattern?: string;
     matched?: string;
     logLine?: number;
+    /**
+     * Why an `"unverified"` verdict here is expected rather than a gap to close — a claim this device
+     * or controller cannot exhibit at all, as against a pattern nobody has written yet. Such a check
+     * leaves its step at `"pass"`; every other unverified check makes the step `"unverified"` and fails
+     * the run. Ignored for a `"pass"`/`"fail"` verdict, which state what was observed.
+     */
+    accepted?: string;
 }
 
 /**
@@ -82,8 +95,10 @@ export interface CheckRecord {
 export interface StepRecorder {
     beginStep(step: CertStepDefinition): void;
     /**
-     * Records evidence only; a failed check does not itself change the step's {@link StepVerdict}.
-     * A step signals failure by having its `run` throw, not by calling `check` with a failing verdict.
+     * A step signals failure by having its `run` throw, not by calling `check` with a failing verdict:
+     * a `"fail"` here is recorded, not acted on. An `"unverified"` verdict does reach the step's own
+     * {@link StepVerdict} unless the check carries {@link CheckRecord.accepted}, since a step whose
+     * claim went unobserved has not passed.
      */
     check(record: CheckRecord): void;
     /** Returns the checks recorded for `step` (empty if it never began), for the caller's own end-of-step reporting. */
@@ -115,9 +130,9 @@ export interface StepRecorder {
     recordControllerUnsupportedSkips?(count: number): void;
     /**
      * Records how many of the run's checks reported `"unverified"` — a check whose claim could not be
-     * evaluated at all, which the step engine treats as neither proof nor failure. A step made
-     * entirely of unverified checks still ends with a "pass" verdict, so without this the persisted
-     * record alone would not say how much of what the steps claim was actually observed.
+     * evaluated at all. Counts the checks that declared their gap ({@link CheckRecord.accepted})
+     * alongside those that did not, so this says how much the run left unobserved whatever the
+     * verdicts say.
      */
     recordUnverifiedChecks?(count: number): void;
     /**
@@ -145,9 +160,11 @@ export interface StepRecorder {
      * record states no verdict, so a run that never reaches it cannot leave one behind. `outcome` is
      * the run's own result as its runner will report it — recorded for every failed run, whatever else
      * the record already names — so a failed run cannot settle as a pass over a cause this recorder was
-     * never told about (see {@link EvidenceRecorder.concludeRun}).
+     * never told about (see {@link EvidenceRecorder.concludeRun}). `outcome.unproven` says the run's
+     * only failure is that some step ended `"unverified"`, which the record states as its own verdict
+     * rather than as a failure of the device.
      */
-    concludeRun?(outcome: { failed: boolean; detail?: string }): Promise<void>;
+    concludeRun?(outcome: { failed: boolean; detail?: string; unproven?: boolean }): Promise<void>;
 }
 
 /**

--- a/packages/testing/src/chip/cert/cert-context.ts
+++ b/packages/testing/src/chip/cert/cert-context.ts
@@ -83,7 +83,8 @@ export interface CheckRecord {
      * Why an `"unverified"` verdict here is expected rather than a gap to close — a claim this device
      * or controller cannot exhibit at all, as against a pattern nobody has written yet. Such a check
      * leaves its step at `"pass"`; every other unverified check makes the step `"unverified"` and fails
-     * the run. Ignored for a `"pass"`/`"fail"` verdict, which state what was observed.
+     * the run, a blank reason included, since a field left empty accounts for nothing. Ignored for a
+     * `"pass"`/`"fail"` verdict, which state what was observed.
      */
     accepted?: string;
 }

--- a/packages/testing/src/chip/cert/cert-test.ts
+++ b/packages/testing/src/chip/cert/cert-test.ts
@@ -71,21 +71,22 @@ export class CertTest extends BaseTest {
         // a response check on essentially every step. Counting them is what lets a controller refusal
         // discovered *after* the step acted be told apart from one discovered before it acted.
         let observedThisStep = 0;
+        let unaccountedThisStep = 0;
         let unverifiedChecks = 0;
         const recorded = cx.recorder;
 
         // A StepRecorder may be a class instance, whose members live on its prototype — so each is
         // forwarded by name.
         const recorder: StepRecorder = {
-            beginStep: step => {
-                observedThisStep = 0;
-                recorded.beginStep(step);
-            },
+            beginStep: step => recorded.beginStep(step),
             check: record => {
                 observedThisStep++;
                 recorded.check(record);
                 if (record.verdict === "unverified") {
                     unverifiedChecks++;
+                    if (record.accepted === undefined) {
+                        unaccountedThisStep++;
+                    }
                 }
             },
             endStep: (step, verdict, skipReason) => recorded.endStep(step, verdict, skipReason),
@@ -122,6 +123,8 @@ export class CertTest extends BaseTest {
         let failure: unknown;
         let failed = false;
         let controllerUnsupportedSkips = 0;
+        let unverifiedSteps = 0;
+        let unproven = false;
         let reportingFailure: unknown;
 
         // Ends a step and announces its outcome. A throw here must not become the step's outcome —
@@ -187,6 +190,8 @@ export class CertTest extends BaseTest {
 
                     step(`Test Step ${stepDef.number}: ${stepDef.text}`);
                     announceStepStart(cx, tc, stepDef);
+                    observedThisStep = 0;
+                    unaccountedThisStep = 0;
                     recorder.beginStep(stepDef);
 
                     await raceAgainstDeviceExit(stepDef.run(cx), deviceExitWatch.exit, tc, stepDef.number);
@@ -222,6 +227,12 @@ export class CertTest extends BaseTest {
                     continue;
                 }
 
+                if (unaccountedThisStep > 0) {
+                    unverifiedSteps++;
+                    report(stepDef, "unverified");
+                    continue;
+                }
+
                 report(stepDef, "pass");
             }
 
@@ -235,21 +246,19 @@ export class CertTest extends BaseTest {
             // recorded count are what would tell a reader the run proved less than its verdict
             // suggests; a raw result.json with no attached logs must say it too.
             if (controllerUnsupportedSkips > 0) {
-                try {
-                    announceControllerSkipSummary(cx, tc, controllerUnsupportedSkips);
-                    recorder.recordControllerUnsupportedSkips?.(controllerUnsupportedSkips);
-                } catch (e) {
-                    console.warn("Cert test controller-skip summary reporting failed:", e);
-                }
+                recordSummary(
+                    () => recorder.recordControllerUnsupportedSkips?.(controllerUnsupportedSkips),
+                    () => announceControllerSkipSummary(cx, tc, controllerUnsupportedSkips),
+                    "controller-skip",
+                );
             }
 
             if (unverifiedChecks > 0) {
-                try {
-                    announceUnverifiedSummary(cx, tc, unverifiedChecks);
-                    recorder.recordUnverifiedChecks?.(unverifiedChecks);
-                } catch (e) {
-                    console.warn("Cert test unverified-check summary reporting failed:", e);
-                }
+                recordSummary(
+                    () => recorder.recordUnverifiedChecks?.(unverifiedChecks),
+                    () => announceUnverifiedSummary(cx, tc, unverifiedChecks),
+                    "unverified-check",
+                );
             }
         } catch (e) {
             // Kept before rethrowing: the handlers inside cover what a step can do, and everything else
@@ -346,10 +355,28 @@ export class CertTest extends BaseTest {
                 }
             }
 
+            // Only where nothing else failed: a device that died or cleanup that threw is the run's
+            // own outcome, and a step that observed nothing is the weaker claim of the two.
+            if (!failed && unverifiedSteps > 0) {
+                unproven = true;
+                failed = true;
+                failure = new Error(
+                    `Cert test ${tc}: ${unverifiedSteps} step${unverifiedSteps === 1 ? "" : "s"} ended with a ` +
+                        "check that could not be evaluated, so the run proved less than those steps claim. Close " +
+                        "the gap — a device-log check usually needs the pattern for this device's flavor written " +
+                        "— or, where this run genuinely cannot observe the claim, say so in the check's " +
+                        '"accepted" field.',
+                );
+            }
+
             // Last, so the outcome handed over is the one this method is about to report. The record
             // states no verdict until here, and a run that cannot get this far leaves one saying so.
             try {
-                await recorder.concludeRun?.({ failed, detail: failed ? errorText(failure) : undefined });
+                await recorder.concludeRun?.({
+                    failed,
+                    detail: failed ? errorText(failure) : undefined,
+                    unproven,
+                });
             } catch (e) {
                 if (failed) {
                     console.warn("Cert test could not settle its evidence record after a failure:", e);
@@ -480,6 +507,24 @@ function announceRunHeader(cx: CertStepContext, recorder: StepRecorder): void {
     const lines = recorder.runHeaderLines?.();
     if (lines && lines.length > 0) {
         announceStep(cx, lines);
+    }
+}
+
+/**
+ * Persists a run-level summary and then announces it. In that order and in separate attempts: the
+ * count is what a bundle with no attached logs has, so a banner that cannot be written must not cost
+ * it.
+ */
+function recordSummary(record: () => void, announce: () => void, what: string): void {
+    try {
+        record();
+    } catch (e) {
+        console.warn(`Cert test ${what} summary could not be recorded:`, e);
+    }
+    try {
+        announce();
+    } catch (e) {
+        console.warn(`Cert test ${what} summary could not be announced:`, e);
     }
 }
 

--- a/packages/testing/src/chip/cert/cert-test.ts
+++ b/packages/testing/src/chip/cert/cert-test.ts
@@ -84,7 +84,9 @@ export class CertTest extends BaseTest {
                 recorded.check(record);
                 if (record.verdict === "unverified") {
                     unverifiedChecks++;
-                    if (record.accepted === undefined) {
+                    // A blank reason accounts for nothing: an empty string would otherwise pass a step
+                    // off as proven on a field somebody forgot to fill in.
+                    if (record.accepted === undefined || record.accepted.trim() === "") {
                         unaccountedThisStep++;
                     }
                 }

--- a/packages/testing/src/chip/cert/evidence.ts
+++ b/packages/testing/src/chip/cert/evidence.ts
@@ -48,7 +48,7 @@ export interface RunRecord {
      * finished reporting has no verdict to state — so no hang, interruption or unwritable volume can
      * leave a passing record standing for a run that failed.
      */
-    verdict: "pass" | "fail" | "skipped" | "incomplete";
+    verdict: "pass" | "fail" | "unverified" | "skipped" | "incomplete";
     deviceExit?: { code: number | null; signal?: string };
     /** Why the run's own cleanup failed, if it did (see {@link EvidenceRecorder.finalizationFailed}). */
     finalizationError?: string;
@@ -71,8 +71,10 @@ export interface RunRecord {
     controllerUnsupportedSkips?: number;
     /**
      * How many checks reported `"unverified"`, absent if none. Such a check neither proves nor
-     * disproves what its step claims — a step made only of them still passes — so this is what tells a
-     * reader of this record alone how much of the run's claims rest on nothing observed.
+     * disproves what its step claims, so this is what tells a reader of this record alone how much of
+     * the run's claims rest on nothing observed. A step carrying one ends `"unverified"` unless the
+     * check declared its gap ({@link CheckRecord.accepted}), so this count is at least as large as the
+     * unverified step verdicts suggest and says nothing on its own about how many steps they fell in.
      */
     unverifiedChecks?: number;
 }
@@ -107,6 +109,7 @@ export class EvidenceRecorder implements StepRecorder {
     #teardownError?: string;
     #evidenceError?: string;
     #runError?: string;
+    #unproven = false;
     #controllerUnsupportedSkips?: number;
     #unverifiedChecks?: number;
     #concluded = false;
@@ -199,9 +202,9 @@ export class EvidenceRecorder implements StepRecorder {
     }
 
     /**
-     * Records how many checks could not be evaluated (see {@link RunRecord.unverifiedChecks}). Unlike a
-     * failed step this never changes the verdict — such a check is a gap in what the run observed, not
-     * a defect in the device.
+     * Records how many checks could not be evaluated (see {@link RunRecord.unverifiedChecks}). The
+     * count itself settles nothing: a check that did not declare its gap has already made its step's
+     * verdict `"unverified"`, and one that did changes no verdict at all.
      */
     recordUnverifiedChecks(count: number): void {
         this.#unverifiedChecks = count;
@@ -258,10 +261,15 @@ export class EvidenceRecorder implements StepRecorder {
      * cause this recorder was never told about, and `outcome.detail` records that report as
      * {@link RunRecord.runError} whether or not another field already names a mechanism for it.
      */
-    async concludeRun(outcome: { failed: boolean; detail?: string }): Promise<void> {
+    async concludeRun(outcome: { failed: boolean; detail?: string; unproven?: boolean }): Promise<void> {
         this.#concluded = true;
         if (outcome.failed && this.#runError === undefined) {
             this.#runError = outcome.detail ?? "the run failed";
+        }
+        // Only alongside a failure: a run its own runner reported as green cannot be one this record
+        // calls unproven.
+        if (outcome.unproven && outcome.failed) {
+            this.#unproven = true;
         }
         await this.#writeRecord();
     }
@@ -328,7 +336,8 @@ export class EvidenceRecorder implements StepRecorder {
     /**
      * A run where every step was skipped (or that had no steps at all — a malformed definition) is
      * neither a pass nor a fail: nothing was actually exercised, so reporting `"pass"` would overstate
-     * what the run proved. Only a run with at least one non-skipped step can pass.
+     * what the run proved. Only a run with at least one non-skipped step can pass, and only a run
+     * whose every executed step observed what it claims can pass rather than settle `"unverified"`.
      */
     #verdict(): RunRecord["verdict"] {
         if (!this.#concluded) {
@@ -339,12 +348,17 @@ export class EvidenceRecorder implements StepRecorder {
             this.#finalizationError !== undefined ||
             this.#teardownError !== undefined ||
             this.#evidenceError !== undefined ||
-            this.#runError !== undefined
+            // A run whose only failure is a step that observed nothing states that as its verdict; the
+            // catch-all otherwise makes every such run indistinguishable from a device that misbehaved.
+            (this.#runError !== undefined && !this.#unproven)
         ) {
             return "fail";
         }
         if (this.#steps.some(step => step.verdict === "fail" || step.verdict === "aborted")) {
             return "fail";
+        }
+        if (this.#unproven || this.#steps.some(step => step.verdict === "unverified")) {
+            return "unverified";
         }
         if (this.#steps.some(step => step.verdict === "pass")) {
             return "pass";

--- a/support/chip-testing/README.md
+++ b/support/chip-testing/README.md
@@ -233,20 +233,30 @@ attached log stream (`device-<role>.log`, `controller-<name>.log`). Sketch of `r
 }
 ```
 
-A run-level `verdict` is one of `"pass" | "fail" | "skipped" | "incomplete"`; a step's is
-`"pass" | "fail" | "skipped" | "aborted"` (`"aborted"` for a step never reached after an earlier one
-failed). A run-level `"skipped"` means every step was skipped (a flavor or PICS gap) — not a failure.
+A run-level `verdict` is one of `"pass" | "fail" | "unverified" | "skipped" | "incomplete"`; a step's
+is `"pass" | "fail" | "unverified" | "skipped" | "aborted"` (`"aborted"` for a step never reached
+after an earlier one failed). A run-level `"skipped"` means every step was skipped (a flavor or PICS
+gap) — not a failure.
+
+`"unverified"` means the step ran without failing but one of its checks could not be evaluated, so it
+observed less than it claims; the test itself then fails, and the run reads `"unverified"` unless
+something stronger — a device that exited, cleanup or teardown that threw, evidence that could not be
+assembled, another step that failed — makes it `"fail"`. A gap in what was observed must not read as
+proof. A check whose claim the run genuinely cannot observe states why in its own `accepted` field,
+which keeps its step at `"pass"`.
 
 `"incomplete"` means the run never reached the point where its verdict is settled: a teardown that
 hung, a process killed mid-run, a volume that stopped accepting writes. Treat it as a failure of the
 run, not a statement about the device.
 
-Alongside `verdict`, a failed run carries `runError` (how the run's own runner reported the failure)
+Alongside `verdict`, every run the harness reported as failed — `"unverified"` runs included — carries
+`runError` (how the run's own runner reported the failure)
 and, where they apply, `deviceExit`, `finalizationError` (cleanup threw), `teardownError` (a
 controller or device would not close) and `evidenceError` (evidence the checks cite could not be
-assembled). `unverifiedChecks` counts checks whose claim could not be evaluated at all, and
-`controllerUnsupportedSkips` counts steps the controller could not express — both are gaps in what a
-passing run proved, not failures.
+assembled). `unverifiedChecks` counts checks whose claim could not be evaluated at all, those that
+stated a reason in `accepted` included, so it says how much the run left unobserved whatever the
+verdicts say; `controllerUnsupportedSkips` counts steps the controller could not express, a gap in
+what a passing run proved rather than a failure.
 
 Every attached `.log` file also carries a step-boundary banner (chip python/yaml style) at the point
 a step starts and again when it ends, e.g.:

--- a/support/chip-testing/src/ChipToolWebSocketHandler.ts
+++ b/support/chip-testing/src/ChipToolWebSocketHandler.ts
@@ -580,7 +580,16 @@ export class ChipToolWebSocketHandler {
         }
         // Do start the controllers just if needed
         if (!handler.started) {
-            await handler.start();
+            try {
+                await handler.start();
+            } catch (error) {
+                // A controller of ours that will not come up is not the device refusing: left as it
+                // arrives, a storage or socket error here answers the bare failure 40 steps of the
+                // corpus expect, and they would pass on it.
+                throw new InternalError(`Controller "${controllerName ?? "alpha"}" failed to start`, {
+                    cause: error,
+                });
+            }
         }
         return handler;
     }

--- a/support/chip-testing/src/ChipToolWebSocketHandler.ts
+++ b/support/chip-testing/src/ChipToolWebSocketHandler.ts
@@ -59,8 +59,12 @@ import {
 import { NodeNotConnectedError } from "@project-chip/matter.js/device";
 import { WebSocketServer } from "ws";
 import { log } from "./GenericTestApp.js";
-import { AttributeResponseData, DiscoveryResponse, EventResponseData } from "./handler/CommandHandler.js";
-import { LegacyControllerCommandHandler } from "./handler/LegacyControllerCommandHandler.js";
+import {
+    AttributeResponseData,
+    CommandHandler,
+    DiscoveryResponse,
+    EventResponseData,
+} from "./handler/CommandHandler.js";
 
 const logger = new Logger("ChipToolWebSocketHandler");
 
@@ -542,7 +546,7 @@ interface OutgoingChipWebSocketCommandResponse extends ChipWebSocketCommandRespo
 export class ChipToolWebSocketHandler {
     readonly #wsPort: number;
     #wsServer?: WebSocketServer;
-    #commandHandlers?: Map<string, LegacyControllerCommandHandler>;
+    #commandHandlers?: Map<string, CommandHandler>;
     #startRecording?: () => void;
     #stopRecording?: () => { module: string; category: string; message: string }[];
     readonly #subscriptionData = new Array<AttributeResponseData | EventResponseData>();
@@ -552,7 +556,7 @@ export class ChipToolWebSocketHandler {
         this.#wsPort = wsPort;
     }
 
-    initialize(commandHandlers: Map<string, LegacyControllerCommandHandler>) {
+    initialize(commandHandlers: Map<string, CommandHandler>) {
         logger.info(`Initialize with Command handlers for Identities ${Array.from(commandHandlers.keys()).join(", ")}`);
         this.#commandHandlers = commandHandlers;
 
@@ -581,11 +585,39 @@ export class ChipToolWebSocketHandler {
         return handler;
     }
 
-    start() {
-        this.#wsServer = new WebSocketServer({ host: "127.0.0.1", port: this.#wsPort }, () => {
-            logger.info(`WebSocketServer started on port ${this.#wsPort}`);
-            log.directive("== WebSocket Server Ready"); // Testrunner uses this to detect that WS server has been started
+    /**
+     * The port the server actually listens on, which is the configured one unless that was 0 — then the
+     * OS picks it and only the bound socket knows. `undefined` before {@link start} resolves.
+     */
+    get port(): number | undefined {
+        const address = this.#wsServer?.address();
+        if (address === undefined || address === null || typeof address === "string") {
+            return undefined;
+        }
+        return address.port;
+    }
+
+    /**
+     * Starts listening. Resolves once the socket is bound, so a caller that reports "started" says
+     * something true, and rejects where the port could not be taken rather than raising an
+     * unhandled error event.
+     */
+    async start(): Promise<void> {
+        const server = new WebSocketServer({ host: "127.0.0.1", port: this.#wsPort });
+        this.#wsServer = server;
+
+        await new Promise<void>((resolve, reject) => {
+            const failed = (error: Error) => reject(error);
+            server.once("listening", () => {
+                server.off("error", failed);
+                logger.info(`WebSocketServer started on port ${this.port}`);
+                log.directive("== WebSocket Server Ready"); // Testrunner uses this to detect that WS server has been started
+                resolve();
+            });
+            server.once("error", failed);
         });
+
+        server.on("error", error => logger.error("Testrunner WebSocket server error", error));
 
         this.#wsServer.on("connection", ws => {
             logger.info("Testrunner connected to WebSocket");
@@ -616,7 +648,10 @@ export class ChipToolWebSocketHandler {
             }
         } catch (error) {
             logger.error("WebSocket Message parsing error", error);
-            result = { results: [{ error: (error as Error).message }, { error: "FAILURE" }] };
+            // Only this shim's own faults reach here — every call to the device runs inside a handler's
+            // own try — and an error carrying no message would otherwise answer with an empty error
+            // entry, which the runner reads as a command that succeeded.
+            result = failureResponseFor(error);
         }
 
         // Grab logs and send response including logs

--- a/support/chip-testing/src/ControllerTestInstance.ts
+++ b/support/chip-testing/src/ControllerTestInstance.ts
@@ -189,7 +189,7 @@ export class ControllerTestInstance extends TestInstance {
         this.#env.vars.set("mdns.networkInterface", "en0");
         */
 
-        this.#commandHandler.start();
+        await this.#commandHandler.start();
 
         logger.info("STARTED");
     }

--- a/support/chip-testing/src/handler/CommandHandler.ts
+++ b/support/chip-testing/src/handler/CommandHandler.ts
@@ -194,6 +194,24 @@ export type IssueNocChainResponse = {
 };
 
 export abstract class CommandHandler {
+    /**
+     * Whether {@link start} has completed. A consumer starts a handler on first use rather than up
+     * front, so a run that never addresses a controller never pays for starting it.
+     */
+    abstract get started(): boolean;
+
+    /** Brings the underlying controller up. Idempotent: starting an already-started handler is a no-op. */
+    abstract start(): Promise<void>;
+
+    /** Establishes a PASE session with the commissionee the request names, without commissioning it. */
+    abstract handlePaseConnection(data: InitialPairingRequest): Promise<void>;
+
+    /**
+     * Drops the session with `nodeId`. The YAML corpus expects a failed interaction to stay failed, so
+     * a caller uses this where an automatic reconnection would answer a step that must not succeed.
+     */
+    abstract disconnectNode(nodeId: NodeId): Promise<void>;
+
     abstract handleReadAttribute(data: ReadAttributeRequest): Promise<ReadAttributeResponse>;
     abstract handleSubscribeAttribute(data: SubscribeAttributeRequest): Promise<SubscribeAttributeResponse>;
     abstract handleWriteAttribute(data: WriteAttributeRequest): Promise<void>;

--- a/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
+++ b/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
@@ -60,6 +60,7 @@ export class LegacyControllerCommandHandler extends CommandHandler {
     #identity: string;
     #controllerInstance: CommissioningController;
     #started = false;
+    #starting?: Promise<void>;
     #paseSession?: SecureSession;
 
     constructor(identity: string, controllerInstance: CommissioningController) {
@@ -74,8 +75,19 @@ export class LegacyControllerCommandHandler extends CommandHandler {
 
     async start() {
         if (this.#started) return;
-        this.#started = true;
 
+        // A start that threw must not leave the handler claiming to be started: every later command
+        // would then run against a controller that never came up.
+        this.#starting ??= this.#startController()
+            .then(() => {
+                this.#started = true;
+            })
+            .finally(() => (this.#starting = undefined));
+
+        return this.#starting;
+    }
+
+    async #startController() {
         try {
             await this.#controllerInstance.start();
             logger.info(`-----> Controller ${this.#identity} started`);

--- a/support/chip-testing/test/cert-framework/cert-test.test.ts
+++ b/support/chip-testing/test/cert-framework/cert-test.test.ts
@@ -2594,6 +2594,44 @@ describe("CertTest", () => {
         ]);
     });
 
+    it("counts a blank reason as no reason at all", async () => {
+        const definition: CertTestDefinition = {
+            tc: "TC-CADMIN-1.17",
+            plan: "multiplefabrics.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [
+                {
+                    number: 1,
+                    text: "Step whose gap was declared with an empty reason",
+                    run: async cx => {
+                        cx.recorder.check({ type: "response", verdict: "unverified", accepted: "   " });
+                    },
+                },
+            ],
+        };
+
+        const endStepVerdicts = new Array<{ number: number | string; verdict: StepVerdict }>();
+        const cx: CertStepContext = {
+            controllers: {},
+            devices: {},
+            recorder: stubRecorder({
+                endStep(step, verdict) {
+                    endStepVerdicts.push({ number: step.number, verdict });
+                    return [];
+                },
+            }),
+        };
+
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
+
+        await expect(test.invoke(stubSubject(new PicsFile([])), () => {}, [], false)).rejectedWith(
+            "1 step ended with a check that could not be evaluated",
+        );
+
+        expect(endStepVerdicts).deep.equal([{ number: 1, verdict: "unverified" }]);
+    });
+
     it("fails a step whose second check went unverified although the first one stated its own gap", async () => {
         const definition: CertTestDefinition = {
             tc: "TC-CADMIN-1.17",

--- a/support/chip-testing/test/cert-framework/cert-test.test.ts
+++ b/support/chip-testing/test/cert-framework/cert-test.test.ts
@@ -1307,7 +1307,7 @@ describe("CertTest", () => {
             steps: [{ number: 1, text: "A step that never runs", run: async () => {} }],
         };
 
-        const outcomes = new Array<{ failed: boolean; detail?: string }>();
+        const outcomes = new Array<{ failed: boolean; detail?: string; unproven?: boolean }>();
         const cx: CertStepContext = {
             controllers: {},
             devices: {},
@@ -1327,7 +1327,7 @@ describe("CertTest", () => {
 
         // The throw came from outside every step, so only the run's own outcome can keep the record
         // from settling as though nothing went wrong.
-        expect(outcomes).deep.equal([{ failed: true, detail: "PICS accessor exploded" }]);
+        expect(outcomes).deep.equal([{ failed: true, detail: "PICS accessor exploded", unproven: false }]);
     });
 
     it("reports a device that died rather than a controller that would not close", async () => {
@@ -2278,6 +2278,70 @@ describe("CertTest", () => {
         }
     });
 
+    it("writes a record that says unverified for a run whose step observed nothing", async () => {
+        const outDir = await mkdtemp(join(tmpdir(), "matter-cert-test-evidence-"));
+        try {
+            const definition: CertTestDefinition = {
+                tc: "TC-CADMIN-1.17",
+                plan: "multiplefabrics.adoc",
+                pics: [],
+                app: "all-clusters",
+                steps: [
+                    {
+                        number: 1,
+                        text: "Step whose log check names no pattern for this flavor",
+                        run: async cx => {
+                            cx.recorder.check({ type: "response", verdict: "pass" });
+                            cx.recorder.check({ type: "device-log", verdict: "unverified" });
+                        },
+                    },
+                    {
+                        number: 2,
+                        text: "Step whose one gap it can explain",
+                        run: async cx => {
+                            cx.recorder.check({
+                                type: "response",
+                                verdict: "unverified",
+                                accepted: "the app defines no manufacturer-specific cluster",
+                            });
+                        },
+                    },
+                ],
+            };
+
+            const recorder = new EvidenceRecorder(outDir, {
+                tc: "TC-CADMIN-1.17",
+                plan: "multiplefabrics.adoc",
+                timestamp: "2026-08-07T00:00:00.000Z",
+                controller: "dut",
+                controllerImplementation: "matterjs",
+                device: "matterjs:all-clusters",
+                matterJsCommit: "abc1234",
+            });
+            const resultPath = join(outDir, "2026-08-07T00-00-00.000Z-TC-CADMIN-1.17", "result.json");
+            const cx: CertStepContext = { controllers: {}, devices: {}, recorder };
+
+            const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
+
+            await expect(test.invoke(stubSubject(new PicsFile([])), () => {}, [], false)).rejectedWith(
+                "1 step ended with a check that could not be evaluated",
+            );
+
+            const resultJson = JSON.parse(await readFile(resultPath, "utf8"));
+            expect(resultJson.verdict).equal("unverified");
+            expect(resultJson.steps.map((step: { verdict: string }) => step.verdict)).deep.equal([
+                "unverified",
+                "pass",
+            ]);
+
+            // Both gaps counted, the accepted one included.
+            expect(resultJson.unverifiedChecks).equal(2);
+            expect(resultJson.runError).match(/could not be evaluated/);
+        } finally {
+            await rm(outDir, { recursive: true, force: true });
+        }
+    });
+
     it("persists the log-attachment failure, so the written record does not report a pass", async () => {
         const outDir = await mkdtemp(join(tmpdir(), "matter-cert-test-evidence-"));
         try {
@@ -2367,7 +2431,7 @@ describe("CertTest", () => {
         await expect(test.invoke(stubSubject(new PicsFile([])), () => {}, [], false)).rejectedWith("boom");
     });
 
-    it("counts the checks that could not be verified, and reports them at run level", async () => {
+    it("counts the checks that could not be verified, fails the run and reports them at run level", async () => {
         const definition: CertTestDefinition = {
             tc: "TC-CADMIN-1.17",
             plan: "multiplefabrics.adoc",
@@ -2394,10 +2458,78 @@ describe("CertTest", () => {
 
         const deviceLog = new LogFollower(noLines(), "device");
         const unverified = new Array<number>();
+        const endStepVerdicts = new Array<{ number: number | string; verdict: StepVerdict }>();
+        const outcomes = new Array<{ failed: boolean; detail?: string; unproven?: boolean }>();
         const cx: CertStepContext = {
             controllers: {},
             devices: { th: { ...stubCertDevice(new Promise<DeviceExitInfo>(() => {})), log: deviceLog } },
             recorder: stubRecorder({
+                endStep(step, verdict) {
+                    endStepVerdicts.push({ number: step.number, verdict });
+                    return [];
+                },
+                recordUnverifiedChecks(count) {
+                    unverified.push(count);
+                },
+                async concludeRun(outcome) {
+                    outcomes.push(outcome);
+                },
+            }),
+        };
+
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
+
+        // A step that observed nothing must not read as one that proved something, so the run itself
+        // fails rather than leaving the gap to whoever reads the bundle.
+        await expect(test.invoke(stubSubject(new PicsFile([])), () => {}, [], false)).rejectedWith(
+            "2 steps ended with a check that could not be evaluated",
+        );
+
+        expect(endStepVerdicts).deep.equal([
+            { number: 1, verdict: "unverified" },
+            { number: 2, verdict: "unverified" },
+        ]);
+        expect(unverified).deep.equal([2]);
+        expect(outcomes.length).equal(1);
+        expect(outcomes[0].failed).equal(true);
+        expect(outcomes[0].unproven).equal(true);
+
+        const banners = deviceLog.lines.filter(line => line.synthetic).map(line => line.text);
+        expect(banners).to.include("TC-CADMIN-1.17 — 2 checks could not be verified");
+        expect(banners).to.include("TC-CADMIN-1.17 — Test Step 1: UNVERIFIED");
+    });
+
+    it("keeps a step whose check declares why it could not be evaluated at pass, and the run with it", async () => {
+        const definition: CertTestDefinition = {
+            tc: "TC-CADMIN-1.17",
+            plan: "multiplefabrics.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [
+                {
+                    number: 1,
+                    text: "Step whose claim this device cannot exhibit at all",
+                    run: async cx => {
+                        cx.recorder.check({
+                            type: "response",
+                            verdict: "unverified",
+                            accepted: "the matter.js app defines no manufacturer-specific cluster",
+                        });
+                    },
+                },
+            ],
+        };
+
+        const unverified = new Array<number>();
+        const endStepVerdicts = new Array<{ number: number | string; verdict: StepVerdict }>();
+        const cx: CertStepContext = {
+            controllers: {},
+            devices: {},
+            recorder: stubRecorder({
+                endStep(step, verdict) {
+                    endStepVerdicts.push({ number: step.number, verdict });
+                    return [];
+                },
                 recordUnverifiedChecks(count) {
                     unverified.push(count);
                 },
@@ -2407,10 +2539,232 @@ describe("CertTest", () => {
         const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
         await test.invoke(stubSubject(new PicsFile([])), () => {}, [], false);
 
-        expect(unverified).deep.equal([2]);
+        expect(endStepVerdicts).deep.equal([{ number: 1, verdict: "pass" }]);
 
-        const banners = deviceLog.lines.filter(line => line.synthetic).map(line => line.text);
-        expect(banners).to.include("TC-CADMIN-1.17 — 2 checks could not be verified");
+        // Still counted: the declaration says the gap is expected, not that the run observed the claim.
+        expect(unverified).deep.equal([1]);
+    });
+
+    it("fails a run whose later step went unverified even where an earlier one passed", async () => {
+        const definition: CertTestDefinition = {
+            tc: "TC-CADMIN-1.17",
+            plan: "multiplefabrics.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [
+                {
+                    number: 1,
+                    text: "Step that observed what it claims",
+                    run: async cx => {
+                        cx.recorder.check({ type: "response", verdict: "pass" });
+                    },
+                },
+                {
+                    number: 2,
+                    text: "Step whose log check names no pattern for this flavor",
+                    run: async cx => {
+                        cx.recorder.check({ type: "response", verdict: "pass" });
+                        cx.recorder.check({ type: "device-log", verdict: "unverified" });
+                    },
+                },
+            ],
+        };
+
+        const endStepVerdicts = new Array<{ number: number | string; verdict: StepVerdict }>();
+        const cx: CertStepContext = {
+            controllers: {},
+            devices: {},
+            recorder: stubRecorder({
+                endStep(step, verdict) {
+                    endStepVerdicts.push({ number: step.number, verdict });
+                    return [];
+                },
+            }),
+        };
+
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
+
+        await expect(test.invoke(stubSubject(new PicsFile([])), () => {}, [], false)).rejectedWith(
+            "1 step ended with a check that could not be evaluated",
+        );
+
+        expect(endStepVerdicts).deep.equal([
+            { number: 1, verdict: "pass" },
+            { number: 2, verdict: "unverified" },
+        ]);
+    });
+
+    it("fails a step whose second check went unverified although the first one stated its own gap", async () => {
+        const definition: CertTestDefinition = {
+            tc: "TC-CADMIN-1.17",
+            plan: "multiplefabrics.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [
+                {
+                    number: 1,
+                    text: "Step with one gap it can explain and one it cannot",
+                    run: async cx => {
+                        cx.recorder.check({
+                            type: "response",
+                            verdict: "unverified",
+                            accepted: "the app defines no manufacturer-specific cluster",
+                        });
+                        cx.recorder.check({ type: "device-log", verdict: "unverified" });
+                    },
+                },
+            ],
+        };
+
+        const endStepVerdicts = new Array<{ number: number | string; verdict: StepVerdict }>();
+        const cx: CertStepContext = {
+            controllers: {},
+            devices: {},
+            recorder: stubRecorder({
+                endStep(step, verdict) {
+                    endStepVerdicts.push({ number: step.number, verdict });
+                    return [];
+                },
+            }),
+        };
+
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
+
+        await expect(test.invoke(stubSubject(new PicsFile([])), () => {}, [], false)).rejectedWith(
+            "1 step ended with a check that could not be evaluated",
+        );
+
+        expect(endStepVerdicts).deep.equal([{ number: 1, verdict: "unverified" }]);
+    });
+
+    it("keeps a step's unverified count across a recorder frame the step itself opened", async () => {
+        const definition: CertTestDefinition = {
+            tc: "TC-CADMIN-1.17",
+            plan: "multiplefabrics.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [
+                {
+                    number: 1,
+                    text: "Step that opens a recorder frame of its own",
+                    run: async cx => {
+                        cx.recorder.check({ type: "device-log", verdict: "unverified" });
+                        cx.recorder.beginStep({ number: 1, text: "inner", run: async () => {} });
+                        cx.recorder.check({ type: "response", verdict: "pass" });
+                    },
+                },
+            ],
+        };
+
+        const endStepVerdicts = new Array<{ number: number | string; verdict: StepVerdict }>();
+        const cx: CertStepContext = {
+            controllers: {},
+            devices: {},
+            recorder: stubRecorder({
+                endStep(step, verdict) {
+                    endStepVerdicts.push({ number: step.number, verdict });
+                    return [];
+                },
+            }),
+        };
+
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
+
+        await expect(test.invoke(stubSubject(new PicsFile([])), () => {}, [], false)).rejectedWith(
+            "1 step ended with a check that could not be evaluated",
+        );
+
+        expect(endStepVerdicts).deep.equal([{ number: 1, verdict: "unverified" }]);
+    });
+
+    it("reports a device that died rather than the unverified step it died after", async () => {
+        let exit!: (info: DeviceExitInfo) => void;
+        const exitPromise = new Promise<DeviceExitInfo>(resolve => {
+            exit = resolve;
+        });
+
+        const definition: CertTestDefinition = {
+            tc: "TC-CADMIN-1.17",
+            plan: "multiplefabrics.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [
+                {
+                    number: 1,
+                    text: "Step whose log check names no pattern for this flavor",
+                    run: async cx => {
+                        cx.recorder.check({ type: "device-log", verdict: "unverified" });
+                        // Settles too late for any step's own race, so the run's teardown finds it.
+                        exit({ code: 134, signal: null });
+                    },
+                },
+            ],
+        };
+
+        const outcomes = new Array<{ failed: boolean; detail?: string; unproven?: boolean }>();
+        const cx: CertStepContext = {
+            controllers: {},
+            devices: { th: stubCertDevice(exitPromise) },
+            recorder: stubRecorder({
+                async concludeRun(outcome) {
+                    outcomes.push(outcome);
+                },
+            }),
+        };
+
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
+
+        await expect(test.invoke(stubSubject(new PicsFile([])), () => {}, [], false)).rejectedWith(
+            "exited unexpectedly",
+        );
+
+        expect(outcomes.length).equal(1);
+        expect(outcomes[0].unproven).equal(false);
+    });
+
+    it("reports a step failure rather than the unverified check of an earlier step", async () => {
+        const definition: CertTestDefinition = {
+            tc: "TC-CADMIN-1.17",
+            plan: "multiplefabrics.adoc",
+            pics: [],
+            app: "all-clusters",
+            steps: [
+                {
+                    number: 1,
+                    text: "Step whose log check names no pattern for this flavor",
+                    run: async cx => {
+                        cx.recorder.check({ type: "device-log", verdict: "unverified" });
+                    },
+                },
+                {
+                    number: 2,
+                    text: "Step that failed",
+                    run: async () => {
+                        throw new Error("the device answered UNSUPPORTED_ACCESS");
+                    },
+                },
+            ],
+        };
+
+        const outcomes = new Array<{ failed: boolean; detail?: string; unproven?: boolean }>();
+        const cx: CertStepContext = {
+            controllers: {},
+            devices: {},
+            recorder: stubRecorder({
+                async concludeRun(outcome) {
+                    outcomes.push(outcome);
+                },
+            }),
+        };
+
+        const test = new TestCertTest(definition, stubDescriptor(), stubContainer(), cx);
+
+        await expect(test.invoke(stubSubject(new PicsFile([])), () => {}, [], false)).rejectedWith(
+            "the device answered UNSUPPORTED_ACCESS",
+        );
+
+        expect(outcomes.length).equal(1);
+        expect(outcomes[0].unproven).equal(false);
     });
 
     it("reports no unverified-check count for a run where every check was evaluated", async () => {

--- a/support/chip-testing/test/cert-framework/chip-tool-websocket-server.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-websocket-server.test.ts
@@ -57,8 +57,14 @@ class FakeCommandHandler extends CommandHandler {
         return this.#started;
     }
 
+    /** Thrown by `start()`, where set. */
+    startFailure?: unknown;
+
     async start() {
         this.startCalls++;
+        if (this.startFailure !== undefined) {
+            throw this.startFailure;
+        }
         this.#started = true;
     }
 
@@ -399,6 +405,29 @@ describe("ChipToolWebSocketHandler over the wire", () => {
         );
 
         expect(handler.startCalls).equal(1);
+    });
+
+    it("reports a controller of its own that would not start as its own fault", async () => {
+        // Plain Error, as a storage or socket failure arrives: the classification has to come from
+        // where the start was driven, not from the error's own type.
+        handler.startFailure = new Error("EADDRINUSE");
+
+        const reply = await send(
+            port,
+            jsonFrame({
+                cluster: "onoff",
+                command: "write",
+                command_specifier: "on-time",
+                arguments: {
+                    "destination-id": "0x12344321",
+                    "endpoint-id-ignored-for-group-commands": "1",
+                    "attribute-values": "5",
+                },
+            }),
+        );
+
+        expect(reply.results[0].error).match(/^Test harness failure — InternalError: Controller "alpha" failed/);
+        expect(reply.results[1]).deep.equal({ error: "FAILURE" });
     });
 
     it("reports a command addressed to a controller it does not have as its own fault", async () => {

--- a/support/chip-testing/test/cert-framework/chip-tool-websocket-server.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-websocket-server.test.ts
@@ -1,0 +1,417 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Logger, NodeId, Observable } from "@matter/main";
+import { Status, StatusResponseError } from "@matter/main/types";
+import { NodeNotConnectedError } from "@project-chip/matter.js/device";
+import { expect } from "chai";
+import { WebSocket } from "ws";
+import { ChipToolWebSocketHandler } from "../../src/ChipToolWebSocketHandler.js";
+import {
+    AttributeResponseData,
+    CommandHandler,
+    DelayRequest,
+    DiscoveryRequest,
+    DiscoveryResponse,
+    InitialPairingRequest,
+    InvokeByIdRequest,
+    InvokeRequest,
+    IssueNocChainRequest,
+    IssueNocChainResponse,
+    ReadAttributeRequest,
+    ReadAttributeResponse,
+    ReadEventRequest,
+    ReadEventResponse,
+    RootCertificateResponse,
+    SubscribeAttributeRequest,
+    SubscribeAttributeResponse,
+    SubscribeEventRequest,
+    SubscribeEventResponse,
+    WriteAttributeByIdRequest,
+    WriteAttributeRequest,
+} from "../../src/handler/CommandHandler.js";
+
+/**
+ * A {@link CommandHandler} that answers from canned data instead of driving a controller, so a test can
+ * assert on the frames the shim puts on the wire. The reply shapes are the thing under test here: the
+ * helpers that decide them have their own tests, and those pass even where nothing calls them.
+ */
+class FakeCommandHandler extends CommandHandler {
+    #started = false;
+    startCalls = 0;
+    disconnectedNodes = new Array<NodeId>();
+    writes = new Array<WriteAttributeRequest>();
+    discoveries = new Array<DiscoveryRequest>();
+    paseConnections = new Array<NodeId>();
+
+    /** Answer for the next discovery; empty means "found nothing". */
+    discoveryResult: DiscoveryResponse = [];
+
+    /** Thrown by whichever operation a test drives, where set. */
+    failure?: unknown;
+
+    get started() {
+        return this.#started;
+    }
+
+    async start() {
+        this.startCalls++;
+        this.#started = true;
+    }
+
+    async disconnectNode(nodeId: NodeId) {
+        this.disconnectedNodes.push(nodeId);
+    }
+
+    async handlePaseConnection(data: InitialPairingRequest) {
+        this.paseConnections.push(data.nodeId);
+        this.#throwIfFailing();
+    }
+
+    async handleInitialPairing(_data: InitialPairingRequest) {
+        this.#throwIfFailing();
+    }
+
+    async handleDiscovery(data: DiscoveryRequest): Promise<DiscoveryResponse> {
+        this.discoveries.push(data);
+        this.#throwIfFailing();
+        return this.discoveryResult;
+    }
+
+    async handleWriteAttribute(data: WriteAttributeRequest) {
+        this.writes.push(data);
+        this.#throwIfFailing();
+    }
+
+    async handleWriteAttributeById(_data: WriteAttributeByIdRequest) {
+        this.#throwIfFailing();
+    }
+
+    async handleReadAttribute(_data: ReadAttributeRequest): Promise<ReadAttributeResponse> {
+        this.#throwIfFailing();
+        return { values: new Array<AttributeResponseData>() };
+    }
+
+    async handleSubscribeAttribute(_data: SubscribeAttributeRequest): Promise<SubscribeAttributeResponse> {
+        this.#throwIfFailing();
+        return { values: new Array<AttributeResponseData>(), updated: Observable<[void]>() };
+    }
+
+    async handleReadEvent(_data: ReadEventRequest): Promise<ReadEventResponse> {
+        this.#throwIfFailing();
+        return { values: [] };
+    }
+
+    async handleSubscribeEvent(_data: SubscribeEventRequest): Promise<SubscribeEventResponse> {
+        this.#throwIfFailing();
+        return { values: [], updated: Observable<[void]>() };
+    }
+
+    async handleInvoke(_data: InvokeRequest) {
+        this.#throwIfFailing();
+        return undefined;
+    }
+
+    async handleInvokeById(_data: InvokeByIdRequest) {
+        this.#throwIfFailing();
+    }
+
+    async handleDelay(_data: DelayRequest) {
+        this.#throwIfFailing();
+    }
+
+    getCommissionerNodeId() {
+        return NodeId(0x112233);
+    }
+
+    getCommissionerRootCertificate(): RootCertificateResponse {
+        return { RCAC: new Uint8Array() };
+    }
+
+    async commissionerIssueNocChain(_data: IssueNocChainRequest): Promise<IssueNocChainResponse> {
+        throw new Error("not used by these tests");
+    }
+
+    #throwIfFailing() {
+        if (this.failure !== undefined) {
+            throw this.failure;
+        }
+    }
+}
+
+interface ChipReply {
+    results: { error?: string; clusterError?: number }[];
+    logs: unknown[];
+}
+
+/** One command in, one reply out, over a real socket to a real server. */
+async function send(port: number, frame: string): Promise<ChipReply> {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    try {
+        await new Promise<void>((resolve, reject) => {
+            ws.once("open", resolve);
+            ws.once("error", reject);
+        });
+
+        const reply = new Promise<string>((resolve, reject) => {
+            ws.once("message", data => resolve(data.toString()));
+            ws.once("error", reject);
+        });
+        ws.send(frame);
+
+        return JSON.parse(await reply);
+    } finally {
+        ws.close();
+    }
+}
+
+function jsonFrame(command: { cluster: string; command: string; command_specifier?: string; arguments: object }) {
+    const { arguments: args, ...rest } = command;
+    return `json:${JSON.stringify({
+        ...rest,
+        arguments: `base64:${Buffer.from(JSON.stringify(args), "utf8").toString("base64")}`,
+    })}`;
+}
+
+describe("ChipToolWebSocketHandler over the wire", () => {
+    let server: ChipToolWebSocketHandler;
+    let handler: FakeCommandHandler;
+    let port: number;
+    let restoreLogWriter: () => void;
+
+    beforeEach(async () => {
+        // initialize() installs a log interceptor on the shared default destination and never removes
+        // it, so every test here has to put the destination back for whatever runs next.
+        const write = Logger.destinations.default.write;
+        const format = Logger.format;
+        restoreLogWriter = () => {
+            Logger.destinations.default.write = write;
+            Logger.format = format;
+        };
+
+        handler = new FakeCommandHandler();
+        server = new ChipToolWebSocketHandler(0);
+        server.initialize(new Map([["alpha", handler]]));
+        await server.start();
+        const bound = server.port;
+        expect(bound).not.equal(undefined);
+        port = bound!;
+    });
+
+    afterEach(() => {
+        server.close();
+        restoreLogWriter();
+    });
+
+    it("answers a discovery that found nothing as a failure, not as a command that succeeded", async () => {
+        handler.discoveryResult = [];
+
+        const reply = await send(
+            port,
+            jsonFrame({
+                cluster: "discover",
+                command: "find-commissionable-by-long-discriminator",
+                arguments: { value: "3840" },
+            }),
+        );
+
+        expect(reply.results).deep.equal([{ error: "FAILURE" }]);
+        expect(handler.discoveries).deep.equal([{ findBy: { longDiscriminator: 3840 } }]);
+    });
+
+    it("answers a discovery that found a device with what it found", async () => {
+        handler.discoveryResult = [
+            {
+                value: {
+                    commissioningMode: 1,
+                    deviceName: "TH",
+                    deviceType: 257,
+                    hostName: "0011223344556677",
+                    instanceName: "1122334455667788",
+                    longDiscriminator: 3840,
+                    numIPs: 1,
+                    pairingHint: 33,
+                    pairingInstruction: "",
+                    port: 5540,
+                    productId: 32769,
+                    rotatingId: "",
+                    rotatingIdLen: 0,
+                    shortDiscriminator: 15,
+                    supportsTcpClient: false,
+                    supportsTcpServer: false,
+                    vendorId: 65521,
+                },
+            },
+        ];
+
+        const reply = await send(
+            port,
+            jsonFrame({
+                cluster: "discover",
+                command: "find-commissionable-by-long-discriminator",
+                arguments: { value: "3840" },
+            }),
+        );
+
+        expect(reply.results.length).equal(1);
+        expect(reply.results[0].error).equal(undefined);
+    });
+
+    it("refuses a write whose payload it could not read, rather than reporting the device accepted it", async () => {
+        const reply = await send(
+            port,
+            jsonFrame({
+                cluster: "userlabel",
+                command: "write",
+                command_specifier: "label-list",
+                arguments: {
+                    "destination-id": "0x12344321",
+                    "endpoint-id-ignored-for-group-commands": "0",
+                    "attribute-values": "[{not json}]",
+                },
+            }),
+        );
+
+        expect(reply.results[0].error).match(/^Test harness failure — ImplementationError: Cannot read the payload/);
+        expect(reply.results[1]).deep.equal({ error: "FAILURE" });
+
+        // The write never reached the device, which is the point of refusing it.
+        expect(handler.writes).deep.equal([]);
+    });
+
+    it("answers a device that refused with the status the device gave", async () => {
+        handler.failure = new StatusResponseError("device says no", Status.UnsupportedWrite);
+
+        const reply = await send(
+            port,
+            jsonFrame({
+                cluster: "onoff",
+                command: "write",
+                command_specifier: "on-time",
+                arguments: {
+                    "destination-id": "0x12344321",
+                    "endpoint-id-ignored-for-group-commands": "1",
+                    "attribute-values": "5",
+                },
+            }),
+        );
+
+        expect(reply.results).deep.equal([{ error: "UNSUPPORTED_WRITE" }, { error: "FAILURE" }]);
+    });
+
+    it("answers a fault of its own as its own, not as the bare failure a device gives", async () => {
+        handler.failure = new TypeError("cannot read properties of undefined");
+
+        const reply = await send(
+            port,
+            jsonFrame({
+                cluster: "onoff",
+                command: "write",
+                command_specifier: "on-time",
+                arguments: {
+                    "destination-id": "0x12344321",
+                    "endpoint-id-ignored-for-group-commands": "1",
+                    "attribute-values": "5",
+                },
+            }),
+        );
+
+        expect(reply.results[0].error).equal("Test harness failure — TypeError: cannot read properties of undefined");
+        expect(reply.results[1]).deep.equal({ error: "FAILURE" });
+    });
+
+    it("answers a device that plainly failed with the bare failure the corpus expects", async () => {
+        handler.failure = new Error("the device did not answer");
+
+        const reply = await send(
+            port,
+            jsonFrame({
+                cluster: "onoff",
+                command: "write",
+                command_specifier: "on-time",
+                arguments: {
+                    "destination-id": "0x12344321",
+                    "endpoint-id-ignored-for-group-commands": "1",
+                    "attribute-values": "5",
+                },
+            }),
+        );
+
+        expect(reply.results).deep.equal([{ error: "FAILURE" }]);
+    });
+
+    it("drops the session where the device could not be reached, so the failure stays failed", async () => {
+        handler.failure = new NodeNotConnectedError("no session");
+
+        const reply = await send(
+            port,
+            jsonFrame({
+                cluster: "onoff",
+                command: "write",
+                command_specifier: "on-time",
+                arguments: {
+                    "destination-id": "0x12344321",
+                    "endpoint-id-ignored-for-group-commands": "1",
+                    "attribute-values": "5",
+                },
+            }),
+        );
+
+        expect(reply.results).deep.equal([{ error: "FAILURE" }]);
+        expect(handler.disconnectedNodes).deep.equal([NodeId(0x12344321)]);
+    });
+
+    it("establishes a PASE session for a pairing command that asks for one only", async () => {
+        const reply = await send(
+            port,
+            jsonFrame({
+                cluster: "pairing",
+                command: "code-paseonly",
+                arguments: { "node-id": "0x12344321", payload: "MT:-24J042C00KA0648G00" },
+            }),
+        );
+
+        expect(reply.results).deep.equal([]);
+        expect(handler.paseConnections).deep.equal([NodeId(0x12344321)]);
+    });
+
+    it("starts the controller once, on the first command that addresses it", async () => {
+        expect(handler.startCalls).equal(0);
+
+        await send(
+            port,
+            jsonFrame({
+                cluster: "discover",
+                command: "find-commissionable-by-short-discriminator",
+                arguments: { value: "15" },
+            }),
+        );
+        await send(
+            port,
+            jsonFrame({
+                cluster: "discover",
+                command: "find-commissionable-by-short-discriminator",
+                arguments: { value: "15" },
+            }),
+        );
+
+        expect(handler.startCalls).equal(1);
+    });
+
+    it("reports a command addressed to a controller it does not have as its own fault", async () => {
+        const reply = await send(
+            port,
+            jsonFrame({
+                cluster: "discover",
+                command: "find-commissionable-by-short-discriminator",
+                arguments: { value: "15", "commissioner-name": "delta" },
+            }),
+        );
+
+        expect(reply.results[0].error).match(/^Test harness failure — ImplementationError: Unknown controller: delta/);
+        expect(reply.results[1]).deep.equal({ error: "FAILURE" });
+    });
+});

--- a/support/chip-testing/test/cert-framework/chip-tool-websocket-server.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-websocket-server.test.ts
@@ -8,6 +8,7 @@ import { Logger, NodeId, Observable } from "@matter/main";
 import { Status, StatusResponseError } from "@matter/main/types";
 import { NodeNotConnectedError } from "@project-chip/matter.js/device";
 import { expect } from "chai";
+import { createServer, type Server } from "node:net";
 import { WebSocket } from "ws";
 import { ChipToolWebSocketHandler } from "../../src/ChipToolWebSocketHandler.js";
 import {
@@ -210,6 +211,29 @@ describe("ChipToolWebSocketHandler over the wire", () => {
     afterEach(() => {
         server.close();
         restoreLogWriter();
+    });
+
+    it("refuses to start on a port already taken, rather than reporting a server nobody can reach", async () => {
+        const occupier: Server = createServer();
+        await new Promise<void>((resolve, reject) => {
+            occupier.once("listening", resolve);
+            occupier.once("error", reject);
+            occupier.listen(0, "127.0.0.1");
+        });
+
+        const address = occupier.address();
+        expect(address !== null && typeof address !== "string").equal(true);
+        const taken = address !== null && typeof address !== "string" ? address.port : 0;
+
+        const blocked = new ChipToolWebSocketHandler(taken);
+        blocked.initialize(new Map([["alpha", new FakeCommandHandler()]]));
+        try {
+            await expect(blocked.start()).rejected;
+            expect(blocked.port).equal(undefined);
+        } finally {
+            blocked.close();
+            await new Promise<void>(resolve => occupier.close(() => resolve()));
+        }
     });
 
     it("answers a discovery that found nothing as a failure, not as a command that succeeded", async () => {

--- a/support/chip-testing/test/cert-framework/evidence.test.ts
+++ b/support/chip-testing/test/cert-framework/evidence.test.ts
@@ -360,6 +360,117 @@ describe("EvidenceRecorder", () => {
         expect("controllerUnsupportedSkips" in resultJson).equal(false);
     });
 
+    it("settles a run whose step observed nothing as unverified rather than as a device failure", async () => {
+        const recorder = new EvidenceRecorder(outDir, {
+            tc: "TC-IDM-2.1",
+            plan: "interactiondatamodel.adoc",
+            timestamp: "2026-08-07T00:00:00.000Z",
+            controller: "dut",
+            controllerImplementation: "matterjs",
+            device: "matterjs:all-clusters",
+            matterJsCommit: "abc1234",
+        });
+
+        recorder.beginStep(step1);
+        recorder.check({ type: "device-log", verdict: "unverified" });
+        recorder.endStep(step1, "unverified");
+        recorder.recordUnverifiedChecks(1);
+
+        await recorder.flush();
+        await recorder.concludeRun({ failed: true, detail: "1 step ended with a check ...", unproven: true });
+
+        const resultJson = JSON.parse(
+            await fsp.readFile(pathMod.join(outDir, "2026-08-07T00-00-00.000Z-TC-IDM-2.1", "result.json"), "utf8"),
+        );
+
+        expect(resultJson.verdict).equal("unverified");
+        expect(resultJson.runError).equal("1 step ended with a check ...");
+        expect(resultJson.unverifiedChecks).equal(1);
+    });
+
+    it("keeps a run its runner reported as green at pass, whatever else the outcome claims", async () => {
+        const recorder = new EvidenceRecorder(outDir, {
+            tc: "TC-IDM-2.1",
+            plan: "interactiondatamodel.adoc",
+            timestamp: "2026-08-07T00:00:00.000Z",
+            controller: "dut",
+            controllerImplementation: "matterjs",
+            device: "matterjs:all-clusters",
+            matterJsCommit: "abc1234",
+        });
+
+        recorder.beginStep(step1);
+        recorder.check({ type: "response", verdict: "pass" });
+        recorder.endStep(step1, "pass");
+
+        await recorder.flush();
+        await recorder.concludeRun({ failed: false, unproven: true });
+
+        const resultJson = JSON.parse(
+            await fsp.readFile(pathMod.join(outDir, "2026-08-07T00-00-00.000Z-TC-IDM-2.1", "result.json"), "utf8"),
+        );
+
+        expect(resultJson.verdict).equal("pass");
+    });
+
+    it("fails a run that both observed nothing and lost its device, since the device outranks the gap", async () => {
+        const recorder = new EvidenceRecorder(outDir, {
+            tc: "TC-IDM-2.1",
+            plan: "interactiondatamodel.adoc",
+            timestamp: "2026-08-07T00:00:00.000Z",
+            controller: "dut",
+            controllerImplementation: "matterjs",
+            device: "matterjs:all-clusters",
+            matterJsCommit: "abc1234",
+        });
+
+        recorder.beginStep(step1);
+        recorder.check({ type: "device-log", verdict: "unverified" });
+        recorder.endStep(step1, "unverified");
+        recorder.deviceExited({ code: 134, signal: null });
+
+        await recorder.flush();
+        await recorder.concludeRun({ failed: true, detail: "device exited", unproven: true });
+
+        const resultJson = JSON.parse(
+            await fsp.readFile(pathMod.join(outDir, "2026-08-07T00-00-00.000Z-TC-IDM-2.1", "result.json"), "utf8"),
+        );
+
+        expect(resultJson.verdict).equal("fail");
+    });
+
+    it("keeps a check's own reason for its gap in the record", async () => {
+        const recorder = new EvidenceRecorder(outDir, {
+            tc: "TC-IDM-2.1",
+            plan: "interactiondatamodel.adoc",
+            timestamp: "2026-08-07T00:00:00.000Z",
+            controller: "dut",
+            controllerImplementation: "matterjs",
+            device: "matterjs:all-clusters",
+            matterJsCommit: "abc1234",
+        });
+
+        recorder.beginStep(step1);
+        recorder.check({
+            type: "response",
+            verdict: "unverified",
+            detail: "no manufacturer-specific cluster in the wildcard read",
+            accepted: "the matter.js app defines none",
+        });
+        recorder.endStep(step1, "pass");
+
+        const dir = await publish(recorder);
+        const resultJson = JSON.parse(await fsp.readFile(pathMod.join(dir, "result.json"), "utf8"));
+
+        expect(resultJson.verdict).equal("pass");
+        expect(resultJson.steps[0].checks[0]).deep.equal({
+            type: "response",
+            verdict: "unverified",
+            detail: "no manufacturer-specific cluster in the wildcard read",
+            accepted: "the matter.js app defines none",
+        });
+    });
+
     it("records a teardown failure arriving between the evidence and the verdict, and fails the run over it", async () => {
         const recorder = new EvidenceRecorder(outDir, {
             tc: "TC-IDM-2.1",
@@ -509,7 +620,7 @@ describe("EvidenceRecorder", () => {
         expect("runError" in resultJson).equal(false);
     });
 
-    it("persists the unverified-check count, so a bare result.json says how much of a passing run rests on nothing observed", async () => {
+    it("persists the unverified-check count, so a bare result.json says how much of the run rests on nothing observed", async () => {
         const recorder = new EvidenceRecorder(outDir, {
             tc: "TC-IDM-5.1",
             plan: "interactiondatamodel.adoc",
@@ -521,14 +632,15 @@ describe("EvidenceRecorder", () => {
         });
 
         recorder.beginStep(step1);
-        recorder.check({ type: "device-log", verdict: "unverified" });
+        recorder.check({ type: "device-log", verdict: "unverified", accepted: "the app cannot exhibit the claim" });
         recorder.endStep(step1, "pass");
         recorder.recordUnverifiedChecks(3);
 
         const dir = await publish(recorder);
         const resultJson = JSON.parse(await fsp.readFile(pathMod.join(dir, "result.json"), "utf8"));
 
-        // An unverified check is a gap in what was observed, not a defect — the verdict stays a pass.
+        // The count covers the declared gaps too, which are the only unverified checks a passing run
+        // can carry.
         expect(resultJson.verdict).equal("pass");
         expect(resultJson.unverifiedChecks).equal(3);
     });

--- a/support/chip-testing/test/cert-framework/legacy-controller-command-handler.test.ts
+++ b/support/chip-testing/test/cert-framework/legacy-controller-command-handler.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Environment } from "@matter/main";
+import { CommissioningController } from "@project-chip/matter.js";
+import { expect } from "chai";
+import { LegacyControllerCommandHandler } from "../../src/handler/LegacyControllerCommandHandler.js";
+
+/**
+ * A controller whose `start()` never settles on its own, so a test decides when — and whether — the
+ * handler's own startup completes. Nothing here reaches the real controller: `start()` is the only
+ * member the handler's startup touches before the work that follows it.
+ */
+class ControlledController extends CommissioningController {
+    starts = 0;
+    #reject?: (error: Error) => void;
+
+    constructor() {
+        super({
+            environment: { environment: new Environment("legacy-handler-test", Environment.default), id: "alpha" },
+            autoConnect: false,
+            adminFabricLabel: "alpha",
+        });
+    }
+
+    override async start() {
+        this.starts++;
+        return new Promise<void>((_resolve, reject) => {
+            this.#reject = reject;
+        });
+    }
+
+    failStart(error: Error) {
+        const reject = this.#reject;
+        this.#reject = undefined;
+        expect(reject).not.equal(undefined);
+        reject?.(error);
+    }
+}
+
+describe("LegacyControllerCommandHandler startup", () => {
+    it("starts the controller once for two commands that arrive together", async () => {
+        const controller = new ControlledController();
+        const handler = new LegacyControllerCommandHandler("alpha", controller);
+
+        const first = handler.start();
+        const second = handler.start();
+
+        // Both callers are waiting on the same start, so the controller has been asked exactly once.
+        expect(controller.starts).equal(1);
+
+        controller.failStart(new Error("controller would not come up"));
+
+        await expect(first).rejectedWith("controller would not come up");
+        await expect(second).rejectedWith("controller would not come up");
+    });
+
+    it("leaves the handler unstarted after a failed start, and tries again on the next command", async () => {
+        const controller = new ControlledController();
+        const handler = new LegacyControllerCommandHandler("alpha", controller);
+
+        const first = handler.start();
+        controller.failStart(new Error("first attempt failed"));
+        await expect(first).rejectedWith("first attempt failed");
+
+        expect(handler.started).equal(false);
+
+        const second = handler.start();
+        expect(controller.starts).equal(2);
+
+        controller.failStart(new Error("second attempt failed"));
+        await expect(second).rejectedWith("second attempt failed");
+        expect(handler.started).equal(false);
+    });
+});

--- a/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
@@ -315,18 +315,28 @@ describe("subscribeAndModify", () => {
     });
 
     it("leaves the shortfall a gap to close on any other controller", async () => {
-        const fixture = new Fixture("chip-local", (f, _index) => {
-            f.pushReport(SUBSCRIPTION_ID);
-            f.report(true);
-        });
+        const originalController = env.MATTER_CERT_CONTROLLER;
+        env.MATTER_CERT_CONTROLLER = "matterjs";
+        try {
+            const fixture = new Fixture("chip-local", (f, _index) => {
+                f.pushReport(SUBSCRIPTION_ID);
+                f.report(true);
+            });
 
-        await withFixture(fixture, async f => {
-            await f.run(VALUES, IMPATIENT);
+            await withFixture(fixture, async f => {
+                await f.run(VALUES, IMPATIENT);
 
-            const unverified = f.checks.filter(check => check.verdict === "unverified");
-            expect(unverified).to.have.lengthOf(1);
-            expect(unverified[0].accepted).equal(undefined);
-        });
+                const unverified = f.checks.filter(check => check.verdict === "unverified");
+                expect(unverified).to.have.lengthOf(1);
+                expect(unverified[0].accepted).equal(undefined);
+            });
+        } finally {
+            if (originalController === undefined) {
+                delete env.MATTER_CERT_CONTROLLER;
+            } else {
+                env.MATTER_CERT_CONTROLLER = originalController;
+            }
+        }
     });
 
     it("records the mismatch when a report carries a value nobody wrote", async () => {

--- a/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
@@ -16,6 +16,7 @@ import type {
     Subject,
 } from "@matter/testing";
 import { LineQueue, LogFollower, PicsFile } from "@matter/testing";
+import { env } from "node:process";
 import type { SubscribeAndModifyTimeouts } from "../cert/tc-idm-4.1-support.js";
 import { subscribeAndModify } from "../cert/tc-idm-4.1-support.js";
 import { CertCheckFailedError } from "../cert/tc-support.js";
@@ -285,6 +286,46 @@ describe("subscribeAndModify", () => {
             const unverified = f.checks.filter(check => check.verdict === "unverified");
             expect(unverified).to.have.lengthOf(1);
             expect(unverified[0].detail).match(/matched 1\/3/);
+        });
+    });
+
+    it("accepts the shortfall under chip-tool, whose server drops all but the first result of a batch", async () => {
+        const originalController = env.MATTER_CERT_CONTROLLER;
+        env.MATTER_CERT_CONTROLLER = "chip-tool";
+        try {
+            const fixture = new Fixture("chip-local", (f, _index) => {
+                f.pushReport(SUBSCRIPTION_ID);
+                f.report(true);
+            });
+
+            await withFixture(fixture, async f => {
+                await f.run(VALUES, IMPATIENT);
+
+                const unverified = f.checks.filter(check => check.verdict === "unverified");
+                expect(unverified).to.have.lengthOf(1);
+                expect(unverified[0].accepted).match(/only the first result of a batch/);
+            });
+        } finally {
+            if (originalController === undefined) {
+                delete env.MATTER_CERT_CONTROLLER;
+            } else {
+                env.MATTER_CERT_CONTROLLER = originalController;
+            }
+        }
+    });
+
+    it("leaves the shortfall a gap to close on any other controller", async () => {
+        const fixture = new Fixture("chip-local", (f, _index) => {
+            f.pushReport(SUBSCRIPTION_ID);
+            f.report(true);
+        });
+
+        await withFixture(fixture, async f => {
+            await f.run(VALUES, IMPATIENT);
+
+            const unverified = f.checks.filter(check => check.verdict === "unverified");
+            expect(unverified).to.have.lengthOf(1);
+            expect(unverified[0].accepted).equal(undefined);
         });
     });
 

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -96,13 +96,18 @@ The convention this series has followed, worth stating explicitly for the next T
   matter.js names a whole interaction, and every path it carried, on one line. So a matterjs pattern
   is a separate authoring job, not a translation of the chip one — which is why
   `expectAdjacentLines`/`expectSequence` take a `{chip, matterjs}` pair of sequences whose lengths
-  differ. A check with no pattern for the running flavor resolves `"unverified"`: not a failure, but
-  a gap in that step's device-side evidence, with the accompanying `type: "response"` check the only
-  thing left proving controller behavior. `RunRecord.unverifiedChecks` counts them, so a bundle says
-  how much of a passing run rests on nothing observed — bring the count down, don't add to it. As of
-  this writing every device-log check in this directory carries both flavors' patterns, and the whole
-  matterjs leg reports one unverified check: TC-IDM-2.1 step 21's honest "matter.js's all-clusters app
-  defines no manufacturer-specific cluster".
+  differ. A check with no pattern for the running flavor resolves `"unverified"`, which leaves that
+  step's device-side claim resting on nothing observed — so the step's verdict becomes
+  `"unverified"` and the run fails over it. Write the missing pattern; where this run genuinely cannot
+  observe the claim, say why in the check's own `accepted: "<why>"`, which keeps its step at `"pass"`.
+  That field is for a claim no pattern could ever match here — the app has no such cluster, the
+  controller has no such callback — not for a pattern nobody has written yet, and it belongs on the one
+  check that cannot be settled rather than on the step, so a second gap in the same step still fails
+  the run. `RunRecord.unverifiedChecks` counts every unverified check, accepted or not, so a bundle
+  says how much of the run rests on nothing observed. As of this writing every device-log check in this
+  directory carries both flavors' patterns, and the whole matterjs leg reports one unverified check,
+  accepted: TC-IDM-2.1 step 21's "matter.js's all-clusters app defines no manufacturer-specific
+  cluster".
 
   Two things bite when writing the matterjs half:
 
@@ -191,7 +196,7 @@ verdict; shape: `RunRecord` in `evidence.ts`) plus one `<name>.log` per `attachL
 `${MATTER_CERT_EVIDENCE_DIR}/<timestamp>-<tc>/`. A step's own evidence lives in `RunRecord.steps[]`
 as `{ step, text, expected, checks: CheckRecord[], verdict, skipReason? }`; `CheckRecord` is
 `{ type: "response" | "device-log" | "network", verdict: "pass" | "fail" | "unverified", detail?,
-pattern?, matched?, logLine? }`.
+pattern?, matched?, logLine?, accepted? }`.
 
 What a check's `type` should be:
 
@@ -203,18 +208,21 @@ What a check's `type` should be:
   usually wrapped so a timeout/close error becomes a recorded `"fail"` rather than propagating
   uncaught — see `TC-ACT-3.2`'s `recordInvokeStatus`/adversarial-review fix below for why an
   uncaught log-check error is a real evidence gap, not just noise). `"unverified"` means no pattern
-  was supplied for the running flavor (see "Flavor policy" above) — an evidence gap to close by
-  writing that pattern, not a failure and not a bug in the run.
+  was supplied for the running flavor (see "Flavor policy" above) — an evidence gap that fails the
+  run until the pattern is written or the check states why it cannot be settled here, rather than a
+  claim about the device.
 - **`"network"`** — `expectMdns`'s own check kind (mDNS record presence/absence).
 
-A step passing means its `run` callback didn't throw — `recorder.check(...)` only records evidence,
-it never fails the step by itself (see "Shape of a cert test" above; this is worth repeating because
-it's the single easiest mistake to make writing a new step). `RunRecord.verdict` is computed by
-`EvidenceRecorder`, not hand-set: until `concludeRun` runs ⇒ `"incomplete"`; then the run's own
-reported failure (`runError`), or `deviceExit`/`finalizationError`/`teardownError`/`evidenceError`
-set, or any step `"fail"`/`"aborted"` ⇒ `"fail"`; else any step `"pass"` ⇒ `"pass"`; else (every step
-skipped, or zero steps ran, e.g. `TC-ACT-3.2` under `matterjs` or `TC-SC-3.5` when its prerequisite is
-missing) ⇒ `"skipped"`.
+A step passing means its `run` callback didn't throw *and* every check it recorded was settled — a
+`"fail"` check is recorded rather than acted on, so a check that must gate the step still has to
+throw (see "Shape of a cert test" above; this is the single easiest mistake to make writing a new
+step), while an `"unverified"` check that did not state why makes the step `"unverified"` on its own.
+`RunRecord.verdict` is computed by `EvidenceRecorder`, not hand-set: until `concludeRun` runs ⇒
+`"incomplete"`; then `deviceExit`/`finalizationError`/`teardownError`/`evidenceError` set, the run's
+own reported failure (`runError`) where that failure is not merely an unverified step, or any step
+`"fail"`/`"aborted"` ⇒ `"fail"`; else any step `"unverified"` ⇒ `"unverified"`, which fails the run;
+else any step `"pass"` ⇒ `"pass"`; else (every step skipped, or zero steps ran, e.g. `TC-ACT-3.2`
+under `matterjs` or `TC-SC-3.5` when its prerequisite is missing) ⇒ `"skipped"`.
 
 A `"skipped"` run-level verdict is a legitimate, expected outcome for a flavor-gapped or
 prerequisite-blocked TC — it is not the same as `"fail"`, and shouldn't be treated as a failure when
@@ -223,7 +231,7 @@ treat it as a failed run whose cause is outside the record.
 
 Every attached `.log` also carries a step-boundary banner (chip python/yaml style) at the point a
 step starts and again when it ends (`<tc> — Test Step <number>: <text>` / `<tc> — Test Step
-<number>: PASS|FAIL|SKIPPED|ABORTED`, each between a rule of dashes). `CertTest.invoke()`
+<number>: PASS|FAIL|UNVERIFIED|SKIPPED|ABORTED`, each between a rule of dashes). `CertTest.invoke()`
 (`cert-test.ts`) injects these via `LogFollower.annotate()` into every device's and controller's log
 buffer; they're flagged synthetic so a step's own `log.expect()` never matches one, even against a
 catch-all pattern. This is purely for log readability — it doesn't change `RunRecord`'s shape.
@@ -244,8 +252,9 @@ certTest("TC-XXX-0.0", { plan: "n/a" | "<plan doc id>", pics: [], app: "all-clus
   throwing from `run`. So a check that should gate the step goes through `record(cx, check, what)`
   (`tc-support.ts`), which records it and throws `CertCheckFailedError` on `"fail"` — hand-rolling
   the `if (verdict === "fail") throw` after a `check()` is how one such gate came to be missing.
-  `"unverified"` passes through: that is what a log check reports on a flavor nobody wrote a pattern
-  for. Use `cx.recorder.check` directly only for a record that is provenance rather than a gate — the
+  `"unverified"` passes through rather than throwing: that is what a log check reports on a flavor
+  nobody wrote a pattern for, and the engine turns it into the step's verdict instead.
+  Use `cx.recorder.check` directly only for a record that is provenance rather than a gate — the
   unconditional "this is what the DUT answered" line beside an `await` that would have thrown.
 - Never throw a plain `Error` from a step: `CertCheckFailedError` is the step-assertion type, and
   `InternalError` is for a harness invariant that cannot hold.
@@ -1587,7 +1596,10 @@ Two traps in those lines. matter.js renders a subscription id through `Subscript
 fewer than eight significant digits. And an event report says `ev:` where an attribute report says
 `attr:`, which TC-IDM-6.4 needs.
 
-With the device's own log carrying every write, `subscribeAndModify` no longer fails a step when the
-controller's `onUpdate` callbacks come up short — it records that as `"unverified"` with the counts.
-A report carrying a value nobody wrote is still a failure. What this gives up: a controller that
-delivered the values out of order is no longer caught, which the plan never asked about anyway.
+With the device's own log carrying every write, `subscribeAndModify` does not fail a step outright when
+the controller's `onUpdate` callbacks come up short — it records that as `"unverified"` with the
+counts, and states the gap as `accepted` only under chip-tool, whose interactive server is known to
+hand over just the first result of a batch. On any other controller the shortfall is that controller's
+own defect, so the check stands unaccepted and fails the run. A report carrying a value nobody wrote is
+still a failure. What this gives up: a controller that delivered the values out of order is no longer
+caught, which the plan never asked about anyway.

--- a/support/chip-testing/test/cert/TC-IDM-2.1.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-2.1.test.ts
@@ -744,6 +744,9 @@ certTest("TC-IDM-2.1", { plan: "interactiondatamodel.adoc", pics: ["MCORE.IDM.C.
                     type: "response",
                     verdict: "unverified",
                     detail: "matter.js all-clusters app defines no manufacturer-specific cluster",
+                    accepted:
+                        "the matter.js all-clusters app defines no manufacturer-specific cluster, so this " +
+                        "device cannot answer the read the step asks for",
                 });
                 if (!sizePass) {
                     throw new CertCheckFailedError(

--- a/support/chip-testing/test/cert/tc-idm-4.1-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-4.1-support.ts
@@ -5,6 +5,7 @@
  */
 
 import { Duration, Millis, Seconds, Time } from "@matter/main";
+import { resolveControllerImplementation } from "@matter/testing";
 import type { AttributePathSpec, CertNodeRef, CertStepContext } from "@matter/testing";
 import {
     CertCheckFailedError,
@@ -201,12 +202,16 @@ export async function subscribeAndModify<Value>(
         // What the plan asks to verify is the TH's own view: it reported, and the DUT acked Success,
         // which the loop above took from the TH's log for every write. A value missing from the
         // controller's own callbacks is a gap in that controller's delivery rather than in the
-        // behaviour under test — chip-tool's interactive server hands over only the first result of a
-        // batch and discards the rest, so a report the TH coalesced with another attribute reaches no
-        // callback at all.
+        // behaviour under test — but only chip-tool is known to have one, so on any other controller
+        // this stays a gap to close.
         cx.recorder.check({
             type: "response",
             verdict: "unverified",
+            accepted:
+                resolveControllerImplementation() === "chip-tool"
+                    ? "chip-tool's interactive server hands over only the first result of a batch and discards " +
+                      "the rest, so a report the TH coalesced with another attribute reaches no callback at all"
+                    : undefined,
             detail:
                 `step ${step}: onUpdate delivered ${JSON.stringify(reported)} of the written values ` +
                 `${JSON.stringify(values)} (matched ${matched}/${values.length}); every write is confirmed by the ` +

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -44,8 +44,9 @@ export class CertCheckFailedError extends MatterError {}
 /**
  * Records `check` and fails the step on a `"fail"` verdict — `recorder.check()` only records, so a
  * step whose evidence must gate it has to throw for itself, which is the single easiest thing to
- * forget. `"unverified"` passes through: that is what a log check reports on a flavor nobody wrote a
- * pattern for, and it is not a failure (see the flavor-pattern policy in this directory's AGENTS.md).
+ * forget. `"unverified"` passes through rather than throwing: that is what a log check reports on a
+ * flavor nobody wrote a pattern for, and the engine makes it the step's verdict (see the
+ * flavor-pattern policy in this directory's AGENTS.md).
  */
 export function record(cx: CertStepContext, check: CheckRecord, what: string) {
     cx.recorder.check(check);


### PR DESCRIPTION
A certification step records *checks*: pieces of evidence, each of which either proves what the step
claims, disproves it, or cannot be evaluated at all. The third case is spelled `"unverified"` — the
device's log carries no pattern anyone has written for the implementation under test, or the test
application simply has nothing the step can look at. Such a check used to leave its step passing, and
the run's record said `"pass"`, so a step that observed nothing read exactly like one that proved
something.

## A step that observed nothing fails the run

A step carrying an unverified check now ends `"unverified"`, and the run fails. The record tells the
two reasons a run can fail apart: its verdict is `"unverified"` where the only thing wrong is that a
step proved less than it claims, and `"fail"` where a device exited, cleanup or teardown threw, the
evidence could not be assembled, or a step actually failed. Both are red for whoever reads the run;
only the second says something about the device.

Where a claim genuinely cannot be observed on the device or controller in front of us, the check says
why in a new `accepted` field and its step keeps passing. That field sits on the check rather than on
the step deliberately: a step usually records several checks, so a reason declared once for the step
would silently cover a second, unrelated gap appearing there later.

Two checks declare a reason:

- **TC-IDM-2.1 step 21** reads every attribute of every cluster and expects a manufacturer-specific
  one among them, which the matter.js test application does not define.
- **TC-IDM-4.1** reports a shortfall when the controller's own update callbacks deliver fewer values
  than the step wrote — accepted only under chip-tool, whose interactive server hands over just the
  first result of a batch. On any other controller that shortfall is that controller's own defect, so
  it now fails the run instead of being recorded and passed over. This check is independent of the
  device implementation, so without that distinction it would have failed the three chip-tool legs.

The run-level count of unverified checks covers both kinds, so a bundle still says how much of a run
rests on nothing observed.

## The YAML shim's answers are covered by tests over a real socket

CHIP's test runner drives our controller through a small server of ours that speaks chip-tool's
websocket protocol. Recent work decided what that server answers when a discovery finds nothing, when
a write payload cannot be read, and when the fault is the harness's own rather than the device's —
but those decisions were covered as functions only: deleting the call that used one left the tests
green, because nothing exercised the server itself.

Now a test can. The four things the server needs from a command handler — whether the controller was
started, starting it, opening a PASE session, dropping a node's session — move onto the abstract
handler, so a test supplies a fake one instead of a real controller. `start()` resolves once the
socket is bound rather than before, and reports the bound port, so a test can ask for an ephemeral
one. Ten tests send real frames over a real socket and assert the exact reply, including that a
controller is started once on first use and that a device which cannot be reached has its session
dropped.

Two faults those tests found:

- The catch that answers anything thrown outside a command's own error handling reported the error's
  message directly. An error with no message therefore produced an empty error entry, which the
  runner reads as no error at all — a command that failed reported as one that succeeded. It answers
  through the same formatting every other failure path uses now, which never yields an empty message
  and tells our own faults apart from the device's.
- Starting a controller marked it started *before* doing the work, so a start that threw left the
  handler claiming to be up and every later command ran against a controller that never came up. The
  flag is set after the work succeeds, and a pending start is shared so two commands arriving at once
  still start it once.

## Evidence

- Whole matterjs certification leg run locally: 15 runs, all pass; TC-IDM-2.1 reports
  `unverifiedChecks: 1` with its reason recorded in the check.
- Every added branch was mutation-proven: eight mutations, each confirmed to turn exactly the
  intended test red (acceptance ignored, no run-level failure, unproven without a failure, per-step
  counter reset, device exit outranking the gap, empty discovery reported as success, own faults
  spelled as the device's, controller started per command).
- Root `build`, `format-verify`, `lint` clean; full suite green; certification framework suite 665
  checks green.
- The chip legs cannot run on this machine (`chip-cert-bins` is arm64-only against an amd64 harness
  container), so CI is the arbiter for them. The change that could bite there is TC-IDM-4.1's
  accepted shortfall, which is why it is gated on the controller rather than on the device.

## Review provenance

The two pre-ship passes behind this diff — an adversarial read of the shim harness and an audit of
every prose claim against the code — were run by the same session that wrote the code, not as
independent reviewers, because the subagents hit a session limit. An earlier independent pair did
review the verdict change: they found the TC-IDM-4.1 chip-tool trap described above, a field that
could land on a failed step, and several stale doc claims, all fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
