### PR TITLE
CI and the dev container run on Node.js 24, and the matrices gain a 26 leg

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,7 +7,7 @@
 # Includes dev tools required for matter.js, claude code, quality-of-life tweaks, and attempts to lock down the
 # "matter" user so that it cannot run arbitrary code as root
 
-FROM mcr.microsoft.com/devcontainers/javascript-node:22-bookworm
+FROM mcr.microsoft.com/devcontainers/javascript-node:24-bookworm
 
 ARG TZ
 ENV TZ="$TZ"

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -33,7 +33,7 @@ Enable the following in Docker Desktop settings:
 
 Once running, the container provides:
 
-- Node.js 22 (Debian Bookworm)
+- Node.js 24 (Debian Bookworm)
 - Docker-in-Docker for running nested containers
 - ZSH with productivity enhancements (fzf, git-delta)
 - All matter.js dependencies installed via `npm ci`
@@ -104,10 +104,10 @@ Edit the `customizations.vscode.extensions` array in `devcontainer.json`.
 Update the base image in `Dockerfile`:
 
 ```dockerfile
-FROM mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm
+FROM mcr.microsoft.com/devcontainers/javascript-node:24-bookworm
 ```
 
-Replace `22` with your desired Node.js major version.
+Replace `24` with your desired Node.js major version.
 
 ### Updating Claude Code
 

--- a/.devcontainer/bin/set-permissions.sh
+++ b/.devcontainer/bin/set-permissions.sh
@@ -3,10 +3,10 @@
 # Copyright 2022-2026 Matter.js Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# ROLE: Installed during container build; run with sudo via post-start.sh
+# ROLE: Installed during container build; run with sudo via post-create.sh
 
 # Make the container's node_modules volume writable
 chown -R matter:matter /matter.js/node_modules
 
-# Have had an issue here too, make sure permissions are correct
-chown -R matter:matter /home/matter/.claude
+# A volume mounted over a build-time directory arrives root-owned, undoing the Dockerfile's chown
+chown -R matter:matter /home/matter/.claude /home/matter/.commandhistory

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -61,12 +61,12 @@
 	},
 	"mounts": [
 		"source=matter-js-npm-${devcontainerId},target=/matter.js/node_modules,type=volume",
-		"source=matter-js-bashhistory-${devcontainerId},target=/home/node/.commandhistory,type=volume",
-		"source=matter-js-claude-config-${devcontainerId},target=/home/node/.claude,type=volume",
+		"source=matter-js-bashhistory-${devcontainerId},target=/home/matter/.commandhistory,type=volume",
+		"source=matter-js-claude-config-${devcontainerId},target=/home/matter/.claude,type=volume",
 		"type=tmpfs,destination=/tmp,tmpfs-mode=1770,tmpfs-size=64m"
 	],
 	"containerEnv": {
 		//"NODE_OPTIONS": "--max-old-space-size=4096",
-		"CLAUDE_CONFIG_DIR": "/home/node/.claude"
+		"CLAUDE_CONFIG_DIR": "/home/matter/.claude"
 	}
 }

--- a/.github/actions/prepare-env/action.yml
+++ b/.github/actions/prepare-env/action.yml
@@ -5,7 +5,7 @@ inputs:
   node-version:
     description: 'Node.js version'
     required: true
-    default: '22.x'
+    default: '24.x'
   os:
     description: 'Operating system'
     required: true

--- a/.github/actions/run-chip-tests/action.yml
+++ b/.github/actions/run-chip-tests/action.yml
@@ -26,7 +26,7 @@ inputs:
   node-version:
     description: 'Node.js version'
     required: true
-    default: '22.x'
+    default: '24.x'
 
 runs:
   using: 'composite'

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -395,7 +395,7 @@ export * from "@matter/node/behaviors";
 
 - Avoid Node.js-specific APIs in core packages
 - Use dependency injection for platform services
-- Test on multiple Node.js versions (20.x, 22.x, 24.x)
+- Test on multiple Node.js versions (20.x, 22.x, 24.x, 26.x)
 
 ## Performance Guidelines
 

--- a/.github/workflows/build-test.js.yml
+++ b/.github/workflows/build-test.js.yml
@@ -38,7 +38,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [ 22.x, 24.x ]
+        # No 20.x leg: building matter.js runs the build toolchain, which requires 22.x or newer.
+        # The library itself supports 20.x, and the test job below covers it.
+        node-version: [ 22.x, 24.x, 26.x ]
         os: [ macos-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v7
@@ -55,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 20.x, 22.x, 24.x ]
+        node-version: [ 20.x, 22.x, 24.x, 26.x ]
     steps:
       - uses: actions/checkout@v7
       - name: Prepare testing environment

