### PR TITLE
Model validation: an override may remove a default, and a finished model may be validated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A default stating a number no integer form matches, such as `1e-3`, is rejected instead of stored as the digits preceding the exponent
     - Fix: `FieldValue.cast()` treats "no value" as a value of every type, so an override removes a default rather than making the value invalid
     - Fix: A rejected default is reported as the value it states and the type that rejected it
+    - Fix: `ValidateModel()` no longer writes a normalized default to a final model, which threw because a final model is frozen; it reports on such a model without normalizing it
     - Fix: A percentage on a type other than `percent` or `percent100ths` no longer resolves to the printed number as though it were already encoded
     - Fix: A constraint bound's unit takes its scale from the types the value derives from, not from its own type name alone
     - Enhancement: New `Scope.isMandatory()` tells whether a member is mandatory under a schema's supported features, and the new `MandatoryDefaultValue()` computes the value such a member assumes when no real value exists (schema default, else the specification's fallback value, recursing into structs) — the basis for what an unreported client node attribute reads, usable wherever schema-derived fallback values are needed; `SelectDefaultValue()` exposes the shallow variant used for server state seeding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: New `EncodedConstraint.bounds()` reports which of a constraint's bounds state a number in encoding units and which state a unit with no known scale
     - Fix: The model build rejects a value stating a unit with no known scale, a fraction an integer type cannot hold, or a negative an unsigned type cannot hold
     - Fix: A default stating a number no integer form matches, such as `1e-3`, is rejected instead of stored as the digits preceding the exponent
+    - Fix: `FieldValue.cast()` treats "no value" as a value of every type, so an override removes a default rather than making the value invalid
+    - Fix: A rejected default is reported as the value it states and the type that rejected it
     - Fix: A percentage on a type other than `percent` or `percent100ths` no longer resolves to the printed number as though it were already encoded
     - Fix: A constraint bound's unit takes its scale from the types the value derives from, not from its own type name alone
     - Enhancement: New `Scope.isMandatory()` tells whether a member is mandatory under a schema's supported features, and the new `MandatoryDefaultValue()` computes the value such a member assumes when no real value exists (schema default, else the specification's fallback value, recursing into structs) — the basis for what an unreported client node attribute reads, usable wherever schema-derived fallback values are needed; `SelectDefaultValue()` exposes the shallow variant used for server state seeding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A default stating a number no integer form matches, such as `1e-3`, is rejected instead of stored as the digits preceding the exponent
     - Fix: `FieldValue.cast()` treats "no value" as a value of every type, so an override removes a default rather than making the value invalid
     - Fix: A rejected default is reported as the value it states and the type that rejected it
+    - Fix: `FieldValue.cast()` reads a duration, which it previously rejected whatever the value stated
     - Fix: `ValidateModel()` no longer writes a normalized default to a final model, which threw because a final model is frozen; it reports on such a model without normalizing it
     - Fix: A percentage on a type other than `percent` or `percent100ths` no longer resolves to the printed number as though it were already encoded
     - Fix: A constraint bound's unit takes its scale from the types the value derives from, not from its own type name alone

