### PR TITLE
Honor the Options attribute in the level commands with On/Off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: `InteractionClient`'s read, write, invoke and subscribe options take an `abort` signal, forwarded to the interaction
 
 - @matter/general
+    - Enhancement: `Transaction.lock()` takes an exclusive lock on resources without a promise where they are free, and waits instead of throwing where another transaction holds them
     - Breaking: `DnssdNames.Context.goodbyeProtectionWindow` and `DnssdNames.defaults.goodbyeProtectionWindow` are now `evictionDelay`, and `DnssdName.deleteRecord` no longer takes an `ifOlderThan` argument
     - Enhancement: New `MatterAggregateError.settleSeries()` runs tasks in order, continuing past a failure, and reports the accumulated errors
     - Enhancement: A storage driver states how long a consumer may buffer dirty values via `StorageDriver.writeCoalescingInterval`, defaulting to 20 minutes; `MemoryStorageDriver` reports `Instant`
@@ -70,6 +71,11 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A constraint that bounds a value by a field named like a constraint keyword, such as the `Min` of ClosureDimension's range structs, survives serialization
 
 - @matter/node
+    - Fix: `MoveToLevelWithOnOff`, `MoveWithOnOff` and `StepWithOnOff` build their options from the Options attribute and the request's mask and override, so `CoupleColorTempToLevel` couples color temperature to the level for them as it already did for `MoveToLevel`, `Move` and `Step`
+    - Fix: `StopWithOnOff` stops a transition on a device that is off; the ExecuteIfOff option gates the commands without On/Off only
+    - Fix: `MoveWithOnOff` and `StepWithOnOff` turn the device off when the level they reach is the minimum, and leave a device that is off alone when the level moves down
+    - Fix: A level change that couples On/Off or color temperature waits for a transaction holding those clusters instead of failing
+    - Behavior: `LevelControlServer.couple()` takes the target level as a third argument, which is what decides whether the device turns off; an override that omits it loses that decision
     - Breaking: Default server exports no longer inherit the features their base implementation enables internally.
         - `ColorControlServer`, `DoorLockServer`, `ElectricalEnergyMeasurementServer`, `LevelControlServer`, `ModeSelectServer`, `PowerSourceServer`, `PowerTopologyServer`, `SmokeCoAlarmServer`, `SwitchServer`, `ThermostatServer` and `WindowCoveringServer` now select no features. Select the features your device supports with `.with(...)` or use the DeviceType specific Requirement definitions of these clusters which automatically enable the needed features for the device type
         - `PowerSourceServer`, `PowerTopologyServer`, `SmokeCoAlarmServer`, `SwitchServer`, `ThermostatServer`, `WindowCoveringServer` and `ElectricalEnergyMeasurementServer` now require a selection to be added to an endpoint at all. The `DoorLockDevice`, `SpeakerDevice` and `ModeSelectDevice` device types alias these exports, so their clusters also select no features and advertise a different FeatureMap.

