### PR TITLE
Stop the level transition's remaining time at zero, and report it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/node
     - Fix: `Stop` and `StopWithOnOff` set `RemainingTime` to zero and report it, including where the application manages transitions and stated an end time
-    - Breaking: `LevelControlServer` and `ColorControlServer` state `transitionEndTimeMs` is now `transitionEndTime`, a `Timestamp`; the value is unchanged but the name and type are not
+    - Breaking: The `transitionEndTimeMs` state field on `LevelControlServer` and `ColorControlServer` is now `transitionEndTime`, a `Timestamp`; the value is unchanged but the name and type are not
     - Fix: `MoveToLevelWithOnOff`, `MoveWithOnOff` and `StepWithOnOff` build their options from the Options attribute and the request's mask and override, so `CoupleColorTempToLevel` couples color temperature to the level for them as it already did for `MoveToLevel`, `Move` and `Step`
     - Fix: `StopWithOnOff` stops a transition on a device that is off; the ExecuteIfOff option gates the commands without On/Off only
     - Fix: `MoveWithOnOff` and `StepWithOnOff` turn the device off when the level they reach is the minimum, and leave a device that is off alone when the level moves down

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A constraint that bounds a value by a field named like a constraint keyword, such as the `Min` of ClosureDimension's range structs, survives serialization
 
 - @matter/node
+    - Fix: `Stop` and `StopWithOnOff` set `RemainingTime` to zero and report it, including where the application manages transitions and stated an end time
+    - Breaking: `LevelControlServer` and `ColorControlServer` state `transitionEndTimeMs` is now `transitionEndTime`, a `Timestamp`; the value is unchanged but the name and type are not
     - Fix: `MoveToLevelWithOnOff`, `MoveWithOnOff` and `StepWithOnOff` build their options from the Options attribute and the request's mask and override, so `CoupleColorTempToLevel` couples color temperature to the level for them as it already did for `MoveToLevel`, `Move` and `Step`
     - Fix: `StopWithOnOff` stops a transition on a device that is off; the ExecuteIfOff option gates the commands without On/Off only
     - Fix: `MoveWithOnOff` and `StepWithOnOff` turn the device off when the level they reach is the minimum, and leave a device that is off alone when the level moves down

