### PR TITLE
test(chip-testing): a cert step's mark separates cause from effect, and the network never witnesses one

### DIFF
--- a/packages/testing/src/chip/cert/log-follower.ts
+++ b/packages/testing/src/chip/cert/log-follower.ts
@@ -148,10 +148,38 @@ export class LogFollower implements LogSource {
     /**
      * Sets the default cursor a subsequent {@link expect} call scans from when it doesn't specify
      * `from` itself. Typically called once at the start of a step.
+     *
+     * This counts lines **ingested**, not lines the device has printed. The pump reads its source
+     * asynchronously, so a line the device wrote just before this call may still be in flight and
+     * land at an index at or after the mark — where a check reads it as having been caused by
+     * whatever the caller does next. Use {@link markSettled} for a mark that has to separate cause
+     * from effect.
      */
     mark(): number {
         this.#lastMark = this.#lines.length;
         return this.#lastMark;
+    }
+
+    /**
+     * {@link mark}, after letting the pump deliver what its source already holds.
+     *
+     * This is the mark to take before doing something whose effect a later check attributes to it:
+     * a plain {@link mark} can sit *behind* a line the device had already written, and the check
+     * then passes on evidence that predates its own cause.
+     *
+     * What it promises is bounded, and deliberately so: it yields two macrotask turns, which is what
+     * every source this class is given today needs — a process stream, a {@link LineQueue}, or a
+     * follower reading another follower all reach {@link #consume} through microtasks after one poll
+     * phase. A source that inserts a macrotask of its own between read and append would need more,
+     * and would get a mark that is silently too early rather than an error. A line the device has not
+     * yet flushed is not observable by any means here.
+     */
+    async markSettled(): Promise<number> {
+        // Two turns: the first lets a pending read resolve, the second lets the pump's own
+        // continuation append what it read.
+        await delay(0).promise;
+        await delay(0).promise;
+        return this.mark();
     }
 
     /**

--- a/support/chip-testing/test/cert-framework/log-follower.test.ts
+++ b/support/chip-testing/test/cert-framework/log-follower.test.ts
@@ -110,6 +110,52 @@ describe("LogFollower", () => {
         await follower.close();
     });
 
+    // The hazard mark() has and markSettled() does not: a line the device already wrote but whose
+    // delivery is still in flight lands after a plain mark, and a check then reads it as having been
+    // caused by whatever the caller does next.
+    it("mark() can sit behind a line the source has already produced", async () => {
+        const source = new TestSource();
+        const follower = new LogFollower(source, "dut");
+
+        source.push("device ready");
+        // Deliberately no drain here — this is what a step doing mark()-then-act looks like
+        expect(follower.mark()).equal(0);
+
+        const result = await follower.expect({ chip: /ready/ }, { flavor: "chip", timeoutMs: 2_000 });
+        expect(result.verdict).equal("pass");
+
+        await follower.close();
+    });
+
+    it("markSettled() lets the pump deliver what the source already holds", async () => {
+        const source = new TestSource();
+        const follower = new LogFollower(source, "dut");
+
+        source.push("device ready");
+        expect(await follower.markSettled()).equal(1);
+
+        await expect(follower.expect({ chip: /ready/ }, { flavor: "chip", timeoutMs: 30 })).rejectedWith(
+            CertLogTimeoutError,
+        );
+
+        await follower.close();
+    });
+
+    it("markSettled() still matches a line that arrives after it", async () => {
+        const source = new TestSource();
+        const follower = new LogFollower(source, "dut");
+
+        source.push("earlier");
+        await follower.markSettled();
+        source.push("device ready");
+
+        const result = await follower.expect({ chip: /ready/ }, { flavor: "chip", timeoutMs: 2_000 });
+        expect(result.verdict).equal("pass");
+        expect(result.verdict === "pass" && result.matched.text).equal("device ready");
+
+        await follower.close();
+    });
+
     it("does not match a line emitted before mark()", async () => {
         const source = new TestSource();
         const follower = new LogFollower(source, "dut");

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -30,6 +30,7 @@ import type { ManualPairingCodeParts, TransitionMark } from "../cert/tc-dd-suppo
 import {
     checkGeneratedManualCode,
     checkGeneratedPayload,
+    commissionByQr,
     CommissioningRefusals,
     manualPairingCode,
     manualPairingCodeDigits,
@@ -1261,6 +1262,33 @@ describe("restoreCommissioningMode, through recordVendorOutcome", () => {
         ).rejectedWith(CertCheckFailedError);
 
         expect(fixture.commissioned.get("dut")).equal(undefined);
+    });
+});
+
+describe("commissionByQr's own causal boundary", () => {
+    const completion = (fabric: string) =>
+        `2026-08-27 19:31:27.056 NOTICE GeneralCommissioningClusterHandler Commissioned fabric: ${fabric} (#1) node: 1`;
+
+    // The mark this takes has to sit behind a completion the TH had already written, or the check
+    // matches that one and reports a commissioning this call never performed. The markSettled tests
+    // above prove the primitive; this one proves the call site actually uses it.
+    it("matches the completion its own commissioning caused, not one already in flight", async () => {
+        const fixture = new UnpairFixture("matterjs", {
+            commission: async () => {
+                fixture.push(completion("bbbbbbbbbbbbbbbb"));
+                return "peer1" as CertNodeRef;
+            },
+        });
+
+        // Written before the call and deliberately left undrained, which is exactly the state a plain
+        // mark() cannot distinguish from a line this commissioning caused
+        fixture.push(completion("aaaaaaaaaaaaaaaa"));
+
+        await commissionByQr(fixture.cx, "MT:-24J042C00KA0648G00", new CommissionedRefs());
+
+        const matched = fixture.checks.find(check => check.type === "device-log")?.matched ?? "";
+        expect(matched).contains("bbbbbbbbbbbbbbbb");
+        expect(matched).not.contains("aaaaaaaaaaaaaaaa");
     });
 });
 

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -26,7 +26,7 @@ import { LineQueue, LogFollower, PicsFile } from "@matter/testing";
 import { expect } from "chai";
 import { ChipToolCommandError } from "../../src/cert/ChipToolControllerAdapter.js";
 import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload.js";
-import type { ManualPairingCodeParts } from "../cert/tc-dd-support.js";
+import type { ManualPairingCodeParts, TransitionMark } from "../cert/tc-dd-support.js";
 import {
     checkGeneratedManualCode,
     checkGeneratedPayload,
@@ -994,10 +994,11 @@ class UnpairFixture {
         options: {
             fabricIndex?: number;
             backchannel?: () => void;
+            onDecommission?: () => void;
             commission?: () => Promise<CertNodeRef>;
         } = {},
     ) {
-        const { fabricIndex = 1, backchannel = () => {} } = options;
+        const { fabricIndex = 1, backchannel = () => {}, onDecommission = () => {} } = options;
         const log = new LogFollower(this.#source, "th");
         this.#log = log;
         const unused = () => Promise.reject(new InternalError("not used by these tests"));
@@ -1019,6 +1020,7 @@ class UnpairFixture {
             operationalMdnsInstanceName: unused,
             decommission: async () => {
                 this.calls.push("decommission");
+                onDecommission();
             },
         };
 
@@ -1079,8 +1081,8 @@ class UnpairFixture {
         this.#source.close();
     }
 
-    mark(): number {
-        return this.#log.mark();
+    async markTransition(): Promise<TransitionMark> {
+        return this.#log.markSettled();
     }
 
     /** Lets the follower's pump ingest what was pushed, so a later `mark()` is past it. */
@@ -1099,8 +1101,9 @@ const MATTERJS_ADVERTISING_COMMISSIONABLE =
 
 describe("recordUnpair", () => {
     it("records the removal and the ended sessions, and gives up the ref", async () => {
-        const fixture = new UnpairFixture("chip-local");
-        fixture.push(CHIP_FABRIC_REMOVED, CHIP_SESSIONS_EXPIRED);
+        const fixture = new UnpairFixture("chip-local", {
+            onDecommission: () => fixture.push(CHIP_FABRIC_REMOVED, CHIP_SESSIONS_EXPIRED),
+        });
 
         await recordUnpair(fixture.cx, fixture.commissioned);
 
@@ -1115,8 +1118,9 @@ describe("recordUnpair", () => {
     // The in-process controller drops the peer as the device announces the removal, so the index the
     // device assigned this controller cannot be read once the fabric is gone
     it("reads the fabric index before removing the fabric", async () => {
-        const fixture = new UnpairFixture("chip-local");
-        fixture.push(CHIP_FABRIC_REMOVED, CHIP_SESSIONS_EXPIRED);
+        const fixture = new UnpairFixture("chip-local", {
+            onDecommission: () => fixture.push(CHIP_FABRIC_REMOVED, CHIP_SESSIONS_EXPIRED),
+        });
 
         await recordUnpair(fixture.cx, fixture.commissioned);
 
@@ -1124,9 +1128,13 @@ describe("recordUnpair", () => {
     });
 
     it("judges both lines against the fabric index the device assigned", async () => {
-        const fixture = new UnpairFixture("chip-local", { fabricIndex: 2 });
-        fixture.push(CHIP_FABRIC_REMOVED, CHIP_SESSIONS_EXPIRED);
-        fixture.close();
+        const fixture = new UnpairFixture("chip-local", {
+            fabricIndex: 2,
+            onDecommission: () => {
+                fixture.push(CHIP_FABRIC_REMOVED, CHIP_SESSIONS_EXPIRED);
+                fixture.close();
+            },
+        });
 
         await expect(recordUnpair(fixture.cx, fixture.commissioned)).rejectedWith(CertCheckFailedError);
 
@@ -1137,16 +1145,33 @@ describe("recordUnpair", () => {
     // matter.js closes the removed fabric's sessions before it answers the invoke, so a search
     // starting where the removal matched would never reach them
     it("finds a session end the TH logged before the removal it answered", async () => {
-        const fixture = new UnpairFixture("matterjs");
-        fixture.push(
-            "2026-08-22 21:48:06.401 INFO Session @1:1946ee4c0f86d574•c677 Session ended",
-            "2026-08-22 21:48:06.406 INFO ProtocolService Invoke » binford-6100.operationalCredentials.removeFabric " +
-                "@1:9a52bb47a4ee167d•c675⇵68ce✉09f1964b statusCode: 0 fabricIndex: 1",
-        );
+        const fixture = new UnpairFixture("matterjs", {
+            onDecommission: () =>
+                fixture.push(
+                    "2026-08-22 21:48:06.401 INFO Session @1:1946ee4c0f86d574•c677 Session ended",
+                    "2026-08-22 21:48:06.406 INFO ProtocolService Invoke » binford-6100.operationalCredentials." +
+                        "removeFabric @1:9a52bb47a4ee167d•c675⇵68ce✉09f1964b statusCode: 0 fabricIndex: 1",
+                ),
+        });
 
         await recordUnpair(fixture.cx, fixture.commissioned);
 
         expect(fixture.checks.map(check => check.verdict)).deep.equal(["pass", "pass", "pass"]);
+    });
+
+    // The contract TC-DD-3.20's steps 4 and 5 rest on: the mark predates the removal, so a check
+    // anchored on it sees what the TH did in response
+    it("returns a mark taken before the fabric came off", async () => {
+        const fixture = new UnpairFixture("chip-local", {
+            onDecommission: () => fixture.push(CHIP_FABRIC_REMOVED, CHIP_SESSIONS_EXPIRED),
+        });
+
+        const mark = await recordUnpair(fixture.cx, fixture.commissioned);
+
+        // Both lines the TH printed because of the removal are at or after it
+        const lines = fixture.cx.devices.th.log.lines;
+        expect(lines.length).greaterThan(mark);
+        expect(lines.slice(mark).map(line => line.text)).deep.equal([CHIP_FABRIC_REMOVED, CHIP_SESSIONS_EXPIRED]);
     });
 
     it("fails, but still gives up the ref, when the TH never logs the removal", async () => {
@@ -1160,9 +1185,12 @@ describe("recordUnpair", () => {
     });
 
     it("records both outcomes before failing on the first bad one", async () => {
-        const fixture = new UnpairFixture("chip-local");
-        fixture.push(CHIP_FABRIC_REMOVED);
-        fixture.close();
+        const fixture = new UnpairFixture("chip-local", {
+            onDecommission: () => {
+                fixture.push(CHIP_FABRIC_REMOVED);
+                fixture.close();
+            },
+        });
 
         await expect(recordUnpair(fixture.cx, fixture.commissioned)).rejectedWith(CertCheckFailedError);
 
@@ -1172,9 +1200,12 @@ describe("recordUnpair", () => {
     // The bundle must carry the session-end outcome even though the removal check ahead of it is what
     // fails the step: recording the two in sequence would throw on the first and drop the second
     it("records the session-end outcome even when the removal check is the one that failed", async () => {
-        const fixture = new UnpairFixture("chip-local");
-        fixture.push(CHIP_SESSIONS_EXPIRED);
-        fixture.close();
+        const fixture = new UnpairFixture("chip-local", {
+            onDecommission: () => {
+                fixture.push(CHIP_SESSIONS_EXPIRED);
+                fixture.close();
+            },
+        });
 
         await expect(recordUnpair(fixture.cx, fixture.commissioned)).rejectedWith(CertCheckFailedError);
 
@@ -1208,7 +1239,7 @@ describe("restoreCommissioningMode, through recordVendorOutcome", () => {
 
         // The restore's own probe, and no second one: a restore that ran has already proven the TH
         // is there, so the attempt does not probe again
-        expect(probed).deep.equal(["TH back in commissioning mode"]);
+        expect(probed).deep.equal(["TH advertising as commissionable again"]);
     });
 
     // The fabric is off the TH once decommission() resolves, whatever the reset that follows does, so
@@ -1254,13 +1285,16 @@ describe("recordBackInCommissioningMode", () => {
     // restart a TH that needs nothing
     it("does not reset a matterjs TH, and takes its own announcement instead", async () => {
         const fixture = new UnpairFixture("matterjs");
-        fixture.push(MATTERJS_ADVERTISING_COMMISSIONABLE);
         const probed = new Array<string>();
 
-        await recordBackInCommissioningMode(fixture.cx, {
+        // The announcement has to land after the helper's own settled mark, which costs a couple of
+        // event-loop turns; the delay is what keeps that ordering out of the scheduler's hands
+        const pending = recordBackInCommissioningMode(fixture.cx, {
             what: "TH advertising again",
             probeCommissionable: async (_cx, what) => void probed.push(what),
         });
+        setTimeout(() => fixture.push(MATTERJS_ADVERTISING_COMMISSIONABLE), 25);
+        await pending;
 
         expect(fixture.calls).deep.equal([]);
         expect(fixture.checks.map(check => check.verdict)).deep.equal(["pass"]);
@@ -1286,14 +1320,14 @@ describe("recordBackInCommissioningMode", () => {
 
     it("searches the announcement from the caller's mark, not from its own entry", async () => {
         const fixture = new UnpairFixture("matterjs");
-        const before = fixture.mark();
+        const before = await fixture.markTransition();
         // A TH that returned to commissioning mode before this helper was entered, which is the
         // ordinary case: the decommission that caused it happened in the caller
         fixture.push(MATTERJS_ADVERTISING_COMMISSIONABLE);
         await fixture.drain();
 
         await recordBackInCommissioningMode(fixture.cx, {
-            from: before,
+            since: before,
             probeCommissionable: async () => {},
         });
 

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1729,47 +1729,67 @@ controller still owns the peer either way.
 holds a ref, and step 3 cleared it, so the TC's own steps 3 and 4 are what run — the helper does not
 factory-reset a TH that was just reset.
 
-## Freshness: a cache hit is not a state transition — OPEN
+## Freshness: a cache hit is not a state transition
 
-TC-DD-3.20 closed this for its own step 4 by requiring the device's own announcement. The instruments
-themselves still have the property, and three other places still rest on them. Recorded here in the
-same spirit as "Known limitations carried forward from `TC-ACT-3.2`" and the TC-DD-3.11 section's
-"Unsettled, worth resolving before the next per-transport TC" above.
+A step that *drives* a transition must not prove it with a check that only observes a *condition* —
+the condition was already true beforehand. The instrument that witnesses a transition here is the
+**device's own log**. The network cannot do it, and the reason is worth knowing before anyone tries
+again.
 
-**The shape.** A step that drives a transition proves it with a check that observes a *condition*, and
-the condition was already true before the transition.
+**The mDNS probe cannot witness anything.** `checkCommissionable` primes from the process-global
+`Environment.default.get(MdnsService).names` and fires on any cached device matching the long
+discriminator. Every flavor pins discriminator 3840 across restarts and a commissionable record
+outlives its announcement by about two minutes, so a record cached several steps earlier answers with
+nothing on the wire. Measured in TC-DD-3.20 before this was fixed: its step-4 probe passed at
+13:05:44.088 and the device published the record at 13:05:44.123 — green for 35 ms on evidence that
+predated its own cause.
 
-- **`expectMdns({ commissionable: true })`.** `checkCommissionable` builds a
-  `CommissionableMdnsScanner` over the process-global `Environment.default.get(MdnsService).names`,
-  primes from `discoveredNames`, and fires as soon as any cached device matches the long
-  discriminator. Every flavor pins discriminator 3840 across restarts and a commissionable record
-  lives about two minutes, so a record cached several steps earlier answers it with nothing on the
-  wire. See the measured 35 ms window in the TC-DD-3.20 section above.
-- **`LogFollower.mark()`.** It returns the count of lines *ingested*, not lines the device has
-  printed. The follower pumps asynchronously, so a line the TH emitted before the mark but which had
-  not yet been drained lands at an index at or after `from` and reads as "after the mark".
-  `expectSequence`'s own doc already states this; anything anchoring on a mark inherits it.
+**And dating the record does not rescue it.** A `DnssdName.Record` carries `installedAt`, so "was this
+announced after my mark?" looks answerable, and it was built and then cut. Two reasons, both in our
+own code:
 
-**Where it still bites:**
+- `DnssdNames.#processMessage` installs records from a **query's** known-answer list exactly as it
+  does from a response. Any other commissioner on the LAN — another `chip-tool`, a Home Assistant or
+  python-matter-server instance running commissionable discovery — refreshes `installedAt` while the
+  device says nothing. On a developer LAN that is not hypothetical.
+- Soliciting for a fresh announcement makes it worse, not better: our query carries the record we
+  already hold as a known answer, and `MdnsServer`'s known-answer suppression tells the responder not
+  to answer while that record has more than half its TTL left — which is exactly the window the check
+  cares about. `checkOperationalRecords` states the same hazard in its own comment ("Never solicit a
+  name whose SRV is already live").
 
-1. `restoreCommissioningMode` now takes its own pre-decommission mark and requires the announcement,
-   so the composed path is covered too. What is *not* covered is any step whose only evidence is a
-   bare `recordCommissionable` — TC-DD-3.21 step 1 and TC-DD-3.20 step 1 among them. Those are
-   preconditions rather than transitions, so a cached record is arguably the right answer there; the
-   distinction is worth making explicit rather than left to whoever reads the step next.
-2. Steps 2.a/5.a of TC-DD-3.20 and 2.a of TC-DD-3.21 gate on `MCORE.DD.SCAN_QR_CODE` while their `.b`
-   siblings repeat the same parse ungated — so a controller whose PICS says it cannot scan gets a
-   `skipped` step and two parse passes in the same bundle. The plan gives the `.b` steps no PICS,
-   which is why both TCs read this way; the leg-integrity rule TC-DD-3.11 states argues the other way.
-3. `thQrPayload` searches `from: 0`, so a step after a factory reset re-reads the payload the *dead*
-   generation printed. Benign while `chip-app-subject.ts` pins the discriminator and passcode across
-   restarts, and wrong the moment a TH's payload changes across a reset.
+So `recordCommissionable` stays what it is — "the TH is advertising", a precondition — and a step
+proving a transition takes the device's own line:
+`mDNS service published: _matterc._udp` (chip) / `MdnsAdvertisement Publishing kind: commissionable`
+(matter.js), which is what `recordBackInCommissioningMode` requires, with the probe beside it as
+corroboration. Pick such a pattern from CHIP's *source*, not from a local run: `Registering service …`
+is `platform/Darwin` only and would pass on a Mac while matching nothing on a Linux CI build.
 
-**What would close the rest.** A freshness primitive: an mDNS probe that rejects a record installed
-before a caller-supplied mark (`DnssdName.Record` already carries `installedAt`, and `DnssdNames`
-already retires records on a goodbye), plus a log anchor that waits for the follower to drain to real
-time before taking its mark. Both are framework changes in `packages/testing` and `packages/general`
-touching every existing TC's evidence, so they are a decision rather than a fixup.
+**The other instrument is fixed rather than documented.** `LogFollower.mark()` counts lines
+*ingested*, so a line the device wrote just before the mark can still be in flight and land after it,
+where a check reads it as caused by whatever the caller did next. `markSettled()` lets the pump
+deliver what its source already holds first, and `markTransition(cx)` is the cert-side wrapper. A
+mark that anchors a causal claim must be one of those, and it must be taken before the **cause** —
+which for a matter.js TH returning to commissioning mode is the *previous* step's `decommission()`,
+not anything the checking step does. `recordUnpair` returns the mark it took for exactly that reason,
+and TC-DD-3.20's steps 4 and 5 use it.
+
+**Related, and fixed with it:** `thQrPayload` takes a cursor. Its default reads the whole log and so
+returns the payload the generation *before* a restart printed, which is benign only while the harness
+pins the discriminator and passcode across restarts.
+
+**Also fixed:** a gated scan step's claim is no longer re-recorded by its ungated sibling. `2.a` is
+gated on `MCORE.DD.SCAN_QR_CODE` and owns the parse evidence; `2.b` commissions (TC-DD-3.20,
+TC-DD-3.21, and TC-DD-3.11's `3.b`/`3.c`, where the capability offering was duplicated as well).
+Before, a controller whose PICS said it cannot scan got a `skipped` step and a pass for that same
+step's claim in one bundle. Commissioning from the payload is itself evidence the DUT parsed it, so
+the trade is deliberate: on a controller that cannot scan, those steps now record the commissioning
+result alone.
+
+**TC-DD-1.8 is the exception, and stays as it is.** Its `.b` steps carry their own expected outcome —
+"verify the TH's QR code *with the appended TLV data* was parsed successfully" — which is a different
+claim from `.a`'s "the QR code has been scanned successfully". Read the plan's expected column before
+deciding a `.b` step's parse is redundant: it usually is, and there it is not.
 
 ## chip-tool delivers one result per async report and discards the rest
 

--- a/support/chip-testing/test/cert/TC-DD-3.11.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.11.test.ts
@@ -176,11 +176,12 @@ certTest("TC-DD-3.11", {
         "Using the DUT, parse the TH's QR code and follow any steps needed for the Commissioner/Commissionee to " +
             "complete the commissioning process using IP Network",
         async cx => {
+            // The parse and the capability it offers are step 3.b's claims, and 3.b is where the
+            // PICS gate for them sits; recording them again here would put a pass for a skipped
+            // step's claim in the same bundle
             const payload = qrPayloadWith(await thQrPayload(cx.devices.th), {
                 discoveryCapabilities: ON_NETWORK_ONLY,
             });
-            await recordParse(cx, payload);
-            await recordPayloadOffering(cx, payload, "onIpNetwork");
             await recordCommissionable(cx);
             await commissionByQr(cx, payload, commissioned);
         },

--- a/support/chip-testing/test/cert/TC-DD-3.20.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.20.test.ts
@@ -6,6 +6,7 @@
 
 import { InternalError } from "@matter/main";
 import { certTest } from "@matter/testing";
+import type { TransitionMark } from "./tc-dd-support.js";
 import {
     commissionByQr,
     recordBackInCommissioningMode,
@@ -18,9 +19,17 @@ import { CommissionedRefs } from "./tc-support.js";
 
 const commissioned = new CommissionedRefs();
 
-// Step 4's claim is about a transition step 3 caused, so its evidence has to be searched from before
-// that removal. A mark taken in step 4 can already be past the line on a TH that returns on its own.
-let unpairedAt: number | undefined;
+// Step 4's claim is about a transition step 3 caused, so its evidence has to start before that
+// removal. A mark taken in step 4 can already be past the device's own announcement, and the network
+// still holds the advertisement the TH published before it was ever commissioned.
+let unpairedAt: TransitionMark | undefined;
+
+function unpaired(): TransitionMark {
+    if (unpairedAt === undefined) {
+        throw new InternalError("Step ran before the TH was unpaired");
+    }
+    return unpairedAt;
+}
 
 certTest("TC-DD-3.20", {
     plan: "devicediscovery.adoc",
@@ -46,9 +55,7 @@ certTest("TC-DD-3.20", {
         "DUT parses TH's QR code. Follow any steps needed for the Commissioner/Commissionee to complete the " +
             "commissioning process over the TH Commissionee's method of device discovery",
         async cx => {
-            const payload = await thQrPayload(cx.devices.th);
-            await recordParse(cx, payload);
-            await commissionByQr(cx, payload, commissioned);
+            await commissionByQr(cx, await thQrPayload(cx.devices.th), commissioned);
         },
         {
             expected:
@@ -68,22 +75,14 @@ certTest("TC-DD-3.20", {
         4,
         "Place TH Commissionee back into commissioning mode using the TH manufacturer's means to be discovered " +
             "by the DUT Commissioner",
-        cx => {
-            if (unpairedAt === undefined) {
-                throw new InternalError("Step ran before the TH was unpaired");
-            }
-            return recordBackInCommissioningMode(cx, {
-                what: "TH advertising as commissionable again",
-                from: unpairedAt,
-            });
-        },
+        cx => recordBackInCommissioningMode(cx, { since: unpaired() }),
         { expected: "Verify that the TH is advertising and able to be discovered by a commissioner." },
     )
     .step(
         "5.a",
         "Scan TH's QR code using the DUT Commissioner.",
         async cx => {
-            await recordParse(cx, await thQrPayload(cx.devices.th));
+            await recordParse(cx, await thQrPayload(cx.devices.th, unpaired()));
         },
         { pics: "MCORE.DD.SCAN_QR_CODE", expected: "Verify the QR code has been scanned successfully." },
     )
@@ -92,9 +91,9 @@ certTest("TC-DD-3.20", {
         "DUT parses TH's QR code. Follow any steps needed for the Commissioner/Commissionee to complete the " +
             "commissioning process over the TH Commissionee's method of device discovery",
         async cx => {
-            const payload = await thQrPayload(cx.devices.th);
-            await recordParse(cx, payload);
-            await commissionByQr(cx, payload, commissioned);
+            // Read after the unpair, so a chip TH restarted in step 4 is scanned from its own
+            // payload rather than from the one the generation that went down had printed
+            await commissionByQr(cx, await thQrPayload(cx.devices.th, unpaired()), commissioned);
         },
         {
             expected:

--- a/support/chip-testing/test/cert/TC-DD-3.21.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.21.test.ts
@@ -101,9 +101,7 @@ certTest("TC-DD-3.21", {
         "DUT parses TH's QR code. Follow any steps needed for the Commissioner/Commissionee to complete the " +
             "commissioning process over the TH Commissionee's method of device discovery",
         async cx => {
-            const payload = await thQrPayload(cx.devices.th);
-            await recordParse(cx, payload);
-            await commissionByQr(cx, payload, commissioned);
+            await commissionByQr(cx, await thQrPayload(cx.devices.th), commissioned);
         },
         {
             expected:

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -38,6 +38,26 @@ import {
     settleWithin,
 } from "./tc-support.js";
 
+/**
+ * Where a later step's evidence has to start: a log cursor taken before whatever causes the
+ * transition the step will check, once the follower has caught up with what the device already
+ * wrote.
+ *
+ * **The network cannot supply the other half of this.** A commissionable mDNS record can be dated
+ * (`DnssdName` stamps `installedAt`), but not attributed: `DnssdNames` installs records from a
+ * *query's* known-answer list as readily as from a response, so any other commissioner on the LAN
+ * refreshes the date with the device silent — and soliciting for one ourselves attaches the record
+ * we hold as a known answer, which tells the responder to suppress the very reply we want
+ * (`MdnsServer`'s known-answer suppression). A device's own log line is what witnesses a transition
+ * here; see this directory's AGENTS.md.
+ */
+export type TransitionMark = number;
+
+/** Takes a {@link TransitionMark} on the TH, after letting its log pump settle. */
+export async function markTransition(cx: CertStepContext): Promise<TransitionMark> {
+    return cx.devices.th.log.markSettled();
+}
+
 /** Bounds a wait for a line a device prints as it comes up, with a whole commissioning flow ahead of it. */
 export const COMMISSIONING_LOG_TIMEOUT = Seconds(30);
 export const MDNS_TIMEOUT = Seconds(30);
@@ -92,15 +112,20 @@ const ADVERTISING_COMMISSIONABLE = {
  * The onboarding payload the TH publishes for its own setup code. A subject that renders one reports
  * it directly; a chip app only prints it, and the first of the two it prints is the standard
  * commissioning flow's.
+ *
+ * `from` is the log cursor to read it at, and a step after a device restart must supply one: the
+ * default reads the whole log and so returns the payload the *previous* generation printed. That is
+ * harmless only while a flavor pins its discriminator and passcode across restarts, which is a
+ * property of the harness rather than of any device it may run.
  */
-export async function thQrPayload(th: CertDevice): Promise<string> {
+export async function thQrPayload(th: CertDevice, from = 0): Promise<string> {
     if (th.commissioning.qrPairingCode) {
         return th.commissioning.qrPairingCode;
     }
 
     const result = await th.log.expect(
         { chip: SETUP_QR_CODE, matterjs: SETUP_QR_CODE },
-        { flavor: th.flavor, from: 0, timeoutMs: COMMISSIONING_LOG_TIMEOUT },
+        { flavor: th.flavor, from, timeoutMs: COMMISSIONING_LOG_TIMEOUT },
     );
     if (result.verdict === "unverified") {
         throw new InternalError(`${th.flavor} devices neither report nor print an onboarding payload`);
@@ -776,8 +801,8 @@ export async function recordVendorOutcome(
     /** Overridden by the unit tests, which have no advertisement to observe. */
     probeCommissionable: (cx: CertStepContext, what: string) => Promise<void> = recordCommissionable,
 ): Promise<void> {
-    // The same override the caller passed for this helper's own probe: without it a restore reaching
-    // live mDNS is what a unit test would wait out, and its default is the real probe either way.
+    // Passed on to the restore as well: without it a restore reaching live mDNS is what a unit test
+    // would wait out, and its default is the real probe either way.
     const restored = await restoreCommissioningMode(cx, commissioned, probeCommissionable);
 
     // A rejection is evidence about the code only if the TH was there to be found; without this the
@@ -871,14 +896,15 @@ export async function recordVendorOutcome(
  * that flavor it says a fabric went, and only the session line says which. A caller with a second
  * admin on the TH would have another fabric's removal satisfy the first check.
  */
-export async function recordUnpair(cx: CertStepContext, commissioned: CommissionedRefs): Promise<number> {
+export async function recordUnpair(cx: CertStepContext, commissioned: CommissionedRefs): Promise<TransitionMark> {
     const th = cx.devices.th;
     const ref = commissioned.require("dut");
     const node = cx.controllers.dut.node(ref);
 
     const fabricIndex = await readOwnFabricIndex(node);
 
-    const from = th.log.mark();
+    const since = await markTransition(cx);
+    const from = since;
     await node.decommission();
     commissioned.clear("dut");
     cx.recorder.check({
@@ -894,7 +920,7 @@ export async function recordUnpair(cx: CertStepContext, commissioned: Commission
         { check: () => expired.check, what: "TH ended the DUT's fabric's sessions" },
     ]);
 
-    return from;
+    return since;
 }
 
 /**
@@ -925,17 +951,18 @@ export async function recordBackInCommissioningMode(
     cx: CertStepContext,
     options: {
         what?: string;
-        from?: number;
+        since?: TransitionMark;
         /** Overridden by the unit tests, which have no mDNS to answer. */
         probeCommissionable?: (cx: CertStepContext, what: string) => Promise<void>;
     } = {},
 ): Promise<void> {
     const th = cx.devices.th;
     const {
-        what = "TH back in commissioning mode",
+        what = "TH advertising as commissionable again",
         probeCommissionable = recordCommissionable,
-        from = th.log.mark(),
+        since = await markTransition(cx),
     } = options;
+    const from = since;
 
     if (th.flavor !== "matterjs") {
         await th.backchannel({ name: "factoryReset" });
@@ -962,8 +989,9 @@ export async function recordBackInCommissioningMode(
         "TH announced it is advertising commissionable again",
     );
 
-    // The TH advertises itself commissionable on its own schedule, and a discovery started before
-    // that finds only the devices this run is not looking for.
+    // Corroboration only. On its own this is answered by any live record for the TH's discriminator,
+    // including the one it published before it was ever commissioned; the announcement checked above
+    // is what witnesses the transition.
     await probeCommissionable(cx, what);
 }
 
@@ -984,11 +1012,11 @@ async function restoreCommissioningMode(
         return false;
     }
 
-    const from = cx.devices.th.log.mark();
+    const since = await markTransition(cx);
     await cx.controllers.dut.node(previous).decommission();
     commissioned.clear("dut");
 
-    await recordBackInCommissioningMode(cx, { from, probeCommissionable });
+    await recordBackInCommissioningMode(cx, { since, probeCommissionable });
     return true;
 }
 
@@ -1023,7 +1051,9 @@ async function commissionByTarget(
 
     await restoreCommissioningMode(cx, commissioned);
 
-    const from = th.log.mark();
+    // Settled, because the line this waits for names no fabric on either flavor: a completion still
+    // in flight from an earlier commissioning would otherwise satisfy this one
+    const from = await th.log.markSettled();
     let ref;
     try {
         ref = await dut.commission(target);

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -114,9 +114,13 @@ const ADVERTISING_COMMISSIONABLE = {
  * commissioning flow's.
  *
  * `from` is the log cursor to read it at, and a step after a device restart must supply one: the
- * default reads the whole log and so returns the payload the *previous* generation printed. That is
- * harmless only while a flavor pins its discriminator and passcode across restarts, which is a
- * property of the harness rather than of any device it may run.
+ * default reads the whole log and so returns the payload the *previous* generation printed.
+ *
+ * That is harmless because a subject's identity is fixed at construction and reused on every start —
+ * `ChipLocalSubject.start()` rebuilds `--discriminator`/`--passcode` from `this.commissioning` on each
+ * spawn, and the matter.js instances take theirs from their config — so a `factoryReset` comes back
+ * with the same setup code. It is a property of the harness, not of any device it may run, and it is
+ * what lets `commissionByQr` restore a TH *after* its caller has already read the payload.
  */
 export async function thQrPayload(th: CertDevice, from = 0): Promise<string> {
     if (th.commissioning.qrPairingCode) {
@@ -938,7 +942,7 @@ export async function recordUnpair(cx: CertStepContext, commissioned: Commission
  * theorised: on a matterjs run the probe passed at 13:05:44.088 and the device published its
  * commissionable record at 13:05:44.123, 35 ms later.
  *
- * `options.from` is where the announcement is searched from, and must precede whatever caused the
+ * `options.since` is where the announcement is searched from, and must precede whatever caused the
  * transition — for a matter.js TH that is the caller's own `decommission()`, which happens before
  * this function is entered, so a mark taken here would already be too late. {@link recordUnpair}
  * returns exactly that mark.


### PR DESCRIPTION
Closes the trap left open by #4337: a cert step that *drives* a transition could prove it with a check that only observes a *condition*, and the condition was already true beforehand.

## The measured case

TC-DD-3.20's step 4 asks the harness to return to commissioning mode. Its mDNS probe passed at 13:05:44.088; the device published the record it claimed to observe at 13:05:44.123. The step was green for 35 ms on evidence that predated its own cause. #4337 fixed that one step by requiring the device's own announcement. This makes the underlying instruments say what they mean, so the next step does not have to rediscover it.

## What ships

- **`LogFollower.markSettled()`** — lets the pump deliver what its source already holds before taking the cursor. A plain `mark()` counts lines *ingested*, not lines the device has printed, so a line written just before it can still be in flight and land after it, where a check reads it as caused by whatever the caller did next.
- **`markTransition(cx)`** — the cert-side wrapper, and `recordUnpair` now returns the mark it took, *before* the removal. That is the contract steps 4 and 5 of TC-DD-3.20 rest on: for a matter.js harness the cause of "back in commissioning mode" is the previous step's `decommission()`, so a mark taken by the checking step is already too late.
- **`commissionByTarget` takes a settled mark** — the completion line it waits for names no fabric on either flavour, so one still in flight from an earlier commissioning would have satisfied it.
- **`thQrPayload` takes a cursor** — its default reads the whole log and so returns the payload the generation *before* a restart printed. Benign only while the harness pins the discriminator and passcode across restarts, which is a property of the harness rather than of any device it runs.
- **A gated scan step's claim is no longer re-recorded by its ungated sibling** — TC-DD-3.20, TC-DD-3.21, and TC-DD-3.11 (where the offered capability was duplicated too). Before, a controller whose PICS said it cannot scan got a `skipped` step and a pass for that same step's claim in one bundle.

## What was built and cut, and why it matters more than what shipped

A `DnssdName.Record` carries `installedAt`, so "was this advertisement announced after my mark?" looks answerable. I built it — `expectMdns`'s `freshSince`, plus a `recordBecameCommissionable` helper — and it passed a live proof against a real device, and its mutation test. Then two properties of our own code killed it:

- **`DnssdNames.#processMessage` installs records from a query's known-answer list exactly as it does from a response.** Any other commissioner on the LAN — another `chip-tool`, a Home Assistant or python-matter-server instance running commissionable discovery — refreshes `installedAt` while the device says nothing. On a developer LAN that is not hypothetical.
- **Soliciting for a fresh announcement makes it worse.** Our query carries the record we already hold as a known answer, and `MdnsServer`'s known-answer suppression then tells the responder not to reply while that record has more than half its TTL left — exactly the window the check cares about. `checkOperationalRecords` states the same hazard in its own comment; the new sibling ignored it.

So mDNS can *date* an announcement but cannot *attribute* one. The device's own log line is the witness — which is what `recordBackInCommissioningMode` already requires — the probe beside it stays corroboration, and `recordCommissionable` stays what its name says: a precondition. `AGENTS.md` records the reasoning so the next attempt starts from it instead of rebuilding it.

One defect found in my own work before review reached it: `markTransition` first dated the mark with `Time.nowUs` (monotonic, `performance`-derived) while `installedAt` is stamped from `Time.nowMs` (`Date.now()`). Different clocks; drift either way would have made the check silently accept a stale announcement or reject a genuine one.

## Deliberate trade

On a controller whose PICS lacks `MCORE.DD.SCAN_QR_CODE`, the `.b` steps of TC-DD-3.20/3.21 and `3.c` of TC-DD-3.11 now record the commissioning result alone rather than a parse as well. Commissioning from the payload is itself evidence the DUT parsed it, and the explicit parse claim belongs to the gated `.a` step that owns it. TC-DD-1.8 keeps its duplicate: its `.b` steps carry a distinct plan outcome ("verify the QR code *with the appended TLV data* was parsed"), which `.a` does not claim.

## Verification

- Whole cert suite on the matterjs flavour: 15 test cases, matching the documented baseline (TC-IDM-2.1's one accepted unverified check, TC-DD-3.11 and 3.14 at two PICS skips each). The device-discovery block on chip-local: all green.
- `test/cert-framework` 767/767; root `npm test` green on every leg; `npm run lint` and `npm run format-verify` clean.
- Every added branch is mutation-proven: taking `recordUnpair`'s mark after the removal instead of before turns five tests red, including the one written for that contract; a plain `mark()` in place of `markSettled()` turns its own test red.
- The two `markSettled` tests are paired deliberately: one is a characterization test showing a plain `mark()` *can* sit behind a line the source already produced, the other shows `markSettled()` does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