--- a/.github/workflows/chip-cert-tests.yml
+++ b/.github/workflows/chip-cert-tests.yml
@@ -306,10 +306,10 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.ref }}
 
-      - name: Use Node.js 22.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v7
         with:
-          node-version: 22.x
+          node-version: 24.x
 
       - name: Install matter.js
         run: npm ci --foreground-scripts
@@ -344,10 +344,10 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.ref }}
 
-      - name: Use Node.js 22.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v7
         with:
-          node-version: 22.x
+          node-version: 24.x
 
       - name: Install matter.js
         run: npm ci --foreground-scripts

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [ 20.x, 22.x, 24.x ]
+        node-version: [ 20.x, 22.x, 24.x, 26.x ]
         os: [ macos-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v7
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 20.x, 22.x, 24.x ]
+        node-version: [ 20.x, 22.x, 24.x, 26.x ]
     steps:
       - uses: actions/checkout@v7
       - name: Prepare testing environment


### PR DESCRIPTION
## Node.js 24 wherever we pin a version

Every place our CI or dev tooling selects a *single* Node.js version now selects 24.x instead of
22.x. Node 24 is the current LTS line, so that is what we build, lint, run the CHIP tests and run
the certification tests on, and what a contributor gets from the dev container.

Most of those jobs never named a version. `.github/actions/prepare-env` is the shared "install
dependencies" composite action, and its `node-version` default was what the lint and format gate,
the official release build, the nightly dev release and the `.d.ts` validation job all actually ran
on, because none of them passes the input. `.github/actions/run-chip-tests` does the same for every
CHIP test group. The two jobs in `chip-cert-tests.yml` that call `actions/setup-node` directly — the
certification framework gate and the per-leg certification runs — had the version written out by
hand.

`.devcontainer/Dockerfile` moves to the `24-bookworm` base image, and the three places the dev
container README states or demonstrates its Node.js version were updated to match the file they
describe. No other Docker image in the repository carries Node.js: the CHIP harness image built from
`support/chip/Dockerfile` is Ubuntu plus the chip binaries, and matter.js runs on the host against
it.

## Node.js 26 added to the support matrices

The four multi-version matrices — build and test, in both `build-test.js.yml` and `release-npm.yml`
— gain a 26.x leg. Node 26 is released but is still the Current line rather than an LTS one, so this
leg is an early warning: it reports a break on the next LTS while there is still time to act on it,
rather than on the day it is promoted.

The 20.x and 22.x legs stay. Those matrices exist to prove the published packages work on every
Node.js version we tell users they can run, and our `engines` fields still admit anything from 20.19
upward, so dropping a leg would mean no longer testing a version we claim to support. The minimum
versions stated in the root README are unchanged for the same reason: this changes which versions CI
exercises, not the floor we support.

The non-Linux build matrix has no 20.x leg, because building matter.js runs the build toolchain and
that needs 22.x or newer, while the library itself supports 20.x. That constraint is now recorded
next to the matrix, since the asymmetry between the two build matrices otherwise reads as an
oversight.

## Dev container: the volumes now land in the user's real home directory

Unrelated to the version bump, but found while checking that the dev container still hangs together.

The dev container image renames the base image's `node` user to `matter` and moves its home
directory to `/home/matter`. Two named volumes — one holding shell history, one holding the Claude
Code configuration — were still mounted at `/home/node/.commandhistory` and `/home/node/.claude`,
and `CLAUDE_CONFIG_DIR` still pointed into `/home/node`. Nothing created or owned those paths, so
Docker created them as root and the `matter` user could not write to either, while the permission
fixup script was meanwhile correcting a `/home/matter/.claude` that nothing was mounted over.

The mounts and `CLAUDE_CONFIG_DIR` now point at `/home/matter`, and the fixup script takes ownership
of both directories: a volume mounted over a directory created during the image build arrives owned
by root, so the ownership the Dockerfile sets does not reach the running container. The effect is
that shell history and Claude Code settings survive a container rebuild, which is what the volumes
were there for.

## Testing

`npm run format-verify`, `npm run lint`, `actionlint` on all touched workflows and `shellcheck` on
the changed script are clean, and `devcontainer.json` parses and resolves to the intended paths.
There is no unit test coverage to add: the diff is CI configuration, a Dockerfile and documentation.
The real verification is this pull request's own CI — which now runs on 24.x and includes the new
26.x legs — plus a dev container rebuild for the home-directory half.
