### PR TITLE
test(chip-testing): TC-DD-3.11, commissioning from a standard-flow QR code

### DIFF
--- a/packages/testing/src/chip/cert/cert-dsl.ts
+++ b/packages/testing/src/chip/cert/cert-dsl.ts
@@ -171,6 +171,13 @@ export function certTest(tc: string, options: CertTestOptions): CertTestBuilder 
                 );
             }
 
+            // The expression is parsed where it is declared, not only where it is evaluated: a
+            // malformed one reaching the run is caught by the per-step handler and recorded as the
+            // step failing, which reads as a defect of the device under test.
+            if (opts?.pics !== undefined) {
+                new PicsExpression(opts.pics);
+            }
+
             definition.steps.push({
                 number,
                 text,

--- a/packages/testing/src/chip/cert/cert-dsl.ts
+++ b/packages/testing/src/chip/cert/cert-dsl.ts
@@ -171,9 +171,9 @@ export function certTest(tc: string, options: CertTestOptions): CertTestBuilder 
                 );
             }
 
-            // The expression is parsed where it is declared, not only where it is evaluated: a
-            // malformed one reaching the run is caught by the per-step handler and recorded as the
-            // step failing, which reads as a defect of the device under test.
+            // Constructing the expression is the validation: unparsed until the run, a malformed one
+            // is caught by the per-step handler and recorded as the step failing, i.e. as a defect of
+            // the device under test.
             if (opts?.pics !== undefined) {
                 new PicsExpression(opts.pics);
             }

--- a/support/chip-testing/test/cert-framework/multi-device-guard.test.ts
+++ b/support/chip-testing/test/cert-framework/multi-device-guard.test.ts
@@ -48,6 +48,32 @@ describe("certTest step declaration guard", () => {
         }
     });
 
+    it("rejects a malformed step PICS expression at declaration time", () => {
+        const originalDescribe = Reflect.get(globalThis, "describe");
+        Reflect.set(globalThis, "describe", () => {});
+        try {
+            const builder = certTest("TC-BAD-PICS-GUARD-0.0", {
+                plan: "n/a",
+                pics: [],
+                app: "all-clusters",
+            });
+
+            expect(() =>
+                builder.step(1, "Step gated on a doubled operator", async () => {}, {
+                    pics: "MCORE.DD.SCAN_QR_CODE && MCORE.DD.DISCOVERY_BLE",
+                }),
+            ).to.throw(/Invalid PICS expression/);
+
+            expect(() =>
+                builder.step(2, "Step gated on an expression", async () => {}, {
+                    pics: "MCORE.DD.SCAN_QR_CODE & MCORE.DD.DISCOVERY_BLE",
+                }),
+            ).to.not.throw();
+        } finally {
+            Reflect.set(globalThis, "describe", originalDescribe);
+        }
+    });
+
     it("rejects a blank notApplicable reason at declaration time", () => {
         const originalDescribe = Reflect.get(globalThis, "describe");
         Reflect.set(globalThis, "describe", () => {});

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -30,6 +30,7 @@ import {
     qrPayloadWithPrefix,
     recordDiscoveryCapabilityAbsent,
     recordGeneratedManualCode,
+    recordPayloadOffering,
     recordGeneratedPayload,
     recordVendorOutcome,
 } from "../cert/tc-dd-support.js";
@@ -302,6 +303,47 @@ describe("CommissioningRefusals", () => {
         await expect(refusals.requireRefusal(cx, { qrPairingCode: "MT:whatever" }, "must be refused")).rejected;
 
         await expect(refusals.settle(cx)).rejectedWith(CertCleanupError, /still running/);
+    });
+});
+
+describe("recordPayloadOffering", () => {
+    function contextWithParser(): CertStepContext {
+        const cx = contextWith(() => Promise.reject(new InternalError("not used by these tests")));
+        cx.controllers.dut.parseQrPayload = async payload => {
+            const { version, vendorId, productId, flowType, discoveryCapabilities, discriminator, passcode } =
+                qrPayloadFields(payload);
+            return { version, vendorId, productId, flowType, discoveryCapabilities, discriminator, passcode };
+        };
+        return cx;
+    }
+
+    // chip-all-clusters-app's own payload: standard flow, BLE alone
+    const BLE_PAYLOAD = "MT:-24J042C00KA0648G00";
+
+    it("passes for a standard-flow payload offering the capability asked for", async () => {
+        const cx = contextWithParser();
+
+        await recordPayloadOffering(cx, BLE_PAYLOAD, "ble");
+
+        expect(checksOf(cx).map(({ verdict }) => verdict)).deep.equal(["pass"]);
+    });
+
+    it("fails when the payload offers a capability other than the one asked for", async () => {
+        const cx = contextWithParser();
+
+        await expect(
+            recordPayloadOffering(cx, qrPayloadWith(BLE_PAYLOAD, { discoveryCapabilities: ON_NETWORK_ONLY }), "ble"),
+        ).rejectedWith(CertCheckFailedError, /does not offer ble/);
+    });
+
+    it("fails when the payload names a commissioning flow other than the standard one", async () => {
+        const cx = contextWithParser();
+
+        // The plan's own example payload, which carries the custom flow
+        await expect(recordPayloadOffering(cx, PLAN_PAYLOAD, "onIpNetwork")).rejectedWith(
+            CertCheckFailedError,
+            /flowType 2 rather than the standard flow/,
+        );
     });
 });
 

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1565,6 +1565,52 @@ outcome that satisfies `requireRefusal` also satisfies it, so a malformed genera
 step 4 pass at ~1ms having never reached discovery. The two checks are only a partition because the
 predicate says so.
 
