### PR TITLE
test(chip-testing): a keepalive no longer counts as the report a write asked for

### DIFF
--- a/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
@@ -109,7 +109,11 @@ class Fixture {
             subscribe: async (_path, opts) => {
                 this.#onUpdate = opts.onUpdate;
                 this.push(...subscribeRequestLines(PATH), ...subscribeResponseLines(SUBSCRIPTION_ID));
-                this.pushReport(SUBSCRIPTION_ID);
+                if (this.primingCarriesData) {
+                    this.pushReport(SUBSCRIPTION_ID);
+                } else {
+                    this.pushKeepalive(SUBSCRIPTION_ID);
+                }
                 this.onSubscribe(this);
                 // Every line pushed so far is in the log before the helper takes its first per-write
                 // mark, which is what makes "this report predates the write" deterministic here.
@@ -162,6 +166,12 @@ class Fixture {
             this.#source.push(line);
         }
     }
+
+    /**
+     * Whether the priming report carries data. A subscription can be established with nothing to report
+     * yet — ordinary for an event subscription — so the priming check must accept a report without any.
+     */
+    primingCarriesData = true;
 
     /**
      * One report on `subscriptionId` carrying attribute data, plus the DUT's ack on the same CHIP
@@ -285,6 +295,20 @@ describe("subscribeAndModify", () => {
                 CertCheckFailedError,
                 /ack check failed for step 3, write 1\/1/,
             );
+        });
+    });
+
+    it("accepts a priming report that carries nothing, which an event subscription may well send", async () => {
+        const fixture = new Fixture("chip-local", (f, _index, value) => {
+            f.pushReport(SUBSCRIPTION_ID);
+            f.report(value);
+        });
+        fixture.primingCarriesData = false;
+
+        await withFixture(fixture, async f => {
+            await f.run([true], IMPATIENT);
+
+            expect(f.failures).deep.equal([]);
         });
     });
 

--- a/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
@@ -164,16 +164,31 @@ class Fixture {
     }
 
     /**
-     * One report on `subscriptionId`, plus the DUT's ack on the same CHIP exchange unless `acked` is
-     * false. `status` is the ack's own status line, so a caller can hand back a rejection.
+     * One report on `subscriptionId` carrying attribute data, plus the DUT's ack on the same CHIP
+     * exchange unless `acked` is false. `status` is the ack's own status line, so a caller can hand back
+     * a rejection.
      */
     pushReport(subscriptionId: number, acked = true, status = "Status = 0x00 (SUCCESS),"): void {
+        this.#pushReportData(subscriptionId, ["[DMG] AttributeReportIBs =", "[DMG] ["], acked, status);
+    }
+
+    /**
+     * One keepalive on `subscriptionId`: the report an idle subscription sends at its maximum interval,
+     * which carries no data and prints `InteractionModelRevision` where a report prints its data — the
+     * shape a chip-local TC-IDM-4.1 run's device log holds six of. It is acked like any other report.
+     */
+    pushKeepalive(subscriptionId: number, acked = true, status = "Status = 0x00 (SUCCESS),"): void {
+        this.#pushReportData(subscriptionId, ["[DMG] InteractionModelRevision = 12"], acked, status);
+    }
+
+    #pushReportData(subscriptionId: number, body: string[], acked: boolean, status: string): void {
         const exchange = ++this.#exchange;
         this.push(
             `[DMG] >> to UDP:[fe80::1%en0]:5540 | 1234${exchange} | [Interaction Model  (1) / Report Data (0x05) / Session = 1 / Exchange = ${exchange}]`,
             "[DMG] ReportDataMessage =",
             "[DMG] {",
             `[DMG] SubscriptionId = 0x${subscriptionId.toString(16)},`,
+            ...body,
         );
         if (acked) {
             this.push(
@@ -270,6 +285,36 @@ describe("subscribeAndModify", () => {
                 CertCheckFailedError,
                 /ack check failed for step 3, write 1\/1/,
             );
+        });
+    });
+
+    it("does not let a keepalive stand in for the report a write asked for", async () => {
+        const fixture = new Fixture("chip-local", (f, _index, value) => {
+            // What an idle subscription sends at its maximum interval: acked like a report, and on the
+            // same subscription, but carrying nothing the write could have caused.
+            f.pushKeepalive(SUBSCRIPTION_ID);
+            f.report(value);
+        });
+
+        await withFixture(fixture, async f => {
+            await expect(f.run([true], IMPATIENT)).rejectedWith(
+                CertCheckFailedError,
+                /ack check failed for step 3, write 1\/1/,
+            );
+        });
+    });
+
+    it("accepts the report that follows a keepalive on the same subscription", async () => {
+        const fixture = new Fixture("chip-local", (f, _index, value) => {
+            f.pushKeepalive(SUBSCRIPTION_ID);
+            f.pushReport(SUBSCRIPTION_ID);
+            f.report(value);
+        });
+
+        await withFixture(fixture, async f => {
+            await f.run([true], IMPATIENT);
+
+            expect(f.failures).deep.equal([]);
         });
     });
 

