### PR TITLE
feat(protocol): a caller can abandon an interaction, and the YAML shim honors a step's timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A certification run's `result.json` no longer reports a passing verdict for a run that failed
     - Fix: A failure to attach a certification run's device logs fails the run instead of only warning
 
+- @matter/protocol
+    - Enhancement: An interaction can be abandoned by the caller: `ClientRequest.abort` takes an `AbortSignal`, honored for read, write, invoke and subscribe
+
+- @project-chip/matter.js
+    - Enhancement: `InteractionClient`'s read, write, invoke and subscribe options take an `abort` signal, forwarded to the interaction
+
 - @matter/general
     - Breaking: `DnssdNames.Context.goodbyeProtectionWindow` and `DnssdNames.defaults.goodbyeProtectionWindow` are now `evictionDelay`, and `DnssdName.deleteRecord` no longer takes an `ifOlderThan` argument
     - Enhancement: New `MatterAggregateError.settleSeries()` runs tasks in order, continuing past a failure, and reports the accumulated errors

--- a/packages/matter.js/src/cluster/client/InteractionClient.ts
+++ b/packages/matter.js/src/cluster/client/InteractionClient.ts
@@ -190,6 +190,9 @@ export type InvokeOptions<C extends ClusterType.Command = ClusterType.Command> =
      */
     expectedProcessingTime?: Duration;
 
+    /** Abandon the invoke when this aborts (see {@link ClientRequest.abort}). */
+    abort?: AbortSignal;
+
     /** Use an extended Message Response Timeout as defined for FailSafe cases which is 30s. */
     useExtendedFailSafeMessageResponseTimeout?: boolean;
 
@@ -403,6 +406,9 @@ export class InteractionClient {
                 valueChanged?: boolean,
                 oldValue?: any,
             ) => void;
