### PR TITLE
test(node): a test waits for the work it depends on instead of one task turn

### DIFF
--- a/packages/node/test/behavior/system/icd/IcdClientTest.ts
+++ b/packages/node/test/behavior/system/icd/IcdClientTest.ts
@@ -25,7 +25,7 @@ import { FabricId, NodeId, SubjectId, VendorId } from "@matter/types";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { commission, LIT_CONFIG, wakeDevice, wakefulnessOf } from "../../../node/icd-helpers.js";
 import { MockSite } from "../../../node/mock-site.js";
-import { seedPeerCache, subscribedPeer } from "../../../node/node-helpers.js";
+import { seedPeerCache, settled, subscribedPeer } from "../../../node/node-helpers.js";
 
 const RootWithIcd = ServerNode.RootEndpoint.with(IcdManagementServer);
 
@@ -285,7 +285,7 @@ describe("IcdClient", () => {
             await device.act(agent => agent.get(DslsIcdServer).setOperatingMode(IcdManagement.OperatingMode.Lit));
             await commission(controller, device);
             const peer1 = await subscribedPeer(controller, "peer1");
-            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+            await settled(controller, peer1);
 
             expect(peer1.stateOf(IcdClient).registered).false;
         });
@@ -296,7 +296,7 @@ describe("IcdClient", () => {
                 device: { type: RootWithDslsIcd, icdManagement: LIT_CONFIG },
             });
             const peer1 = await subscribedPeer(controller, "peer1");
-            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+            await settled(controller, peer1);
 
             expect(peer1.stateOf(IcdClient).registered).false;
         });