--- a/support/chip-testing/test/cert-framework/tc-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-support.test.ts
@@ -858,7 +858,7 @@ describe("expectSubscriptionId and expectReportAck against a matter.js TH", () =
         "DEBUG MessageExchange Message « for: I/StatusResponse id: @1:1b669•2d86⇵7689✉082f5518 type: 0x1/0x1 " +
         "acked: 05ab904b reqAck size: 8 payload: 1524000024ff0c18";
 
-    async function ack(lines: string[], subscriptionId = 0x54c99e7e) {
+    async function ack(lines: string[], subscriptionId = 0x54c99e7e, options?: { carriesData?: boolean }) {
         return withFollower(
             lines,
             follower =>
@@ -868,6 +868,7 @@ describe("expectSubscriptionId and expectReportAck against a matter.js TH", () =
                     { outcome: "found", subscriptionId, check: { type: "device-log", verdict: "pass" } },
                     0,
                     Millis(200),
+                    options,
                 ),
             { endSource: true },
         );
@@ -947,6 +948,25 @@ describe("expectSubscriptionId and expectReportAck against a matter.js TH", () =
 
         expect((await ack([keepalive, keepaliveAck])).verdict).equal("fail");
         expect((await ack([keepalive, keepaliveAck, REPORT, ACK])).verdict).equal("pass");
+    });
+
+    it("accepts a report carrying nothing where the caller allows one, with its own ack", async () => {
+        const empty = REPORT.replace("attr: 1", "empty").replace("✉05ab904b", "✉05ab9052");
+        const emptyAck = ACK.replace("acked: 05ab904b", "acked: 05ab9052");
+
+        // The priming report of a subscription established with nothing to report yet — the case
+        // TC-IDM-6.4 relies on.
+        const record = await ack([empty, emptyAck], 0x54c99e7e, { carriesData: false });
+
+        expect(record.verdict).equal("pass");
+        expect(record.matched).equal(emptyAck);
+    });
+
+    it("still refuses a report carrying nothing whose ack never arrives", async () => {
+        const empty = REPORT.replace("attr: 1", "empty").replace("✉05ab904b", "✉05ab9052");
+
+        // Permissive about the data, not about the ack: the DUT must still answer that report.
+        expect((await ack([empty], 0x54c99e7e, { carriesData: false })).verdict).equal("fail");
     });
 
     it("matches an id of fewer digits, which the TH pads to eight", async () => {

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1591,7 +1591,11 @@ and `expectReportAck` now have matterjs branches:
 - `Message » for: I/SubscribeResponse sub#: <id>` names the subscription.
 - `Message » for: I/ReportData sub#: <id> attr: N` (or `ev: N`) is a report carrying data; the
   keepalive an idle subscription sends at its maximum interval is marked `empty` and must not stand in
-  for one.
+  for one. chip draws the same line differently: a report prints `AttributeReportIBs` (or
+  `EventReportIBs`) right after its subscription id, where a keepalive prints
+  `InteractionModelRevision`, so `expectReportAck` requires that data line on both flavors. A
+  chip-local TC-IDM-4.1 run's device log carries six keepalives on the subscriptions the steps use, so
+  this is a window that really opens, not a theoretical one.
 - `Message « for: I/StatusResponse … acked: <that report's counter> … payload: 152400 00` is the DUT's
   answer to **that** report — matter.js names the acked message counter, which is a tighter correlation
   than the chip path's exchange id — and the byte after `152400` is the status, `00` being Success.

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1593,9 +1593,11 @@ and `expectReportAck` now have matterjs branches:
   keepalive an idle subscription sends at its maximum interval is marked `empty` and must not stand in
   for one. chip draws the same line differently: a report prints `AttributeReportIBs` (or
   `EventReportIBs`) right after its subscription id, where a keepalive prints
-  `InteractionModelRevision`, so `expectReportAck` requires that data line on both flavors. A
-  chip-local TC-IDM-4.1 run's device log carries six keepalives on the subscriptions the steps use, so
-  this is a window that really opens, not a theoretical one.
+  `InteractionModelRevision`. `expectReportAck` requires that data line by default — a chip-local
+  TC-IDM-4.1 run's device log carries six keepalives on the subscriptions the steps use, so this is a
+  window that really opens — and takes `{ carriesData: false }` for the one case where an empty report
+  is a legitimate answer: a priming report, since a subscription can be established with nothing to
+  report yet, which is ordinary for an event subscription (`TC-IDM-6.4`).
 - `Message « for: I/StatusResponse … acked: <that report's counter> … payload: 152400 00` is the DUT's
   answer to **that** report — matter.js names the acked message counter, which is a tighter correlation
   than the chip path's exchange id — and the byte after `152400` is the status, `00` being Success.

--- a/support/chip-testing/test/cert/TC-IDM-6.4.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-6.4.test.ts
@@ -152,7 +152,10 @@ certTest("TC-IDM-6.4", {
             const idLookup = await expectSubscriptionId(th.log, th.flavor, from, LOG_TIMEOUT);
             record(cx, idLookup.check, "SubscribeResponseMessage");
 
-            const ackCheck = await expectReportAck(th.log, th.flavor, idLookup, from, LOG_TIMEOUT);
+            // The priming report of an event subscription legitimately carries no events yet.
+            const ackCheck = await expectReportAck(th.log, th.flavor, idLookup, from, LOG_TIMEOUT, {
+                carriesData: false,
+            });
             record(cx, ackCheck, "Report ack");
         }),
         { expected: "Verify that the DUT sends Status Response Action with a success Status Code." },

--- a/support/chip-testing/test/cert/tc-idm-4.1-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-4.1-support.ts
@@ -92,8 +92,10 @@ export interface SubscribeAndModifyTimeouts {
  *
  * What the log confirmation does not prove: that the report it matched carried this write's data
  * rather than another change on the same subscription. A report carrying no data at all — the
- * keepalive an idle subscription sends — is excluded on both flavors, each by requiring the line on
- * which its own log says what the report carried.
+ * keepalive an idle subscription sends — is excluded for the per-write confirmations, on both flavors,
+ * each by requiring the line on which its own log says what the report carried. Only the priming report
+ * is checked without that requirement, since a subscription can legitimately be established with
+ * nothing to report yet.
  */
 export async function subscribeAndModify<Value>(
     cx: CertStepContext,
@@ -155,7 +157,12 @@ export async function subscribeAndModify<Value>(
         );
     }
 
-    const primingAckCheck = await expectReportAck(th.log, th.flavor, idLookup, established, establish);
+    // A subscription can be established with nothing to report yet, so this one report is allowed to
+    // carry no data; every later check in this step requires data, which is what tells a report of this
+    // write from a keepalive on the same subscription.
+    const primingAckCheck = await expectReportAck(th.log, th.flavor, idLookup, established, establish, {
+        carriesData: false,
+    });
     record(cx, primingAckCheck, `Priming-report status for step ${step}`);
 
     let ackCursor = primingAckCheck.logLine !== undefined ? primingAckCheck.logLine + 1 : th.log.mark();

--- a/support/chip-testing/test/cert/tc-idm-4.1-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-4.1-support.ts
@@ -92,7 +92,8 @@ export interface SubscribeAndModifyTimeouts {
  *
  * What the log confirmation does not prove: that the report it matched carried this write's data
  * rather than another change on the same subscription. A report carrying no data at all — the
- * keepalive an idle subscription sends — is excluded on both flavors.
+ * keepalive an idle subscription sends — is excluded on both flavors, each by requiring the line on
+ * which its own log says what the report carried.
  */
 export async function subscribeAndModify<Value>(
     cx: CertStepContext,

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -279,11 +279,12 @@ export const SUBSCRIBE_RESPONSE_MESSAGE = /\[DMG\] SubscribeResponseMessage =\s*
 /**
  * What a report carries, on the line chip prints right after the subscription id.
  *
- * A report with neither is the keepalive an idle subscription sends at its maximum interval, which
- * prints `InteractionModelRevision` here instead — captured in a chip-local TC-IDM-4.1 run, whose
- * device log holds six of them. It is acked like any report, so nothing downstream of the ack can tell
- * the two apart; requiring this line is what keeps a keepalive from standing in for the report a step
- * asked for.
+ * A report carrying neither prints `InteractionModelRevision` here instead, and two very different
+ * reports have that shape: the keepalive an idle subscription sends at its maximum interval, and the
+ * priming report of a subscription established with nothing to report yet. Both are acked like any
+ * report, so nothing downstream of the ack tells them from a report either — which is why requiring
+ * this line is the caller's choice (`expectReportAck`'s `carriesData`) rather than always on. A
+ * chip-local TC-IDM-4.1 run's device log holds six of the first kind.
  */
 export const REPORT_DATA_IBS = /(?:Attribute|Event)ReportIBs =\s*$/;
 export const SUBSCRIPTION_ID_LINE = /SubscriptionId = 0x([0-9a-f]+),\s*$/;
@@ -1443,10 +1444,10 @@ async function matterjsReportAck(
  * carries, so the ack is matched to this very report rather than to whatever answered on the same
  * exchange next.
  *
- * A report carrying no data — the keepalive an idle subscription sends — is not accepted, because it is
- * acked exactly like a report and so could stand in for one the step asked for. Pass
- * `{ carriesData: false }` where an empty report is a legitimate answer: a subscription can be
- * established with nothing to report yet, which is ordinary for events.
+ * A report carrying no data is not accepted by default, because it is acked exactly like a report and so
+ * could stand in for one the step asked for — that is the keepalive an idle subscription sends. Pass
+ * `{ carriesData: false }` where a report carrying nothing is itself a legitimate answer: the priming
+ * report of a subscription established with nothing to report yet, which is ordinary for events.
  */
 export async function expectReportAck(
     log: LogFollower,

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -275,6 +275,17 @@ export const REPORT_DATA_MESSAGE = /\[DMG\] ReportDataMessage =\s*$/;
 // Test_TC_IDM_4_4.yaml. Correlating on it is what attributes a report to one subscription when
 // several are live at once.
 export const SUBSCRIBE_RESPONSE_MESSAGE = /\[DMG\] SubscribeResponseMessage =\s*$/;
+
+/**
+ * What a report carries, on the line chip prints right after the subscription id.
+ *
+ * A report with neither is the keepalive an idle subscription sends at its maximum interval, which
+ * prints `InteractionModelRevision` here instead — captured in a chip-local TC-IDM-4.1 run, whose
+ * device log holds six of them. It is acked like any report, so nothing downstream of the ack can tell
+ * the two apart; requiring this line is what keeps a keepalive from standing in for the report a step
+ * asked for.
+ */
+export const REPORT_DATA_IBS = /(?:Attribute|Event)ReportIBs =\s*$/;
 export const SUBSCRIPTION_ID_LINE = /SubscriptionId = 0x([0-9a-f]+),\s*$/;
 
 /** matter.js names the subscription it just minted on the response that carries it. */
@@ -1454,7 +1465,7 @@ export async function expectReportAck(
         const report = await expectAdjacentLines(
             log,
             flavor,
-            { chip: [REPORT_DATA_MESSAGE, /\{\s*$/, subscriptionIdPattern(subscriptionId)] },
+            { chip: [REPORT_DATA_MESSAGE, /\{\s*$/, subscriptionIdPattern(subscriptionId), REPORT_DATA_IBS] },
             from,
             remaining(),
         );

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -297,9 +297,12 @@ const MATTERJS_SUBSCRIBE_RESPONSE = /Message » for: I\/SubscribeResponse sub#: 
  * where the keepalive an idle subscription sends at its maximum interval is marked `empty`, and a
  * keepalive's ack must not stand in for a report's.
  */
-function matterjsReportPattern(subscriptionId: number): RegExp {
+function matterjsReportPattern(subscriptionId: number, carriesData: boolean): RegExp {
+    // matter.js prints the counts a report carried, and flags a report carrying neither as `empty`
+    // (`InteractionMessenger`'s report logContext), so requiring the counts is what excludes a keepalive.
+    const carried = carriesData ? "(?:attr|ev): \\d+" : "";
     return new RegExp(
-        `Message » for: I/ReportData sub#: ${matterjsSubscriptionIdOf(subscriptionId)} (?:attr|ev): \\d+.*?✉([0-9a-f]+)`,
+        `Message » for: I/ReportData sub#: ${matterjsSubscriptionIdOf(subscriptionId)} ${carried}.*?✉([0-9a-f]+)`,
     );
 }
 
@@ -1366,10 +1369,11 @@ async function matterjsReportAck(
     subscriptionId: number,
     from: number,
     timeout: Duration,
+    carriesData: boolean,
 ): Promise<CheckRecord> {
     const deadline = Time.nowUs + timeout;
     const remaining = () => Millis(Math.max(1, deadline - Time.nowUs));
-    const reportPattern = matterjsReportPattern(subscriptionId);
+    const reportPattern = matterjsReportPattern(subscriptionId, carriesData);
     const pattern = `${reportPattern} then its own Success StatusResponse`;
 
     try {
@@ -1438,6 +1442,11 @@ async function matterjsReportAck(
  * Against a matter.js TH the correlation is tighter still: it names the message counter each ack
  * carries, so the ack is matched to this very report rather than to whatever answered on the same
  * exchange next.
+ *
+ * A report carrying no data — the keepalive an idle subscription sends — is not accepted, because it is
+ * acked exactly like a report and so could stand in for one the step asked for. Pass
+ * `{ carriesData: false }` where an empty report is a legitimate answer: a subscription can be
+ * established with nothing to report yet, which is ordinary for events.
  */
 export async function expectReportAck(
     log: LogFollower,
@@ -1445,6 +1454,7 @@ export async function expectReportAck(
     subscription: SubscriptionIdLookup,
     from: number,
     timeout: Duration,
+    options: { carriesData?: boolean } = {},
 ): Promise<CheckRecord> {
     // Takes the lookup rather than its id so a failure cannot arrive here as an unverified nobody can
     // explain. Callers gate on `check` first, so this is the second line of defence, not the first.
@@ -1452,20 +1462,25 @@ export async function expectReportAck(
         return subscription.check;
     }
     const { subscriptionId } = subscription;
+    const { carriesData = true } = options;
 
     if (flavor === "matterjs") {
-        return matterjsReportAck(log, flavor, subscriptionId, from, timeout);
+        return matterjsReportAck(log, flavor, subscriptionId, from, timeout, carriesData);
     }
 
     const deadline = Time.nowUs + timeout;
     const remaining = () => Millis(Math.max(1, deadline - Time.nowUs));
-    const pattern = `ReportDataMessage(SubscriptionId = 0x${subscriptionId.toString(16)}) then its own ${STATUS_RESPONSE_SUCCESS} (matched by Exchange id)`;
+    const pattern = `ReportDataMessage(SubscriptionId = 0x${subscriptionId.toString(16)})${carriesData ? " carrying data" : ""} then its own ${STATUS_RESPONSE_SUCCESS} (matched by Exchange id)`;
 
     try {
         const report = await expectAdjacentLines(
             log,
             flavor,
-            { chip: [REPORT_DATA_MESSAGE, /\{\s*$/, subscriptionIdPattern(subscriptionId), REPORT_DATA_IBS] },
+            {
+                chip: carriesData
+                    ? [REPORT_DATA_MESSAGE, /\{\s*$/, subscriptionIdPattern(subscriptionId), REPORT_DATA_IBS]
+                    : [REPORT_DATA_MESSAGE, /\{\s*$/, subscriptionIdPattern(subscriptionId)],
+            },
             from,
             remaining(),
         );


### PR DESCRIPTION
TC-IDM-4.1 confirms each write by finding the TH's report for it in the device's own log, and the DUT's
ack of that report. On the chip flavors the report was matched by three lines — the message name, its
opening brace, and the subscription id.

A keepalive prints exactly those three lines. The report an idle subscription sends at its maximum
interval carries no data, and it is acked like any other report, so nothing downstream of the ack can
tell the two apart: a write's confirmation could be satisfied by a report that could not have carried
the write.

## The window really opens

The device log of a chip-local run of this very case — the `chiptool-vs-cert-bins` evidence bundle from
run 32821447232 — carries six keepalives on the subscriptions its steps use:

```
[DMG] ReportDataMessage =
[DMG] {
[DMG] 	SubscriptionId = 0xe69d24ec,
[DMG] 	InteractionModelRevision = 12
[DMG] }
```

## What distinguishes them

chip says what a report carried on the line right after the subscription id: `AttributeReportIBs` or
`EventReportIBs` for a report, `InteractionModelRevision` for a keepalive. The match requires that data
line now, which is the same distinction the matterjs branch already made by requiring its own `attr:` or
`ev:` count — so the claim both docs made, that a keepalive is excluded on both flavors, is true rather
than half true. Adjacency is not assumed: the same log shows a real report printing
`SubscriptionId = 0x…,` immediately followed by `AttributeReportIBs =`.

## Why no test caught it

The fixture's report emitted the keepalive's shape, so its "the report arrived" tests were satisfied by
the very thing the check should reject. Its report now carries attribute data, and a keepalive is its own
emitter beside it. Two tests follow: a keepalive in the window fails the write's check, and a report
arriving after a keepalive is still accepted.

## Evidence

- Mutation-proven: restoring the three-line match fails exactly the keepalive test.
- Root `build`, `format-verify`, `lint` clean; certification framework suite 689 checks green; the live
  `TC-IDM-4.1` cert case passes against a real device on the matterjs leg.
- The full suite is green apart from one `Semaphore ➡ concurrency` timing flake in `@matter/general`,
  which passes on its own rerun and which this change cannot reach.
- The chip legs are where the changed pattern runs for real, so CI decides there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