--- a/packages/model/src/common/FieldValue.ts
+++ b/packages/model/src/common/FieldValue.ts
@@ -344,6 +344,11 @@ export namespace FieldValue {
      * @returns the cast value or FieldValue.Invalid if cast is not possible
      */
     export function cast<const T extends Metatype>(type: T, value: any): FieldValue | FieldValue.Invalid | undefined {
+        // "No value" is a value of every type, so an override may use it to remove a default the specification states
+        if (FieldValue.is(value, FieldValue.none)) {
+            return undefined;
+        }
+
         if (value === undefined || value === null || type === "any") {
             return value;
         }

--- a/packages/model/src/common/FieldValue.ts
+++ b/packages/model/src/common/FieldValue.ts
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes as ByteUtils, Duration, serialize as stringSerialize, UnexpectedDataError } from "@matter/general";
+import {
+    Bytes as ByteUtils,
+    Duration,
+    DurationFormatError,
+    serialize as stringSerialize,
+    UnexpectedDataError,
+} from "@matter/general";
 import type { Metatype } from "./Metatype.js";
 
 /**
@@ -490,6 +496,16 @@ export namespace FieldValue {
                     return FieldValue.Invalid;
                 }
                 return value;
+
+            case "duration":
+                try {
+                    return Duration(value);
+                } catch (e) {
+                    if (e instanceof DurationFormatError) {
+                        return FieldValue.Invalid;
+                    }
+                    throw e;
+                }
 
             case "object":
                 if (FieldValue.is(value, FieldValue.properties)) {

--- a/packages/model/src/logic/ValidateModel.ts
+++ b/packages/model/src/logic/ValidateModel.ts
@@ -16,10 +16,11 @@ const logger = Logger.get("ValidateModel");
  * Ensures that a model's definition is correct.  Places errors into the error
  * array of invalid models.
  *
- * Makes a few minor modifications to the model as a side effect:
+ * Modifies the model as a side effect: a default value is cast to the type that carries it, and a type whose case does
+ * not match its definition is corrected.
  *
- * - Default values are cast to the correct type if possible
- * - Cross-references are deleted if they're redundant with the parent
+ * A final model is frozen, so validating one reports without normalizing it: a default remains as stated, and a type
+ * whose case does not match is reported as having no type rather than corrected.
  *
  * Note that we run validation against model classes rather than element
  * datatypes.  The classes implement type resolution, error handling and other

--- a/packages/model/src/logic/definition-validation/ModelValidator.ts
+++ b/packages/model/src/logic/definition-validation/ModelValidator.ts
@@ -30,13 +30,6 @@ export class ModelValidator<T extends Model> {
             }
         }
 
-        if (this.model.xref) {
-            const parentXref = this.model.parent?.effectiveXref;
-            if (parentXref && this.model.xref === parentXref) {
-                delete this.model.xref;
-            }
-        }
-
         this.validateChildUniqueness();
     }
 

--- a/packages/model/src/logic/definition-validation/ValueValidator.ts
+++ b/packages/model/src/logic/definition-validation/ValueValidator.ts
@@ -301,7 +301,10 @@ export class ValueValidator<T extends ValueModel> extends ModelValidator<T> {
         }
 
         if (cast === FieldValue.Invalid) {
-            this.error("INVALID_VALUE", `Value "${defaultValue}" is not a ${metatype}`);
+            this.error(
+                "INVALID_VALUE",
+                `Default value "${FieldValue.serialize(defaultValue)}" is not a valid ${metatype} for type ${this.model.effectiveType}`,
+            );
             return;
         }
         defaultValue = cast;

--- a/packages/model/src/logic/definition-validation/ValueValidator.ts
+++ b/packages/model/src/logic/definition-validation/ValueValidator.ts
@@ -47,6 +47,8 @@ function groupBy<T>(bounds: EncodedConstraint.Bound<T>[], keyOf: (model: ValueMo
  * Validates models that extend DataModel.
  */
 export class ValueValidator<T extends ValueModel> extends ModelValidator<T> {
+    #normalizedDefault?: { value: FieldValue | undefined };
+
     override validate() {
         this.validateProperty({ name: "type", type: "string" });
         this.validateProperty({ name: "byteSize", type: "number" });
@@ -69,10 +71,27 @@ export class ValueValidator<T extends ValueModel> extends ModelValidator<T> {
         // discards what it cannot represent, so what was stated is kept to notice that
         const stated = this.model.default;
         this.#validateType();
-        this.#validateNumericValues(stated);
+        this.#validateNumericValues(stated, this.#effectiveDefault);
         this.#validateEntries();
 
         super.validate();
+    }
+
+    /**
+     * The default the model carries once validation has normalized it, which is the value the remaining checks judge.
+     *
+     * A final model is frozen so normalization cannot write to it; the value it would have written is recorded here so
+     * validating a final model reports exactly what validating the same model unfrozen does.
+     */
+    get #effectiveDefault() {
+        return this.#normalizedDefault === undefined ? this.model.default : this.#normalizedDefault.value;
+    }
+
+    #normalizeDefault(value: FieldValue | undefined) {
+        this.#normalizedDefault = { value };
+        if (!this.model.isFinal) {
+            this.model.default = value;
+        }
     }
 
     /**
@@ -88,7 +107,7 @@ export class ValueValidator<T extends ValueModel> extends ModelValidator<T> {
      * This reads what the model states rather than what it inherits, so one bad definition is reported once instead
      * of once per model deriving from it.
      */
-    #validateNumericValues(stated?: FieldValue) {
+    #validateNumericValues(stated: FieldValue | undefined, effective: FieldValue | undefined) {
         const encoded = new Array<EncodedConstraint.Bound<number | bigint>>();
         const unscaled = new Array<EncodedConstraint.Bound<FieldValue>>();
 
@@ -101,16 +120,15 @@ export class ValueValidator<T extends ValueModel> extends ModelValidator<T> {
 
         // A number states itself; only a unit needs converting.  Asking for the encoded form of every default would
         // lose one too large to be a number, which is where the values of a 64 bit type live
-        const fallback = this.model.default;
         let reportedUnit = false;
-        if (typeof fallback === "number" || typeof fallback === "bigint") {
-            encoded.push({ value: fallback, model: this.model });
-        } else if (fallback !== undefined) {
-            const value = EncodedValue(this.model, fallback);
+        if (typeof effective === "number" || typeof effective === "bigint") {
+            encoded.push({ value: effective, model: this.model });
+        } else if (effective !== undefined) {
+            const value = EncodedValue(this.model, effective);
             if (value !== undefined) {
                 encoded.push({ value, model: this.model });
-            } else if (FieldValue.is(fallback, FieldValue.percent) || FieldValue.is(fallback, FieldValue.celsius)) {
-                unscaled.push({ value: fallback, model: this.model });
+            } else if (FieldValue.is(effective, FieldValue.percent) || FieldValue.is(effective, FieldValue.celsius)) {
+                unscaled.push({ value: effective, model: this.model });
                 reportedUnit = true;
             }
         }
@@ -272,7 +290,7 @@ export class ValueValidator<T extends ValueModel> extends ModelValidator<T> {
             // Metatype doesn't handle this case because otherwise you'd never be able to have a string called "empty".
             // In this case though the data likely comes from the spec so we're going to take a flyer and say you can
             // never have "empty" as a default value
-            delete this.model.default;
+            this.#normalizeDefault(undefined);
             return;
         }
 
@@ -295,7 +313,7 @@ export class ValueValidator<T extends ValueModel> extends ModelValidator<T> {
                 referenced = this.model.owner(ClusterModel)?.member(defaultValue);
             }
             if (referenced instanceof ValueModel && referenced.effectiveType === this.model.effectiveType) {
-                this.model.default = FieldValue.Reference(referenced.name);
+                this.#normalizeDefault(FieldValue.Reference(referenced.name));
                 return;
             }
         }
@@ -329,7 +347,7 @@ export class ValueValidator<T extends ValueModel> extends ModelValidator<T> {
             }
         }
 
-        this.model.default = defaultValue;
+        this.#normalizeDefault(defaultValue);
     }
 
     #validateEntries() {