--- a/packages/node/src/behavior/Transitions.ts
+++ b/packages/node/src/behavior/Transitions.ts
@@ -331,6 +331,51 @@ export class Transitions<B extends Behavior> {
     }
 
     /**
+     * Stop a transition of one or more attributes at the request of a command.
+     *
+     * Unlike {@link finish} the transition has not reached its target value, and unlike {@link stop} the remaining
+     * time of the transitions this instance manages becomes zero and is reported, which the specification requires
+     * whenever it changes to zero.  Where the transition time is stated elsewhere the caller owns clearing it.
+     */
+    cancel(name?: Transitions.PropertyOf<B>): void {
+        // The value read before the transition ends is what the change is measured against
+        const previousRemainingTime = this.remainingTime;
+
+        const names = typeof name === "string" ? [name] : [...this].map(({ name }) => name);
+
+        this.stop(name);
+
+        for (const stopped of names) {
+            const event = (this.#endpoint.events as Events.Generic<ClusterEvents.ChangedObservable<any>>)[
+                this.#config.type.id
+            ]?.[`${stopped}$Changed`];
+
+            // Per specification a quieter event always emits at the end of a transition, and a command that stops one
+            // ends it
+            if (event?.isQuieter) {
+                event.quiet.emitNow();
+            }
+        }
+
+        if (Object.keys(this.#propertyStates).length) {
+            // Other transitions are ongoing, but ending the longest of them shortens the remaining time, which is
+            // reportable where a command causes it to change by more than the reporting floor
+            this.#updateRemainingTime(undefined, true);
+            return;
+        }
+
+        this.#staticRemainingTime = 0;
+
+        // Nothing publishes the remaining time where the transition is managed elsewhere, so the value that was
+        // readable is the baseline; without it the report of zero looks like no change
+        if (previousRemainingTime > 10) {
+            this.#prevPublishedRemainingTime = previousRemainingTime;
+        }
+
+        this.#updateRemainingTime(0);
+    }
+
+    /**
      * Free resources.
      */
     async close() {
@@ -361,8 +406,8 @@ export class Transitions<B extends Behavior> {
      */
     get remainingTime() {
         if (this.#config.manageTransitions === false) {
-            if (this.#config.transitionEndTimeMs !== undefined) {
-                const remaining = Timespan(Time.nowMs, this.#config.transitionEndTimeMs).duration;
+            if (this.#config.transitionEndTime !== undefined) {
+                const remaining = Timespan(Time.nowMs, this.#config.transitionEndTime).duration;
                 if (remaining < 0) {
                     return 0;
                 }
@@ -696,7 +741,7 @@ export namespace Transitions {
         /**
          * The end time for a transition if transition management is disabled.
          */
-        readonly transitionEndTimeMs?: number;
+        readonly transitionEndTime?: Timestamp;
 
         /**
          * An observable associated with the "remaining time" value.

--- a/packages/node/src/behaviors/color-control/ColorControlServer.ts
+++ b/packages/node/src/behaviors/color-control/ColorControlServer.ts
@@ -21,6 +21,7 @@ import {
     Logger,
     MaybePromise,
     Millis,
+    type Timestamp,
 } from "@matter/general";
 import { Val } from "@matter/protocol";
 import { Status, StatusResponseError } from "@matter/types";
@@ -1655,8 +1656,8 @@ export class ColorControlBaseServer extends ColorControlBase {
                 return readOnlyState.managedTransitionTimeHandling;
             },
 
-            get transitionEndTimeMs() {
-                return readOnlyState.transitionEndTimeMs;
+            get transitionEndTime() {
+                return readOnlyState.transitionEndTime;
             },
 
             get stepInterval() {
@@ -1916,7 +1917,7 @@ export namespace ColorControlBaseServer {
          * If transition management is disabled you may specify this as the "end time" for transitions.  The remaining
          * time attribute will then report correctly.
          */
-        transitionEndTimeMs?: number;
+        transitionEndTime?: Timestamp;
 
         /**
          * When managing transitions, this is the interval at which steps occur in ms.
@@ -1955,7 +1956,8 @@ export namespace ColorControlBaseServer {
     }
 
     export class Events extends ColorControlBase.Events {
-        transitionEndTime$Changed = AsyncObservable<[value: number, oldValue: number, context: ActionContext]>();
+        transitionEndTime$Changed =
+            AsyncObservable<[value: Timestamp | undefined, oldValue: Timestamp | undefined, context: ActionContext]>();
     }
 
     export declare const ExtensionInterface: {

--- a/packages/node/src/behaviors/level-control/LevelControlServer.ts
+++ b/packages/node/src/behaviors/level-control/LevelControlServer.ts
@@ -22,6 +22,7 @@ import {
     MaybePromise,
     Millis,
     type Transaction,
+    type Timestamp,
 } from "@matter/general";
 import { Val } from "@matter/protocol";
 import { Status, StatusResponseError } from "@matter/types";
@@ -174,8 +175,8 @@ export class LevelControlBaseServer extends LevelControlBase {
                 return readOnlyState.managedTransitionTimeHandling;
             },
 
-            get transitionEndTimeMs() {
-                return readOnlyState.transitionEndTimeMs;
+            get transitionEndTime() {
+                return readOnlyState.transitionEndTime;
             },
 
             get stepInterval() {
@@ -502,7 +503,19 @@ export class LevelControlBaseServer extends LevelControlBase {
      * Default stop logic. This aborts any level transition currently underway and sets the remaining time to 0.
      */
     protected stopLogic(_options: LevelControl.Options = {}): MaybePromise {
-        this.internal.transitions?.stop();
+        this.internal.transitions?.cancel();
+
+        // Where the application manages transitions it states the end time, and the remaining time is computed from it
+        // until it passes
+        if (this.state.transitionEndTime === undefined) {
+            return;
+        }
+
+        // A transition step holds this behavior's lock across its own await, so a synchronous write here fails a stop
+        // that lands mid-step
+        return MaybePromise.then(this.context.transaction.lock(this), () => {
+            this.state.transitionEndTime = undefined;
+        });
     }
 
     /**
@@ -780,8 +793,10 @@ export namespace LevelControlBaseServer {
         /**
          * If transition management is disabled you may specify this as the "end time" for transitions.  The remaining
          * time attribute will then report correctly.
+         *
+         * A stop clears this, because the remaining time is zero once the transition ends.
          */
-        transitionEndTimeMs = undefined;
+        transitionEndTime: Timestamp | undefined = undefined;
 
         /**
          * When managing transitions, this is the interval at which steps occur in ms.
@@ -809,7 +824,8 @@ export namespace LevelControlBaseServer {
     }
 
     export class Events extends LevelControlBase.Events {
-        transitionEndTime$Changed = AsyncObservable<[value: number, oldValue: number, context: ActionContext]>();
+        transitionEndTime$Changed =
+            AsyncObservable<[value: Timestamp | undefined, oldValue: Timestamp | undefined, context: ActionContext]>();
     }
 
     export declare const ExtensionInterface: {

--- a/packages/node/test/behaviors/level-control/RemainingTimeTest.ts
+++ b/packages/node/test/behaviors/level-control/RemainingTimeTest.ts
@@ -5,6 +5,7 @@
  */
 
 import { DimmableLightDevice } from "#devices/dimmable-light";
+import { Timestamp } from "@matter/general";
 import { MockServerNode } from "../../node/mock-server-node.js";
 
 async function transitioningLight() {
@@ -50,6 +51,49 @@ describe("LevelControl RemainingTime", () => {
         await node.close(10);
     });
 
+    it("reads zero and reports it when a stop ends the transition", async () => {
+        const { node, endpoint } = await transitioningLight();
+
+        const reports = new Array<number>();
+        endpoint.events.levelControl.remainingTime$Changed.on(value => void reports.push(value));
+
+        await advance(10);
+        expect(endpoint.state.levelControl.remainingTime).greaterThan(0);
+
+        await node.online({ command: true }, async agent => {
+            await endpoint.agentFor(agent.context).levelControl.stop({ optionsMask: {}, optionsOverride: {} });
+        });
+
+        expect(endpoint.state.levelControl.remainingTime).equals(0);
+
+        // The specification requires a report whenever the remaining time changes to zero, and only then
+        expect(reports).deep.equals([0]);
+
+        await node.close(10);
+    });
+
+    it("reports nothing for a stop with no transition underway", async () => {
+        MockTime.reset();
+
+        const node = await MockServerNode.createOnline(undefined, { device: undefined });
+        const endpoint = await node.add(DimmableLightDevice, {
+            onOff: { onOff: true },
+            levelControl: { managedTransitionTimeHandling: true, currentLevel: 100 },
+        });
+
+        const reports = new Array<number>();
+        endpoint.events.levelControl.remainingTime$Changed.on(value => void reports.push(value));
+
+        await node.online({ command: true }, async agent => {
+            await endpoint.agentFor(agent.context).levelControl.stop({ optionsMask: {}, optionsOverride: {} });
+        });
+
+        expect(reports).deep.equals([]);
+        expect(endpoint.state.levelControl.remainingTime).equals(0);
+
+        await node.close(10);
+    });
+
     it("reads zero once the transition completes", async () => {
         const { node, endpoint } = await transitioningLight();
 
@@ -88,6 +132,63 @@ describe("LevelControl RemainingTime with an application-supplied value", () => 
         await advance(10);
 
         expect(endpoint.state.levelControl.remainingTime).greaterThan(0);
+
+        await node.close(10);
+    });
+});
+
+describe("LevelControl RemainingTime with an application-supplied remaining time", () => {
+    before(MockTime.enable);
+
+    it("reads zero after a stop, although the application stated a remaining time", async () => {
+        MockTime.reset();
+
+        const node = await MockServerNode.createOnline(undefined, { device: undefined });
+        const endpoint = await node.add(DimmableLightDevice, {
+            onOff: { onOff: true },
+            levelControl: { currentLevel: 1 },
+        });
+
+        await MockTime.resolve(endpoint.set({ levelControl: { remainingTime: 150 } }), { macrotasks: true });
+        expect(endpoint.state.levelControl.remainingTime).equals(150);
+
+        const reports = new Array<number>();
+        endpoint.events.levelControl.remainingTime$Changed.on(value => void reports.push(value));
+
+        await node.online({ command: true }, async agent => {
+            await endpoint.agentFor(agent.context).levelControl.stop({ optionsMask: {}, optionsOverride: {} });
+        });
+
+        expect(endpoint.state.levelControl.remainingTime).equals(0);
+        expect(reports).deep.equals([0]);
+
+        await node.close(10);
+    });
+});
+
+describe("LevelControl RemainingTime with an application-managed transition", () => {
+    before(MockTime.enable);
+
+    it("reads zero after a stop, although the application stated a later end time", async () => {
+        MockTime.reset();
+
+        const node = await MockServerNode.createOnline(undefined, { device: undefined });
+        const endpoint = await node.add(DimmableLightDevice, {
+            onOff: { onOff: true },
+            levelControl: { currentLevel: 1, transitionEndTime: Timestamp(MockTime.nowMs + 15000) },
+        });
+
+        expect(endpoint.state.levelControl.remainingTime).greaterThan(0);
+
+        const reports = new Array<number>();
+        endpoint.events.levelControl.remainingTime$Changed.on(value => void reports.push(value));
+
+        await node.online({ command: true }, async agent => {
+            await endpoint.agentFor(agent.context).levelControl.stop({ optionsMask: {}, optionsOverride: {} });
+        });
+
+        expect(endpoint.state.levelControl.remainingTime).equals(0);
+        expect(reports).deep.equals([0]);
 
         await node.close(10);
     });


### PR DESCRIPTION
`Stop` and `StopWithOnOff` cleared the transition but left `RemainingTime` alone. Two consequences:

- The attribute never reported reaching zero. The specification lists "when it changes to 0" as a reportable case for `RemainingTime`, alongside the two delta cases, so a subscribed controller never learned the movement had ended.
- Where the application manages transitions and states an end time, the attribute kept counting down, because nothing cleared it. The specification is explicit for Stop: "The value of CurrentLevel SHALL be left at its value upon receipt of the Stop command, and RemainingTime SHALL be set to zero."

`Transitions` gains `cancel()` for a transition a command ends, distinct from `finish()` for one that reached its target and from `stop()`, which is internal teardown and must stay silent — it also runs during `close()`. `cancel()` stops the transition, flushes the quiet event of each property it halted the way `finish` does, and reports a remaining time of zero. Where other transitions continue it reports the shortened time instead, since ending the longest of them changes the value in its own right.

That report needed a baseline. `#updateRemainingTime` measures the change against what was last *published*, and nothing publishes the remaining time where the transition is managed elsewhere, so the value stays zero and a report of zero reads as no change and is suppressed. `cancel` therefore reads the value before ending the transition and, where it exceeded the specification's one-second reporting floor, treats it as the baseline.

`stopLogic` clears the end time the application stated. It takes the behavior's lock first: a managed transition step holds that lock across its own await, so a synchronous write would throw `SynchronousTransactionConflictError` and fail a stop that lands mid-step.

## The end time is now a `Timestamp`

`transitionEndTimeMs` was a plain number whose declared type was the inferred `undefined`, so the end time the feature exists for could not be assigned without a cast. It is now `transitionEndTime`, typed `Timestamp`, on both `LevelControlServer` and `ColorControlServer`. The value is unchanged, and the field is a synthetic extension field, so it neither persists nor maps to an attribute.

The rename also matches the `transitionEndTime$Changed` event both clusters already declared. `Datasource.changedEventFor` looks up `<field>$Changed`, so under the old name that event could never fire and an application had no way to observe the field — which matters now that a stop clears it.

## Tests

Seven cases in `RemainingTimeTest`, asserting the report list exactly rather than just its last entry:

- a stop mid-transition reads zero and reports `[0]`
- a stop with no transition underway reports nothing, which is the invariant the baseline change could have broken
- an application-supplied remaining time reads zero after a stop and reports `[0]`
- an application-stated end time in the future reads zero after a stop and reports `[0]`

Each added branch was mutation-checked: removing the baseline fails the two application-managed cases, and removing the static-value reset fails the application-supplied case.

## Certification

The only Level Control certification test that sends a Stop is `Test_TC_LVL_6_1`, which reads `CurrentLevel` and neither reads nor subscribes to `RemainingTime`, so nothing there is newly satisfied or newly violated. `Test_TC_LVL_2_3` asserts an exact report count over a wildcard subscription but sends no Stop, and `stop()`'s existing callers — transition start, error and close — are untouched, so no report is injected into any timed path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)