+## A transport the controller has no radio for is not applicable, not skipped (`TC-DD-3.11`)
+
+The plan runs the same three steps over BLE, Wi-Fi PAF and IP: produce a QR code offering that
+capability, scan it, commission over it. A payload's discovery-capability bitmask is what the
+*commissionee* offers, though, and nothing makes a commissioner use it. `InProcessControllerAdapter`
+takes only the discriminator, passcode, vendor and product out of a QR target and discards the bitmask
+entirely, and neither adapter wires a radio — so a commissioning step driven from a BLE payload
+proceeds over IP and passes on a transport it never used.
+
+Those two steps therefore carry `notApplicable`, whose reason reaches the bundle as `skipReason`.
+A PICS gate cannot express it. The value that reaches a step's gate is the device file's, and
+`ci-pics-values` answers `MCORE.DD.DISCOVERY_BLE=1` / `MCORE.DD.DISCOVERY_PAF=0`; the controller
+adapters deliberately declare neither (`controller-adapter.test.ts` holds them to that). So the BLE
+leg is gated by an answer about the TH while the step is about the DUT, and the bundle carries both
+statements side by side — the `notApplicable` text says which subject it means for that reason.
+
+**Unsettled, worth resolving before the next per-transport TC:** the PICS register
+(`chip-test-plans/tools/PICS_Automation/Pics_XML_Files/XML__Files/Base.xml`) defines
+`MCORE.DD.DISCOVERY_BLE` as "Does the commissioner support Discovery Capability over BLE?", which
+makes it a DUT question in TC-DD-3.14 as well, where this directory currently treats it as a TH one.
+If the register governs, the adapters declaring `= 0` would be the cleaner gate and `notApplicable`
+would become unnecessary.
+
+Generating and parsing a payload needs no radio, so those steps are left executable — though only the
+BLE leg's actually run today, since `DISCOVERY_PAF=0` skips the PAF leg entirely. A leg is reported as
+a unit, so its scan step must not outlive its generate step's gate: step 2.b is gated on
+`MCORE.DD.SCAN_QR_CODE & MCORE.DD.DISCOVERY_PAF`, not because it consumes 2.a's artifact (it rebuilds
+its own) but because recording a PAF-leg scan while the PAF leg is out of scope misreads. Step-level
+`pics` takes a full expression (`&`, `|`, `!`, parentheses), and `certTest` parses it at declaration
+time so a typo cannot surface as the step failing.
+
+**A scan step must judge the field that defines its leg.** `recordParse` settles its verdict on the
+discriminator and passcode alone, so every leg's scan step otherwise passes on identical evidence and
+one handed another leg's payload still passes. `recordPayloadOffering` puts the capability and the
+commissioning flow into the verdict, read back through the DUT's own parse.
+
+**The TH's own QR code already satisfies the plan's precondition**, so this TC verifies rather than
+fabricates: both chip builds publish `flowType` 0 — `MT:-24J042C00KA0648G00` from the cert-bins app,
+discovery `0b10`, BLE only, and `MT:-24J0AFN00KA0648G00` from the own-built app, discovery `0b100`,
+OnNetwork. Only the capability bitmask needs substituting. Assert the version explicitly rather than
+through `unchangedFrom`, which supplies it from the source payload and so compares the TH's version
+against itself — the plan's "ensure the Version bit string follows the current Matter spec" is a claim
+about the artifact, not about the TH. Note the plan's own example payload, `MT:-24J029Q00KA0648G00`,
+decodes to `flowType` 2: it is copy-pasted into 3.11, 3.12 and 3.14 from 3.13, the one case whose flow
+value it actually matches.
+
 ## chip-tool delivers one result per async report and discards the rest
 
 `step 4: write 1/3 … produced no subscription report carrying "tc-idm-4-1-a" within 30s`,

