### PR TITLE
Stop Color Control's remaining time at zero, and report it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/node
     - Fix: `Stop` and `StopWithOnOff` set `RemainingTime` to zero and report it, including where the application manages transitions and stated an end time
+    - Fix: `StopMoveStep` and `MoveColor` with both rates zero set Color Control's `RemainingTime` to zero and report it, and clear the end time stated where the application manages transitions. `StopMoveStep` leaves the remaining time alone while a color loop runs, since a color loop ends only on `ColorLoopSet`
+    - Fix: A Color Control color mode switch no longer discards the promise from `stopAllColorMovement()`, so an asynchronous override of it completes before the color values are converted
     - Breaking: The `transitionEndTimeMs` state field on `LevelControlServer` and `ColorControlServer` is now `transitionEndTime`, a `Timestamp`; the value is unchanged but the name and type are not
     - Fix: `MoveToLevelWithOnOff`, `MoveWithOnOff` and `StepWithOnOff` build their options from the Options attribute and the request's mask and override, so `CoupleColorTempToLevel` couples color temperature to the level for them as it already did for `MoveToLevel`, `Move` and `Step`
     - Fix: `StopWithOnOff` stops a transition on a device that is off; the ExecuteIfOff option gates the commands without On/Off only

--- a/packages/node/src/behaviors/color-control/ColorControlServer.ts
+++ b/packages/node/src/behaviors/color-control/ColorControlServer.ts
@@ -1221,8 +1221,9 @@ export class ColorControlBaseServer extends ColorControlBase {
         }
 
         // An active color loop is stopped by ColorLoopSet alone, so a transition survives this command and the
