### PR TITLE
A device type may require more than one of the same component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/model
     - Fix: A device type requiring several instances of one component, such as `BatteryStorage` with two electrical sensors and two power sources, no longer reports each instance as a duplicate of the others
+    - Enhancement: The model build reports an instance number stated on a requirement other than a component device type, where the specification numbers nothing
     - Enhancement: A model element's `extend()` can remove an inherited quality, stated as `!N` in the quality definition; the removal survives further extension, and a definition that extends one carrying a removal may state the quality again
     - Fix: A quality definition given as an array of flags, such as `["N", "T"]`, loads those flags instead of reading as empty
     - Fix: A quality states which of its flags are not qualities, so a definition another rewrites still carries the flags it could not parse and the errors they raise

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: The `Symbol.metadata` polyfill no longer conflicts with `lib.esnext.decorators` in the published declarations
 
 - @matter/model
+    - Fix: A device type requiring several instances of one component, such as `BatteryStorage` with two electrical sensors and two power sources, no longer reports each instance as a duplicate of the others
     - Enhancement: A model element's `extend()` can remove an inherited quality, stated as `!N` in the quality definition; the removal survives further extension, and a definition that extends one carrying a removal may state the quality again
     - Fix: A quality definition given as an array of flags, such as `["N", "T"]`, loads those flags instead of reading as empty
     - Fix: A quality states which of its flags are not qualities, so a definition another rewrites still carries the flags it could not parse and the errors they raise

--- a/packages/model/src/logic/definition-validation/ModelValidator.ts
+++ b/packages/model/src/logic/definition-validation/ModelValidator.ts
@@ -6,6 +6,7 @@
 
 import { CrossReference } from "#models/CrossReference.js";
 import { ElementTag } from "../../common/index.js";
+import { RequirementElement } from "../../elements/index.js";
 import { CommandModel, Model, RequirementModel, ValueModel } from "../../models/index.js";
 
 /**
@@ -105,8 +106,13 @@ export class ModelValidator<T extends Model> {
                     id = `${id}:${child.direction}`;
                 } else if (child instanceof RequirementModel) {
                     // A device type may require several instances of one component, numbered from 1, and each is a
-                    // requirement of its own
-                    id = `${id}:${child.element}${child.instance === undefined ? "" : `:${child.instance}`}`;
+                    // requirement of its own.  Only a component states an instance; elsewhere the number would let
+                    // two requirements that are genuinely the same escape this check
+                    const instance =
+                        child.element === RequirementElement.ElementType.DeviceType && child.instance !== undefined
+                            ? `:${child.instance}`
+                            : "";
+                    id = `${id}:${child.element}${instance}`;
                 }
                 const identity = `${child.tag};${id};${(child as ValueModel).conformance}`;
                 if (identities[identity]) {

--- a/packages/model/src/logic/definition-validation/ModelValidator.ts
+++ b/packages/model/src/logic/definition-validation/ModelValidator.ts
@@ -109,8 +109,9 @@ export class ModelValidator<T extends Model> {
                     // requirement of its own.  Only a component states an instance; elsewhere the number would let
                     // two requirements that are genuinely the same escape this check
                     const instance =
-                        child.element === RequirementElement.ElementType.DeviceType && child.instance !== undefined
-                            ? `:${child.instance}`
+                        child.element === RequirementElement.ElementType.DeviceType &&
+                        child.instanceNumber !== undefined
+                            ? `:${child.instanceNumber}`
                             : "";
                     id = `${id}:${child.element}${instance}`;
                 }

--- a/packages/model/src/logic/definition-validation/ModelValidator.ts
+++ b/packages/model/src/logic/definition-validation/ModelValidator.ts
@@ -104,7 +104,9 @@ export class ModelValidator<T extends Model> {
                 if (child instanceof CommandModel) {
                     id = `${id}:${child.direction}`;
                 } else if (child instanceof RequirementModel) {
-                    id = `${id}:${child.element}`;
+                    // A device type may require several instances of one component, numbered from 1, and each is a
+                    // requirement of its own
+                    id = `${id}:${child.element}${child.instance === undefined ? "" : `:${child.instance}`}`;
                 }
                 const identity = `${child.tag};${id};${(child as ValueModel).conformance}`;
                 if (identities[identity]) {

--- a/packages/model/src/logic/definition-validation/RequirementValidator.ts
+++ b/packages/model/src/logic/definition-validation/RequirementValidator.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ElementTag } from "../../common/index.js";
+import { ElementTag, FieldValue } from "../../common/index.js";
 import { RequirementElement } from "../../elements/index.js";
 import { FieldModel, RequirementModel } from "../../models/index.js";
 import { ModelValidator } from "./ModelValidator.js";
@@ -20,11 +20,21 @@ ModelValidator.validators[RequirementElement.Tag] = class RequirementValidator e
             required: true,
         });
 
-        if (this.model.instance !== undefined && this.model.element !== RequirementElement.ElementType.DeviceType) {
-            this.error(
-                "INSTANCE_NOT_APPLICABLE",
-                `Only a component device type is required in numbered instances, not ${this.model.element}`,
-            );
+        const { instance } = this.model;
+        if (instance !== undefined) {
+            if (this.model.element !== RequirementElement.ElementType.DeviceType) {
+                this.error(
+                    "INSTANCE_NOT_APPLICABLE",
+                    `Only a component device type is required in numbered instances, not ${this.model.element}`,
+                );
+            } else if (typeof instance !== "number" || !Number.isInteger(instance) || instance < 1) {
+                // Instances are numbered from one, and the number tells two requirements apart, so a number that
+                // states no instance would make requirements that are the same look different
+                this.error(
+                    "INVALID_INSTANCE",
+                    `Instance ${FieldValue.serialize(instance)} is not a number of an instance, which counts from 1`,
+                );
+            }
         }
 
         const parentTag = this.model.parent?.tag;

--- a/packages/model/src/logic/definition-validation/RequirementValidator.ts
+++ b/packages/model/src/logic/definition-validation/RequirementValidator.ts
@@ -20,6 +20,13 @@ ModelValidator.validators[RequirementElement.Tag] = class RequirementValidator e
             required: true,
         });
 
+        if (this.model.instance !== undefined && this.model.element !== RequirementElement.ElementType.DeviceType) {
+            this.error(
+                "INSTANCE_NOT_APPLICABLE",
+                `Only a component device type is required in numbered instances, not ${this.model.element}`,
+            );
+        }
+
         const parentTag = this.model.parent?.tag;
         if (parentTag) {
             switch (this.model.element) {

--- a/packages/model/src/logic/definition-validation/RequirementValidator.ts
+++ b/packages/model/src/logic/definition-validation/RequirementValidator.ts
@@ -27,9 +27,7 @@ ModelValidator.validators[RequirementElement.Tag] = class RequirementValidator e
                     "INSTANCE_NOT_APPLICABLE",
                     `Only a component device type is required in numbered instances, not ${this.model.element}`,
                 );
-            } else if (typeof instance !== "number" || !Number.isInteger(instance) || instance < 1) {
-                // Instances are numbered from one, and the number tells two requirements apart, so a number that
-                // states no instance would make requirements that are the same look different
+            } else if (this.model.instanceNumber === undefined) {
                 this.error(
                     "INVALID_INSTANCE",
                     `Instance ${FieldValue.serialize(instance)} is not a number of an instance, which counts from 1`,

--- a/packages/model/src/models/RequirementModel.ts
+++ b/packages/model/src/models/RequirementModel.ts
@@ -25,6 +25,18 @@ export class RequirementModel extends Model<RequirementElement, RequirementModel
         return this.element;
     }
 
+    /**
+     * The instance this requirement is one of, where it states a number that counts instances.
+     *
+     * Instances are numbered from one, so a number that counts none states no instance at all.  This is the only
+     * reading of {@link instance}: a requirement is told apart by the instance it belongs to, so a number that means
+     * nothing must not make two requirements that are the same look different.
+     */
+    get instanceNumber() {
+        const { instance } = this;
+        return typeof instance === "number" && Number.isInteger(instance) && instance >= 1 ? instance : undefined;
+    }
+
     get constraint(): Constraint {
         return this.#constraint;
     }