@@ -453,7 +471,7 @@ export class ValueValidator<T extends ValueModel> extends ModelValidator<T> {
         if (typeof def === "string") {
             const other = this.model.parent?.member(def);
             if (other) {
-                this.model.default = FieldValue.Reference(other.name);
+                this.#normalizeDefault(FieldValue.Reference(other.name));
                 return true;
             }
         }
@@ -474,6 +492,12 @@ export class ValueValidator<T extends ValueModel> extends ModelValidator<T> {
     }
 
     #correctCaseFromShadow() {
+        // The correction is a write, which a final model cannot take.  Claiming it succeeded would suppress the error
+        // that says the type does not resolve, so a final model reports rather than repairs
+        if (this.model.isFinal) {
+            return false;
+        }
+
         const tag = this.model.tag;
         const name = this.model.name.toLowerCase();
         return (

--- a/packages/model/src/standard/elements/commodity-tariff.element.ts
+++ b/packages/model/src/standard/elements/commodity-tariff.element.ts
@@ -278,11 +278,8 @@ export const CommodityTariff = Cluster(
         Field({ name: "Price", id: 0x1, type: "TariffPriceStruct", conformance: "[PRICE].b+", quality: "X" }),
         Field({ name: "FriendlyCredit", id: 0x2, type: "bool", conformance: "[FCRED].b+" }),
         Field({ name: "AuxiliaryLoad", id: 0x3, type: "AuxiliaryLoadSwitchSettingsStruct", conformance: "[AUXLD].b+" }),
-        Field({ name: "PeakPeriod", id: 0x4, type: "PeakPeriodStruct", conformance: "[PEAKP].b+", default: { type: "none" } }),
-        Field({
-            name: "PowerThreshold", id: 0x5, type: "PowerThresholdStruct", conformance: "[PWRTHLD].b+",
-            default: { type: "none" }
-        }),
+        Field({ name: "PeakPeriod", id: 0x4, type: "PeakPeriodStruct", conformance: "[PEAKP].b+" }),
+        Field({ name: "PowerThreshold", id: 0x5, type: "PowerThresholdStruct", conformance: "[PWRTHLD].b+" }),
         Field({ name: "Threshold", id: 0x6, type: "int64", conformance: "M", quality: "X" }),
         Field({ name: "Label", id: 0x7, type: "string", conformance: "O", constraint: "max 128", quality: "X" }),
         Field({ name: "Predicted", id: 0x8, type: "bool", conformance: "O" })

--- a/packages/model/test/MatterTest.ts
+++ b/packages/model/test/MatterTest.ts
@@ -22,7 +22,7 @@ describe("MatterDefinition", () => {
 
     it("has not increased in errors", () => {
         validate().report();
-        expect(validationResult?.errors.length).most(11);
+        expect(validationResult?.errors.length).most(4);
     });
 
     it("has not decreased in scope", () => {

--- a/packages/model/test/common/FieldValueTest.ts
+++ b/packages/model/test/common/FieldValueTest.ts
@@ -20,6 +20,21 @@ describe("FieldValue", () => {
             expect(FieldValue.cast(Metatype.boolean, 1)).equal(true);
         });
 
+        // An override states no value to remove a default; casting it to the type would state a value of that type
+        it("reads no value as no value on every type", () => {
+            for (const type of [
+                Metatype.any,
+                Metatype.object,
+                Metatype.integer,
+                Metatype.string,
+                Metatype.boolean,
+                Metatype.bytes,
+                Metatype.array,
+            ]) {
+                expect(FieldValue.cast(type, FieldValue.None)).undefined;
+            }
+        });
+
         it("retains the fraction of a temperature", () => {
             expect(FieldValue.cast(Metatype.integer, "25.5°C")).deep.equal(FieldValue.Celsius(25.5));
             expect(FieldValue.numericValue(FieldValue.Celsius(25.5), "UnsignedTemperature")).equal(255);

--- a/packages/model/test/common/FieldValueTest.ts
+++ b/packages/model/test/common/FieldValueTest.ts
@@ -5,6 +5,7 @@
  */
 
 import { FieldValue, Metatype } from "#common/index.js";
+import { Seconds } from "@matter/general";
 
 describe("FieldValue", () => {
     describe("cast", () => {
@@ -33,6 +34,12 @@ describe("FieldValue", () => {
             ]) {
                 expect(FieldValue.cast(type, FieldValue.None)).undefined;
             }
+        });
+
+        it("reads a duration the way Duration does", () => {
+            expect(FieldValue.cast(Metatype.duration, 2000)).equals(Seconds(2));
+            expect(FieldValue.cast(Metatype.duration, "2s")).equals(Seconds(2));
+            expect(FieldValue.cast(Metatype.duration, "nonsense")).equals(FieldValue.Invalid);
         });
 
         it("retains the fraction of a temperature", () => {

--- a/packages/model/test/logic/definition-validation/ValueValidatorTest.ts
+++ b/packages/model/test/logic/definition-validation/ValueValidatorTest.ts
@@ -18,10 +18,11 @@ import {
     uint8,
     uint16,
     string,
+    struct,
     uint64,
     ValidateModel,
 } from "#index.js";
-import { ClusterModel, DatatypeModel, MatterModel } from "#models/index.js";
+import { AttributeModel, ClusterModel, DatatypeModel, MatterModel } from "#models/index.js";
 
 const CODES = new Set(["UNIT_WITHOUT_SCALE", "FRACTION_ON_INTEGER_TYPE", "NEGATIVE_ON_UNSIGNED_TYPE", "INVALID_VALUE"]);
 
@@ -59,8 +60,8 @@ function validateList(entryType: string, constraint: string) {
     return ValidateModel(Matter).errors.filter(e => CODES.has(e.code));
 }
 
-function validateDefault(type: string, dflt: FieldValue) {
-    const Matter = new MatterModel(
+function modelWithDefault(type: string, dflt: FieldValue) {
+    return new MatterModel(
         {},
         uint8.clone(),
         uint16.clone(),
@@ -68,13 +69,23 @@ function validateDefault(type: string, dflt: FieldValue) {
         int8.clone(),
         percent100ths.clone(),
         string.clone(),
+        struct.clone(),
         bool.clone(),
         new DatatypeModel({ name: "UnsignedTemperature", type: "uint8" }),
         new ClusterModel({ name: "Test", id: 0xfff1 }, Attribute({ name: "Bounded", id: 1, type, default: dflt })),
     );
+}
 
+function validateDefault(type: string, dflt: FieldValue) {
     // Not finalized: validation normalizes a default by writing it back, which a finalized model refuses
-    return ValidateModel(Matter).errors.filter(e => CODES.has(e.code));
+    return ValidateModel(modelWithDefault(type, dflt)).errors.filter(e => CODES.has(e.code));
+}
+
+/** The default validation leaves on the model, which is the value generation then emits */
+function normalizedDefault(type: string, dflt: FieldValue) {
+    const model = modelWithDefault(type, dflt);
+    ValidateModel(model);
+    return model.get(ClusterModel, "Test")?.get(AttributeModel, "Bounded")?.default;
 }
 
 /** An enum states no unit, so a percentage default on one has nowhere to go */
@@ -331,6 +342,53 @@ describe("ValueValidator", () => {
 
         it("accepts a fraction the unit scales to a whole number", () => {
             expect(validateConstraint("percent100ths", "min 0.01%")).deep.equals([]);
+        });
+    });
+
+    // An override states no value to remove a default the specification states
+    describe("a default of no value", () => {
+        it("leaves no default on a type no scalar could state", () => {
+            expect(validateDefault("struct", FieldValue.None)).deep.equals([]);
+            expect(normalizedDefault("struct", FieldValue.None)).undefined;
+        });
+
+        it("leaves no default on a scalar type", () => {
+            expect(validateDefault("uint16", FieldValue.None)).deep.equals([]);
+            expect(normalizedDefault("uint16", FieldValue.None)).undefined;
+        });
+
+        // Casting it to the type would state a value of that type: "[object Object]" on a string, true on a boolean
+        it("leaves no default on a type that could render it", () => {
+            for (const type of ["string", "bool"]) {
+                expect(validateDefault(type, FieldValue.None)).deep.equals([]);
+                expect(normalizedDefault(type, FieldValue.None)).undefined;
+            }
+        });
+    });
+
+    describe("a rejected default", () => {
+        it("names the value and the type it rejects", () => {
+            const errors = validateDefault("struct", "0");
+
+            expect(errors.length).equals(1);
+            expect(errors[0].code).equals("INVALID_VALUE");
+            expect(errors[0].message).equals('Default value "0" is not a valid object for type struct');
+        });
+
+        it("names a value stated with a unit", () => {
+            const errors = validateDefault("struct", { type: "percent", value: 0.01 });
+
+            expect(errors.map(error => error.message)).contains(
+                'Default value "0.01%" is not a valid object for type struct',
+            );
+        });
+
+        it("names a value stating properties", () => {
+            const errors = validateDefault("uint16", { type: FieldValue.properties, properties: { a: 1 } });
+
+            expect(errors.map(error => error.message)).contains(
+                'Default value "{ a: 1 }" is not a valid integer for type uint16',
+            );
         });
     });
 });

--- a/packages/model/test/logic/definition-validation/ValueValidatorTest.ts
+++ b/packages/model/test/logic/definition-validation/ValueValidatorTest.ts
@@ -16,6 +16,7 @@ import {
     percent100ths,
     single,
     uint8,
+    duration,
     uint16,
     string,
     struct,
@@ -23,6 +24,7 @@ import {
     ValidateModel,
 } from "#index.js";
 import { AttributeModel, ClusterModel, DatatypeModel, FieldModel, MatterModel } from "#models/index.js";
+import { Seconds } from "@matter/general";
 
 const CODES = new Set(["UNIT_WITHOUT_SCALE", "FRACTION_ON_INTEGER_TYPE", "NEGATIVE_ON_UNSIGNED_TYPE", "INVALID_VALUE"]);
 
@@ -70,6 +72,7 @@ function modelWithDefault(type: string, dflt: FieldValue) {
         percent100ths.clone(),
         string.clone(),
         struct.clone(),
+        duration.clone(),
         bool.clone(),
         new DatatypeModel({ name: "UnsignedTemperature", type: "uint8" }),
         new ClusterModel({ name: "Test", id: 0xfff1 }, Attribute({ name: "Bounded", id: 1, type, default: dflt })),
@@ -400,6 +403,12 @@ describe("ValueValidator", () => {
 
         it("accepts a whole entry bound on a list whose own bound is whole", () => {
             expect(validateList("uint8", "max 4[0 to 10]")).deep.equals([]);
+        });
+
+        it("accepts a duration stated as a number of milliseconds or as text", () => {
+            expect(validateDefault("duration", Seconds(2))).deep.equals([]);
+            expect(validateDefault("duration", "2s")).deep.equals([]);
+            expect(validateDefault("duration", "nonsense").map(error => error.code)).deep.equals(["INVALID_VALUE"]);
         });
 
         it("accepts a fraction the unit scales to a whole number", () => {

--- a/packages/model/test/logic/definition-validation/ValueValidatorTest.ts
+++ b/packages/model/test/logic/definition-validation/ValueValidatorTest.ts
@@ -22,7 +22,7 @@ import {
     uint64,
     ValidateModel,
 } from "#index.js";
-import { AttributeModel, ClusterModel, DatatypeModel, MatterModel } from "#models/index.js";
+import { AttributeModel, ClusterModel, DatatypeModel, FieldModel, MatterModel } from "#models/index.js";
 
 const CODES = new Set(["UNIT_WITHOUT_SCALE", "FRACTION_ON_INTEGER_TYPE", "NEGATIVE_ON_UNSIGNED_TYPE", "INVALID_VALUE"]);
 
@@ -77,8 +77,70 @@ function modelWithDefault(type: string, dflt: FieldValue) {
 }
 
 function validateDefault(type: string, dflt: FieldValue) {
-    // Not finalized: validation normalizes a default by writing it back, which a finalized model refuses
     return ValidateModel(modelWithDefault(type, dflt)).errors.filter(e => CODES.has(e.code));
+}
+
+/** Validation of a final model, which is frozen and so cannot be normalized */
+function validateFinalDefault(type: string, dflt: FieldValue) {
+    const model = modelWithDefault(type, dflt);
+    model.finalize();
+
+    return {
+        errors: ValidateModel(model).errors,
+        default: model.get(ClusterModel, "Test")?.get(AttributeModel, "Bounded")?.default,
+    };
+}
+
+/** Every error validation reports, not only those of the numeric rules */
+function allErrors(type: string, dflt: FieldValue) {
+    return ValidateModel(modelWithDefault(type, dflt)).errors;
+}
+
+/** A default naming a sibling field, which normalization turns into a reference to it */
+function modelWithReferenceDefault() {
+    return new MatterModel(
+        {},
+        uint8.clone(),
+        new ClusterModel(
+            { name: "Test", id: 0xfff1 },
+            Attribute({ name: "Bounded", id: 1, type: "uint8", default: "Other" }),
+            Attribute({ name: "Other", id: 2, type: "uint8" }),
+        ),
+    );
+}
+
+/** A default naming a cluster attribute, which the struct that carries the default does not shadow */
+function modelWithClusterReferenceDefault() {
+    return new MatterModel(
+        {},
+        uint8.clone(),
+        struct.clone(),
+        new ClusterModel(
+            { name: "Test", id: 0xfff1 },
+            Attribute({ name: "Limit", id: 1, type: "uint8" }),
+            new DatatypeModel(
+                { name: "Holder", type: "struct" },
+                FieldElement({ name: "Bounded", type: "uint8", default: "Limit" }),
+            ),
+        ),
+    );
+}
+
+/** A member whose type resolves only once its name is corrected to the case its definition uses */
+function modelWithCaseMismatch() {
+    return new MatterModel(
+        {},
+        uint8.clone(),
+        new ClusterModel({ name: "Base", id: 0xfff0 }, Attribute({ name: "Foo", id: 1, type: "uint8" })),
+        new ClusterModel({ name: "Derived", id: 0xfff1, type: "Base" }, Attribute({ name: "foo", id: 1 })),
+    );
+}
+
+function validate(model: MatterModel, final: boolean) {
+    if (final) {
+        model.finalize();
+    }
+    return ValidateModel(model).errors;
 }
 
 /** The default validation leaves on the model, which is the value generation then emits */
@@ -362,6 +424,88 @@ describe("ValueValidator", () => {
             for (const type of ["string", "bool"]) {
                 expect(validateDefault(type, FieldValue.None)).deep.equals([]);
                 expect(normalizedDefault(type, FieldValue.None)).undefined;
+            }
+        });
+    });
+
+    describe("a final model", () => {
+        it("reports what the same model reports unfrozen", () => {
+            for (const [type, dflt] of [
+                ["uint16", "5"],
+                ["uint16", "-1"],
+                ["uint16", 0.01],
+                ["struct", "0"],
+                ["string", "empty"],
+                ["UnsignedTemperature", "25.5°C"],
+                ["percent100ths", { type: "percent", value: 0.01 }],
+            ] as [string, FieldValue][]) {
+                expect(validateFinalDefault(type, dflt).errors).deep.equals(allErrors(type, dflt));
+            }
+        });
+
+        it("leaves the default it cannot normalize as stated", () => {
+            expect(validateFinalDefault("uint16", "5").default).equals("5");
+            expect(normalizedDefault("uint16", "5")).equals(5);
+
+            // The specification's way of stating that a string has no default
+            expect(validateFinalDefault("string", "empty").default).equals("empty");
+            expect(normalizedDefault("string", "empty")).undefined;
+        });
+
+        it("leaves a default naming a sibling as the name it states", () => {
+            const final = modelWithReferenceDefault();
+            expect(validate(final, true)).deep.equals(validate(modelWithReferenceDefault(), false));
+            expect(final.get(ClusterModel, "Test")?.get(AttributeModel, "Bounded")?.default).equals("Other");
+
+            const normalized = modelWithReferenceDefault();
+            ValidateModel(normalized);
+            expect(normalized.get(ClusterModel, "Test")?.get(AttributeModel, "Bounded")?.default).deep.equals(
+                FieldValue.Reference("Other"),
+            );
+        });
+
+        it("leaves a default naming a cluster member as the name it states", () => {
+            const final = modelWithClusterReferenceDefault();
+            expect(validate(final, true)).deep.equals(validate(modelWithClusterReferenceDefault(), false));
+
+            const holder = (model: MatterModel) =>
+                model.get(ClusterModel, "Test")?.get(DatatypeModel, "Holder")?.get(FieldModel, "Bounded")?.default;
+            expect(holder(final)).equals("Limit");
+
+            const normalized = modelWithClusterReferenceDefault();
+            ValidateModel(normalized);
+            expect(holder(normalized)).deep.equals(FieldValue.Reference("Limit"));
+        });
+
+        // Correcting the case is a write, so a final model reports the type as absent instead of resolving it
+        it("reports a type it cannot correct the case of", () => {
+            const final = modelWithCaseMismatch();
+            expect(validate(final, true).map(error => error.code)).deep.equals(["NO_TYPE"]);
+            expect(final.get(ClusterModel, "Derived")?.get(AttributeModel, "foo")?.name).equals("foo");
+
+            const corrected = modelWithCaseMismatch();
+            expect(validate(corrected, false)).deep.equals([]);
+            expect(corrected.get(ClusterModel, "Derived")?.get(AttributeModel, "Foo")?.effectiveType).equals("Foo");
+        });
+
+        // Characterization: a cross-reference redundant with the parent's survives validation, final or not.  The
+        // generator drops these itself
+        it("keeps a cross-reference redundant with its parent", () => {
+            const xref = { document: "cluster", section: "1.2.3" } as const;
+            const build = () =>
+                new MatterModel(
+                    {},
+                    uint8.clone(),
+                    new ClusterModel(
+                        { name: "Test", id: 0xfff1, xref },
+                        Attribute({ name: "Bounded", id: 1, type: "uint8", xref }),
+                    ),
+                );
+
+            for (const final of [true, false]) {
+                const model = build();
+                expect(() => validate(model, final)).not.throws();
+                expect(model.get(ClusterModel, "Test")?.get(AttributeModel, "Bounded")?.xref?.section).equals("1.2.3");
             }
         });
     });

--- a/packages/model/test/standard/MatterDefinitionTest.ts
+++ b/packages/model/test/standard/MatterDefinitionTest.ts
@@ -38,7 +38,7 @@ describe("MatterDefinition", () => {
 
     it("has not increased in errors", () => {
         validate().report();
-        expect(validationResult?.errors.length).most(16);
+        expect(validationResult?.errors.length).most(4);
     });
 
     it("has not decreased in scope", () => {

--- a/support/codegen/src/util/finalize-model.ts
+++ b/support/codegen/src/util/finalize-model.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isDeepEqual, Logger } from "#general";
+import { InternalError, isDeepEqual, Logger } from "#general";
 import {
     AnyElement,
     AttributeModel,
@@ -30,6 +30,11 @@ const logger = Logger.get("create-model");
  * Create and validate the final model for export
  **/
 export function finalizeModel(matter: MatterModel) {
+    // Generation emits what validation normalizes, and validation cannot normalize a frozen model
+    if (matter.isFinal) {
+        throw new InternalError(`Cannot generate from ${matter.name} because it is final`);
+    }
+
     const scopedDatatypes = collectScopedDatatypes(matter);
 
     const semanticNamespaces = new Array<SemanticNamespaceModel>();
@@ -95,7 +100,7 @@ export type ScopedDatatypes = Record<string, Model | undefined>;
 function updateSemanticNamespaces(semanticNamespaces: SemanticNamespaceModel[], matter: MatterModel) {
     const namespace = matter.get(DatatypeModel, "namespace");
     if (!namespace) {
-        throw new Error("Namespace datatype not found in model. This should never happen");
+        throw new InternalError("Namespace datatype not found in model");
     }
 
     namespace.children = semanticNamespaces


### PR DESCRIPTION
Two fixes to model definition validation, both in `@matter/model`.

## An override that removes a default no longer makes the value invalid

A `LocalMatter` override removes a default the specification states by setting `FieldValue.None`, the
"no value" marker. It has to state something rather than nothing: the variant merge skips an undefined
property, so an override cannot mask a specification default by leaving the property out. Validation is
what turns the marker into a real absence — and `FieldValue.cast()` refused it for most types instead.
On a struct, an integer, a float, a date, a byte string or a list the value was reported as invalid; on
a string it became the text `"[object Object]"`, and on a boolean it became `true`.

Two errors shipped on every model build because of it. `CommodityTariff`'s `TariffComponentStruct` has
two struct-typed fields for which the specification writes a fallback of `0`, which no struct can hold,
so our override removes them — and the removal itself was then reported as the invalid value. The
model now validates with only its four known duplicate-requirement errors, and the generated model no
longer carries the marker as a default. The specification defect behind it is filed upstream
separately.

The message those errors carried was also unreadable: it interpolated the value object into text, so
it said `Value "[object Object]" is not a object` without naming either the value or the field's type.
It now renders the value the way the sibling messages do and names the type that rejected it:
`Default value "0" is not a valid object for type PeakPeriodStruct`.

The error ceilings the model tests assert were loose by more than these two errors, so they are
tightened to the count the model actually carries.

## Validation reports on a finished model instead of throwing

A model can be marked final, which freezes it so the code that treats it as operational schema may
assume it never changes. Validation normalizes as it goes — it casts a default to the type that
carries it, and corrects the case of a type name that does not match its definition — and both are
writes, so validating a finished model threw `TypeError: Cannot assign to read only property 'default'`
instead of reporting anything. Every realistic model states a default somewhere, so this was every
finished model.

Validation now records the value it would have written and writes only to a model that can take it.
The remaining checks read the recorded value rather than the model, so what is reported does not depend
on whether the write happened. Without that, a finished model stating a default of `"-1"` on an
unsigned type would have gone unreported, because the checks would have seen the text rather than the
number it denotes.

Correcting the case of a type name is a write with no such fallback, so on a finished model the type is
now reported as absent rather than silently left unresolved — which is what the first draft of this
change did, and what the review caught.

Generation depends on the normalization, so it now refuses a final model rather than emitting values
validation could not normalize.

The validator's attempt to delete a cross-reference redundant with its parent's is also dropped. It
never did anything: a cross-reference lives on a model's resource behind an accessor, so deleting the
property on the model itself is a no-op. The generator does this cleanup itself, by assignment, and
continues to.

## Testing

`npm run build`, `npm run format-verify`, `npm run lint` and the full `npm test` suite pass. Each
production branch is mutation-tested: reverting it fails a named test, and the failures are the ones
the fix exists to prevent (`Cannot assign to read only property 'default'` for the frozen-model writes,
a dropped `NEGATIVE_ON_UNSIGNED_TYPE` for the value the checks read, a surviving `{ type: "none" }` for
the marker). `npm run generate-model` reproduces the committed model unchanged apart from the two dead
defaults.