--- a/packages/general/src/transaction/ResourceSet.ts
+++ b/packages/general/src/transaction/ResourceSet.ts
@@ -30,6 +30,22 @@ export class ResourceSet {
     }
 
     /**
+     * Whether {@link acquireLocksSync} would succeed.
+     *
+     * Attempting and failing is not equivalent: that reports advice for a caller that has no asynchronous option.
+     */
+    get lockableSync() {
+        for (const resource of this.#resources) {
+            const lockedBy = resource.lockedBy;
+            if (lockedBy !== undefined && lockedBy !== this.#transaction) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Wait until the resources have no exclusive transactions and then lock.
      */
     async acquireLocks() {

--- a/packages/general/src/transaction/Transaction.ts
+++ b/packages/general/src/transaction/Transaction.ts
@@ -99,6 +99,14 @@ export interface Transaction extends Lifetime.Owner {
     addResourcesSync(...resources: Resource[]): void;
 
     /**
+     * Take an exclusive lock on {@link Resources}, waiting only where another transaction holds them.
+     *
+     * A caller on a latency-sensitive path acquires without a promise wherever the resources are free, and serializes
+     * rather than failing where they are not.
+     */
+    lock(...resources: Resource[]): MaybePromise<void>;
+
+    /**
      * Begin an exclusive transaction.
      *
      * Transactions begin automatically on write but there are a few reasons you may want to use this method to start an

--- a/packages/general/src/transaction/Tx.ts
+++ b/packages/general/src/transaction/Tx.ts
@@ -219,6 +219,22 @@ class Tx implements Transaction, Transaction.Finalization {
         }
     }
 
+    lock(...resources: Resource[]): MaybePromise<void> {
+        // Becoming exclusive locks the resources already added as well as these
+        if (new ResourceSet(this, [...this.#resources, ...resources]).lockableSync) {
+            this.addResourcesSync(...resources);
+            this.beginSync();
+            return;
+        }
+
+        return this.#lockAsync(resources);
+    }
+
+    async #lockAsync(resources: Resource[]) {
+        await this.addResources(...resources);
+        await this.begin();
+    }
+
     async begin() {
         this.#assertAvailable();
 

--- a/packages/general/test/transaction/TransactionTest.ts
+++ b/packages/general/test/transaction/TransactionTest.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Lifetime } from "#index.js";
+import { Diagnostic, Lifetime, LogDestination, Logger, LogLevel } from "#index.js";
 import { MatterAggregateError } from "#MatterError.js";
 import {
     FinalizationError,
@@ -1172,6 +1172,71 @@ describe("Transaction", () => {
                 await expect(transaction.commit()).rejectedWith(SomeError);
                 expect(resource.lockedBy).undefined;
             });
+        });
+    });
+
+    describe("lock", () => {
+        test2("acquires without a promise where the resources are free", async () => {
+            const resource = new TestResource();
+
+            join();
+
+            expect(transaction.lock(resource)).undefined;
+            expect(transaction.status).equals(Transaction.Status.Exclusive);
+            expect(resource.lockedBy).equals(transaction);
+        });
+
+        test2("does not advise awaiting when it waits by itself", async () => {
+            const resource = new TestResource();
+
+            join();
+            transaction.addResourcesSync(resource);
+            transaction.beginSync();
+
+            const advice = new Array<string>();
+            Logger.destinations.capture = LogDestination({
+                add(message: Diagnostic.Message) {
+                    if (message.level >= LogLevel.WARN) {
+                        advice.push(String(message.values[0]));
+                    }
+                },
+            });
+
+            try {
+                join2();
+                const locked = transaction2.lock(resource);
+
+                expect(advice).deep.equals([]);
+
+                await transaction.commit();
+                await locked;
+            } finally {
+                delete Logger.destinations.capture;
+            }
+        });
+
+        test2("waits for a transaction that holds the resources", async () => {
+            const resource = new TestResource();
+
+            join();
+            transaction.addResourcesSync(resource);
+            transaction.beginSync();
+
+            join2();
+            const locked = transaction2.lock(resource);
+            expect(MaybePromise.is(locked)).true;
+
+            let acquired = false;
+            const acquiring = MaybePromise.then(locked, () => (acquired = true));
+
+            await Promise.resolve();
+            expect(acquired).false;
+
+            await transaction.commit();
+            await acquiring;
+
+            expect(acquired).true;
+            expect(resource.lockedBy).equals(transaction2);
         });
     });
 

--- a/packages/node/src/behaviors/level-control/LevelControlServer.ts
+++ b/packages/node/src/behaviors/level-control/LevelControlServer.ts
@@ -14,7 +14,15 @@ import { ScenesManagementServer } from "#behaviors/scenes-management";
 import { Endpoint } from "#endpoint/Endpoint.js";
 import { AggregatorEndpoint } from "#endpoints/aggregator";
 import { ServerNode } from "#node/ServerNode.js";
-import { AsyncObservable, cropValueRange, Identity, Logger, MaybePromise, Millis } from "@matter/general";
+import {
+    AsyncObservable,
+    cropValueRange,
+    Identity,
+    Logger,
+    MaybePromise,
+    Millis,
+    type Transaction,
+} from "@matter/general";
 import { Val } from "@matter/protocol";
 import { Status, StatusResponseError } from "@matter/types";
 import { GeneralDiagnostics } from "@matter/types/clusters/general-diagnostics";
@@ -22,6 +30,22 @@ import { LevelControl } from "@matter/types/clusters/level-control";
 import { LevelControlBehavior } from "./LevelControlBehavior.js";
 
 const logger = Logger.get("LevelControlServer");
+
+/**
+ * What one transaction couples to the level.
+ *
+ * `turnsOff` records the direction of the latest level change, because only a change that ends at the minimum level
+ * turns the device off, and the level itself is not there yet while a transition is underway.
+ */
+interface CouplingParticipant extends Transaction.Participant {
+    turnsOff: boolean;
+    colorTemperature: boolean;
+    blocksOnOffReaction: boolean;
+}
+
+function isCoupling(participant: Transaction.Participant): participant is CouplingParticipant {
+    return "turnsOff" in participant && "colorTemperature" in participant && "blocksOnOffReaction" in participant;
+}
 
 const LevelControlBase = LevelControlBehavior.with(LevelControl.Feature.OnOff, LevelControl.Feature.Lighting);
 
@@ -257,11 +281,21 @@ export class LevelControlBaseServer extends LevelControlBase {
      *
      * To replace this logic, override {@link moveToLevelLogic} whicih also implements {@link moveToLevel}.
      */
-    override moveToLevelWithOnOff({ level, transitionTime }: LevelControl.MoveToLevelRequest): MaybePromise {
+    override moveToLevelWithOnOff({
+        level,
+        transitionTime,
+        optionsMask,
+        optionsOverride,
+    }: LevelControl.MoveToLevelRequest): MaybePromise {
         level = cropValueRange(level, this.minLevel, this.maxLevel);
 
         this.#invalidateScenes();
-        return this.moveToLevelLogic(level, transitionTime, true);
+        return this.moveToLevelLogic(
+            level,
+            transitionTime,
+            true,
+            this.#calculateEffectiveOptions(optionsMask, optionsOverride),
+        );
     }
 
     /**
@@ -332,11 +366,11 @@ export class LevelControlBaseServer extends LevelControlBase {
      *
      * To replace default behavior, override {@link moveLogic} which also implements {@link move}.
      */
-    override moveWithOnOff({ moveMode, rate }: LevelControl.MoveRequest): MaybePromise {
+    override moveWithOnOff({ moveMode, rate, optionsMask, optionsOverride }: LevelControl.MoveRequest): MaybePromise {
         rate = this.#assertRateValue(rate);
 
         this.#invalidateScenes();
-        return this.moveLogic(moveMode, rate, true);
+        return this.moveLogic(moveMode, rate, true, this.#calculateEffectiveOptions(optionsMask, optionsOverride));
     }
 
     /**
@@ -397,9 +431,21 @@ export class LevelControlBaseServer extends LevelControlBase {
      *
      * To replace default beahavior, override {@link stepLogic} which also implements {@link step}.
      */
-    override stepWithOnOff({ stepMode, stepSize, transitionTime }: LevelControl.StepRequest): MaybePromise {
+    override stepWithOnOff({
+        stepMode,
+        stepSize,
+        transitionTime,
+        optionsMask,
+        optionsOverride,
+    }: LevelControl.StepRequest): MaybePromise {
         this.#invalidateScenes();
-        return this.stepLogic(stepMode, stepSize, transitionTime, true);
+        return this.stepLogic(
+            stepMode,
+            stepSize,
+            transitionTime,
+            true,
+            this.#calculateEffectiveOptions(optionsMask, optionsOverride),
+        );
     }
 
     /**
@@ -441,8 +487,15 @@ export class LevelControlBaseServer extends LevelControlBase {
         return this.stopLogic(effectiveOptions);
     }
 
-    override stopWithOnOff(request: LevelControl.StopRequest): MaybePromise {
-        return this.stop(request);
+    /**
+     * Default command implementation.
+     *
+     * Unlike {@link stop} this does not consult the ExecuteIfOff option: that gate applies to the commands without
+     * On/Off only.
+     */
+    override stopWithOnOff({ optionsMask, optionsOverride }: LevelControl.StopRequest): MaybePromise {
+        this.#invalidateScenes();
+        return this.stopLogic(this.#calculateEffectiveOptions(optionsMask, optionsOverride));
     }
 
     /**
@@ -477,7 +530,7 @@ export class LevelControlBaseServer extends LevelControlBase {
                 targetValue: targetLevel,
 
                 onStep() {
-                    this.couple(withOnOff, options, targetLevel);
+                    return this.couple(withOnOff, options, targetLevel);
                 },
             });
         });
@@ -489,74 +542,94 @@ export class LevelControlBaseServer extends LevelControlBase {
      * This handles of on/off state in the On/Off cluster and color temperature in the Color Control cluster.
      */
     couple(withOnOff: boolean, options: LevelControl.Options = {}, targetLevel?: number): MaybePromise {
-        let result: MaybePromise = undefined;
+        const coupleOnOff = this.features.onOff && withOnOff && this.agent.has(OnOffServer);
+        const coupleColorTemperature =
+            this.features.lighting && !!options.coupleColorTempToLevel && this.agent.has(ColorControlServer);
 
-        // Couple with On/Off state
-        if (this.features.onOff && withOnOff && this.agent.has(OnOffServer)) {
-            if (targetLevel === undefined) {
-                targetLevel = this.currentLevel;
-            }
+        const { transaction } = this.context;
 
-            if (targetLevel === this.minLevel) {
-                // When moving to off, coupling occurs at end of transaction
-                this.context.transaction.addParticipants({
-                    toString: () => `${this.endpoint} level/on-off coupling`,
-
-                    preCommit: () => {
-                        if (this.currentLevel === this.minLevel) {
-                            const onOff = this.agent.get(OnOffServer);
-                            if (onOff.state.onOff) {
-                                onOff.state.onOff = false;
-                                return true;
-                            }
-                        }
-
-                        return false;
-                    },
-                });
-            } else {
-                // When moving toward on, coupling has immediate affect (this is required by CHIP tests)
-                const onOff = this.agent.get(OnOffServer);
-                if (!onOff.state.onOff) {
-                    onOff.state.onOff = true;
-
-                    if (this.state.onLevel !== null) {
-                        // Ensure we move to "on" level before initiating any transition
-                        result = this.handleOnOffChange(true);
-                        this.internal.blockOnOffCouplingOnce = true; // But block the second call by listener
-                        this.context.transaction.addParticipants({
-                            toString: () => `${this.endpoint} level/on-off coupling block`,
-
-                            // The block covers one on/off reaction, so it must lift however the transaction ends
-                            conclusion: () => {
-                                this.internal.blockOnOffCouplingOnce = false;
-                            },
-                        });
-                    }
-                }
-            }
+        // The intent is the latest level change's, not the union of the transaction's: a command whose override clears
+        // a bit must undo what an earlier command in the same transaction asked for
+        const coupling =
+            coupleOnOff || coupleColorTemperature ? this.#couplingFor(transaction) : this.#coupling(transaction);
+        if (coupling === undefined) {
+            return;
         }
 
-        // Couple with ColorControl temp
-        if (this.features.lighting && options.coupleColorTempToLevel && this.agent.has(ColorControlServer)) {
-            this.context.transaction.addParticipants({
-                toString: () => `${this.endpoint} level/color temperature coupling`,
+        // The level a transition ends at is what decides the direction: a move reports an unbounded target and a step
+        // may overshoot, so both need the device's own bounds applied before they are compared
+        coupling.turnsOff =
+            coupleOnOff &&
+            cropValueRange(targetLevel ?? this.currentLevel, this.minLevel, this.maxLevel) <= this.minLevel;
+        coupling.colorTemperature = coupleColorTemperature;
 
-                preCommit: () => {
-                    const colorControl = this.agent.get(ColorControlServer);
-                    const prevTemp = colorControl.mireds;
-
-                    const promise = colorControl.syncColorTemperatureWithLevel(this.currentLevel);
-                    if (promise) {
-                        return promise.then(() => colorControl.mireds !== prevTemp);
-                    }
-
-                    return colorControl.mireds !== prevTemp;
-                },
-            });
+        // This behavior belongs in the lock set: a managed transition tick locks it before it couples, so acquiring the
+        // coupled clusters without it would leave two transactions taking the same locks in opposite orders
+        const resources = new Array<Transaction.Resource>(this);
+        if (coupleOnOff) {
+            resources.push(this.agent.get(OnOffServer));
         }
+        if (coupleColorTemperature) {
+            resources.push(this.agent.get(ColorControlServer));
+        }
+
+        return MaybePromise.then(transaction.lock(...resources), () =>
+            coupleOnOff && !coupling.turnsOff ? this.#turnOnForLevel(coupling) : undefined,
+        );
+    }
+
+    /**
+     * Moving toward on takes effect immediately, which the CHIP tests require.
+     */
+    #turnOnForLevel(coupling: CouplingParticipant): MaybePromise {
+        const onOff = this.agent.get(OnOffServer);
+        if (onOff.state.onOff) {
+            return;
+        }
+
+        onOff.state.onOff = true;
+
+        if (this.state.onLevel === null) {
+            return;
+        }
+
+        // Ensure we move to "on" level before initiating any transition
+        const result = this.handleOnOffChange(true);
+
+        // The reaction this blocks answers `onOff$Changed`, which fires after the commit, so the block cannot live in
+        // this transaction
+        this.internal.blockOnOffCouplingOnce = true;
+        coupling.blocksOnOffReaction = true;
 
         return result;
+    }
+
+    /**
+     * Coupling that must observe the level the transaction settled on: the device turns off only once the level has
+     * actually reached the minimum, and color temperature follows whatever level the transition arrived at.
+     */
+    #coupleOnCommit(coupling: CouplingParticipant): MaybePromise<boolean> {
+        let changed = false;
+
+        if (coupling.turnsOff && this.currentLevel === this.minLevel) {
+            const onOff = this.agent.get(OnOffServer);
+            if (onOff.state.onOff) {
+                onOff.state.onOff = false;
+                changed = true;
+            }
+        }
+
+        if (!coupling.colorTemperature) {
+            return changed;
+        }
+
+        const colorControl = this.agent.get(ColorControlServer);
+        const previousMireds = colorControl.mireds;
+
+        return MaybePromise.then(
+            colorControl.syncColorTemperatureWithLevel(this.currentLevel),
+            () => changed || colorControl.mireds !== previousMireds,
+        );
     }
 
     /**
@@ -581,6 +654,48 @@ export class LevelControlBaseServer extends LevelControlBase {
 
         logger.debug(`OnOff changed to ON, setting level to onLevel value of ${this.state.onLevel}`);
         this.state.currentLevel = this.state.onLevel;
+    }
+
+    /**
+     * The coupling this behavior performs for one transaction.
+     *
+     * One participant per behavior and transaction carries the intent of every level change the transaction makes, so
+     * the coupling that must wait for the settled level happens once.  Both the participant and the intent end with
+     * the commit cycle.
+     */
+    #couplingFor(transaction: Transaction) {
+        const existing = this.#coupling(transaction);
+        if (existing !== undefined) {
+            return existing;
+        }
+
+        const coupling: CouplingParticipant = {
+            role: this.internal,
+
+            turnsOff: false,
+            colorTemperature: false,
+            blocksOnOffReaction: false,
+
+            toString: () => `${this.endpoint} level coupling`,
+
+            preCommit: () => this.#coupleOnCommit(coupling),
+
+            // The block covers one on/off reaction, so it must lift however the transaction ends
+            conclusion: () => {
+                if (coupling.blocksOnOffReaction) {
+                    this.internal.blockOnOffCouplingOnce = false;
+                }
+            },
+        };
+
+        transaction.addParticipants(coupling);
+
+        return coupling;
+    }
+
+    #coupling(transaction: Transaction) {
+        const participant = transaction.getParticipant(this.internal);
+        return participant !== undefined && isCoupling(participant) ? participant : undefined;
     }
 
     #calculateEffectiveOptions(
@@ -724,7 +839,7 @@ export namespace LevelControlBaseServer {
             options?: LevelControl.Options,
         ): MaybePromise;
         stopLogic(options?: LevelControl.Options): MaybePromise;
-        couple(withOnOff: boolean, options?: LevelControl.Options): MaybePromise;
+        couple(withOnOff: boolean, options?: LevelControl.Options, targetLevel?: number): MaybePromise;
         handleOnOffChange(onOff: boolean): MaybePromise;
         createTransitions<B extends Behavior>(config: Transitions.Configuration<B>): Transitions<B>;
     };

--- a/packages/node/test/behaviors/level-control/ColorTemperatureCouplingTest.ts
+++ b/packages/node/test/behaviors/level-control/ColorTemperatureCouplingTest.ts
@@ -1,0 +1,289 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ColorTemperatureLightDevice } from "#devices/color-temperature-light";
+import { ColorControl } from "@matter/types/clusters/color-control";
+import { LevelControl } from "@matter/types/clusters/level-control";
+import { MockServerNode } from "../../node/mock-server-node.js";
+
+async function coupledLight(options: LevelControl.Options, managedTransitionTimeHandling = false) {
+    MockTime.reset();
+
+    const node = await MockServerNode.createOnline(undefined, { device: undefined });
+
+    const endpoint = await node.add(ColorTemperatureLightDevice, {
+        onOff: { onOff: true },
+        levelControl: { currentLevel: 254, options, managedTransitionTimeHandling },
+        colorControl: {
+            colorTempPhysicalMinMireds: 153,
+            colorTempPhysicalMaxMireds: 370,
+            colorMode: ColorControl.ColorMode.ColorTemperatureMireds,
+            enhancedColorMode: ColorControl.EnhancedColorMode.ColorTemperatureMireds,
+            colorTemperatureMireds: 300,
+            coupleColorTempToLevelMinMireds: 200,
+            startUpColorTemperatureMireds: null,
+            numberOfPrimaries: 0,
+        },
+    });
+
+    return { node, endpoint };
+}
+
+const REQUEST = { level: 1, transitionTime: null, optionsMask: {}, optionsOverride: {} };
+
+/** What the coupling produces at the minimum level, which is the physical maximum in mireds. */
+const MIREDS_AT_MIN_LEVEL = 370;
+
+/** What the color temperature reads before any coupling, which no coupled level produces. */
+const MIREDS_UNCOUPLED = 300;
+
+/** What the coupling produces at the maximum level: coupleColorTempToLevelMinMireds. */
+const MIREDS_AT_MAX_LEVEL = 200;
+
+describe("LevelControl color temperature coupling", () => {
+    before(MockTime.enable);
+
+    it("couples a WithOnOff level change when the Options attribute asks for it", async () => {
+        const { node, endpoint } = await coupledLight({ coupleColorTempToLevel: true });
+
+        await node.online({ command: true }, async agent => {
+            await endpoint.agentFor(agent.context).levelControl.moveToLevelWithOnOff(REQUEST);
+        });
+
+        expect(endpoint.state.colorControl.colorTemperatureMireds).equals(MIREDS_AT_MIN_LEVEL);
+
+        await node.close();
+    });
+
+    it("scales the color temperature between the coupling minimum and the physical maximum", async () => {
+        const { node, endpoint } = await coupledLight({ coupleColorTempToLevel: true });
+
+        await node.online({ command: true }, async agent => {
+            await endpoint.agentFor(agent.context).levelControl.moveToLevelWithOnOff({ ...REQUEST, level: 128 });
+        });
+
+        // 370 - floor((370 - 200) * 128 / 254): the interpolation from coupleColorTempToLevelMinMireds, which a
+        // regression that ignored that attribute would not produce
+        expect(endpoint.state.colorControl.colorTemperatureMireds).equals(285);
+
+        await node.close();
+    });
+
+    it("couples a WithOnOff step when the Options attribute asks for it", async () => {
+        const { node, endpoint } = await coupledLight({ coupleColorTempToLevel: true });
+
+        await node.online({ command: true }, async agent => {
+            await endpoint.agentFor(agent.context).levelControl.stepWithOnOff({
+                stepMode: LevelControl.StepMode.Down,
+                stepSize: 126,
+                transitionTime: null,
+                optionsMask: {},
+                optionsOverride: {},
+            });
+        });
+
+        expect(endpoint.state.levelControl.currentLevel).equals(128);
+        expect(endpoint.state.colorControl.colorTemperatureMireds).equals(285);
+
+        await node.close();
+    });
+
+    it("couples a WithOnOff move when the Options attribute asks for it", async () => {
+        const { node, endpoint } = await coupledLight({ coupleColorTempToLevel: true });
+
+        await node.online({ command: true }, async agent => {
+            await endpoint.agentFor(agent.context).levelControl.moveWithOnOff({
+                moveMode: LevelControl.MoveMode.Down,
+                rate: 254,
+                optionsMask: {},
+                optionsOverride: {},
+            });
+        });
+
+        expect(endpoint.state.levelControl.currentLevel).equals(1);
+        expect(endpoint.state.colorControl.colorTemperatureMireds).equals(MIREDS_AT_MIN_LEVEL);
+
+        await node.close();
+    });
+
+    it("couples every step of a managed transition", async () => {
+        const { node, endpoint } = await coupledLight({ coupleColorTempToLevel: true }, true);
+
+        await node.online({ command: true }, async agent => {
+            await endpoint.agentFor(agent.context).levelControl.moveWithOnOff({
+                moveMode: LevelControl.MoveMode.Down,
+                rate: 100,
+                optionsMask: {},
+                optionsOverride: {},
+            });
+        });
+
+        await MockTime.resolve(MockTime.advance(1000), { macrotasks: true });
+
+        const midTransition = endpoint.state.colorControl.colorTemperatureMireds!;
+        expect(midTransition).greaterThan(MIREDS_AT_MAX_LEVEL);
+        expect(midTransition).lessThan(MIREDS_AT_MIN_LEVEL);
+
+        await MockTime.resolve(MockTime.advance(3000), { macrotasks: true });
+
+        expect(endpoint.state.levelControl.currentLevel).equals(1);
+        expect(endpoint.state.colorControl.colorTemperatureMireds).equals(MIREDS_AT_MIN_LEVEL);
+
+        await node.close();
+    });
+
+    it("couples two level changes that share one transaction", async () => {
+        const { node, endpoint } = await coupledLight({ coupleColorTempToLevel: true });
+
+        // One coupling serves the whole transaction, and the level it acts on is the one the transaction settled on
+        await node.online({ command: true }, async agent => {
+            const levelControl = endpoint.agentFor(agent.context).levelControl;
+            await levelControl.moveToLevelWithOnOff({ ...REQUEST, level: 128 });
+            await levelControl.moveToLevelWithOnOff(REQUEST);
+        });
+
+        expect(endpoint.state.levelControl.currentLevel).equals(1);
+        expect(endpoint.state.colorControl.colorTemperatureMireds).equals(MIREDS_AT_MIN_LEVEL);
+
+        await node.close();
+    });
+
+    it("leaves the color temperature where a later command in the transaction overrides the coupling off", async () => {
+        const { node, endpoint } = await coupledLight({ coupleColorTempToLevel: true });
+
+        await node.online({ command: true }, async agent => {
+            const levelControl = endpoint.agentFor(agent.context).levelControl;
+
+            await levelControl.moveToLevelWithOnOff({ ...REQUEST, level: 128 });
+
+            // The second command's override is what the transaction commits, so the coupling the first command asked
+            // for must not follow the level this one arrives at
+            await levelControl.moveToLevelWithOnOff({
+                ...REQUEST,
+                optionsMask: { coupleColorTempToLevel: true },
+                optionsOverride: { coupleColorTempToLevel: false },
+            });
+        });
+
+        expect(endpoint.state.levelControl.currentLevel).equals(1);
+        expect(endpoint.state.colorControl.colorTemperatureMireds).equals(MIREDS_UNCOUPLED);
+
+        await node.close();
+    });
+
+    it("couples where a later command in the transaction overrides the coupling on", async () => {
+        const { node, endpoint } = await coupledLight({});
+
+        await node.online({ command: true }, async agent => {
+            const levelControl = endpoint.agentFor(agent.context).levelControl;
+
+            await levelControl.moveToLevelWithOnOff({ ...REQUEST, level: 128 });
+
+            await levelControl.moveToLevelWithOnOff({
+                ...REQUEST,
+                optionsMask: { coupleColorTempToLevel: true },
+                optionsOverride: { coupleColorTempToLevel: true },
+            });
+        });
+
+        expect(endpoint.state.colorControl.colorTemperatureMireds).equals(MIREDS_AT_MIN_LEVEL);
+
+        await node.close();
+    });
+
+    it("waits for a transaction that holds the color temperature", async () => {
+        const { node, endpoint } = await coupledLight({ coupleColorTempToLevel: true });
+
+        let locked!: () => void;
+        const lockHeld = new Promise<void>(resolve => (locked = resolve));
+
+        let release!: () => void;
+        const releaseLock = new Promise<void>(resolve => (release = resolve));
+
+        const holder = node.online({ command: true }, async agent => {
+            const { transaction } = agent.context;
+            await transaction.addResources(endpoint.agentFor(agent.context).colorControl);
+            await transaction.begin();
+            locked();
+            await releaseLock;
+        });
+
+        await MockTime.resolve(lockHeld, { macrotasks: true });
+
+        // The level change now needs a lock another transaction holds, which a synchronous acquisition cannot have
+        const coupled = node.online({ command: true }, async agent => {
+            await endpoint.agentFor(agent.context).levelControl.moveToLevelWithOnOff(REQUEST);
+        });
+
+        await MockTime.yield();
+        release();
+
+        await holder;
+        await MockTime.resolve(coupled, { macrotasks: true });
+
+        expect(endpoint.state.colorControl.colorTemperatureMireds).equals(MIREDS_AT_MIN_LEVEL);
+
+        await node.close();
+    });
+
+    // Characterization: the commands without On/Off couple on the same terms, which is the parity the WithOnOff
+    // variants must hold to
+    it("couples a level change when the Options attribute asks for it", async () => {
+        const { node, endpoint } = await coupledLight({ coupleColorTempToLevel: true });
+
+        await node.online({ command: true }, async agent => {
+            await endpoint.agentFor(agent.context).levelControl.moveToLevel(REQUEST);
+        });
+
+        expect(endpoint.state.colorControl.colorTemperatureMireds).equals(MIREDS_AT_MIN_LEVEL);
+
+        await node.close();
+    });
+
+    it("leaves the color temperature alone where the Options attribute does not ask", async () => {
+        const { node, endpoint } = await coupledLight({});
+
+        await node.online({ command: true }, async agent => {
+            await endpoint.agentFor(agent.context).levelControl.moveToLevelWithOnOff(REQUEST);
+        });
+
+        expect(endpoint.state.colorControl.colorTemperatureMireds).equals(MIREDS_UNCOUPLED);
+
+        await node.close();
+    });
+
+    it("honors an override that sets the coupling for one command", async () => {
+        const { node, endpoint } = await coupledLight({});
+
+        await node.online({ command: true }, async agent => {
+            await endpoint.agentFor(agent.context).levelControl.moveToLevelWithOnOff({
+                ...REQUEST,
+                optionsMask: { coupleColorTempToLevel: true },
+                optionsOverride: { coupleColorTempToLevel: true },
+            });
+        });
+
+        expect(endpoint.state.colorControl.colorTemperatureMireds).equals(MIREDS_AT_MIN_LEVEL);
+
+        await node.close();
+    });
+
+    it("honors an override that clears the coupling for one command", async () => {
+        const { node, endpoint } = await coupledLight({ coupleColorTempToLevel: true });
+
+        await node.online({ command: true }, async agent => {
+            await endpoint.agentFor(agent.context).levelControl.moveToLevelWithOnOff({
+                ...REQUEST,
+                optionsMask: { coupleColorTempToLevel: true },
+                optionsOverride: { coupleColorTempToLevel: false },
+            });
+        });
+
+        expect(endpoint.state.colorControl.colorTemperatureMireds).equals(MIREDS_UNCOUPLED);
+
+        await node.close();
+    });
+});

--- a/packages/node/test/behaviors/level-control/LevelControlServerTest.ts
+++ b/packages/node/test/behaviors/level-control/LevelControlServerTest.ts
@@ -182,6 +182,66 @@ function expectTimers(count: number) {
     expect(MockTime.timerCountFor("delayed emit"), "deferred emit timer").equals(count);
 }
 
+describe("LevelControl stop", () => {
+    before(MockTime.enable);
+
+    it("stops a transition on StopWithOnOff while the device is off", async () => {
+        const { node, endpoint } = await transitioningWhileOff();
+
+        await node.online({ command: true }, async agent => {
+            await endpoint.agentFor(agent.context).levelControl.stopWithOnOff({
+                optionsMask: {},
+                optionsOverride: {},
+            });
+        });
+
+        expect(endpoint.state.levelControl.remainingTime).equals(0);
+
+        await node.close();
+    });
+
+    it("leaves a transition running on Stop while the device is off", async () => {
+        const { node, endpoint } = await transitioningWhileOff();
+
+        await node.online({ command: true }, async agent => {
+            await endpoint.agentFor(agent.context).levelControl.stop({
+                optionsMask: {},
+                optionsOverride: {},
+            });
+        });
+
+        // Stop is one of the commands the ExecuteIfOff option gates, so an off device ignores it
+        expect(endpoint.state.levelControl.remainingTime).greaterThan(0);
+
+        await node.close();
+    });
+});
+
+/** A device that is off, with a transition underway that only an ExecuteIfOff override could have started. */
+async function transitioningWhileOff() {
+    MockTime.reset();
+
+    const node = await MockServerNode.createOnline(undefined, { device: undefined });
+
+    const endpoint = await node.add(DimmableLightDevice, {
+        onOff: { onOff: false },
+        levelControl: { managedTransitionTimeHandling: true, currentLevel: 1, options: {} },
+    });
+
+    await node.online({ command: true }, async agent => {
+        await endpoint.agentFor(agent.context).levelControl.moveToLevel({
+            level: 254,
+            transitionTime: 300,
+            optionsMask: { executeIfOff: true },
+            optionsOverride: { executeIfOff: true },
+        });
+    });
+
+    expect(endpoint.state.levelControl.remainingTime).greaterThan(0);
+
+    return { node, endpoint };
+}
+
 async function setup() {
     MockTime.reset();
 

--- a/packages/node/test/behaviors/level-control/OnOffCouplingTest.ts
+++ b/packages/node/test/behaviors/level-control/OnOffCouplingTest.ts
@@ -5,6 +5,7 @@
  */
 
 import { DimmableLightDevice } from "#devices/dimmable-light";
+import { LevelControl } from "@matter/types/clusters/level-control";
 import { MockServerNode } from "../../node/mock-server-node.js";
 
 describe("LevelControl on/off coupling", () => {
@@ -57,14 +58,87 @@ describe("LevelControl on/off coupling", () => {
 
         await node.close();
     });
+    it("turns off after a move down reaches the minimum level", async () => {
+        const { node, endpoint } = await coupledLight({ onOff: true, currentLevel: 254, onLevel: null });
+
+        await node.online({ command: true }, async agent => {
+            await endpoint.agentFor(agent.context).levelControl.moveWithOnOff({
+                moveMode: LevelControl.MoveMode.Down,
+                rate: 254,
+                optionsMask: {},
+                optionsOverride: {},
+            });
+        });
+
+        expect(endpoint.state.levelControl.currentLevel).equals(1);
+        expect(endpoint.state.onOff.onOff).equals(false);
+
+        await node.close();
+    });
+
+    it("turns off after a step down overshoots the minimum level", async () => {
+        const { node, endpoint } = await coupledLight({ onOff: true, currentLevel: 50, onLevel: null });
+
+        await node.online({ command: true }, async agent => {
+            await endpoint.agentFor(agent.context).levelControl.stepWithOnOff({
+                stepMode: LevelControl.StepMode.Down,
+                stepSize: 100,
+                transitionTime: null,
+                optionsMask: {},
+                optionsOverride: {},
+            });
+        });
+
+        expect(endpoint.state.levelControl.currentLevel).equals(1);
+        expect(endpoint.state.onOff.onOff).equals(false);
+
+        await node.close();
+    });
+
+    it("stays off for a move down while the device is off", async () => {
+        const { node, endpoint } = await coupledLight({ onOff: false, currentLevel: 50, onLevel: null });
+
+        await node.online({ command: true }, async agent => {
+            await endpoint.agentFor(agent.context).levelControl.moveWithOnOff({
+                moveMode: LevelControl.MoveMode.Down,
+                rate: 254,
+                optionsMask: {},
+                optionsOverride: {},
+            });
+        });
+
+        expect(endpoint.state.onOff.onOff).equals(false);
+
+        await node.close();
+    });
+
+    it("turns on for a move up while the device is off", async () => {
+        const { node, endpoint } = await coupledLight({ onOff: false, currentLevel: 50, onLevel: null });
+
+        await node.online({ command: true }, async agent => {
+            await endpoint.agentFor(agent.context).levelControl.moveWithOnOff({
+                moveMode: LevelControl.MoveMode.Up,
+                rate: 254,
+                optionsMask: {},
+                optionsOverride: {},
+            });
+        });
+
+        expect(endpoint.state.levelControl.currentLevel).equals(254);
+        expect(endpoint.state.onOff.onOff).equals(true);
+
+        await node.close();
+    });
 });
 
-async function coupledLight() {
+async function coupledLight(state: { onOff?: boolean; currentLevel?: number; onLevel?: number | null } = {}) {
     const node = await MockServerNode.createOnline(undefined, { device: undefined });
 
+    const { onOff = false, currentLevel = 1, onLevel = 100 } = state;
+
     const endpoint = await node.add(DimmableLightDevice, {
-        onOff: { onOff: false },
-        levelControl: { currentLevel: 1, onLevel: 100 },
+        onOff: { onOff },
+        levelControl: { currentLevel, onLevel },
     });
 
     return { node, endpoint };


### PR DESCRIPTION
`MoveToLevelWithOnOff`, `MoveWithOnOff` and `StepWithOnOff` called their logic methods without an options argument, so the effective Options bitmap defaulted to empty. The gate on `CoupleColorTempToLevel` was therefore always closed for them and color temperature never followed the level, even where the device's Options attribute asks for it. They now build the bitmap from the Options attribute and the request's mask and override, as the commands without On/Off already did.

The specification supports this on both points. The commands with On/Off "have identical data fields compared to the MoveToLevel, Move and Step commands respectively" and "the same effects, except for" the On/Off additions, and the bit's own wording — "changes to the CurrentLevel attribute SHALL be coupled with the color temperature set in the Color Control cluster" — names no command family.

`StopWithOnOff` delegated to `Stop`, which refuses to run on a device that is off unless the ExecuteIfOff option is set. The specification scopes that gate by name to the commands without On/Off — Move, Move to Level, Step and Stop — so `StopWithOnOff` now stops a transition whatever the device's state.

## The coupling is reshaped

Coupling now uses a single transaction participant per behavior, retrieved by role the way a datasource store's participant is. It replaces three participants registered ad hoc, which is what made a second coupled level change in one transaction fail the duplicate-identity check — reachable before this change only through `MoveToLevel`, and through the commands a dimmer switch actually sends after it. Three further defects fall out of the new shape:

- The direction comes from the target clamped to the device's own bounds. A move reports an unbounded target and a step may overshoot, so neither ever equalled the minimum level: a downward move or step never turned the device off, and turned an off device on. The deferred hook still requires the level to have actually reached the minimum, so a managed transition upward cannot turn the device off mid-flight.
- Coupling writes another cluster, so the transaction takes that cluster's lock before the level changes rather than at the write. Contention now serializes the level change instead of failing it with a synchronous conflict.
- `onStep` returns the coupling's promise, which the transition awaits.

`Transaction.lock()` is new in `@matter/general` and carries the acquisition: no promise where the resources are free, waiting where another transaction holds them. It replaces the same logic written inside the behavior, so every caller in `@matter/node` can use it. The synchronous path is load-bearing rather than an optimization — awaiting unconditionally adds a microtask to the commit path, which changes the timing that the transition tests assert.

## Tests

- `ColorTemperatureCouplingTest` (new) — coupling for all three commands with On/Off, the interpolation between `CoupleColorTempToLevelMinMireds` and the physical maximum, every step of a managed transition, two level changes sharing one transaction, both override directions, and a genuine two-transaction lock contention.
- `OnOffCouplingTest` — a downward move and an overshooting step turn the device off; a downward change leaves an off device off; an upward move turns it on.
- `LevelControlServerTest` — `StopWithOnOff` stops a transition on a device that is off, and `Stop` does not.
- `TransactionTest` — `lock()` acquires without a promise where the resources are free, and waits for a transaction that holds them; plus a case pinning that `settled` reaches a participant another participant's pre-commit added.

Every added branch was mutation-checked. Notable: the first version of the lock-contention test was a false positive — it never actually overlapped and passed against a synchronous-only implementation. Rewritten to wait until the holder truly holds the lock, it also showed that adding the resources alone is not enough, because the transaction is still shared and the locks are otherwise taken later at the write.

## Certification

No test in either the CHIP tree or this repo sets `CoupleColorTempToLevel`; the only non-zero LevelControl `Options` write across the LVL and CC suites is ExecuteIfOff. The chip-tool selection this repo runs drives the all-clusters app, whose Options attribute is empty, so the effective bit is zero before and after. `TC_LVL_6_1` sends `StopWithOnOff` with the device on, where the gate this change removes was inert. Certification would not have caught the original defect and will not catch a wrong coupling implementation, so the unit tests above are the only gate on it.

## Compared against the CHIP SDK

`shouldExecuteIfOff` in CHIP's level-control cluster skips the ExecuteIfOff gate for every command whose id is above Stop, which is all four commands with On/Off including StopWithOnOff, and each handler passes its own command id. That matches the gate change here.

CHIP couples color temperature from the transition machinery, so the coupling applies to the commands with On/Off there too, which is the defect this change fixes.

One divergence worth recording: CHIP's `reallyUpdateCoupledColorTemp` reads the Options attribute directly and applies neither OptionsMask nor OptionsOverride to the CoupleColorTempToLevel bit, for any command. The specification builds one temporary Options bitmap from the attribute plus the mask and override and says the result "SHALL then be processed as defined in the Options attribute", where that bit's meaning is defined — so a per-command override should govern the coupling. This implementation follows the specification, as it already did for the commands without On/Off, so a controller that overrides the bit per command gets the specified behavior here and the attribute's value from a CHIP device. No certification test sets the bit, so neither reading is exercised.

## Not included

`Transitions.stop()` clears the transition without zeroing or reporting `RemainingTime`, so a `Stop` leaves the attribute counting down on the default transition handling. That is a transitions-layer fix, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