--- a/packages/model/test/MatterTest.ts
+++ b/packages/model/test/MatterTest.ts
@@ -22,7 +22,7 @@ describe("MatterDefinition", () => {
 
     it("has not increased in errors", () => {
         validate().report();
-        expect(validationResult?.errors.length).most(4);
+        expect(validationResult?.errors.length).most(0);
     });
 
     it("has not decreased in scope", () => {

--- a/packages/model/test/logic/definition-validation/RequirementValidatorTest.ts
+++ b/packages/model/test/logic/definition-validation/RequirementValidatorTest.ts
@@ -69,6 +69,16 @@ describe("RequirementValidator", () => {
             expect(withComponents("1" as unknown as number)).deep.equals(["INVALID_INSTANCE"]);
         });
 
+        // Reporting the number is not enough: a number that states no instance must not stand in for one, or a
+        // requirement carrying it escapes the check for duplicates
+        it("does not let a number that is no instance hide a duplicate", () => {
+            expect(withComponents(undefined, 0).sort()).deep.equals([
+                "DUPLICATE_CHILD",
+                "DUPLICATE_CHILD",
+                "INVALID_INSTANCE",
+            ]);
+        });
+
         it("accepts the numbers the specification counts", () => {
             expect(withComponents(1)).deep.equals([]);
             expect(withComponents(2)).deep.equals([]);

--- a/packages/model/test/logic/definition-validation/RequirementValidatorTest.ts
+++ b/packages/model/test/logic/definition-validation/RequirementValidatorTest.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ValidateModel } from "#index.js";
+import { DeviceTypeModel, MatterModel, RequirementModel } from "#models/index.js";
+
+/** A device type requiring the same component twice, as Battery Storage requires two electrical sensors */
+function withComponents(...instances: (number | undefined)[]) {
+    const Matter = new MatterModel(
+        {},
+        new DeviceTypeModel(
+            { name: "Composite", id: 0xff01, classification: "simple" },
+            ...instances.map(
+                instance => new RequirementModel({ name: "PowerSource", id: 0x11, element: "deviceType", instance }),
+            ),
+        ),
+    );
+    Matter.finalize();
+
+    return ValidateModel(Matter).errors.map(error => error.code);
+}
+
+/** A requirement that is not a component, so an instance number means nothing on it */
+function withNumberedAttributes(...instances: (number | undefined)[]) {
+    const Matter = new MatterModel(
+        {},
+        new DeviceTypeModel(
+            { name: "Numbered", id: 0xff02, classification: "simple" },
+            new RequirementModel(
+                { name: "OnOff", id: 0x6, element: "serverCluster" },
+                ...instances.map(instance => new RequirementModel({ name: "OnTime", element: "attribute", instance })),
+            ),
+        ),
+    );
+    Matter.finalize();
+
+    return ValidateModel(Matter).errors.map(error => error.code);
+}
+
+describe("RequirementValidator", () => {
+    describe("a component required in several instances", () => {
+        it("accepts one requirement per instance", () => {
+            expect(withComponents(1, 2)).deep.equals([]);
+        });
+
+        it("reports two requirements for one instance", () => {
+            expect(withComponents(1, 1)).deep.equals(["DUPLICATE_CHILD", "DUPLICATE_CHILD"]);
+        });
+
+        it("reports two requirements stating no instance", () => {
+            expect(withComponents(undefined, undefined)).deep.equals(["DUPLICATE_CHILD", "DUPLICATE_CHILD"]);
+        });
+    });
+
+    describe("an instance number where the specification states none", () => {
+        it("reports it, and still reports the duplicate it would otherwise hide", () => {
+            expect(withNumberedAttributes(1, 2)).deep.equals([
+                "DUPLICATE_CHILD",
+                "INSTANCE_NOT_APPLICABLE",
+                "INSTANCE_NOT_APPLICABLE",
+            ]);
+        });
+
+        it("accepts an attribute requirement stating no instance", () => {
+            expect(withNumberedAttributes(undefined)).deep.equals([]);
+        });
+    });
+});

--- a/packages/model/test/logic/definition-validation/RequirementValidatorTest.ts
+++ b/packages/model/test/logic/definition-validation/RequirementValidatorTest.ts
@@ -55,6 +55,26 @@ describe("RequirementValidator", () => {
         });
     });
 
+    describe("a number that is no instance number", () => {
+        // The number tells two requirements apart, so one that states no instance would make requirements that are
+        // the same look different
+        it("reports a number that does not count from one", () => {
+            expect(withComponents(0)).deep.equals(["INVALID_INSTANCE"]);
+            expect(withComponents(-1)).deep.equals(["INVALID_INSTANCE"]);
+            expect(withComponents(1.5)).deep.equals(["INVALID_INSTANCE"]);
+            expect(withComponents(Number.NaN)).deep.equals(["INVALID_INSTANCE"]);
+        });
+
+        it("reports a value that is no number at all", () => {
+            expect(withComponents("1" as unknown as number)).deep.equals(["INVALID_INSTANCE"]);
+        });
+
+        it("accepts the numbers the specification counts", () => {
+            expect(withComponents(1)).deep.equals([]);
+            expect(withComponents(2)).deep.equals([]);
+        });
+    });
+
     describe("an instance number where the specification states none", () => {
         it("reports it, and still reports the duplicate it would otherwise hide", () => {
             expect(withNumberedAttributes(1, 2)).deep.equals([

--- a/packages/model/test/standard/MatterDefinitionTest.ts
+++ b/packages/model/test/standard/MatterDefinitionTest.ts
@@ -38,7 +38,7 @@ describe("MatterDefinition", () => {
 
     it("has not increased in errors", () => {
         validate().report();
-        expect(validationResult?.errors.length).most(4);
+        expect(validationResult?.errors.length).most(0);
     });
 
     it("has not decreased in scope", () => {


### PR DESCRIPTION
`BatteryStorage` requires two electrical sensors — one alternating current, one direct — and two power sources. The specification numbers such instances, and `RequirementElement.instance` records the number, documented for exactly this case.

`validateChildUniqueness` did not read it. A requirement's identity was `tag;name-or-id:element;conformance`, so the two `ElectricalSensor` requirements looked identical, as did the two `PowerSource`. Each requirement is counted under both its name and its id, so four legitimate instances produced four errors:

```
Duplicate requirement ElectricalSensor:deviceType
Duplicate requirement 1296:deviceType
Duplicate requirement PowerSource:deviceType
Duplicate requirement 17:deviceType
```

The instance number is now part of what makes a requirement distinct, exactly as `direction` already is for a command.

## The test change is the point

These four were the only errors the specification's own model produced, and `MatterTest.ts` tolerated them with `expect(errors.length).most(4)`. With them gone the model validates completely clean, so that assertion now expects `most(0)`.

That budget was not free. It had no headroom, so every definition rule added recently had to be measured against the shipped model and shown to report nothing, or it would have failed CI by exceeding four. Anyone adding a rule that legitimately reports something will now have to raise this number deliberately rather than fitting under it unnoticed — which is the intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)