--- a/support/chip-testing/test/cert/TC-DD-3.11.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.11.test.ts
@@ -1,0 +1,189 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DiscoveryCapabilitiesSchema } from "@matter/main/types";
+import { certTest } from "@matter/testing";
+import {
+    commissionByQr,
+    ON_NETWORK_ONLY,
+    qrPayloadWith,
+    recordCommissionable,
+    recordGeneratedPayload,
+    recordParse,
+    recordPayloadOffering,
+    STANDARD_FLOW,
+    STANDARD_VERSION,
+    thQrPayload,
+} from "./tc-dd-support.js";
+import { CommissionedRefs } from "./tc-support.js";
+
+/**
+ * Why the two transport-specific commissioning steps cannot be run rather than skipped.
+ *
+ * A payload's discovery-capability bitmask is what the commissionee offers, not what the commissioner
+ * uses, so driving either step on a controller without that radio commissions over IP and records a
+ * pass the transport never earned. The PICS column cannot express it: it answers for the DUT, and the
+ * value reaching this gate comes from the TH's own file.
+ */
+function noRadio(transport: string) {
+    return (
+        `The DUT-commissioner has no ${transport} radio — a commissioning driven from a payload naming ` +
+        `${transport} would proceed over IP and prove nothing about the transport. The PICS value that ` +
+        "reaches this step is the TH's, and answers for the TH"
+    );
+}
+
+const BLE_ONLY = DiscoveryCapabilitiesSchema.encode({ ble: true });
+const WIFI_PAF_ONLY = DiscoveryCapabilitiesSchema.encode({ wifiPublicActionFrame: true });
+
+const commissioned = new CommissionedRefs();
+
+certTest("TC-DD-3.11", {
+    plan: "devicediscovery.adoc",
+    pics: ["MCORE.ROLE.COMMISSIONER", "MCORE.DD.QR_COMMISSIONING", "MCORE.DD.STANDARD_COMM_FLOW"],
+    app: "all-clusters",
+})
+    .step(
+        "1.a",
+        "Standard Commissioning Flow: Use a Commissionee with a QR code that has the Custom Flow field set to 0 " +
+            "and supports BLE for its Discovery Capability. Ensure the Version bit string follows the current " +
+            "Matter spec. documentation.",
+        async cx => {
+            const source = await thQrPayload(cx.devices.th);
+            recordGeneratedPayload(
+                cx,
+                qrPayloadWith(source, { discoveryCapabilities: BLE_ONLY }),
+                {
+                    version: STANDARD_VERSION,
+                    flowType: STANDARD_FLOW,
+                    discoveryCapabilities: BLE_ONLY,
+                    unchangedFrom: source,
+                },
+                "BLE standard-flow payload",
+            );
+        },
+        { pics: "MCORE.DD.DISCOVERY_BLE", expected: "User has a QR code to pass into DUT" },
+    )
+    .step(
+        "1.b",
+        "Scan the QR code from the previous step using the DUT.",
+        async cx => {
+            const payload = qrPayloadWith(await thQrPayload(cx.devices.th), { discoveryCapabilities: BLE_ONLY });
+            await recordParse(cx, payload);
+            await recordPayloadOffering(cx, payload, "ble");
+        },
+        {
+            // A leg's steps stand or fall together: this one scans "the QR code from the previous
+            // step", so it must not run where that step was gated out
+            pics: "MCORE.DD.SCAN_QR_CODE & MCORE.DD.DISCOVERY_BLE",
+            expected: "Verify the QR code has been scanned successfully.",
+        },
+    )
+    .step(
+        "1.c",
+        "Using the DUT, parse the TH's QR code and follow any steps needed for the Commissioner/Commissionee to " +
+            "complete the commissioning process using BLE",
+        async () => {},
+        {
+            notApplicable: noRadio("BLE"),
+            expected: "DUT parses QR code and DUT commissions TH to the Matter network",
+        },
+    )
+    .step(
+        "2.a",
+        "Standard Commissioning Flow: Use a Commissionee with a QR code that has the Custom Flow field set to 0 " +
+            "and supports Wi-Fi PAF for its Discovery Capability. Ensure the Version bit string follows the " +
+            "current Matter spec. documentation.",
+        async cx => {
+            const source = await thQrPayload(cx.devices.th);
+            recordGeneratedPayload(
+                cx,
+                qrPayloadWith(source, { discoveryCapabilities: WIFI_PAF_ONLY }),
+                {
+                    version: STANDARD_VERSION,
+                    flowType: STANDARD_FLOW,
+                    discoveryCapabilities: WIFI_PAF_ONLY,
+                    unchangedFrom: source,
+                },
+                "Wi-Fi PAF standard-flow payload",
+            );
+        },
+        { pics: "MCORE.DD.DISCOVERY_PAF", expected: "User has a QR code to pass into DUT" },
+    )
+    .step(
+        "2.b",
+        "Scan the QR code from the previous step using the DUT.",
+        async cx => {
+            const payload = qrPayloadWith(await thQrPayload(cx.devices.th), {
+                discoveryCapabilities: WIFI_PAF_ONLY,
+            });
+            await recordParse(cx, payload);
+            await recordPayloadOffering(cx, payload, "wifiPublicActionFrame");
+        },
+        {
+            pics: "MCORE.DD.SCAN_QR_CODE & MCORE.DD.DISCOVERY_PAF",
+            expected: "Verify the QR code has been scanned successfully.",
+        },
+    )
+    .step(
+        "2.c",
+        "Using the DUT, parse the TH's QR code and follow any steps needed for the Commissioner/Commissionee to " +
+            "complete the commissioning process using Wi-Fi PAF",
+        async () => {},
+        {
+            notApplicable: noRadio("Wi-Fi PAF"),
+            expected: "DUT parses QR code and DUT commissions TH to the Matter network",
+        },
+    )
+    .step(
+        "3.a",
+        "Standard Commissioning Flow: Use a Commissionee with a QR code that has the Custom Flow field set to 0, " +
+            "supports IP Network for its Discovery Capability and is already on the same IP network as the DUT " +
+            "commissioner. Ensure the Version bit string follows the current Matter spec. documentation.",
+        async cx => {
+            const source = await thQrPayload(cx.devices.th);
+            recordGeneratedPayload(
+                cx,
+                qrPayloadWith(source, { discoveryCapabilities: ON_NETWORK_ONLY }),
+                {
+                    version: STANDARD_VERSION,
+                    flowType: STANDARD_FLOW,
+                    discoveryCapabilities: ON_NETWORK_ONLY,
+                    unchangedFrom: source,
+                },
+                "OnNetwork standard-flow payload",
+            );
+        },
+        { expected: "User has a QR code to pass into DUT" },
+    )
+    .step(
+        "3.b",
+        "Scan the QR code from the previous step using the DUT.",
+        async cx => {
+            const payload = qrPayloadWith(await thQrPayload(cx.devices.th), {
+                discoveryCapabilities: ON_NETWORK_ONLY,
+            });
+            await recordParse(cx, payload);
+            await recordPayloadOffering(cx, payload, "onIpNetwork");
+        },
+        { pics: "MCORE.DD.SCAN_QR_CODE", expected: "Verify the QR code has been scanned successfully." },
+    )
+    .step(
+        "3.c",
+        "Using the DUT, parse the TH's QR code and follow any steps needed for the Commissioner/Commissionee to " +
+            "complete the commissioning process using IP Network",
+        async cx => {
+            const payload = qrPayloadWith(await thQrPayload(cx.devices.th), {
+                discoveryCapabilities: ON_NETWORK_ONLY,
+            });
+            await recordParse(cx, payload);
+            await recordPayloadOffering(cx, payload, "onIpNetwork");
+            await recordCommissionable(cx);
+            await commissionByQr(cx, payload, commissioned);
+        },
+        { expected: "DUT parses QR code and DUT commissions TH to the Matter network" },
+    )
+    .finalize(cx => commissioned.decommissionAll(cx));

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -145,6 +145,55 @@ export async function onNetworkOnlyPayload(cx: CertStepContext): Promise<string>
     return qrPayloadWith(await thQrPayload(cx.devices.th), { discoveryCapabilities: ON_NETWORK_ONLY });
 }
 