-        // remaining time is not this command's to end
-        if (this.state.colorLoopActive !== ColorControl.ColorLoopActive.Inactive) {
+        // remaining time is not this command's to end.  Without the ColorLoop feature the attribute reads undefined,
+        // so only an explicitly active loop may bypass the end of the transition
+        if (this.state.colorLoopActive === ColorControl.ColorLoopActive.Active) {
             return this.stopMoveStepLogic();
         }
 
@@ -1237,7 +1238,7 @@ export class ColorControlBaseServer extends ColorControlBase {
      * @protected
      */
     protected stopMoveStepLogic(): MaybePromise {
-        if (this.state.colorLoopActive === ColorControl.ColorLoopActive.Inactive) {
+        if (this.state.colorLoopActive !== ColorControl.ColorLoopActive.Active) {
             this.internal.transitions?.stop("enhancedCurrentHue");
         }
         this.internal.transitions?.stop("currentHue");

--- a/packages/node/src/behaviors/color-control/ColorControlServer.ts
+++ b/packages/node/src/behaviors/color-control/ColorControlServer.ts
@@ -826,7 +826,7 @@ export class ColorControlBaseServer extends ColorControlBase {
         }
 
         if (rateX === 0 && rateY === 0) {
-            return this.stopAllColorMovement();
+            return MaybePromise.then(this.stopAllColorMovement(), () => this.#endTransitions());
         }
 
         return MaybePromise.then(this.setColorMode(ColorControl.ColorMode.CurrentXAndCurrentY), () =>
@@ -1219,7 +1219,14 @@ export class ColorControlBaseServer extends ColorControlBase {
         if (!this.#optionsAllowExecution(optionsMask, optionsOverride)) {
             return;
         }
-        return this.stopMoveStepLogic();
+
+        // An active color loop is stopped by ColorLoopSet alone, so a transition survives this command and the
+        // remaining time is not this command's to end
+        if (this.state.colorLoopActive !== ColorControl.ColorLoopActive.Inactive) {
+            return this.stopMoveStepLogic();
+        }
+
+        return MaybePromise.then(this.stopMoveStepLogic(), () => this.#endTransitions());
     }
 
     /**
@@ -1447,7 +1454,7 @@ export class ColorControlBaseServer extends ColorControlBase {
         if (oldMode === newMode) {
             return;
         }
-        MaybePromise.then(this.stopAllColorMovement(), () => {
+        return MaybePromise.then(this.stopAllColorMovement(), () => {
             switch (oldMode) {
                 case ColorControl.ColorMode.CurrentHueAndCurrentSaturation:
                     if (this.state.currentHue === undefined || this.state.currentSaturation === undefined) {
@@ -1712,6 +1719,27 @@ export class ColorControlBaseServer extends ColorControlBase {
         }
 
         return this.internal.transitions?.start(transition);
+    }
+
+    /**
+     * End the cluster's transition at the request of a command that stops every movement.
+     *
+     * The remaining time becomes zero and is reported, which the specification requires whenever it changes to zero.
+     * The end time stated where the application manages transitions describes the movement that is now over, so it no
+     * longer applies either.
+     */
+    #endTransitions(): MaybePromise {
+        this.internal.transitions?.cancel();
+
+        if (this.state.transitionEndTime === undefined) {
+            return;
+        }
+
+        // A transition step holds this behavior's lock across its own await, so a synchronous write here fails a stop
+        // that lands mid-step
+        return MaybePromise.then(this.context.transaction.lock(this), () => {
+            this.state.transitionEndTime = undefined;
+        });
     }
 
     #getBootReason() {

--- a/packages/node/test/behaviors/color-control/ColorControlServerTest.ts
+++ b/packages/node/test/behaviors/color-control/ColorControlServerTest.ts
@@ -6,9 +6,14 @@
 
 import { ColorControlServer } from "#behaviors/color-control";
 import { ExtendedColorLightDevice } from "#devices/extended-color-light";
-import { Duration, Time, Timespan } from "@matter/general";
+import { Agent } from "#endpoint/Agent.js";
+import { Duration, MaybePromise, Millis, Time, Timespan, Timestamp } from "@matter/general";
 import { ColorControl } from "@matter/types/clusters/color-control";
 import { MockServerNode } from "../../node/mock-server-node.js";
+
+const ColorLightDevice = ExtendedColorLightDevice.with(
+    ColorControlServer.with("HueSaturation", "EnhancedHue", "ColorLoop", "Xy", "ColorTemperature"),
+);
 
 describe("ColorControlServer", () => {
     it("transitions cyclic hue downwards with correct events", async () => {
@@ -60,10 +65,10 @@ describe("ColorControlServer", () => {
     });
 });
 
-async function setup() {
+async function setup(state?: { managedTransitionTimeHandling: boolean }) {
     MockTime.reset();
 
-    const { node, endpoint } = await initializeDimmableHueLight();
+    const { node, endpoint } = await initializeDimmableHueLight(state);
 
     const events = Array<{
         kind: "hue" | "time";
@@ -71,10 +76,13 @@ async function setup() {
         ms: Duration;
     }>();
 
+    const reports = Array<number>();
+
     let last = Time.nowMs;
 
     endpoint.events.colorControl.remainingTime$Changed!.online.on(value => {
         events.push({ kind: "time", value, ms: Timespan(last, Time.nowMs).duration });
+        reports.push(value);
         last = Time.nowMs;
     });
 
@@ -91,35 +99,237 @@ async function setup() {
         }),
     );
 
-    return { node, endpoint, events, complete };
+    const invoke = async (actor: (agent: Agent.Instance<typeof ColorLightDevice>) => MaybePromise) => {
+        await node.online({ command: true }, async agent => {
+            await actor(endpoint.agentFor(agent.context));
+        });
+    };
+
+    return { node, endpoint, events, reports, complete, invoke };
 }
 
-async function initializeDimmableHueLight() {
+async function initializeDimmableHueLight(state?: { managedTransitionTimeHandling: boolean }) {
     const node = await MockServerNode.createOnline(undefined, {
         device: undefined,
     });
 
-    const endpoint = await node.add(
-        ExtendedColorLightDevice.with(ColorControlServer.with("HueSaturation", "Xy", "ColorTemperature")),
-        {
-            onOff: { onOff: true },
-            levelControl: {
-                currentLevel: 254,
-            },
-            colorControl: {
-                managedTransitionTimeHandling: true,
-                colorTempPhysicalMinMireds: 153,
-                colorTempPhysicalMaxMireds: 370,
-                colorMode: ColorControl.ColorMode.CurrentHueAndCurrentSaturation,
-                enhancedColorMode: ColorControl.EnhancedColorMode.CurrentHueAndCurrentSaturation,
-                remainingTime: 0,
-                options: { executeIfOff: true },
-                numberOfPrimaries: 0,
-                coupleColorTempToLevelMinMireds: 153,
-                startUpColorTemperatureMireds: null,
-            },
+    const endpoint = await node.add(ColorLightDevice, {
+        onOff: { onOff: true },
+        levelControl: {
+            currentLevel: 254,
         },
-    );
+        colorControl: {
+            managedTransitionTimeHandling: state?.managedTransitionTimeHandling ?? true,
+            colorTempPhysicalMinMireds: 153,
+            colorTempPhysicalMaxMireds: 370,
+            colorMode: ColorControl.ColorMode.CurrentHueAndCurrentSaturation,
+            enhancedColorMode: ColorControl.EnhancedColorMode.CurrentHueAndCurrentSaturation,
+            remainingTime: 0,
+            options: { executeIfOff: true },
+            numberOfPrimaries: 0,
+            coupleColorTempToLevelMinMireds: 153,
+            startUpColorTemperatureMireds: null,
+        },
+    });
 
     return { node, endpoint };
+}
+
+describe("ColorControl stop", () => {
+    before(MockTime.enable);
+
+    it("reports zero remaining time on StopMoveStep", async () => {
+        const { node, endpoint, reports, invoke } = await transitioningColorTemperature();
+
+        await invoke(agent =>
+            agent.colorControl.stopMoveStep({
+                optionsMask: {},
+                optionsOverride: {},
+            }),
+        );
+
+        expect(reports).deep.equals([100, 0]);
+        expect(endpoint.state.colorControl.remainingTime).equals(0);
+
+        await node.close();
+    });
+
+    it("reports zero once where StopMoveStep ends several transitions", async () => {
+        const { node, reports, invoke } = await setup();
+
+        await invoke(agent =>
+            agent.colorControl.moveToHue({
+                hue: 200,
+                direction: ColorControl.Direction.Up,
+                transitionTime: 200,
+                optionsMask: {},
+                optionsOverride: {},
+            }),
+        );
+
+        await invoke(agent =>
+            agent.colorControl.moveToSaturation({
+                saturation: 254,
+                transitionTime: 100,
+                optionsMask: {},
+                optionsOverride: {},
+            }),
+        );
+
+        expect(reports).deep.equals([200]);
+
+        await invoke(agent =>
+            agent.colorControl.stopMoveStep({
+                optionsMask: {},
+                optionsOverride: {},
+            }),
+        );
+
+        expect(reports).deep.equals([200, 0]);
+
+        await node.close();
+    });
+
+    it("reports zero remaining time on MoveColor with zero rates", async () => {
+        const { node, endpoint, reports, invoke } = await setup();
+
+        await invoke(agent =>
+            agent.colorControl.moveToColor({
+                colorX: 32768,
+                colorY: 19660,
+                transitionTime: 100,
+                optionsMask: {},
+                optionsOverride: {},
+            }),
+        );
+
+        await invoke(agent =>
+            agent.colorControl.moveColor({
+                rateX: 0,
+                rateY: 0,
+                optionsMask: {},
+                optionsOverride: {},
+            }),
+        );
+
+        expect(reports).deep.equals([100, 0]);
+        expect(endpoint.state.colorControl.remainingTime).equals(0);
+
+        await node.close();
+    });
+
+    it("clears the end time the application states on StopMoveStep", async () => {
+        const { node, endpoint, reports, invoke } = await setup({ managedTransitionTimeHandling: false });
+
+        await endpoint.set({
+            colorControl: { transitionEndTime: Timestamp(Time.nowMs + 10_000) },
+        });
+
+        expect(endpoint.state.colorControl.remainingTime).equals(100);
+
+        await invoke(agent =>
+            agent.colorControl.stopMoveStep({
+                optionsMask: {},
+                optionsOverride: {},
+            }),
+        );
+
+        expect(reports).deep.equals([0]);
+        expect(endpoint.state.colorControl.transitionEndTime).equals(undefined);
+        expect(endpoint.state.colorControl.remainingTime).equals(0);
+
+        await node.close();
+    });
+
+    it("leaves the remaining time alone on StopMoveStep while a color loop runs", async () => {
+        const { node, endpoint, reports, invoke } = await setup();
+
+        await invoke(agent =>
+            agent.colorControl.colorLoopSet({
+                updateFlags: { updateAction: true },
+                action: ColorControl.ColorLoopAction.ActivateFromEnhancedCurrentHue,
+                direction: ColorControl.ColorLoopDirection.Increment,
+                time: 25,
+                startHue: 0,
+                optionsMask: {},
+                optionsOverride: {},
+            }),
+        );
+
+        await invoke(agent =>
+            agent.colorControl.moveToSaturation({
+                saturation: 254,
+                transitionTime: 100,
+                optionsMask: {},
+                optionsOverride: {},
+            }),
+        );
+
+        expect(reports).deep.equals([100]);
+
+        await invoke(agent =>
+            agent.colorControl.stopMoveStep({
+                optionsMask: {},
+                optionsOverride: {},
+            }),
+        );
+
+        expect(reports).deep.equals([100]);
+        expect(endpoint.state.colorControl.colorLoopActive).equals(ColorControl.ColorLoopActive.Active);
+
+        const hueBefore = endpoint.state.colorControl.enhancedCurrentHue;
+        await MockTime.advance(Millis(1000));
+        await MockTime.yield();
+
+        expect(endpoint.state.colorControl.enhancedCurrentHue).not.equals(hueBefore);
+
+        await node.close();
+    });
+
+    // Characterization test: a color mode switch ends the transitions it replaces silently, so the remaining time the
+    // client sees is the one the new transition states
+    it("reports only the new remaining time where a command switches color mode", async () => {
+        const { node, endpoint, reports, invoke } = await setup();
+
+        await invoke(agent =>
+            agent.colorControl.moveToHue({
+                hue: 200,
+                direction: ColorControl.Direction.Up,
+                transitionTime: 200,
+                optionsMask: {},
+                optionsOverride: {},
+            }),
+        );
+
+        await invoke(agent =>
+            agent.colorControl.moveToColorTemperature({
+                colorTemperatureMireds: 370,
+                transitionTime: 100,
+                optionsMask: {},
+                optionsOverride: {},
+            }),
+        );
+
+        expect(endpoint.state.colorControl.colorMode).equals(ColorControl.ColorMode.ColorTemperatureMireds);
+        expect(reports).deep.equals([200, 100]);
+
+        await node.close();
+    });
+});
+
+async function transitioningColorTemperature() {
+    const result = await setup();
+
+    await result.invoke(agent =>
+        agent.colorControl.moveToColorTemperature({
+            colorTemperatureMireds: 370,
+            transitionTime: 100,
+            optionsMask: {},
+            optionsOverride: {},
+        }),
+    );
+
+    expect(result.endpoint.state.colorControl.remainingTime).greaterThan(0);
+
+    return result;
 }

--- a/packages/node/test/behaviors/color-control/ColorControlServerTest.ts
+++ b/packages/node/test/behaviors/color-control/ColorControlServerTest.ts
@@ -15,6 +15,10 @@ const ColorLightDevice = ExtendedColorLightDevice.with(
     ColorControlServer.with("HueSaturation", "EnhancedHue", "ColorLoop", "Xy", "ColorTemperature"),
 );
 
+const ColorLightDeviceWithoutColorLoop = ExtendedColorLightDevice.with(
+    ColorControlServer.with("HueSaturation", "EnhancedHue", "Xy", "ColorTemperature"),
+);
+
 describe("ColorControlServer", () => {
     it("transitions cyclic hue downwards with correct events", async () => {
         const { node, endpoint, events, complete } = await setup();
@@ -65,10 +69,30 @@ describe("ColorControlServer", () => {
     });
 });
 
-async function setup(state?: { managedTransitionTimeHandling: boolean }) {
+async function setupWithoutColorLoop() {
     MockTime.reset();
 
-    const { node, endpoint } = await initializeDimmableHueLight(state);
+    const node = await MockServerNode.createOnline(undefined, { device: undefined });
+    const endpoint = await node.add(ColorLightDeviceWithoutColorLoop, colorLightState(true));
+
+    const reports = Array<number>();
+    endpoint.events.colorControl.remainingTime$Changed!.online.on(value => {
+        reports.push(value);
+    });
+
+    const invoke = async (actor: (agent: Agent.Instance<typeof ColorLightDeviceWithoutColorLoop>) => MaybePromise) => {
+        await node.online({ command: true }, async agent => {
+            await actor(endpoint.agentFor(agent.context));
+        });
+    };
+
+    return { node, endpoint, reports, invoke };
+}
+
+async function setup(options?: { managedTransitionTimeHandling?: boolean }) {
+    MockTime.reset();
+
+    const { node, endpoint } = await initializeDimmableHueLight(options);
 
     const events = Array<{
         kind: "hue" | "time";
@@ -108,18 +132,24 @@ async function setup(state?: { managedTransitionTimeHandling: boolean }) {
     return { node, endpoint, events, reports, complete, invoke };
 }
 
-async function initializeDimmableHueLight(state?: { managedTransitionTimeHandling: boolean }) {
+async function initializeDimmableHueLight(options?: { managedTransitionTimeHandling?: boolean }) {
     const node = await MockServerNode.createOnline(undefined, {
         device: undefined,
     });
 
-    const endpoint = await node.add(ColorLightDevice, {
+    const endpoint = await node.add(ColorLightDevice, colorLightState(options?.managedTransitionTimeHandling ?? true));
+
+    return { node, endpoint };
+}
+
+function colorLightState(managedTransitionTimeHandling: boolean) {
+    return {
         onOff: { onOff: true },
         levelControl: {
             currentLevel: 254,
         },
         colorControl: {
-            managedTransitionTimeHandling: state?.managedTransitionTimeHandling ?? true,
+            managedTransitionTimeHandling,
             colorTempPhysicalMinMireds: 153,
             colorTempPhysicalMaxMireds: 370,
             colorMode: ColorControl.ColorMode.CurrentHueAndCurrentSaturation,
@@ -130,9 +160,7 @@ async function initializeDimmableHueLight(state?: { managedTransitionTimeHandlin
             coupleColorTempToLevelMinMireds: 153,
             startUpColorTemperatureMireds: null,
         },
-    });
-
-    return { node, endpoint };
+    };
 }
 
 describe("ColorControl stop", () => {
@@ -207,6 +235,33 @@ describe("ColorControl stop", () => {
             agent.colorControl.moveColor({
                 rateX: 0,
                 rateY: 0,
+                optionsMask: {},
+                optionsOverride: {},
+            }),
+        );
+
+        expect(reports).deep.equals([100, 0]);
+        expect(endpoint.state.colorControl.remainingTime).equals(0);
+
+        await node.close();
+    });
+
+    // The attribute the color loop carve-out consults is absent without the feature, so it reads undefined rather
+    // than Inactive
+    it("reports zero remaining time on StopMoveStep without the ColorLoop feature", async () => {
+        const { node, endpoint, reports, invoke } = await setupWithoutColorLoop();
+
+        await invoke(agent =>
+            agent.colorControl.moveToColorTemperature({
+                colorTemperatureMireds: 370,
+                transitionTime: 100,
+                optionsMask: {},
+                optionsOverride: {},
+            }),
+        );
+
+        await invoke(agent =>
+            agent.colorControl.stopMoveStep({
                 optionsMask: {},
                 optionsOverride: {},
             }),


### PR DESCRIPTION
## What this fixes

Color Control's `RemainingTime` attribute reports how long the movement underway still has to run. Two commands that stop a movement left it alone: `StopMoveStep`, and `MoveColor` with both rates set to zero. A client that had subscribed to the attribute was therefore never told the movement had ended — the specification requires a report whenever the value changes to zero — and where the application drives the movement itself and told us when it will finish, the attribute went on counting down after the movement had already been stopped.

Both commands now end the cluster's transition once the stop logic has run: the remaining time becomes zero and is reported, and the end time the application stated no longer applies.

The reporting lives in the command method, not in the overridable stop logic. An application that replaces the stop logic to drive its own hardware still meets the conformance requirement.

`StopMoveStep` leaves the remaining time alone while a color loop is active. A color loop is ended only by `ColorLoopSet`, so a movement survives the command and its remaining time is not this command's to zero. The CHIP SDK skips the command altogether in that case (`stopMoveStepCommand` in `src/app/clusters/color-control-server`), so no controller can be relying on a report here.

A color mode switch also discarded the promise from `stopAllColorMovement()`. That is a no-op with the implementation we ship, but an application whose override of that method is asynchronous had its hardware stop running outside the command's transaction. It is now awaited.

## Deliberately not in scope

The commands that stop only *part* of the cluster's movements are unchanged: `MoveHue`, `EnhancedMoveHue` and `MoveSaturation` with MoveMode Stop, and `ColorLoopSet` with action Deactivate.

Where the application manages transitions — the default — there is a single `transitionEndTime` for the whole cluster and no per-property information. A command that stops some movements cannot tell whether one it did not stop is still running, so reporting zero and clearing the end time would be wrong for exactly the case the field exists for. Making those commands report correctly needs a decision about the shape of the end time rather than another guard, so it is filed rather than guessed at.

## Verification

```
$ npm run build-clean
  ✓ Clean (1.1s)
  ✓ Type check (4.3s)
  ✓ Transpile (3.0s)

$ npm run format-verify
All matched files use the correct format.
Finished in 55ms on 2342 files using 14 threads.

$ npm run lint
> oxlint --type-aware --tsconfig tsconfig.json examples packages support
(no findings)

$ npm test
exit 0, no failures
```

Each of the four production branches was proven by reverting it and re-running the suite:

| Reverted | Red tests |
| --- | --- |
| `StopMoveStep` ending the transition | reports zero remaining time on StopMoveStep; reports zero once where StopMoveStep ends several transitions; clears the end time the application states on StopMoveStep |
| the color loop guard | leaves the remaining time alone on StopMoveStep while a color loop runs |
| clearing the stated end time | clears the end time the application states on StopMoveStep |
| `MoveColor` with zero rates ending the transition | reports zero remaining time on MoveColor with zero rates |

The added `return` on the color mode switch changes nothing with the implementation we ship, so it carries no test; the test covering that path is labelled a characterization test.

## Specification

Matter 1.6 §3.2.8.20 (StopMoveStep) — "any MoveTo, Move or Step command currently in process SHALL be terminated … and the RemainingTime attribute SHALL be set to zero".
§3.2.8.13 (MoveColor) — with both rates zero the command has "no effect other than stopping the operation of any previously received command of this cluster".
§3.2.7.4 (RemainingTime) — changes are reportable "when it changes to 0".
§3.2.8 — a color loop "SHALL only be stopped by sending a specific ColorLoopSet command frame with a request to deactivate the color loop".
