### PR TITLE
test(chip-testing): TC-DD-3.20, commissioning a device, unpairing it and commissioning it again

### DIFF
--- a/support/chip-testing/test/cert-framework/tc-cadmin-1.17-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-cadmin-1.17-support.test.ts
@@ -14,10 +14,8 @@ import { NoCommissionedPeerError } from "../../src/cert/InProcessControllerAdapt
 import { ChipToolStartupError } from "../../src/chip-tool/chip-tool-client.js";
 import {
     COMMISSIONING_COMPLETE,
-    fabricSessionsEnded,
     isPostRemovalRefusal,
     removeFabricResponseFailure,
-    removeFabricSucceeded,
     WINDOW_OPEN,
 } from "../cert/tc-cadmin-1.17-support.js";
 import { expectDeviceLog } from "../cert/tc-support.js";
@@ -26,8 +24,6 @@ import { expectDeviceLog } from "../cert/tc-support.js";
 const CHIP = {
     commissioned: "[1787433099.093] [23362:73430237:chip] [SVR] Commissioning completed successfully",
     windowOpen: "[1787433099.731] [23362:73430237:chip] [ZCL] Commissioning window is now open",
-    removed: "[1787433103.742] [23362:73430237:chip] [ZCL] OpCreds: RemoveFabric successful",
-    expiring: "[1787433103.742] [23362:73430237:chip] [IN] Expiring all sessions for fabric 0x2!!",
 };
 
 const MATTERJS = {
@@ -35,9 +31,6 @@ const MATTERJS = {
         "2026-08-23 22:41:11.299 NOTICE GeneralCommissioningClusterHandler Commissioned fabric: 0670b2d454b688b9 (#1) node: 0000000000000001",
     windowOpen:
         "2026-08-23 22:41:11.766 DEBUG AdministratorCommissioningServer Commissioning window timer started for 3m for @1:d8845766d0bbb69f•d9ca.",
-    removed:
-        "2026-08-22 21:48:06.406 INFO ProtocolService Invoke » binford-6100.operationalCredentials.removeFabric @1:9a52bb47a4ee167d•c675⇵68ce✉09f1964b statusCode: 0 fabricIndex: 2",
-    sessionEnded: "2026-08-22 21:48:06.401 INFO Session @2:1946ee4c0f86d574•c677 Session ended",
 };
 
 async function check(flavor: string, patterns: LogExpectPatterns, lines: string[]) {
@@ -68,49 +61,6 @@ describe("TC-CADMIN-1.17's device-log patterns", () => {
     it("does not take a commissioning window for a completed commissioning", async () => {
         expect((await check("chip-local", COMMISSIONING_COMPLETE, [CHIP.windowOpen])).verdict).equal("fail");
         expect((await check("matterjs", COMMISSIONING_COMPLETE, [MATTERJS.windowOpen])).verdict).equal("fail");
-    });
-
-    it("finds the removal of the fabric it asked about", async () => {
-        expect((await check("chip-local", removeFabricSucceeded(2), [CHIP.removed])).verdict).equal("pass");
-        expect((await check("matterjs", removeFabricSucceeded(2), [MATTERJS.removed])).verdict).equal("pass");
-    });
-
-    it("does not take another fabric's removal for the one it asked about", async () => {
-        expect((await check("matterjs", removeFabricSucceeded(3), [MATTERJS.removed])).verdict).equal("fail");
-    });
-
-    it("does not take fabric 20's removal for fabric 2's", async () => {
-        const fabric20 = MATTERJS.removed.replace("fabricIndex: 2", "fabricIndex: 20");
-
-        expect((await check("matterjs", removeFabricSucceeded(2), [fabric20])).verdict).equal("fail");
-    });
-
-    it("does not pass a removal the device answered with a failure status", async () => {
-        const rejected = MATTERJS.removed.replace("statusCode: 0", "statusCode: 11");
-
-        expect((await check("matterjs", removeFabricSucceeded(2), [rejected])).verdict).equal("fail");
-    });
-
-    it("finds the removed fabric's sessions ending in either device's log", async () => {
-        expect((await check("chip-local", fabricSessionsEnded(2), [CHIP.expiring])).verdict).equal("pass");
-        expect((await check("matterjs", fabricSessionsEnded(2), [MATTERJS.sessionEnded])).verdict).equal("pass");
-    });
-
-    it("does not take another fabric's session ending for the removed fabric's", async () => {
-        expect((await check("matterjs", fabricSessionsEnded(1), [MATTERJS.sessionEnded])).verdict).equal("fail");
-        expect((await check("chip-local", fabricSessionsEnded(1), [CHIP.expiring])).verdict).equal("fail");
-    });
-
-    it("does not take fabric 20's session ending for fabric 2's", async () => {
-        const fabric20 = MATTERJS.sessionEnded.replace("@2:", "@20:");
-
-        expect((await check("matterjs", fabricSessionsEnded(2), [fabric20])).verdict).equal("fail");
-    });
-
-    it("does not take a PASE session ending for a removed fabric's", async () => {
-        const unsecured = "2026-08-23 22:41:11.220 INFO Session •unsecured#7372af0fa8e6f033 Session ended";
-
-        expect((await check("matterjs", fabricSessionsEnded(2), [unsecured])).verdict).equal("fail");
     });
 });
 

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -12,8 +12,17 @@ import {
     Millis,
     UnexpectedDataError,
 } from "@matter/main";
-import type { CertNodeApi, CertNodeRef, CertStepContext, CheckRecord, ControllerAdapter } from "@matter/testing";
-import { LogFollower } from "@matter/testing";
+import type {
+    CertDevice,
+    CertNodeApi,
+    CertNodeRef,
+    CertStepContext,
+    CheckRecord,
+    ControllerAdapter,
+    DeviceExitInfo,
+    DeviceFlavor,
+} from "@matter/testing";
+import { LineQueue, LogFollower, PicsFile } from "@matter/testing";
 import { expect } from "chai";
 import { ChipToolCommandError } from "../../src/cert/ChipToolControllerAdapter.js";
 import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload.js";
@@ -29,9 +38,11 @@ import {
     qrPayloadWith,
     qrPayloadWithPrefix,
     recordDiscoveryCapabilityAbsent,
+    recordBackInCommissioningMode,
     recordGeneratedManualCode,
     recordPayloadOffering,
     recordGeneratedPayload,
+    recordUnpair,
     recordVendorOutcome,
 } from "../cert/tc-dd-support.js";
 import { CertCheckFailedError, CertCleanupError, CommissionedRefs } from "../cert/tc-support.js";
@@ -963,5 +974,289 @@ describe("unchangedFrom", () => {
         expect(
             checkGeneratedManualCode("749701123365522327692", { vendorId: 0xfff2, unchangedFrom: PLAN_CODE }).detail,
         ).contain("checkDigit=2 (correct)");
+    });
+});
+
+/**
+ * Drives {@link recordUnpair}/{@link recordBackInCommissioningMode} against a hand-fed TH log and a
+ * {@link CertNodeApi} that answers the two identifier reads, recording the order it was asked in.
+ */
+class UnpairFixture {
+    readonly checks = new Array<CheckRecord>();
+    readonly calls = new Array<string>();
+    readonly cx: CertStepContext;
+    readonly commissioned = new CommissionedRefs();
+    readonly #source = new LineQueue();
+
+    constructor(
+        flavor: DeviceFlavor,
+        options: {
+            fabricIndex?: number;
+            backchannel?: () => void;
+            commission?: () => Promise<CertNodeRef>;
+        } = {},
+    ) {
+        const { fabricIndex = 1, backchannel = () => {} } = options;
+        const log = new LogFollower(this.#source, "th");
+        const unused = () => Promise.reject(new InternalError("not used by these tests"));
+
+        const node: CertNodeApi = {
+            invoke: unused,
+            invokeBatch: unused,
+            readAttributes: unused,
+            writeAttribute: unused,
+            writeAttributes: unused,
+            subscribe: unused,
+            readEvents: unused,
+            subscribeEvents: unused,
+            openCommissioningWindow: unused,
+            readAttribute: async () => {
+                this.calls.push("readFabricIndex");
+                return fabricIndex;
+            },
+            operationalMdnsInstanceName: unused,
+            decommission: async () => {
+                this.calls.push("decommission");
+            },
+        };
+
+        const device: CertDevice = {
+            id: "th",
+            app: "all-clusters",
+            commissioning: { kind: "on-network", passcode: 20202021, discriminator: 3840, qrPairingCode: "" },
+            pics: new PicsFile([]),
+            async initialize() {},
+            async start() {},
+            async stop() {},
+            async close() {},
+            async snapshot() {
+                return {};
+            },
+            async restore() {},
+            backchannel: async () => {
+                this.calls.push("backchannel");
+                backchannel();
+            },
+            flavor,
+            log,
+            exit: new Promise<DeviceExitInfo>(() => {}),
+        };
+
+        const controller: ControllerAdapter = {
+            id: "dut",
+            log,
+            async start() {},
+            async close() {},
+            commission: options.commission ?? unused,
+            parseQrPayload: unused,
+            parseManualPairingCode: unused,
+            node: () => node,
+        };
+
+        this.cx = {
+            devices: { th: device },
+            controllers: { dut: controller },
+            recorder: {
+                beginStep: () => {},
+                check: record => void this.checks.push(record),
+                endStep: () => [],
+                flush: async () => "",
+            },
+        };
+        this.commissioned.set("dut", "peer1" as CertNodeRef);
+    }
+
+    push(...lines: string[]): void {
+        for (const line of lines) {
+            this.#source.push(line);
+        }
+    }
+
+    /** Ends the log, which is what makes a check for a line the TH never printed fail promptly. */
+    close(): void {
+        this.#source.close();
+    }
+}
+
+const CHIP_FABRIC_REMOVED = "[1787433103.742] [23362:73430237:chip] [ZCL] OpCreds: RemoveFabric successful";
+const CHIP_SESSIONS_EXPIRED = "[1787433103.742] [23362:73430237:chip] [IN] Expiring all sessions for fabric 0x1!!";
+const CHIP_SETUP_QR_CODE = "[1787433105.001] [23362:73430237:chip] [SVR] SetupQRCode: [MT:-24J042C00KA0648G00]";
+
+describe("recordUnpair", () => {
+    it("records the removal and the ended sessions, and gives up the ref", async () => {
+        const fixture = new UnpairFixture("chip-local");
+        fixture.push(CHIP_FABRIC_REMOVED, CHIP_SESSIONS_EXPIRED);
+
+        await recordUnpair(fixture.cx, fixture.commissioned);
+
+        expect(fixture.commissioned.get("dut")).equal(undefined);
+        expect(fixture.checks.map(check => `${check.type}:${check.verdict}`)).deep.equal([
+            "response:pass",
+            "device-log:pass",
+            "device-log:pass",
+        ]);
+    });
+
+    // The in-process controller drops the peer as the device announces the removal, so the index the
+    // device assigned this controller cannot be read once the fabric is gone
+    it("reads the fabric index before removing the fabric", async () => {
+        const fixture = new UnpairFixture("chip-local");
+        fixture.push(CHIP_FABRIC_REMOVED, CHIP_SESSIONS_EXPIRED);
+
+        await recordUnpair(fixture.cx, fixture.commissioned);
+
+        expect(fixture.calls).deep.equal(["readFabricIndex", "decommission"]);
+    });
+
+    it("judges both lines against the fabric index the device assigned", async () => {
+        const fixture = new UnpairFixture("chip-local", { fabricIndex: 2 });
+        fixture.push(CHIP_FABRIC_REMOVED, CHIP_SESSIONS_EXPIRED);
+        fixture.close();
+
+        await expect(recordUnpair(fixture.cx, fixture.commissioned)).rejectedWith(CertCheckFailedError);
+
+        // The removal line names no fabric on chip, so only the session line can tell fabric 2 from 1
+        expect(fixture.checks.map(check => check.verdict)).deep.equal(["pass", "pass", "fail"]);
+    });
+
+    // matter.js closes the removed fabric's sessions before it answers the invoke, so a search
+    // starting where the removal matched would never reach them
+    it("finds a session end the TH logged before the removal it answered", async () => {
+        const fixture = new UnpairFixture("matterjs");
+        fixture.push(
+            "2026-08-22 21:48:06.401 INFO Session @1:1946ee4c0f86d574•c677 Session ended",
+            "2026-08-22 21:48:06.406 INFO ProtocolService Invoke » binford-6100.operationalCredentials.removeFabric " +
+                "@1:9a52bb47a4ee167d•c675⇵68ce✉09f1964b statusCode: 0 fabricIndex: 1",
+        );
+
+        await recordUnpair(fixture.cx, fixture.commissioned);
+
+        expect(fixture.checks.map(check => check.verdict)).deep.equal(["pass", "pass", "pass"]);
+    });
+
+    it("fails, but still gives up the ref, when the TH never logs the removal", async () => {
+        const fixture = new UnpairFixture("chip-local");
+        fixture.close();
+
+        await expect(recordUnpair(fixture.cx, fixture.commissioned)).rejectedWith(CertCheckFailedError);
+
+        // The fabric is off the TH whatever the log said, so cleanup must not try to remove it again
+        expect(fixture.commissioned.get("dut")).equal(undefined);
+    });
+
+    it("records both outcomes before failing on the first bad one", async () => {
+        const fixture = new UnpairFixture("chip-local");
+        fixture.push(CHIP_FABRIC_REMOVED);
+        fixture.close();
+
+        await expect(recordUnpair(fixture.cx, fixture.commissioned)).rejectedWith(CertCheckFailedError);
+
+        expect(fixture.checks.map(check => check.verdict)).deep.equal(["pass", "pass", "fail"]);
+    });
+
+    // The bundle must carry the session-end outcome even though the removal check ahead of it is what
+    // fails the step: recording the two in sequence would throw on the first and drop the second
+    it("records the session-end outcome even when the removal check is the one that failed", async () => {
+        const fixture = new UnpairFixture("chip-local");
+        fixture.push(CHIP_SESSIONS_EXPIRED);
+        fixture.close();
+
+        await expect(recordUnpair(fixture.cx, fixture.commissioned)).rejectedWith(CertCheckFailedError);
+
+        expect(fixture.checks.map(check => check.verdict)).deep.equal(["pass", "fail", "pass"]);
+    });
+});
+
+describe("restoreCommissioningMode, through recordVendorOutcome", () => {
+    // The composed path every pre-existing caller uses: an earlier attempt onboarded the TH, so the
+    // next one has to put it back into commissioning mode first.
+    it("resets the TH and gives up the ref before the next attempt", async () => {
+        const fixture = new UnpairFixture("chip-local", {
+            backchannel: () => fixture.push(CHIP_SETUP_QR_CODE),
+            commission: () => Promise.reject(new DiscoveryError("No commissionable device was discovered")),
+        });
+        const probed = new Array<string>();
+
+        await recordVendorOutcome(
+            fixture.cx,
+            "34970112332",
+            fixture.commissioned,
+            new CommissioningRefusals({ refusalTimeout: Millis(50), settleTimeout: Millis(50) }),
+            "vendor outcome",
+            Millis(50),
+            { vendorId: 0xfff2, thVendorId: 0xfff1 },
+            async (_cx, what) => void probed.push(what),
+        );
+
+        expect(fixture.calls).deep.equal(["decommission", "backchannel"]);
+        expect(fixture.commissioned.get("dut")).equal(undefined);
+
+        // The restore's own probe, and no second one: a restore that ran has already proven the TH
+        // is there, so the attempt does not probe again
+        expect(probed).deep.equal(["TH back in commissioning mode"]);
+    });
+
+    // The fabric is off the TH once decommission() resolves, whatever the reset that follows does, so
+    // a ref surrendered only on success would have the finalizer remove a fabric that is gone
+    it("gives up the ref even when the reset that follows never completes", async () => {
+        const fixture = new UnpairFixture("chip-local", { backchannel: () => fixture.close() });
+
+        await expect(
+            recordVendorOutcome(
+                fixture.cx,
+                "34970112332",
+                fixture.commissioned,
+                new CommissioningRefusals({ refusalTimeout: Millis(50), settleTimeout: Millis(50) }),
+                "vendor outcome",
+                Millis(50),
+                { vendorId: 0xfff2, thVendorId: 0xfff1 },
+                async () => {},
+            ),
+        ).rejectedWith(CertCheckFailedError);
+
+        expect(fixture.commissioned.get("dut")).equal(undefined);
+    });
+});
+
+describe("recordBackInCommissioningMode", () => {
+    it("factory-resets a chip TH and waits for the restarted app's own payload", async () => {
+        const fixture = new UnpairFixture("chip-local", { backchannel: () => fixture.push(CHIP_SETUP_QR_CODE) });
+        const probed = new Array<string>();
+
+        await recordBackInCommissioningMode(fixture.cx, "TH advertising again", async (_cx, what) => {
+            probed.push(what);
+        });
+
+        expect(fixture.calls).deep.equal(["backchannel"]);
+        expect(fixture.checks.map(check => check.verdict)).deep.equal(["pass"]);
+        expect(probed).deep.equal(["TH advertising again"]);
+    });
+
+    // A matter.js device returns to commissioning mode when its last fabric goes, so erasing it would
+    // restart a TH that needs nothing
+    it("only probes a matterjs TH", async () => {
+        const fixture = new UnpairFixture("matterjs");
+        const probed = new Array<string>();
+
+        await recordBackInCommissioningMode(fixture.cx, "TH advertising again", async (_cx, what) => {
+            probed.push(what);
+        });
+
+        expect(fixture.calls).deep.equal([]);
+        expect(fixture.checks).deep.equal([]);
+        expect(probed).deep.equal(["TH advertising again"]);
+    });
+
+    it("fails, without probing, when the restarted chip TH never prints its payload", async () => {
+        const fixture = new UnpairFixture("chip-local", { backchannel: () => fixture.close() });
+        const probed = new Array<string>();
+
+        await expect(
+            recordBackInCommissioningMode(fixture.cx, "TH advertising again", async (_cx, what) => {
+                probed.push(what);
+            }),
+        ).rejectedWith(CertCheckFailedError);
+
+        expect(probed).deep.equal([]);
     });
 });

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -987,6 +987,7 @@ class UnpairFixture {
     readonly cx: CertStepContext;
     readonly commissioned = new CommissionedRefs();
     readonly #source = new LineQueue();
+    readonly #log: LogFollower;
 
     constructor(
         flavor: DeviceFlavor,
@@ -998,6 +999,7 @@ class UnpairFixture {
     ) {
         const { fabricIndex = 1, backchannel = () => {} } = options;
         const log = new LogFollower(this.#source, "th");
+        this.#log = log;
         const unused = () => Promise.reject(new InternalError("not used by these tests"));
 
         const node: CertNodeApi = {
@@ -1076,11 +1078,24 @@ class UnpairFixture {
     close(): void {
         this.#source.close();
     }
+
+    mark(): number {
+        return this.#log.mark();
+    }
+
+    /** Lets the follower's pump ingest what was pushed, so a later `mark()` is past it. */
+    async drain(): Promise<void> {
+        await new Promise(resolve => setImmediate(resolve));
+    }
 }
 
 const CHIP_FABRIC_REMOVED = "[1787433103.742] [23362:73430237:chip] [ZCL] OpCreds: RemoveFabric successful";
 const CHIP_SESSIONS_EXPIRED = "[1787433103.742] [23362:73430237:chip] [IN] Expiring all sessions for fabric 0x1!!";
 const CHIP_SETUP_QR_CODE = "[1787433105.001] [23362:73430237:chip] [SVR] SetupQRCode: [MT:-24J042C00KA0648G00]";
+const CHIP_ADVERTISING_COMMISSIONABLE =
+    "[1787433105.010] [23362:73430237:chip] [DIS] mDNS service published: _matterc._udp; instance name: 245375FD9D5602FE";
+const MATTERJS_ADVERTISING_COMMISSIONABLE =
+    "2026-08-27 13:05:44.123 INFO MdnsAdvertisement Publishing kind: commissionable service: mdns:036341AECBC96116._matterc._udp.local";
 
 describe("recordUnpair", () => {
     it("records the removal and the ended sessions, and gives up the ref", async () => {
@@ -1172,7 +1187,7 @@ describe("restoreCommissioningMode, through recordVendorOutcome", () => {
     // next one has to put it back into commissioning mode first.
     it("resets the TH and gives up the ref before the next attempt", async () => {
         const fixture = new UnpairFixture("chip-local", {
-            backchannel: () => fixture.push(CHIP_SETUP_QR_CODE),
+            backchannel: () => fixture.push(CHIP_SETUP_QR_CODE, CHIP_ADVERTISING_COMMISSIONABLE),
             commission: () => Promise.reject(new DiscoveryError("No commissionable device was discovered")),
         });
         const probed = new Array<string>();
@@ -1220,31 +1235,69 @@ describe("restoreCommissioningMode, through recordVendorOutcome", () => {
 
 describe("recordBackInCommissioningMode", () => {
     it("factory-resets a chip TH and waits for the restarted app's own payload", async () => {
-        const fixture = new UnpairFixture("chip-local", { backchannel: () => fixture.push(CHIP_SETUP_QR_CODE) });
+        const fixture = new UnpairFixture("chip-local", {
+            backchannel: () => fixture.push(CHIP_SETUP_QR_CODE, CHIP_ADVERTISING_COMMISSIONABLE),
+        });
         const probed = new Array<string>();
 
-        await recordBackInCommissioningMode(fixture.cx, "TH advertising again", async (_cx, what) => {
-            probed.push(what);
+        await recordBackInCommissioningMode(fixture.cx, {
+            what: "TH advertising again",
+            probeCommissionable: async (_cx, what) => void probed.push(what),
         });
 
         expect(fixture.calls).deep.equal(["backchannel"]);
-        expect(fixture.checks.map(check => check.verdict)).deep.equal(["pass"]);
+        expect(fixture.checks.map(check => check.verdict)).deep.equal(["pass", "pass"]);
         expect(probed).deep.equal(["TH advertising again"]);
     });
 
     // A matter.js device returns to commissioning mode when its last fabric goes, so erasing it would
     // restart a TH that needs nothing
-    it("only probes a matterjs TH", async () => {
+    it("does not reset a matterjs TH, and takes its own announcement instead", async () => {
         const fixture = new UnpairFixture("matterjs");
+        fixture.push(MATTERJS_ADVERTISING_COMMISSIONABLE);
         const probed = new Array<string>();
 
-        await recordBackInCommissioningMode(fixture.cx, "TH advertising again", async (_cx, what) => {
-            probed.push(what);
+        await recordBackInCommissioningMode(fixture.cx, {
+            what: "TH advertising again",
+            probeCommissionable: async (_cx, what) => void probed.push(what),
         });
 
         expect(fixture.calls).deep.equal([]);
-        expect(fixture.checks).deep.equal([]);
+        expect(fixture.checks.map(check => check.verdict)).deep.equal(["pass"]);
         expect(probed).deep.equal(["TH advertising again"]);
+    });
+
+    // The probe alone passes off a record cached before the TH was ever commissioned, so the device
+    // saying so is what carries the claim — and a TH that never returns must not reach the probe
+    it("fails, without probing, when a matterjs TH never announces the advertisement", async () => {
+        const fixture = new UnpairFixture("matterjs");
+        fixture.close();
+        const probed = new Array<string>();
+
+        await expect(
+            recordBackInCommissioningMode(fixture.cx, {
+                what: "TH advertising again",
+                probeCommissionable: async (_cx, what) => void probed.push(what),
+            }),
+        ).rejectedWith(CertCheckFailedError);
+
+        expect(probed).deep.equal([]);
+    });
+
+    it("searches the announcement from the caller's mark, not from its own entry", async () => {
+        const fixture = new UnpairFixture("matterjs");
+        const before = fixture.mark();
+        // A TH that returned to commissioning mode before this helper was entered, which is the
+        // ordinary case: the decommission that caused it happened in the caller
+        fixture.push(MATTERJS_ADVERTISING_COMMISSIONABLE);
+        await fixture.drain();
+
+        await recordBackInCommissioningMode(fixture.cx, {
+            from: before,
+            probeCommissionable: async () => {},
+        });
+
+        expect(fixture.checks.map(check => check.verdict)).deep.equal(["pass"]);
     });
 
     it("fails, without probing, when the restarted chip TH never prints its payload", async () => {
@@ -1252,8 +1305,9 @@ describe("recordBackInCommissioningMode", () => {
         const probed = new Array<string>();
 
         await expect(
-            recordBackInCommissioningMode(fixture.cx, "TH advertising again", async (_cx, what) => {
-                probed.push(what);
+            recordBackInCommissioningMode(fixture.cx, {
+                what: "TH advertising again",
+                probeCommissionable: async (_cx, what) => void probed.push(what),
             }),
         ).rejectedWith(CertCheckFailedError);
 

--- a/support/chip-testing/test/cert-framework/tc-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-support.test.ts
@@ -5,7 +5,14 @@
  */
 
 import { InternalError, Millis, Time, Seconds } from "@matter/main";
-import type { AttributePathSpec, CertNodeApi, CertStepContext, CheckRecord, ControllerAdapter } from "@matter/testing";
+import type {
+    AttributePathSpec,
+    CertNodeApi,
+    CertStepContext,
+    CheckRecord,
+    ControllerAdapter,
+    LogExpectPatterns,
+} from "@matter/testing";
 import { LogFollower } from "@matter/testing";
 import {
     attributePathIBSequence,
@@ -22,15 +29,19 @@ import {
     expectRejection,
     expectReportAck,
     expectSequence,
+    expectDeviceLog,
     expectSubscriptionId,
     fabricFilteredPattern,
+    fabricSessionsEnded,
     matterjsReadEventPath,
     matterjsSubscribeEventPath,
     matterjsSubscribeFlags,
     matterjsSubscribeTiming,
     READ_REQUEST_MESSAGE,
+    readOwnFabricIndex,
     recordAll,
     CertCleanupErrors,
+    removeFabricSucceeded,
     requireId,
     runCleanups,
     WRITE_REQUEST_MESSAGE,
@@ -1269,6 +1280,100 @@ describe("requireId", () => {
 
     it("throws when the id is undefined", () => {
         expect(() => requireId(undefined, "thing")).to.throw(/thing has no numeric id/);
+    });
+});
+
+describe("readOwnFabricIndex", () => {
+    function nodeReporting(value: unknown): CertNodeApi {
+        const unused = () => Promise.reject(new InternalError("not used by these tests"));
+        return {
+            invoke: unused,
+            invokeBatch: unused,
+            readAttributes: unused,
+            writeAttribute: unused,
+            writeAttributes: unused,
+            subscribe: unused,
+            readEvents: unused,
+            subscribeEvents: unused,
+            openCommissioningWindow: unused,
+            operationalMdnsInstanceName: unused,
+            decommission: unused,
+            readAttribute: async () => value,
+        };
+    }
+
+    it("returns the index the device reported", async () => {
+        expect(await readOwnFabricIndex(nodeReporting(2))).equal(2);
+    });
+
+    // The caller uses this to build a log pattern, so a non-numeric read would become a pattern
+    // matching a fabric no device has rather than a failure anyone can see
+    it("refuses a read that is not a number", async () => {
+        await expect(readOwnFabricIndex(nodeReporting(null))).rejectedWith(
+            InternalError,
+            /Expected CurrentFabricIndex to read as a number/,
+        );
+    });
+});
+
+describe("fabric-removal log patterns", () => {
+    // Lines captured from real runs against each device flavor.
+    const CHIP_REMOVED = "[1787433103.742] [23362:73430237:chip] [ZCL] OpCreds: RemoveFabric successful";
+    const CHIP_EXPIRING = "[1787433103.742] [23362:73430237:chip] [IN] Expiring all sessions for fabric 0x2!!";
+    const MATTERJS_REMOVED =
+        "2026-08-22 21:48:06.406 INFO ProtocolService Invoke » binford-6100.operationalCredentials.removeFabric @1:9a52bb47a4ee167d•c675⇵68ce✉09f1964b statusCode: 0 fabricIndex: 2";
+    const MATTERJS_SESSION_ENDED = "2026-08-22 21:48:06.401 INFO Session @2:1946ee4c0f86d574•c677 Session ended";
+
+    async function check(flavor: string, patterns: LogExpectPatterns, lines: string[]) {
+        return withFollower(lines, async follower => {
+            return (await expectDeviceLog(follower, flavor, patterns, 0, Millis(100))).check;
+        });
+    }
+
+    const removalCheck = (flavor: string, fabricIndex: number, lines: string[]) =>
+        check(flavor, removeFabricSucceeded(fabricIndex), lines);
+
+    it("finds the removal of the fabric it asked about", async () => {
+        expect((await removalCheck("chip-local", 2, [CHIP_REMOVED])).verdict).equal("pass");
+        expect((await removalCheck("matterjs", 2, [MATTERJS_REMOVED])).verdict).equal("pass");
+    });
+
+    it("does not take another fabric's removal for the one it asked about", async () => {
+        expect((await removalCheck("matterjs", 3, [MATTERJS_REMOVED])).verdict).equal("fail");
+    });
+
+    it("does not take fabric 20's removal for fabric 2's", async () => {
+        const fabric20 = MATTERJS_REMOVED.replace("fabricIndex: 2", "fabricIndex: 20");
+
+        expect((await removalCheck("matterjs", 2, [fabric20])).verdict).equal("fail");
+    });
+
+    it("does not pass a removal the device answered with a failure status", async () => {
+        const rejected = MATTERJS_REMOVED.replace("statusCode: 0", "statusCode: 11");
+
+        expect((await removalCheck("matterjs", 2, [rejected])).verdict).equal("fail");
+    });
+
+    it("finds the removed fabric's sessions ending in either device's log", async () => {
+        expect((await check("chip-local", fabricSessionsEnded(2), [CHIP_EXPIRING])).verdict).equal("pass");
+        expect((await check("matterjs", fabricSessionsEnded(2), [MATTERJS_SESSION_ENDED])).verdict).equal("pass");
+    });
+
+    it("does not take another fabric's session ending for the removed fabric's", async () => {
+        expect((await check("matterjs", fabricSessionsEnded(1), [MATTERJS_SESSION_ENDED])).verdict).equal("fail");
+        expect((await check("chip-local", fabricSessionsEnded(1), [CHIP_EXPIRING])).verdict).equal("fail");
+    });
+
+    it("does not take fabric 20's session ending for fabric 2's", async () => {
+        const fabric20 = MATTERJS_SESSION_ENDED.replace("@2:", "@20:");
+
+        expect((await check("matterjs", fabricSessionsEnded(2), [fabric20])).verdict).equal("fail");
+    });
+
+    it("does not take a PASE session ending for a removed fabric's", async () => {
+        const unsecured = "2026-08-23 22:41:11.220 INFO Session •unsecured#7372af0fa8e6f033 Session ended";
+
+        expect((await check("matterjs", fabricSessionsEnded(2), [unsecured])).verdict).equal("fail");
     });
 });
 

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1405,9 +1405,11 @@ probe can run before the new generation exists at all.
 **What the wait does not do is make the probe witness the restart.** `checkCommissionable` primes
 from the DNS-SD names already cached and fires on any live record for the TH's discriminator, which
 every flavor pins across restarts — so a record cached before the TH was ever commissioned answers it
-just as well. On the chip legs the restart check beside it is what separates the generations; the
-probe on its own states that *something* is advertising that discriminator, not that this device just
-returned to commissioning mode. See "Freshness: a cache hit is not a state transition" below.
+just as well. `recordBackInCommissioningMode` therefore requires the device's own announcement that
+it is advertising commissionable (`mDNS service published: _matterc._udp` /
+`MdnsAdvertisement Publishing kind: commissionable`) and treats the probe as corroboration. See
+"Freshness: a cache hit is not a state transition" below for where the same instrument is still the
+only evidence.
 
 Earlier revisions instead opened a *basic* commissioning window and then removed the fabric, which
 works on paper but publishes `_matterc._udp` twice inside about 15 ms; avahi calls that a name
@@ -1670,22 +1672,43 @@ from the two exported halves the TC drives directly:
   `fabricSessionsEnded` / `readOwnFabricIndex`, all promoted from TC-CADMIN-1.17's support module to
   `tc-support.ts` now that a second TC needs them).
 - **`recordBackInCommissioningMode`** is the plan's "manufacturer's means" precondition: a chip TH
-  factory-resets and its restarted app's own `SetupQRCode` line is waited for, a matterjs TH needs
-  nothing.
+  factory-resets and its restarted app's own `SetupQRCode` line is waited for, a matterjs TH returns
+  on its own. Either way the step then requires the **device's own announcement** that it is
+  advertising commissionable again, and only treats the mDNS probe as corroboration.
+
+**A probe alone passed 35 ms before the device returned to commissioning mode.** Measured, in this
+TC's own matterjs bundle: step 4's `commissionable` check passed at 13:05:44.088 off a record cached
+in step 1, and the TH logged `MdnsAdvertisement Publishing kind: commissionable` at 13:05:44.123. The
+step was green for 35 ms on evidence that predated the transition it claims. That is why the device's
+line is what carries the claim here. `mDNS service published: _matterc._udp` is the chip half:
+`Discovery_ImplPlatform` and `Advertiser_ImplMinimalMdns` print the same prefix, so it is the one form
+a Linux CI build and a Darwin build both emit — chip's `Registering service …` line is Darwin-only and
+would have passed locally and gone unverified in CI.
+
+**The announcement is searched from a mark the *caller* took.** For a matter.js TH the transition is
+caused by the previous step's `decommission()`, so a mark taken inside
+`recordBackInCommissioningMode` can already be past the line. `recordUnpair` returns the mark it took
+before removing the fabric, and TC-DD-3.20 threads it into step 4 — the same capture-in-one-step,
+use-in-a-later-one shape TC-CADMIN-1.17 uses for its operational instance name.
 
 **The network does not settle this within a step's budget.** The first revision proved the removal
 with `operationalRecords: 0` against the node's own instance name. It passes on matterjs and fails on
 chip-local: `expectMdns` still held a live `_matter._tcp` SRV for the removed fabric's instance after
-its full 30 s window (`observed 1`). The device is *not* at fault — its log carries
-`[DIS] Updating services using commissioning mode 0` 4 ms before `OpCreds: RemoveFabric successful`,
-which is `DnssdServer::StartServer()` running `RemoveServices()` and then re-advertising only the
-fabrics that remain (`OperationalCredentialsCluster::OnFabricRemoved` is a `FabricTable::Delegate`
-and calls it for exactly this reason). **Why the withdrawal is not observable within the window is
-not established** — a goodbye that is never sent, one that is sent but not ingested, or the check's
-own rule of never re-soliciting a name it still holds live, leaving the cached record to run out its
-TTL. TC-CADMIN-1.17 step 10 fails the same way on the same host, and it removes one fabric of three,
-so the symptom does not depend on the removed fabric being the last. Until someone captures the wire,
-the device's own log is the evidence this step rests on.
+its full 30 s window.
+
+What the *code* establishes, independently of any run: chip's fabric-removal path does update its
+advertising. `OperationalCredentialsCluster::OnFabricRemoved` is a `FabricTable::Delegate` and calls
+`DnssdServer::StartServer()`, which runs `RemoveServices()` and then re-advertises only the fabrics
+that remain. So "chip does not withdraw the record" is not a defensible reading of the symptom.
+
+**Why the withdrawal is not observable within the window is not established, and this file does not
+claim it.** Candidates: a goodbye that is never sent, one that is sent but not ingested, or the
+check's own rule of never re-soliciting a name it still holds live, leaving the cached record to run
+out its TTL. Settling it needs a capture of port 5353 across the removal, which nobody has taken —
+per this repository's own policy, no root-cause claim without the raw log it comes from. Note also
+that TC-CADMIN-1.17 step 10 shows the same symptom on the same host while removing one fabric of
+three, so whatever it is does not depend on the removed fabric being the last. Until then the
+device's own log is the evidence this step rests on.
 
 **The fabric index is read before the fabric comes off**, because the in-process controller drops the
 peer as the device announces the removal and it cannot be read afterwards. On chip only the session
@@ -1706,47 +1729,47 @@ controller still owns the peer either way.
 holds a ref, and step 3 cleared it, so the TC's own steps 3 and 4 are what run — the helper does not
 factory-reset a TH that was just reset.
 
-## Freshness: a cache hit is not a state transition — OPEN, needs a decision
+## Freshness: a cache hit is not a state transition — OPEN
 
-An adversarial review of TC-DD-3.20 found one cause behind several steps across this directory. It is
-recorded here rather than patched, because closing it properly means a new framework primitive.
+TC-DD-3.20 closed this for its own step 4 by requiring the device's own announcement. The instruments
+themselves still have the property, and three other places still rest on them. Recorded here in the
+same spirit as "Known limitations carried forward from `TC-ACT-3.2`" and the TC-DD-3.11 section's
+"Unsettled, worth resolving before the next per-transport TC" above.
 
-**The shape.** A step that drives a transition proves it with a check that observes a *condition*,
-and the condition was already true before the transition. Two instruments have this property:
+**The shape.** A step that drives a transition proves it with a check that observes a *condition*, and
+the condition was already true before the transition.
 
 - **`expectMdns({ commissionable: true })`.** `checkCommissionable` builds a
   `CommissionableMdnsScanner` over the process-global `Environment.default.get(MdnsService).names`,
   primes from `discoveredNames`, and fires as soon as any cached device matches the long
-  discriminator. Every flavor pins discriminator 3840 across restarts, and a Matter commissionable
-  record lives ~120 s, so a record cached in step 1 answers a probe in step 4 without the TH having
-  sent anything. Where the step's claim is "the TH went *back* into commissioning mode"
-  (TC-DD-3.20 step 4, `restoreCommissioningMode`, the probe after a decommission in `commissionByQr`),
-  the instrument cannot distinguish that from "it was advertising before, and the cache remembers".
+  discriminator. Every flavor pins discriminator 3840 across restarts and a commissionable record
+  lives about two minutes, so a record cached several steps earlier answers it with nothing on the
+  wire. See the measured 35 ms window in the TC-DD-3.20 section above.
 - **`LogFollower.mark()`.** It returns the count of lines *ingested*, not lines the device has
   printed. The follower pumps asynchronously, so a line the TH emitted before the mark but which had
   not yet been drained lands at an index at or after `from` and reads as "after the mark".
   `expectSequence`'s own doc already states this; anything anchoring on a mark inherits it.
 
-**Where it currently bites, in order of how much it would hide:**
+**Where it still bites:**
 
-1. TC-DD-3.20 step 4, and every `restoreCommissioningMode`: a TH that never returns to commissioning
-   mode still passes. On the chip legs the restart check beside it (the new generation's own
-   `SetupQRCode` line) is what carries the claim; on matterjs nothing does.
-2. Steps 2.a/5.a of TC-DD-3.20 and 2.a of TC-DD-3.21 gate on `MCORE.DD.SCAN_QR_CODE` while their
-   `.b` siblings repeat the same parse ungated — so a controller whose PICS says it cannot scan gets
-   a `skipped` step and two parse passes in the same bundle. The plan gives the `.b` steps no PICS,
+1. `restoreCommissioningMode` now takes its own pre-decommission mark and requires the announcement,
+   so the composed path is covered too. What is *not* covered is any step whose only evidence is a
+   bare `recordCommissionable` — TC-DD-3.21 step 1 and TC-DD-3.20 step 1 among them. Those are
+   preconditions rather than transitions, so a cached record is arguably the right answer there; the
+   distinction is worth making explicit rather than left to whoever reads the step next.
+2. Steps 2.a/5.a of TC-DD-3.20 and 2.a of TC-DD-3.21 gate on `MCORE.DD.SCAN_QR_CODE` while their `.b`
+   siblings repeat the same parse ungated — so a controller whose PICS says it cannot scan gets a
+   `skipped` step and two parse passes in the same bundle. The plan gives the `.b` steps no PICS,
    which is why both TCs read this way; the leg-integrity rule TC-DD-3.11 states argues the other way.
 3. `thQrPayload` searches `from: 0`, so a step after a factory reset re-reads the payload the *dead*
    generation printed. Benign while `chip-app-subject.ts` pins the discriminator and passcode across
    restarts, and wrong the moment a TH's payload changes across a reset.
 
-**What would close it.** A freshness primitive: an mDNS probe that rejects a record installed before
-a caller-supplied mark (`DnssdName.Record` already carries `installedAt`, and `DnssdNames` already
-retires records on a goodbye), plus a log anchor that waits for the follower to drain to real time
-before taking its mark. Both are framework changes in `packages/testing` and `packages/general`,
-touching every existing TC's evidence, so they are a decision rather than a fixup — the alternative
-is to keep the weaker instruments and state their limit in each step's `detail`, which is what the
-helpers' JSDoc does today.
+**What would close the rest.** A freshness primitive: an mDNS probe that rejects a record installed
+before a caller-supplied mark (`DnssdName.Record` already carries `installedAt`, and `DnssdNames`
+already retires records on a goodbye), plus a log anchor that waits for the follower to drain to real
+time before taking its mark. Both are framework changes in `packages/testing` and `packages/general`
+touching every existing TC's evidence, so they are a decision rather than a fixup.
 
 ## chip-tool delivers one result per async report and discards the rest
 

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1376,11 +1376,15 @@ The TC asserts the length it built rather than trusting the arithmetic, since a 
 misses lands on a payload the plan did not ask for.
 
 **Onboarding the same TH twice: factory reset it between attempts.** A chip TH does not return to
-commissioning mode when its last fabric goes — after `RemoveFabric succeeds` its log stops there, and
-the next commissioning fails as `No device could be commissioned (1 of 1 started attempt(s) failed, 1
-discovered)` against a stale advertisement. The plans cover this with a precondition ("place the TH
-back into commissioning mode using the TH manufacturer's means"), and for a TC that drives everything
-itself that means asking the device for a factory reset:
+commissioning mode when its last fabric goes. It re-advertises as the fabric is removed —
+`[DIS] Updating services using commissioning mode 0` — and mode 0 is `kDisabled`, so no commissionable
+service goes out; the next commissioning then fails as `No device could be commissioned (1 of 1
+started attempt(s) failed, 1 discovered)` against a stale advertisement. The plans cover this with a
+precondition ("place the TH back into commissioning mode using the TH manufacturer's means"), and for
+a TC that drives everything itself that means asking the device for a factory reset. Two helpers in
+`tc-dd-support.ts` split the work — `recordUnpair` removes the fabric, `recordBackInCommissioningMode`
+does the reset — and `restoreCommissioningMode` is the private assembly `commissionByQr` runs when a
+TC has not driven the steps itself:
 
 ```ts
 await cx.controllers.dut.node(ref).decommission();
@@ -1395,9 +1399,15 @@ Three things about that shape are load-bearing. The fabric comes off first, so t
 holds a peer for a fabric the device has forgotten — a later `decommissionAll` against a wiped device
 fails. The matterjs leg is excluded because it is already back in commissioning mode, and erasing it
 would restart a TH that needs nothing. And the wait for the restarted app matters because
-`ChipLocalDevice.start()` returns when the *process* is up, not when the app is, while
-`checkCommissionable` primes from the DNS-SD names already cached — so without it the check can be
-answered by an advertisement the generation that just died had published.
+`ChipLocalDevice.start()` returns when the *process* is up, not when the app is, so without it the
+probe can run before the new generation exists at all.
+
+**What the wait does not do is make the probe witness the restart.** `checkCommissionable` primes
+from the DNS-SD names already cached and fires on any live record for the TH's discriminator, which
+every flavor pins across restarts — so a record cached before the TH was ever commissioned answers it
+just as well. On the chip legs the restart check beside it is what separates the generations; the
+probe on its own states that *something* is advertising that discriminator, not that this device just
+returned to commissioning mode. See "Freshness: a cache hit is not a state transition" below.
 
 Earlier revisions instead opened a *basic* commissioning window and then removed the fabric, which
 works on paper but publishes `_matterc._udp` twice inside about 15 ms; avahi calls that a name
@@ -1647,6 +1657,96 @@ against itself — the plan's "ensure the Version bit string follows the current
 about the artifact, not about the TH. Note the plan's own example payload, `MT:-24J029Q00KA0648G00`,
 decodes to `flowType` 2: it is copy-pasted into 3.11, 3.12 and 3.14 from 3.13, the one case whose flow
 value it actually matches.
+
+## Commission, unpair, re-commission (`TC-DD-3.20`)
+
+The plan drives the same device onto the fabric twice, with an explicit unpair between the attempts,
+so what `commissionByQr` had been doing silently — return the TH to a factory-new state before a
+second onboarding — becomes two of the plan's own steps. `restoreCommissioningMode` is now assembled
+from the two exported halves the TC drives directly:
+
+- **`recordUnpair`** removes the DUT's fabric and takes the TH's own two statements about it: the
+  removal succeeded, and the removed fabric's sessions are gone (`removeFabricSucceeded` /
+  `fabricSessionsEnded` / `readOwnFabricIndex`, all promoted from TC-CADMIN-1.17's support module to
+  `tc-support.ts` now that a second TC needs them).
+- **`recordBackInCommissioningMode`** is the plan's "manufacturer's means" precondition: a chip TH
+  factory-resets and its restarted app's own `SetupQRCode` line is waited for, a matterjs TH needs
+  nothing.
+
+**The network does not settle this within a step's budget.** The first revision proved the removal
+with `operationalRecords: 0` against the node's own instance name. It passes on matterjs and fails on
+chip-local: `expectMdns` still held a live `_matter._tcp` SRV for the removed fabric's instance after
+its full 30 s window (`observed 1`). The device is *not* at fault — its log carries
+`[DIS] Updating services using commissioning mode 0` 4 ms before `OpCreds: RemoveFabric successful`,
+which is `DnssdServer::StartServer()` running `RemoveServices()` and then re-advertising only the
+fabrics that remain (`OperationalCredentialsCluster::OnFabricRemoved` is a `FabricTable::Delegate`
+and calls it for exactly this reason). **Why the withdrawal is not observable within the window is
+not established** — a goodbye that is never sent, one that is sent but not ingested, or the check's
+own rule of never re-soliciting a name it still holds live, leaving the cached record to run out its
+TTL. TC-CADMIN-1.17 step 10 fails the same way on the same host, and it removes one fabric of three,
+so the symptom does not depend on the removed fabric being the last. Until someone captures the wire,
+the device's own log is the evidence this step rests on.
+
+**The fabric index is read before the fabric comes off**, because the in-process controller drops the
+peer as the device announces the removal and it cannot be read afterwards. On chip only the session
+line names a fabric — the removal line is unqualified — so the index is what separates this removal
+from another's on one leg and from nothing on the other.
+
+**Both lines are searched from the step's own mark, not from each other.** matter.js closes the
+removed fabric's sessions before it answers the invoke and chip after, which is the same rule
+TC-CADMIN-1.17 step 7 states.
+
+**The ref is surrendered as soon as `decommission()` resolves, not once the checks pass.** The fabric
+is off the TH whatever the log went on to say, and a `commissioned` entry outliving it has the
+finalizer remove a fabric that is already gone. This is the opposite of TC-CADMIN-1.17 step 7, which
+holds its ref until its checks pass — there the removal is a raw `RemoveFabric` invoke and the
+controller still owns the peer either way.
+
+**Step 5 needs no restore of its own.** `commissionByQr` restores only where `commissioned` still
+holds a ref, and step 3 cleared it, so the TC's own steps 3 and 4 are what run — the helper does not
+factory-reset a TH that was just reset.
+
+## Freshness: a cache hit is not a state transition — OPEN, needs a decision
+
+An adversarial review of TC-DD-3.20 found one cause behind several steps across this directory. It is
+recorded here rather than patched, because closing it properly means a new framework primitive.
+
+**The shape.** A step that drives a transition proves it with a check that observes a *condition*,
+and the condition was already true before the transition. Two instruments have this property:
+
+- **`expectMdns({ commissionable: true })`.** `checkCommissionable` builds a
+  `CommissionableMdnsScanner` over the process-global `Environment.default.get(MdnsService).names`,
+  primes from `discoveredNames`, and fires as soon as any cached device matches the long
+  discriminator. Every flavor pins discriminator 3840 across restarts, and a Matter commissionable
+  record lives ~120 s, so a record cached in step 1 answers a probe in step 4 without the TH having
+  sent anything. Where the step's claim is "the TH went *back* into commissioning mode"
+  (TC-DD-3.20 step 4, `restoreCommissioningMode`, the probe after a decommission in `commissionByQr`),
+  the instrument cannot distinguish that from "it was advertising before, and the cache remembers".
+- **`LogFollower.mark()`.** It returns the count of lines *ingested*, not lines the device has
+  printed. The follower pumps asynchronously, so a line the TH emitted before the mark but which had
+  not yet been drained lands at an index at or after `from` and reads as "after the mark".
+  `expectSequence`'s own doc already states this; anything anchoring on a mark inherits it.
+
+**Where it currently bites, in order of how much it would hide:**
+
+1. TC-DD-3.20 step 4, and every `restoreCommissioningMode`: a TH that never returns to commissioning
+   mode still passes. On the chip legs the restart check beside it (the new generation's own
+   `SetupQRCode` line) is what carries the claim; on matterjs nothing does.
+2. Steps 2.a/5.a of TC-DD-3.20 and 2.a of TC-DD-3.21 gate on `MCORE.DD.SCAN_QR_CODE` while their
+   `.b` siblings repeat the same parse ungated — so a controller whose PICS says it cannot scan gets
+   a `skipped` step and two parse passes in the same bundle. The plan gives the `.b` steps no PICS,
+   which is why both TCs read this way; the leg-integrity rule TC-DD-3.11 states argues the other way.
+3. `thQrPayload` searches `from: 0`, so a step after a factory reset re-reads the payload the *dead*
+   generation printed. Benign while `chip-app-subject.ts` pins the discriminator and passcode across
+   restarts, and wrong the moment a TH's payload changes across a reset.
+
+**What would close it.** A freshness primitive: an mDNS probe that rejects a record installed before
+a caller-supplied mark (`DnssdName.Record` already carries `installedAt`, and `DnssdNames` already
+retires records on a goodbye), plus a log anchor that waits for the follower to drain to real time
+before taking its mark. Both are framework changes in `packages/testing` and `packages/general`,
+touching every existing TC's evidence, so they are a decision rather than a fixup — the alternative
+is to keep the weaker instruments and state their limit in each step's `detail`, which is what the
+helpers' JSDoc does today.
 
 ## chip-tool delivers one result per async report and discards the rest
 

--- a/support/chip-testing/test/cert/TC-CADMIN-1.17.test.ts
+++ b/support/chip-testing/test/cert/TC-CADMIN-1.17.test.ts
@@ -11,10 +11,8 @@ import { certTest } from "@matter/testing";
 import { expectMdns } from "../../src/cert/mdns-check.js";
 import {
     COMMISSIONING_COMPLETE,
-    fabricSessionsEnded,
     isPostRemovalRefusal,
     removeFabricResponseFailure,
-    removeFabricSucceeded,
     WINDOW_OPEN,
 } from "./tc-cadmin-1.17-support.js";
 import {
@@ -22,10 +20,13 @@ import {
     CommissionedRefs,
     expectDeviceLog,
     expectRejection,
+    fabricSessionsEnded,
     LOG_TIMEOUT,
     PendingPairingCode,
+    readOwnFabricIndex,
     record,
     recordAll,
+    removeFabricSucceeded,
 } from "./tc-support.js";
 
 const BASIC_INFORMATION = Matter.clusters.require("BasicInformation");
@@ -33,7 +34,6 @@ const VENDOR_ID = BASIC_INFORMATION.attributes.require("vendorId");
 const NODE_LABEL = BASIC_INFORMATION.attributes.require("nodeLabel");
 const OPERATIONAL_CREDENTIALS = Matter.clusters.require("OperationalCredentials");
 const FABRICS = OPERATIONAL_CREDENTIALS.attributes.require("fabrics");
-const CURRENT_FABRIC_INDEX = OPERATIONAL_CREDENTIALS.attributes.require("currentFabricIndex");
 
 const CW_DURATION_SECONDS = 180;
 const EXPECTED_CR2_FABRIC_INDEX = 2;
@@ -78,24 +78,6 @@ function asFabricEntries(value: unknown[]): FabricEntry[] {
         throw new InternalError(
             `Expected Fabrics attribute entries with fabricIndex/label, got ${describeFabrics(value)}`,
         );
-    }
-    return value;
-}
-
-/**
- * The fabric index the TH assigned to `node`'s own controller, read over that controller's own session
- * — the only discriminator every controller has without setup. A fabric's `Label` is empty until an
- * admin writes one (Core § 11.18.6.2) and the plan's own `FabricIndex = 2` assumes commissioning order,
- * so neither identifies a fabric for a harness that must work with any controller implementation.
- */
-async function readOwnFabricIndex(node: CertNodeApi): Promise<number> {
-    const value = await node.readAttribute({
-        endpoint: 0,
-        cluster: OPERATIONAL_CREDENTIALS.id,
-        attribute: CURRENT_FABRIC_INDEX.id,
-    });
-    if (typeof value !== "number") {
-        throw new InternalError(`Expected CurrentFabricIndex to read as a number, got ${JSON.stringify(value)}`);
     }
     return value;
 }
@@ -316,8 +298,9 @@ certTest("TC-CADMIN-1.17", {
             record(cx, removed.check, "RemoveFabric-successful log");
 
             // Searched from the step's own mark, not from the line above: matter.js closes the removed
-            // fabric's sessions before it answers the invoke, chip after. Both patterns name the fabric
-            // index, and the mark precedes this step's removal, so neither can match another removal's.
+            // fabric's sessions before it answers the invoke, chip after. This step drives the only
+            // removal after that mark, which is what keeps the checks attributable — chip's success
+            // line names no fabric, so on that flavor only the session line identifies one.
             const expiring = await expectDeviceLog(
                 th.log,
                 th.flavor,

--- a/support/chip-testing/test/cert/TC-DD-3.20.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.20.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { certTest } from "@matter/testing";
+import {
+    commissionByQr,
+    recordBackInCommissioningMode,
+    recordCommissionable,
+    recordParse,
+    recordUnpair,
+    thQrPayload,
+} from "./tc-dd-support.js";
+import { CommissionedRefs } from "./tc-support.js";
+
+const commissioned = new CommissionedRefs();
+
+certTest("TC-DD-3.20", {
+    plan: "devicediscovery.adoc",
+    pics: ["MCORE.ROLE.COMMISSIONER", "MCORE.DD.QR_COMMISSIONING"],
+    app: "all-clusters",
+})
+    .step(
+        1,
+        "Place TH into commissioning mode using the TH manufacturer's means to be discovered by the DUT Commissioner",
+        recordCommissionable,
+        { expected: "Verify that the TH is advertising and able to be discovered by a commissioner." },
+    )
+    .step(
+        "2.a",
+        "Scan TH's QR code using the DUT Commissioner.",
+        async cx => {
+            await recordParse(cx, await thQrPayload(cx.devices.th));
+        },
+        { pics: "MCORE.DD.SCAN_QR_CODE", expected: "Verify the QR code has been scanned successfully." },
+    )
+    .step(
+        "2.b",
+        "DUT parses TH's QR code. Follow any steps needed for the Commissioner/Commissionee to complete the " +
+            "commissioning process over the TH Commissionee's method of device discovery",
+        async cx => {
+            const payload = await thQrPayload(cx.devices.th);
+            await recordParse(cx, payload);
+            await commissionByQr(cx, payload, commissioned);
+        },
+        {
+            expected:
+                "DUT parses TH's QR code and DUT commissions TH to the Matter network. Verify that the TH has " +
+                "been commissioned onto the Matter network.",
+        },
+    )
+    .step(
+        3,
+        "Using DUT Commissioner, unpair the TH Commissionee from the Matter network.",
+        cx => recordUnpair(cx, commissioned),
+        { expected: "Verify the TH is no longer on the Matter network." },
+    )
+    .step(
+        4,
+        "Place TH Commissionee back into commissioning mode using the TH manufacturer's means to be discovered " +
+            "by the DUT Commissioner",
+        cx => recordBackInCommissioningMode(cx, "TH advertising as commissionable again"),
+        { expected: "Verify that the TH is advertising and able to be discovered by a commissioner." },
+    )
+    .step(
+        "5.a",
+        "Scan TH's QR code using the DUT Commissioner.",
+        async cx => {
+            await recordParse(cx, await thQrPayload(cx.devices.th));
+        },
+        { pics: "MCORE.DD.SCAN_QR_CODE", expected: "Verify the QR code has been scanned successfully." },
+    )
+    .step(
+        "5.b",
+        "DUT parses TH's QR code. Follow any steps needed for the Commissioner/Commissionee to complete the " +
+            "commissioning process over the TH Commissionee's method of device discovery",
+        async cx => {
+            const payload = await thQrPayload(cx.devices.th);
+            await recordParse(cx, payload);
+            await commissionByQr(cx, payload, commissioned);
+        },
+        {
+            expected:
+                "DUT parses TH's QR code and DUT commissions TH to the Matter network. Verify that the TH has " +
+                "been commissioned onto the Matter network.",
+        },
+    )
+    .finalize(cx => commissioned.decommissionAll(cx));

--- a/support/chip-testing/test/cert/TC-DD-3.20.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.20.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { InternalError } from "@matter/main";
 import { certTest } from "@matter/testing";
 import {
     commissionByQr,
@@ -16,6 +17,10 @@ import {
 import { CommissionedRefs } from "./tc-support.js";
 
 const commissioned = new CommissionedRefs();
+
+// Step 4's claim is about a transition step 3 caused, so its evidence has to be searched from before
+// that removal. A mark taken in step 4 can already be past the line on a TH that returns on its own.
+let unpairedAt: number | undefined;
 
 certTest("TC-DD-3.20", {
     plan: "devicediscovery.adoc",
@@ -54,14 +59,24 @@ certTest("TC-DD-3.20", {
     .step(
         3,
         "Using DUT Commissioner, unpair the TH Commissionee from the Matter network.",
-        cx => recordUnpair(cx, commissioned),
+        async cx => {
+            unpairedAt = await recordUnpair(cx, commissioned);
+        },
         { expected: "Verify the TH is no longer on the Matter network." },
     )
     .step(
         4,
         "Place TH Commissionee back into commissioning mode using the TH manufacturer's means to be discovered " +
             "by the DUT Commissioner",
-        cx => recordBackInCommissioningMode(cx, "TH advertising as commissionable again"),
+        cx => {
+            if (unpairedAt === undefined) {
+                throw new InternalError("Step ran before the TH was unpaired");
+            }
+            return recordBackInCommissioningMode(cx, {
+                what: "TH advertising as commissionable again",
+                from: unpairedAt,
+            });
+        },
         { expected: "Verify that the TH is advertising and able to be discovered by a commissioner." },
     )
     .step(

--- a/support/chip-testing/test/cert/tc-cadmin-1.17-support.ts
+++ b/support/chip-testing/test/cert/tc-cadmin-1.17-support.ts
@@ -29,32 +29,6 @@ export const WINDOW_OPEN: LogExpectPatterns = {
 };
 
 /**
- * A `RemoveFabric` the device answered with success. matter.js's line is the invoke's own answer,
- * which names the fabric it removed and the status it answered with, where chip logs an unqualified
- * success line.
- */
-export function removeFabricSucceeded(fabricIndex: number): LogExpectPatterns {
-    return {
-        chip: /OpCreds: RemoveFabric successful/,
-        matterjs: new RegExp(
-            `operationalCredentials\\.removeFabric .*statusCode: 0 fabricIndex: ${fabricIndex}(?!\\d)`,
-        ),
-    };
-}
-
-/**
- * The removed fabric's sessions going away. A matter.js session is named
- * `@<fabricIndex>:<fabricId>•<id>`, so one such line per session is what chip states once as
- * "Expiring all sessions for fabric N".
- */
-export function fabricSessionsEnded(fabricIndex: number): LogExpectPatterns {
-    return {
-        chip: new RegExp(`Expiring all sessions for fabric 0x${fabricIndex.toString(16)}!!`),
-        matterjs: new RegExp(`Session @${fabricIndex}:[0-9a-f]+•[0-9a-f]+ Session ended`),
-    };
-}
-
-/**
  * How step 8's post-removal write/read fails on a controller whose fabric the device removed, as
  * captured across all six CI legs. The in-process controller normally refuses locally: it reacts to
  * the device's Leave event by deleting the peer, so every later node operation reports

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -25,10 +25,16 @@ import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload
 import {
     CertCleanupError,
     CommissionedRefs,
+    expectDeviceLog,
     expectRejection,
     expectSequence,
+    fabricSessionsEnded,
+    LOG_TIMEOUT,
     MATTERJS_COMMISSIONED_FABRIC,
+    readOwnFabricIndex,
     record,
+    recordAll,
+    removeFabricSucceeded,
     settleWithin,
 } from "./tc-support.js";
 
@@ -756,7 +762,9 @@ export async function recordVendorOutcome(
     /** Overridden by the unit tests, which have no advertisement to observe. */
     probeCommissionable: (cx: CertStepContext, what: string) => Promise<void> = recordCommissionable,
 ): Promise<void> {
-    const restored = await restoreCommissioningMode(cx, commissioned);
+    // The same override the caller passed for this helper's own probe: without it a restore reaching
+    // live mDNS is what a unit test would wait out, and its default is the real probe either way.
+    const restored = await restoreCommissioningMode(cx, commissioned, probeCommissionable);
 
     // A rejection is evidence about the code only if the TH was there to be found; without this the
     // step passes on a TH that stopped advertising after an earlier attempt. A restore that ran has
@@ -831,31 +839,78 @@ export async function recordVendorOutcome(
 }
 
 /**
- * Returns the TH to a factory-new state if a fabric from an earlier onboarding is still on it, which
- * is what a plan means by commissioning the same device again.
+ * Removes the fabric an earlier step commissioned and records that the TH left the Matter network,
+ * which the device states twice in its own log: the removal succeeded, and the removed fabric's
+ * sessions are gone.
  *
- * The fabric comes off first, so the controller never holds a peer for a fabric the device has
- * forgotten. A chip TH then needs a factory reset, which is what actually puts it back into
- * commissioning mode — removing its last fabric does not. A matter.js device is already there, and
- * erasing it would restart a TH that needs nothing.
+ * The network does not settle this within a step's budget: against a chip TH, `operationalRecords: 0`
+ * for the removed fabric's own instance name still observes a live SRV record after 30 s, although
+ * the device's log shows it updating its advertisement as it removes the fabric. See this
+ * directory's AGENTS.md for what is and is not established about that.
+ *
+ * The fabric index is read while the fabric is still there; the in-process controller drops the peer
+ * as the device announces the removal, so it cannot be read afterwards. Both checks search from the
+ * step's own mark, not from each other, because matter.js closes the removed fabric's sessions
+ * before it answers the invoke and chip after.
+ *
+ * **Only one fabric may be removable after the mark.** chip's success line names no fabric, so on
+ * that flavor it says a fabric went, and only the session line says which. A caller with a second
+ * admin on the TH would have another fabric's removal satisfy the first check.
  */
-async function restoreCommissioningMode(cx: CertStepContext, commissioned: CommissionedRefs): Promise<boolean> {
-    const previous = commissioned.get("dut");
-    if (previous === undefined) {
-        return false;
-    }
-
+export async function recordUnpair(cx: CertStepContext, commissioned: CommissionedRefs): Promise<void> {
     const th = cx.devices.th;
-    await cx.controllers.dut.node(previous).decommission();
+    const ref = commissioned.require("dut");
+    const node = cx.controllers.dut.node(ref);
+
+    const fabricIndex = await readOwnFabricIndex(node);
+
+    const from = th.log.mark();
+    await node.decommission();
     commissioned.clear("dut");
+    cx.recorder.check({
+        type: "response",
+        verdict: "pass",
+        detail: `DUT removed its fabric (index ${fabricIndex}) from the TH, giving up node ${ref}`,
+    });
+
+    const removed = await expectDeviceLog(th.log, th.flavor, removeFabricSucceeded(fabricIndex), from, LOG_TIMEOUT);
+    const expired = await expectDeviceLog(th.log, th.flavor, fabricSessionsEnded(fabricIndex), from, LOG_TIMEOUT);
+    recordAll(cx, [
+        { check: () => removed.check, what: "TH reported a successful fabric removal" },
+        { check: () => expired.check, what: "TH ended the DUT's fabric's sessions" },
+    ]);
+}
+
+/**
+ * Puts the TH back into commissioning mode by its manufacturer's means and records that it is
+ * advertising there.
+ *
+ * A chip TH needs a factory reset: removing its last fabric does not return it to commissioning
+ * mode. A matter.js device is already there, and erasing it would restart a TH that needs nothing.
+ *
+ * **Every fabric on the TH must already be surrendered.** The reset wipes all of them, so a
+ * `CommissionedRefs` still holding one would have the finalizer remove a fabric that is gone and
+ * report a cleanup failure in place of the run's real outcome.
+ *
+ * What this proves is bounded: `probeCommissionable` is answered by any live commissionable record
+ * for the TH's discriminator, including one cached from before it was commissioned, so on its own it
+ * does not witness the transition back. The restart check is what separates the generations on a
+ * chip TH — see this directory's AGENTS.md.
+ */
+export async function recordBackInCommissioningMode(
+    cx: CertStepContext,
+    what = "TH back in commissioning mode",
+    /** Overridden by the unit tests, which have no mDNS to answer. */
+    probeCommissionable: (cx: CertStepContext, what: string) => Promise<void> = recordCommissionable,
+): Promise<void> {
+    const th = cx.devices.th;
 
     if (th.flavor !== "matterjs") {
         const from = th.log.mark();
         await th.backchannel({ name: "factoryReset" });
 
-        // A chip app's start() returns when the process is up, not when the app is; without waiting
-        // for the new generation to reach its own onboarding print, the check below can be answered
-        // by a cached advertisement from the generation that just went down.
+        // A chip app's start() returns when the process is up, not when the app is, so without this
+        // the probe below can run before the new generation exists at all.
         record(
             cx,
             await expectSequence(
@@ -872,7 +927,30 @@ async function restoreCommissioningMode(cx: CertStepContext, commissioned: Commi
 
     // The TH advertises itself commissionable on its own schedule, and a discovery started before
     // that finds only the devices this run is not looking for.
-    await recordCommissionable(cx, "TH back in commissioning mode");
+    await probeCommissionable(cx, what);
+}
+
+/**
+ * Returns the TH to a factory-new state if a fabric from an earlier onboarding is still on it, which
+ * is what a plan means by commissioning the same device again.
+ *
+ * The fabric comes off first, so the controller never holds a peer for a fabric the device has
+ * forgotten.
+ */
+async function restoreCommissioningMode(
+    cx: CertStepContext,
+    commissioned: CommissionedRefs,
+    probeCommissionable?: (cx: CertStepContext, what: string) => Promise<void>,
+): Promise<boolean> {
+    const previous = commissioned.get("dut");
+    if (previous === undefined) {
+        return false;
+    }
+
+    await cx.controllers.dut.node(previous).decommission();
+    commissioned.clear("dut");
+
+    await recordBackInCommissioningMode(cx, undefined, probeCommissionable);
     return true;
 }
 

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -75,6 +75,20 @@ const SETUP_QR_CODE = /SetupQRCode: \[(MT:[^\]]+)\]/;
 const COMMISSIONING_COMPLETE = /Commissioning completed successfully/;
 
 /**
+ * The device announcing that it is now advertising itself commissionable — the transition a plan's
+ * "place the TH back into commissioning mode" step asks for, stated by the device rather than
+ * inferred from a record a scanner holds.
+ *
+ * chip's line comes from `Discovery_ImplPlatform`/`Advertiser_ImplMinimalMdns`, which print the same
+ * prefix, so it is the one form both a Linux CI build and a Darwin build emit. The platform build
+ * appends `; instance name: <name>`.
+ */
+const ADVERTISING_COMMISSIONABLE = {
+    chip: /mDNS service published: _matterc\._udp/,
+    matterjs: /MdnsAdvertisement Publishing kind: commissionable/,
+};
+
+/**
  * The onboarding payload the TH publishes for its own setup code. A subject that renders one reports
  * it directly; a chip app only prints it, and the first of the two it prints is the standard
  * commissioning flow's.
@@ -857,7 +871,7 @@ export async function recordVendorOutcome(
  * that flavor it says a fabric went, and only the session line says which. A caller with a second
  * admin on the TH would have another fabric's removal satisfy the first check.
  */
-export async function recordUnpair(cx: CertStepContext, commissioned: CommissionedRefs): Promise<void> {
+export async function recordUnpair(cx: CertStepContext, commissioned: CommissionedRefs): Promise<number> {
     const th = cx.devices.th;
     const ref = commissioned.require("dut");
     const node = cx.controllers.dut.node(ref);
@@ -879,38 +893,55 @@ export async function recordUnpair(cx: CertStepContext, commissioned: Commission
         { check: () => removed.check, what: "TH reported a successful fabric removal" },
         { check: () => expired.check, what: "TH ended the DUT's fabric's sessions" },
     ]);
+
+    return from;
 }
 
 /**
- * Puts the TH back into commissioning mode by its manufacturer's means and records that it is
- * advertising there.
+ * Puts the TH back into commissioning mode by its manufacturer's means and records that it got
+ * there: the device's own announcement that it is advertising commissionable again, and then an
+ * mDNS observation of that advertisement.
  *
- * A chip TH needs a factory reset: removing its last fabric does not return it to commissioning
- * mode. A matter.js device is already there, and erasing it would restart a TH that needs nothing.
+ * A chip TH needs a factory reset: removing its last fabric leaves it re-advertising with
+ * `commissioning mode 0` (`kDisabled`), which publishes no commissionable service. A matter.js
+ * device returns on its own, and erasing it would restart a TH that needs nothing.
+ *
+ * **The device's line is what witnesses the transition; the mDNS probe corroborates it.** A probe on
+ * its own is answered by any live record for the TH's discriminator, including one cached before it
+ * was ever commissioned — and every flavor pins its discriminator across restarts. Measured, not
+ * theorised: on a matterjs run the probe passed at 13:05:44.088 and the device published its
+ * commissionable record at 13:05:44.123, 35 ms later.
+ *
+ * `options.from` is where the announcement is searched from, and must precede whatever caused the
+ * transition — for a matter.js TH that is the caller's own `decommission()`, which happens before
+ * this function is entered, so a mark taken here would already be too late. {@link recordUnpair}
+ * returns exactly that mark.
  *
  * **Every fabric on the TH must already be surrendered.** The reset wipes all of them, so a
  * `CommissionedRefs` still holding one would have the finalizer remove a fabric that is gone and
  * report a cleanup failure in place of the run's real outcome.
- *
- * What this proves is bounded: `probeCommissionable` is answered by any live commissionable record
- * for the TH's discriminator, including one cached from before it was commissioned, so on its own it
- * does not witness the transition back. The restart check is what separates the generations on a
- * chip TH — see this directory's AGENTS.md.
  */
 export async function recordBackInCommissioningMode(
     cx: CertStepContext,
-    what = "TH back in commissioning mode",
-    /** Overridden by the unit tests, which have no mDNS to answer. */
-    probeCommissionable: (cx: CertStepContext, what: string) => Promise<void> = recordCommissionable,
+    options: {
+        what?: string;
+        from?: number;
+        /** Overridden by the unit tests, which have no mDNS to answer. */
+        probeCommissionable?: (cx: CertStepContext, what: string) => Promise<void>;
+    } = {},
 ): Promise<void> {
     const th = cx.devices.th;
+    const {
+        what = "TH back in commissioning mode",
+        probeCommissionable = recordCommissionable,
+        from = th.log.mark(),
+    } = options;
 
     if (th.flavor !== "matterjs") {
-        const from = th.log.mark();
         await th.backchannel({ name: "factoryReset" });
 
         // A chip app's start() returns when the process is up, not when the app is, so without this
-        // the probe below can run before the new generation exists at all.
+        // the checks below can run before the new generation exists at all.
         record(
             cx,
             await expectSequence(
@@ -924,6 +955,12 @@ export async function recordBackInCommissioningMode(
             "TH factory reset",
         );
     }
+
+    record(
+        cx,
+        (await expectDeviceLog(th.log, th.flavor, ADVERTISING_COMMISSIONABLE, from, COMMISSIONING_LOG_TIMEOUT)).check,
+        "TH announced it is advertising commissionable again",
+    );
 
     // The TH advertises itself commissionable on its own schedule, and a discovery started before
     // that finds only the devices this run is not looking for.
@@ -947,10 +984,11 @@ async function restoreCommissioningMode(
         return false;
     }
 
+    const from = cx.devices.th.log.mark();
     await cx.controllers.dut.node(previous).decommission();
     commissioned.clear("dut");
 
-    await recordBackInCommissioningMode(cx, undefined, probeCommissionable);
+    await recordBackInCommissioningMode(cx, { from, probeCommissionable });
     return true;
 }
 

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -17,6 +17,7 @@ import {
 import { Matter } from "@matter/model";
 import type {
     AttributePathSpec,
+    CertNodeApi,
     CertNodeRef,
     CertStepContext,
     CheckRecord,
@@ -34,6 +35,13 @@ import { CertLogClosedError, CertLogTimeoutError, forFlavor } from "@matter/test
  * while answering the interaction the step drove, not one it writes after work of its own.
  */
 export const LOG_TIMEOUT = Seconds(15);
+
+const OPERATIONAL_CREDENTIALS = Matter.clusters.require("OperationalCredentials");
+const OPERATIONAL_CREDENTIALS_ID = requireId(OPERATIONAL_CREDENTIALS.id, "OperationalCredentials cluster");
+const CURRENT_FABRIC_INDEX_ID = requireId(
+    OPERATIONAL_CREDENTIALS.attributes.require("currentFabricIndex").id,
+    "OperationalCredentials.currentFabricIndex",
+);
 
 /** A cert run left a fabric (and whatever it carries) behind on the TH. */
 export class CertCleanupError extends MatterError {}
@@ -542,6 +550,50 @@ function matterjsElement(name: string | undefined, id: number | undefined): stri
  * that completed it belongs to — the equivalent of chip's "Commissioning completed successfully".
  */
 export const MATTERJS_COMMISSIONED_FABRIC = /GeneralCommissioningClusterHandler Commissioned fabric:/;
+
+/**
+ * A `RemoveFabric` the device answered with success. matter.js's line is the invoke's own answer,
+ * which names the fabric it removed and the status it answered with, where chip logs an unqualified
+ * success line.
+ */
+export function removeFabricSucceeded(fabricIndex: number): LogExpectPatterns {
+    return {
+        chip: /OpCreds: RemoveFabric successful/,
+        matterjs: new RegExp(
+            `operationalCredentials\\.removeFabric .*statusCode: 0 fabricIndex: ${fabricIndex}(?!\\d)`,
+        ),
+    };
+}
+
+/**
+ * The removed fabric's sessions going away. A matter.js session is named
+ * `@<fabricIndex>:<fabricId>•<id>`, so one such line per session is what chip states once as
+ * "Expiring all sessions for fabric N".
+ */
+export function fabricSessionsEnded(fabricIndex: number): LogExpectPatterns {
+    return {
+        chip: new RegExp(`Expiring all sessions for fabric 0x${fabricIndex.toString(16)}!!`),
+        matterjs: new RegExp(`Session @${fabricIndex}:[0-9a-f]+•[0-9a-f]+ Session ended`),
+    };
+}
+
+/**
+ * The fabric index the TH assigned to `node`'s own controller, read over that controller's own session
+ * — the only discriminator every controller has without setup. A fabric's `Label` is empty until an
+ * admin writes one (Core § 11.18.6.2), so it identifies nothing for a harness that must work with any
+ * controller implementation.
+ */
+export async function readOwnFabricIndex(node: CertNodeApi): Promise<number> {
+    const value = await node.readAttribute({
+        endpoint: 0,
+        cluster: OPERATIONAL_CREDENTIALS_ID,
+        attribute: CURRENT_FABRIC_INDEX_ID,
+    });
+    if (typeof value !== "number") {
+        throw new InternalError(`Expected CurrentFabricIndex to read as a number, got ${JSON.stringify(value)}`);
+    }
+    return value;
+}
 
 // A path is one entry of a comma-separated list, so a match needs both ends bounded: without this,
 // the path a step asked for matches as the tail of a longer endpoint number or the head of a longer


### PR DESCRIPTION
Adds TC-DD-3.20 from the device-discovery test plan: a commissioner commissions a test harness, unpairs it, and commissions it again.

## What the test case does

The plan drives the same harness onto the fabric twice with an explicit unpair between the attempts. The return to a factory-new state that `commissionByQr` had been doing silently therefore becomes two of the plan's own steps:

- **`recordUnpair`** (step 3) removes the fabric and records three things: that the controller removed it, and the device's own two statements that it did — the removal succeeded, and the removed fabric's sessions are gone.
- **`recordBackInCommissioningMode`** (step 4) performs the plan's "manufacturer's means" precondition: a factory reset on a chip harness, nothing on a matter.js one, which returns to commissioning mode by itself.

`recordBackInCommissioningMode` is lifted out of the existing private `restoreCommissioningMode`, which still runs it for a test case that does not drive these steps itself. `recordUnpair` is new. Existing test cases that commission through `commissionByQr` record exactly the same checks, with the same labels, as before.

`removeFabricSucceeded`, `fabricSessionsEnded` and `readOwnFabricIndex` move from TC-CADMIN-1.17's support module to `tc-support.ts`, with their unit tests, now that a second test case needs them.

## Why step 3 reads the device's log instead of the network

The first revision proved the removal from the network — no operational `_matter._tcp` record for the node's own instance name. That passes against matter.js and fails against a chip harness, where the record is still observed live after the check's full 30 s window.

The device is not at fault. Its log carries `[DIS] Updating services using commissioning mode 0` four milliseconds before `OpCreds: RemoveFabric successful` — that is `DnssdServer::StartServer()` withdrawing its advertisements and re-publishing only the fabrics that remain, which `OperationalCredentialsCluster::OnFabricRemoved` calls for exactly this purpose.

**Why the withdrawal is not observable inside that window is not established.** It could be a goodbye that is never sent, one that is sent but not ingested, or the check's own rule of never re-soliciting a name it still holds live, leaving the cached record to run out its TTL. TC-CADMIN-1.17's own record check fails the same way on the same host, and that one removes one fabric of three — so it is not a property of removing the last fabric. Until someone captures the wire this is left as an open question in `AGENTS.md`; the device's log is the evidence both implementations produce, so that is what the step rests on.

## Step 4 waits for the device to say it is back

Step 4 asks the harness to return to commissioning mode, and the first revision proved that with an mDNS probe alone. That probe fires on any live commissionable record for the harness's discriminator, including one cached several steps earlier — every flavour pins its discriminator across restarts — so it does not witness the transition it claims.

Measured rather than reasoned: in the matterjs evidence bundle the probe passed at 13:05:44.088 off a record cached in step 1, and the device logged that it was publishing its commissionable record at 13:05:44.123. The step was green for 35 ms on evidence that predated the transition.

`recordBackInCommissioningMode` now requires the device's own announcement and treats the probe as corroboration. The chip half of the pattern is `mDNS service published: _matterc._udp`, printed by both the minimal-mDNS advertiser and the platform implementation, so it holds on a Linux CI build as well as a Darwin one — chip's `Registering service …` line is Darwin-only and would have passed locally while proving nothing in CI.

The announcement is searched from a mark the *caller* took. For a matter.js harness the transition is caused by the previous step's `decommission()`, so a mark taken inside the helper can already be past the line; `recordUnpair` returns the mark it takes before removing the fabric and the test case threads it into step 4, the same capture-in-one-step, use-in-a-later-one shape TC-CADMIN-1.17 uses for its operational instance name.

## What is left open, and recorded rather than fixed

The two instruments still have the property in general, and `AGENTS.md` names the three places that still rest on them: steps whose only evidence is a bare commissionable probe, the `MCORE.DD.SCAN_QR_CODE` gate on the `.a` steps while their `.b` siblings repeat the same parse ungated (TC-DD-3.21 ships that shape too, and the plan gives the `.b` steps no PICS), and `thQrPayload` searching from index 0 so a step after a factory reset re-reads the payload the dead generation printed.

Closing those means a freshness primitive — an mDNS probe that rejects a record installed before a caller's mark, and a log anchor that drains to real time first — in `packages/testing` and `packages/general`, touching every existing test case's evidence. That is a decision to take, not a fixup to slip into this branch.

## Verification

- TC-DD-3.20 runs green on both device flavours locally, checked per step from the evidence bundle rather than the exit code: matterjs 7/7 and chip-local 7/7, no unverified checks, no PICS skips.
- The whole cert suite on the matterjs flavour: 15 test cases, matching the documented baseline (TC-IDM-2.1's one accepted unverified check, TC-DD-3.11 and 3.14 at two PICS skips each).
- The device-discovery block plus TC-CADMIN-1.17 on chip-local: every device-discovery case green. TC-CADMIN-1.17 step 10 fails on this host, before and independently of this branch — it is the same operational-record symptom described above, and this branch touches that file's imports only.
- `test/cert-framework` 762/762, root `npm test` green on all legs, `npm run lint` and `npm run format-verify` clean.
- Every branch this adds is mutation-proven: reverting the production line turns exactly the test that covers it red. That includes the three cases added after a coverage review found them uncovered (recording both outcomes when the first check is the one that failed, surrendering the node reference when the reset that follows fails, and refusing a fabric index the device did not report as a number), and the two for the freshness fix (removing the announcement check, and ignoring the caller's mark in favour of a fresh one).
- Step 4's evidence now reads `device-log, network` on matterjs and `device-log, device-log, network` on chip-local, both from real runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