+
+            /** Abandon the read when this aborts (see {@link ClientRequest.abort}). */
+            abort?: AbortSignal;
         } = {},
     ): Promise<{
         attributeData: DecodedAttributeReportValue<any>[];
@@ -427,6 +433,9 @@ export class InteractionClient {
             events?: { endpointId?: EndpointNumber; clusterId?: ClusterId; eventId?: EventId }[];
             eventFilters?: TypeFromSchema<typeof TlvEventFilter>[];
             isFabricFiltered?: boolean;
+
+            /** Abandon the read when this aborts (see {@link ClientRequest.abort}). */
+            abort?: AbortSignal;
         } = {},
     ): Promise<{ eventData: DecodedEventReportValue<any>[]; eventStatus?: DecodedEventReportStatus[] }> {
         const { eventReports, eventStatus } = await this.getMultipleAttributesAndEvents(options);
@@ -441,6 +450,9 @@ export class InteractionClient {
             eventFilters?: TypeFromSchema<typeof TlvEventFilter>[];
             isFabricFiltered?: boolean;
             attributeChangeListener?: (data: DecodedAttributeReportValue<any>) => void;
+
+            /** Abandon the read when this aborts (see {@link ClientRequest.abort}). */
+            abort?: AbortSignal;
         } = {},
     ): Promise<ResponseDataReport> {
         if (this.isGroupAddress) {
@@ -454,6 +466,7 @@ export class InteractionClient {
             eventFilters,
             isFabricFiltered = true,
             attributeChangeListener: attributeListener,
+            abort,
         } = options;
 
         const read = (this.#interaction as ClientNodeInteraction).read({
@@ -468,6 +481,7 @@ export class InteractionClient {
                 fabricFilter: isFabricFiltered,
                 interactionModelRevision: Specification.INTERACTION_MODEL_REVISION,
             }),
+            abort,
             includeKnownVersions: !dataVersionFilters,
             [Diagnostic.value]: () =>
                 Diagnostic.dict({
@@ -628,10 +642,14 @@ export class InteractionClient {
         timedRequestTimeout?: Duration;
         suppressResponse?: boolean;
         chunkLists?: boolean;
+
+        /** Abandon the write when this aborts (see {@link ClientRequest.abort}). */
+        abort?: AbortSignal;
     }): Promise<void> {
-        const { attributeData, asTimedRequest, timedRequestTimeout, suppressResponse, chunkLists } = options;
+        const { attributeData, asTimedRequest, timedRequestTimeout, suppressResponse, chunkLists, abort } = options;
         const { endpointId, clusterId, attribute, value, dataVersion } = attributeData;
         const response = await this.setMultipleAttributes({
+            abort,
             attributes: [{ endpointId, clusterId, attribute, value, dataVersion }],
             asTimedRequest,
             timedRequestTimeout,
@@ -666,6 +684,9 @@ export class InteractionClient {
         timedRequestTimeout?: Duration;
         suppressResponse?: boolean;
         chunkLists?: boolean;
+
+        /** Abandon the write when this aborts (see {@link ClientRequest.abort}). */
+        abort?: AbortSignal;
     }): Promise<AttributeStatus[]> {
         const {
             attributes,
@@ -725,6 +746,7 @@ export class InteractionClient {
         }
 
         const response = await this.#interaction.write({
+            abort: options.abort,
             ...Write({
                 writes: writeRequests,
                 timed: asTimedRequest,
@@ -772,6 +794,9 @@ export class InteractionClient {
         listener?: (value: T, version: number) => void;
         updateTimeoutHandler?: () => void;
         updateReceived?: () => void;
+
+        /** Abandon establishing the subscription when this aborts (see {@link ClientRequest.abort}). */
+        abort?: AbortSignal;
     }): Promise<{
         maxInterval: number;
     }> {
@@ -790,10 +815,12 @@ export class InteractionClient {
             keepSubscriptions = true,
             updateTimeoutHandler,
             updateReceived,
+            abort,
         } = options;
         const { id: attributeId } = attribute;
 
         const { maxInterval } = await this.subscribeMultipleAttributesAndEvents({
+            abort,
             attributes: [{ endpointId, clusterId, attributeId }],
             minIntervalFloorSeconds,
             maxIntervalCeilingSeconds,
@@ -822,6 +849,9 @@ export class InteractionClient {
         listener?: (value: DecodedEventData<T>) => void;
         updateTimeoutHandler?: () => void;
         updateReceived?: () => void;
+
+        /** Abandon establishing the subscription when this aborts (see {@link ClientRequest.abort}). */
+        abort?: AbortSignal;
     }): Promise<{
         maxInterval: number;
     }> {
@@ -841,10 +871,12 @@ export class InteractionClient {
             listener,
             updateTimeoutHandler,
             updateReceived,
+            abort,
         } = options;
         const { id: eventId } = event;
 
         const { maxInterval } = await this.subscribeMultipleAttributesAndEvents({
+            abort,
             events: [{ endpointId, clusterId, eventId, isUrgent }],
             eventFilters: minimumEventNumber !== undefined ? [{ eventMin: minimumEventNumber }] : undefined,
             minIntervalFloorSeconds,
@@ -875,6 +907,9 @@ export class InteractionClient {
         dataVersionFilters?: { endpointId: EndpointNumber; clusterId: ClusterId; dataVersion: number }[];
         updateTimeoutHandler?: () => void;
         updateReceived?: () => void;
+
+        /** Abandon establishing the subscription when this aborts (see {@link ClientRequest.abort}). */
+        abort?: AbortSignal;
     }): Promise<{
         attributeReports?: DecodedAttributeReportValue<any>[];
         eventReports?: DecodedEventReportValue<any>[];
@@ -901,6 +936,9 @@ export class InteractionClient {
         dataVersionFilters?: { endpointId: EndpointNumber; clusterId: ClusterId; dataVersion: number }[];
         updateTimeoutHandler?: () => void;
         updateReceived?: () => void;
+
+        /** Abandon establishing the subscription when this aborts (see {@link ClientRequest.abort}). */
+        abort?: AbortSignal;
     }): Promise<{
         attributeReports?: DecodedAttributeReportValue<any>[];
         eventReports?: DecodedEventReportValue<any>[];
@@ -922,6 +960,7 @@ export class InteractionClient {
             dataVersionFilters,
             updateTimeoutHandler,
             updateReceived,
+            abort,
         } = options;
 
         // Will be set to undefined when initially send and then no longer collected
@@ -931,6 +970,7 @@ export class InteractionClient {
         };
 
         const subscribe = await (this.#interaction as ClientNodeInteraction).subscribe({
+            abort,
             ...Subscribe({
                 interactionModelRevision: Specification.INTERACTION_MODEL_REVISION,
                 attributes: attributeRequests,
@@ -1061,8 +1101,9 @@ export class InteractionClient {
 
         const clusterModel = Matter.clusters(clusterId);
         const cluster = { id: clusterId, name: clusterModel?.name ?? `Unknown (${Diagnostic.hex(clusterId)})` };
-        const invoke = this.#interaction.invoke(
-            Invoke({
+        const invoke = this.#interaction.invoke({
+            abort: options.abort,
+            ...Invoke({
                 commands: [
                     endpointId === undefined
                         ? Invoke.WildcardCommandRequest({
@@ -1087,7 +1128,7 @@ export class InteractionClient {
                         ? DEFAULT_MINIMUM_RESPONSE_TIMEOUT_WITH_FAILSAFE
                         : undefined),
             }),
-        );
+        });
 
         for await (const chunks of invoke) {
             for (const chunk of chunks) {
@@ -1128,6 +1169,9 @@ export class InteractionClient {
         asTimedRequest?: boolean;
         timedRequestTimeout?: Duration;
         skipValidation?: boolean;
+
+        /** Abandon the invoke when this aborts (see {@link ClientRequest.abort}). */
+        abort?: AbortSignal;
     }): Promise<void> {
         return this.#invoke({ ...options, suppressResponse: true }) as Promise<void>;
     }

--- a/packages/matter.js/src/cluster/client/InteractionClient.ts
+++ b/packages/matter.js/src/cluster/client/InteractionClient.ts
@@ -331,6 +331,9 @@ export class InteractionClient {
                 valueChanged?: boolean,
                 oldValue?: any,
             ) => void;
+
+            /** Abandon the read when this aborts (see {@link ClientRequest.abort}). */
+            abort?: AbortSignal;
         } = {},
     ): Promise<DecodedAttributeReportValue<any>[]> {
         return (
@@ -345,6 +348,9 @@ export class InteractionClient {
         options: {
             eventFilters?: TypeFromSchema<typeof TlvEventFilter>[];
             isFabricFiltered?: boolean;
+
+            /** Abandon the read when this aborts (see {@link ClientRequest.abort}). */
+            abort?: AbortSignal;
         } = {},
     ): Promise<DecodedEventReportValue<any>[]> {
         return (
@@ -369,6 +375,9 @@ export class InteractionClient {
                 valueChanged?: boolean,
                 oldValue?: any,
             ) => void;
+
+            /** Abandon the read when this aborts (see {@link ClientRequest.abort}). */
+            abort?: AbortSignal;
         } = {},
     ): Promise<{
         attributeReports: DecodedAttributeReportValue<any>[];
@@ -391,6 +400,9 @@ export class InteractionClient {
                 valueChanged?: boolean,
                 oldValue?: any,
             ) => void;
+
+            /** Abandon the read when this aborts (see {@link ClientRequest.abort}). */
+            abort?: AbortSignal;
         } = {},
     ): Promise<DecodedAttributeReportValue<any>[]> {
         return (await this.getMultipleAttributesAndEvents(options)).attributeReports;
@@ -423,6 +435,9 @@ export class InteractionClient {
             events?: { endpointId?: EndpointNumber; clusterId?: ClusterId; eventId?: EventId }[];
             eventFilters?: TypeFromSchema<typeof TlvEventFilter>[];
             isFabricFiltered?: boolean;
+
+            /** Abandon the read when this aborts (see {@link ClientRequest.abort}). */
+            abort?: AbortSignal;
         } = {},
     ): Promise<DecodedEventReportValue<any>[]> {
         return (await this.getMultipleAttributesAndEvents(options)).eventReports;

--- a/packages/protocol/src/action/client/ClientInteraction.ts
+++ b/packages/protocol/src/action/client/ClientInteraction.ts
@@ -112,6 +112,7 @@ interface PendingCommand {
     pathKey: string;
     network?: string;
     additionalMrpDelay?: Duration;
+    abort?: AbortSignal;
     resolve: (entry: InvokeResult.DecodedData | undefined) => void;
     reject: (error: Error) => void;
     aborted?: boolean;
@@ -699,6 +700,7 @@ export class ClientInteraction<
             pathKey,
             network: request.network,
             additionalMrpDelay: request.additionalMrpDelay,
+            abort: request.abort,
             resolve: resolver,
             reject: rejecter,
         };
@@ -833,6 +835,7 @@ export class ClientInteraction<
     }
 
     async #executeBatch(commands: Map<number, PendingCommand>) {
+        let releaseAbortListeners: (() => void) | undefined;
         try {
             // Filter out commands aborted between snapshot and send
             for (const [ref, pending] of commands) {
@@ -860,10 +863,38 @@ export class ClientInteraction<
             // Use #invokeSingle directly to avoid re-entering the batching path in invoke()
             // Skip validation: already validated on submit. timed=false: only non-timed commands
             // reach this path (gate in invoke()); prevents Invoke() spec-based auto-promotion.
+            // A batch outlives the caller of any one of its commands, so it stops sending only once
+            // every command in it has been abandoned — until then the others still want the peer's
+            // answer. A batch holding even one command without a deadline can never reach that point.
+            const batchAbort = new AbortController();
+            const commandSignals = commandList.map(({ abort }) => abort);
+            const abandonable = commandSignals.every(signal => signal !== undefined);
+            let unabandoned = abandonable ? commandSignals.filter(signal => !signal.aborted).length : Infinity;
+            const onCommandAbort = () => {
+                if (--unabandoned === 0) {
+                    batchAbort.abort(new AbortedError());
+                }
+            };
+            if (abandonable) {
+                if (unabandoned === 0) {
+                    batchAbort.abort(new AbortedError());
+                } else {
+                    for (const signal of commandSignals) {
+                        signal.addEventListener("abort", onCommandAbort, { once: true });
+                    }
+                    releaseAbortListeners = () => {
+                        for (const signal of commandSignals) {
+                            signal.removeEventListener("abort", onCommandAbort);
+                        }
+                    };
+                }
+            }
+
             const batchRequest = {
                 ...Invoke({ commands: invokeRequests, skipValidation: true, timed: false }),
                 network: batchNetwork,
                 additionalMrpDelay: batchAdditionalMrpDelay,
+                abort: abandonable ? batchAbort.signal : undefined,
             } as ClientInvoke;
             const maxPathsPerInvoke = this.#exchangeProvider.maxPathsPerInvoke ?? 1;
             const chunks =
@@ -905,6 +936,8 @@ export class ClientInteraction<
                     pending.reject(asError(error));
                 }
             }
+        } finally {
+            releaseAbortListeners?.();
         }
     }
 

--- a/packages/protocol/src/action/client/ClientInteraction.ts
+++ b/packages/protocol/src/action/client/ClientInteraction.ts
@@ -869,24 +869,28 @@ export class ClientInteraction<
             const batchAbort = new AbortController();
             const commandSignals = commandList.map(({ abort }) => abort);
             const abandonable = commandSignals.every(signal => signal !== undefined);
-            let unabandoned = abandonable ? commandSignals.filter(signal => !signal.aborted).length : Infinity;
-            const onCommandAbort = () => {
-                if (--unabandoned === 0) {
-                    batchAbort.abort(new AbortedError());
-                }
-            };
             if (abandonable) {
-                if (unabandoned === 0) {
-                    batchAbort.abort(new AbortedError());
-                } else {
-                    for (const signal of commandSignals) {
-                        signal.addEventListener("abort", onCommandAbort, { once: true });
+                // Per command, not per signal: two commands may share one signal, and a listener
+                // registered twice with the same callback counts once, which would strand the batch
+                // one abandonment short of stopping.
+                let unabandoned = commandSignals.filter(signal => !signal.aborted).length;
+                const releases = new Array<() => void>();
+                for (const signal of commandSignals) {
+                    if (signal.aborted) {
+                        continue;
                     }
-                    releaseAbortListeners = () => {
-                        for (const signal of commandSignals) {
-                            signal.removeEventListener("abort", onCommandAbort);
+                    const onCommandAbort = () => {
+                        if (--unabandoned === 0) {
+                            batchAbort.abort(new AbortedError());
                         }
                     };
+                    signal.addEventListener("abort", onCommandAbort, { once: true });
+                    releases.push(() => signal.removeEventListener("abort", onCommandAbort));
+                }
+                releaseAbortListeners = () => releases.forEach(release => release());
+
+                if (unabandoned === 0) {
+                    batchAbort.abort(new AbortedError());
                 }
             }
 

--- a/packages/protocol/src/action/client/ClientInteraction.ts
+++ b/packages/protocol/src/action/client/ClientInteraction.ts
@@ -698,10 +698,11 @@ export class ClientInteraction<
 
         this.#pendingCommands.set(commandRef, pending);
 
-        // Register per-command abort listener
-        const abortSignal = session?.abort;
-        if (abortSignal) {
-            if (abortSignal.aborted) {
+        // Register per-command abort listeners. A batch carries commands of several callers, so an
+        // abort belongs to its own command: it rejects that one and leaves the batch to the others.
+        const abortSignals = [session?.abort, request.abort].filter(signal => signal !== undefined);
+        if (abortSignals.length) {
+            if (abortSignals.some(signal => signal.aborted)) {
                 this.#pendingCommands.delete(commandRef);
                 throw new AbortedError();
             }
@@ -711,8 +712,14 @@ export class ClientInteraction<
                 this.#pendingCommands.delete(commandRef);
                 pending.reject(new AbortedError());
             };
-            abortSignal.addEventListener("abort", onAbort, { once: true });
-            pending.cleanup = () => abortSignal.removeEventListener("abort", onAbort);
+            for (const signal of abortSignals) {
+                signal.addEventListener("abort", onAbort, { once: true });
+            }
+            pending.cleanup = () => {
+                for (const signal of abortSignals) {
+                    signal.removeEventListener("abort", onAbort);
+                }
+            };
         }
 
         const duration = request.batchDuration || Instant;
@@ -1107,7 +1114,7 @@ export class ClientInteraction<
                 );
             }
 
-            abort = new Abort({ abort: [session?.abort, this.#abort, extraAbort] });
+            abort = new Abort({ abort: [session?.abort, this.#abort, extraAbort, request.abort] });
 
             try {
                 messenger = await InteractionClientMessenger.create(this.#exchangeProvider, {

--- a/packages/protocol/src/action/client/ClientInteraction.ts
+++ b/packages/protocol/src/action/client/ClientInteraction.ts
@@ -675,10 +675,17 @@ export class ClientInteraction<
             throw new ImplementationError("Client interaction unavailable after close");
         }
 
-        // Validate peer connectivity before queuing — respects connectionTimeout and abort
+        if (request.abort?.aborted) {
+            throw new AbortedError();
+        }
+
+        // Validate peer connectivity before queuing — respects connectionTimeout and abort. The
+        // caller's signal has to reach this too: establishing the connection is where a command
+        // addressed to an unreachable peer spends its time.
+        using connectAbort = Abort.any(session?.abort, request.abort);
         await this.#exchangeProvider.connect({
             connectionTimeout: session?.connectionTimeout,
-            abort: session?.abort,
+            abort: connectAbort.signal,
         });
 
         const cmd = [...request.commands.values()][0];
@@ -1029,7 +1036,9 @@ export class ClientInteraction<
                 peer,
                 closed: () => this.subscriptions.delete(subscription),
                 request,
-                abort: session?.abort,
+                // Both, or an abort by the caller would end only the attempt in flight while the
+                // sustainer treats that as a failure to retry
+                abort: [session?.abort, request.abort],
                 retries: this.#sustainRetries,
                 read,
                 probe: abort =>

--- a/packages/protocol/src/action/client/ClientRequest.ts
+++ b/packages/protocol/src/action/client/ClientRequest.ts
@@ -47,4 +47,17 @@ export interface ClientRequest {
      * it per-call. On expiry the operation rejects with `IcdPeerAsleepError`. Ignored for non-LIT peers.
      */
     icdAwaitTimeout?: Duration;
+
+    /**
+     * Abandon this interaction when the signal aborts.
+     *
+     * The exchange stops sending and stops waiting — no further MRP retransmission — and the operation
+     * rejects with `AbortedError`. A caller that must bound an interaction more tightly than the
+     * peer's own response time uses this; without it the operation runs until matter.js gives up on
+     * the peer, which is a property of the peer rather than of the caller's deadline.
+     *
+     * Aborting abandons the interaction rather than telling the peer anything, so a write or invoke
+     * already in flight may still be acted on by the peer.
+     */
+    abort?: AbortSignal;
 }

--- a/packages/protocol/src/action/client/subscription/ClientSubscription.ts
+++ b/packages/protocol/src/action/client/subscription/ClientSubscription.ts
@@ -108,6 +108,10 @@ export namespace ClientSubscription {
         peer: PeerAddress;
         closed: () => void;
         lifetime: Lifetime.Owner;
-        abort?: AbortSignal;
+        /**
+         * Signals that end the subscription's own life, not merely the attempt in flight: its session's
+         * and, where the caller gave one, its request's.
+         */
+        abort?: Abort.Options["abort"];
     }
 }

--- a/packages/protocol/test/action/client/ClientInteractionInvokeTest.ts
+++ b/packages/protocol/test/action/client/ClientInteractionInvokeTest.ts
@@ -242,9 +242,15 @@ class HangingDeviceExchangeProvider extends ExchangeProvider {
     readonly peerAddress = undefined;
 
     #sendObserved = createPromise<void>();
+    #receiveAborted = false;
 
     get sendObserved() {
         return this.#sendObserved.promise;
+    }
+
+    /** Whether the exchange stopped waiting for the peer, rather than only the caller giving up. */
+    get receiveAborted() {
+        return this.#receiveAborted;
     }
 
     constructor() {
@@ -264,10 +270,18 @@ class HangingDeviceExchangeProvider extends ExchangeProvider {
             new Promise((_, reject) => {
                 const abort = options?.abort;
                 if (abort?.aborted) {
+                    this.#receiveAborted = true;
                     reject(new AbortedError());
                     return;
                 }
-                abort?.addEventListener("abort", () => reject(new AbortedError()), { once: true });
+                abort?.addEventListener(
+                    "abort",
+                    () => {
+                        this.#receiveAborted = true;
+                        reject(new AbortedError());
+                    },
+                    { once: true },
+                );
             });
         return exchange;
     }
@@ -402,6 +416,35 @@ describe("ClientInteraction invoke commandRef wire handling", () => {
         } finally {
             await client.close();
         }
+    });
+
+    it("stops a batch's own exchange once every command in it has been abandoned", async () => {
+        const provider = new HangingDeviceExchangeProvider();
+        const client = new ClientInteraction({
+            environment: Environment.default,
+            exchangeProvider: provider,
+        });
+
+        const controller = new AbortController();
+        const request = Invoke(
+            Invoke.ConcreteCommandRequest({ endpoint: EndpointNumber(1), cluster: OnOff, command: "off" }),
+        );
+        request.abort = controller.signal;
+
+        const invokePromise = (async () => {
+            for await (const _chunk of client.invoke(request));
+        })();
+        const rejection = expect(invokePromise).rejectedWith(AbortedError);
+
+        await MockTime.resolve(Promise.race([provider.sendObserved, invokePromise]));
+        controller.abort();
+        await MockTime.resolve(rejection);
+
+        // The exchange the batch sent on is what keeps retransmitting, so abandoning the batch's last
+        // live command has to reach it rather than only the caller.
+        expect(provider.receiveAborted).equal(true);
+
+        await client.close();
     });
 
     it("abandons a read whose request signal aborts, not only an invoke", async () => {

--- a/packages/protocol/test/action/client/ClientInteractionInvokeTest.ts
+++ b/packages/protocol/test/action/client/ClientInteractionInvokeTest.ts
@@ -6,6 +6,7 @@
 
 import { ClientInteraction } from "#action/client/ClientInteraction.js";
 import { Invoke } from "#action/request/Invoke.js";
+import { Read } from "#action/request/Read.js";
 import { InvokeResult } from "#action/response/InvokeResult.js";
 import { MessageType } from "#interaction/InteractionMessenger.js";
 import { ExchangeManager } from "#protocol/ExchangeManager.js";
@@ -372,6 +373,88 @@ describe("ClientInteraction invoke commandRef wire handling", () => {
         await MockTime.resolve(Promise.race([provider.sendObserved, invokePromise]));
         await MockTime.resolve(client.close());
         await rejection;
+    });
+
+    it("abandons an in-flight command when the caller's own request signal aborts", async () => {
+        const provider = new HangingDeviceExchangeProvider();
+        const client = new ClientInteraction({
+            environment: Environment.default,
+            exchangeProvider: provider,
+        });
+
+        const controller = new AbortController();
+        const request = Invoke(
+            Invoke.ConcreteCommandRequest({ endpoint: EndpointNumber(1), cluster: OnOff, command: "off" }),
+        );
+        request.abort = controller.signal;
+
+        const invokePromise = (async () => {
+            for await (const _chunk of client.invoke(request));
+        })();
+        const rejection = expect(invokePromise).rejectedWith(AbortedError);
+
+        // Race so a premature rejection surfaces instead of hanging the send wait
+        await MockTime.resolve(Promise.race([provider.sendObserved, invokePromise]));
+        controller.abort();
+
+        try {
+            await MockTime.resolve(rejection);
+        } finally {
+            await client.close();
+        }
+    });
+
+    it("abandons a read whose request signal aborts, not only an invoke", async () => {
+        const provider = new HangingDeviceExchangeProvider();
+        const client = new ClientInteraction({
+            environment: Environment.default,
+            exchangeProvider: provider,
+        });
+
+        const controller = new AbortController();
+        const readPromise = (async () => {
+            for await (const _chunk of client.read({
+                ...Read({ attributes: [{ endpointId: EndpointNumber(1), clusterId: OnOff.id }] }),
+                abort: controller.signal,
+            }));
+        })();
+        const rejection = expect(readPromise).rejectedWith(AbortedError);
+
+        await MockTime.resolve(Promise.race([provider.sendObserved, readPromise]));
+        controller.abort();
+
+        try {
+            await MockTime.resolve(rejection);
+        } finally {
+            await client.close();
+        }
+    });
+
+    it("throws when a request carries an already-aborted signal, before sending anything", async () => {
+        const sentRequests = new Array<InvokeRequest>();
+        const client = new ClientInteraction({
+            environment: Environment.default,
+            exchangeProvider: new RefLessDeviceExchangeProvider(10, sentRequests),
+        });
+
+        const controller = new AbortController();
+        controller.abort();
+
+        const request = Invoke(
+            Invoke.ConcreteCommandRequest({ endpoint: EndpointNumber(1), cluster: OnOff, command: "off" }),
+        );
+        request.abort = controller.signal;
+
+        const invokePromise = (async () => {
+            for await (const _chunk of client.invoke(request));
+        })();
+
+        try {
+            await expect(MockTime.resolve(invokePromise)).rejectedWith(AbortedError);
+            expect(sentRequests.length).equals(0);
+        } finally {
+            await client.close();
+        }
     });
 
     it("throws when invoked with an already-aborted session signal", async () => {

--- a/packages/protocol/test/action/client/ClientInteractionInvokeTest.ts
+++ b/packages/protocol/test/action/client/ClientInteractionInvokeTest.ts
@@ -447,6 +447,43 @@ describe("ClientInteraction invoke commandRef wire handling", () => {
         await client.close();
     });
 
+    it("stops a batch whose two commands share one abort signal", async () => {
+        const provider = new HangingDeviceExchangeProvider();
+        const client = new ClientInteraction({
+            environment: Environment.default,
+            exchangeProvider: provider,
+        });
+
+        const controller = new AbortController();
+        const invokeOne = (async () => {
+            const request = Invoke(
+                Invoke.ConcreteCommandRequest({ endpoint: EndpointNumber(1), cluster: OnOff, command: "off" }),
+            );
+            request.abort = controller.signal;
+            for await (const _chunk of client.invoke(request));
+        })();
+        const invokeTwo = (async () => {
+            const request = Invoke(
+                Invoke.ConcreteCommandRequest({ endpoint: EndpointNumber(2), cluster: OnOff, command: "on" }),
+            );
+            request.abort = controller.signal;
+            for await (const _chunk of client.invoke(request));
+        })();
+        const rejections = Promise.all([
+            expect(invokeOne).rejectedWith(AbortedError),
+            expect(invokeTwo).rejectedWith(AbortedError),
+        ]);
+
+        await MockTime.resolve(Promise.race([provider.sendObserved, invokeOne, invokeTwo]));
+        controller.abort();
+        await MockTime.resolve(rejections);
+
+        // Both commands are gone, so nothing is left waiting for the peer.
+        expect(provider.receiveAborted).equal(true);
+
+        await client.close();
+    });
+
     it("abandons a read whose request signal aborts, not only an invoke", async () => {
         const provider = new HangingDeviceExchangeProvider();
         const client = new ClientInteraction({

--- a/support/chip-testing/src/ChipToolWebSocketHandler.ts
+++ b/support/chip-testing/src/ChipToolWebSocketHandler.ts
@@ -5,15 +5,19 @@
  */
 
 import {
+    AbortedError,
     Bytes,
     causedBy,
     Diagnostic,
+    Duration,
     ImplementationError,
     InternalError,
     Logger,
     LogLevel,
     Millis,
     NotImplementedError,
+    Seconds,
+    Time,
 } from "@matter/general";
 import {
     AttributeId,
@@ -210,6 +214,24 @@ export function discoveryResponseFor(results: DiscoveryResponse, command: string
         return { results: [{ error: "FAILURE" }] };
     }
     return { results };
+}
+
+/**
+ * The deadline a step declared, as a {@link Duration}, or `undefined` where it declared none.
+ *
+ * The runner encodes a step's `timeout:` as an argument, and real chip-tool honours it by giving up and
+ * tearing its command down. Ignoring it leaves the operation running until matter.js gives up on the
+ * peer instead — tens of seconds, and a property of the peer rather than of the deadline the plan set.
+ */
+export function stepDeadline(commandArguments: unknown): Duration | undefined {
+    if (!isObject(commandArguments) || commandArguments.timeout === undefined) {
+        return undefined;
+    }
+    const seconds = Number(commandArguments.timeout);
+    if (!Number.isFinite(seconds) || seconds <= 0) {
+        throw new ImplementationError(`A step declared the unusable timeout "${commandArguments.timeout}"`);
+    }
+    return Seconds(seconds);
 }
 
 /**
@@ -564,6 +586,9 @@ interface ChipWebSocketCommand {
     command: string;
     arguments?: any;
     command_specifier?: string;
+
+    /** Aborts when the step's own `timeout` expires, absent where the step declared none. */
+    abort?: AbortSignal;
 }
 
 /** Incoming Websocket command with base64 encoded arguments. */
@@ -725,19 +750,10 @@ export class ChipToolWebSocketHandler {
 
         logger.info("Received Text based command:", data);
 
-        // Empty data means we return the subscription data
-        if (data === "") {
-            if (!this.#subscriptionUpdated) {
-                throw new ImplementationError("No subscription active");
-            }
-            if (this.#subscriptionData.length === 0) {
-                // If no data are there we wait for next subscription update
-                await this.#subscriptionUpdated;
-            }
-            const data = [...this.#subscriptionData];
-            this.#subscriptionData.length = 0;
-            logger.info("Subscription-Data returns", data.length, "entries");
-            return { results: data };
+        // The runner sends a bare frame for a `wait-for-report` step: empty for one that waits
+        // indefinitely, and the number of seconds alone for one that declared a timeout.
+        if (data === "" || /^\d+$/.test(data)) {
+            return await this.#awaitSubscriptionData(data === "" ? undefined : Seconds(Number(data)));
         }
 
         const commandData = data.split(" ");
@@ -764,6 +780,46 @@ export class ChipToolWebSocketHandler {
             }
         }
         throw new NotImplementedError(`Text command ${commandData[0]}`);
+    }
+
+    /**
+     * Answers a `wait-for-report` step with whatever the live subscription has reported.
+     *
+     * Where the step declared a deadline, the wait is bounded by it and answers the failure chip-tool
+     * gives on its own timeout — a step waiting for a report the device never sends must not hold the
+     * whole run until the runner gives up on the test.
+     */
+    async #awaitSubscriptionData(deadline?: Duration): Promise<ChipWebSocketCommandResponse> {
+        if (!this.#subscriptionUpdated) {
+            throw new ImplementationError("No subscription active");
+        }
+
+        if (this.#subscriptionData.length === 0) {
+            if (deadline === undefined) {
+                await this.#subscriptionUpdated;
+            } else {
+                const abort = new AbortController();
+                const timer = Time.getTimer("Report timeout", deadline, () => abort.abort()).start();
+                try {
+                    await Promise.race([
+                        this.#subscriptionUpdated,
+                        new Promise<void>(resolve => abort.signal.addEventListener("abort", () => resolve())),
+                    ]);
+                } finally {
+                    timer.stop();
+                }
+
+                if (this.#subscriptionData.length === 0) {
+                    logger.error(`No subscription report within ${Duration.format(deadline)}`);
+                    return { results: [{ error: "FAILURE" }] };
+                }
+            }
+        }
+
+        const reported = [...this.#subscriptionData];
+        this.#subscriptionData.length = 0;
+        logger.info("Subscription-Data returns", reported.length, "entries");
+        return { results: reported };
     }
 
     /** Handles an incoming JSON based command */
@@ -793,10 +849,27 @@ export class ChipToolWebSocketHandler {
         };
         logger.info("Received JSON", toChipJson(data));
 
-        const { cluster } = data;
+        const deadline = stepDeadline(commandArguments);
+        if (deadline === undefined) {
+            return await this.#dispatchJsonCommand(data);
+        }
 
+        // The operation itself observes the signal, so it stops rather than running on unobserved, and
+        // the abort reaches the runner as the failure chip-tool gives when its own timeout expires.
+        const abort = new AbortController();
+        const timer = Time.getTimer("Step timeout", deadline, () =>
+            abort.abort(new AbortedError(`The step's own timeout of ${Duration.format(deadline)} expired`)),
+        ).start();
+        try {
+            return await this.#dispatchJsonCommand({ ...data, abort: abort.signal });
+        } finally {
+            timer.stop();
+        }
+    }
+
+    async #dispatchJsonCommand(data: ChipWebSocketCommand): Promise<ChipWebSocketCommandResponse> {
         // Handles the commands from special testing clusters, else cluster commands
-        switch (cluster) {
+        switch (data.cluster) {
             case "delay": {
                 return await this.#handleDelayCommands(data);
             }
@@ -832,6 +905,7 @@ export class ChipToolWebSocketHandler {
         await (
             await this.#commandHandlerFor(commissionerName)
         ).handleDelay({
+            abort: data.abort,
             nodeId: NodeId(parseNumber(nodeId)),
             expireExistingSession: expireExistingSession !== "false",
         });
@@ -850,6 +924,7 @@ export class ChipToolWebSocketHandler {
                 const { "node-id": nodeId, payload } = commandArguments;
                 try {
                     await handler.handleInitialPairing({
+                        abort: data.abort,
                         nodeId: NodeId(parseNumber(nodeId)),
                         qrCode: payload,
                     });
@@ -863,6 +938,7 @@ export class ChipToolWebSocketHandler {
                 const { "node-id": nodeId, payload } = commandArguments;
                 try {
                     await handler.handlePaseConnection({
+                        abort: data.abort,
                         nodeId: NodeId(parseNumber(nodeId)),
                         qrCode: payload,
                     });
@@ -957,6 +1033,7 @@ export class ChipToolWebSocketHandler {
 
         try {
             await handler.handleInvokeById({
+                abort: data.abort,
                 nodeId: NodeId(parseNumber(destinationId)),
                 endpointId: EndpointNumber(parseInt(endpointId)),
                 clusterId: ClusterId(parseInt(clusterId)),
@@ -986,6 +1063,7 @@ export class ChipToolWebSocketHandler {
 
         try {
             const { values, status } = await handler.handleReadAttribute({
+                abort: data.abort,
                 nodeId: NodeId(parseNumber(destinationId)),
                 endpointId: EndpointNumber(parseInt(endpointId)),
                 clusterId: ClusterId(parseInt(clusterId)),
@@ -1038,6 +1116,7 @@ export class ChipToolWebSocketHandler {
         const nodeId = NodeId(parseNumber(destinationId));
         try {
             await handler.handleWriteAttributeById({
+                abort: data.abort,
                 nodeId,
                 endpointId: GroupId.isGroupNodeId(nodeId) ? undefined : EndpointNumber(parseInt(endpointId)),
                 clusterId: ClusterId(parseInt(clusterId)),
@@ -1066,6 +1145,7 @@ export class ChipToolWebSocketHandler {
 
         try {
             const { values, updated } = await handler.handleSubscribeAttribute({
+                abort: data.abort,
                 nodeId: NodeId(parseNumber(destinationId)),
                 endpointId: EndpointNumber(parseInt(endpointIds)),
                 clusterId: ClusterId(parseInt(clusterId)),
@@ -1100,6 +1180,7 @@ export class ChipToolWebSocketHandler {
             const results = await (
                 await this.#commandHandlerFor(commissionerName)
             ).handleDiscovery({
+                abort: data.abort,
                 findBy,
             });
             return discoveryResponseFor(results, command);
@@ -1157,6 +1238,7 @@ export class ChipToolWebSocketHandler {
 
         try {
             const { values, status } = await handler.handleReadAttribute({
+                abort: data.abort,
                 nodeId: NodeId(parseNumber(destinationId)),
                 endpointId: EndpointNumber(parseInt(endpointIds)),
                 clusterId: clusterData.clusterId,
@@ -1207,6 +1289,7 @@ export class ChipToolWebSocketHandler {
         const eventModel = eventModelFor(clusterData, cluster, commandSpecifier);
         try {
             const { values, status } = await handler.handleReadEvent({
+                abort: data.abort,
                 nodeId: NodeId(parseNumber(destinationId)),
                 endpointId: EndpointNumber(parseInt(endpointIds)),
                 clusterId: clusterData.clusterId,
@@ -1257,6 +1340,7 @@ export class ChipToolWebSocketHandler {
         const attributeModel = attributeModelFor(clusterData, cluster, commandSpecifier);
         try {
             const { values, updated } = await handler.handleSubscribeAttribute({
+                abort: data.abort,
                 nodeId: NodeId(parseNumber(destinationId)),
                 endpointId: EndpointNumber(parseInt(endpointIds)),
                 clusterId: clusterData.clusterId,
@@ -1306,6 +1390,7 @@ export class ChipToolWebSocketHandler {
         const eventModel = eventModelFor(clusterData, cluster, commandSpecifier);
         try {
             const { values, updated } = await handler.handleSubscribeEvent({
+                abort: data.abort,
                 nodeId: NodeId(parseNumber(destinationId)),
                 endpointId: EndpointNumber(parseInt(endpointIds)),
                 clusterId: clusterData.clusterId,
@@ -1366,6 +1451,7 @@ export class ChipToolWebSocketHandler {
         const nodeId = NodeId(parseNumber(destinationId));
         try {
             await handler.handleWriteAttribute({
+                abort: data.abort,
                 nodeId,
                 endpointId: GroupId.isGroupNodeId(nodeId) ? undefined : EndpointNumber(parseInt(endpointId)),
                 clusterId: clusterData.clusterId,
@@ -1406,6 +1492,7 @@ export class ChipToolWebSocketHandler {
         const isGroupNode = GroupId.isGroupNodeId(nodeId);
         try {
             const result = await handler.handleInvoke({
+                abort: data.abort,
                 nodeId,
                 endpointId: isGroupNode ? undefined : EndpointNumber(parseInt(endpointId)),
                 clusterId: clusterData.clusterId,

--- a/support/chip-testing/src/ChipToolWebSocketHandler.ts
+++ b/support/chip-testing/src/ChipToolWebSocketHandler.ts
@@ -854,6 +854,15 @@ export class ChipToolWebSocketHandler {
             return await this.#dispatchJsonCommand(data);
         }
 
+        // Commissioning and waiting for a commissionee run to their own conclusion, so a deadline on
+        // one of those would be a promise this shim cannot keep.
+        if (data.cluster === "delay" || data.cluster === "pairing") {
+            throw new ImplementationError(
+                `A "${data.cluster}" step declared a timeout of ${Duration.format(deadline)}, which this shim ` +
+                    "cannot bound: the controller API it drives takes no abort signal",
+            );
+        }
+
         // The operation itself observes the signal, so it stops rather than running on unobserved, and
         // the abort reaches the runner as the failure chip-tool gives when its own timeout expires.
         const abort = new AbortController();
@@ -905,7 +914,6 @@ export class ChipToolWebSocketHandler {
         await (
             await this.#commandHandlerFor(commissionerName)
         ).handleDelay({
-            abort: data.abort,
             nodeId: NodeId(parseNumber(nodeId)),
             expireExistingSession: expireExistingSession !== "false",
         });
@@ -924,7 +932,6 @@ export class ChipToolWebSocketHandler {
                 const { "node-id": nodeId, payload } = commandArguments;
                 try {
                     await handler.handleInitialPairing({
-                        abort: data.abort,
                         nodeId: NodeId(parseNumber(nodeId)),
                         qrCode: payload,
                     });
@@ -938,7 +945,6 @@ export class ChipToolWebSocketHandler {
                 const { "node-id": nodeId, payload } = commandArguments;
                 try {
                     await handler.handlePaseConnection({
-                        abort: data.abort,
                         nodeId: NodeId(parseNumber(nodeId)),
                         qrCode: payload,
                     });
@@ -1482,7 +1488,8 @@ export class ChipToolWebSocketHandler {
                 key !== "destination-id" &&
                 key !== "commissioner-name" &&
                 key !== "endpoint-id-ignored-for-group-commands" &&
-                key !== "timedInteractionTimeoutMs"
+                key !== "timedInteractionTimeoutMs" &&
+                key !== "timeout"
             ) {
                 commandData[camelize(key)] = commandArguments[key];
             }

--- a/support/chip-testing/src/handler/CommandHandler.ts
+++ b/support/chip-testing/src/handler/CommandHandler.ts
@@ -19,11 +19,14 @@ import { CommissionableDeviceIdentifiers } from "@matter/main/protocol";
 import { EndpointNumber, Status } from "@matter/main/types";
 
 /**
- * What every operation a step drives accepts: the step's own deadline, where it declared one.
+ * The step's own deadline, for the operations that can honour one.
  *
  * A YAML step may carry `timeout: <seconds>`, which real chip-tool honours by giving up and tearing its
  * command down. The operation is abandoned when this aborts — see `ClientRequest.abort` for what that
  * does and does not tell the device.
+ *
+ * An operation whose underlying API takes no signal does not accept this, so a deadline is never handed
+ * to something that would ignore it: `DelayRequest` and `InitialPairingRequest` say why.
  */
 export type AbandonableRequest = {
     abort?: AbortSignal;
@@ -152,12 +155,21 @@ export type InvokeByIdRequest = AbandonableRequest & {
     timedInteractionTimeout?: Duration;
 };
 
-export type DelayRequest = AbandonableRequest & {
+/**
+ * Waiting for a commissionee is bounded by its own discovery timeout and by nothing else: the
+ * controller API this drives takes no signal, so this request deliberately does not accept one — see
+ * {@link AbandonableRequest}.
+ */
+export type DelayRequest = {
     nodeId?: NodeId;
     expireExistingSession?: boolean;
 };
 
-export type InitialPairingRequest = AbandonableRequest & {
+/**
+ * Commissioning runs to its own conclusion: `CommissioningController.commissionNode` takes no signal,
+ * so this request deliberately does not accept one — see {@link AbandonableRequest}.
+ */
+export type InitialPairingRequest = {
     nodeId: NodeId;
     knownAddress?: { ip: string; port: number };
 } & ({ qrCode: string } | { manualCode: string } | { passcode: number; vendorId: number; productId: number });

--- a/support/chip-testing/src/handler/CommandHandler.ts
+++ b/support/chip-testing/src/handler/CommandHandler.ts
@@ -18,7 +18,18 @@ import {
 import { CommissionableDeviceIdentifiers } from "@matter/main/protocol";
 import { EndpointNumber, Status } from "@matter/main/types";
 
-export type ReadAttributeRequest = {
+/**
+ * What every operation a step drives accepts: the step's own deadline, where it declared one.
+ *
+ * A YAML step may carry `timeout: <seconds>`, which real chip-tool honours by giving up and tearing its
+ * command down. The operation is abandoned when this aborts — see `ClientRequest.abort` for what that
+ * does and does not tell the device.
+ */
+export type AbandonableRequest = {
+    abort?: AbortSignal;
+};
+
+export type ReadAttributeRequest = AbandonableRequest & {
     nodeId: NodeId;
     endpointId: EndpointNumber;
     clusterId: ClusterId;
@@ -41,7 +52,7 @@ export type AttributeResponseStatus = {
 };
 export type ReadAttributeResponse = { values: AttributeResponseData[]; status?: AttributeResponseStatus[] };
 
-export type ReadByIdRequest = {
+export type ReadByIdRequest = AbandonableRequest & {
     nodeId: NodeId;
     endpointId: EndpointNumber;
     clusterId: ClusterId;
@@ -67,7 +78,7 @@ export type SubscribeAttributeResponse = {
     updated: Observable<[void]>;
 };
 
-export type WriteAttributeRequest = {
+export type WriteAttributeRequest = AbandonableRequest & {
     nodeId: NodeId;
     endpointId?: EndpointNumber;
     clusterId: ClusterId;
@@ -75,7 +86,7 @@ export type WriteAttributeRequest = {
     value: unknown;
 };
 
-export type WriteAttributeByIdRequest = {
+export type WriteAttributeByIdRequest = AbandonableRequest & {
     nodeId: NodeId;
     endpointId?: EndpointNumber;
     clusterId: ClusterId;
@@ -83,7 +94,7 @@ export type WriteAttributeByIdRequest = {
     value: unknown;
 };
 
-export type ReadEventRequest = {
+export type ReadEventRequest = AbandonableRequest & {
     nodeId: NodeId;
     endpointId: EndpointNumber;
     clusterId: ClusterId;
@@ -116,7 +127,7 @@ export type SubscribeEventResponse = {
     updated: Observable<[void]>;
 };
 
-export type InvokeRequest = {
+export type InvokeRequest = AbandonableRequest & {
     nodeId: NodeId;
     endpointId?: EndpointNumber;
     clusterId: ClusterId;
@@ -132,7 +143,7 @@ export type InvokeResponse = {
     value?: unknown;
 };
 
-export type InvokeByIdRequest = {
+export type InvokeByIdRequest = AbandonableRequest & {
     nodeId: NodeId;
     endpointId: EndpointNumber;
     clusterId: ClusterId;
@@ -141,17 +152,17 @@ export type InvokeByIdRequest = {
     timedInteractionTimeout?: Duration;
 };
 
-export type DelayRequest = {
+export type DelayRequest = AbandonableRequest & {
     nodeId?: NodeId;
     expireExistingSession?: boolean;
 };
 
-export type InitialPairingRequest = {
+export type InitialPairingRequest = AbandonableRequest & {
     nodeId: NodeId;
     knownAddress?: { ip: string; port: number };
 } & ({ qrCode: string } | { manualCode: string } | { passcode: number; vendorId: number; productId: number });
 
-export type DiscoveryRequest = {
+export type DiscoveryRequest = AbandonableRequest & {
     findBy: CommissionableDeviceIdentifiers;
 };
 

--- a/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
+++ b/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
@@ -607,6 +607,10 @@ export class LegacyControllerCommandHandler extends CommandHandler {
 
     /** Discover commissionable devices */
     async handleDiscovery({ findBy, abort }: DiscoveryRequest): Promise<DiscoveryResponse> {
+        // A signal that already aborted never fires an event, so the window would run in full before
+        // anyone noticed.
+        abort?.throwIfAborted();
+
         // Discovery resolves when its own window closes or when cancelled, so the step's deadline is
         // honoured by cancelling rather than by abandoning the wait.
         const onAbort = () =>

--- a/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
+++ b/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
@@ -606,13 +606,26 @@ export class LegacyControllerCommandHandler extends CommandHandler {
     }
 
     /** Discover commissionable devices */
-    async handleDiscovery({ findBy }: DiscoveryRequest): Promise<DiscoveryResponse> {
-        const result = await this.#controllerInstance.discoverCommissionableDevices(
-            findBy,
-            { onIpNetwork: true },
-            undefined,
-            Seconds(3),
-        );
+    async handleDiscovery({ findBy, abort }: DiscoveryRequest): Promise<DiscoveryResponse> {
+        // Discovery resolves when its own window closes or when cancelled, so the step's deadline is
+        // honoured by cancelling rather than by abandoning the wait.
+        const onAbort = () =>
+            this.#controllerInstance.cancelCommissionableDeviceDiscovery(findBy, { onIpNetwork: true });
+        abort?.addEventListener("abort", onAbort, { once: true });
+
+        let result;
+        try {
+            result = await this.#controllerInstance.discoverCommissionableDevices(
+                findBy,
+                { onIpNetwork: true },
+                undefined,
+                Seconds(3),
+            );
+        } finally {
+            abort?.removeEventListener("abort", onAbort);
+        }
+
+        abort?.throwIfAborted();
         logger.info("Discovered result", result);
         // Chip is not removing old discoveries when being stopped, so we still have old and new devices in the result
         // but the expectation is that it was reset and only new devices are in the result

--- a/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
+++ b/support/chip-testing/src/handler/LegacyControllerCommandHandler.ts
@@ -157,10 +157,11 @@ export class LegacyControllerCommandHandler extends CommandHandler {
     }
 
     async handleReadAttribute(data: ReadAttributeRequest): Promise<ReadAttributeResponse> {
-        const { nodeId, endpointId, clusterId, attributeId, fabricFiltered = true } = data;
+        const { nodeId, endpointId, clusterId, attributeId, fabricFiltered = true, abort } = data;
         const client = await (await this.#controllerInstance.getNode(nodeId)).getInteractionClient();
 
         const { attributeData, attributeStatus } = await client.getMultipleAttributesAndStatus({
+            abort,
             attributes: [
                 {
                     endpointId,
@@ -192,9 +193,10 @@ export class LegacyControllerCommandHandler extends CommandHandler {
     }
 
     async handleReadEvent(data: ReadEventRequest): Promise<ReadEventResponse> {
-        const { nodeId, endpointId, clusterId, eventId, eventMin } = data;
+        const { nodeId, endpointId, clusterId, eventId, eventMin, abort } = data;
         const client = await (await this.#controllerInstance.getNode(nodeId)).getInteractionClient();
         const { eventData, eventStatus } = await client.getMultipleEventsAndStatus({
+            abort,
             events: [
                 {
                     endpointId,
@@ -226,11 +228,12 @@ export class LegacyControllerCommandHandler extends CommandHandler {
     }
 
     async handleSubscribeAttribute(data: SubscribeAttributeRequest): Promise<SubscribeAttributeResponse> {
-        const { nodeId, endpointId, clusterId, attributeId, minInterval, maxInterval, changeListener } = data;
+        const { nodeId, endpointId, clusterId, attributeId, minInterval, maxInterval, changeListener, abort } = data;
         const client = await (await this.#controllerInstance.getNode(nodeId)).getInteractionClient();
         const updated = Observable<[void]>();
         let ignoreData = true; // We ignore data coming in during initial seeding
         const { attributeReports = [] } = await client.subscribeMultipleAttributesAndEvents({
+            abort,
             attributes: [
                 {
                     endpointId,
@@ -272,11 +275,12 @@ export class LegacyControllerCommandHandler extends CommandHandler {
     }
 
     async handleSubscribeEvent(data: SubscribeEventRequest): Promise<SubscribeEventResponse> {
-        const { nodeId, endpointId, clusterId, eventId, minInterval, maxInterval, changeListener } = data;
+        const { nodeId, endpointId, clusterId, eventId, minInterval, maxInterval, changeListener, abort } = data;
         const client = await (await this.#controllerInstance.getNode(nodeId)).getInteractionClient();
         const updated = Observable<[void]>();
         let ignoreData = true; // We ignore data coming in during initial seeding
         const { eventReports = [] } = await client.subscribeMultipleAttributesAndEvents({
+            abort,
             events: [
                 {
                     endpointId,
@@ -320,7 +324,7 @@ export class LegacyControllerCommandHandler extends CommandHandler {
     }
 
     async handleWriteAttribute(data: WriteAttributeRequest): Promise<void> {
-        const { nodeId, endpointId, clusterId, attributeName, value } = data;
+        const { nodeId, endpointId, clusterId, attributeName, value, abort } = data;
 
         const client = await (await this.#controllerInstance.getNode(nodeId)).getInteractionClient();
         const clusterModel = Matter.clusters(clusterId);
@@ -335,6 +339,7 @@ export class LegacyControllerCommandHandler extends CommandHandler {
 
         logger.info("Writing attribute", attributeName, "with value", value);
         await client.setAttribute({
+            abort,
             attributeData: {
                 endpointId,
                 clusterId,
@@ -353,6 +358,7 @@ export class LegacyControllerCommandHandler extends CommandHandler {
             data: commandData,
             timedInteractionTimeout,
             suppressResponse,
+            abort,
         } = data;
         let client: InteractionClient;
         if (this.#paseSession) {
@@ -397,6 +403,7 @@ export class LegacyControllerCommandHandler extends CommandHandler {
         // intentionally sends invalid values to test server-side error handling
         if (suppressResponse) {
             return await client.invokeWithSuppressedResponse({
+                abort,
                 endpointId,
                 clusterId,
                 command: nsCmd,
@@ -405,6 +412,7 @@ export class LegacyControllerCommandHandler extends CommandHandler {
             });
         }
         return await client.invoke({
+            abort,
             endpointId,
             clusterId,
             command: nsCmd,
@@ -417,7 +425,7 @@ export class LegacyControllerCommandHandler extends CommandHandler {
 
     /** InvokeById minimalistic handler because only used for error testing */
     async handleInvokeById(data: InvokeByIdRequest): Promise<void> {
-        const { nodeId, endpointId, clusterId, commandId, data: commandData, timedInteractionTimeout } = data;
+        const { nodeId, endpointId, clusterId, commandId, data: commandData, timedInteractionTimeout, abort } = data;
         const client = await (await this.#controllerInstance.getNode(nodeId)).getInteractionClient();
 
         // Try to look up the real model for proper encoding
@@ -432,6 +440,7 @@ export class LegacyControllerCommandHandler extends CommandHandler {
             });
 
         await client.invoke({
+            abort,
             endpointId,
             clusterId: clusterId,
             command: { id: commandId, name: cmdModel.name, schema: cmdModel },
@@ -442,7 +451,7 @@ export class LegacyControllerCommandHandler extends CommandHandler {
     }
 
     async handleWriteAttributeById(data: WriteAttributeByIdRequest): Promise<void> {
-        const { nodeId, endpointId, clusterId, attributeId, value } = data;
+        const { nodeId, endpointId, clusterId, attributeId, value, abort } = data;
 
         const client = await (await this.#controllerInstance.getNode(nodeId)).getInteractionClient();
 
@@ -452,6 +461,7 @@ export class LegacyControllerCommandHandler extends CommandHandler {
         const attrModel = realAttr ?? inferAttrModel(attributeId, value);
 
         await client.setAttribute({
+            abort,
             attributeData: {
                 endpointId,
                 clusterId,

--- a/support/chip-testing/test/cert-framework/chip-tool-websocket-server.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-websocket-server.test.ts
@@ -46,6 +46,7 @@ class FakeCommandHandler extends CommandHandler {
     disconnectedNodes = new Array<NodeId>();
     writes = new Array<WriteAttributeRequest>();
     discoveries = new Array<DiscoveryRequest>();
+    invokes = new Array<InvokeRequest>();
     paseConnections = new Array<NodeId>();
 
     /** Answer for the next discovery; empty means "found nothing". */
@@ -153,7 +154,9 @@ class FakeCommandHandler extends CommandHandler {
         return { values: [], updated: Observable<[void]>() };
     }
 
-    async handleInvoke(_data: InvokeRequest) {
+    async handleInvoke(data: InvokeRequest) {
+        this.invokes.push(data);
+        this.signals.push(data.abort);
         this.#throwIfFailing();
         return undefined;
     }
@@ -610,6 +613,31 @@ describe("ChipToolWebSocketHandler over the wire", () => {
 
         expect(reply.results).deep.equal([{ error: "FAILURE" }]);
         expect(handler.discoveryCancellations).deep.equal([{ longDiscriminator: 3840 }]);
+    });
+
+    it("keeps a command's own Timeout field while reading the step's timeout beside it", async () => {
+        // The runner sends a command field under its specification name and the step's own deadline in
+        // lower case, so the two never collide — Door Lock's UnlockWithTimeout carries both at once.
+        await send(
+            port,
+            jsonFrame({
+                cluster: "doorlock",
+                command: "UnlockWithTimeout",
+                arguments: {
+                    "destination-id": "0x12344321",
+                    "endpoint-id-ignored-for-group-commands": "1",
+                    Timeout: 10,
+                    PINCode: "123456",
+                    timeout: "30",
+                },
+            }),
+        );
+
+        expect(handler.invokes.length).equal(1);
+        expect(handler.invokes[0].data).deep.equal({ timeout: 10, pinCode: 123456 });
+
+        // The step's deadline reached the operation, and did not become a command field.
+        expect(handler.invokes[0].abort).not.equal(undefined);
     });
 
     it("refuses a deadline on an operation it cannot bound, rather than dropping it", async () => {

--- a/support/chip-testing/test/cert-framework/chip-tool-websocket-server.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-websocket-server.test.ts
@@ -54,6 +54,12 @@ class FakeCommandHandler extends CommandHandler {
     /** Thrown by whichever operation a test drives, where set. */
     failure?: unknown;
 
+    /** Signals a test handed to the operation it drove, in order. */
+    signals = new Array<AbortSignal | undefined>();
+
+    /** Where true, a read waits for its own signal instead of answering. */
+    readWaitsForAbort = false;
+
     get started() {
         return this.#started;
     }
@@ -90,6 +96,7 @@ class FakeCommandHandler extends CommandHandler {
 
     async handleWriteAttribute(data: WriteAttributeRequest) {
         this.writes.push(data);
+        this.signals.push(data.abort);
         this.#throwIfFailing();
     }
 
@@ -97,8 +104,18 @@ class FakeCommandHandler extends CommandHandler {
         this.#throwIfFailing();
     }
 
-    async handleReadAttribute(_data: ReadAttributeRequest): Promise<ReadAttributeResponse> {
+    async handleReadAttribute(data: ReadAttributeRequest): Promise<ReadAttributeResponse> {
+        this.signals.push(data.abort);
         this.#throwIfFailing();
+
+        if (this.readWaitsForAbort) {
+            // What an operation that outlives its step's deadline does: it observes the signal rather
+            // than answering, exactly as a real interaction abandoned mid-flight does.
+            await new Promise<void>((_resolve, reject) => {
+                data.abort?.addEventListener("abort", () => reject(data.abort?.reason));
+            });
+        }
+
         return { values: new Array<AttributeResponseData>() };
     }
 
@@ -249,7 +266,7 @@ describe("ChipToolWebSocketHandler over the wire", () => {
         );
 
         expect(reply.results).deep.equal([{ error: "FAILURE" }]);
-        expect(handler.discoveries).deep.equal([{ findBy: { longDiscriminator: 3840 } }]);
+        expect(handler.discoveries.map(({ findBy }) => findBy)).deep.equal([{ longDiscriminator: 3840 }]);
     });
 
     it("answers a discovery that found a device with what it found", async () => {
@@ -492,6 +509,72 @@ describe("ChipToolWebSocketHandler over the wire", () => {
 
         expect(reply.results[0].error).match(/has no event "not-an-event"/);
         expect(reply.results[1]).deep.equal({ error: "FAILURE" });
+    });
+
+    it("gives up on an operation that outlives the timeout its step declared", async () => {
+        handler.readWaitsForAbort = true;
+
+        const reply = await send(
+            port,
+            jsonFrame({
+                cluster: "onoff",
+                command: "read",
+                command_specifier: "on-off",
+                arguments: { "destination-id": "0x12344321", "endpoint-ids": "1", timeout: "1" },
+            }),
+        );
+
+        // The failure a device that did not answer gives, which is what the step expects — not a fault
+        // of the harness.
+        expect(reply.results).deep.equal([{ error: "FAILURE" }]);
+
+        expect(handler.signals.length).equal(1);
+        expect(handler.signals[0]?.aborted).equal(true);
+    });
+
+    it("hands the operation its step's deadline, and nothing where the step declared none", async () => {
+        await send(
+            port,
+            jsonFrame({
+                cluster: "onoff",
+                command: "read",
+                command_specifier: "on-off",
+                arguments: { "destination-id": "0x12344321", "endpoint-ids": "1", timeout: "30" },
+            }),
+        );
+        await send(
+            port,
+            jsonFrame({
+                cluster: "onoff",
+                command: "read",
+                command_specifier: "on-off",
+                arguments: { "destination-id": "0x12344321", "endpoint-ids": "1" },
+            }),
+        );
+
+        expect(handler.signals.length).equal(2);
+        expect(handler.signals[0]).not.equal(undefined);
+
+        // A deadline that has not expired must not reach the operation as one that has.
+        expect(handler.signals[0]?.aborted).equal(false);
+        expect(handler.signals[1]).equal(undefined);
+    });
+
+    it("refuses a timeout it cannot read rather than running the step unbounded", async () => {
+        const reply = await send(
+            port,
+            jsonFrame({
+                cluster: "onoff",
+                command: "read",
+                command_specifier: "on-off",
+                arguments: { "destination-id": "0x12344321", "endpoint-ids": "1", timeout: "soon" },
+            }),
+        );
+
+        expect(reply.results[0].error).match(
+            /^Test harness failure — ImplementationError: A step declared the unusable/,
+        );
+        expect(handler.signals).deep.equal([]);
     });
 
     it("reports a controller of its own that would not start as its own fault", async () => {

--- a/support/chip-testing/test/cert-framework/chip-tool-websocket-server.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-websocket-server.test.ts
@@ -60,6 +60,9 @@ class FakeCommandHandler extends CommandHandler {
     /** Where true, a read waits for its own signal instead of answering. */
     readWaitsForAbort = false;
 
+    /** Discoveries this handler was asked to cancel, by the identifier they named. */
+    discoveryCancellations = new Array<DiscoveryRequest["findBy"]>();
+
     get started() {
         return this.#started;
     }
@@ -90,9 +93,25 @@ class FakeCommandHandler extends CommandHandler {
 
     async handleDiscovery(data: DiscoveryRequest): Promise<DiscoveryResponse> {
         this.discoveries.push(data);
+        this.signals.push(data.abort);
         this.#throwIfFailing();
+
+        // As the real handler does: a signal that already aborted never fires, so it is read rather
+        // than waited on.
+        data.abort?.throwIfAborted();
+        data.abort?.addEventListener("abort", () => this.discoveryCancellations.push(data.findBy), { once: true });
+
+        if (this.discoveryWaitsForAbort) {
+            await new Promise<void>((_resolve, reject) => {
+                data.abort?.addEventListener("abort", () => reject(data.abort?.reason));
+            });
+        }
+
         return this.discoveryResult;
     }
+
+    /** Where true, a discovery waits for its own signal instead of answering. */
+    discoveryWaitsForAbort = false;
 
     async handleWriteAttribute(data: WriteAttributeRequest) {
         this.writes.push(data);
@@ -575,6 +594,22 @@ describe("ChipToolWebSocketHandler over the wire", () => {
             /^Test harness failure — ImplementationError: A step declared the unusable/,
         );
         expect(handler.signals).deep.equal([]);
+    });
+
+    it("cancels a discovery whose step deadline expired, rather than waiting out its window", async () => {
+        handler.discoveryWaitsForAbort = true;
+
+        const reply = await send(
+            port,
+            jsonFrame({
+                cluster: "discover",
+                command: "find-commissionable-by-long-discriminator",
+                arguments: { value: "3840", timeout: "1" },
+            }),
+        );
+
+        expect(reply.results).deep.equal([{ error: "FAILURE" }]);
+        expect(handler.discoveryCancellations).deep.equal([{ longDiscriminator: 3840 }]);
     });
 
     it("refuses a deadline on an operation it cannot bound, rather than dropping it", async () => {

--- a/support/chip-testing/test/cert-framework/chip-tool-websocket-server.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-websocket-server.test.ts
@@ -577,6 +577,29 @@ describe("ChipToolWebSocketHandler over the wire", () => {
         expect(handler.signals).deep.equal([]);
     });
 
+    it("refuses a deadline on an operation it cannot bound, rather than dropping it", async () => {
+        for (const frame of [
+            jsonFrame({
+                cluster: "delay",
+                command: "wait-for-commissionee",
+                arguments: { nodeId: "0x12344321", timeout: "5" },
+            }),
+            jsonFrame({
+                cluster: "pairing",
+                command: "code",
+                arguments: { "node-id": "0x12344321", payload: "MT:-24J042C00KA0648G00", timeout: "5" },
+            }),
+        ]) {
+            const reply = await send(port, frame);
+
+            expect(reply.results[0].error).match(/^Test harness failure — ImplementationError: A ".*" step declared/);
+            expect(reply.results[1]).deep.equal({ error: "FAILURE" });
+        }
+
+        // Neither operation was driven at all, so neither was handed a deadline it would ignore.
+        expect(handler.paseConnections).deep.equal([]);
+    });
+
     it("reports a controller of its own that would not start as its own fault", async () => {
         // Plain Error, as a storage or socket failure arrives: the classification has to come from
         // where the start was driven, not from the error's own type.

--- a/support/chip-testing/test/core/CADMIN.test.ts
+++ b/support/chip-testing/test/core/CADMIN.test.ts
@@ -53,19 +53,6 @@ describe("CADMIN", () => {
         ),
     );
 
-    // CADMIN/1.16 waits for timeouts for two operations on BasicInformation NodeLabel which ends up being roughly
-    // fourty seconds.  Attempted to reduce to 4 since we know that 2s. per is more than generous for local comms.  But
-    // this causes test to fail at step 12 with an error even though no error occurs.  Reducing to 5s. per works, any
-    // whole integer less does not.
-    before(() =>
-        chip.testFor("CADMIN/1.16").edit(
-            edit.insert({
-                after: "      PICS: BINFO.S.A0005",
-                lines: "      timeout: 5",
-            }),
-        ),
-    );
-
     // CHIP expects general error code 0xb when the proper response is NodeOperationalCertStatus.TableFull
     //
     // For now we just patch the test to convert 0xb (whatever that is) to 0x587, which appears to be an internal


### PR DESCRIPTION
A YAML certification step may carry `timeout: <seconds>`: how long the controller waits for that one
operation before declaring it failed. Real chip-tool honors it by giving up and tearing its command
down. The runner encodes it into the frame and enforces nothing itself — it bounds the whole test, not
the step — so honoring it is the controller's job, and our shim ignored it.

The operation therefore ran until matter.js gave up on the peer instead: tens of seconds, with the
step's verdict resting on the peer's retransmission budget rather than on the deadline the plan set.
CADMIN/1.16 is where this bites in the corpus — after removing a fabric, two steps write and read an
attribute over that dead fabric and expect a failure within five seconds.

Rather than have the shim stop *waiting* while the operation ran on unobserved, the interaction itself
can now be abandoned.

## A caller can abandon an interaction

Every client interaction request takes an `abort` signal, honored by read, write, invoke and subscribe:
the exchange stops sending and stops waiting, and the operation rejects. Little of this is new
machinery — the exchange layer already accepted such a signal, and a client interaction already
composed one from its session and its own lifetime, so the caller's signal joins that composition.
`InteractionClient`'s options accept one and forward it.

Invoke needed more. Commands are queued and sent as one batch whose request is built fresh from the
queued commands, and a batch carries the commands of several callers — so an abort belongs to its own
command: it rejects that command and leaves the batch to the others, which is what the pending
command's existing "aborted" handling was already shaped for.

Abandoning an interaction tells the peer nothing, so a write or invoke already in flight may still be
acted on by it. That is stated where the option is declared, because a caller has to account for it.

## The shim honors the step's deadline

It arms the deadline, hands the operation the signal, and lets the abort surface: it reaches the runner
as the same bare failure a device that did not answer gives, which is exactly what those steps expect,
so no new answer shape appears on the wire. Every operation a step can drive accepts the signal.

Two smaller gaps close with it. A `wait-for-report` step with a timeout arrives as the bare number of
seconds, which the shim did not understand at all; it now waits for the subscription's report bounded by
that deadline. And a timeout that cannot be read is refused rather than silently running the step
unbounded.

Also removed: our own edit inserting `timeout: 5` into CADMIN/1.16. Upstream carries it on both those
steps now, so the edit duplicated a YAML key.

## Evidence

- Three interaction tests: an in-flight invoke abandoned by the caller's signal, a request whose signal
  is already aborted sending nothing at all, and the same for a read. Mutation-proven: restoring the
  session-only signal fails exactly the two invoke tests.
- Three shim tests over a real socket: an operation that outlives its step's deadline answers the
  device-failure shape with the signal aborted, a deadline that has not expired reaches the operation
  unaborted while a step without one gets no signal, and an unreadable timeout is refused.
- Root `build`, `format-verify`, `lint` clean; full suite green; `@matter/protocol` suite green;
  certification framework suite 683 checks green; `test/core/Discovery.test.ts` — the YAML suite that
  runs end to end through the shim — green.
- CADMIN/1.16 itself cannot run on this machine: its python steps pair from inside the harness
  container, which cannot discover a host device here, and that fails identically without this change.
  It is the one place where this feature is load-bearing in CI, so that is where to look.

## Stacked

The first commit of this branch is PR #4317, which is on automerge; this PR's own two commits are the
library capability and the shim change. Rebase once #4317 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
