### PR TITLE
test(chip-testing): a cert test can name more than one device, and TC-DD-3.18 does

### DIFF
--- a/packages/testing/src/chip/cert/cert-dsl.ts
+++ b/packages/testing/src/chip/cert/cert-dsl.ts
@@ -97,24 +97,92 @@ export interface CertTestBuilder {
 }
 
 /**
- * Thrown by {@link certTest} when `options.devices` declares more than one device. Every device
- * flavor (`ChipDockerSubject`/`ChipLocalSubject`/the matterjs registry) currently starts every
- * device with the same hardcoded discriminator (3840), passcode (20202021), and operational port
- * — fine for one device per run, but two devices in the same run would advertise identical mDNS
- * commissionable records and (for chip flavors) contend for the same UDP port. Multi-device cert
- * tests need per-role discriminator/passcode/port assignment before this can work; until then this
- * throws instead of silently producing a flaky, ambiguous run.
+ * A role name reaches a subject as part of its id, and every flavor constrains those differently — a
+ * matter.js subject rejects a dot outright, because an id becomes an endpoint id. Rather than guess
+ * each flavor's rules, roles are held to the intersection every flavor accepts.
  */
-export class MultiDeviceUnsupportedError extends Error {
-    constructor(tc: string, roles: string[]) {
-        super(
-            `certTest "${tc}" declares ${roles.length} devices (${roles.join(", ")}) via options.devices; ` +
-                "every device flavor hardcodes discriminator 3840/passcode 20202021 (and, for chip flavors, " +
-                "a fixed operational port), so more than one device in a single run collides on mDNS " +
-                "advertisement and likely UDP port contention. Multi-device cert tests need per-role " +
-                "discriminator/passcode/port assignment in the device flavors before this can be supported.",
+function assertUsableRoleName(tc: string, role: string) {
+    if (!/^[a-z][a-z0-9_]*$/i.test(role)) {
+        throw new Error(
+            `certTest "${tc}" declares a device role "${role}"; a role name becomes part of the subject's id, so ` +
+                "it must start with a letter and carry only letters, digits and underscores",
         );
     }
+}
+
+/**
+ * Rejects a run whose devices do not all use the same app.
+ *
+ * Nothing needs one yet, and an evidence bundle cannot currently describe one: `RunRecord` names a
+ * single `device` and resolves one chip image revision, both from `options.app`. A mixed-app run would
+ * therefore publish a passing bundle that never names the second binary or the revision it came from,
+ * which is a worse outcome than not supporting it. Lift this together with per-role metadata in the
+ * recorder.
+ */
+function assertOneApp(tc: string, deviceRoles: Record<string, string>) {
+    const apps = new Set(Object.values(deviceRoles));
+    if (apps.size > 1) {
+        throw new Error(
+            `certTest "${tc}" declares devices running different apps (${[...apps].join(", ")}); the evidence ` +
+                "bundle records one app and one chip image revision, so such a run could not say what it ran " +
+                "against. Give the recorder per-role metadata before declaring one",
+        );
+    }
+}
+
+/**
+ * Thrown when a cert test declares more devices than there are discriminators left to give them.
+ *
+ * Its own type, so a caller can tell it from an unrelated failure during test collection — and so the
+ * boundary test asserts the condition rather than a message. A plain `Error` because
+ * `packages/testing` carries no dependency on the library and therefore no `MatterError`.
+ */
+export class DeviceIdentityExhaustedError extends Error {
+    constructor(index: number, discriminator: number) {
+        super(
+            `A cert test cannot declare this many devices: device ${index} would take discriminator ` +
+                `${discriminator}, which does not fit the 12 bits Matter gives it`,
+        );
+    }
+}
+
+/**
+ * The onboarding identity every flavor uses for a single-subject run: chip's own example-app defaults,
+ * which the whole cert suite and its evidence are written against.
+ */
+const PRIMARY_IDENTITY: Subject.Identity = { discriminator: 3840, passcode: 20202021, port: 5540 };
+
+/**
+ * Identities for a run's non-primary devices, one per role, in declaration order.
+ *
+ * The primary keeps {@link PRIMARY_IDENTITY} so every existing single-device test case is untouched
+ * — same discriminator in its evidence, same port, same payload. Only a test case that declares a
+ * second device gets new values, and only for that second device.
+ *
+ * Deterministic by position rather than random, so a bundle's discriminator means the same thing
+ * across runs and a failure is reproducible. The cost is that a collision with an unrelated device on
+ * the LAN repeats every run instead of clearing on the next one; that is the better failure, because
+ * it is diagnosable.
+ *
+ * Discriminators stay inside the 12 bits § 5.1.1.1 gives them. Passcodes step by one from chip's
+ * default, which cannot reach any value § 5.1.7.1 forbids — those are the repeated-digit and
+ * sequential codes, none of which is adjacent to 20202021.
+ */
+export function identityFor(index: number): Subject.Identity {
+    if (index === 0) {
+        return PRIMARY_IDENTITY;
+    }
+
+    const discriminator = PRIMARY_IDENTITY.discriminator + index;
+    if (discriminator > 0xfff) {
+        throw new DeviceIdentityExhaustedError(index, discriminator);
+    }
+
+    return {
+        discriminator,
+        passcode: PRIMARY_IDENTITY.passcode + index,
+        port: (PRIMARY_IDENTITY.port ?? 5540) + index,
+    };
 }
 
 /**
@@ -127,10 +195,14 @@ export function certTest(tc: string, options: CertTestOptions): CertTestBuilder 
     const controllerRoles = options.controllers ?? { dut: "dut" };
     const deviceRoles = options.devices ?? { th: options.app };
 
-    const deviceRoleNames = Object.keys(deviceRoles);
-    if (deviceRoleNames.length > 1) {
-        throw new MultiDeviceUnsupportedError(tc, deviceRoleNames);
-    }
+    // Both of these are pure properties of the declaration, so they are knowable now rather than
+    // after the primary device is already running — a failure inside #buildContext writes no evidence
+    // bundle at all.
+    Object.keys(deviceRoles).forEach((role, index) => {
+        identityFor(index);
+        assertUsableRoleName(tc, role);
+    });
+    assertOneApp(tc, deviceRoles);
 
     const definition: CertTestDefinition = {
         tc,
@@ -155,8 +227,8 @@ export function certTest(tc: string, options: CertTestOptions): CertTestBuilder 
 
     const builder: CertTestBuilder = {
         step(number, text, run, opts) {
-            // Declaration-time, like the MultiDeviceUnsupportedError guard above: an empty list
-            // is a defect of the test definition, not a run-time condition of any one flavor.
+            // Declaration-time: an empty list is a defect of the test definition, not a run-time
+            // condition of any one flavor.
             if (opts?.flavors !== undefined && opts.flavors.length === 0) {
                 throw new Error(
                     `certTest "${tc}" step ${number} declares an empty "flavors" list, which would skip it on ` +
@@ -540,12 +612,20 @@ class WiredCertTest extends CertTest {
         // run never gets to use should not leak the controllers/devices it already started.
         let recorder: EvidenceRecorder;
         try {
+            // The primary already exists and holds index 0; the rest are numbered in declaration
+            // order, which is what makes a role's identity the same on every run.
+            let identityIndex = 0;
             for (const [role, app] of Object.entries(this.#deviceRoles)) {
                 if (role === this.#primaryRole) {
                     continue;
                 }
                 const factory = subjectFactoryFor(this.#flavor, app, this.definition.appVariant);
-                const device = factory(`${this.descriptor.name}-${role}`);
+                // The role, not the test case's name: the primary's domain is `descriptor.kind`
+                // ("cert"), and a name like "TC-DD-3.18" carries dots a matter.js subject rejects as
+                // an endpoint id.
+                const device = factory(`${this.descriptor.kind ?? "cert"}-${role}`, {
+                    identity: identityFor(++identityIndex),
+                });
                 extra.push(device);
                 await device.initialize();
                 await device.start();

--- a/packages/testing/src/chip/cert/chip-app-subject.ts
+++ b/packages/testing/src/chip/cert/chip-app-subject.ts
@@ -44,11 +44,11 @@ const CONTAINER_STOP_TIMEOUT_MS = 30_000;
 // against (see TC-IDM-2.1's AGENTS.md section) never appear at all, on any platform build.
 const TRACE_ARGS = ["--trace_log", "1", "--trace_decode", "1"];
 
-function defaultCommissioning(): Subject.CommissioningParameters {
+function commissioningFor(identity?: Subject.Identity): Subject.CommissioningParameters {
     return {
         kind: "on-network",
-        passcode: DEFAULT_PASSCODE,
-        discriminator: DEFAULT_DISCRIMINATOR,
+        passcode: identity?.passcode ?? DEFAULT_PASSCODE,
+        discriminator: identity?.discriminator ?? DEFAULT_DISCRIMINATOR,
 
         // A real onboarding QR code needs the spec's base38 payload encoder, which lives in
         // matter.js and is out of reach here per the packages/testing dependency invariant.
@@ -56,6 +56,15 @@ function defaultCommissioning(): Subject.CommissioningParameters {
         // via discriminator/passcode instead.
         qrPairingCode: "",
     };
+}
+
+/**
+ * `--secured-device-port` for a subject that was given one. Without it every chip app binds 5540, so
+ * a second one in the same run fails to start — the failure surfaces as the device exiting while a
+ * step runs, which reads as a crash rather than as a port collision.
+ */
+function portArgs(identity?: Subject.Identity): string[] {
+    return identity?.port === undefined ? [] : ["--secured-device-port", String(identity.port)];
 }
 
 /**
@@ -170,9 +179,9 @@ class ChipLocalDevice implements CertDevice {
         this.app = app;
         this.appVariant = appVariant;
         this.id = domain;
-        this.commissioning = defaultCommissioning();
+        this.commissioning = commissioningFor(options?.identity);
         this.log = new LogFollower(this.#hub.follow(), domain);
-        this.#appArgs = options?.appArgs ?? [];
+        this.#appArgs = [...portArgs(options?.identity), ...(options?.appArgs ?? [])];
     }
 
     /**
@@ -498,9 +507,9 @@ export class ChipDockerDevice implements CertDevice {
         this.app = app;
         this.appVariant = appVariant;
         this.id = domain;
-        this.commissioning = defaultCommissioning();
+        this.commissioning = commissioningFor(options?.identity);
         this.log = new LogFollower(this.#hub.follow(), domain);
-        this.#appArgs = options?.appArgs ?? [];
+        this.#appArgs = [...portArgs(options?.identity), ...(options?.appArgs ?? [])];
         this.#docker = docker;
     }
 

--- a/packages/testing/src/chip/cert/log-follower.ts
+++ b/packages/testing/src/chip/cert/log-follower.ts
@@ -175,11 +175,24 @@ export class LogFollower implements LogSource {
      * yet flushed is not observable by any means here.
      */
     async markSettled(): Promise<number> {
+        await this.settled();
+        return this.mark();
+    }
+
+    /**
+     * Lets the pump deliver what its source already holds, without taking a mark.
+     *
+     * What {@link markSettled} does before marking, for a caller that instead reads the buffer
+     * directly — {@link count} and {@link lastMatchBefore} see only what has been ingested, so a line
+     * the device wrote moments ago is invisible to them until this has run. Same bound as
+     * {@link markSettled}: it yields two macrotask turns, which is what every source this class is
+     * given today needs.
+     */
+    async settled(): Promise<void> {
         // Two turns: the first lets a pending read resolve, the second lets the pump's own
         // continuation append what it read.
         await delay(0).promise;
         await delay(0).promise;
-        return this.mark();
     }
 
     /**

--- a/packages/testing/src/chip/index.ts
+++ b/packages/testing/src/chip/index.ts
@@ -22,7 +22,9 @@ export type {
     StepRecorder,
     StepVerdict,
 } from "./cert/cert-context.js";
-export { certTest, MultiDeviceUnsupportedError } from "./cert/cert-dsl.js";
+export { certTest } from "./cert/cert-dsl.js";
+/** @internal Test seam — not API. Per-device identity assignment for a multi-device run. */
+export { DeviceIdentityExhaustedError, identityFor } from "./cert/cert-dsl.js";
 export type { CertStepOptions, CertTestBuilder, CertTestOptions } from "./cert/cert-dsl.js";
 /** @internal Test seam — not API. The gate `certTest()` applies before a test's device starts. */
 export { certPicsFile, unmetTestPics } from "./cert/cert-dsl.js";

--- a/packages/testing/src/device/subject.ts
+++ b/packages/testing/src/device/subject.ts
@@ -42,6 +42,26 @@ export namespace Subject {
      */
     export interface Options {
         appArgs?: string[];
+
+        /**
+         * Overrides the onboarding identity and operational port this subject would otherwise take
+         * from its flavor's defaults.
+         *
+         * Every flavor defaults to discriminator 3840 / passcode 20202021 / port 5540, which is what
+         * a single-subject run wants and what two subjects in one run cannot share: mDNS discovery
+         * here matches on the long discriminator alone, and two chip apps contend for the port. A
+         * run with more than one subject assigns each its own.
+         */
+        identity?: Identity;
+    }
+
+    /** See {@link Options.identity}. */
+    export interface Identity {
+        discriminator: number;
+        passcode: number;
+
+        /** Operational port. Ignored by a flavor that does not bind one of its own. */
+        port?: number;
     }
 
     export type CommissioningMethod = "onnetwork";

--- a/support/chip-testing/src/AllClustersTestInstance.ts
+++ b/support/chip-testing/src/AllClustersTestInstance.ts
@@ -303,7 +303,7 @@ export class AllClustersTestInstance extends NodeTestInstance {
                     nonvolatile: NodeTestInstance.nonvolatileEvents,
                 },
                 network: {
-                    port: 5540,
+                    port: this.config.port ?? 5540,
                     tcp: true,
                     transportPreference: process.env.TEST_PREFER_TCP === "1" ? "tcp" : "udp",
                     //advertiseOnStartup: false,

--- a/support/chip-testing/src/AllDevicesTestInstance.ts
+++ b/support/chip-testing/src/AllDevicesTestInstance.ts
@@ -128,6 +128,7 @@ export class AllDevicesTestInstance extends NodeTestInstance {
             wifi,
             discriminator: this.config.discriminator ?? 3840,
             passcode: this.config.passcode ?? 20202021,
+            port: this.config.port,
             enableKeyHex,
         });
 

--- a/support/chip-testing/src/BridgeTestInstance.ts
+++ b/support/chip-testing/src/BridgeTestInstance.ts
@@ -38,7 +38,7 @@ export class BridgeTestInstance extends NodeTestInstance {
                 id: this.id,
                 environment: this.env,
                 network: {
-                    port: 5540,
+                    port: this.config.port ?? 5540,
                     tcp: true,
                     transportPreference: process.env.TEST_PREFER_TCP === "1" ? "tcp" : "udp",
                     //advertiseOnStartup: false,

--- a/support/chip-testing/src/GenericTestApp.ts
+++ b/support/chip-testing/src/GenericTestApp.ts
@@ -156,6 +156,12 @@ export interface TestInstanceConfig {
     storage?: Storage;
     discriminator?: number;
     passcode?: number;
+
+    /**
+     * Operational port. Defaults to Matter's 5540; a run with more than one instance in the same
+     * process gives each its own, since they would otherwise contend for it.
+     */
+    port?: number;
     domain?: string;
 }
 

--- a/support/chip-testing/src/IcdTestInstance.ts
+++ b/support/chip-testing/src/IcdTestInstance.ts
@@ -114,7 +114,7 @@ export class IcdTestInstance extends NodeTestInstance {
                 nonvolatile: NodeTestInstance.nonvolatileEvents,
             },
             network: {
-                port: 5540,
+                port: this.config.port ?? 5540,
                 tcp: true,
                 transportPreference: process.env.TEST_PREFER_TCP === "1" ? "tcp" : "udp",
             },

--- a/support/chip-testing/src/RvcTestInstance.ts
+++ b/support/chip-testing/src/RvcTestInstance.ts
@@ -188,7 +188,7 @@ export class RvcTestInstance extends NodeTestInstance {
                 id: this.id,
                 environment: this.env,
                 network: {
-                    port: 5540,
+                    port: this.config.port ?? 5540,
                     tcp: true,
                     transportPreference: process.env.TEST_PREFER_TCP === "1" ? "tcp" : "udp",
                     //advertiseOnStartup: false,

--- a/support/chip-testing/src/TvTestInstance.ts
+++ b/support/chip-testing/src/TvTestInstance.ts
@@ -30,7 +30,7 @@ export class TvTestInstance extends NodeTestInstance {
                 id: this.id,
                 environment: this.env,
                 network: {
-                    port: 5540,
+                    port: this.config.port ?? 5540,
                     tcp: true,
                     transportPreference: process.env.TEST_PREFER_TCP === "1" ? "tcp" : "udp",
                     //advertiseOnStartup: false,

--- a/support/chip-testing/src/cert/index.ts
+++ b/support/chip-testing/src/cert/index.ts
@@ -64,8 +64,16 @@ function runTaggedForDevice<T>(id: string, fn: () => Promise<T>): Promise<T> {
  * Log attribution is best-effort: `initialize()`/`start()`/`stop()`/`close()` tag the matter.js
  * `Logger` sink with this device's id via `AsyncLocalStorage`, which Node propagates through any
  * async work descending from those calls (including most of a server node's own background
- * activity). It does not guarantee attribution for every line if multiple matterjs-flavored devices
- * ever ran concurrently in one process — today's cert tests only ever activate one at a time.
+ * activity).
+ *
+ * **A cert test may now declare several devices, so several of these do run concurrently.** Each
+ * node's own transport and storage are created inside `runTaggedForDevice`, so its own lines carry
+ * its own tag. What this cannot tag correctly is a service resolved lazily from the shared parent
+ * environment during whichever device happened to start first: that resolution captures the first
+ * device's tag for good, and lines it later emits on behalf of another device land in the first
+ * device's log. Attribution is therefore reliable for a device's own interactions — which is what a
+ * step's device-log checks read — and not for shared-service chatter. A step that must attribute a
+ * line to one of several devices should assert on something only that device says.
  */
 class MatterJsCertDevice implements CertDevice {
     readonly flavor: DeviceFlavor = "matterjs";
@@ -153,8 +161,9 @@ function MatterJsCertSubject(implementation: DeviceTestInstanceConstructor<NodeT
         const inner = new implementation({
             domain,
             commandPipeFactory: async () => {},
-            discriminator: 3840,
-            passcode: 20202021,
+            discriminator: options?.identity?.discriminator ?? 3840,
+            passcode: options?.identity?.passcode ?? 20202021,
+            port: options?.identity?.port,
             appArgs: options?.appArgs,
         });
         return new MatterJsCertDevice(inner, `${inner.id}`);

--- a/support/chip-testing/src/devices/RootEndpoint.ts
+++ b/support/chip-testing/src/devices/RootEndpoint.ts
@@ -32,6 +32,9 @@ export interface RootNodeOptions {
     wifi: boolean;
     discriminator: number;
     passcode: number;
+
+    /** Operational port, defaulting to Matter's 5540. See `TestInstanceConfig.port`. */
+    port?: number;
     /** Optional override for the test enable key (hex). When undefined, NodeTestInstance.testEnableKey is used. */
     enableKeyHex?: string;
 }
@@ -84,7 +87,7 @@ export async function buildRootNode(opts: RootNodeOptions): Promise<ServerNode> 
                 nonvolatile: NodeTestInstance.nonvolatileEvents,
             },
             network: {
-                port: 5540,
+                port: opts.port ?? 5540,
                 tcp: true,
                 transportPreference: process.env.TEST_PREFER_TCP === "1" ? "tcp" : "udp",
                 //advertiseOnStartup: false,

--- a/support/chip-testing/test/cert-framework/cert-dsl-guards.test.ts
+++ b/support/chip-testing/test/cert-framework/cert-dsl-guards.test.ts
@@ -4,24 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { certTest, MultiDeviceUnsupportedError } from "@matter/testing";
+import { certTest, DeviceIdentityExhaustedError, identityFor } from "@matter/testing";
 import { expect } from "chai";
-
-// Calling certTest() with more than one declared device must reject synchronously, before it
-// registers anything with mocha — a `describe`/`it` registered straight at module scope in this
-// spec glob would otherwise crash the whole cert-dir run's collection phase, not just this check.
-describe("certTest multi-device guard", () => {
-    it("rejects a definition with more than one device", () => {
-        expect(() =>
-            certTest("TC-MULTI-DEVICE-GUARD-0.0", {
-                plan: "n/a",
-                pics: [],
-                app: "all-clusters",
-                devices: { th: "all-clusters", th2: "bridge" },
-            }),
-        ).to.throw(MultiDeviceUnsupportedError, /declares 2 devices \(th, th2\)/);
-    });
-});
 
 describe("certTest step declaration guard", () => {
     it("rejects an empty flavors list at declaration time", () => {
@@ -114,6 +98,80 @@ describe("certTest step declaration guard", () => {
             expect(() => builder.finalize(async () => {})).to.throw("declares finalize() twice");
         } finally {
             Reflect.set(globalThis, "describe", originalDescribe);
+        }
+    });
+});
+
+describe("multi-device declaration guards", () => {
+    function declare(tc: string, devices: Record<string, string>) {
+        const originalDescribe = Reflect.get(globalThis, "describe");
+        Reflect.set(globalThis, "describe", () => {});
+        try {
+            certTest(tc, { plan: "n/a", pics: [], app: "all-clusters", devices });
+        } finally {
+            Reflect.set(globalThis, "describe", originalDescribe);
+        }
+    }
+
+    // A role name becomes part of the subject's id, and a matter.js subject rejects a dot outright
+    // because an id becomes an endpoint id
+    it("rejects a role name a subject cannot carry in its id", () => {
+        expect(() => declare("TC-ROLE-DOT-0.0", { th: "all-clusters", "th.2": "all-clusters" })).to.throw(
+            /role name becomes part of the subject's id/,
+        );
+    });
+
+    it("accepts the role names plans actually use", () => {
+        expect(() => declare("TC-ROLE-OK-0.0", { th1: "all-clusters", th2: "all-clusters" })).to.not.throw();
+    });
+
+    // The bundle records one app and one chip image revision, so a mixed-app run could not say what
+    // it ran against
+    it("rejects devices running different apps", () => {
+        expect(() => declare("TC-MIXED-APP-0.0", { th: "all-clusters", helper: "bridge" })).to.throw(
+            /could not say what it ran against/,
+        );
+    });
+});
+
+describe("per-device identity", () => {
+    // Two subjects in one run cannot share an identity: mDNS discovery here matches on the long
+    // discriminator alone, and two chip apps would contend for the same operational port.
+    it("gives every declared device its own discriminator, passcode and port", () => {
+        const identities = [0, 1, 2].map(index => identityFor(index));
+
+        expect(new Set(identities.map(i => i.discriminator)).size).equal(3);
+        expect(new Set(identities.map(i => i.passcode)).size).equal(3);
+        expect(new Set(identities.map(i => i.port)).size).equal(3);
+    });
+
+    // Every existing single-device test case records this discriminator in its evidence and commissions
+    // with this passcode; a change here rewrites all of them
+    it("leaves the primary device on chip's own defaults", () => {
+        expect(identityFor(0)).deep.equal({ discriminator: 3840, passcode: 20202021, port: 5540 });
+    });
+
+    it("is deterministic, so a role's identity is the same on every run", () => {
+        expect(identityFor(1)).deep.equal(identityFor(1));
+    });
+
+    // At the boundary itself: 3840 + 255 is the last that fits, so an off-by-one in the guard shows
+    // up here and nowhere else
+    it("keeps every discriminator inside the 12 bits Matter gives it", () => {
+        expect(identityFor(255).discriminator).equal(0xfff);
+        expect(() => identityFor(256)).to.throw(DeviceIdentityExhaustedError, /does not fit the 12 bits/);
+    });
+
+    // Section 5.1.7.1 forbids the repeated-digit and sequential codes; a run that assigned one would
+    // be refused by the commissionee rather than by us
+    it("never assigns a passcode the specification forbids", () => {
+        const forbidden = new Set([
+            0, 11111111, 22222222, 33333333, 44444444, 55555555, 66666666, 77777777, 88888888, 99999999, 12345678,
+            87654321,
+        ]);
+
+        for (let index = 0; index <= 255; index++) {
+            expect(forbidden.has(identityFor(index).passcode)).equal(false);
         }
     });
 });

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -43,6 +43,7 @@ import {
     recordGeneratedManualCode,
     recordPayloadOffering,
     recordGeneratedPayload,
+    recordNotCommissioned,
     recordUnpair,
     recordVendorOutcome,
 } from "../cert/tc-dd-support.js";
@@ -1289,6 +1290,63 @@ describe("commissionByQr's own causal boundary", () => {
         const matched = fixture.checks.find(check => check.type === "device-log")?.matched ?? "";
         expect(matched).contains("bbbbbbbbbbbbbbbb");
         expect(matched).not.contains("aaaaaaaaaaaaaaaa");
+    });
+});
+
+describe("recordNotCommissioned", () => {
+    const CHIP_COMMISSIONED = "[1787433110.001] [23362:73430237:chip] [SVR] Commissioning completed successfully";
+    const MATTERJS_COMMISSIONED =
+        "2026-08-27 19:31:27.056 NOTICE GeneralCommissioningClusterHandler Commissioned fabric: 6ad0fe468a5d1880 (#1) node: 1";
+
+    // A negative check passes on a run where nothing happened whether or not it looks in the right
+    // place, so the case that proves it is the one where the device DID commission
+    it("fails when the device completed a commissioning after the mark", async () => {
+        const fixture = new UnpairFixture("chip-local");
+        const from = await fixture.markTransition();
+        // Deliberately not drained: the helper has to settle the log itself, or it counts a buffer
+        // the completion has not reached yet and reports the device idle
+        fixture.push(CHIP_COMMISSIONED);
+
+        await expect(
+            recordNotCommissioned(fixture.cx, fixture.cx.devices.th, from, "TH2 was not commissioned"),
+        ).rejectedWith(CertCheckFailedError);
+
+        expect(fixture.checks.map(check => check.verdict)).deep.equal(["fail"]);
+        expect(fixture.checks[0].detail).contains("completed 1 commissioning");
+    });
+
+    it("ignores a commissioning the device completed before the mark", async () => {
+        const fixture = new UnpairFixture("chip-local");
+        fixture.push(CHIP_COMMISSIONED);
+        const from = await fixture.markTransition();
+
+        await recordNotCommissioned(fixture.cx, fixture.cx.devices.th, from, "TH2 was not commissioned");
+
+        expect(fixture.checks.map(check => check.verdict)).deep.equal(["pass"]);
+    });
+
+    it("reads the matterjs device's own form of the line", async () => {
+        const fixture = new UnpairFixture("matterjs");
+        const from = await fixture.markTransition();
+        fixture.push(MATTERJS_COMMISSIONED);
+
+        await expect(
+            recordNotCommissioned(fixture.cx, fixture.cx.devices.th, from, "TH1 was not commissioned again"),
+        ).rejectedWith(CertCheckFailedError);
+
+        expect(fixture.checks.map(check => check.verdict)).deep.equal(["fail"]);
+    });
+
+    it("counts every commissioning in the window, not just the first", async () => {
+        const fixture = new UnpairFixture("chip-local");
+        const from = await fixture.markTransition();
+        fixture.push(CHIP_COMMISSIONED, CHIP_COMMISSIONED);
+
+        await expect(
+            recordNotCommissioned(fixture.cx, fixture.cx.devices.th, from, "TH2 was not commissioned"),
+        ).rejectedWith(CertCheckFailedError);
+
+        expect(fixture.checks[0].detail).contains("completed 2 commissioning");
     });
 });
 

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1791,6 +1791,65 @@ result alone.
 claim from `.a`'s "the QR code has been scanned successfully". Read the plan's expected column before
 deciding a `.b` step's parse is redundant: it usually is, and there it is not.
 
+## More than one device in a run (`TC-DD-3.18`)
+
+`certTest`'s `devices` option takes as many roles as a plan names, and each declared device gets its
+own onboarding identity — discriminator, passcode, and operational port — from `identityFor(index)`
+in `cert-dsl.ts`. This used to throw.
+
+**Why it had to.** Every discovery instrument in this directory matches on the long discriminator
+alone, and every flavor defaulted to 3840 / 20202021 / 5540. Two subjects sharing that would have the
+commissioner reach whichever the scanner found first, and the run would pass having proven nothing
+about which device it talked to. The chip flavors would not even get that far: two apps contend for
+port 5540 and the second exits, which surfaces as "a cert-test device exited unexpectedly while a
+step was running" rather than as a port collision.
+
+**The primary keeps chip's defaults, deliberately.** Index 0 is 3840 / 20202021 / 5540, so all
+fifteen existing single-device TCs record exactly what they recorded before — same discriminator in
+their evidence, same payload. Only a second device gets new values. Identity is assigned by
+declaration order rather than randomly, so a bundle's discriminator means the same thing across runs
+and a failure reproduces; the cost is that a clash with an unrelated device on the LAN repeats every
+run instead of clearing, which is the better failure because it is diagnosable.
+
+**What each flavor needed:**
+
+| Flavor | Discriminator / passcode | Port |
+| --- | --- | --- |
+| `chip-local`, `chip-docker` | already per-instance `--discriminator`/`--passcode` | new `--secured-device-port` |
+| `matterjs` | already per-instance via `TestInstanceConfig` | new `port` on `TestInstanceConfig`, replacing a hardcoded 5540 in each `TestInstance` |
+
+**Two traps this cost:**
+
+- **A non-primary device's domain cannot be the TC's name.** The primary's is `descriptor.kind`
+  ("cert"); a name like `TC-DD-3.18` carries dots, and a matter.js subject rejects them as an endpoint
+  id. Non-primary devices are named `cert-<role>`.
+- **`CommissionedRefs` is keyed by *controller* role, not device role** — `decommissionAll` removes
+  each fabric through `cx.controllers[role]`. A plan whose devices share one controller therefore
+  gives each device its own `CommissionedRefs` and joins them with `runCleanups`, rather than
+  inventing device-named roles that resolve to no controller.
+
+**"Only TH1 was commissioned" is a claim about TH2, and TH2's own log is what states it.**
+`recordNotCommissioned` counts completion lines in the step's window and fails if there are any.
+The obvious alternative — a device that joined a fabric stops advertising commissionable, so check
+that TH2 still does — is the freshness trap above: the probe is answered out of the shared DNS-SD
+cache, which still holds the record step 1.b installed whether or not TH2 has since joined. The first
+draft of this TC used it. Step 3.b makes the symmetric check, that TH1 was not commissioned a second
+time, which the plan asks for in the same words.
+
+**A negative check cannot be proven by a run where nothing happened** — it passes whether or not it
+looks in the right place. Its unit tests supply the positive case: a completion after the mark must
+fail it, one before the mark must not.
+
+**The precondition is that the two devices differ in their long discriminator**, since that is the
+only field discovery matches on, and it is read out of the payloads the *devices themselves printed*.
+Comparing `device.commissioning` would not do: on a chip flavour that is the identity the harness
+handed the app, so it compares `identityFor(0)` with `identityFor(1)` and cannot fail. Comparing whole
+payloads is also not enough — two could differ only in passcode and leave discovery just as ambiguous.
+
+**Steps 4.a/4.b name the node and operational instance they reached.** Both harnesses run the same app
+with the same vendor id, so the attribute value alone cannot tell them apart and swapping the two refs
+would satisfy either step.
+
 ## chip-tool delivers one result per async report and discards the rest
 
 `step 4: write 1/3 … produced no subscription report carrying "tc-idm-4-1-a" within 30s`,

--- a/support/chip-testing/test/cert/TC-DD-3.18.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.18.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InternalError } from "@matter/main";
+import { Matter } from "@matter/model";
+import type { CertNodeRef, CertStepContext } from "@matter/testing";
+import { certTest } from "@matter/testing";
+import { expectMdns } from "../../src/cert/mdns-check.js";
+import {
+    commissionByQr,
+    MDNS_TIMEOUT,
+    qrPayloadFields,
+    recordNotCommissioned,
+    recordParse,
+    thQrPayload,
+} from "./tc-dd-support.js";
+import { CommissionedRefs, record, requireId, runCleanups } from "./tc-support.js";
+
+const BASIC_INFORMATION = Matter.clusters.require("BasicInformation");
+const BASIC_INFORMATION_ID = requireId(BASIC_INFORMATION.id, "BasicInformation cluster");
+const VENDOR_ID = requireId(BASIC_INFORMATION.attributes.require("vendorId").id, "BasicInformation.vendorId");
+
+// One per device rather than one keyed by device: `CommissionedRefs` removes each fabric through
+// `cx.controllers[role]`, and both of these harnesses are commissioned by the same controller.
+const th1Commissioned = new CommissionedRefs();
+const th2Commissioned = new CommissionedRefs();
+
+/**
+ * The two harnesses, with the invariant every other step here depends on: they must be separately
+ * addressable, because discovery in this directory matches on the long discriminator alone.
+ *
+ * `device.commissioning` is not evidence of that on a chip flavour — it is the identity the harness
+ * handed the app, so comparing the two would compare `identityFor(0)` with `identityFor(1)` and could
+ * not fail. What the *devices* say is their printed onboarding payloads, which encode the
+ * discriminator and passcode each app actually came up with; steps 2.a and 3.a then check what the
+ * DUT parses out of them against the same identity.
+ */
+async function distinctSubjects(cx: CertStepContext) {
+    const th1 = cx.devices.th1;
+    const th2 = cx.devices.th2;
+    if (th1 === undefined || th2 === undefined) {
+        throw new InternalError("TC-DD-3.18 requires two devices");
+    }
+    return { th1, th2 };
+}
+
+async function recordDistinctPayloads(cx: CertStepContext) {
+    const { th1, th2 } = await distinctSubjects(cx);
+    const [first, second] = await Promise.all([thQrPayload(th1), thQrPayload(th2)]);
+
+    // The discriminator specifically, not the payload as a whole: two payloads differing only in
+    // passcode would leave discovery just as ambiguous, and every instrument here matches on the
+    // long discriminator alone.
+    const [firstFields, secondFields] = [qrPayloadFields(first), qrPayloadFields(second)];
+
+    record(
+        cx,
+        {
+            type: "response",
+            verdict: firstFields.discriminator !== secondFields.discriminator ? "pass" : "fail",
+            detail:
+                `TH1 published ${first} (discriminator ${firstFields.discriminator}), ` +
+                `TH2 published ${second} (discriminator ${secondFields.discriminator})`,
+        },
+        "The two THs advertise different discriminators",
+    );
+
+    return { th1, th2 };
+}
+
+/**
+ * Reads an attribute back through `ref` and records which node answered.
+ *
+ * Both harnesses run the same app, so the value alone cannot tell them apart — swapping the two refs
+ * would satisfy either step. The node's own operational instance name is what makes the bundle say
+ * which fabric entry was exercised.
+ */
+async function recordStillReachable(cx: CertStepContext, ref: CertNodeRef, who: string) {
+    const node = cx.controllers.dut.node(ref);
+    const [vendorId, instanceName] = await Promise.all([
+        node.readAttribute({ endpoint: 0, cluster: BASIC_INFORMATION_ID, attribute: VENDOR_ID }),
+        node.operationalMdnsInstanceName(),
+    ]);
+
+    record(
+        cx,
+        {
+            type: "response",
+            verdict: typeof vendorId === "number" ? "pass" : "fail",
+            detail:
+                `${who} (node ${ref}, operational instance ${instanceName}) answered ` +
+                `BasicInformation.vendorId with ${JSON.stringify(vendorId)}`,
+        },
+        `${who} still reachable`,
+    );
+}
+
+certTest("TC-DD-3.18", {
+    plan: "devicediscovery.adoc",
+    pics: ["MCORE.ROLE.COMMISSIONER", "MCORE.DD.QR_COMMISSIONING"],
+    app: "all-clusters",
+    devices: { th1: "all-clusters", th2: "all-clusters" },
+})
+    .step(
+        "1.a",
+        "Place TH1 into commissioning mode using the TH manufacturer's means to be discovered by a commissioner",
+        async cx => {
+            const { th1 } = await recordDistinctPayloads(cx);
+            record(cx, await expectMdns(th1, { commissionable: true }, { timeoutMs: MDNS_TIMEOUT }), "TH1 advertising");
+        },
+        { expected: "Verify that TH1 is advertising and able to be discovered by a commissioner." },
+    )
+    .step(
+        "1.b",
+        "Place TH2 into commissioning mode using the TH manufacturer's means to be discovered by a commissioner",
+        async cx => {
+            const { th2 } = await distinctSubjects(cx);
+            record(cx, await expectMdns(th2, { commissionable: true }, { timeoutMs: MDNS_TIMEOUT }), "TH2 advertising");
+        },
+        { expected: "Verify that TH2 is advertising and able to be discovered by a commissioner." },
+    )
+    .step(
+        "2.a",
+        "Scan TH1's QR code using the DUT Commissioner.",
+        async cx => {
+            const { th1 } = await distinctSubjects(cx);
+            await recordParse(cx, await thQrPayload(th1), th1);
+        },
+        { pics: "MCORE.DD.SCAN_QR_CODE", expected: "Verify the QR code has been scanned successfully." },
+    )
+    .step(
+        "2.b",
+        "DUT parses TH1's QR code. Follow any steps needed for the Commissioner/Commissionee to complete the " +
+            "commissioning process over the TH Commissionee's method of device discovery",
+        async cx => {
+            const { th1, th2 } = await distinctSubjects(cx);
+            const th2From = await th2.log.markSettled();
+
+            await commissionByQr(cx, await thQrPayload(th1), th1Commissioned, th1);
+
+            // "Only TH1" is a claim about TH2, and TH2's own log is what states it. A commissionable
+            // probe cannot: it is answered out of the shared DNS-SD cache, which still holds the
+            // record step 1.b installed whether or not TH2 has since joined a fabric.
+            await recordNotCommissioned(cx, th2, th2From, "TH2 was not commissioned");
+        },
+        {
+            expected:
+                "DUT parses TH1's QR code and DUT commissions TH1 onto the Matter network. Verify that only TH1 " +
+                "has been commissioned onto the Matter network and that TH2 has not been commissioned.",
+        },
+    )
+    .step(
+        "3.a",
+        "Scan TH2's QR code using the DUT Commissioner.",
+        async cx => {
+            const { th2 } = await distinctSubjects(cx);
+            await recordParse(cx, await thQrPayload(th2), th2);
+        },
+        { pics: "MCORE.DD.SCAN_QR_CODE", expected: "Verify the QR code has been scanned successfully." },
+    )
+    .step(
+        "3.b",
+        "DUT parses TH2's QR code. Follow any steps needed for the Commissioner/Commissionee to complete the " +
+            "commissioning process over the TH Commissionee's method of device discovery",
+        async cx => {
+            const { th1, th2 } = await distinctSubjects(cx);
+            const th1From = await th1.log.markSettled();
+
+            await commissionByQr(cx, await thQrPayload(th2), th2Commissioned, th2);
+
+            // The plan asks the same of this step, the other way round: TH1 is already commissioned,
+            // so what must not happen is a second commissioning of it.
+            await recordNotCommissioned(cx, th1, th1From, "TH1 was not commissioned again");
+        },
+        {
+            expected:
+                "DUT parses TH2's QR code and DUT commissions TH2 onto the Matter network. Verify that only TH2 " +
+                "has been commissioned onto the Matter network in this step.",
+        },
+    )
+    .step(
+        "4.a",
+        "Verify the Commissioner can still interact with TH1 (ex: Read any cluster's attribute from TH1)",
+        cx => recordStillReachable(cx, th1Commissioned.require("dut"), "TH1"),
+        { expected: "Verify TH1 remains commissioned onto the Matter network." },
+    )
+    .step(
+        "4.b",
+        "Verify the Commissioner can still interact with TH2 (ex: Read any cluster's attribute from TH2)",
+        cx => recordStillReachable(cx, th2Commissioned.require("dut"), "TH2"),
+        { expected: "Verify TH2 remains commissioned onto the Matter network." },
+    )
+    .finalize(cx =>
+        runCleanups(
+            () => th1Commissioned.decommissionAll(cx),
+            () => th2Commissioned.decommissionAll(cx),
+        ),
+    );

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -19,6 +19,7 @@ import {
 import { Base38, DiscoveryCapabilitiesBitmap, DiscoveryCapabilitiesSchema } from "@matter/main/types";
 import type { CertNodeRef, CertStepContext, CheckRecord, CommissioningTarget } from "@matter/testing";
 import type { CertDevice } from "@matter/testing";
+import { forFlavor } from "@matter/testing";
 import { ChipToolCommandError } from "../../src/cert/ChipToolControllerAdapter.js";
 import { expectMdns } from "../../src/cert/mdns-check.js";
 import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload.js";
@@ -53,9 +54,27 @@ import {
  */
 export type TransitionMark = number;
 
-/** Takes a {@link TransitionMark} on the TH, after letting its log pump settle. */
-export async function markTransition(cx: CertStepContext): Promise<TransitionMark> {
-    return cx.devices.th.log.markSettled();
+/** Takes a {@link TransitionMark} on `th`, after letting its log pump settle. */
+export async function markTransition(cx: CertStepContext, th = theTh(cx)): Promise<TransitionMark> {
+    return th.log.markSettled();
+}
+
+/**
+ * The device these helpers act on where a plan names only one.
+ *
+ * A plan may now declare several devices under names of its own (`devices: { th1, th2 }`), and then
+ * there is no `th` role at all. Reaching for one is a defect in the calling step rather than anything
+ * the run can recover from, so it says so instead of failing later on a property of `undefined`.
+ */
+function theTh(cx: CertStepContext): CertDevice {
+    const th = cx.devices.th;
+    if (th === undefined) {
+        throw new ImplementationError(
+            `This step's plan declares no "th" device (it has ${Object.keys(cx.devices).join(", ") || "none"}); ` +
+                "a helper acting on one device takes it as a parameter when the plan names more than one",
+        );
+    }
+    return th;
 }
 
 /** Bounds a wait for a line a device prints as it comes up, with a whole commissioning flow ahead of it. */
@@ -93,6 +112,51 @@ const SETUP_QR_CODE = /SetupQRCode: \[(MT:[^\]]+)\]/;
 
 /** chip-all-clusters-app announces a completed commissioning. */
 const COMMISSIONING_COMPLETE = /Commissioning completed successfully/;
+
+/** A device announcing it completed a commissioning, in whichever form its implementation prints. */
+export const COMMISSIONED = { chip: COMMISSIONING_COMPLETE, matterjs: MATTERJS_COMMISSIONED_FABRIC };
+
+/**
+ * Records that `th` did **not** complete a commissioning since `from`, which is how a plan's "only
+ * the other device was commissioned" is stated: the device that must not have joined is the only
+ * thing that can say so.
+ *
+ * A commissionable mDNS probe cannot. It is answered out of the process-global DNS-SD cache, so it
+ * reports a record this run installed several steps earlier just as readily as a live one — see this
+ * directory's AGENTS.md on freshness. The device's own log is not cached and not shared.
+ */
+export async function recordNotCommissioned(
+    cx: CertStepContext,
+    th: CertDevice,
+    from: number,
+    what: string,
+): Promise<void> {
+    // Counting reads the buffer directly, so a completion the device printed moments ago is
+    // invisible until the pump has delivered it — and this runs immediately after a commissioning,
+    // which is exactly when such a line is in flight.
+    await th.log.settled();
+
+    const pattern = forFlavor(COMMISSIONED, th.flavor);
+    if (pattern === undefined) {
+        record(cx, { type: "device-log", verdict: "unverified" }, what);
+        return;
+    }
+
+    const completions = th.log.count(pattern, from);
+    record(
+        cx,
+        {
+            type: "device-log",
+            verdict: completions === 0 ? "pass" : "fail",
+            pattern: String(pattern),
+            detail:
+                completions === 0
+                    ? `${th.id} logged no completed commissioning in this step`
+                    : `${th.id} completed ${completions} commissioning(s) in this step`,
+        },
+        what,
+    );
+}
 
 /**
  * The device announcing that it is now advertising itself commissionable — the transition a plan's
@@ -147,9 +211,8 @@ export async function thQrPayload(th: CertDevice, from = 0): Promise<string> {
  * parse is the DUT's, not the step's: a step that decoded the payload itself would pass against a
  * controller that cannot read one at all.
  */
-export async function recordParse(cx: CertStepContext, payload: string): Promise<void> {
-    const th = cx.devices.th;
-
+export async function recordParse(cx: CertStepContext, payload: string, th?: CertDevice): Promise<void> {
+    th ??= theTh(cx);
     let parsed;
     try {
         parsed = await cx.controllers.dut.parseQrPayload(payload);
@@ -191,7 +254,7 @@ export const ON_NETWORK_ONLY = DiscoveryCapabilitiesSchema.encode({ onIpNetwork:
  * a BLE-only bitmask, so the precondition does not otherwise hold on that TH at all.
  */
 export async function onNetworkOnlyPayload(cx: CertStepContext): Promise<string> {
-    return qrPayloadWith(await thQrPayload(cx.devices.th), { discoveryCapabilities: ON_NETWORK_ONLY });
+    return qrPayloadWith(await thQrPayload(theTh(cx)), { discoveryCapabilities: ON_NETWORK_ONLY });
 }
 
 /** § 5.1.3.1 Table 59's version string for this revision of the specification. */
@@ -680,7 +743,7 @@ export async function thManualPairingCode(
 export async function thCodeParts(
     cx: CertStepContext,
 ): Promise<ManualPairingCodeParts & { vendorId: number; productId: number }> {
-    const th = cx.devices.th;
+    const th = theTh(cx);
     const { vendorId, productId } = await cx.controllers.dut.parseQrPayload(await thQrPayload(th));
     if (vendorId === undefined || productId === undefined) {
         // parseQrPayload reports § 2.5.2/§ 2.5.3's "unspecified" as absent, and Table 64's 21-digit
@@ -706,7 +769,7 @@ export async function thCodeParts(
  * cannot read one.
  */
 export async function recordManualParse(cx: CertStepContext, code: string): Promise<void> {
-    const th = cx.devices.th;
+    const th = theTh(cx);
 
     let parsed;
     try {
@@ -743,8 +806,9 @@ export const SHORT_DISCRIMINATOR_SHIFT = 8;
 export async function recordCommissionable(
     cx: CertStepContext,
     what = "TH advertising as commissionable",
+    th = theTh(cx),
 ): Promise<void> {
-    record(cx, await expectMdns(cx.devices.th, { commissionable: true }, { timeoutMs: MDNS_TIMEOUT }), what);
+    record(cx, await expectMdns(th, { commissionable: true }, { timeoutMs: MDNS_TIMEOUT }), what);
 }
 
 /**
@@ -901,7 +965,7 @@ export async function recordVendorOutcome(
  * admin on the TH would have another fabric's removal satisfy the first check.
  */
 export async function recordUnpair(cx: CertStepContext, commissioned: CommissionedRefs): Promise<TransitionMark> {
-    const th = cx.devices.th;
+    const th = theTh(cx);
     const ref = commissioned.require("dut");
     const node = cx.controllers.dut.node(ref);
 
@@ -956,15 +1020,19 @@ export async function recordBackInCommissioningMode(
     options: {
         what?: string;
         since?: TransitionMark;
+        /** The device this acts on, where the plan names more than one. */
+        th?: CertDevice;
         /** Overridden by the unit tests, which have no mDNS to answer. */
         probeCommissionable?: (cx: CertStepContext, what: string) => Promise<void>;
     } = {},
 ): Promise<void> {
-    const th = cx.devices.th;
+    const th = options.th ?? theTh(cx);
     const {
         what = "TH advertising as commissionable again",
-        probeCommissionable = recordCommissionable,
-        since = await markTransition(cx),
+        // Bound to this device rather than to the plan's single-device role, which a multi-device
+        // plan does not have
+        probeCommissionable = (cx: CertStepContext, what: string) => recordCommissionable(cx, what, th),
+        since = await markTransition(cx, th),
     } = options;
     const from = since;
 
@@ -1010,17 +1078,19 @@ async function restoreCommissioningMode(
     cx: CertStepContext,
     commissioned: CommissionedRefs,
     probeCommissionable?: (cx: CertStepContext, what: string) => Promise<void>,
+    subject?: CertDevice,
 ): Promise<boolean> {
     const previous = commissioned.get("dut");
     if (previous === undefined) {
         return false;
     }
 
-    const since = await markTransition(cx);
+    const th = subject ?? theTh(cx);
+    const since = await markTransition(cx, th);
     await cx.controllers.dut.node(previous).decommission();
     commissioned.clear("dut");
 
-    await recordBackInCommissioningMode(cx, { since, probeCommissionable });
+    await recordBackInCommissioningMode(cx, { since, probeCommissionable, th });
     return true;
 }
 
@@ -1041,19 +1111,27 @@ export async function commissionByQr(
     cx: CertStepContext,
     payload: string,
     commissioned: CommissionedRefs,
+    /**
+     * The device being onboarded, where the plan names more than one. Its node ref is still filed
+     * under the `dut` role, because `CommissionedRefs.decommissionAll` removes a fabric through
+     * `cx.controllers[role]` — so a plan whose devices share one controller gives each device its own
+     * `CommissionedRefs` rather than its own role.
+     */
+    th?: CertDevice,
 ): Promise<void> {
-    await commissionByTarget(cx, { qrPairingCode: payload }, commissioned);
+    await commissionByTarget(cx, { qrPairingCode: payload }, commissioned, th);
 }
 
 async function commissionByTarget(
     cx: CertStepContext,
     target: CommissioningTarget,
     commissioned: CommissionedRefs,
+    subject?: CertDevice,
 ): Promise<void> {
     const dut = cx.controllers.dut;
-    const th = cx.devices.th;
+    const th = subject ?? theTh(cx);
 
-    await restoreCommissioningMode(cx, commissioned);
+    await restoreCommissioningMode(cx, commissioned, undefined, subject);
 
     // Settled, because the line this waits for names no fabric on either flavor: a completion still
     // in flight from an earlier commissioning would otherwise satisfy this one
@@ -1082,7 +1160,7 @@ async function commissionByTarget(
             from,
             COMMISSIONING_LOG_TIMEOUT,
         ),
-        "TH commissioning",
+        `${th.id} commissioning`,
     );
 }
 


### PR DESCRIPTION
Adds TC-DD-3.18 from the device-discovery plan (commission two harnesses, verify only the intended one each time), and the framework support it needs.

## Why this was blocked

`certTest` used to throw for a `devices` map with more than one role. Every device flavour defaulted to discriminator 3840, passcode 20202021 and port 5540, and two subjects sharing those cannot be told apart: discovery in this directory matches on the long discriminator alone, so the commissioner would reach whichever the scanner found first and the run would pass having proven nothing about which device it talked to. On the chip flavours the second app would not even start — both want port 5540, which surfaces as "a cert-test device exited unexpectedly while a step was running" rather than as a port collision.

## Per-device identity

Each declared device now gets its own discriminator, passcode and port, assigned by declaration order.

**The primary keeps chip's own defaults**, so every existing single-device test case records exactly what it recorded before — same discriminator in its evidence, same payload. Verified by running the whole suite on both flavours and comparing per-test-case verdicts against the documented baseline. Only a second device gets new values.

**Deterministic rather than random**, so a bundle's discriminator means the same thing across runs and a failure reproduces. The cost is that a clash with an unrelated device on the network repeats every run instead of clearing — the better failure, because it can be diagnosed. Easy to flip if you disagree.

The chip subjects already spawned with per-instance discriminator and passcode and needed only `--secured-device-port`. The matter.js instances already took discriminator and passcode from their config; the port was hardcoded in each of them and now comes from the same place.

## What the test case actually proves

The plan names two harnesses because the interesting claim is "only the intended one each time". Getting that evidenced properly took a rewrite after review:

- **"Only TH1 was commissioned" comes from TH2's own log**, not from a commissionable mDNS probe. A probe cannot answer it — it is served from the process-global DNS-SD cache, which still holds the record step 1.b installed whether or not TH2 has since joined a fabric. This is the same freshness trap #4339 documents, and the first draft of this test case walked straight into it.
- **Step 3.b now checks the symmetric claim**, which the plan asks for and nothing had checked: TH1 must not be commissioned a second time.
- **The two devices are distinguished by their own printed payloads**, not by comparing the identities the harness handed them. On a chip flavour `device.commissioning` *is* what we passed in, so comparing the two would have compared `identityFor(0)` with `identityFor(1)` and could not fail — a unit test of the allocator written into the bundle as a device observation.
- **Steps 4.a/4.b name the node and operational instance** they reached. Both harnesses run the same app with the same vendor id, so the value alone could not tell them apart and swapping the two refs would have passed both.

## Verification

- TC-DD-3.18 green on matterjs and chip-local, checked per step from the evidence bundle. On chip-local the two apps print genuinely different payloads (`MT:-24J042C00KA0648G00` / `MT:-24J0CEK010O0648G00`), so the identity reached the binary rather than only the harness's bookkeeping.
- Whole cert suite on matterjs: 16 test cases, baseline unchanged. Device-discovery block on chip-local: all green.
- `npm run build` from the repository root, with `support/chip-testing/build` deleted first so no incremental cache could mask an error in a dependent package: type check and transpile clean, exit 0.
- `test/cert-framework` 777/777, root `npm test` green on every leg, `npm run lint` and `npm run format-verify` clean.
- The negative "was not commissioned" check settles the device's log before counting — it reads the buffer directly, and it runs immediately after a commissioning, which is exactly when the other device's completion line is in flight. It is proven by its positive case in unit tests — a log carrying a completion after the mark must fail it, one before the mark must not, and it counts every completion in the window. A live run cannot prove this: it passes whether or not the check looks in the right place.

## Also from review

- Five `TestInstance` subclasses got the configurable port; a sixth (`AllDevicesTestInstance` via `buildRootNode`) still hardcoded 5540. Not reachable from a cert test today, but it was the one structurally identical file left inconsistent.
- Helpers that assume a single `th` role now fail with a typed error naming the multi-device case instead of dereferencing `undefined`, since this change is what makes a plan with no `th` role possible.
- `appVariant` no longer follows a role running a different app (`chip-bridge-app-nlfaultinject` is not built by anyone).
- Identity overflow is now rejected at declaration time rather than after the primary device is already running with no evidence bundle written.
- The log-attribution note in `cert/index.ts` said concurrent matter.js devices never happen. They do now; it says what is and is not reliably attributed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