@@ -322,7 +322,7 @@ describe("IcdClient", () => {
             // behavior the wrong registration lands well within this window (empirically by the 6th step).
             for (let i = 0; i < 15; i++) {
                 await MockTime.advance(Millis(200));
-                await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+                await settled(controller, peer1);
             }
 
             expect(peer1.stateOf(IcdClient).registered).false;
@@ -335,7 +335,7 @@ describe("IcdClient", () => {
                 device: { type: RootWithDslsIcd, icdManagement: LIT_CONFIG },
             });
             const peer1 = await subscribedPeer(controller, "peer1");
-            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+            await settled(controller, peer1);
             expect(peer1.stateOf(IcdClient).registered).false;
 
             const modeChanged = new Promise<void>(resolve =>
@@ -416,7 +416,7 @@ describe("IcdClient", () => {
             peer1.eventsOf(IcdClient).checkedIn.on(observer);
 
             await wakeDevice(device);
-            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+            await settled(controller, peer1);
             peer1.eventsOf(IcdClient).checkedIn.off(observer);
 
             // The replayed Check-In is dropped at the fabric layer: no event, no client-state change.
@@ -457,7 +457,7 @@ describe("IcdClient", () => {
             await wakeDevice(device);
             await MockTime.resolve(refreshed, { macrotasks: true });
             // keyRefreshed emits inside the refresh transaction; let it commit before reading state.
-            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+            await settled(controller, peer1);
 
             const state = peer1.stateOf(IcdClient);
             // counterStart advancing proves the re-key registerClient round-trip ran (MockCrypto.randomBytes is
@@ -695,11 +695,12 @@ describe("IcdClient", () => {
             await reRegisterWithSubject(peer1, SubjectId(NodeId(0xabcdn)));
 
             await MockTime.advance(Seconds(3700));
-            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+            // One task turn: this observes the lapse itself, as the subscription's next report re-arms availability
+            await MockTime.macrotask;
             expect(peer1.stateOf(IcdClient).available).false;
 
             await wakeDevice(device);
-            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+            await settled(controller, peer1);
 
             expect(peer1.stateOf(IcdClient).available).true;
             expect(wakefulnessOf(controller, peer1)!.available.value).true;
@@ -718,7 +719,7 @@ describe("IcdClient", () => {
             expect(wakefulnessOf(controller, peer1)!.requiresAwait).false;
 
             await MockTime.advance(Seconds(3700));
-            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+            await settled(controller, peer1);
             expect(peer1.stateOf(IcdClient).available).true;
         });
 
@@ -790,7 +791,8 @@ describe("IcdClient", () => {
             });
 
             await peer1.act(agent => agent.get(IcdClient).unregister());
-            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+            // One task turn: registration is mandatory for a LIT peer, so auto-registration re-registers after this
+            await MockTime.macrotask;
 
             expect(peer1.stateOf(IcdClient).registered).false;
             expect(missed).equals(0);
@@ -832,7 +834,7 @@ describe("IcdClient", () => {
 
             // activeModeThreshold is 5s, so absent the StayActive extension awake would already have lapsed by now.
             await MockTime.advance(Seconds(30));
-            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+            await settled(controller, peer1);
             expect(wakefulness.awake.value).true;
         });
 
@@ -893,11 +895,12 @@ describe("IcdClient", () => {
             expect(await peer1.act(agent => agent.get(IcdClient).awake)).equals(true); // seeded on register
 
             await MockTime.advance(Seconds(3700)); // past idle+margin, no check-in
-            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+            // One task turn: this observes the lapse itself, as the subscription's next report re-arms the peer
+            await MockTime.macrotask;
             expect(await peer1.act(agent => agent.get(IcdClient).awake)).equals(false);
 
             await wakeDevice(device); // device Check-In re-arms awake
-            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+            await settled(peer1);
             expect(await peer1.act(agent => agent.get(IcdClient).awake)).equals(true);
         });
     });
@@ -967,7 +970,7 @@ describe("IcdClient", () => {
                 device: { type: RootWithDslsIcd, icdManagement: LIT_CONFIG },
             });
             const peer1 = await subscribedPeer(controller, "peer1");
-            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+            await settled(controller, peer1);
 
             // Established while SIT/unfed: no wakefulness exists, so the underlying subscription runs as plain sustained.
             expect(peer1.stateOf(IcdClient).registered).false;
@@ -988,7 +991,7 @@ describe("IcdClient", () => {
             await settleAutoRegistration(peer1);
             for (let i = 0; i < 5; i++) {
                 await MockTime.advance(Millis(200));
-                await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+                await settled(controller, peer1);
             }
 
             expect(peer1.stateOf(IcdClient).registered).true;

--- a/packages/node/test/behavior/system/network/ConnectionStateTest.ts
+++ b/packages/node/test/behavior/system/network/ConnectionStateTest.ts
@@ -13,7 +13,7 @@ import { ServerNode } from "#node/ServerNode.js";
 import { Crypto, MockCrypto } from "@matter/general";
 import { Peer, SustainedSubscription } from "@matter/protocol";
 import { MockSite } from "../../../node/mock-site.js";
-import { subscribedPeer } from "../../../node/node-helpers.js";
+import { settled, subscribedPeer } from "../../../node/node-helpers.js";
 
 const RootWithIcd = ServerNode.RootEndpoint.with(IcdManagementServer);
 
@@ -23,7 +23,7 @@ async function loseSubscription(peer: ClientNode, device: ServerNode) {
     SustainedSubscription.assert(subscription);
     await MockTime.resolve(device.stop());
     await MockTime.resolve(subscription.inactive);
-    await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+    await settled(peer);
     return subscription;
 }
 
@@ -61,7 +61,7 @@ describe("ConnectionState", () => {
         expect(peer1.lifecycle.connectionState).equals(NodeConnectionState.Reconnecting);
 
         peer1.env.get(Peer).establishmentUnresponsive.emit();
-        await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+        await settled(peer1);
 
         expect(peer1.lifecycle.connectionState).equals(NodeConnectionState.WaitingForDeviceDiscovery);
         expect(peer1.lifecycle.isConnected).false;
@@ -80,13 +80,13 @@ describe("ConnectionState", () => {
 
         const protopeer = peer1.env.get(Peer);
         protopeer.establishmentUnresponsive.emit();
-        await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+        await settled(peer1);
         expect(states).deep.equals([NodeConnectionState.Reconnecting, NodeConnectionState.WaitingForDeviceDiscovery]);
 
         // A repeated establishment-unresponsive emit must not re-emit the transition (idempotent latch).
         protopeer.establishmentUnresponsive.emit();
         protopeer.establishmentUnresponsive.emit();
-        await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+        await settled(peer1);
         expect(states).deep.equals([NodeConnectionState.Reconnecting, NodeConnectionState.WaitingForDeviceDiscovery]);
     });
 
@@ -97,7 +97,7 @@ describe("ConnectionState", () => {
 
         const subscription = await loseSubscription(peer1, device);
         peer1.env.get(Peer).establishmentUnresponsive.emit();
-        await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+        await settled(peer1);
         expect(peer1.lifecycle.connectionState).equals(NodeConnectionState.WaitingForDeviceDiscovery);
 
         const states = new Array<NodeConnectionState>();
@@ -173,7 +173,7 @@ describe("ConnectionState", () => {
         for (const session of [...protopeer.sessions]) {
             protopeer.sessions.delete(session);
         }
-        await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+        await settled(peer1);
 
         expect(peer1.lifecycle.connectionState).equals(NodeConnectionState.Reconnecting);
         expect(peer1.lifecycle.isConnected).false;
@@ -191,7 +191,7 @@ describe("ConnectionState", () => {
         expect(peer1.lifecycle.connectionState).equals(NodeConnectionState.Reconnecting);
 
         peer1.eventsOf(IcdClient).checkInMissed.emit();
-        await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+        await settled(peer1);
 
         expect(peer1.lifecycle.connectionState).equals(NodeConnectionState.WaitingForDeviceDiscovery);
     });

--- a/packages/node/test/behavior/system/network/FabricLabelReconciliationTest.ts
+++ b/packages/node/test/behavior/system/network/FabricLabelReconciliationTest.ts
@@ -14,7 +14,7 @@ async function reconcile(peer: Awaited<ReturnType<typeof subscribedPeer>>, until
     peer.behaviors.internalsOf(NetworkClient).fabricLabelReconciled = false;
     peer.eventsOf(NetworkClient).subscriptionAlive.emit();
     for (let i = 0; i < 20 && !until(); i++) {
-        await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+        await MockTime.macrotask;
     }
 }
 

--- a/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
@@ -26,7 +26,7 @@ import { IcdManagement } from "@matter/types/clusters/icd-management";
 import { MockExchange } from "../../node/mock-exchange.js";
 import { MockServerNode } from "../../node/mock-server-node.js";
 import { MockSite } from "../../node/mock-site.js";
-import { subscribedPeer } from "../../node/node-helpers.js";
+import { settled, subscribedPeer } from "../../node/node-helpers.js";
 
 const RootWithIcd = ServerNode.RootEndpoint.with(IcdManagementServer);
 const RootWithIcdOnline = MockServerNode.RootEndpoint.with(IcdManagementServer);
@@ -179,7 +179,7 @@ describe("IcdManagementServer", () => {
                 if (icdCounter === undefined) throw new Error("icdCounter not initialized");
                 icdCounter.increment();
             });
-            await MockTime.resolve(Promise.resolve());
+            await settled(device);
 
             const after = device.stateOf(IcdManagementServer).icdCounter;
             expect(after).equals(before + 1);
@@ -758,7 +758,7 @@ describe("IcdManagementServer", () => {
                 key: Bytes.fromHex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"),
                 clientType: IcdManagement.ClientType.Permanent,
             });
-            await MockTime.resolve(Promise.resolve());
+            await settled(device);
 
             expect(device.stateOf(litServer).operatingMode).equals(IcdManagement.OperatingMode.Lit);
             expect(refreshCount).greaterThan(0);
@@ -792,7 +792,7 @@ describe("IcdManagementServer", () => {
                 key: Bytes.fromHex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"),
                 clientType: IcdManagement.ClientType.Permanent,
             });
-            await MockTime.resolve(Promise.resolve());
+            await settled(device);
             expect(device.stateOf(litServer).operatingMode).equals(IcdManagement.OperatingMode.Lit);
 
             const deviceAdvertiser = device.env.get(DeviceAdvertiser);
@@ -804,7 +804,7 @@ describe("IcdManagementServer", () => {
             };
 
             await cmds.unregisterClient({ checkInNodeId });
-            await MockTime.resolve(Promise.resolve());
+            await settled(device);
 
             expect(device.stateOf(litServer).operatingMode).equals(IcdManagement.OperatingMode.Sit);
             expect(refreshAfterUnregister).greaterThan(0);
@@ -839,7 +839,7 @@ describe("IcdManagementServer", () => {
                 key: Bytes.fromHex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"),
                 clientType: IcdManagement.ClientType.Permanent,
             });
-            await MockTime.resolve(Promise.resolve());
+            await settled(device);
 
             // Still SIT after registration — non-LITS server never flips to LIT.
             await deviceAdvertiser.refreshOperationalAdvertisement(fabric);
@@ -942,7 +942,7 @@ describe("IcdManagementServer", () => {
             };
 
             await device.act(agent => agent.get(dslsServer).setOperatingMode(IcdManagement.OperatingMode.Lit));
-            await MockTime.resolve(Promise.resolve());
+            await settled(device);
 
             expect(device.stateOf(dslsServer).operatingMode).equals(IcdManagement.OperatingMode.Lit);
             expect(refreshCount).greaterThan(0);
@@ -968,7 +968,7 @@ describe("IcdManagementServer", () => {
 
             // Force to LIT first.
             await device.act(agent => agent.get(dslsServer).setOperatingMode(IcdManagement.OperatingMode.Lit));
-            await MockTime.resolve(Promise.resolve());
+            await settled(device);
             expect(device.stateOf(dslsServer).operatingMode).equals(IcdManagement.OperatingMode.Lit);
 
             const deviceAdvertiser = device.env.get(DeviceAdvertiser);
@@ -981,7 +981,7 @@ describe("IcdManagementServer", () => {
 
             // Switch back to SIT.
             await device.act(agent => agent.get(dslsServer).setOperatingMode(IcdManagement.OperatingMode.Sit));
-            await MockTime.resolve(Promise.resolve());
+            await settled(device);
 
             expect(device.stateOf(dslsServer).operatingMode).equals(IcdManagement.OperatingMode.Sit);
             expect(refreshCount).greaterThan(0);
@@ -1006,7 +1006,7 @@ describe("IcdManagementServer", () => {
 
             // Force LIT with no registrations.
             await device.act(agent => agent.get(dslsServer).setOperatingMode(IcdManagement.OperatingMode.Lit));
-            await MockTime.resolve(Promise.resolve());
+            await settled(device);
             expect(device.stateOf(dslsServer).operatingMode).equals(IcdManagement.OperatingMode.Lit);
 
             const deviceAdvertiser = device.env.get(DeviceAdvertiser);
@@ -1019,7 +1019,7 @@ describe("IcdManagementServer", () => {
 
             // Withdraw the override → registration-driven mode; no registrations means SIT.
             await device.act(agent => agent.get(dslsServer).withdrawForcedOperatingMode());
-            await MockTime.resolve(Promise.resolve());
+            await settled(device);
 
             expect(device.stateOf(dslsServer).operatingMode).equals(IcdManagement.OperatingMode.Sit);
             expect(refreshCount).greaterThan(0);
@@ -1079,7 +1079,7 @@ describe("IcdManagementServer", () => {
 
             // No registrations → registration-driven mode is SIT; requesting SIT is allowed without DSLS.
             await device.act(agent => agent.get(litServer).setOperatingMode(IcdManagement.OperatingMode.Sit));
-            await MockTime.resolve(Promise.resolve());
+            await settled(device);
 
             expect(device.stateOf(litServer).operatingMode).equals(IcdManagement.OperatingMode.Sit);
         });
@@ -1225,7 +1225,8 @@ describe("IcdManagementServer", () => {
         async function wake(device: ServerNode) {
             await device.act(agent => agent.get(IcdManagementServer).enterIdleMode());
             await device.act(agent => agent.get(IcdManagementServer).requestActiveMode());
-            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+
+            await settled(device);
         }
 
         async function commissionedRecordingPair() {
@@ -1406,7 +1407,7 @@ describe("IcdManagementServer", () => {
             // UAT resets the back-off; the wake it triggers sends immediately.
             await device.act(agent => agent.get(IcdManagementServer).enterIdleMode());
             await device.act(agent => agent.get(IcdManagementServer).triggerUserActiveMode());
-            await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+            await settled(device);
 
             expect(sent.length).equals(beforeSuppressed + 1);
         });

--- a/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
@@ -1004,9 +1004,10 @@ describe("IcdManagementServer", () => {
                 device: { type: RootWithDsls, icdManagement: DSLS_CONFIG },
             });
 
-            // Force LIT with no registrations.
+            // Force LIT with no registrations.  One task turn throughout: forcing LIT prompts the commissioned
+            // controller to register as a Check-In client, and a registration would drive the mode to LIT on its own
             await device.act(agent => agent.get(dslsServer).setOperatingMode(IcdManagement.OperatingMode.Lit));
-            await settled(device);
+            await MockTime.macrotask;
             expect(device.stateOf(dslsServer).operatingMode).equals(IcdManagement.OperatingMode.Lit);
 
             const deviceAdvertiser = device.env.get(DeviceAdvertiser);
@@ -1019,7 +1020,7 @@ describe("IcdManagementServer", () => {
 
             // Withdraw the override → registration-driven mode; no registrations means SIT.
             await device.act(agent => agent.get(dslsServer).withdrawForcedOperatingMode());
-            await settled(device);
+            await MockTime.macrotask;
 
             expect(device.stateOf(dslsServer).operatingMode).equals(IcdManagement.OperatingMode.Sit);
             expect(refreshCount).greaterThan(0);

--- a/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
+++ b/packages/node/test/behaviors/icd-management/IcdManagementServerTest.ts
@@ -917,7 +917,18 @@ describe("IcdManagementServer", () => {
             IcdManagement.Feature.UserActiveModeTrigger,
             IcdManagement.Feature.DynamicSitLitSupport,
         );
-        const RootWithDsls = ServerNode.RootEndpoint.with(dslsServer);
+        const RootWithDsls = MockServerNode.RootEndpoint.with(dslsServer);
+
+        /**
+         * A DSLS device with a fabric but no controller.  A commissioned controller auto-registers as a Check-In
+         * client for a LIT peer, and a registration drives the operating mode to LIT on its own, which would mask the
+         * forced-mode behavior these tests assert.
+         */
+        async function dslsDevice() {
+            const device = await MockServerNode.createOnline(RootWithDsls, { icdManagement: DSLS_CONFIG });
+            await device.addFabric();
+            return device;
+        }
 
         const DSLS_CONFIG = {
             operatingMode: IcdManagement.OperatingMode.Sit,
@@ -928,10 +939,7 @@ describe("IcdManagementServer", () => {
         } as const;
 
         it("setOperatingMode(Lit) with no registrations forces LIT and refreshes advertisement", async () => {
-            await using site = new MockSite();
-            const { device } = await site.addCommissionedPair({
-                device: { type: RootWithDsls, icdManagement: DSLS_CONFIG },
-            });
+            await using device = await dslsDevice();
 
             const deviceAdvertiser = device.env.get(DeviceAdvertiser);
             let refreshCount = 0;
@@ -961,10 +969,7 @@ describe("IcdManagementServer", () => {
         });
 
         it("setOperatingMode(Sit) after forced LIT switches back to SIT and refreshes advertisement", async () => {
-            await using site = new MockSite();
-            const { device } = await site.addCommissionedPair({
-                device: { type: RootWithDsls, icdManagement: DSLS_CONFIG },
-            });
+            await using device = await dslsDevice();
 
             // Force to LIT first.
             await device.act(agent => agent.get(dslsServer).setOperatingMode(IcdManagement.OperatingMode.Lit));
@@ -999,15 +1004,11 @@ describe("IcdManagementServer", () => {
         });
 
         it("withdrawForcedOperatingMode reverts a forced LIT to the registration-driven mode and refreshes", async () => {
-            await using site = new MockSite();
-            const { device } = await site.addCommissionedPair({
-                device: { type: RootWithDsls, icdManagement: DSLS_CONFIG },
-            });
+            await using device = await dslsDevice();
 
-            // Force LIT with no registrations.  One task turn throughout: forcing LIT prompts the commissioned
-            // controller to register as a Check-In client, and a registration would drive the mode to LIT on its own
+            // Force LIT with no registrations.
             await device.act(agent => agent.get(dslsServer).setOperatingMode(IcdManagement.OperatingMode.Lit));
-            await MockTime.macrotask;
+            await settled(device);
             expect(device.stateOf(dslsServer).operatingMode).equals(IcdManagement.OperatingMode.Lit);
 
             const deviceAdvertiser = device.env.get(DeviceAdvertiser);
@@ -1020,8 +1021,9 @@ describe("IcdManagementServer", () => {
 
             // Withdraw the override → registration-driven mode; no registrations means SIT.
             await device.act(agent => agent.get(dslsServer).withdrawForcedOperatingMode());
-            await MockTime.macrotask;
+            await settled(device);
 
+            expect(device.stateOf(dslsServer).registeredClients).empty;
             expect(device.stateOf(dslsServer).operatingMode).equals(IcdManagement.OperatingMode.Sit);
             expect(refreshCount).greaterThan(0);
         });

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -1352,7 +1352,7 @@ describe("ClientNode", () => {
                 const write = ep1Client.setStateOf(OnOffClient, { startUpOnOff: OnOff.StartUpOnOff.Toggle });
                 for (let i = 0; i < 80; i++) {
                     await MockTime.advance(Seconds(1));
-                    await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+                    await MockTime.macrotask;
                 }
                 await write;
             });
@@ -1377,7 +1377,7 @@ describe("ClientNode", () => {
                 // nothing left to send
                 for (let i = 0; i < 3; i++) {
                     await MockTime.advance(Millis(100));
-                    await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+                    await MockTime.macrotask;
                 }
 
                 // The device applied the write and reported it; only the write response was lost.  A report carrying
@@ -1391,7 +1391,7 @@ describe("ClientNode", () => {
 
                 for (let i = 0; i < 80; i++) {
                     await MockTime.advance(Seconds(1));
-                    await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+                    await MockTime.macrotask;
                 }
                 await write;
             });

--- a/packages/node/test/node/SettledTest.ts
+++ b/packages/node/test/node/SettledTest.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NodeActivity } from "#behavior/context/NodeActivity.js";
+import { Environment } from "@matter/general";
+import { settled } from "./node-helpers.js";
+
+function nodeWithActivity(name: string) {
+    const env = new Environment(name);
+    const activity = new NodeActivity();
+    env.set(NodeActivity, activity);
+    return { env, activity };
+}
+
+describe("settled", () => {
+    before(() => MockTime.init());
+
+    it("waits past the turn in which a node goes idle with work still to start", async () => {
+        const first = nodeWithActivity("first");
+        const second = nodeWithActivity("second");
+
+        let done = false;
+
+        const actor = first.activity.begin("first-work");
+
+        const work = (async () => {
+            await MockTime.macrotask;
+
+            // The gap the helper must not mistake for quiescence: nothing is active, but the second node's work is
+            // scheduled for a later turn
+            actor.close();
+            await MockTime.macrotask;
+
+            const next = second.activity.begin("second-work");
+            await MockTime.macrotask;
+
+            next.close();
+            done = true;
+        })();
+
+        await settled(first, second);
+
+        expect(done).true;
+
+        await work;
+    });
+
+    it("returns once every node is idle", async () => {
+        const first = nodeWithActivity("first");
+        const second = nodeWithActivity("second");
+
+        await settled(first, second);
+
+        expect(first.activity.inactive.value).true;
+        expect(second.activity.inactive.value).true;
+    });
+});

--- a/packages/node/test/node/client/ClientNodeInteractionIcdTest.ts
+++ b/packages/node/test/node/client/ClientNodeInteractionIcdTest.ts
@@ -54,7 +54,8 @@ async function registeredLitPair(site: MockSite) {
     await peer1.act(agent => agent.get(IcdClient).register({ monitoredSubject: MONITORED }));
     // register seeds a signal (awake for activeModeThreshold = 5s); let that window lapse so the peer is idle.
     await MockTime.advance(Seconds(6));
-    await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+    // One task turn applies the lapsed window; settling further would let the peer's recovery work re-arm it
+    await MockTime.macrotask;
     return { controller, device, peer1 };
 }
 
@@ -119,8 +120,9 @@ describe("ClientNodeInteraction ICD hold", () => {
             },
         );
 
-        // Let the gate park; the read must not transmit while the peer is asleep.
-        await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+        // Let the gate park; the read must not transmit while the peer is asleep.  One task turn is the point: the
+        // read must still be outstanding, so there is no completion to wait for
+        await MockTime.macrotask;
         expect(settled).false;
 
         await wakeDevice(device);
@@ -194,7 +196,8 @@ describe("ClientNodeInteraction ICD hold", () => {
         expect(wakefulnessOf(controller, peer1)!.awake.value).false;
 
         const read = drainRead(peer1);
-        await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+        // The read parks until the device wakes, so there is nothing to settle here
+        await MockTime.macrotask;
 
         await wakeDevice(device);
         await MockTime.resolve(read, { macrotasks: true });

--- a/packages/node/test/node/client/PeersLoadFailureTest.ts
+++ b/packages/node/test/node/client/PeersLoadFailureTest.ts
@@ -139,7 +139,8 @@ describe("Peers load failures", () => {
         );
         expect(warnings.length).equals(1);
 
-        await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+        // A turn for any rejection to surface; there is no completion to wait for
+        await MockTime.macrotask;
         expect(tracker.rejections.filter(reason => `${reason}`.includes("Behaviors have errors"))).deep.equals([]);
     });
 });

--- a/packages/node/test/node/icd-helpers.ts
+++ b/packages/node/test/node/icd-helpers.ts
@@ -11,6 +11,7 @@ import { ServerNode } from "#node/index.js";
 import { Crypto, MockCrypto, Seconds } from "@matter/general";
 import { FabricManager } from "@matter/protocol";
 import { IcdManagement } from "@matter/types/clusters/icd-management";
+import { settled } from "./node-helpers.js";
 
 /** Shared LIT ICD server configuration for the ICD test suites. */
 export const LIT_CONFIG = {
@@ -25,7 +26,7 @@ export const LIT_CONFIG = {
 export async function wakeDevice(device: ServerNode) {
     await device.act(agent => agent.get(IcdManagementServer).enterIdleMode());
     await device.act(agent => agent.get(IcdManagementServer).requestActiveMode());
-    await MockTime.resolve(Promise.resolve(), { macrotasks: true });
+    await settled(device);
 }
 
 export async function commission(controller: ServerNode, device: ServerNode) {

--- a/packages/node/test/node/node-helpers.ts
+++ b/packages/node/test/node/node-helpers.ts
@@ -5,6 +5,7 @@
  */
 
 import type { ClusterBehavior } from "#behavior/cluster/ClusterBehavior.js";
+import { NodeActivity } from "#behavior/context/NodeActivity.js";
 import { BasicInformationBehavior } from "#behaviors/basic-information";
 import { EndpointInitializer } from "#endpoint/properties/EndpointInitializer.js";
 import {
@@ -16,7 +17,7 @@ import {
     NetworkClient,
     ServerNode,
 } from "#index.js";
-import { Bytes, Crypto, InternalError } from "@matter/general";
+import { Bytes, Crypto, type Environment, InternalError } from "@matter/general";
 import { Specification } from "@matter/model";
 import {
     Certificate,
@@ -51,6 +52,27 @@ import {
 } from "@matter/types";
 import { GeneralCommissioning } from "@matter/types/clusters/general-commissioning";
 import { MockServerNode } from "./mock-server-node.js";
+
+/**
+ * Wait until the given nodes have no activity in flight.
+ *
+ * Work a node performs in reaction to an event registers as activity only once the reactor runs, so a node can look
+ * idle with work imminent.  This yields task turns until every node reports itself idle, and never advances mock time
+ * — a test that needs a timer to fire advances the clock itself, and doing so here would change what it observes.
+ */
+export async function settled(...nodes: Array<{ env: Environment }>) {
+    const activities = nodes.map(node => node.env.get(NodeActivity));
+
+    for (let turn = 0; turn < 1000; turn++) {
+        await MockTime.macrotask;
+
+        if (activities.every(activity => activity.inactive.value)) {
+            return;
+        }
+    }
+
+    throw new InternalError("Nodes did not settle; work is blocked on time that the test must advance itself");
+}
 
 export const FAILSAFE_LENGTH_S = 60;
 

--- a/packages/node/test/node/node-helpers.ts
+++ b/packages/node/test/node/node-helpers.ts
@@ -63,11 +63,29 @@ import { MockServerNode } from "./mock-server-node.js";
 export async function settled(...nodes: Array<{ env: Environment }>) {
     const activities = nodes.map(node => node.env.get(NodeActivity));
 
-    for (let turn = 0; turn < 1000; turn++) {
-        await MockTime.macrotask;
+    let transitions = 0;
+    const observer = () => {
+        transitions++;
+    };
+    for (const activity of activities) {
+        activity.inactive.on(observer);
+    }
 
-        if (activities.every(activity => activity.inactive.value)) {
-            return;
+    try {
+        for (let turn = 0; turn < 1000; turn++) {
+            const before = transitions;
+
+            await MockTime.macrotask;
+
+            // Idle alone is not quiescence: one reactor may have closed while scheduling another for the next turn.
+            // A turn in which nothing started or finished means nothing is waiting to run
+            if (transitions === before && activities.every(activity => activity.inactive.value)) {
+                return;
+            }
+        }
+    } finally {
+        for (const activity of activities) {
+            activity.inactive.off(observer);
         }
     }
 


### PR DESCRIPTION
`MockTime.resolve(Promise.resolve(), { macrotasks: true })` appears 44 times across the node tests and reads as "let pending work run". It does not. The promise it is handed is already resolved, so the loop inside `resolve` registers its `.then`, finds `resolved` still false on the synchronous pass, awaits exactly one task turn and returns. It waits for nothing in particular. Every test using it passes only while the work it depends on happens to fit inside that one turn.

## The flake this produced

`IcdManagementServer ➡ Check-In sending ➡ advances the ICDCounter once per Check-In sent across multiple registered clients` failed once in a full-suite run and was green on rerun.

The Check-In pass awaits `sender.send()` per registered client, and each send does an async crypto encode plus a transmit. Two clients need two of those inside a one-turn window. One client fits; two are marginal, and on a loaded machine the second had not landed when the assertions ran.

Injecting a single extra task turn per send reproduces it deterministically and fails four of the six tests in that block:

```
sends one Check-In per wake …        FAIL  expected [] to have a length of 1 but got +0
advances the ICDCounter once per …   FAIL  expected [] to have a length of 2 but got +0
follows the back-off schedule …      FAIL  expected [1,3,10] to deeply equal [+0,1,3,7,11]
triggerUserActiveMode resets the …   FAIL  expected 2 to equal 1
```

So the whole block was exposed, not only the test that happened to flake.

## What replaces it

A new `settled(...nodes)` helper yields task turns until the nodes named are quiescent, judged through `NodeActivity`. Three properties matter:

- **Idle alone is not quiescence.** A reactor can close its activity while scheduling another for the next turn, and a check taken in that gap would see idle nodes and return — the very race the helper exists to remove. It counts activity transitions and accepts only a turn in which nothing started or finished.
- **It never advances mock time.** A test that needs a timer to fire advances the clock itself; advancing inside the wait changes what the test observes, and an earlier version of this helper that did so broke unrelated cases.
- **It takes several nodes.** Settling one may start work on another, so it loops until all are quiescent.

32 of the 44 sites now wait on that condition. With the helper in place, the Check-In tests pass with five injected task turns per send, where the old code failed with one.

The remaining 12 do not wait for anything, and now say so with `await MockTime.macrotask` and a comment naming the reason. Some assert an absence — a read that must still be parked, a rejection that must not appear — where there is no completion to wait for. Three observe a state that genuinely holds for one turn:

- an ICD peer's availability lapses, and the subscription's next report re-arms it
- `unregister()` on a LIT peer is followed by auto-registration, because registration is mandatory there
- the same lapse-and-re-arm for `awake`

Each of those was traced to the code that restores the state, so the comments state the mechanism rather than warning the next reader off vaguely.

## A premise the wait exposed

The DSLS operating-mode cases assert "no registrations means SIT" while running against a commissioned controller. That controller's `IcdClient` auto-registers as a Check-In client for a LIT peer, and a registration drives the operating mode to LIT on its own — so those assertions could hold even with the forced-mode path broken. They now run against a device that has a fabric but no controller, and assert the registration list is empty. Removing the line that clears the forced mode fails the withdrawal case, which it did not do before.

## Testing

`npm run build-clean`, the full suite, `format-verify` and `lint` are green, and `packages/node` passes on all three legs. Every conversion was verified per file. `SettledTest` covers the helper itself: it drives one node's activity closing while another node's work is scheduled for a later turn, and fails deterministically against an idle-only check. The ICD fix was verified by injecting task-turn delays into the Check-In sender — red before the change, green after, at one and at five injected turns.