+/** § 5.1.3.1 Table 59's version string for this revision of the specification. */
+export const STANDARD_VERSION = 0;
+
+/** § 5.1.3.1 Table 59's standard commissioning flow. */
+export const STANDARD_FLOW = 0;
+
+/**
+ * Records that the DUT reads `payload` as offering `capability` over the standard commissioning flow.
+ *
+ * The capability is what tells one leg of a per-transport plan from another, and the flow is what such
+ * a plan is named for, so both belong in the verdict. Left to the prose, every leg's scan step passes
+ * on the same evidence — that the DUT read some payload's discriminator and passcode — and a step
+ * handed the wrong leg's payload still passes.
+ */
+export async function recordPayloadOffering(
+    cx: CertStepContext,
+    payload: string,
+    capability: keyof typeof DiscoveryCapabilitiesBitmap,
+): Promise<void> {
+    const parsed = await cx.controllers.dut.parseQrPayload(payload);
+    const offered = DiscoveryCapabilitiesSchema.decode(parsed.discoveryCapabilities);
+    const names = Object.entries(offered)
+        .filter(([, set]) => set)
+        .map(([name]) => name);
+
+    const wrong = new Array<string>();
+    if (!offered[capability]) {
+        wrong.push(`does not offer ${capability}`);
+    }
+    if (parsed.flowType !== STANDARD_FLOW) {
+        wrong.push(`carries flowType ${parsed.flowType} rather than the standard flow`);
+    }
+
+    record(
+        cx,
+        {
+            type: "response",
+            verdict: wrong.length ? "fail" : "pass",
+            detail:
+                `DUT read ${payload} as flowType=${parsed.flowType} offering discovery over ` +
+                `${names.join(", ") || "nothing"} (bitmask 0b${parsed.discoveryCapabilities
+                    .toString(2)
+                    .padStart(8, "0")})` +
+                (wrong.length ? `; the payload ${wrong.join(" and ")}` : ""),
+        },
+        `Payload offers ${capability} over the standard flow`,
+    );
+}
+
 /**
  * Records that `payload` does not offer `capability`, read back through the DUT so a controller that
  * cannot report a bitmask fails here rather than silently proving nothing.


### PR DESCRIPTION
TC-DD-3.11 checks that a commissioner can scan a device's QR code and commission it using the standard
commissioning flow. The plan runs the same three steps over three transports — produce a QR code
offering that discovery capability, scan it, commission over it — for BLE, Wi-Fi PAF and IP.

## The IP leg runs; the two transport-specific commissioning steps say why they cannot

A QR payload's discovery-capability bitmask is what the *commissionee* offers, and nothing makes a
commissioner use it. `InProcessControllerAdapter` takes only the discriminator, passcode, vendor and
product out of a QR target and discards the bitmask entirely, and neither controller wires a radio. So
a commissioning step driven from a BLE payload proceeds over IP and passes on a transport it never
used.

That is not hypothetical — it is what the first version of this test did, and it is reproducible. Give
step 1.c the body `recordParse` + `commissionByQr(cx, blePayload, commissioned)` gated on
`MCORE.DD.DISCOVERY_BLE`, then run `MATTER_MDNS_NETWORKINTERFACE=en0 npx matter-test
--spec=test/cert/TC-DD-3.11.test.ts` in `support/chip-testing`. The bundle lands in
`build/cert-evidence/<timestamp>-TC-DD-3.11` and is not committed (`build-clean` wipes it). From that
bundle:

1. `result.json`, step 1.c check 1 — the payload the step used: `discoveryCapabilities=0b00000010`,
   BLE alone.
2. `result.json`, step 1.c — `"verdict": "pass"`, check 2 `commissioned as node 1`.
3. `device-th.log` — the PASE arrives as `SC/PbkdfParamRequest ... •unsecured#d0af86de2d9fb8ff` on the
   UDP channel the TH opened at startup (`NodejsChannel ... type: udp4`). The file carries no BLE or
   BTP transport line: the only `ble` matches in it are the step text and the check detail echoed into
   the log.

The run corroborates; it is not the primary justification. That one is static — the adapter discards
the bitmask, so the step could not have proven the transport whatever any run showed.

Both commissioning steps therefore carry `notApplicable`, whose reason reaches the bundle as
`skipReason`. A PICS gate cannot express it: the value that reaches a step's gate is the *device*
file's, and `ci-pics-values` answers `MCORE.DD.DISCOVERY_BLE=1`, while the step is about the DUT. The
reason text names which subject it means, because the bundle otherwise carries both statements side by
side with no way to reconcile them.

Generating and parsing such a payload needs no radio, so those steps stay executable — though only the
BLE leg's run today, since `MCORE.DD.DISCOVERY_PAF=0` skips the PAF leg entirely.

## Verified rather than fabricated

The TH's own QR code already satisfies the plan's precondition. Both chip builds publish `flowType` 0:
`MT:-24J042C00KA0648G00` from the cert-bins app (discovery `0b10`, BLE only) and
`MT:-24J0AFN00KA0648G00` from the own-built app (discovery `0b100`, OnNetwork). Only the capability
bitmask is substituted.

The version is asserted against the specification's value rather than through `unchangedFrom`, which
supplies it from the source payload and so would compare the TH's version against itself. The plan's
"ensure the Version bit string follows the current Matter spec" is a claim about the artifact.

A scan step judges the capability and the commissioning flow that define its leg, read back through the
DUT's own parse (`recordPayloadOffering`). `recordParse` settles its verdict on the discriminator and
passcode alone, so without this every leg's scan step passes on identical evidence, and a step handed
another leg's payload still passes.

The commissioning step proves the TH was advertising before it begins, so a TH that stopped advertising
after an earlier attempt is not recorded as the DUT failing.

## One framework change

A leg is reported as a unit, so a scan step must not outlive its generate step's gate — which makes
this the first step-level PICS gate in the suite to carry an operator. `certTest` now parses a step's
PICS expression where it is declared. Reaching the run, a malformed one (`&&` instead of `&`, a trap
the code's own comment already flags) is caught by the per-step handler and recorded as **the step
failing**, i.e. blamed on the device under test.

## Left unsettled, deliberately

The PICS register (`chip-test-plans/tools/PICS_Automation/Pics_XML_Files/XML__Files/Base.xml`) defines
`MCORE.DD.DISCOVERY_BLE` as "Does the commissioner support Discovery Capability over BLE?" — a DUT
question. This directory currently treats it as a TH question in TC-DD-3.14, and a test deliberately
holds both adapters to declaring neither key. If the register governs, adapters declaring `= 0` would
be the cleaner gate here and `notApplicable` would become unnecessary. That is a cross-cutting decision
about PICS scoping, so it is written up in `AGENTS.md` rather than decided in this PR.

## Verification

From the repository root: `npm run build-clean` exit 0, `npm run format-verify` exit 0, `npm run lint`
exit 0, `npm test` exit 0. In `support/chip-testing`: `npm run test-cert-framework` pass, and the full
local cert leg (`MATTER_MDNS_NETWORKINTERFACE=en0 npm run test-cert`) pass, with TC-DD-3.11 recording
`1.a=pass 1.b=pass 1.c=skipped 2.a=skipped 2.b=skipped 2.c=skipped 3.a=pass 3.b=pass 3.c=pass`,
`picsSkips: 2`.

Mutation-proven, each against the named step:

| assertion defeated | red |
|---|---|
| the version is the specification's | step 1.a |
| the scan judges its own leg's capability | step 1.b (given the wrong leg's capability, previously passed) |
| the flow is the standard flow | step 1.a |
| a step's PICS expression is parsed at declaration time | `rejects a malformed step PICS expression at declaration time` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
