### PR TITLE
test(chip-testing): a commissioning step says what the commissioner read, and one step per case proves it used it

### DIFF
--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -18,6 +18,7 @@ import type {
     CertNodeRef,
     CertStepContext,
     CheckRecord,
+    CommissioningTarget,
     ControllerAdapter,
     DeviceExitInfo,
     DeviceFlavor,
@@ -42,6 +43,7 @@ import {
     qrPayloadWith,
     qrPayloadWithPrefix,
     recordDiscoveryCapabilityAbsent,
+    recordDiscriminatorHonored,
     recordBackInCommissioningMode,
     recordGeneratedManualCode,
     recordPayloadOffering,
@@ -135,6 +137,15 @@ describe("qrPayloadWith", () => {
 
     it("refuses a code that is not a QR onboarding payload", () => {
         expect(() => qrPayloadWith("34970112336552132769", { version: 2 })).throw(InternalError);
+    });
+
+    it("substitutes the discriminator, which is what names a device nothing advertises", () => {
+        expect(qrPayloadWith(PLAN_PAYLOAD, { discriminator: 255 })).equal("MT:-24J0KI827R-.548G00");
+        expect(qrPayloadWith(PLAN_PAYLOAD, { discriminator: 0 })).equal("MT:-24J029Q00YZ.548G00");
+    });
+
+    it("refuses a discriminator too wide for the twelve bits the field holds", () => {
+        expect(() => qrPayloadWith(PLAN_PAYLOAD, { discriminator: 0x1000 })).throw(InternalError);
     });
 
     it("refuses a flow too wide for the two bits the field holds", () => {
@@ -1056,7 +1067,7 @@ class UnpairFixture {
             fabricIndex?: number;
             backchannel?: () => void;
             onDecommission?: () => void;
-            commission?: () => Promise<CertNodeRef>;
+            commission?: (target: CommissioningTarget) => Promise<CertNodeRef>;
         } = {},
     ) {
         const { fabricIndex = 1, backchannel = () => {}, onDecommission = () => {} } = options;
@@ -1113,7 +1124,8 @@ class UnpairFixture {
             async start() {},
             async close() {},
             commission: options.commission ?? unused,
-            parseQrPayload: unused,
+            // The commissioning helpers record what the DUT reads from the code before they use it
+            parseQrPayload: async payload => qrPayloadFields(payload),
             parseManualPairingCode: unused,
             node: () => node,
         };
@@ -1349,6 +1361,89 @@ describe("commissionByQr's own causal boundary", () => {
         const matched = fixture.checks.find(check => check.type === "device-log")?.matched ?? "";
         expect(matched).contains("bbbbbbbbbbbbbbbb");
         expect(matched).not.contains("aaaaaaaaaaaaaaaa");
+    });
+});
+
+describe("commissionByQr's payload evidence", () => {
+    const completion = (fabric: string) =>
+        `2026-08-27 19:31:27.056 NOTICE GeneralCommissioningClusterHandler Commissioned fabric: ${fabric} (#1) node: 1`;
+
+    function fixtureThatCommissions() {
+        const fixture: UnpairFixture = new UnpairFixture("matterjs", {
+            commission: async () => {
+                fixture.push(completion("bbbbbbbbbbbbbbbb"));
+                return "peer1" as CertNodeRef;
+            },
+        });
+        return fixture;
+    }
+
+    // A commissioner that ignored the code and onboarded whatever it could find writes the same
+    // completion line, so the step needs the code itself in evidence
+    it("records what the DUT read from the code it commissions with", async () => {
+        const fixture = fixtureThatCommissions();
+
+        await commissionByQr(fixture.cx, "MT:-24J042C00KA0648G00", new CommissionedRefs());
+
+        expect(fixture.checks[0]?.detail).contains("discriminator=3840 passcode=20202021");
+    });
+
+    it("fails when the code names a setup other than the TH's own", async () => {
+        const fixture = fixtureThatCommissions();
+
+        await expect(
+            commissionByQr(
+                fixture.cx,
+                qrPayloadWith("MT:-24J042C00KA0648G00", { passcode: 12345678 }),
+                new CommissionedRefs(),
+            ),
+        ).rejectedWith(CertCheckFailedError, /Onboarding payload parse/);
+    });
+});
+
+describe("recordDiscriminatorHonored", () => {
+    const TH_PAYLOAD = "MT:-24J042C00KA0648G00";
+
+    // The TH's own discriminator is 3840, so the substitute is 3840 ^ 0xfff
+    const ABSENT = 255;
+
+    it("passes when the DUT gives up on the discriminator nothing advertises", async () => {
+        const asked = new Array<string>();
+        const fixture = new UnpairFixture("matterjs", {
+            commission: async target => {
+                asked.push(target.qrPairingCode ?? "");
+                throw new InternalError("no commissionable device was discovered");
+            },
+        });
+
+        await recordDiscriminatorHonored(fixture.cx, TH_PAYLOAD, new CommissioningRefusals());
+
+        expect(qrPayloadFields(asked[0] ?? "").discriminator).equal(ABSENT);
+        expect(fixture.checks.map(check => check.verdict)).deep.equal(["pass"]);
+    });
+
+    // The case that gives the check its meaning: a commissioner that ignores the field onboards the
+    // only commissionable device there is, and every other check in the step still passes
+    it("fails when the DUT commissions a device its code did not name", async () => {
+        const fixture = new UnpairFixture("matterjs", {
+            commission: async () => "peer1" as CertNodeRef,
+        });
+
+        await expect(recordDiscriminatorHonored(fixture.cx, TH_PAYLOAD, new CommissioningRefusals())).rejectedWith(
+            CertCheckFailedError,
+        );
+    });
+
+    it("refuses a substitute another device in the run advertises", async () => {
+        const fixture = new UnpairFixture("matterjs");
+        const th = fixture.cx.devices.th;
+        const other = { ...th, id: "th2", commissioning: { ...th.commissioning, discriminator: ABSENT } };
+        const cx = { ...fixture.cx, devices: { th, th2: other } };
+
+        await expect(recordDiscriminatorHonored(cx, TH_PAYLOAD, new CommissioningRefusals())).rejectedWith(
+            InternalError,
+            /th2 advertises it/,
+        );
     });
 });
 

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -25,6 +25,7 @@ import type {
 } from "@matter/testing";
 import { LineQueue, LogFollower, PicsFile } from "@matter/testing";
 import { expect } from "chai";
+import { env } from "node:process";
 import { ChipToolCommandError } from "../../src/cert/ChipToolControllerAdapter.js";
 import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload.js";
 import type { ManualPairingCodeParts, TransitionMark } from "../cert/tc-dd-support.js";
@@ -43,6 +44,7 @@ import {
     qrPayloadWith,
     qrPayloadWithPrefix,
     recordDiscoveryCapabilityAbsent,
+    ABSENT_DEVICE_GIVE_UP,
     recordDiscriminatorHonored,
     recordBackInCommissioningMode,
     recordGeneratedManualCode,
@@ -1422,14 +1424,17 @@ describe("recordDiscriminatorHonored", () => {
 
     it("passes when the DUT gives up on the discriminator nothing advertises", async () => {
         const asked = new Array<string>();
+        const budgets = new Array<number | undefined>();
         const fixture = fixtureFor(async target => {
             asked.push(target.qrPairingCode ?? "");
+            budgets.push(target.giveUpAfterMs);
             throw new DiscoveryError("no commissionable device was discovered");
         });
 
         await recordDiscriminatorHonored(fixture.cx, new CommissioningRefusals(), undefined, advertising);
 
         expect(qrPayloadFields(asked[0] ?? "").discriminator).equal(ABSENT);
+        expect(budgets[0]).equal(ABSENT_DEVICE_GIVE_UP);
         expect(fixture.checks.at(-1)?.verdict).equal("pass");
         expect(fixture.checks.at(-1)?.detail).contains(`discriminator 3840 replaced by ${ABSENT}`);
     });
@@ -1469,6 +1474,32 @@ describe("recordDiscriminatorHonored", () => {
         await expect(
             recordDiscriminatorHonored(fixture.cx, new CommissioningRefusals(), undefined, advertising),
         ).rejectedWith(CertCheckFailedError);
+    });
+
+    // chip-tool reports every command failure the same way, so an attempt there would spend its own
+    // discovery timeout to produce a verdict that could not have failed
+    it("states the gap rather than attempting anything on chip-tool", async () => {
+        const attempts = new Array<string>();
+        const fixture = fixtureFor(async target => {
+            attempts.push(target.qrPairingCode ?? "");
+            throw new DiscoveryError("no commissionable device was discovered");
+        });
+
+        const original = env.MATTER_CERT_CONTROLLER;
+        env.MATTER_CERT_CONTROLLER = "chip-tool";
+        try {
+            await recordDiscriminatorHonored(fixture.cx, new CommissioningRefusals(), undefined, advertising);
+        } finally {
+            if (original === undefined) {
+                delete env.MATTER_CERT_CONTROLLER;
+            } else {
+                env.MATTER_CERT_CONTROLLER = original;
+            }
+        }
+
+        expect(attempts).deep.equal([]);
+        expect(fixture.checks.at(-1)?.verdict).equal("unverified");
+        expect(fixture.checks.at(-1)?.accepted).contains("one command error");
     });
 
     it("refuses a substitute another device in the run advertises", async () => {

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -1068,6 +1068,7 @@ class UnpairFixture {
             backchannel?: () => void;
             onDecommission?: () => void;
             commission?: (target: CommissioningTarget) => Promise<CertNodeRef>;
+            qrPairingCode?: string;
         } = {},
     ) {
         const { fabricIndex = 1, backchannel = () => {}, onDecommission = () => {} } = options;
@@ -1099,7 +1100,12 @@ class UnpairFixture {
         const device: CertDevice = {
             id: "th",
             app: "all-clusters",
-            commissioning: { kind: "on-network", passcode: 20202021, discriminator: 3840, qrPairingCode: "" },
+            commissioning: {
+                kind: "on-network",
+                passcode: 20202021,
+                discriminator: 3840,
+                qrPairingCode: options.qrPairingCode ?? "",
+            },
             pics: new PicsFile([]),
             async initialize() {},
             async start() {},
@@ -1402,45 +1408,76 @@ describe("commissionByQr's payload evidence", () => {
 });
 
 describe("recordDiscriminatorHonored", () => {
-    const TH_PAYLOAD = "MT:-24J042C00KA0648G00";
-
-    // The TH's own discriminator is 3840, so the substitute is 3840 ^ 0xfff
+    // The fixture TH's own discriminator is 3840, so the substitute is 3840 ^ 0xfff
     const ABSENT = 255;
+
+    const advertising = async () => {};
+    const notAdvertising = async () => {
+        throw new CertCheckFailedError("TH is not advertising as commissionable");
+    };
+
+    function fixtureFor(commission: (target: CommissioningTarget) => Promise<CertNodeRef>) {
+        return new UnpairFixture("matterjs", { commission, qrPairingCode: "MT:-24J042C00KA0648G00" });
+    }
 
     it("passes when the DUT gives up on the discriminator nothing advertises", async () => {
         const asked = new Array<string>();
-        const fixture = new UnpairFixture("matterjs", {
-            commission: async target => {
-                asked.push(target.qrPairingCode ?? "");
-                throw new InternalError("no commissionable device was discovered");
-            },
+        const fixture = fixtureFor(async target => {
+            asked.push(target.qrPairingCode ?? "");
+            throw new DiscoveryError("no commissionable device was discovered");
         });
 
-        await recordDiscriminatorHonored(fixture.cx, TH_PAYLOAD, new CommissioningRefusals());
+        await recordDiscriminatorHonored(fixture.cx, new CommissioningRefusals(), undefined, advertising);
 
         expect(qrPayloadFields(asked[0] ?? "").discriminator).equal(ABSENT);
-        expect(fixture.checks.map(check => check.verdict)).deep.equal(["pass"]);
+        expect(fixture.checks.at(-1)?.verdict).equal("pass");
+        expect(fixture.checks.at(-1)?.detail).contains(`discriminator 3840 replaced by ${ABSENT}`);
     });
 
     // The case that gives the check its meaning: a commissioner that ignores the field onboards the
     // only commissionable device there is, and every other check in the step still passes
     it("fails when the DUT commissions a device its code did not name", async () => {
-        const fixture = new UnpairFixture("matterjs", {
-            commission: async () => "peer1" as CertNodeRef,
+        const fixture = fixtureFor(async () => "peer1" as CertNodeRef);
+
+        await expect(
+            recordDiscriminatorHonored(fixture.cx, new CommissioningRefusals(), undefined, advertising),
+        ).rejectedWith(CertCheckFailedError);
+    });
+
+    // Without this the DUT gives up because there was nothing to find, and the check passes on the
+    // TH's absence rather than on the DUT's use of the field
+    it("fails when the TH was not advertising to begin with", async () => {
+        const commissioned = new Array<string>();
+        const fixture = fixtureFor(async target => {
+            commissioned.push(target.qrPairingCode ?? "");
+            throw new DiscoveryError("no commissionable device was discovered");
         });
 
-        await expect(recordDiscriminatorHonored(fixture.cx, TH_PAYLOAD, new CommissioningRefusals())).rejectedWith(
-            CertCheckFailedError,
-        );
+        await expect(
+            recordDiscriminatorHonored(fixture.cx, new CommissioningRefusals(), undefined, notAdvertising),
+        ).rejectedWith(CertCheckFailedError);
+
+        expect(commissioned).deep.equal([]);
+    });
+
+    // A controller that would not start rejects too, and that says nothing about the discriminator
+    it("fails on a rejection that is not the DUT giving up on discovery", async () => {
+        const fixture = fixtureFor(async () => {
+            throw new OnboardingPayloadRefusedError("the DUT refused the code itself");
+        });
+
+        await expect(
+            recordDiscriminatorHonored(fixture.cx, new CommissioningRefusals(), undefined, advertising),
+        ).rejectedWith(CertCheckFailedError);
     });
 
     it("refuses a substitute another device in the run advertises", async () => {
-        const fixture = new UnpairFixture("matterjs");
+        const fixture = new UnpairFixture("matterjs", { qrPairingCode: "MT:-24J042C00KA0648G00" });
         const th = fixture.cx.devices.th;
         const other = { ...th, id: "th2", commissioning: { ...th.commissioning, discriminator: ABSENT } };
         const cx = { ...fixture.cx, devices: { th, th2: other } };
 
-        await expect(recordDiscriminatorHonored(cx, TH_PAYLOAD, new CommissioningRefusals())).rejectedWith(
+        await expect(recordDiscriminatorHonored(cx, new CommissioningRefusals(), undefined, advertising)).rejectedWith(
             InternalError,
             /th2 advertises it/,
         );

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1785,9 +1785,10 @@ pins the discriminator and passcode across restarts.
 gated on `MCORE.DD.SCAN_QR_CODE` and owns the parse evidence; `2.b` commissions (TC-DD-3.20,
 TC-DD-3.21, and TC-DD-3.11's `3.b`/`3.c`, where the capability offering was duplicated as well).
 Before, a controller whose PICS said it cannot scan got a `skipped` step and a pass for that same
-step's claim in one bundle. Commissioning from the payload is itself evidence the DUT parsed it, so
-the trade is deliberate: on a controller that cannot scan, those steps now record the commissioning
-result alone.
+step's claim in one bundle. The reasoning at the time — that commissioning from the payload is itself
+evidence the DUT parsed it — has since been retired; see "What a commissioning step owes its own
+evidence". A commissioning step now records its own parse, which is that step's claim rather than the
+scan step's, so the two no longer collide.
 
 **TC-DD-1.8 is the exception, and stays as it is.** Its `.b` steps carry their own expected outcome —
 "verify the TH's QR code *with the appended TLV data* was parsed successfully" — which is a different
@@ -1852,6 +1853,45 @@ payloads is also not enough — two could differ only in passcode and leave disc
 **Steps 4.a/4.b name the node and operational instance they reached.** Both harnesses run the same app
 with the same vendor id, so the attribute value alone cannot tell them apart and swapping the two refs
 would satisfy either step.
+
+## What a commissioning step owes its own evidence
+
+A step that commissions from an onboarding code used to record two things: that the commissioning
+succeeded, and that the TH logged it completing. Neither says the DUT read the code. The rule this
+directory used to state — "commissioning from the payload is itself evidence the DUT parsed it" —
+does not hold, and it is now retired.
+
+**`commissionByTarget` records what the DUT read from the code before it uses it.** Every caller of
+`commissionByQr`/`commissionByManualCode` gets this, so a commissioning step's own bundle carries the
+parse, and `recordParse` compares that parse against the TH's own discriminator and passcode rather
+than merely reporting it. Do not add a second `recordParse` beside a `commissionByQr` in the same
+step — it records the same claim twice. Where a scan step and a commissioning step are different
+steps, both legitimately parse, and both should say so.
+
+**What that still does not prove, and what does.** A commissioning that succeeds proves the passcode
+by itself: SPAKE2+ cannot complete on a wrong one. It proves nothing about the discriminator. On a
+network holding one commissionable device — which is every run of this harness — a commissioner that
+discarded the discriminator entirely passes every check above and onboards the TH anyway.
+
+`recordDiscriminatorHonored` separates the two. It hands the DUT the same payload carrying a
+discriminator nothing advertises and requires it to give up: a DUT that uses the field cannot find
+the device, and one that ignores it commissions and fails the check. The substitute is the TH's own
+discriminator inverted, because `identityFor` hands devices consecutive values and an inverted one
+lands far outside that span whatever the plan declares — and the helper throws if it names a device
+in the run anyway, since that would turn the control into an ordinary commissioning.
+
+**Establish it once per test case, before the first commissioning whose evidence rests on it.** The
+claim is about the commissioner, not about a step, and each control costs a full
+`ABSENT_DEVICE_TIMEOUT` — discovery for a discriminator nothing answers has nothing to finish early
+on. The wait for the outcome is `REFUSAL_TIMEOUT`, deliberately longer: a give-up that arrives exactly
+when its own deadline expires has to be observed after that deadline, not in a race with it. Passing
+the same value for both is what "neither resolved nor rejected within 5s" means.
+
+The test case owns a `CommissioningRefusals` for the attempt and settles it in `finalize` alongside
+`decommissionAll`, through `runCleanups` so a failing settle cannot skip the decommission.
+
+**What this still does not cover.** Which discovery capability the DUT honoured: every leg commissions
+over IP whatever the payload's bitmask says, so that field remains parse evidence only.
 
 ## A flow the TH cannot publish has to be fabricated (`TC-DD-3.12`, `TC-DD-3.13`)
 

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1858,40 +1858,65 @@ would satisfy either step.
 
 A step that commissions from an onboarding code used to record two things: that the commissioning
 succeeded, and that the TH logged it completing. Neither says the DUT read the code. The rule this
-directory used to state — "commissioning from the payload is itself evidence the DUT parsed it" —
-does not hold, and it is now retired.
+directory used to state — "commissioning from the payload is itself evidence the DUT parsed it" — is
+retired.
 
-**`commissionByTarget` records what the DUT read from the code before it uses it.** Every caller of
-`commissionByQr`/`commissionByManualCode` gets this, so a commissioning step's own bundle carries the
-parse, and `recordParse` compares that parse against the TH's own discriminator and passcode rather
-than merely reporting it. Do not add a second `recordParse` beside a `commissionByQr` in the same
-step — it records the same claim twice. Where a scan step and a commissioning step are different
-steps, both legitimately parse, and both should say so.
+**`commissionByTarget` records what the DUT read from the code before it uses it.** All twelve
+`commissionByQr` call sites get it, and `recordParse` compares that reading against the TH's own
+discriminator and passcode rather than merely reporting it. Do not add a second `recordParse` beside a
+`commissionByQr` in the same step — it records the same claim twice. Where a scan step and a
+commissioning step are different steps, both legitimately parse: the scan step's claim is that the
+payload was *scanned*, the commissioning step's is about the code that commissioning used. Their
+verdicts sit under different labels for that reason.
 
 **What that still does not prove, and what does.** A commissioning that succeeds proves the passcode
 by itself: SPAKE2+ cannot complete on a wrong one. It proves nothing about the discriminator. On a
 network holding one commissionable device — which is every run of this harness — a commissioner that
 discarded the discriminator entirely passes every check above and onboards the TH anyway.
 
-`recordDiscriminatorHonored` separates the two. It hands the DUT the same payload carrying a
-discriminator nothing advertises and requires it to give up: a DUT that uses the field cannot find
-the device, and one that ignores it commissions and fails the check. The substitute is the TH's own
+`recordDiscriminatorHonored` separates the two. It offers the DUT the TH's own payload carrying a
+discriminator nothing advertises and requires it to give up: a DUT that uses the field cannot find the
+device, and one that ignores it commissions and fails the check. The substitute is the payload's own
 discriminator inverted, because `identityFor` hands devices consecutive values and an inverted one
-lands far outside that span whatever the plan declares — and the helper throws if it names a device
-in the run anyway, since that would turn the control into an ordinary commissioning.
+lands far outside that span whatever the plan declares — and the helper throws if it names a device in
+the run anyway, since that would turn the control into an ordinary commissioning.
 
-**Establish it once per test case, before the first commissioning whose evidence rests on it.** The
-claim is about the commissioner, not about a step, and each control costs a full
-`ABSENT_DEVICE_TIMEOUT` — discovery for a discriminator nothing answers has nothing to finish early
-on. The wait for the outcome is `REFUSAL_TIMEOUT`, deliberately longer: a give-up that arrives exactly
-when its own deadline expires has to be observed after that deadline, not in a race with it. Passing
-the same value for both is what "neither resolved nor rejected within 5s" means.
+**Because a refusal is what a pass looks like here, two conditions are established rather than
+assumed.** The TH is observed advertising first, or the DUT gives up because there was nothing to find
+and the check passes on the TH's absence. And only a give-up counts (`isCommissioningGiveUp`), where
+`requireNoCommissioning` takes every failure but a payload refusal — that helper serves a plan with no
+commissionee at all, so a controller that would not start satisfies it.
+
+**On chip-tool the control cannot be run at all.** `ChipToolCommandError` covers discovery, PASE,
+attestation, CASE, timeout and argument-parse failures alike, so a give-up is indistinguishable from a
+controller that failed for any other reason — and the attempt would spend chip-tool's own discovery
+timeout to record a pass that examined nothing. The step records an `unverified` check carrying
+`accepted` instead, and makes no attempt. This is the shape to reach for whenever a controller cannot
+exhibit the thing a check is about: state the gap in the bundle, do not spend time producing a verdict
+that could not have failed.
+
+**Budgets.** `ABSENT_DEVICE_GIVE_UP` (20s) is what the DUT is asked to spend; `ABSENT_DEVICE_WAIT`
+(90s) is how long the harness waits for that give-up. They must not be equal: a wait equal to the
+deadline it is waiting on observes the attempt still pending and records the DUT as having neither
+onboarded nor refused. TC-DD-3.17 step 4 sets the same pair, and its comment records chip-tool's own
+give-up as roughly 45 seconds where a measured run of this control saw 30 — take 45 as the bound.
+
+**Where it goes.** A precondition step numbered `0`, before the first commissioning whose evidence
+rests on it, following the `0.1`/`0.2` precedent in TC-IDM-1.3. The claim is about the commissioner
+rather than about any plan step, and a step of its own is also the only placement no PICS gate can
+skip: attaching it to TC-DD-3.14's `3.b`, which is gated on `MCORE.DD.DISCOVERY_BLE`, let a DUT
+without BLE skip the control and commission unbacked two steps later. No plan table numbers a step
+`0`, so the step's `expected` text says it is a precondition — a reviewer diffing bundle against plan
+has to be able to see why it is there.
 
 The test case owns a `CommissioningRefusals` for the attempt and settles it in `finalize` alongside
 `decommissionAll`, through `runCleanups` so a failing settle cannot skip the decommission.
 
 **What this still does not cover.** Which discovery capability the DUT honoured: every leg commissions
-over IP whatever the payload's bitmask says, so that field remains parse evidence only.
+over IP whatever the payload's bitmask says, so that field remains parse evidence only. And the
+substituted discriminator is only known absent from `cx.devices` — a foreign commissionable device on
+the LAN answering it would make matter.js record a failure for an unrelated reason. The value is
+deterministic, so if that ever happens it happens every run.
 
 ## A flow the TH cannot publish has to be fabricated (`TC-DD-3.12`, `TC-DD-3.13`)
 

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1898,8 +1898,11 @@ that could not have failed.
 **Budgets.** `ABSENT_DEVICE_GIVE_UP` (20s) is what the DUT is asked to spend; `ABSENT_DEVICE_WAIT`
 (90s) is how long the harness waits for that give-up. They must not be equal: a wait equal to the
 deadline it is waiting on observes the attempt still pending and records the DUT as having neither
-onboarded nor refused. TC-DD-3.17 step 4 sets the same pair, and its comment records chip-tool's own
-give-up as roughly 45 seconds where a measured run of this control saw 30 — take 45 as the bound.
+onboarded nor refused. Only matter.js reaches the attempt, and it honors the bound, so the slack
+between the two is for a loaded runner delivering the rejection late rather than for a controller
+that ignores the deadline. Erring long only delays reporting a DUT that hangs; erring short fails a
+working one. If the chip-tool path ever runs the attempt, the wait has to outlast chip-tool's own
+give-up instead — TC-DD-3.17 step 4 documents that as roughly 45 seconds and sets this same pair.
 
 **Where it goes.** A precondition step numbered `0`, before the first commissioning whose evidence
 rests on it, following the `0.1`/`0.2` precedent in TC-IDM-1.3. The claim is about the commissioner

--- a/support/chip-testing/test/cert/TC-DD-1.8.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-1.8.test.ts
@@ -74,6 +74,16 @@ certTest("TC-DD-1.8", {
     app: "all-clusters",
 })
     .step(
+        "0",
+        "Precondition: the DUT is a commissioner that uses the discriminator its onboarding code names.",
+        cx => recordDiscriminatorHonored(cx, refusals),
+        {
+            expected:
+                "DUT does not commission the TH from a code naming a discriminator no device advertises. " +
+                "Every later step's commissioning rests on this.",
+        },
+    )
+    .step(
         1,
         "Scan the TH Device's QR code using DUT",
         async cx => {
@@ -86,7 +96,6 @@ certTest("TC-DD-1.8", {
         "Using the DUT, parse the TH's QR code to onboard the TH Device onto the Matter network.",
         async cx => {
             const payload = await thQrPayload(cx.devices.th);
-            await recordDiscriminatorHonored(cx, payload, refusals);
             await commissionByQr(cx, payload, commissioned);
         },
         { expected: "Verify the TH's QR code was parsed successfully by the DUT" },

--- a/support/chip-testing/test/cert/TC-DD-1.8.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-1.8.test.ts
@@ -8,8 +8,14 @@ import { Bytes, InternalError } from "@matter/main";
 import type { QrCodeData } from "@matter/main/types";
 import { QrPairingCodeCodec } from "@matter/main/types";
 import { certTest } from "@matter/testing";
-import { commissionByQr, recordParse, thQrPayload } from "./tc-dd-support.js";
-import { CommissionedRefs } from "./tc-support.js";
+import {
+    commissionByQr,
+    CommissioningRefusals,
+    recordDiscriminatorHonored,
+    recordParse,
+    thQrPayload,
+} from "./tc-dd-support.js";
+import { CommissionedRefs, runCleanups } from "./tc-support.js";
 
 /**
  * The plan's own example TLV payload (§ 5.1.5): an anonymous structure carrying serial number
@@ -28,6 +34,7 @@ const LARGE_QR_CODE_LENGTH = 255;
 const LARGE_TLV_STRING_LENGTH = 135;
 
 const commissioned = new CommissionedRefs();
+const refusals = new CommissioningRefusals();
 
 function decodeSingle(payload: string): QrCodeData {
     const payloads = QrPairingCodeCodec.decode(payload);
@@ -79,7 +86,7 @@ certTest("TC-DD-1.8", {
         "Using the DUT, parse the TH's QR code to onboard the TH Device onto the Matter network.",
         async cx => {
             const payload = await thQrPayload(cx.devices.th);
-            await recordParse(cx, payload);
+            await recordDiscriminatorHonored(cx, payload, refusals);
             await commissionByQr(cx, payload, commissioned);
         },
         { expected: "Verify the TH's QR code was parsed successfully by the DUT" },
@@ -97,7 +104,6 @@ certTest("TC-DD-1.8", {
         "Using the DUT, parse the TH's QR code to onboard the TH Device onto the Matter network.",
         async cx => {
             const payload = withTlvData(await thQrPayload(cx.devices.th), PLAN_TLV_DATA);
-            await recordParse(cx, payload);
             await commissionByQr(cx, payload, commissioned);
         },
         {
@@ -120,7 +126,6 @@ certTest("TC-DD-1.8", {
         "Using the DUT, parse the TH's QR code to onboard the TH Device onto the Matter network.",
         async cx => {
             const payload = largeQrPayload(await thQrPayload(cx.devices.th));
-            await recordParse(cx, payload);
             await commissionByQr(cx, payload, commissioned);
         },
         {
@@ -129,4 +134,9 @@ certTest("TC-DD-1.8", {
                 "DUT may ignore the TLV contents)",
         },
     )
-    .finalize(cx => commissioned.decommissionAll(cx));
+    .finalize(cx =>
+        runCleanups(
+            () => refusals.settle(cx),
+            () => commissioned.decommissionAll(cx),
+        ),
+    );

--- a/support/chip-testing/test/cert/TC-DD-3.11.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.11.test.ts
@@ -8,9 +8,11 @@ import { DiscoveryCapabilitiesSchema } from "@matter/main/types";
 import { certTest } from "@matter/testing";
 import {
     commissionByQr,
+    CommissioningRefusals,
     ON_NETWORK_ONLY,
     qrPayloadWith,
     recordCommissionable,
+    recordDiscriminatorHonored,
     recordGeneratedPayload,
     recordParse,
     recordPayloadOffering,
@@ -18,7 +20,7 @@ import {
     STANDARD_VERSION,
     thQrPayload,
 } from "./tc-dd-support.js";
-import { CommissionedRefs } from "./tc-support.js";
+import { CommissionedRefs, runCleanups } from "./tc-support.js";
 
 /**
  * Why the two transport-specific commissioning steps cannot be run rather than skipped.
@@ -40,6 +42,7 @@ const BLE_ONLY = DiscoveryCapabilitiesSchema.encode({ ble: true });
 const WIFI_PAF_ONLY = DiscoveryCapabilitiesSchema.encode({ wifiPublicActionFrame: true });
 
 const commissioned = new CommissionedRefs();
+const refusals = new CommissioningRefusals();
 
 certTest("TC-DD-3.11", {
     plan: "devicediscovery.adoc",
@@ -183,8 +186,14 @@ certTest("TC-DD-3.11", {
                 discoveryCapabilities: ON_NETWORK_ONLY,
             });
             await recordCommissionable(cx);
+            await recordDiscriminatorHonored(cx, payload, refusals);
             await commissionByQr(cx, payload, commissioned);
         },
         { expected: "DUT parses QR code and DUT commissions TH to the Matter network" },
     )
-    .finalize(cx => commissioned.decommissionAll(cx));
+    .finalize(cx =>
+        runCleanups(
+            () => refusals.settle(cx),
+            () => commissioned.decommissionAll(cx),
+        ),
+    );

--- a/support/chip-testing/test/cert/TC-DD-3.11.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.11.test.ts
@@ -189,9 +189,9 @@ certTest("TC-DD-3.11", {
         "Using the DUT, parse the TH's QR code and follow any steps needed for the Commissioner/Commissionee to " +
             "complete the commissioning process using IP Network",
         async cx => {
-            // The parse and the capability it offers are step 3.b's claims, and 3.b is where the
-            // PICS gate for them sits; recording them again here would put a pass for a skipped
-            // step's claim in the same bundle
+            // The capability offering is step 3.b's claim and 3.b is where its PICS gate sits;
+            // recording it again here would put a pass for a skipped step's claim in the same bundle.
+            // The parse below it is `commissionByQr`'s own, about the code this commissioning used
             const payload = qrPayloadWith(await thQrPayload(cx.devices.th), {
                 discoveryCapabilities: ON_NETWORK_ONLY,
             });

--- a/support/chip-testing/test/cert/TC-DD-3.11.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.11.test.ts
@@ -50,6 +50,16 @@ certTest("TC-DD-3.11", {
     app: "all-clusters",
 })
     .step(
+        "0",
+        "Precondition: the DUT is a commissioner that uses the discriminator its onboarding code names.",
+        cx => recordDiscriminatorHonored(cx, refusals),
+        {
+            expected:
+                "DUT does not commission the TH from a code naming a discriminator no device advertises. " +
+                "Every later step's commissioning rests on this.",
+        },
+    )
+    .step(
         "1.a",
         "Standard Commissioning Flow: Use a Commissionee with a QR code that has the Custom Flow field set to 0 " +
             "and supports BLE for its Discovery Capability. Ensure the Version bit string follows the current " +
@@ -186,7 +196,6 @@ certTest("TC-DD-3.11", {
                 discoveryCapabilities: ON_NETWORK_ONLY,
             });
             await recordCommissionable(cx);
-            await recordDiscriminatorHonored(cx, payload, refusals);
             await commissionByQr(cx, payload, commissioned);
         },
         { expected: "DUT parses QR code and DUT commissions TH to the Matter network" },

--- a/support/chip-testing/test/cert/TC-DD-3.14.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.14.test.ts
@@ -7,13 +7,14 @@
 import { certTest } from "@matter/testing";
 import {
     checkGeneratedPayload,
-    CommissioningRefusals,
     commissionByQr,
+    CommissioningRefusals,
     INVALID_PASSCODES,
     onNetworkOnlyPayload,
     qrPayloadWith,
     qrPayloadWithPrefix,
     recordDiscoveryCapabilityAbsent,
+    recordDiscriminatorHonored,
     recordGeneratedPayload,
     recordParse,
     thQrPayload,
@@ -91,7 +92,9 @@ certTest("TC-DD-3.14", {
         "3.b",
         "Scan/read the QR code of the TH device using the DUT",
         async cx => {
-            await commissionByQr(cx, await onNetworkOnlyPayload(cx), commissioned);
+            const payload = await onNetworkOnlyPayload(cx);
+            await recordDiscriminatorHonored(cx, payload, refusals);
+            await commissionByQr(cx, payload, commissioned);
         },
         {
             pics: "MCORE.DD.DISCOVERY_BLE",

--- a/support/chip-testing/test/cert/TC-DD-3.14.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.14.test.ts
@@ -36,6 +36,16 @@ certTest("TC-DD-3.14", {
     app: "all-clusters",
 })
     .step(
+        "0",
+        "Precondition: the DUT is a commissioner that uses the discriminator its onboarding code names.",
+        cx => recordDiscriminatorHonored(cx, refusals),
+        {
+            expected:
+                "DUT does not commission the TH from a code naming a discriminator no device advertises. " +
+                "Every later step's commissioning rests on this.",
+        },
+    )
+    .step(
         1,
         "Locate and scan/read the Commissionee's QR code using DUT",
         async cx => {
@@ -93,7 +103,6 @@ certTest("TC-DD-3.14", {
         "Scan/read the QR code of the TH device using the DUT",
         async cx => {
             const payload = await onNetworkOnlyPayload(cx);
-            await recordDiscriminatorHonored(cx, payload, refusals);
             await commissionByQr(cx, payload, commissioned);
         },
         {

--- a/support/chip-testing/test/cert/TC-DD-3.18.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.18.test.ts
@@ -11,8 +11,10 @@ import { certTest } from "@matter/testing";
 import { expectMdns } from "../../src/cert/mdns-check.js";
 import {
     commissionByQr,
+    CommissioningRefusals,
     MDNS_TIMEOUT,
     qrPayloadFields,
+    recordDiscriminatorHonored,
     recordNotCommissioned,
     recordParse,
     thQrPayload,
@@ -26,6 +28,7 @@ const VENDOR_ID = requireId(BASIC_INFORMATION.attributes.require("vendorId").id,
 // One per device rather than one keyed by device: `CommissionedRefs` removes each fabric through
 // `cx.controllers[role]`, and both of these harnesses are commissioned by the same controller.
 const th1Commissioned = new CommissionedRefs();
+const refusals = new CommissioningRefusals();
 const th2Commissioned = new CommissionedRefs();
 
 /**
@@ -139,7 +142,9 @@ certTest("TC-DD-3.18", {
             const { th1, th2 } = await distinctSubjects(cx);
             const th2From = await th2.log.markSettled();
 
-            await commissionByQr(cx, await thQrPayload(th1), th1Commissioned, th1);
+            const payload = await thQrPayload(th1);
+            await recordDiscriminatorHonored(cx, payload, refusals, th1);
+            await commissionByQr(cx, payload, th1Commissioned, th1);
 
             // "Only TH1" is a claim about TH2, and TH2's own log is what states it. A commissionable
             // probe cannot: it is answered out of the shared DNS-SD cache, which still holds the
@@ -195,6 +200,7 @@ certTest("TC-DD-3.18", {
     )
     .finalize(cx =>
         runCleanups(
+            () => refusals.settle(cx),
             () => th1Commissioned.decommissionAll(cx),
             () => th2Commissioned.decommissionAll(cx),
         ),

--- a/support/chip-testing/test/cert/TC-DD-3.18.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.18.test.ts
@@ -108,6 +108,16 @@ certTest("TC-DD-3.18", {
     devices: { th1: "all-clusters", th2: "all-clusters" },
 })
     .step(
+        "0",
+        "Precondition: the DUT is a commissioner that uses the discriminator its onboarding code names.",
+        cx => recordDiscriminatorHonored(cx, refusals, cx.devices.th1),
+        {
+            expected:
+                "DUT does not commission the TH from a code naming a discriminator no device advertises. " +
+                "Every later step's commissioning rests on this.",
+        },
+    )
+    .step(
         "1.a",
         "Place TH1 into commissioning mode using the TH manufacturer's means to be discovered by a commissioner",
         async cx => {
@@ -143,7 +153,6 @@ certTest("TC-DD-3.18", {
             const th2From = await th2.log.markSettled();
 
             const payload = await thQrPayload(th1);
-            await recordDiscriminatorHonored(cx, payload, refusals, th1);
             await commissionByQr(cx, payload, th1Commissioned, th1);
 
             // "Only TH1" is a claim about TH2, and TH2's own log is what states it. A commissionable

--- a/support/chip-testing/test/cert/TC-DD-3.20.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.20.test.ts
@@ -40,6 +40,16 @@ certTest("TC-DD-3.20", {
     app: "all-clusters",
 })
     .step(
+        "0",
+        "Precondition: the DUT is a commissioner that uses the discriminator its onboarding code names.",
+        cx => recordDiscriminatorHonored(cx, refusals),
+        {
+            expected:
+                "DUT does not commission the TH from a code naming a discriminator no device advertises. " +
+                "Every later step's commissioning rests on this.",
+        },
+    )
+    .step(
         1,
         "Place TH into commissioning mode using the TH manufacturer's means to be discovered by the DUT Commissioner",
         recordCommissionable,
@@ -59,7 +69,6 @@ certTest("TC-DD-3.20", {
             "commissioning process over the TH Commissionee's method of device discovery",
         async cx => {
             const payload = await thQrPayload(cx.devices.th);
-            await recordDiscriminatorHonored(cx, payload, refusals);
             await commissionByQr(cx, payload, commissioned);
         },
         {

--- a/support/chip-testing/test/cert/TC-DD-3.20.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.20.test.ts
@@ -9,15 +9,18 @@ import { certTest } from "@matter/testing";
 import type { TransitionMark } from "./tc-dd-support.js";
 import {
     commissionByQr,
+    CommissioningRefusals,
     recordBackInCommissioningMode,
     recordCommissionable,
+    recordDiscriminatorHonored,
     recordParse,
     recordUnpair,
     thQrPayload,
 } from "./tc-dd-support.js";
-import { CommissionedRefs } from "./tc-support.js";
+import { CommissionedRefs, runCleanups } from "./tc-support.js";
 
 const commissioned = new CommissionedRefs();
+const refusals = new CommissioningRefusals();
 
 // Step 4's claim is about a transition step 3 caused, so its evidence has to start before that
 // removal. A mark taken in step 4 can already be past the device's own announcement, and the network
@@ -55,7 +58,9 @@ certTest("TC-DD-3.20", {
         "DUT parses TH's QR code. Follow any steps needed for the Commissioner/Commissionee to complete the " +
             "commissioning process over the TH Commissionee's method of device discovery",
         async cx => {
-            await commissionByQr(cx, await thQrPayload(cx.devices.th), commissioned);
+            const payload = await thQrPayload(cx.devices.th);
+            await recordDiscriminatorHonored(cx, payload, refusals);
+            await commissionByQr(cx, payload, commissioned);
         },
         {
             expected:
@@ -101,4 +106,9 @@ certTest("TC-DD-3.20", {
                 "been commissioned onto the Matter network.",
         },
     )
-    .finalize(cx => commissioned.decommissionAll(cx));
+    .finalize(cx =>
+        runCleanups(
+            () => refusals.settle(cx),
+            () => commissioned.decommissionAll(cx),
+        ),
+    );

--- a/support/chip-testing/test/cert/TC-DD-3.21.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.21.test.ts
@@ -11,11 +11,13 @@ import { certTest } from "@matter/testing";
 import {
     commissionByQr,
     COMMISSIONING_LOG_TIMEOUT,
+    CommissioningRefusals,
     recordCommissionable,
+    recordDiscriminatorHonored,
     recordParse,
     thQrPayload,
 } from "./tc-dd-support.js";
-import { CommissionedRefs, expectCommandInvoke, record, requireId } from "./tc-support.js";
+import { CommissionedRefs, expectCommandInvoke, record, requireId, runCleanups } from "./tc-support.js";
 
 const DESCRIPTOR = Matter.clusters.require("Descriptor");
 const DESCRIPTOR_ID = requireId(DESCRIPTOR.id, "Descriptor cluster");
@@ -33,6 +35,7 @@ const ROOT_ENDPOINT = 0;
 const ON_OFF_LIGHT_DEVICE_TYPE = 0x0100;
 
 const commissioned = new CommissionedRefs();
+const refusals = new CommissioningRefusals();
 
 function isDeviceType(entry: unknown, deviceType: number): boolean {
     return typeof entry === "object" && entry !== null && "deviceType" in entry && entry.deviceType === deviceType;
@@ -101,7 +104,9 @@ certTest("TC-DD-3.21", {
         "DUT parses TH's QR code. Follow any steps needed for the Commissioner/Commissionee to complete the " +
             "commissioning process over the TH Commissionee's method of device discovery",
         async cx => {
-            await commissionByQr(cx, await thQrPayload(cx.devices.th), commissioned);
+            const payload = await thQrPayload(cx.devices.th);
+            await recordDiscriminatorHonored(cx, payload, refusals);
+            await commissionByQr(cx, payload, commissioned);
         },
         {
             expected:
@@ -165,4 +170,9 @@ certTest("TC-DD-3.21", {
                 "expose an On/Off light device type.",
         },
     )
-    .finalize(cx => commissioned.decommissionAll(cx));
+    .finalize(cx =>
+        runCleanups(
+            () => refusals.settle(cx),
+            () => commissioned.decommissionAll(cx),
+        ),
+    );

--- a/support/chip-testing/test/cert/TC-DD-3.21.test.ts
+++ b/support/chip-testing/test/cert/TC-DD-3.21.test.ts
@@ -86,6 +86,16 @@ certTest("TC-DD-3.21", {
     app: "all-clusters",
 })
     .step(
+        "0",
+        "Precondition: the DUT is a commissioner that uses the discriminator its onboarding code names.",
+        cx => recordDiscriminatorHonored(cx, refusals),
+        {
+            expected:
+                "DUT does not commission the TH from a code naming a discriminator no device advertises. " +
+                "Every later step's commissioning rests on this.",
+        },
+    )
+    .step(
         1,
         "Place TH into commissioning mode using the TH manufacturer's means to be discovered by the DUT Commissioner",
         recordCommissionable,
@@ -105,7 +115,6 @@ certTest("TC-DD-3.21", {
             "commissioning process over the TH Commissionee's method of device discovery",
         async cx => {
             const payload = await thQrPayload(cx.devices.th);
-            await recordDiscriminatorHonored(cx, payload, refusals);
             await commissionByQr(cx, payload, commissioned);
         },
         {

--- a/support/chip-testing/test/cert/tc-dd-flow-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-flow-support.ts
@@ -8,17 +8,19 @@ import { DiscoveryCapabilitiesSchema } from "@matter/main/types";
 import type { CertStepContext, CertTestBuilder } from "@matter/testing";
 import {
     commissionByQr,
+    CommissioningRefusals,
     flowTitle,
     ON_NETWORK_ONLY,
     qrPayloadWith,
     recordCommissionable,
+    recordDiscriminatorHonored,
     recordGeneratedPayload,
     recordParse,
     recordPayloadOffering,
     STANDARD_VERSION,
     thQrPayload,
 } from "./tc-dd-support.js";
-import { CommissionedRefs } from "./tc-support.js";
+import { CommissionedRefs, runCleanups } from "./tc-support.js";
 
 const BLE_ONLY = DiscoveryCapabilitiesSchema.encode({ ble: true });
 const WIFI_PAF_ONLY = DiscoveryCapabilitiesSchema.encode({ wifiPublicActionFrame: true });
@@ -67,6 +69,7 @@ const NOT_COMMISSIONABLE_UNAVAILABLE =
 export function defineFlowQrTest(builder: CertTestBuilder, flowType: number): CertTestBuilder {
     const title = flowTitle(flowType);
     const commissioned = new CommissionedRefs();
+    const refusals = new CommissioningRefusals();
 
     const NOTHING_COMMISSIONS = "no step of this leg commissions the TH, so nothing acts on the flow either";
 
@@ -168,8 +171,10 @@ export function defineFlowQrTest(builder: CertTestBuilder, flowType: number): Ce
                     `commissioning mode and to complete the commissioning process using ${leg.transport}.`,
                 leg.capability === "onIpNetwork"
                     ? async cx => {
+                          const payload = await payloadFor(cx);
                           await recordCommissionable(cx);
-                          await commissionByQr(cx, await payloadFor(cx), commissioned);
+                          await recordDiscriminatorHonored(cx, payload, refusals);
+                          await commissionByQr(cx, payload, commissioned);
                       }
                     : async () => {},
                 leg.capability === "onIpNetwork"
@@ -178,5 +183,10 @@ export function defineFlowQrTest(builder: CertTestBuilder, flowType: number): Ce
             );
     }
 
-    return builder.finalize(cx => commissioned.decommissionAll(cx));
+    return builder.finalize(cx =>
+        runCleanups(
+            () => refusals.settle(cx),
+            () => commissioned.decommissionAll(cx),
+        ),
+    );
 }

--- a/support/chip-testing/test/cert/tc-dd-flow-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-flow-support.ts
@@ -100,6 +100,17 @@ export function defineFlowQrTest(builder: CertTestBuilder, flowType: number): Ce
         },
     ];
 
+    builder.step(
+        "0",
+        "Precondition: the DUT is a commissioner that uses the discriminator its onboarding code names.",
+        cx => recordDiscriminatorHonored(cx, refusals),
+        {
+            expected:
+                "DUT does not commission the TH from a code naming a discriminator no device advertises. " +
+                "Every later step's commissioning rests on this.",
+        },
+    );
+
     for (const leg of legs) {
         // Both `.b` and `.c` parse the code themselves, so both need the scan gate
         const scanGate = leg.pics === undefined ? "MCORE.DD.SCAN_QR_CODE" : `MCORE.DD.SCAN_QR_CODE & ${leg.pics}`;
@@ -171,10 +182,8 @@ export function defineFlowQrTest(builder: CertTestBuilder, flowType: number): Ce
                     `commissioning mode and to complete the commissioning process using ${leg.transport}.`,
                 leg.capability === "onIpNetwork"
                     ? async cx => {
-                          const payload = await payloadFor(cx);
                           await recordCommissionable(cx);
-                          await recordDiscriminatorHonored(cx, payload, refusals);
-                          await commissionByQr(cx, payload, commissioned);
+                          await commissionByQr(cx, await payloadFor(cx), commissioned);
                       }
                     : async () => {},
                 leg.capability === "onIpNetwork"

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -754,23 +754,30 @@ export class CommissioningRefusals {
 }
 
 /**
- * How long the DUT is given to conclude the device a code names is not on the network. Discovery for
- * a discriminator nothing answers has nothing to finish early on, so a step spends this in full. The
- * wait for the outcome is {@link REFUSAL_TIMEOUT} rather than this: a give-up that lands exactly when
- * its own deadline expires has to be observed after it, not in a race with it.
+ * What the DUT is asked to spend looking for a device that is not there. matter.js honors it;
+ * chip-tool cannot be bounded and stops on its own after roughly 45 seconds, which is why
+ * {@link ABSENT_DEVICE_WAIT} has to outlast that rather than this. TC-DD-3.17's step 4 sets the same
+ * pair for the same reason.
  */
-export const ABSENT_DEVICE_TIMEOUT = Seconds(5);
+export const ABSENT_DEVICE_GIVE_UP = Seconds(20);
+
+/**
+ * How long the harness waits for that give-up. A wait equal to the deadline it is waiting on observes
+ * the attempt still pending and records the DUT as having neither onboarded nor refused.
+ */
+export const ABSENT_DEVICE_WAIT = Seconds(90);
 
 /** § 5.1.3.1 Table 59's discriminator field, which is what a substituted value has to fit. */
 const DISCRIMINATOR_MASK = 0xfff;
 
 /**
- * A discriminator no device in this run advertises. Devices take consecutive values from
- * `identityFor`, so inverting one lands far outside the span however many the plan declares — and a
- * value that did name a device would turn the check below into an ordinary commissioning.
+ * A discriminator no device in this run advertises, derived from the one `payload` names so the
+ * substitution is guaranteed to change the field. Devices take consecutive values from `identityFor`,
+ * so inverting one lands far outside the span however many the plan declares — and a value that did
+ * name a device would turn the check below into an ordinary commissioning.
  */
-function absentDiscriminator(cx: CertStepContext, th: CertDevice): number {
-    const absent = th.commissioning.discriminator ^ DISCRIMINATOR_MASK;
+function absentDiscriminator(cx: CertStepContext, payload: string): number {
+    const absent = qrPayloadFields(payload).discriminator ^ DISCRIMINATOR_MASK;
     for (const device of Object.values(cx.devices)) {
         if (device.commissioning.discriminator === absent) {
             throw new InternalError(
@@ -788,26 +795,54 @@ function absentDiscriminator(cx: CertStepContext, th: CertDevice): number {
  * Every other check about a payload asks what the DUT *read*, and a commissioning that succeeds
  * proves only the passcode, which SPAKE2+ settles on its own. On a network holding one commissionable
  * device, a commissioner that discarded the discriminator entirely satisfies all of them and onboards
- * the TH anyway. Handing it the same payload with a discriminator nothing advertises separates the
- * two: a DUT that uses the field gives up, and one that ignores it commissions and fails this check.
+ * the TH anyway. Offering it the TH's own payload with a discriminator nothing advertises separates
+ * the two: a DUT that uses the field cannot find the device, and one that ignores it commissions and
+ * fails this check.
+ *
+ * Two things the evidence has to carry, because here a refusal is what a pass looks like:
+ *
+ * - The TH has to be observed advertising first, or the DUT gives up because there was nothing to
+ *   find and the check passes on the TH's absence rather than on the DUT's use of the field. This is
+ *   the guard {@link recordVendorOutcome} states for the same reason.
+ * - Only a give-up counts ({@link isCommissioningGiveUp}), unlike
+ *   {@link CommissioningRefusals.requireNoCommissioning}, which takes any failure because the plan it
+ *   serves has no commissionee at all. Here the TH is present and the code is well-formed, so a
+ *   payload refusal means the DUT never reached discovery and a controller that would not start
+ *   proves nothing.
  *
  * The claim is about the commissioner rather than about any one step, so a test case establishes it
- * once, before the first commissioning whose evidence rests on it.
+ * once, in a precondition step of its own that no PICS gate can skip.
  */
 export async function recordDiscriminatorHonored(
     cx: CertStepContext,
-    payload: string,
     refusals: CommissioningRefusals,
     subject?: CertDevice,
+    /** Overridden by the unit tests, which have no advertisement to observe. */
+    probeCommissionable: (cx: CertStepContext, what: string, th: CertDevice) => Promise<void> = recordCommissionable,
 ): Promise<void> {
     const th = subject ?? theTh(cx);
-    const absent = qrPayloadWith(payload, { discriminator: absentDiscriminator(cx, th) });
+    const payload = await thQrPayload(th);
+    const absent = absentDiscriminator(cx, payload);
+    const code = qrPayloadWith(payload, { discriminator: absent });
 
-    await refusals.requireNoCommissioning(
+    await probeCommissionable(cx, `${th.id} advertising before the DUT is offered discriminator ${absent}`, th);
+
+    const label = `commissioning from a code naming discriminator ${absent}`;
+    const attempt = cx.controllers.dut.commission({ qrPairingCode: code, giveUpAfterMs: ABSENT_DEVICE_GIVE_UP });
+    refusals.track(attempt);
+
+    const outcome = await expectRejection(label, attempt, ABSENT_DEVICE_WAIT, isCommissioningGiveUp);
+
+    record(
         cx,
-        { qrPairingCode: absent, giveUpAfterMs: ABSENT_DEVICE_TIMEOUT },
+        {
+            ...outcome,
+            detail:
+                `${outcome.detail ?? label}; the code is ${th.id}'s own payload with discriminator ` +
+                `${qrPayloadFields(payload).discriminator} replaced by ${absent}, which no device in this run ` +
+                "advertises",
+        },
         "DUT commissions the device its code names",
-        REFUSAL_TIMEOUT,
     );
 }
 

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -754,16 +754,21 @@ export class CommissioningRefusals {
 }
 
 /**
- * What the DUT is asked to spend looking for a device that is not there. matter.js honors it;
- * chip-tool cannot be bounded and stops on its own after roughly 45 seconds, which is why
- * {@link ABSENT_DEVICE_WAIT} has to outlast that rather than this. TC-DD-3.17's step 4 sets the same
- * pair for the same reason.
+ * What the DUT is asked to spend looking for a device that is not there. Only matter.js reaches this,
+ * and it honors the bound — {@link recordDiscriminatorHonored} states the gap and makes no attempt on
+ * chip-tool, which cannot be bounded at all.
  */
 export const ABSENT_DEVICE_GIVE_UP = Seconds(20);
 
 /**
- * How long the harness waits for that give-up. A wait equal to the deadline it is waiting on observes
- * the attempt still pending and records the DUT as having neither onboarded nor refused.
+ * How long the harness waits for that give-up: the deadline above, plus enough slack that a loaded
+ * runner delivering the rejection late is not read as the DUT having neither onboarded nor refused. A
+ * wait equal to the deadline it waits on observes the attempt still pending and records exactly that,
+ * which is why the two must not be the same value. Erring long only delays reporting a DUT that hangs;
+ * erring short fails a working one.
+ *
+ * Should the chip-tool path ever run the attempt, this has to outlast chip-tool's own give-up instead
+ * — TC-DD-3.17's step 4 documents that as roughly 45 seconds and sets this same pair for it.
  */
 export const ABSENT_DEVICE_WAIT = Seconds(90);
 

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -19,7 +19,7 @@ import {
 import { Base38, DiscoveryCapabilitiesBitmap, DiscoveryCapabilitiesSchema } from "@matter/main/types";
 import type { CertNodeRef, CertStepContext, CheckRecord, CommissioningTarget } from "@matter/testing";
 import type { CertDevice } from "@matter/testing";
-import { forFlavor } from "@matter/testing";
+import { forFlavor, resolveControllerImplementation } from "@matter/testing";
 import { ChipToolCommandError } from "../../src/cert/ChipToolControllerAdapter.js";
 import { expectMdns } from "../../src/cert/mdns-check.js";
 import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload.js";
@@ -441,9 +441,9 @@ function readBits(data: Uint8Array, { offset, length }: { offset: number; length
  * The fields go in as bits rather than through matter.js's own encoder. An unsupported version and the
  * trivial passcodes are exactly what that encoder validates against on the way out (§ 5.1.3.1,
  * § 5.1.7.1), so it cannot produce them at all; the flow and the discovery capabilities it would write
- * happily, but no subject this harness runs publishes the values the plans ask for. One substitution
- * path covers both. The TLV data that may follow the fixed 11-byte structure is carried through
- * untouched.
+ * happily, but no subject this harness runs publishes the values the plans ask for, and a
+ * discriminator naming no device at all is the same case. One substitution path covers all of them.
+ * The TLV data that may follow the fixed 11-byte structure is carried through untouched.
  */
 export function qrPayloadWith(
     payload: string,
@@ -804,11 +804,11 @@ function absentDiscriminator(cx: CertStepContext, payload: string): number {
  * - The TH has to be observed advertising first, or the DUT gives up because there was nothing to
  *   find and the check passes on the TH's absence rather than on the DUT's use of the field. This is
  *   the guard {@link recordVendorOutcome} states for the same reason.
- * - Only a give-up counts ({@link isCommissioningGiveUp}), unlike
- *   {@link CommissioningRefusals.requireNoCommissioning}, which takes any failure because the plan it
- *   serves has no commissionee at all. Here the TH is present and the code is well-formed, so a
- *   payload refusal means the DUT never reached discovery and a controller that would not start
- *   proves nothing.
+ * - Only a give-up counts ({@link isCommissioningGiveUp}), where
+ *   {@link CommissioningRefusals.requireNoCommissioning} takes every failure but a payload refusal —
+ *   it serves a plan with no commissionee at all, so anything that is not the code being rejected
+ *   satisfies it. Here the TH is present and the code is well-formed, so a controller that would not
+ *   start would satisfy that looser test while proving nothing.
  *
  * The claim is about the commissioner rather than about any one step, so a test case establishes it
  * once, in a precondition step of its own that no PICS gate can skip.
@@ -823,6 +823,24 @@ export async function recordDiscriminatorHonored(
     const th = subject ?? theTh(cx);
     const payload = await thQrPayload(th);
     const absent = absentDiscriminator(cx, payload);
+
+    if (resolveControllerImplementation() === "chip-tool") {
+        record(
+            cx,
+            {
+                type: "response",
+                verdict: "unverified",
+                detail: `discriminator ${absent} was not offered to the DUT`,
+                accepted:
+                    "chip-tool funnels discovery, PASE, attestation, CASE, timeout and argument-parse failures " +
+                    "alike into one command error, so a give-up cannot be told from a controller that failed for " +
+                    "another reason, and the attempt would cost its own discovery timeout to prove nothing",
+            },
+            "DUT commissions the device its code names",
+        );
+        return;
+    }
+
     const code = qrPayloadWith(payload, { discriminator: absent });
 
     await probeCommissionable(cx, `${th.id} advertising before the DUT is offered discriminator ${absent}`, th);
@@ -912,8 +930,8 @@ export async function thCodeParts(
  * parse is the DUT's: a step that decoded the code itself would pass against a controller that
  * cannot read one.
  */
-export async function recordManualParse(cx: CertStepContext, code: string, th?: CertDevice): Promise<void> {
-    th ??= theTh(cx);
+export async function recordManualParse(cx: CertStepContext, code: string): Promise<void> {
+    const th = theTh(cx);
 
     let parsed;
     try {
@@ -1281,8 +1299,6 @@ async function commissionByTarget(
     // completion line as one that read it, so the code has to be evidence in its own right
     if (target.qrPairingCode !== undefined) {
         await recordParse(cx, target.qrPairingCode, th);
-    } else if (target.manualPairingCode !== undefined) {
-        await recordManualParse(cx, target.manualPairingCode, th);
     }
 
     // Settled, because the line this waits for names no fabric on either flavor: a completion still

--- a/support/chip-testing/test/cert/tc-dd-support.ts
+++ b/support/chip-testing/test/cert/tc-dd-support.ts
@@ -447,7 +447,13 @@ function readBits(data: Uint8Array, { offset, length }: { offset: number; length
  */
 export function qrPayloadWith(
     payload: string,
-    fields: { version?: number; passcode?: number; discoveryCapabilities?: number; flowType?: number },
+    fields: {
+        version?: number;
+        passcode?: number;
+        discoveryCapabilities?: number;
+        flowType?: number;
+        discriminator?: number;
+    },
 ): string {
     if (!payload.startsWith(QR_PREFIX)) {
         throw new InternalError(`Cannot substitute fields into "${payload}", which is not a QR onboarding payload`);
@@ -465,6 +471,9 @@ export function qrPayloadWith(
     }
     if (fields.flowType !== undefined) {
         writeBits(data, FLOW_TYPE_BITS, fields.flowType);
+    }
+    if (fields.discriminator !== undefined) {
+        writeBits(data, DISCRIMINATOR_BITS, fields.discriminator);
     }
     return QR_PREFIX + Base38.encode(data);
 }
@@ -744,6 +753,64 @@ export class CommissioningRefusals {
     }
 }
 
+/**
+ * How long the DUT is given to conclude the device a code names is not on the network. Discovery for
+ * a discriminator nothing answers has nothing to finish early on, so a step spends this in full. The
+ * wait for the outcome is {@link REFUSAL_TIMEOUT} rather than this: a give-up that lands exactly when
+ * its own deadline expires has to be observed after it, not in a race with it.
+ */
+export const ABSENT_DEVICE_TIMEOUT = Seconds(5);
+
+/** § 5.1.3.1 Table 59's discriminator field, which is what a substituted value has to fit. */
+const DISCRIMINATOR_MASK = 0xfff;
+
+/**
+ * A discriminator no device in this run advertises. Devices take consecutive values from
+ * `identityFor`, so inverting one lands far outside the span however many the plan declares — and a
+ * value that did name a device would turn the check below into an ordinary commissioning.
+ */
+function absentDiscriminator(cx: CertStepContext, th: CertDevice): number {
+    const absent = th.commissioning.discriminator ^ DISCRIMINATOR_MASK;
+    for (const device of Object.values(cx.devices)) {
+        if (device.commissioning.discriminator === absent) {
+            throw new InternalError(
+                `Discriminator ${absent} was meant to name no device in this run, but ${device.id} advertises it`,
+            );
+        }
+    }
+    return absent;
+}
+
+/**
+ * Records that the DUT commissions the device its code names rather than whichever commissionable
+ * device it can reach.
+ *
+ * Every other check about a payload asks what the DUT *read*, and a commissioning that succeeds
+ * proves only the passcode, which SPAKE2+ settles on its own. On a network holding one commissionable
+ * device, a commissioner that discarded the discriminator entirely satisfies all of them and onboards
+ * the TH anyway. Handing it the same payload with a discriminator nothing advertises separates the
+ * two: a DUT that uses the field gives up, and one that ignores it commissions and fails this check.
+ *
+ * The claim is about the commissioner rather than about any one step, so a test case establishes it
+ * once, before the first commissioning whose evidence rests on it.
+ */
+export async function recordDiscriminatorHonored(
+    cx: CertStepContext,
+    payload: string,
+    refusals: CommissioningRefusals,
+    subject?: CertDevice,
+): Promise<void> {
+    const th = subject ?? theTh(cx);
+    const absent = qrPayloadWith(payload, { discriminator: absentDiscriminator(cx, th) });
+
+    await refusals.requireNoCommissioning(
+        cx,
+        { qrPairingCode: absent, giveUpAfterMs: ABSENT_DEVICE_TIMEOUT },
+        "DUT commissions the device its code names",
+        REFUSAL_TIMEOUT,
+    );
+}
+
 function describeTarget(target: CommissioningTarget): string {
     return target.qrPairingCode ?? target.manualPairingCode ?? JSON.stringify(target);
 }
@@ -810,8 +877,8 @@ export async function thCodeParts(
  * parse is the DUT's: a step that decoded the code itself would pass against a controller that
  * cannot read one.
  */
-export async function recordManualParse(cx: CertStepContext, code: string): Promise<void> {
-    const th = theTh(cx);
+export async function recordManualParse(cx: CertStepContext, code: string, th?: CertDevice): Promise<void> {
+    th ??= theTh(cx);
 
     let parsed;
     try {
@@ -1174,6 +1241,14 @@ async function commissionByTarget(
     const th = subject ?? theTh(cx);
 
     await restoreCommissioningMode(cx, commissioned, undefined, subject);
+
+    // A commissioner that ignored the code and onboarded whatever it could find writes the same
+    // completion line as one that read it, so the code has to be evidence in its own right
+    if (target.qrPairingCode !== undefined) {
+        await recordParse(cx, target.qrPairingCode, th);
+    } else if (target.manualPairingCode !== undefined) {
+        await recordManualParse(cx, target.manualPairingCode, th);
+    }
 
     // Settled, because the line this waits for names no fabric on either flavor: a completion still
     // in flight from an earlier commissioning would otherwise satisfy this one


### PR DESCRIPTION
A commissioning step used to record two things: that the commissioning succeeded, and that the device logged it completing. Neither says the commissioner read the code it was given. This makes a commissioning step state what the commissioner read, and adds one step per test case proving it used it.

## What a commissioning succeeding does and does not prove

It proves the passcode, on its own — SPAKE2+ cannot complete on a wrong one. It proves nothing about the discriminator. Every run of this harness has exactly one commissionable device on the network, so a commissioner that discarded the discriminator entirely reaches the device anyway, and every check in the step still passes.

The rule this directory relied on — "commissioning from the payload is itself evidence the DUT parsed it" — does not follow from that, and is retired here.

## The payload becomes evidence in its own right

`commissionByTarget` records what the controller reads from the code before it uses it, so all twelve `commissionByQr` call sites carry it from one place. `recordParse` compares that reading against the device's own discriminator and passcode rather than merely reporting it, so the check is about agreement, not about the parser producing some output.

TC-DD-1.8's three explicit parse calls beside a commissioning came out, since they now record the same claim twice. Where a scan step and a commissioning step are different steps, both legitimately parse and both say so: the scan step's claim is that the payload was *scanned*, the commissioning step's is about the code that commissioning used.

## A precondition step proves the discriminator is used

`recordDiscriminatorHonored` offers the commissioner the device's own payload with a discriminator nothing advertises and requires it to give up. A commissioner that uses the field cannot find the device; one that ignores it commissions and fails the check. The substitute is the payload's own discriminator inverted, which lands far outside the consecutive span `identityFor` assigns, and the helper throws rather than proceeding if it names a device in the run.

Because a refusal is what a pass looks like here, two conditions are established rather than assumed:

- **The device is observed advertising first.** Otherwise the commissioner gives up because there was nothing to find, and the check passes on the device's absence.
- **Only a give-up counts** (`isCommissioningGiveUp`). `requireNoCommissioning` takes every failure but a payload refusal — it serves a plan with no commissionee at all, so a controller that would not start satisfies it.

It is a step of its own, numbered `0`, following the `0.1`/`0.2` precedent in TC-IDM-1.3. The claim is about the commissioner rather than about any plan step, and a step of its own is also the only placement no PICS gate can skip: an earlier revision attached it to TC-DD-3.14's step `3.b`, which is gated on `MCORE.DD.DISCOVERY_BLE`, so a commissioner without BLE skipped the control and commissioned unbacked two steps later. No plan table numbers a step `0`, so the step's expected outcome says it is a precondition.

Each test case owns the `CommissioningRefusals` that tracks the attempt and settles it in `finalize` through `runCleanups`, so a failing settle cannot skip the decommission.

## On chip-tool the control states the gap instead of running

`ChipToolCommandError` covers discovery, PASE, attestation, CASE, timeout and argument-parse failures alike, so a give-up there cannot be told from a controller that failed for any other reason. Running the attempt would spend chip-tool's own discovery timeout to record a pass that could not have failed. The step records an `unverified` check carrying `accepted` instead and makes no attempt — the same shape the harness already uses wherever a controller cannot exhibit the claim under test.

On the matter.js controller `giveUpAfterMs` is honoured, and the pair is `ABSENT_DEVICE_GIVE_UP` (20s) asked of the controller against `ABSENT_DEVICE_WAIT` (90s) waited by the harness. They must not be equal: a wait equal to the deadline it waits on observes the attempt still pending and records the commissioner as having neither onboarded nor refused. TC-DD-3.17 step 4 sets the same pair for the same reason.

## What it still does not prove

Which discovery capability the commissioner honoured — every leg commissions over IP whatever the payload's bitmask says, so that field remains parse evidence only. And the substituted discriminator is only known absent from the run's own devices: a foreign commissionable device on the LAN answering it would fail the check for an unrelated reason, and because the value is deterministic that would happen every run rather than intermittently.

## Verification

- All nine TC-DD test cases pass on all four legs: matter.js controller against **matterjs** and **chip-local** devices, and the **chip-tool** controller. Read per step from the evidence bundles, which carry exactly one control check each.
- The device-discovery suite on chip-tool takes 2m19s; an earlier revision that ran the attempt there took 6m15s.
- `test/cert-framework` 797/797.
- Mutation-checked per added guard: reverting the substitution turns the probe into an ordinary commissioning, removing the collision check lets a substitute name a real device, removing the advertising probe or the give-up predicate each drops its own test, and removing the chip-tool branch makes it attempt a commissioning it should not — each fails exactly its own test.
- `npm run build`, `npm run lint`, `npm run format-verify` clean; root `npm test` green.

## Review

Four pre-ship passes ran over the first two commits and produced 29 raw findings, 14 distinct. The third commit is the reconciliation. The two that changed the design were chip-tool's inability to distinguish a give-up, and a control attached to a PICS-gated step; the rest were dead code, stale prose, and one count in an earlier commit message that was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
