### PR TITLE
test(chip-testing): TC-DD-3.12 and TC-DD-3.13, the two commissioning flows a harness cannot publish

### DIFF
--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -31,6 +31,7 @@ import {
     checkGeneratedManualCode,
     checkGeneratedPayload,
     commissionByQr,
+    CUSTOM_FLOW,
     CommissioningRefusals,
     manualPairingCode,
     manualPairingCodeDigits,
@@ -46,6 +47,7 @@ import {
     recordNotCommissioned,
     recordUnpair,
     recordVendorOutcome,
+    USER_INTENT_FLOW,
 } from "../cert/tc-dd-support.js";
 import { CertCheckFailedError, CertCleanupError, CommissionedRefs } from "../cert/tc-support.js";
 
@@ -347,6 +349,28 @@ describe("recordPayloadOffering", () => {
         await expect(
             recordPayloadOffering(cx, qrPayloadWith(BLE_PAYLOAD, { discoveryCapabilities: ON_NETWORK_ONLY }), "ble"),
         ).rejectedWith(CertCheckFailedError, /does not offer ble/);
+    });
+
+    // The flow a test case is named for is the caller's, not a constant: TC-DD-3.12 and 3.13 fabricate
+    // flows no subject publishes, and a helper hardcoding the standard one would have printed a
+    // verdict naming a flow nobody checked
+    it("judges the payload against the flow the caller asked for", async () => {
+        const cx = contextWithParser();
+
+        await recordPayloadOffering(cx, PLAN_PAYLOAD, "onIpNetwork", CUSTOM_FLOW);
+
+        const check = checksOf(cx).at(-1);
+        expect(check?.verdict).equal("pass");
+        expect(check?.detail).contains("flowType=2");
+    });
+
+    it("fails when the payload carries a different flow from the one asked for", async () => {
+        const cx = contextWithParser();
+
+        await expect(recordPayloadOffering(cx, PLAN_PAYLOAD, "onIpNetwork", USER_INTENT_FLOW)).rejectedWith(
+            CertCheckFailedError,
+            /flowType 2 rather than the user-intent flow/,
+        );
     });
 
     it("fails when the payload names a commissioning flow other than the standard one", async () => {

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -47,6 +47,7 @@ import {
     recordNotCommissioned,
     recordUnpair,
     recordVendorOutcome,
+    STANDARD_FLOW,
     USER_INTENT_FLOW,
 } from "../cert/tc-dd-support.js";
 import { CertCheckFailedError, CertCleanupError, CommissionedRefs } from "../cert/tc-support.js";
@@ -89,6 +90,14 @@ describe("qrPayloadWith", () => {
         expect(qrPayloadWith("MT:-24J042C00KA0648G00", { discoveryCapabilities: ON_NETWORK_ONLY })).equal(
             "MT:-24J0AFN00KA0648G00",
         );
+    });
+
+    it("substitutes the flow, which is the field TC-DD-3.12 and TC-DD-3.13 are named for", () => {
+        // The plan's own example payload carries the custom flow, and the standard-flow form of it is
+        // the payload the capabilities test above arrives at from the other direction
+        expect(qrPayloadWith(PLAN_PAYLOAD, { flowType: STANDARD_FLOW })).equal("MT:-24J0AFN00KA0648G00");
+        expect(qrPayloadWith(PLAN_PAYLOAD, { flowType: USER_INTENT_FLOW })).equal("MT:-24J06VO00KA0648G00");
+        expect(qrPayloadWith("MT:-24J0AFN00KA0648G00", { flowType: CUSTOM_FLOW })).equal(PLAN_PAYLOAD);
     });
 
     it("leaves every other field where it was", () => {

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -572,10 +572,10 @@ this out; a command with a genuine data response (unlike TC-ACT-3.2/TC-IDM-1.1's
 commands) would need a different anchor, so this fix lives in `tc-support.ts` alongside its
 read-side sibling matcher, not generalized into `log-follower.ts` itself.
 
-## Known limitations carried forward from `TC-ACT-3.2`, not yet fixed
+## Three limitations every cert TC inherits, and what to do about each
 
-An adversarial review of this TC surfaced a few items judged real but out of this pilot's scope — noted
-here rather than silently dropped, for whoever picks up the next cert TC or a framework promotion pass:
+An adversarial review of TC-ACT-3.2 surfaced these; they are shared by every TC in this directory, so
+each is written as the thing to do when it bites:
 
 - **`commandPathIBSequence`'s adjacency chain only rules out a lagging *response* echo, not a
   theoretically lagging *previous request*.** Now shared via `tc-support.ts` (see "Promoting the
@@ -820,12 +820,13 @@ import's top-level code always runs the instant the importing module loads, so n
 the import itself behind a runtime-skipped dynamic `import()` keeps those requires from executing (and
 crashing, since the browser has no `require`) during a web test run.
 
-## Prerequisite gap: no fault-injection-capable TH_SERVER binary available (`TC-SC-3.5`)
+## Where `TC-SC-3.5` gets its fault-injection TH_SERVER binary, per flavor
 
 `TC_SC_3_5.py` spawns TH_SERVER itself as a **container-side** subprocess (`--string-arg
 th_server_app_path:<path>`), and needs the `FaultInjection` cluster's `FailAtFault` command to actually
-do something (`CHIP_WITH_NLFAULTINJECTION` compiled in) rather than return `UnsupportedCommand`. Checked
-both parts:
+do something (`CHIP_WITH_NLFAULTINJECTION` compiled in) rather than return `UnsupportedCommand`. Both
+parts are satisfied today; what follows is where each comes from, so a new prompt-driven TC knows what
+to point at:
 
 - **Fault injection itself is likely already fine by default.** `CHIP_WITH_NLFAULTINJECTION` is driven
   by the GN arg `chip_with_nlfaultinjection`, which defaults to `chip_build_tools || chip_build_tests`
@@ -1630,12 +1631,11 @@ adapters deliberately declare neither (`controller-adapter.test.ts` holds them t
 leg is gated by an answer about the TH while the step is about the DUT, and the bundle carries both
 statements side by side — the `notApplicable` text says which subject it means for that reason.
 
-**Unsettled, worth resolving before the next per-transport TC:** the PICS register
-(`chip-test-plans/tools/PICS_Automation/Pics_XML_Files/XML__Files/Base.xml`) defines
-`MCORE.DD.DISCOVERY_BLE` as "Does the commissioner support Discovery Capability over BLE?", which
-makes it a DUT question in TC-DD-3.14 as well, where this directory currently treats it as a TH one.
-If the register governs, the adapters declaring `= 0` would be the cleaner gate and `notApplicable`
-would become unnecessary.
+**Never gate a transport leg on `MCORE.DD.DISCOVERY_BLE` alone.** The value reaching that gate comes
+from the device file and answers for the TH, while the step's claim is about the DUT. Use
+`notApplicable` with a reason naming the subject, as above. (The PICS register defines the key as a
+commissioner question, which would make the adapters the right place to declare it; that is parked
+with the BLE work and does not change what to write today.)
 
 Generating and parsing a payload needs no radio, so those steps are left executable — though only the
 BLE leg's actually run today, since `DISCOVERY_PAF=0` skips the PAF leg entirely. A leg is reported as
@@ -1849,6 +1849,36 @@ payloads is also not enough — two could differ only in passcode and leave disc
 **Steps 4.a/4.b name the node and operational instance they reached.** Both harnesses run the same app
 with the same vendor id, so the attribute value alone cannot tell them apart and swapping the two refs
 would satisfy either step.
+
+## A flow the TH cannot publish has to be fabricated (`TC-DD-3.12`, `TC-DD-3.13`)
+
+These two are one test case with one field changed — user-intent flow (1) and custom flow (2) — so
+they are declared from one place, `tc-dd-flow-support.ts`, and differ only in the constant they pass.
+Three transport legs of four steps each: generate, scan, parse, commission.
+
+**The flow is fabricated, unlike TC-DD-3.11's capability bitmask.** Every subject this harness runs
+publishes `flowType` 0, because a device that needs a user action or a manufacturer's steps is not
+something the harness can produce. `qrPayloadWith` gained a `flowType` field for exactly this, and the
+scan step reads it back through the DUT's own parser — which is what makes the step evidence about the
+flow rather than about the TH.
+
+**`recordPayloadOffering` takes the expected flow as a parameter.** It used to hardcode the standard
+flow in its verdict, so these two would have recorded a `pass` whose text named a flow nobody checked.
+A helper whose verdict names a property must take that property from the caller, or the second test
+case to use it silently asserts the first one's value.
+
+**Step `.c` is the one worth having, and it is negative.** The plan asks to verify the DUT parsed the
+code *and* that the TH has not been commissioned: a flow saying "not commissionable yet" must not have
+the DUT commission the device merely because it read the code. `recordNotCommissioned` states that
+from the TH's own log. This is the only step in either test case that could fail against a correct
+parse, which is the usual pattern — the positive steps confirm plumbing, the negative one is where a
+defect would surface.
+
+**The plan's own example payload is a custom-flow code, in both test cases' preconditions.** It
+decodes to `flowType` 2, which is right for TC-DD-3.13 and contradicts TC-DD-3.12's own title. Worth
+knowing because the run confirms it from the other direction: TC-DD-3.13's IP leg fabricates
+`MT:-24J029Q00KA0648G00`, character for character the payload the plan prints. Reported upstream
+rather than worked around — see the `spec-qr-example-payload-wrong-flow` task.
 
 ## chip-tool delivers one result per async report and discards the rest
 

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1867,6 +1867,21 @@ flow in its verdict, so these two would have recorded a `pass` whose text named 
 A helper whose verdict names a property must take that property from the caller, or the second test
 case to use it silently asserts the first one's value.
 
+**The transition the flow is named for is not exercised, and each leg's `.a` says so.** A user-intent
+or custom flow means the device is not commissionable until someone acts, which is why `.a`'s text
+carries "Commissionee is NOT in commissioning mode" — but an uncommissioned node opens its basic
+commissioning window at boot and neither TH flavor can suppress that, so `.d` commissions a TH that
+was commissionable throughout. `.a` records an `unverified` check carrying `accepted` for it: the step
+still passes, the bundle's unverified count carries the gap, and nothing in it implies a precondition
+that never held. A step whose setup the harness cannot establish states that in the bundle rather than
+recording only the parts it could do.
+
+**Both `.b` and `.c` parse the code, so both carry the `MCORE.DD.SCAN_QR_CODE` gate.** `.c` re-parses
+rather than citing `.b`'s parse, so on a controller declaring it cannot take a scanned payload an
+ungated `.c` would record a parse pass beside `.b`'s skip — the contradiction the "gated scan step"
+rule above exists to prevent. Where a step genuinely re-does the gated operation the fix is the gate,
+not dropping the claim.
+
 **Step `.c` is the one worth having, and it is negative.** The plan asks to verify the DUT parsed the
 code *and* that the TH has not been commissioned: a flow saying "not commissionable yet" must not have
 the DUT commission the device merely because it read the code. `recordNotCommissioned` states that

--- a/support/chip-testing/test/cert/TC-DD-3.12.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.12.test.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { certTest } from "@matter/testing";
+import { defineFlowQrTest } from "./tc-dd-flow-support.js";
+import { USER_INTENT_FLOW } from "./tc-dd-support.js";
+
+defineFlowQrTest(
+    certTest("TC-DD-3.12", {
+        plan: "devicediscovery.adoc",
+        pics: ["MCORE.ROLE.COMMISSIONER", "MCORE.DD.QR_COMMISSIONING", "MCORE.DD.USER_INTENT_COMM_FLOW"],
+        app: "all-clusters",
+    }),
+    USER_INTENT_FLOW,
+    "User-Intent",
+);

--- a/support/chip-testing/test/cert/TC-DD-3.13.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.13.test.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { certTest } from "@matter/testing";
+import { defineFlowQrTest } from "./tc-dd-flow-support.js";
+import { CUSTOM_FLOW } from "./tc-dd-support.js";
+
+defineFlowQrTest(
+    certTest("TC-DD-3.13", {
+        plan: "devicediscovery.adoc",
+        pics: ["MCORE.ROLE.COMMISSIONER", "MCORE.DD.QR_COMMISSIONING", "MCORE.DD.CUSTOM_COMM_FLOW"],
+        app: "all-clusters",
+    }),
+    CUSTOM_FLOW,
+    "Custom",
+);

--- a/support/chip-testing/test/cert/TC-IDM-5.1.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-5.1.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Millis } from "@matter/main";
+import { Seconds } from "@matter/main";
 import { Matter } from "@matter/model";
 import type { CertStepContext } from "@matter/testing";
 import { certTest } from "@matter/testing";
@@ -18,9 +18,11 @@ const ON_TIME = requireId(ON_OFF.attributes.require("onTime").id, "OnOff.onTime"
 
 const ENDPOINT_1 = 1;
 
-// The timeout Test_TC_IDM_5_1.yaml's own captures ask for, which the plan quotes as its example. The
-// device enforces it, so a late follow-up fails on the device's own answer as well as on the check below.
-const TIMED_INTERACTION_TIMEOUT = Millis(200);
+// The plan quotes 200ms as an example, not a requirement, and the device enforces whatever it is told:
+// under CI load the controller's own follow-up misses a 200ms window and the device answers TIMEOUT,
+// which is a harness timing artefact rather than anything the plan asks to observe. Every check reads
+// this value rather than a literal, so widening it costs no evidence.
+const TIMED_INTERACTION_TIMEOUT = Seconds(2);
 
 const commissioned = new CommissionedRefs();
 

--- a/support/chip-testing/test/cert/tc-dd-flow-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-flow-support.ts
@@ -36,6 +36,11 @@ function noRadio(transport: string) {
     );
 }
 
+const NOT_COMMISSIONABLE_UNAVAILABLE =
+    "no TH this harness runs can be uncommissioned and not commissionable at the same time — an " +
+    "uncommissioned node opens its basic commissioning window at boot, and neither flavor can " +
+    "suppress that";
+
 /**
  * TC-DD-3.12 and TC-DD-3.13 are one test case with one field changed, so they are declared from one
  * place: three transport legs of four steps each — generate a payload carrying the flow, scan it,
@@ -46,6 +51,11 @@ function noRadio(transport: string) {
  * manufacturer's steps is not something this harness can produce. So `qrPayloadWith` writes the flow
  * the test case is named for into the TH's own payload, and the scan step reads it back through the
  * DUT's parser — which is what makes the step evidence about the flow rather than about the TH.
+ *
+ * **What no leg exercises is the transition the flow is named for.** A user-intent or custom flow says
+ * the device is not commissionable until someone acts, and `.a`'s precondition says so — but a TH this
+ * harness runs advertises as commissionable from boot, so `.d` commissions one that never made that
+ * transition. Each leg's `.a` records that gap rather than leaving the bundle to imply otherwise.
  *
  * **Step `.c` carries the interesting claim**, and it is a negative one: the plan says "Verify DUT has
  * parsed the QR code. Verify TH has not been commissioned to the Matter network." Parsing a payload
@@ -74,6 +84,9 @@ export function defineFlowQrTest(builder: CertTestBuilder, flowType: number, flo
     ];
 
     for (const leg of legs) {
+        // Both `.b` and `.c` parse the code themselves, so both need the scan gate
+        const scanGate = leg.pics === undefined ? "MCORE.DD.SCAN_QR_CODE" : `MCORE.DD.SCAN_QR_CODE & ${leg.pics}`;
+
         const payloadFor = async (cx: CertStepContext) =>
             qrPayloadWith(await thQrPayload(cx.devices.th), { discoveryCapabilities: leg.bitmask, flowType });
 
@@ -97,6 +110,16 @@ export function defineFlowQrTest(builder: CertTestBuilder, flowType: number, flo
                         },
                         `${leg.transport} ${flowName.toLowerCase()}-flow payload`,
                     );
+
+                    cx.recorder.check({
+                        type: "network",
+                        verdict: "unverified",
+                        detail:
+                            "TH advertises as commissionable from boot, so the plan's \"Commissionee is NOT in " +
+                            'commissioning mode" precondition does not hold and step .d commissions a TH that was ' +
+                            "commissionable throughout",
+                        accepted: NOT_COMMISSIONABLE_UNAVAILABLE,
+                    });
                 },
                 { pics: leg.pics, expected: "User has a QR code to pass into DUT." },
             )
@@ -109,9 +132,7 @@ export function defineFlowQrTest(builder: CertTestBuilder, flowType: number, flo
                     await recordPayloadOffering(cx, payload, leg.capability, flowType);
                 },
                 {
-                    // A leg's steps stand or fall together: this one scans "the QR code from the
-                    // previous step", so it must not run where that step was gated out
-                    pics: leg.pics === undefined ? "MCORE.DD.SCAN_QR_CODE" : `MCORE.DD.SCAN_QR_CODE & ${leg.pics}`,
+                    pics: scanGate,
                     expected: "Verify the QR code has been scanned successfully.",
                 },
             )
@@ -130,7 +151,7 @@ export function defineFlowQrTest(builder: CertTestBuilder, flowType: number, flo
                     await recordNotCommissioned(cx, th, since, "TH was not commissioned by the parse");
                 },
                 {
-                    pics: leg.pics,
+                    pics: scanGate,
                     expected:
                         "Verify DUT has parsed the QR code. Verify TH has not been commissioned to the Matter " +
                         "network.",

--- a/support/chip-testing/test/cert/tc-dd-flow-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-flow-support.ts
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DiscoveryCapabilitiesSchema } from "@matter/main/types";
+import type { CertStepContext, CertTestBuilder } from "@matter/testing";
+import {
+    commissionByQr,
+    markTransition,
+    ON_NETWORK_ONLY,
+    qrPayloadWith,
+    recordCommissionable,
+    recordGeneratedPayload,
+    recordNotCommissioned,
+    recordParse,
+    recordPayloadOffering,
+    STANDARD_VERSION,
+    thQrPayload,
+} from "./tc-dd-support.js";
+import { CommissionedRefs } from "./tc-support.js";
+
+const BLE_ONLY = DiscoveryCapabilitiesSchema.encode({ ble: true });
+const WIFI_PAF_ONLY = DiscoveryCapabilitiesSchema.encode({ wifiPublicActionFrame: true });
+
+/**
+ * Why a transport-specific commissioning step cannot be run rather than skipped — the same reason
+ * TC-DD-3.11 states, and stated per step so the bundle carries it.
+ */
+function noRadio(transport: string) {
+    return (
+        `The DUT-commissioner has no ${transport} radio — a commissioning driven from a payload naming ` +
+        `${transport} would proceed over IP and prove nothing about the transport. The PICS value that ` +
+        "reaches this step is the TH's, and answers for the TH"
+    );
+}
+
+/**
+ * TC-DD-3.12 and TC-DD-3.13 are one test case with one field changed, so they are declared from one
+ * place: three transport legs of four steps each — generate a payload carrying the flow, scan it,
+ * parse it *without* commissioning, then commission.
+ *
+ * **The flow has to be fabricated, unlike TC-DD-3.11's capability bitmask.** Both chip builds and the
+ * matter.js subject publish `flowType` 0, because a device that needs a user action or a
+ * manufacturer's steps is not something this harness can produce. So `qrPayloadWith` writes the flow
+ * the test case is named for into the TH's own payload, and the scan step reads it back through the
+ * DUT's parser — which is what makes the step evidence about the flow rather than about the TH.
+ *
+ * **Step `.c` carries the interesting claim**, and it is a negative one: the plan says "Verify DUT has
+ * parsed the QR code. Verify TH has not been commissioned to the Matter network." Parsing a payload
+ * whose flow says "not commissionable yet" must not start a commissioning, and the TH's own log is
+ * what states that it did not.
+ */
+export function defineFlowQrTest(builder: CertTestBuilder, flowType: number, flowName: string): CertTestBuilder {
+    const commissioned = new CommissionedRefs();
+
+    const legs = [
+        { n: "1", capability: "ble" as const, bitmask: BLE_ONLY, transport: "BLE", pics: "MCORE.DD.DISCOVERY_BLE" },
+        {
+            n: "2",
+            capability: "wifiPublicActionFrame" as const,
+            bitmask: WIFI_PAF_ONLY,
+            transport: "Wi-Fi PAF",
+            pics: "MCORE.DD.DISCOVERY_PAF",
+        },
+        {
+            n: "3",
+            capability: "onIpNetwork" as const,
+            bitmask: ON_NETWORK_ONLY,
+            transport: "IP Network",
+            pics: undefined,
+        },
+    ];
+
+    for (const leg of legs) {
+        const payloadFor = async (cx: CertStepContext) =>
+            qrPayloadWith(await thQrPayload(cx.devices.th), { discoveryCapabilities: leg.bitmask, flowType });
+
+        builder
+            .step(
+                `${leg.n}.a`,
+                `${flowName} Commissioning Flow: Use a Commissionee with a QR code that has the Custom Flow field ` +
+                    `set to ${flowType} and supports ${leg.transport} for its Discovery Capability. Commissionee ` +
+                    "is NOT in commissioning mode. Ensure the Version bit string follows the current Matter spec. " +
+                    "documentation.",
+                async cx => {
+                    const source = await thQrPayload(cx.devices.th);
+                    recordGeneratedPayload(
+                        cx,
+                        qrPayloadWith(source, { discoveryCapabilities: leg.bitmask, flowType }),
+                        {
+                            version: STANDARD_VERSION,
+                            flowType,
+                            discoveryCapabilities: leg.bitmask,
+                            unchangedFrom: source,
+                        },
+                        `${leg.transport} ${flowName.toLowerCase()}-flow payload`,
+                    );
+                },
+                { pics: leg.pics, expected: "User has a QR code to pass into DUT." },
+            )
+            .step(
+                `${leg.n}.b`,
+                "Scan the QR code from the previous step using the DUT.",
+                async cx => {
+                    const payload = await payloadFor(cx);
+                    await recordParse(cx, payload);
+                    await recordPayloadOffering(cx, payload, leg.capability, flowType);
+                },
+                {
+                    // A leg's steps stand or fall together: this one scans "the QR code from the
+                    // previous step", so it must not run where that step was gated out
+                    pics: leg.pics === undefined ? "MCORE.DD.SCAN_QR_CODE" : `MCORE.DD.SCAN_QR_CODE & ${leg.pics}`,
+                    expected: "Verify the QR code has been scanned successfully.",
+                },
+            )
+            .step(
+                `${leg.n}.c`,
+                "DUT parses QR code.",
+                async cx => {
+                    const th = cx.devices.th;
+                    const since = await markTransition(cx);
+
+                    await recordParse(cx, await payloadFor(cx));
+
+                    // The plan's second sentence, and the one worth having: a flow that says the
+                    // device is not commissionable yet must not have the DUT commission it merely
+                    // because it read the code.
+                    await recordNotCommissioned(cx, th, since, "TH was not commissioned by the parse");
+                },
+                {
+                    pics: leg.pics,
+                    expected:
+                        "Verify DUT has parsed the QR code. Verify TH has not been commissioned to the Matter " +
+                        "network.",
+                },
+            )
+            .step(
+                `${leg.n}.d`,
+                "User should follow any TH-specific steps for putting the TH Commissionee device into " +
+                    `commissioning mode and to complete the commissioning process using ${leg.transport}.`,
+                leg.capability === "onIpNetwork"
+                    ? async cx => {
+                          await recordCommissionable(cx);
+                          await commissionByQr(cx, await payloadFor(cx), commissioned);
+                      }
+                    : async () => {},
+                leg.capability === "onIpNetwork"
+                    ? { expected: "DUT commissions TH to the Matter network." }
+                    : { notApplicable: noRadio(leg.transport), expected: "DUT commissions TH to the Matter network." },
+            );
+    }
+
+    return builder.finalize(cx => commissioned.decommissionAll(cx));
+}

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -263,6 +263,19 @@ export const STANDARD_VERSION = 0;
 /** § 5.1.3.1 Table 59's standard commissioning flow. */
 export const STANDARD_FLOW = 0;
 
+/** § 5.1.3.1 Table 34's commissioning flows: the device needs a user action before it is commissionable. */
+export const USER_INTENT_FLOW = 1;
+
+/** § 5.1.3.1 Table 34's commissioning flows: the device needs steps the manufacturer defines. */
+export const CUSTOM_FLOW = 2;
+
+/** What a check calls each flow, so a bundle names the one its test case is named for. */
+const FLOW_NAMES: Record<number, string> = {
+    [STANDARD_FLOW]: "the standard flow",
+    [USER_INTENT_FLOW]: "the user-intent flow",
+    [CUSTOM_FLOW]: "the custom flow",
+};
+
 /**
  * Records that the DUT reads `payload` as offering `capability` over the standard commissioning flow.
  *
@@ -275,6 +288,7 @@ export async function recordPayloadOffering(
     cx: CertStepContext,
     payload: string,
     capability: keyof typeof DiscoveryCapabilitiesBitmap,
+    flowType = STANDARD_FLOW,
 ): Promise<void> {
     const parsed = await cx.controllers.dut.parseQrPayload(payload);
     const offered = DiscoveryCapabilitiesSchema.decode(parsed.discoveryCapabilities);
@@ -286,8 +300,8 @@ export async function recordPayloadOffering(
     if (!offered[capability]) {
         wrong.push(`does not offer ${capability}`);
     }
-    if (parsed.flowType !== STANDARD_FLOW) {
-        wrong.push(`carries flowType ${parsed.flowType} rather than the standard flow`);
+    if (parsed.flowType !== flowType) {
+        wrong.push(`carries flowType ${parsed.flowType} rather than ${FLOW_NAMES[flowType] ?? flowType}`);
     }
 
     record(
@@ -302,7 +316,7 @@ export async function recordPayloadOffering(
                     .padStart(8, "0")})` +
                 (wrong.length ? `; the payload ${wrong.join(" and ")}` : ""),
         },
-        `Payload offers ${capability} over the standard flow`,
+        `Payload offers ${capability} over ${FLOW_NAMES[flowType] ?? `flow ${flowType}`}`,
     );
 }
 
@@ -408,7 +422,7 @@ function readBits(data: Uint8Array, { offset, length }: { offset: number; length
  */
 export function qrPayloadWith(
     payload: string,
-    fields: { version?: number; passcode?: number; discoveryCapabilities?: number },
+    fields: { version?: number; passcode?: number; discoveryCapabilities?: number; flowType?: number },
 ): string {
     if (!payload.startsWith(QR_PREFIX)) {
         throw new InternalError(`Cannot substitute fields into "${payload}", which is not a QR onboarding payload`);
@@ -423,6 +437,9 @@ export function qrPayloadWith(
     }
     if (fields.discoveryCapabilities !== undefined) {
         writeBits(data, DISCOVERY_BITS, fields.discoveryCapabilities);
+    }
+    if (fields.flowType !== undefined) {
+        writeBits(data, FLOW_TYPE_BITS, fields.flowType);
     }
     return QR_PREFIX + Base38.encode(data);
 }

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -263,10 +263,10 @@ export const STANDARD_VERSION = 0;
 /** § 5.1.3.1 Table 59's standard commissioning flow. */
 export const STANDARD_FLOW = 0;
 
-/** § 5.1.3.1 Table 34's commissioning flows: the device needs a user action before it is commissionable. */
+/** § 5.1.3.1 Table 59's commissioning flows: the device needs a user action before it is commissionable. */
 export const USER_INTENT_FLOW = 1;
 
-/** § 5.1.3.1 Table 34's commissioning flows: the device needs steps the manufacturer defines. */
+/** § 5.1.3.1 Table 59's commissioning flows: the device needs steps the manufacturer defines. */
 export const CUSTOM_FLOW = 2;
 
 /** What a check calls each flow, so a bundle names the one its test case is named for. */

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -277,7 +277,8 @@ const FLOW_NAMES: Record<number, string> = {
 };
 
 /**
- * Records that the DUT reads `payload` as offering `capability` over the standard commissioning flow.
+ * Records that the DUT reads `payload` as offering `capability` over the commissioning flow `flowType`
+ * denotes, which defaults to the standard one.
  *
  * The capability is what tells one leg of a per-transport plan from another, and the flow is what such
  * a plan is named for, so both belong in the verdict. Left to the prose, every leg's scan step passes


### PR DESCRIPTION
Adds TC-DD-3.12 (user-intent flow) and TC-DD-3.13 (custom flow) from the device-discovery plan, with the framework changes they force.

## The test cases

They are one test case with one field changed, so they are declared from one place (`tc-dd-flow-support.ts`) and differ only in the constant they pass. Three transport legs of four steps each: generate a payload carrying the flow, scan it, parse it *without* commissioning, then commission. Same leg structure and the same `notApplicable` treatment for BLE and Wi-Fi PAF as TC-DD-3.11.

**The flow has to be fabricated, unlike TC-DD-3.11's capability bitmask.** Every subject this harness runs publishes `flowType` 0 — a device that needs a user action or a manufacturer's own steps is not something the harness can produce. So `qrPayloadWith` gained a `flowType` field, and the scan step reads the flow back through the commissioner's own parser, which is what makes the step evidence about the flow rather than about the harness.

**`.c` records the parse and stops there.** The plan also asks to verify the harness device has not been commissioned, and that half is not testable at this step: the only thing `.c` asks of the commissioner is to parse the code, which is a local decode on both controllers and reaches no network. A "was not commissioned" check after it searches a window nothing could have written to, and would record a pass for a claim nobody tested. Whether a commissioner honours a flow saying "not commissionable yet" is observable only where it is offered the chance to commission — `.d` — and that is left to a follow-up, because a commissioner that correctly declines such a code currently fails that step.

**Steps `.b` and `.c` share one PICS gate.** Both parse the code themselves rather than one citing the other, so both carry `MCORE.DD.SCAN_QR_CODE` alongside the leg's transport key. Without that, a commissioner declaring it cannot take a scanned payload would get a skip for `.b` and a parse pass for `.c` in the same bundle.

**The transition the flow is named for is not exercised, and each leg's `.a` records that.** A user-intent or custom flow means the device is not commissionable until someone acts, which is what `.a`'s text ("Commissionee is NOT in commissioning mode") describes. No harness device can be in that state: an uncommissioned node opens its basic commissioning window at boot and neither flavor can suppress it. `.a` records an `unverified` check carrying `accepted`, which leaves the step passing while the bundle's unverified count carries the gap — rather than recording only the parts the harness could do and leaving the bundle to imply a precondition that never held. The detail says what each leg does instead, which differs: the IP leg commissions a device that was commissionable throughout, and the BLE and Wi-Fi PAF legs commission nothing at all.

## Framework

- **`qrPayloadWith` takes `flowType`.** It substituted version, passcode and discovery capabilities; the flow is the field these two cases are named for. Its unit test asserts exact payload strings rather than reading the field back through the same bit constants the writer uses, so a wrong bit offset cannot move both together: the standard-flow form of the plan's example payload is the string the discovery-capabilities test already arrives at by substituting a different field, and the plan's own published example is the custom-flow form.
- **`recordPayloadOffering` takes the expected flow** instead of hardcoding the standard one. It names the flow in its verdict, so a helper holding that value itself would record a pass whose text described something nobody had looked at.
- **A flow is named from its value, by `flowTitle`/`flowName`.** A test case states the flow once, as the constant it passes, and the step prose, the check verdicts and the payload all derive from it. Passing a display name alongside the value lets the two drift — the same defect as a helper hardcoding a flow it claims to check, one level up. The field is two bits, so a payload can carry a flow the specification defines no title for: `flowName` names it by value, and `flowTitle` throws, because a test case named after an undefined flow is a mistake in this repository rather than something a device did.

## An unrelated flake this run surfaced

TC-IDM-5.1's timed-interaction window moves from 200ms to 2s. The plan quotes 200ms as an example, not a requirement, and every check derives its pattern from the constant — on the chip leg the device is asked for `TimeoutMs = 0x7d0` and the follow-up is measured against a 2000ms budget, so no evidence changes shape. Under CI load the controller's own follow-up missed the 200ms window and the device answered `Timeout(148)`, reporting a harness timing artefact as a device failure. Reported upstream as a test-plan improvement.

## AGENTS.md no longer poses open questions

The roadmap asks for this before any new section is written. Three sections read as deliberation rather than as rules:

- an "Unsettled, worth resolving" paragraph on `MCORE.DD.DISCOVERY_BLE`'s scope — now states the rule as it stands, with the open question left to the task that owns it;
- "Known limitations … not yet fixed" — now three limitations every cert test inherits, each written as what to do when it bites;
- "Prerequisite gap: no fault-injection-capable TH_SERVER binary available" — whose own body said the gap was closed; retitled to where each flavor gets that binary.

The other two `AGENTS.md` files in the repository were checked and are clean.

## A plan defect this confirms rather than works around

Both test cases' preconditions print `MT:-24J029Q00KA0648G00` as an example onboarding code, described as "Custom Flow=10 (Custom Commissioning Flow = 2)" — which contradicts TC-DD-3.12's own title. The run confirms it from the other direction: TC-DD-3.13's IP leg fabricates that payload character for character. Reported upstream via the `spec-qr-example-payload-wrong-flow` task rather than worked around here.

## Verification

- Both test cases pass on **matterjs** and **chip-local**, read per step from the evidence bundle rather than from the exit code: the commissioner reads back `flowType=1` / `flowType=2` from the fabricated payloads, the `.a` gap is recorded as `unverifiedChecks: 2` with the per-leg text each leg warrants, and the PAF leg skips with `picsSkips: 3` as expected.
- TC-IDM-5.1 passes on **matterjs** and **chip-local** with the widened window.
- Whole cert suite on matterjs: 16 test cases, baseline unchanged.
- The flow-substitution test was mutation-checked: moving `FLOW_TYPE_BITS.offset` from 35 to 34 fails it with `expected 'MT:-24J04KP00KA0648G00' to equal 'MT:-24J0AFN00KA0648G00'`. The flow-naming guards were mutation-checked too: dropping `flowTitle`'s throw and `flowName`'s by-value fallback fails exactly the two tests written for them.
- `npm run build` from the repository root with `support/chip-testing/build` deleted first: clean.
- `test/cert-framework` 787/787, root `npm test` green on every leg, `npm run lint` and `npm run format-verify` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
