### PR TITLE
test(chip-testing): a negative check needs something that could have produced what it looks for

### DIFF
--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -32,6 +32,8 @@ import {
     checkGeneratedPayload,
     commissionByQr,
     CUSTOM_FLOW,
+    flowName,
+    flowTitle,
     CommissioningRefusals,
     manualPairingCode,
     manualPairingCodeDigits,
@@ -74,6 +76,26 @@ const PLAN_INVALID_PASSCODE_PAYLOADS: [passcode: number, payload: string][] = [
     [87654321, "MT:-24J029Q00YX018EW10"],
 ];
 
+describe("flow naming", () => {
+    it("titles each flow the plan defines", () => {
+        expect([STANDARD_FLOW, USER_INTENT_FLOW, CUSTOM_FLOW].map(flowTitle)).deep.equal([
+            "Standard",
+            "User-Intent",
+            "Custom",
+        ]);
+    });
+
+    it("refuses to title a flow the specification does not define", () => {
+        // The field is two bits wide, so a test case could name 3 and there is nothing to call it
+        expect(() => flowTitle(3)).throw(InternalError);
+    });
+
+    it("names an undefined flow by its value, because a verdict has to say which one it saw", () => {
+        expect(flowName(3)).equal("flow 3");
+        expect(flowName(USER_INTENT_FLOW)).equal("the user-intent flow");
+    });
+});
+
 describe("qrPayloadWith", () => {
     it("substitutes the version the plan's own example payload does", () => {
         expect(qrPayloadWith(PLAN_PAYLOAD, { version: 0b010 })).equal("MT:034J029Q00KA0648G00");
@@ -113,6 +135,10 @@ describe("qrPayloadWith", () => {
 
     it("refuses a code that is not a QR onboarding payload", () => {
         expect(() => qrPayloadWith("34970112336552132769", { version: 2 })).throw(InternalError);
+    });
+
+    it("refuses a flow too wide for the two bits the field holds", () => {
+        expect(() => qrPayloadWith(PLAN_PAYLOAD, { flowType: 4 })).throw(InternalError);
     });
 
     it("refuses a value too wide for the field it substitutes", () => {

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1185,8 +1185,11 @@ truncated integer and the other as a chip-tool usage error.
 
 What the plan asks to verify, and how each part is evidenced:
 
-- **The timeout the device was asked for** — `TimedRequestMessage =` / `{` / `TimeoutMs = 0xc8,`, all
-  consecutive; the field is bare lowercase hex and the block closes with a bare `}`.
+- **The timeout the device was asked for** — `TimedRequestMessage =` / `{` / `TimeoutMs = 0x7d0,`, all
+  consecutive; the field is bare lowercase hex of the millisecond value the TC's own
+  `TIMED_INTERACTION_TIMEOUT` names, and the block closes with a bare `}`. The plan quotes 200ms as an
+  example, not a requirement, and a window that tight is missed by the controller's own follow-up under
+  CI load, so the TC asks for 2s.
 - **The message was unicast** — chip's own receive line categorises the session: `(S)` secure unicast,
   `(U)` unencrypted unicast, `(G)` secure groupcast (`src/messaging/README.md`). `expectUnicastReceipt`
   scans *backward* from the decode dump for the nearest `Msg RX from` line, which is this message's own
@@ -1862,19 +1865,23 @@ something the harness can produce. `qrPayloadWith` gained a `flowType` field for
 scan step reads it back through the DUT's own parser — which is what makes the step evidence about the
 flow rather than about the TH.
 
-**`recordPayloadOffering` takes the expected flow as a parameter.** It used to hardcode the standard
-flow in its verdict, so these two would have recorded a `pass` whose text named a flow nobody checked.
-A helper whose verdict names a property must take that property from the caller, or the second test
-case to use it silently asserts the first one's value.
+**`recordPayloadOffering` takes the expected flow as a parameter.** A helper whose verdict names a
+property must take that property from the caller; one holding the value itself records a `pass` whose
+text names a flow nobody checked, and the second test case to use it silently asserts the first one's
+value.
 
 **The transition the flow is named for is not exercised, and each leg's `.a` says so.** A user-intent
 or custom flow means the device is not commissionable until someone acts, which is why `.a`'s text
 carries "Commissionee is NOT in commissioning mode" — but an uncommissioned node opens its basic
-commissioning window at boot and neither TH flavor can suppress that, so `.d` commissions a TH that
-was commissionable throughout. `.a` records an `unverified` check carrying `accepted` for it: the step
-still passes, the bundle's unverified count carries the gap, and nothing in it implies a precondition
-that never held. A step whose setup the harness cannot establish states that in the bundle rather than
-recording only the parts it could do.
+commissioning window at boot and neither TH flavor can suppress that. `.a` records an `unverified`
+check carrying `accepted` for it: the step still passes, the bundle's unverified count carries the
+gap, and nothing in it implies a precondition that never held. A step whose setup the harness cannot
+establish states that in the bundle rather than recording only the parts it could do.
+
+The detail names what the leg does instead, and that differs per leg: the IP leg commissions a TH
+that was commissionable throughout, while the BLE and Wi-Fi PAF legs commission nothing at all
+because their `.d` is `notApplicable`. One text for all three put two contradictory statements about
+the same step in one bundle.
 
 **Both `.b` and `.c` parse the code, so both carry the `MCORE.DD.SCAN_QR_CODE` gate.** `.c` re-parses
 rather than citing `.b`'s parse, so on a controller declaring it cannot take a scanned payload an
@@ -1882,12 +1889,26 @@ ungated `.c` would record a parse pass beside `.b`'s skip — the contradiction 
 rule above exists to prevent. Where a step genuinely re-does the gated operation the fix is the gate,
 not dropping the claim.
 
-**Step `.c` is the one worth having, and it is negative.** The plan asks to verify the DUT parsed the
-code *and* that the TH has not been commissioned: a flow saying "not commissionable yet" must not have
-the DUT commission the device merely because it read the code. `recordNotCommissioned` states that
-from the TH's own log. This is the only step in either test case that could fail against a correct
-parse, which is the usual pattern — the positive steps confirm plumbing, the negative one is where a
-defect would surface.
+**`.c` records the parse and stops there, and the plan's second sentence is why this is worth stating.**
+The plan asks to verify the DUT parsed the code *and* that the TH has not been commissioned. The
+second half looks like the valuable claim and is not testable here: the only thing `.c` asks of the
+DUT is `parseQrPayload`, which is a local decode on both controllers — `singleQrPayload` in-process,
+`payload parse-setup-payload` for chip-tool — and reaches no network. A `recordNotCommissioned` after
+it searches a window nothing could have written to, and passes for a claim nobody tested.
+
+The general rule: before recording a negative check, ask what could have produced the thing it looks
+for. If the step's own actions cannot, the check is not evidence, and a bundle full of such checks
+reads exactly like one full of real ones. Whether a commissioner honours a flow that says "not
+commissionable yet" is observable only where it is offered the chance to commission — `.d` — and
+what to do there is an open item, because a commissioner that correctly declines such a code
+currently fails the step.
+
+**The flow's title comes from `flowTitle(flowType)`, not from the caller.** A test case states the
+flow once, as the constant it passes; the step prose, the check verdicts and the payload all derive
+from that. Passing a name alongside the value lets the two drift, which is the same defect as a
+helper hardcoding a flow it claims to check, one level up. `flowName` handles the value the field can
+carry but the specification does not define — the field is two bits, so 3 is reachable — and
+`flowTitle` throws for it, because a test case named after an undefined flow is our own mistake.
 
 **The plan's own example payload is a custom-flow code, in both test cases' preconditions.** It
 decodes to `flowType` 2, which is right for TC-DD-3.13 and contradicts TC-DD-3.12's own title. Worth

--- a/support/chip-testing/test/cert/TC-DD-3.12.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.12.test.ts
@@ -15,5 +15,4 @@ defineFlowQrTest(
         app: "all-clusters",
     }),
     USER_INTENT_FLOW,
-    "User-Intent",
 );

--- a/support/chip-testing/test/cert/TC-DD-3.13.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.13.test.ts
@@ -15,5 +15,4 @@ defineFlowQrTest(
         app: "all-clusters",
     }),
     CUSTOM_FLOW,
-    "Custom",
 );

--- a/support/chip-testing/test/cert/tc-dd-flow-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-flow-support.ts
@@ -8,12 +8,11 @@ import { DiscoveryCapabilitiesSchema } from "@matter/main/types";
 import type { CertStepContext, CertTestBuilder } from "@matter/testing";
 import {
     commissionByQr,
-    markTransition,
+    flowTitle,
     ON_NETWORK_ONLY,
     qrPayloadWith,
     recordCommissionable,
     recordGeneratedPayload,
-    recordNotCommissioned,
     recordParse,
     recordPayloadOffering,
     STANDARD_VERSION,
@@ -54,25 +53,39 @@ const NOT_COMMISSIONABLE_UNAVAILABLE =
  *
  * **What no leg exercises is the transition the flow is named for.** A user-intent or custom flow says
  * the device is not commissionable until someone acts, and `.a`'s precondition says so — but a TH this
- * harness runs advertises as commissionable from boot, so `.d` commissions one that never made that
- * transition. Each leg's `.a` records that gap rather than leaving the bundle to imply otherwise.
+ * harness runs advertises as commissionable from boot, so no leg ever sees that transition. Each leg's
+ * `.a` records the gap, and says what its own leg does instead, rather than leaving the bundle to imply
+ * otherwise.
  *
- * **Step `.c` carries the interesting claim**, and it is a negative one: the plan says "Verify DUT has
- * parsed the QR code. Verify TH has not been commissioned to the Matter network." Parsing a payload
- * whose flow says "not commissionable yet" must not start a commissioning, and the TH's own log is
- * what states that it did not.
+ * **`.c` records the parse alone, not the plan's second sentence.** The plan also asks to verify the TH
+ * was not commissioned, but the only thing `.c` asks of the DUT is `parseQrPayload`, which decodes
+ * locally on both controllers and reaches no network — so a check that the TH was not commissioned by
+ * it examines a window nothing could have written to, and would record a pass for a claim nobody
+ * tested. Whether a commissioner acts on a flow that says "not commissionable yet" is only observable
+ * where it is given the chance to commission, which is `.d`.
  */
-export function defineFlowQrTest(builder: CertTestBuilder, flowType: number, flowName: string): CertTestBuilder {
+export function defineFlowQrTest(builder: CertTestBuilder, flowType: number): CertTestBuilder {
+    const title = flowTitle(flowType);
     const commissioned = new CommissionedRefs();
 
+    const NOTHING_COMMISSIONS = "no step of this leg commissions the TH, so nothing acts on the flow either";
+
     const legs = [
-        { n: "1", capability: "ble" as const, bitmask: BLE_ONLY, transport: "BLE", pics: "MCORE.DD.DISCOVERY_BLE" },
+        {
+            n: "1",
+            capability: "ble" as const,
+            bitmask: BLE_ONLY,
+            transport: "BLE",
+            pics: "MCORE.DD.DISCOVERY_BLE",
+            commissions: NOTHING_COMMISSIONS,
+        },
         {
             n: "2",
             capability: "wifiPublicActionFrame" as const,
             bitmask: WIFI_PAF_ONLY,
             transport: "Wi-Fi PAF",
             pics: "MCORE.DD.DISCOVERY_PAF",
+            commissions: NOTHING_COMMISSIONS,
         },
         {
             n: "3",
@@ -80,6 +93,7 @@ export function defineFlowQrTest(builder: CertTestBuilder, flowType: number, flo
             bitmask: ON_NETWORK_ONLY,
             transport: "IP Network",
             pics: undefined,
+            commissions: "step .d commissions a TH that was commissionable throughout",
         },
     ];
 
@@ -93,7 +107,7 @@ export function defineFlowQrTest(builder: CertTestBuilder, flowType: number, flo
         builder
             .step(
                 `${leg.n}.a`,
-                `${flowName} Commissioning Flow: Use a Commissionee with a QR code that has the Custom Flow field ` +
+                `${title} Commissioning Flow: Use a Commissionee with a QR code that has the Custom Flow field ` +
                     `set to ${flowType} and supports ${leg.transport} for its Discovery Capability. Commissionee ` +
                     "is NOT in commissioning mode. Ensure the Version bit string follows the current Matter spec. " +
                     "documentation.",
@@ -108,7 +122,7 @@ export function defineFlowQrTest(builder: CertTestBuilder, flowType: number, flo
                             discoveryCapabilities: leg.bitmask,
                             unchangedFrom: source,
                         },
-                        `${leg.transport} ${flowName.toLowerCase()}-flow payload`,
+                        `${leg.transport} ${title.toLowerCase()}-flow payload`,
                     );
 
                     cx.recorder.check({
@@ -116,8 +130,7 @@ export function defineFlowQrTest(builder: CertTestBuilder, flowType: number, flo
                         verdict: "unverified",
                         detail:
                             "TH advertises as commissionable from boot, so the plan's \"Commissionee is NOT in " +
-                            'commissioning mode" precondition does not hold and step .d commissions a TH that was ' +
-                            "commissionable throughout",
+                            `commissioning mode" precondition does not hold: ${leg.commissions}`,
                         accepted: NOT_COMMISSIONABLE_UNAVAILABLE,
                     });
                 },
@@ -140,15 +153,7 @@ export function defineFlowQrTest(builder: CertTestBuilder, flowType: number, flo
                 `${leg.n}.c`,
                 "DUT parses QR code.",
                 async cx => {
-                    const th = cx.devices.th;
-                    const since = await markTransition(cx);
-
                     await recordParse(cx, await payloadFor(cx));
-
-                    // The plan's second sentence, and the one worth having: a flow that says the
-                    // device is not commissionable yet must not have the DUT commission it merely
-                    // because it read the code.
-                    await recordNotCommissioned(cx, th, since, "TH was not commissioned by the parse");
                 },
                 {
                     pics: scanGate,

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -269,12 +269,34 @@ export const USER_INTENT_FLOW = 1;
 /** § 5.1.3.1 Table 59's commissioning flows: the device needs steps the manufacturer defines. */
 export const CUSTOM_FLOW = 2;
 
-/** What a check calls each flow, so a bundle names the one its test case is named for. */
-const FLOW_NAMES: Record<number, string> = {
-    [STANDARD_FLOW]: "the standard flow",
-    [USER_INTENT_FLOW]: "the user-intent flow",
-    [CUSTOM_FLOW]: "the custom flow",
+/** What a test case calls each flow, so its steps and its checks cannot name different ones. */
+const FLOW_TITLES: Record<number, string> = {
+    [STANDARD_FLOW]: "Standard",
+    [USER_INTENT_FLOW]: "User-Intent",
+    [CUSTOM_FLOW]: "Custom",
 };
+
+/**
+ * The title `devicediscovery.adoc` gives `flowType`, for a test case declaring the flow it is named
+ * for. Throws for a flow the specification does not define, which in a test case is our own mistake
+ * rather than something a device did.
+ */
+export function flowTitle(flowType: number): string {
+    const title = FLOW_TITLES[flowType];
+    if (title === undefined) {
+        throw new InternalError(`No commissioning flow ${flowType} to name a test case for`);
+    }
+    return title;
+}
+
+/**
+ * How a check's verdict names `flowType`. The § 5.1.3.1 field is two bits wide, so a payload can carry
+ * a flow the specification defines no title for, and a verdict about it has to say which one it saw.
+ */
+export function flowName(flowType: number): string {
+    const title = FLOW_TITLES[flowType];
+    return title === undefined ? `flow ${flowType}` : `the ${title.toLowerCase()} flow`;
+}
 
 /**
  * Records that the DUT reads `payload` as offering `capability` over the commissioning flow `flowType`
@@ -302,7 +324,7 @@ export async function recordPayloadOffering(
         wrong.push(`does not offer ${capability}`);
     }
     if (parsed.flowType !== flowType) {
-        wrong.push(`carries flowType ${parsed.flowType} rather than ${FLOW_NAMES[flowType] ?? flowType}`);
+        wrong.push(`carries flowType ${parsed.flowType} rather than ${flowName(flowType)}`);
     }
 
     record(
@@ -317,7 +339,7 @@ export async function recordPayloadOffering(
                     .padStart(8, "0")})` +
                 (wrong.length ? `; the payload ${wrong.join(" and ")}` : ""),
         },
-        `Payload offers ${capability} over ${FLOW_NAMES[flowType] ?? `flow ${flowType}`}`,
+        `Payload offers ${capability} over ${flowName(flowType)}`,
     );
 }
 
@@ -416,10 +438,12 @@ function readBits(data: Uint8Array, { offset, length }: { offset: number; length
  * `payload` with the named fields substituted, which is what the negative device-discovery plans ask
  * a tester to produce with a QR generator.
  *
- * The fields go in as bits rather than through matter.js's own encoder, because every value these
- * plans want is one that encoder refuses to write: an unsupported version and the trivial passcodes
- * are exactly what it validates against on the way out (§ 5.1.3.1, § 5.1.7.1). The TLV data that may
- * follow the fixed 11-byte structure is carried through untouched.
+ * The fields go in as bits rather than through matter.js's own encoder. An unsupported version and the
+ * trivial passcodes are exactly what that encoder validates against on the way out (§ 5.1.3.1,
+ * § 5.1.7.1), so it cannot produce them at all; the flow and the discovery capabilities it would write
+ * happily, but no subject this harness runs publishes the values the plans ask for. One substitution
+ * path covers both. The TLV data that may follow the fixed 11-byte structure is carried through
+ * untouched.
  */
 export function qrPayloadWith(
     payload: string,


### PR DESCRIPTION
Follow-up to #4342. The pre-ship review passes finished after that PR had already merged, and one of their findings is that its headline claim does not hold.

## A negative check needs something that could have produced what it looks for

TC-DD-3.12/3.13's step `.c` recorded that the device had not been commissioned. The only thing `.c` asks of the commissioner is to parse the onboarding code, and that is a local decode on both controllers — `singleQrPayload` in process, `payload parse-setup-payload` for chip-tool. Neither reaches the network. So the check searched the device's log for a commissioning that nothing in the step could have started: it could not fail, and it recorded a pass for a claim nobody tested. Worse than no check, because a bundle full of such checks reads exactly like one full of real ones.

`.c` now records the parse and stops there.

Whether a commissioner honours a flow saying "not commissionable yet" is observable only where it is offered the chance to commission, which is `.d`. That is deliberately not added here: a commissioner that correctly declines a custom-flow code has `commission()` reject, and `.d` currently records that as a failure — so the test would penalise the behaviour the flow field requests. Left to the follow-up that reworks `.d`'s evidence.

## The gap each leg records now describes its own leg

`.a` records that the plan's "Commissionee is NOT in commissioning mode" precondition cannot be established. One text served all three legs and said "step `.d` commissions a device that was commissionable throughout" — true on the IP leg, false on the BLE and Wi-Fi PAF legs, where `.d` is `notApplicable` and nothing commissions. The bundle carried two contradictory statements about the same step.

## A flow is named from its value

`defineFlowQrTest` took the flow constant and a display name as separate arguments, so the step prose and the value actually checked could drift — the same defect `recordPayloadOffering`'s flow parameter exists to prevent, one level up. A test case now states the flow once and `flowTitle(flowType)` derives the rest.

The field is two bits, so a payload can carry a flow the specification defines no title for. `flowName` names such a value by number, because a verdict has to say which flow it saw; `flowTitle` throws, because a test case named after an undefined flow is a mistake in this repository rather than something a device did. Both branches were previously unreachable from any test and are now covered.

## Three claims the passes falsified

- `AGENTS.md` documented the timed-request evidence as `TimeoutMs = 0xc8` — 200 decimal — after #4342 moved TC-IDM-5.1's window to 2s. A live run prints `0x7d0`.
- `qrPayloadWith`'s documentation said the fields go in as bits "because every value these plans want is one that encoder refuses to write". `QrPairingCodeSchema.validate` checks only the version and the passcode; it never looks at the flow or the discovery capabilities, which the real encoder would write happily. The reason those are fabricated is that no subject publishes them.
- An `AGENTS.md` paragraph narrated the change rather than stating the rule.

## Verification

- `test/cert-framework` 787/787. The two new naming branches were mutation-checked: dropping `flowTitle`'s throw and `flowName`'s by-value fallback fails exactly the two tests written for them, and nothing else.
- TC-DD-3.12 and TC-DD-3.13 pass on **matterjs** and **chip-local**, read per step from the evidence bundle: `.c` now carries one check rather than two, `picsSkips: 3` and `unverifiedChecks: 2` are unchanged, and each leg's gap detail carries the text that leg warrants.
- `npm run build`, `npm run lint`, `npm run format-verify` clean; root `npm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
