### PR TITLE
TC-G-3.2 (Groups commands, DUT as client), and the chip-tool value typing it uncovered

### DIFF
--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -96,6 +96,18 @@ export const CHIP_TOOL_CONTROLLER_PICS: PicsValues = {
     "G.C.C03.Tx": 1,
     "G.C.C04.Tx": 1,
     "G.C.C05.Tx": 1,
+
+    // Every ScenesManagement client command TC-S-3.1 sends. The CHIP PICS file answers 0 for the
+    // cluster and each command because it describes a device, which is not a scenes client.
+    "S.C": 1,
+    "S.C.C00.Tx": 1,
+    "S.C.C01.Tx": 1,
+    "S.C.C02.Tx": 1,
+    "S.C.C03.Tx": 1,
+    "S.C.C04.Tx": 1,
+    "S.C.C05.Tx": 1,
+    "S.C.C06.Tx": 1,
+    "S.C.C40.Tx": 1,
 };
 
 const WILDCARD_CLUSTER = 0xffffffff;

--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -87,6 +87,15 @@ export const CHIP_TOOL_CONTROLLER_PICS: PicsValues = {
     "ACT.C.C09.Tx": 1,
     "ACT.C.C0a.Tx": 1,
     "ACT.C.C0b.Tx": 1,
+
+    // The Groups client commands this run's DUT sends, its preconditions' AddGroup included. The CHIP
+    // PICS file answers 0 for these because it describes a device, which is not a Groups client; here
+    // the client is the controller.
+    "G.C.C00.Tx": 1,
+    "G.C.C02.Tx": 1,
+    "G.C.C03.Tx": 1,
+    "G.C.C04.Tx": 1,
+    "G.C.C05.Tx": 1,
 };
 
 const WILDCARD_CLUSTER = 0xffffffff;

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -126,6 +126,18 @@ export const MATTERJS_CONTROLLER_PICS: PicsValues = {
     "G.C.C03.Tx": 1,
     "G.C.C04.Tx": 1,
     "G.C.C05.Tx": 1,
+
+    // Every ScenesManagement client command TC-S-3.1 sends. The CHIP PICS file answers 0 for the
+    // cluster and each command because it describes a device, which is not a scenes client.
+    "S.C": 1,
+    "S.C.C00.Tx": 1,
+    "S.C.C01.Tx": 1,
+    "S.C.C02.Tx": 1,
+    "S.C.C03.Tx": 1,
+    "S.C.C04.Tx": 1,
+    "S.C.C05.Tx": 1,
+    "S.C.C06.Tx": 1,
+    "S.C.C40.Tx": 1,
 };
 
 const adapterStreams = new Map<string, LineQueue>();

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -117,6 +117,15 @@ export const MATTERJS_CONTROLLER_PICS: PicsValues = {
     "ACT.C.C09.Tx": 1,
     "ACT.C.C0a.Tx": 1,
     "ACT.C.C0b.Tx": 1,
+
+    // The Groups client commands this run's DUT sends, its preconditions' AddGroup included. The CHIP
+    // PICS file answers 0 for these because it describes a device, which is not a Groups client; here
+    // the client is the controller.
+    "G.C.C00.Tx": 1,
+    "G.C.C02.Tx": 1,
+    "G.C.C03.Tx": 1,
+    "G.C.C04.Tx": 1,
+    "G.C.C05.Tx": 1,
 };
 
 const adapterStreams = new Map<string, LineQueue>();

--- a/support/chip-testing/src/chip-tool/json-codec.ts
+++ b/support/chip-testing/src/chip-tool/json-codec.ts
@@ -252,15 +252,15 @@ export function chipJsonToMatter(value: unknown, model: ValueModel, clusterModel
 
 /**
  * `CustomArgumentParser` reads a plain JSON number's TLV type off the value alone
- * (`examples/chip-tool/commands/clusters/CustomArgument.h`), and jsoncpp's `isUInt()`/`isInt()` are
- * both 32-bit, so it can only reach an unsigned TLV integer within these bounds and a signed one
- * within `[INT32_MIN, INT32_MAX]`. Outside them it encodes a *float*, and inside the unsigned range a
- * positive value is unsigned whatever the field's own type is. Either way a peer decoding the field's
- * declared type rejects the element.
+ * (`examples/chip-tool/commands/clusters/CustomArgument.h`): jsoncpp's `isUInt()` first, then
+ * `isInt()`, then a double. Both predicates are 32-bit, and `isUInt()` comes first, so a plain number
+ * reaches an unsigned TLV integer up to this bound — **whatever the field's declared type is** — a
+ * signed one only when it is negative and no smaller than `INT32_MIN`, and a float everywhere else.
+ * A peer decoding the field's declared type rejects anything else: CHIP's own `TLVReader::Get(int64_t)`
+ * answers `CHIP_ERROR_WRONG_TLV_TYPE` for an unsigned element.
  */
 const CHIP_TOOL_PLAIN_UNSIGNED_MAX = 0xffffffffn;
 const CHIP_TOOL_PLAIN_SIGNED_MIN = -0x80000000n;
-const CHIP_TOOL_PLAIN_SIGNED_MAX = 0x7fffffffn;
 
 /**
  * The value chip-tool encodes as the TLV type `model` declares. `u:`/`s:`/`f:`/`d:` are its own
@@ -278,9 +278,9 @@ function chipTypedNumber(value: number | bigint, kind: ConvKind, model: ValueMod
     const magnitude = BigInt(value);
 
     if (kind === ConvKind.Signed) {
-        return magnitude > CHIP_TOOL_PLAIN_SIGNED_MAX || magnitude < CHIP_TOOL_PLAIN_SIGNED_MIN
-            ? `s:${magnitude}`
-            : value;
+        // A non-negative value is the case that looks safe and is not: `isUInt()` runs first, so zero
+        // and every positive int32 would go out as an unsigned element.
+        return magnitude >= 0 || magnitude < CHIP_TOOL_PLAIN_SIGNED_MIN ? `s:${magnitude}` : value;
     }
 
     if (magnitude < 0) {

--- a/support/chip-testing/src/chip-tool/json-codec.ts
+++ b/support/chip-testing/src/chip-tool/json-codec.ts
@@ -263,13 +263,33 @@ const CHIP_TOOL_PLAIN_UNSIGNED_MAX = 0xffffffffn;
 const CHIP_TOOL_PLAIN_SIGNED_MIN = -0x80000000n;
 
 /**
+ * How much of a prefixed value chip-tool keeps: each of its `u:`/`s:`/`f:`/`d:` parsers copies the
+ * text after the prefix into a `char[21]` before `stoull`/`stoll`/`stof`/`stod`, and `CopyString`
+ * truncates to fit rather than failing. The widest integer a Matter field can hold survives exactly —
+ * `18446744073709551615` and `-9223372036854775808` are both 20 characters — but a float need not:
+ * the largest finite double renders as 23. Truncation there is silent and yields a well-formed number
+ * that is not the one asked for, so a value this cannot carry is refused instead.
+ */
+const CHIP_TOOL_PREFIXED_TEXT_MAX = 20;
+
+/**
  * The value chip-tool encodes as the TLV type `model` declares. `u:`/`s:`/`f:`/`d:` are its own
  * prefixes for stating that type explicitly, which is the only way to reach a type its inference
  * cannot; a value it already infers correctly stays a plain JSON number.
  */
 function chipTypedNumber(value: number | bigint, kind: ConvKind, model: ValueModel): unknown {
+    const prefixed = (prefix: string, text: string) => {
+        if (text.length > CHIP_TOOL_PREFIXED_TEXT_MAX) {
+            throw new ImplementationError(
+                `Field "${model.name}" value ${text} is ${text.length} characters, more than the ` +
+                    `${CHIP_TOOL_PREFIXED_TEXT_MAX} chip-tool keeps of a "${prefix}:" value`,
+            );
+        }
+        return `${prefix}:${text}`;
+    };
+
     if (kind === ConvKind.Float || kind === ConvKind.Double) {
-        return `${kind === ConvKind.Float ? "f" : "d"}:${value}`;
+        return prefixed(kind === ConvKind.Float ? "f" : "d", `${value}`);
     }
 
     if (typeof value === "number" && !Number.isInteger(value)) {
@@ -280,13 +300,13 @@ function chipTypedNumber(value: number | bigint, kind: ConvKind, model: ValueMod
     if (kind === ConvKind.Signed) {
         // A non-negative value is the case that looks safe and is not: `isUInt()` runs first, so zero
         // and every positive int32 would go out as an unsigned element.
-        return magnitude >= 0 || magnitude < CHIP_TOOL_PLAIN_SIGNED_MIN ? `s:${magnitude}` : value;
+        return magnitude >= 0 || magnitude < CHIP_TOOL_PLAIN_SIGNED_MIN ? prefixed("s", `${magnitude}`) : value;
     }
 
     if (magnitude < 0) {
         throw new ImplementationError(`Field "${model.name}" is unsigned but was given ${value}`);
     }
-    return magnitude > CHIP_TOOL_PLAIN_UNSIGNED_MAX ? `u:${magnitude}` : value;
+    return magnitude > CHIP_TOOL_PLAIN_UNSIGNED_MAX ? prefixed("u", `${magnitude}`) : value;
 }
 
 /** chip-tool's prefixes for stating a value's type, which it reads before it reads a char string. */

--- a/support/chip-testing/src/chip-tool/json-codec.ts
+++ b/support/chip-testing/src/chip-tool/json-codec.ts
@@ -14,6 +14,11 @@ export type OctetEncoding = "hex" | "base64";
 
 const enum ConvKind {
     Passthrough,
+    Unsigned,
+    Signed,
+    Float,
+    Double,
+    Text,
     EpochS,
     EpochUS,
     Bytes,
@@ -42,7 +47,13 @@ function classifyModel(model: ValueModel): ConvKind {
                 ? ConvKind.EpochS
                 : model.type === "epoch-us"
                   ? ConvKind.EpochUS
-                  : ConvKind.Passthrough;
+                  : model.metabase.name.startsWith("uint")
+                    ? ConvKind.Unsigned
+                    : ConvKind.Signed;
+    } else if (model.metabase?.metatype === "float") {
+        kind = model.metabase.name === "double" ? ConvKind.Double : ConvKind.Float;
+    } else if (model.metabase?.metatype === "string") {
+        kind = ConvKind.Text;
     } else {
         kind = ConvKind.Passthrough;
     }
@@ -170,7 +181,8 @@ export function chipJsonToMatter(value: unknown, model: ValueModel, clusterModel
         return null;
     }
 
-    switch (classifyModel(model)) {
+    const kind = classifyModel(model);
+    switch (kind) {
         case ConvKind.List: {
             if (!Array.isArray(value)) return value;
             const memberModel = listElementModel(model);
@@ -218,6 +230,13 @@ export function chipJsonToMatter(value: unknown, model: ValueModel, clusterModel
         case ConvKind.Bytes:
             return typeof value === "string" ? decodeOctetString(value) : value;
 
+        case ConvKind.Unsigned:
+        case ConvKind.Signed:
+        case ConvKind.Float:
+        case ConvKind.Double:
+        case ConvKind.Text:
+            return value;
+
         case ConvKind.EpochS:
             return typeof value === "number" ? value + MATTER_EPOCH_OFFSET_S : value;
 
@@ -229,6 +248,63 @@ export function chipJsonToMatter(value: unknown, model: ValueModel, clusterModel
         case ConvKind.Passthrough:
             return value;
     }
+}
+
+/**
+ * `CustomArgumentParser` reads a plain JSON number's TLV type off the value alone
+ * (`examples/chip-tool/commands/clusters/CustomArgument.h`), and jsoncpp's `isUInt()`/`isInt()` are
+ * both 32-bit, so it can only reach an unsigned TLV integer within these bounds and a signed one
+ * within `[INT32_MIN, INT32_MAX]`. Outside them it encodes a *float*, and inside the unsigned range a
+ * positive value is unsigned whatever the field's own type is. Either way a peer decoding the field's
+ * declared type rejects the element.
+ */
+const CHIP_TOOL_PLAIN_UNSIGNED_MAX = 0xffffffffn;
+const CHIP_TOOL_PLAIN_SIGNED_MIN = -0x80000000n;
+const CHIP_TOOL_PLAIN_SIGNED_MAX = 0x7fffffffn;
+
+/**
+ * The value chip-tool encodes as the TLV type `model` declares. `u:`/`s:`/`f:`/`d:` are its own
+ * prefixes for stating that type explicitly, which is the only way to reach a type its inference
+ * cannot; a value it already infers correctly stays a plain JSON number.
+ */
+function chipTypedNumber(value: number | bigint, kind: ConvKind, model: ValueModel): unknown {
+    if (kind === ConvKind.Float || kind === ConvKind.Double) {
+        return `${kind === ConvKind.Float ? "f" : "d"}:${value}`;
+    }
+
+    if (typeof value === "number" && !Number.isInteger(value)) {
+        throw new ImplementationError(`Field "${model.name}" is an integer but was given ${value}`);
+    }
+    const magnitude = BigInt(value);
+
+    if (kind === ConvKind.Signed) {
+        return magnitude > CHIP_TOOL_PLAIN_SIGNED_MAX || magnitude < CHIP_TOOL_PLAIN_SIGNED_MIN
+            ? `s:${magnitude}`
+            : value;
+    }
+
+    if (magnitude < 0) {
+        throw new ImplementationError(`Field "${model.name}" is unsigned but was given ${value}`);
+    }
+    return magnitude > CHIP_TOOL_PLAIN_UNSIGNED_MAX ? `u:${magnitude}` : value;
+}
+
+/** chip-tool's prefixes for stating a value's type, which it reads before it reads a char string. */
+const CHIP_TOOL_TYPE_PREFIXES = ["hex:", "u:", "s:", "f:", "d:"];
+
+/**
+ * A char string whose own text starts with one of chip-tool's type prefixes reaches the peer as that
+ * type instead of as a string, and nothing on the wire says so. There is no escape for it, so the
+ * value is refused here rather than silently retyped.
+ */
+function chipText(value: string, model: ValueModel): string {
+    const prefix = CHIP_TOOL_TYPE_PREFIXES.find(candidate => value.startsWith(candidate));
+    if (prefix !== undefined) {
+        throw new ImplementationError(
+            `Field "${model.name}" carries "${value}", which chip-tool reads as a "${prefix}" value rather than a string`,
+        );
+    }
+    return value;
 }
 
 /**
@@ -245,7 +321,8 @@ export function matterToChipJson(
         return null;
     }
 
-    switch (classifyModel(model)) {
+    const kind = classifyModel(model);
+    switch (kind) {
         case ConvKind.List: {
             if (!Array.isArray(value)) return value;
             const memberModel = listElementModel(model);
@@ -299,8 +376,17 @@ export function matterToChipJson(
 
         case ConvKind.EpochUS:
             return typeof value === "number" || typeof value === "bigint"
-                ? BigInt(value) - MATTER_EPOCH_OFFSET_US
+                ? chipTypedNumber(BigInt(value) - MATTER_EPOCH_OFFSET_US, ConvKind.Unsigned, model)
                 : value;
+
+        case ConvKind.Unsigned:
+        case ConvKind.Signed:
+        case ConvKind.Float:
+        case ConvKind.Double:
+            return typeof value === "number" || typeof value === "bigint" ? chipTypedNumber(value, kind, model) : value;
+
+        case ConvKind.Text:
+            return typeof value === "string" ? chipText(value, model) : value;
 
         case ConvKind.Passthrough:
             return value;

--- a/support/chip-testing/test/cert-framework/chip-tool-json-codec.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-json-codec.test.ts
@@ -110,6 +110,30 @@ describe("chip-tool json codec", () => {
         expect(matterToChipJson(2.5, MEASURED_VALUE_ATTRIBUTE, CARBON_DIOXIDE_CONCENTRATION, "hex")).to.equal("f:2.5");
     });
 
+    it("carries the widest integer a Matter field can hold, which fits chip-tool's buffer exactly", () => {
+        // 18446744073709551615 and -9223372036854775808 are both 20 characters, the most chip-tool
+        // keeps of a prefixed value.
+        expect(matterToChipJson(18446744073709551615n, UP_TIME_ATTRIBUTE, GENERAL_DIAGNOSTICS, "hex")).to.equal(
+            "u:18446744073709551615",
+        );
+        expect(
+            matterToChipJson(-9223372036854775808n, VOLTAGE_ATTRIBUTE, ELECTRICAL_POWER_MEASUREMENT, "hex"),
+        ).to.equal("s:-9223372036854775808");
+    });
+
+    it("refuses a float chip-tool's buffer would silently truncate", () => {
+        // The largest finite double renders as 23 characters; chip-tool would keep 20 and parse a
+        // well-formed number that is not this one.
+        expect(() =>
+            matterToChipJson(Number.MAX_VALUE, MEASURED_VALUE_ATTRIBUTE, CARBON_DIOXIDE_CONCENTRATION, "hex"),
+        ).to.throw(ImplementationError, /characters/);
+
+        // 21 characters, just past the budget, and computed so the literal keeps its precision.
+        expect(() =>
+            matterToChipJson(Math.PI * 1e-10, MEASURED_VALUE_ATTRIBUTE, CARBON_DIOXIDE_CONCENTRATION, "hex"),
+        ).to.throw(ImplementationError);
+    });
+
     it("refuses a non-integral value on an integer field, naming the field", () => {
         expect(() => matterToChipJson(1.5, UP_TIME_ATTRIBUTE, GENERAL_DIAGNOSTICS, "hex")).to.throw(
             ImplementationError,

--- a/support/chip-testing/test/cert-framework/chip-tool-json-codec.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-json-codec.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { UnexpectedDataError } from "@matter/general";
+import { ImplementationError, UnexpectedDataError } from "@matter/general";
 import { Bytes } from "@matter/main";
 import { Matter } from "@matter/model";
 import { expect } from "chai";
@@ -43,6 +43,14 @@ const OPERATIONAL_STATUS_ATTRIBUTE = WINDOW_COVERING.attributes.require("operati
 const THERMOSTAT = Matter.clusters.require("Thermostat");
 const SETPOINT_CHANGE_SOURCE_TIMESTAMP_ATTRIBUTE = THERMOSTAT.attributes.require("setpointChangeSourceTimestamp");
 
+const ELECTRICAL_POWER_MEASUREMENT = Matter.clusters.require("ElectricalPowerMeasurement");
+const VOLTAGE_ATTRIBUTE = ELECTRICAL_POWER_MEASUREMENT.attributes.require("voltage");
+
+const CARBON_DIOXIDE_CONCENTRATION = Matter.clusters.require("CarbonDioxideConcentrationMeasurement");
+const MEASURED_VALUE_ATTRIBUTE = CARBON_DIOXIDE_CONCENTRATION.attributes.require("measuredValue");
+
+const NODE_LABEL_ATTRIBUTE = BASIC_INFORMATION.attributes.require("nodeLabel");
+
 const TIME_SYNCHRONIZATION = Matter.clusters.require("TimeSynchronization");
 const UTC_TIME_ATTRIBUTE = TIME_SYNCHRONIZATION.attributes.require("utcTime");
 
@@ -52,15 +60,70 @@ describe("chip-tool json codec", () => {
         expect(matterToChipJson(0xfff1, VENDOR_ID_ATTRIBUTE, BASIC_INFORMATION, "hex")).to.equal(0xfff1);
     });
 
-    it("survives a uint64 value above Number.MAX_SAFE_INTEGER as a bigint and re-encodes losslessly", () => {
+    it("survives a uint64 value above Number.MAX_SAFE_INTEGER as a bigint and re-encodes it as unsigned", () => {
         const wireJson = '{"value":18446744073709551615}';
         expect(parseChipJson(wireJson)).to.deep.equal({ value: 18446744073709551615n });
 
         const matterValue = chipJsonToMatter(18446744073709551615n, UP_TIME_ATTRIBUTE, GENERAL_DIAGNOSTICS);
         expect(matterValue).to.equal(18446744073709551615n);
 
+        // chip-tool's own type inference is 32-bit, so a plain JSON number this large reaches the peer
+        // as a float; the value goes back out in the `u:` form that states its type.
         const wireValue = matterToChipJson(matterValue, UP_TIME_ATTRIBUTE, GENERAL_DIAGNOSTICS, "hex");
-        expect(stringifyChipJson({ value: wireValue })).to.equal(wireJson);
+        expect(stringifyChipJson({ value: wireValue })).to.equal('{"value":"u:18446744073709551615"}');
+    });
+
+    it("leaves an unsigned value chip-tool already encodes as unsigned a plain number", () => {
+        expect(matterToChipJson(0xffffffff, UP_TIME_ATTRIBUTE, GENERAL_DIAGNOSTICS, "hex")).to.equal(0xffffffff);
+        expect(matterToChipJson(0x100000000, UP_TIME_ATTRIBUTE, GENERAL_DIAGNOSTICS, "hex")).to.equal("u:4294967296");
+    });
+
+    it("forces the signed encoding of a signed value outside chip-tool's 32-bit inference", () => {
+        // Both of chip-tool's predicates are 32 bits wide, so a signed field is mistyped in two
+        // directions: as a float below INT32_MIN, as an unsigned element above INT32_MAX.
+        expect(matterToChipJson(-9_000_000_000_000n, VOLTAGE_ATTRIBUTE, ELECTRICAL_POWER_MEASUREMENT, "hex")).to.equal(
+            "s:-9000000000000",
+        );
+        expect(matterToChipJson(3_000_000_000, VOLTAGE_ATTRIBUTE, ELECTRICAL_POWER_MEASUREMENT, "hex")).to.equal(
+            "s:3000000000",
+        );
+    });
+
+    it("leaves a signed value chip-tool already types correctly a plain number", () => {
+        expect(matterToChipJson(-2_000_000, VOLTAGE_ATTRIBUTE, ELECTRICAL_POWER_MEASUREMENT, "hex")).to.equal(
+            -2_000_000,
+        );
+    });
+
+    it("states a float field's type, which chip-tool never infers from a whole number", () => {
+        expect(matterToChipJson(2, MEASURED_VALUE_ATTRIBUTE, CARBON_DIOXIDE_CONCENTRATION, "hex")).to.equal("f:2");
+        expect(matterToChipJson(2.5, MEASURED_VALUE_ATTRIBUTE, CARBON_DIOXIDE_CONCENTRATION, "hex")).to.equal("f:2.5");
+    });
+
+    it("refuses a non-integral value on an integer field, naming the field", () => {
+        expect(() => matterToChipJson(1.5, UP_TIME_ATTRIBUTE, GENERAL_DIAGNOSTICS, "hex")).to.throw(
+            ImplementationError,
+            /UpTime/,
+        );
+    });
+
+    it("refuses a negative value on an unsigned field", () => {
+        expect(() => matterToChipJson(-1, UP_TIME_ATTRIBUTE, GENERAL_DIAGNOSTICS, "hex")).to.throw(ImplementationError);
+    });
+
+    it("refuses a string chip-tool would read as a typed value rather than as a string", () => {
+        for (const value of ["u:1", "s:1", "hex:ab", "f:1", "d:1"]) {
+            expect(() => matterToChipJson(value, NODE_LABEL_ATTRIBUTE, BASIC_INFORMATION, "hex")).to.throw(
+                ImplementationError,
+            );
+        }
+        expect(matterToChipJson("living room", NODE_LABEL_ATTRIBUTE, BASIC_INFORMATION, "hex")).to.equal("living room");
+    });
+
+    it("forces the unsigned encoding of an epoch-us above 32 bits after subtracting the Matter epoch", () => {
+        expect(matterToChipJson(1_600_000_000_000_000n, UTC_TIME_ATTRIBUTE, TIME_SYNCHRONIZATION, "hex")).to.equal(
+            "u:653315200000000",
+        );
     });
 
     it("round-trips a negative int64 value below Number.MIN_SAFE_INTEGER as a bigint, losslessly", () => {

--- a/support/chip-testing/test/cert-framework/chip-tool-json-codec.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-json-codec.test.ts
@@ -78,20 +78,30 @@ describe("chip-tool json codec", () => {
         expect(matterToChipJson(0x100000000, UP_TIME_ATTRIBUTE, GENERAL_DIAGNOSTICS, "hex")).to.equal("u:4294967296");
     });
 
-    it("forces the signed encoding of a signed value outside chip-tool's 32-bit inference", () => {
-        // Both of chip-tool's predicates are 32 bits wide, so a signed field is mistyped in two
-        // directions: as a float below INT32_MIN, as an unsigned element above INT32_MAX.
-        expect(matterToChipJson(-9_000_000_000_000n, VOLTAGE_ATTRIBUTE, ELECTRICAL_POWER_MEASUREMENT, "hex")).to.equal(
-            "s:-9000000000000",
-        );
-        expect(matterToChipJson(3_000_000_000, VOLTAGE_ATTRIBUTE, ELECTRICAL_POWER_MEASUREMENT, "hex")).to.equal(
-            "s:3000000000",
-        );
+    it("forces the signed encoding of every signed value chip-tool would not infer as signed", () => {
+        // `isUInt()` is tried first and is 32-bit, so a signed field is mistyped in three ways: as an
+        // unsigned element for anything from zero up, and as a float outside the 32-bit window.
+        for (const [value, expected] of [
+            [-9_000_000_000_000n, "s:-9000000000000"],
+            [3_000_000_000, "s:3000000000"],
+            [0, "s:0"],
+            [1, "s:1"],
+            [0x7fffffff, "s:2147483647"],
+        ] as const) {
+            expect(
+                matterToChipJson(value, VOLTAGE_ATTRIBUTE, ELECTRICAL_POWER_MEASUREMENT, "hex"),
+                `${value}`,
+            ).to.equal(expected);
+        }
     });
 
     it("leaves a signed value chip-tool already types correctly a plain number", () => {
+        // Negative and no smaller than INT32_MIN is the only case its inference gets right.
         expect(matterToChipJson(-2_000_000, VOLTAGE_ATTRIBUTE, ELECTRICAL_POWER_MEASUREMENT, "hex")).to.equal(
             -2_000_000,
+        );
+        expect(matterToChipJson(-0x80000000, VOLTAGE_ATTRIBUTE, ELECTRICAL_POWER_MEASUREMENT, "hex")).to.equal(
+            -0x80000000,
         );
     });
 

--- a/support/chip-testing/test/cert-framework/controller-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/controller-adapter.test.ts
@@ -643,6 +643,21 @@ describe("ControllerAdapter registry", () => {
         }
     });
 
+    it("declares every Groups client command TC-G-3.2 sends, gated or not", () => {
+        // AddGroup carries no PICS gate of its own — it is a precondition — but a controller that sends
+        // a command it does not declare is exactly the drift the Actions block below guards against.
+        const groupsCommands = ["00", "02", "03", "04", "05"].map(id => `G.C.C${id}.Tx`);
+        const asDevice = new PicsFile(groupsCommands.map(key => `${key}=0`));
+
+        for (const implementation of ["matterjs", "chip-tool"] as const) {
+            const forRun = asDevice.with(controllerPicsOverridesFor(implementation));
+
+            for (const key of groupsCommands) {
+                expect(new PicsExpression(key).evaluate(forRun), `${implementation} ${key}`).equal(true);
+            }
+        }
+    });
+
     it("declares the client-side capabilities the device's own PICS file answers for a device", () => {
         // Every command TC-ACT-3.2 gates a step on, since a declaration missing from the middle of the
         // range skips that step as quietly as one missing from either end.

--- a/support/chip-testing/test/cert-framework/controller-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/controller-adapter.test.ts
@@ -658,6 +658,21 @@ describe("ControllerAdapter registry", () => {
         }
     });
 
+    it("declares the ScenesManagement client commands TC-S-3.1 sends, and the cluster itself", () => {
+        // Unlike Groups, the device file answers 0 for the cluster as well, so an undeclared S.C would
+        // make the whole test pending rather than skipping one step.
+        const scenesKeys = ["00", "01", "02", "03", "04", "05", "06", "40"].map(id => `S.C.C${id}.Tx`);
+        const asDevice = new PicsFile(["S.C=0", ...scenesKeys.map(key => `${key}=0`)]);
+
+        for (const implementation of ["matterjs", "chip-tool"] as const) {
+            const forRun = asDevice.with(controllerPicsOverridesFor(implementation));
+
+            for (const key of ["S.C", ...scenesKeys]) {
+                expect(new PicsExpression(key).evaluate(forRun), `${implementation} ${key}`).equal(true);
+            }
+        }
+    });
+
     it("declares the client-side capabilities the device's own PICS file answers for a device", () => {
         // Every command TC-ACT-3.2 gates a step on, since a declaration missing from the middle of the
         // range skips that step as quietly as one missing from either end.

--- a/support/chip-testing/test/cert-framework/tc-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-support.test.ts
@@ -927,8 +927,8 @@ describe("command, event and subscribe checks against a matter.js TH", () => {
     const SESSION = "@1:6933d77f2aac19fc•8c2d";
     const invokeLine = (paths: string, flags = "") =>
         `2026-08-22 16:56:18.684 INFO InteractionServer Invoke « ${SESSION}⇵4ef3 ${flags}invokes: ${paths}`;
-    const fieldsLine = (command: string, fields: string) =>
-        `2026-08-22 16:54:43.437 INFO ProtocolService Invoke « binford-6100.generalCommissioning.${command} ${SESSION}⇵4ef3✉0d8128da ${fields}`;
+    const fieldsLine = (command: string, fields: string, cluster = "generalCommissioning") =>
+        `2026-08-22 16:54:43.437 INFO ProtocolService Invoke « binford-6100.${cluster}.${command} ${SESSION}⇵4ef3✉0d8128da ${fields}`;
     const readEventLine = (events: string, flags = "fabricFiltered ") =>
         `2026-08-22 16:56:19.727 DEBUG InteractionServer Read « ${SESSION}⇵9376 ${flags}attributes: none events: ${events}`;
     const subscribeFlagsLine = (flags: string) =>
@@ -978,6 +978,92 @@ describe("command, event and subscribe checks against a matter.js TH", () => {
         );
 
         expect(record.verdict).equal("pass");
+    });
+
+    it("checks a string field by the value matter.js prints unquoted", async () => {
+        const record = await withFollower(
+            [
+                invokeLine("1.groups.addGroupIfIdentifying"),
+                fieldsLine("addGroupIfIdentifying", "groupId: 3 groupName: gp3", "groups"),
+            ],
+            follower =>
+                expectCommandInvoke(
+                    follower,
+                    "matterjs",
+                    1,
+                    0x4,
+                    0x5,
+                    [
+                        { id: 0, value: 3 },
+                        { id: 1, value: "gp3" },
+                    ],
+                    0,
+                    Millis(100),
+                ),
+        );
+
+        expect(record.verdict).equal("pass");
+    });
+
+    it("does not take a longer string for the one the step asked for", async () => {
+        const record = await withFollower(
+            [
+                invokeLine("1.groups.addGroupIfIdentifying"),
+                fieldsLine("addGroupIfIdentifying", "groupId: 3 groupName: gp30", "groups"),
+            ],
+            follower =>
+                expectCommandInvoke(follower, "matterjs", 1, 0x4, 0x5, [{ id: 1, value: "gp3" }], 0, Millis(100)),
+        );
+
+        expect(record.verdict).equal("fail");
+    });
+
+    it("does not take a name whose own space ends the value the step asked for", async () => {
+        const record = await withFollower(
+            [
+                invokeLine("1.groups.addGroupIfIdentifying"),
+                fieldsLine("addGroupIfIdentifying", "groupId: 3 groupName: gp 3", "groups"),
+            ],
+            follower =>
+                expectCommandInvoke(follower, "matterjs", 1, 0x4, 0x5, [{ id: 1, value: "gp" }], 0, Millis(100)),
+        );
+
+        expect(record.verdict).equal("fail");
+    });
+
+    it("matches a name that ends the line, and one another field follows", async () => {
+        for (const fields of ["groupId: 3 groupName: gp 3", "groupName: gp 3 groupId: 3"]) {
+            const record = await withFollower(
+                [invokeLine("1.groups.addGroupIfIdentifying"), fieldsLine("addGroupIfIdentifying", fields, "groups")],
+                follower =>
+                    expectCommandInvoke(follower, "matterjs", 1, 0x4, 0x5, [{ id: 1, value: "gp 3" }], 0, Millis(100)),
+            );
+
+            expect(record.verdict, fields).equal("pass");
+        }
+    });
+
+    it("matches a name carrying regular-expression syntax literally", async () => {
+        const record = await withFollower(
+            [
+                invokeLine("1.groups.addGroupIfIdentifying"),
+                fieldsLine("addGroupIfIdentifying", "groupId: 3 groupName: gpX3", "groups"),
+            ],
+            follower =>
+                expectCommandInvoke(follower, "matterjs", 1, 0x4, 0x5, [{ id: 1, value: "gp.3" }], 0, Millis(100)),
+        );
+
+        expect(record.verdict).equal("fail");
+    });
+
+    it("refuses a value matter.js cannot print as a matchable field", async () => {
+        for (const value of ["", "two\nlines"]) {
+            await expect(
+                withFollower([invokeLine("1.groups.addGroupIfIdentifying")], follower =>
+                    expectCommandInvoke(follower, "matterjs", 1, 0x4, 0x5, [{ id: 1, value }], 0, Millis(100)),
+                ),
+            ).rejectedWith(InternalError);
+        }
     });
 
     it("fails when a field carried another value than the step asked for", async () => {
@@ -1433,6 +1519,50 @@ describe("expectCommandInvoke", () => {
         );
 
         expect(record.verdict).equal("unverified");
+    });
+
+    // A string field is rendered by its own TLV type, which chip states as the string's length in
+    // bytes — the shape TC-G-3.2's AddGroupIfIdentifying GroupName is checked by.
+    const STRING_FIELD = '[DMG] 0x1 = "gp3" (3 chars),';
+
+    it("passes on a string field chip printed with its character count", async () => {
+        const record = await withFollower([...PATH, STRING_FIELD], follower =>
+            expectCommandInvoke(follower, "chip-local", 1, 0x6, 0x1, [{ id: 1, value: "gp3" }], 0, Seconds(1)),
+        );
+
+        expect(record.verdict).equal("pass");
+    });
+
+    it("does not take a longer string for the one the step asked for", async () => {
+        const record = await withFollower([...PATH, '[DMG] 0x1 = "gp30" (4 chars),'], follower =>
+            expectCommandInvoke(follower, "chip-local", 1, 0x6, 0x1, [{ id: 1, value: "gp3" }], 0, Seconds(1)),
+        );
+
+        expect(record.verdict).equal("fail");
+    });
+
+    it("counts a string's UTF-8 bytes, as chip does, not its code points", async () => {
+        const record = await withFollower([...PATH, '[DMG] 0x1 = "gpü" (4 chars),'], follower =>
+            expectCommandInvoke(follower, "chip-local", 1, 0x6, 0x1, [{ id: 1, value: "gpü" }], 0, Seconds(1)),
+        );
+
+        expect(record.verdict).equal("pass");
+    });
+
+    it("matches a string carrying regular-expression syntax literally", async () => {
+        const record = await withFollower([...PATH, '[DMG] 0x1 = "g.3" (3 chars),'], follower =>
+            expectCommandInvoke(follower, "chip-local", 1, 0x6, 0x1, [{ id: 1, value: "g.3" }], 0, Seconds(1)),
+        );
+
+        expect(record.verdict).equal("pass");
+    });
+
+    it("does not let a string's regular-expression syntax match another value", async () => {
+        const record = await withFollower([...PATH, '[DMG] 0x1 = "gp3" (3 chars),'], follower =>
+            expectCommandInvoke(follower, "chip-local", 1, 0x6, 0x1, [{ id: 1, value: "g.3" }], 0, Seconds(1)),
+        );
+
+        expect(record.verdict).equal("fail");
     });
 });
 

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -2151,3 +2151,10 @@ reads the prefix before it reads a string).
 This was latent for every field the suite might send through chip-tool whose value leaves the 32-bit
 window — a node id, an event number, a timestamp, a negative int64, any float — not only this TC's
 epoch keys.
+
+The prefixed form has a budget of its own: each of those parsers copies the text after the prefix into
+a `char[21]` and `CopyString` truncates to fit rather than failing, so **20 characters survive**. The
+widest integer a Matter field can hold fits exactly (`18446744073709551615` and
+`-9223372036854775808` are 20 characters each), but a float need not — the largest finite double
+renders as 23, and `stod` on the truncated text yields a well-formed number that is not the one asked
+for. A value that would not survive is refused rather than silently changed.

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -2079,3 +2079,72 @@ and a `& bit` test against it is always falsy — read the named bit instead.
 
 No PICS work: CHIP's register defines no per-command client keys for LevelControl, so `LVL.C` (which
 the device file already answers 1) is the only gate, and choosing which commands to send is ours.
+## The cluster-client block opens with `TC-G-3.2`
+
+The first WP-5 test, and the shape the rest of that block shares: four steps, each "DUT sends
+*command* to TH; TH receives it", proved from the TH's own log through `expectCommandInvoke` — the
+same check `TC-ACT-3.2` and `TC-IDM-1.1` use. What it adds over those two:
+
+- **Preconditions that are themselves interactions.** Before a Groups command means anything the DUT
+  must write a key set to the TH's GroupKeyManagement cluster (`KeySetWrite`), bind both group ids to
+  it in `GroupKeyMap`, and add both groups. `AddGroup` is refused for a group the fabric's
+  `GroupKeyMap` does not name, so the two `AddGroup` invokes are what proves the binding took: the
+  precondition step gates on them rather than asserting a hard-coded pass.
+- **Endpoint 1, not the YAML's endpoint 0.** chip's all-clusters app has Groups on endpoint 0 as
+  well; matter.js's root endpoint has none, and its Groups clusters come from the `OnOffLightDevice`
+  endpoints. Endpoint 1 is an `OnOffLightDevice` on both, so it carries Groups *and* Identify, which
+  step 4 needs — and the plan names the endpoint `PIXIT.G.ENDPOINT` rather than fixing a number.
+- **A `GetGroupMembership` with an empty `GroupList`** asks for every group the endpoint holds for
+  this fabric, so the response names the two groups the preconditions added. The step checks that,
+  because its log check alone cannot: chip renders the empty list field across several lines and
+  `expectCommandInvoke` matches one line per field, so the command path is all the log proves.
+- **`AddGroupIfIdentifying` is a no-op unless the TH is identifying**, so the step invokes
+  `Identify.identify` first, as chip's own worked commands do.
+
+## A command field that is a string (`TC-G-3.2`)
+
+`CommandFieldValue.value` takes a string as well as a number. chip prints one as
+`0x1 = "gp3" (3 chars),` — the count is the string's UTF-8 bytes — where matter.js prints the value
+bare, `groupName: gp3`, so each flavor renders it from the same entry. The value is matched
+literally: a name containing regular-expression syntax is escaped, and a longer name is not accepted
+for a shorter one.
+
+matter.js's bare rendering is the awkward half. Its fields are separated by a single space, so what
+ends a value is either the line's end or the next field's `<name>:`, not "no further non-space" —
+bound it that way and `gp` matches the `gp 3` of a name that has a space in it. A value matter.js
+cannot render on one line, or renders indistinguishably from an absent one (empty, or carrying a
+newline), gets no pattern at all: `matterjsFieldValue` throws rather than waiting out a timeout on a
+line that cannot come.
+
+## An `epoch-us` cannot carry the plan's literal start time
+
+`TC-G-3.2`'s preconditions say `EpochStartTime0 = 1`. matter.js's `TlvEpochUs` takes a **Unix**
+timestamp and subtracts the Matter epoch itself, so it rejects a value already offset to the Matter
+epoch — the plan's literal is one. The TC writes Unix-microsecond start times instead; only their
+order matters, since nothing in it sends group traffic. The chip-tool adapter's codec applies the
+same offset in its own direction, so both controllers put the same instant on the wire.
+
+## chip-tool reads a number's TLV type off the number, and its inference is 32-bit
+
+Found by this TC's `KeySetWrite`: matter.js answered a bare `StatusResponse FAILURE` with
+`Unexpected type 10, was expecting 4` — 10 is `TlvType.Float`, so the epoch start time had arrived as
+a *float* where the field is a `uint64`.
+
+`any command-by-id` and `any write-by-id` take their payload as chip-tool's `CustomArgument`, whose
+parser (`examples/chip-tool/commands/clusters/CustomArgument.h`) types a plain JSON number by asking
+jsoncpp `isUInt()`, then `isInt()`, then falling back to `asDouble()`. Both of those predicates are
+**32-bit** (jsoncpp's `Int`/`UInt` are `int`/`unsigned int`), so from the JSON alone chip-tool can
+reach an unsigned TLV integer only up to `0xffffffff` and a signed one only within
+`[INT32_MIN, INT32_MAX]`. Outside those it writes a float; inside the unsigned range it writes an
+unsigned element whatever the field's declared type is. The field's own type never enters into it.
+
+So the codec states the type instead, through chip-tool's own prefixes — `u:`, `s:`, `f:`, `d:` —
+whenever the plain form would mistype the value (`matterToChipJson`, `chipTypedNumber`). A value
+chip-tool already infers correctly stays a plain number. Two related refusals live there too, both
+`ImplementationError`, because neither has a wire form that says what went wrong: a non-integral
+value on an integer field, and a char string whose text begins with one of those prefixes (chip-tool
+reads the prefix before it reads a string).
+
+This was latent for every field the suite might send through chip-tool whose value leaves the 32-bit
+window — a node id, an event number, a timestamp, a negative int64, any float — not only this TC's
+epoch keys.

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -2174,7 +2174,12 @@ group the fabric's key map must already carry. What it adds:
   (promoted to `tc-support.ts` when this became the second TC to need them) gate on it. A command
   whose schema mandates a status and answers without one fails rather than skipping the check.
 - **`EpochKey2`/`EpochStartTime2` go as null**, which the plan asks for and both adapters carry.
-- **A list or bitmap field carries no log assertion.** `AddScene`'s `ExtensionFieldSetStructs` and
-  `CopyScene`'s `Mode` are rendered across lines (chip) or as named bits (matter.js), and
-  `expectCommandInvoke` matches one line per field; the surrounding scalar fields carry the evidence.
-  Say so in the step's `expected` rather than leaving a reader to assume the whole payload was checked.
+- **A list or bitmap field needs its own lines, not a field entry.** `expectCommandInvoke` matches one
+  line per field, and neither shape is one line on both flavors: chip nests a list across lines and
+  numbers its members, while matter.js prints the whole nested value inline and names them
+  (`extensionFieldSetStructs: { clusterId: 6, attributeValueList: [ { attributeId: 0, valueUnsigned8: 1 } ] }`).
+  A bitmap diverges the same way — chip prints `0x0 = 0 (unsigned),` where matter.js prints
+  `mode: { copyAllScenes: false }`. So these go through `expectSequence` with per-flavor lines instead,
+  anchored on the mark the invoke took, which is what lets the step assert the nested `ClusterID` and
+  `AttributeValueList` the plan actually names. Sending an empty list would have been the quieter
+  mistake: the step would pass while exercising none of the shape it is about.

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -2133,10 +2133,13 @@ a *float* where the field is a `uint64`.
 `any command-by-id` and `any write-by-id` take their payload as chip-tool's `CustomArgument`, whose
 parser (`examples/chip-tool/commands/clusters/CustomArgument.h`) types a plain JSON number by asking
 jsoncpp `isUInt()`, then `isInt()`, then falling back to `asDouble()`. Both of those predicates are
-**32-bit** (jsoncpp's `Int`/`UInt` are `int`/`unsigned int`), so from the JSON alone chip-tool can
-reach an unsigned TLV integer only up to `0xffffffff` and a signed one only within
-`[INT32_MIN, INT32_MAX]`. Outside those it writes a float; inside the unsigned range it writes an
-unsigned element whatever the field's declared type is. The field's own type never enters into it.
+**32-bit** (jsoncpp's `Int`/`UInt` are `int`/`unsigned int`), and `isUInt()` is asked first. So from
+the JSON alone chip-tool reaches an unsigned TLV integer up to `0xffffffff` — whatever the field's
+declared type is — a signed one only when the value is negative and no smaller than `INT32_MIN`, and
+a float everywhere else. The field's own type never enters into it, and a peer decoding that type
+rejects the rest: CHIP's own `TLVReader::Get(int64_t)` answers `CHIP_ERROR_WRONG_TLV_TYPE` for an
+unsigned element. The case that looks safe and is not is a small **positive** value on a signed
+field.
 
 So the codec states the type instead, through chip-tool's own prefixes — `u:`, `s:`, `f:`, `d:` —
 whenever the plain form would mistype the value (`matterToChipJson`, `chipTypedNumber`). A value

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -2158,3 +2158,23 @@ widest integer a Matter field can hold fits exactly (`18446744073709551615` and
 `-9223372036854775808` are 20 characters each), but a float need not — the largest finite double
 renders as 23, and `stod` on the truncated text yields a well-formed number that is not the one asked
 for. A value that would not survive is refused rather than silently changed.
+
+## The second cluster-client TC of the same shape (`TC-S-3.1`)
+
+Eight steps, each "DUT issues *command*, TH receives it", plus the same key-set / GroupKeyMap /
+AddGroup preconditions `TC-G-3.2` needs — scenes are addressed by group, so a scene command names a
+group the fabric's key map must already carry. What it adds:
+
+- **The cluster's own PICS key needs declaring, not only its commands.** CHIP's file answers `S.C=0`
+  as well as `S.C.C0x.Tx=0`, so without the overlay the *whole test* is pending rather than one step
+  being skipped — a quieter failure than the per-command case, and one a `certTest`-level `pics`
+  never announces.
+- **A response's status is a separate claim from the invoke resolving.** Every command here but
+  `RecallScene` answers with a status inside its payload, so `answersWithStatus`/`responseStatusOf`
+  (promoted to `tc-support.ts` when this became the second TC to need them) gate on it. A command
+  whose schema mandates a status and answers without one fails rather than skipping the check.
+- **`EpochKey2`/`EpochStartTime2` go as null**, which the plan asks for and both adapters carry.
+- **A list or bitmap field carries no log assertion.** `AddScene`'s `ExtensionFieldSetStructs` and
+  `CopyScene`'s `Mode` are rendered across lines (chip) or as named bits (matter.js), and
+  `expectCommandInvoke` matches one line per field; the surrounding scalar fields carry the evidence.
+  Say so in the step's `expected` rather than leaving a reader to assume the whole payload was checked.

--- a/support/chip-testing/test/cert/TC-G-3.2.test.ts
+++ b/support/chip-testing/test/cert/TC-G-3.2.test.ts
@@ -1,0 +1,272 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Bytes } from "@matter/main";
+import { Matter } from "@matter/model";
+import type { CertNodeRef, CertStepContext } from "@matter/testing";
+import { certTest } from "@matter/testing";
+import type { CommandFieldValue } from "./tc-support.js";
+import { CommissionedRefs, expectCommandInvoke, LOG_TIMEOUT, record, requireId } from "./tc-support.js";
+
+const GROUPS = Matter.clusters.require("Groups");
+const GROUP_KEY_MANAGEMENT = Matter.clusters.require("GroupKeyManagement");
+
+const GROUPS_ID = requireId(GROUPS.id, "Groups cluster");
+
+/** The endpoint the plan calls `PIXIT.G.ENDPOINT`. Both THs host Groups and Identify on endpoint 1. */
+const ENDPOINT = 1;
+
+/** GroupKeyManagement is a root-node cluster, so its interactions go to endpoint 0 whatever `ENDPOINT` is. */
+const ROOT_ENDPOINT = 0;
+
+const GROUP_KEY_SET_ID = 1;
+
+/** `GroupKeySecurityPolicyEnum.TrustFirst`, the policy the plan's preconditions name. */
+const TRUST_FIRST = 0;
+
+/** The group the DUT removes by id, and the one it adds back while the TH identifies. */
+const REMOVED_GROUP = { id: 0x0002, name: "gp2" };
+const IDENTIFYING_GROUP = { id: 0x0003, name: "gp3" };
+
+/** Long enough that the TH is still identifying when `AddGroupIfIdentifying` reaches it. */
+const IDENTIFY_TIME = 0x0078;
+
+const commissioned = new CommissionedRefs();
+
+function commandId(commandName: string): number {
+    return requireId(GROUPS.commands.require(commandName).id, `Groups.${commandName}`);
+}
+
+/**
+ * Invokes `commandName` on the TH's Groups cluster and verifies the TH's own log recorded the command
+ * it received, with the fields the step sent.
+ *
+ * Unlike TC-ACT-3.2's bridge, this TH implements every command this TC sends, so a non-success status
+ * is a failure of the test rather than tolerated evidence: the throw propagates and fails the step.
+ * A Groups response carries its own status *inside the payload* — an invoke the cluster refused still
+ * resolves — so that status is a second, separate claim: `AddGroup` answering `UnsupportedAccess` is
+ * how a group the fabric's key map does not name is refused, which is what the preconditions exist to
+ * rule out.
+ */
+async function invokeAndCheck(
+    cx: CertStepContext,
+    ref: CertNodeRef,
+    commandName: string,
+    args: object,
+    fields: CommandFieldValue[],
+): Promise<unknown> {
+    const th = cx.devices.th;
+    const from = th.log.mark();
+
+    let response: unknown;
+    try {
+        response = await cx.controllers.dut.node(ref).invoke("Groups", commandName, args, ENDPOINT);
+    } catch (e) {
+        cx.recorder.check({ type: "response", verdict: "fail", detail: String(e) });
+        throw e;
+    }
+    cx.recorder.check({
+        type: "response",
+        verdict: "pass",
+        detail: response === undefined ? "status=Success" : `status=Success, response=${JSON.stringify(response)}`,
+    });
+
+    const payloadStatus = statusOf(response);
+    if (payloadStatus !== undefined) {
+        record(
+            cx,
+            {
+                type: "response",
+                verdict: payloadStatus === 0 ? "pass" : "fail",
+                detail: `${commandName} response status=${payloadStatus}`,
+            },
+            `Groups.${commandName} response status`,
+        );
+    }
+
+    const logCheck = await expectCommandInvoke(
+        th.log,
+        th.flavor,
+        ENDPOINT,
+        GROUPS_ID,
+        commandId(commandName),
+        fields,
+        from,
+        LOG_TIMEOUT,
+    );
+    record(cx, logCheck, `CommandDataIB log for Groups.${commandName}`);
+
+    return response;
+}
+
+/**
+ * The key set the plan's preconditions have the DUT write, in chip's own worked epoch keys. All three
+ * keys are written because the struct's `EpochKey1`/`EpochKey2` are mandatory.
+ *
+ * The start times are not the plan's literal 1/2220001/2220002: matter.js takes an `epoch-us` as a Unix
+ * timestamp and refuses one already offset to the Matter epoch, so the times below are Unix
+ * microseconds instead. Only their order matters here — the DUT never sends group traffic, so the
+ * absolute times are not what any step rests on.
+ */
+function groupKeySet() {
+    const start = 1_600_000_000_000_000n;
+    return {
+        groupKeySetId: GROUP_KEY_SET_ID,
+        groupKeySecurityPolicy: TRUST_FIRST,
+        epochKey0: Bytes.fromHex("d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"),
+        epochStartTime0: start,
+        epochKey1: Bytes.fromHex("d1d1d2d3d4d5d6d7d8d9dadbdcdddedf"),
+        epochStartTime1: start + 1_000_000n,
+        epochKey2: Bytes.fromHex("d2d1d2d3d4d5d6d7d8d9dadbdcdddedf"),
+        epochStartTime2: start + 2_000_000n,
+    };
+}
+
+/** The status a Groups response carries in its payload, or `undefined` for a response that has none. */
+function statusOf(response: unknown): number | undefined {
+    if (typeof response !== "object" || response === null || !("status" in response)) {
+        return undefined;
+    }
+    const { status } = response;
+    return typeof status === "number" ? status : undefined;
+}
+
+/** The group ids a `GetGroupMembership` response carries, whatever shape the controller decoded it into. */
+function groupsIn(response: unknown): number[] {
+    if (typeof response !== "object" || response === null || !("groupList" in response)) {
+        return [];
+    }
+    const { groupList } = response;
+    return Array.isArray(groupList) ? groupList.filter(entry => typeof entry === "number") : [];
+}
+
+certTest("TC-G-3.2", { plan: "Groups.adoc", pics: ["G.C", "GRPKEY.C"], app: "all-clusters" })
+    .step(
+        "0",
+        "Preconditions: the DUT commissions the TH, writes a group key set to the TH's GroupKeyManagement " +
+            "cluster, binds both group ids to it in GroupKeyMap, and adds both groups.",
+        async cx => {
+            const dut = cx.controllers.dut;
+            const th = cx.devices.th;
+
+            const ref = await dut.commission({
+                passcode: th.commissioning.passcode,
+                discriminator: th.commissioning.discriminator,
+            });
+            commissioned.set("dut", ref);
+
+            const node = dut.node(ref);
+            await node.invoke("GroupKeyManagement", "keySetWrite", { groupKeySet: groupKeySet() }, ROOT_ENDPOINT);
+            await node.writeAttribute(
+                {
+                    endpoint: ROOT_ENDPOINT,
+                    cluster: requireId(GROUP_KEY_MANAGEMENT.id, "GroupKeyManagement cluster"),
+                    attribute: requireId(
+                        GROUP_KEY_MANAGEMENT.attributes.require("groupKeyMap").id,
+                        "GroupKeyManagement.groupKeyMap",
+                    ),
+                },
+                [REMOVED_GROUP, IDENTIFYING_GROUP].map(group => ({
+                    groupId: group.id,
+                    groupKeySetId: GROUP_KEY_SET_ID,
+                })),
+            );
+            cx.recorder.check({
+                type: "response",
+                verdict: "pass",
+                detail:
+                    `key set ${GROUP_KEY_SET_ID} written and bound to groups ` +
+                    `${REMOVED_GROUP.id} and ${IDENTIFYING_GROUP.id}`,
+            });
+
+            // A group the fabric's GroupKeyMap does not name is refused, so these also prove the
+            // binding above took: every later step rests on both groups existing on the TH.
+            for (const group of [REMOVED_GROUP, IDENTIFYING_GROUP]) {
+                await invokeAndCheck(cx, ref, "addGroup", { groupId: group.id, groupName: group.name }, [
+                    { id: 0, value: group.id },
+                    { id: 1, value: group.name },
+                ]);
+            }
+        },
+        {
+            expected:
+                "The TH accepts the key set, the GroupKeyMap write and both AddGroup commands, so the DUT's " +
+                "later commands act on groups the TH actually has.",
+        },
+    )
+    .step(
+        1,
+        "DUT sends GetGroupMembership command to TH",
+        commissioned.withRef("dut", async (cx, ref) => {
+            // An empty GroupList asks for every group the endpoint has for this fabric, which is what
+            // makes the response name the two the preconditions added.
+            const response = await invokeAndCheck(cx, ref, "getGroupMembership", { groupList: [] }, []);
+
+            const reported = groupsIn(response);
+            const missing = [REMOVED_GROUP, IDENTIFYING_GROUP].filter(group => !reported.includes(group.id));
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: missing.length === 0 ? "pass" : "fail",
+                    detail:
+                        missing.length === 0
+                            ? `GetGroupMembershipResponse names groups ${reported.join(", ")}`
+                            : `GetGroupMembershipResponse names groups ${reported.join(", ") || "none"}, ` +
+                              `without ${missing.map(group => group.id).join(", ")}`,
+                },
+                "GetGroupMembershipResponse content",
+            );
+        }),
+        { pics: "G.C.C02.Tx", expected: "Test Harness receives the GetGroupMembership command from the DUT." },
+    )
+    .step(
+        2,
+        "DUT sends RemoveGroup command to TH",
+        commissioned.withRef("dut", async (cx, ref) => {
+            await invokeAndCheck(cx, ref, "removeGroup", { groupId: REMOVED_GROUP.id }, [
+                { id: 0, value: REMOVED_GROUP.id },
+            ]);
+        }),
+        { pics: "G.C.C03.Tx", expected: "Test Harness receives the RemoveGroup command from the DUT." },
+    )
+    .step(
+        3,
+        "DUT sends RemoveAllGroups command to TH",
+        commissioned.withRef("dut", async (cx, ref) => {
+            await invokeAndCheck(cx, ref, "removeAllGroups", {}, []);
+        }),
+        { pics: "G.C.C04.Tx", expected: "Test Harness receives the RemoveAllGroups command from the DUT." },
+    )
+    .step(
+        4,
+        "DUT sends AddGroupIfIdentifying command to TH",
+        commissioned.withRef("dut", async (cx, ref) => {
+            // The command is a no-op on a TH that is not identifying, so the plan's own procedure puts
+            // the TH into identify mode first (chip's worked commands do the same).
+            await cx.controllers.dut
+                .node(ref)
+                .invoke("Identify", "identify", { identifyTime: IDENTIFY_TIME }, ENDPOINT);
+            cx.recorder.check({
+                type: "response",
+                verdict: "pass",
+                detail: `Identify.identify identifyTime=${IDENTIFY_TIME} accepted`,
+            });
+
+            await invokeAndCheck(
+                cx,
+                ref,
+                "addGroupIfIdentifying",
+                { groupId: IDENTIFYING_GROUP.id, groupName: IDENTIFYING_GROUP.name },
+                [
+                    { id: 0, value: IDENTIFYING_GROUP.id },
+                    { id: 1, value: IDENTIFYING_GROUP.name },
+                ],
+            );
+        }),
+        { pics: "G.C.C05.Tx", expected: "Test Harness receives the AddGroupIfIdentifying command from the DUT." },
+    )
+    .finalize(cx => commissioned.decommissionAll(cx));

--- a/support/chip-testing/test/cert/TC-G-3.2.test.ts
+++ b/support/chip-testing/test/cert/TC-G-3.2.test.ts
@@ -9,7 +9,15 @@ import { Matter } from "@matter/model";
 import type { CertNodeRef, CertStepContext } from "@matter/testing";
 import { certTest } from "@matter/testing";
 import type { CommandFieldValue } from "./tc-support.js";
-import { CommissionedRefs, expectCommandInvoke, LOG_TIMEOUT, record, requireId } from "./tc-support.js";
+import {
+    answersWithStatus,
+    CommissionedRefs,
+    expectCommandInvoke,
+    LOG_TIMEOUT,
+    record,
+    requireId,
+    responseStatusOf,
+} from "./tc-support.js";
 
 const GROUPS = Matter.clusters.require("Groups");
 const GROUP_KEY_MANAGEMENT = Matter.clusters.require("GroupKeyManagement");
@@ -74,11 +82,11 @@ async function invokeAndCheck(
         detail: response === undefined ? "status=Success" : `status=Success, response=${JSON.stringify(response)}`,
     });
 
-    if (answersWithStatus(commandName)) {
+    if (answersWithStatus(GROUPS, commandName)) {
         // An absent or malformed status is a failure, not a check to skip: skipping it would leave the
         // command resting on the TH's log alone, which says the request arrived and nothing about
         // whether the cluster accepted it.
-        const payloadStatus = statusOf(response);
+        const payloadStatus = responseStatusOf(response);
         record(
             cx,
             {
@@ -129,21 +137,6 @@ function groupKeySet() {
         epochKey2: Bytes.fromHex("d2d1d2d3d4d5d6d7d8d9dadbdcdddedf"),
         epochStartTime2: start + 2_000_000n,
     };
-}
-
-/** Whether `commandName`'s response schema makes a status part of the answer. */
-function answersWithStatus(commandName: string): boolean {
-    const response = GROUPS.commands.require(commandName).responseModel;
-    return response !== undefined && [...response.members].some(member => member.name === "Status");
-}
-
-/** The status a Groups response carries in its payload, or `undefined` where the answer has none. */
-function statusOf(response: unknown): number | undefined {
-    if (typeof response !== "object" || response === null || !("status" in response)) {
-        return undefined;
-    }
-    const { status } = response;
-    return typeof status === "number" ? status : undefined;
 }
 
 /** The group ids a `GetGroupMembership` response carries, whatever shape the controller decoded it into. */

--- a/support/chip-testing/test/cert/TC-G-3.2.test.ts
+++ b/support/chip-testing/test/cert/TC-G-3.2.test.ts
@@ -74,14 +74,20 @@ async function invokeAndCheck(
         detail: response === undefined ? "status=Success" : `status=Success, response=${JSON.stringify(response)}`,
     });
 
-    const payloadStatus = statusOf(response);
-    if (payloadStatus !== undefined) {
+    if (answersWithStatus(commandName)) {
+        // An absent or malformed status is a failure, not a check to skip: skipping it would leave the
+        // command resting on the TH's log alone, which says the request arrived and nothing about
+        // whether the cluster accepted it.
+        const payloadStatus = statusOf(response);
         record(
             cx,
             {
                 type: "response",
                 verdict: payloadStatus === 0 ? "pass" : "fail",
-                detail: `${commandName} response status=${payloadStatus}`,
+                detail:
+                    payloadStatus === undefined
+                        ? `${commandName} answered ${JSON.stringify(response)}, which carries no status`
+                        : `${commandName} response status=${payloadStatus}`,
             },
             `Groups.${commandName} response status`,
         );
@@ -125,7 +131,13 @@ function groupKeySet() {
     };
 }
 
-/** The status a Groups response carries in its payload, or `undefined` for a response that has none. */
+/** Whether `commandName`'s response schema makes a status part of the answer. */
+function answersWithStatus(commandName: string): boolean {
+    const response = GROUPS.commands.require(commandName).responseModel;
+    return response !== undefined && [...response.members].some(member => member.name === "Status");
+}
+
+/** The status a Groups response carries in its payload, or `undefined` where the answer has none. */
 function statusOf(response: unknown): number | undefined {
     if (typeof response !== "object" || response === null || !("status" in response)) {
         return undefined;

--- a/support/chip-testing/test/cert/TC-S-3.1.test.ts
+++ b/support/chip-testing/test/cert/TC-S-3.1.test.ts
@@ -9,10 +9,12 @@ import { Matter } from "@matter/model";
 import type { CertNodeRef, CertStepContext } from "@matter/testing";
 import { certTest } from "@matter/testing";
 import type { CommandFieldValue } from "./tc-support.js";
+import type { LogExpectClaim } from "./tc-support.js";
 import {
     answersWithStatus,
     CommissionedRefs,
     expectCommandInvoke,
+    expectSequence,
     LOG_TIMEOUT,
     record,
     requireId,
@@ -37,6 +39,22 @@ const GROUP = { id: 0x0001, name: "gp1" };
 const SCENE_ID = 0x01;
 const COPIED_SCENE_ID = 0x02;
 const SCENE_NAME = "scene1";
+
+/**
+ * The scene's stored state, which the plan names as ID 4's shape: a list of `ExtensionFieldSetStruct`,
+ * each a `ClusterID` and an `AttributeValueList`. OnOff's `OnOff` attribute is the one both THs carry
+ * on this endpoint, so the set the DUT sends is one a TH could actually apply.
+ */
+const ON_OFF_CLUSTER_ID = requireId(Matter.clusters.require("OnOff").id, "OnOff cluster");
+const ON_OFF_ATTRIBUTE_ID = requireId(Matter.clusters.require("OnOff").attributes.require("onOff").id, "OnOff.onOff");
+const SCENE_ON_OFF_VALUE = 1;
+
+const EXTENSION_FIELD_SETS = [
+    {
+        clusterId: ON_OFF_CLUSTER_ID,
+        attributeValueList: [{ attributeId: ON_OFF_ATTRIBUTE_ID, valueUnsigned8: SCENE_ON_OFF_VALUE }],
+    },
+];
 
 /** Well inside the field's `max 60,000,000` (§ 1.4.9.2), and small enough to leave no transition running. */
 const TRANSITION_TIME = 0;
@@ -81,7 +99,7 @@ async function invokeAndCheck(
     commandName: string,
     args: object,
     fields: CommandFieldValue[],
-): Promise<unknown> {
+): Promise<{ response: unknown; from: number }> {
     const th = cx.devices.th;
     const from = th.log.mark();
 
@@ -126,7 +144,18 @@ async function invokeAndCheck(
     );
     record(cx, logCheck, `CommandDataIB log for ScenesManagement.${commandName}`);
 
-    return response;
+    return { response, from };
+}
+
+/**
+ * Checks a payload the per-field matcher cannot state: it matches one line per field, and a list or a
+ * bitmap is neither one line on chip nor a plain integer on matter.js. The two flavors are given their
+ * own lines rather than the field's value, since they do not merely format it differently — chip
+ * numbers the nested fields and matter.js names them.
+ */
+async function expectPayloadLines(cx: CertStepContext, from: number, label: string, claim: LogExpectClaim) {
+    const th = cx.devices.th;
+    record(cx, await expectSequence(th.log, th.flavor, label, claim, from, LOG_TIMEOUT), label);
 }
 
 certTest("TC-S-3.1", { plan: "scenes.adoc", pics: ["S.C"], app: "all-clusters" })
@@ -193,7 +222,7 @@ certTest("TC-S-3.1", { plan: "scenes.adoc", pics: ["S.C"], app: "all-clusters" }
         1,
         "DUT issues an AddScene command to the Test Harness.",
         commissioned.withRef("dut", async (cx, ref) => {
-            await invokeAndCheck(
+            const { from } = await invokeAndCheck(
                 cx,
                 ref,
                 "addScene",
@@ -202,7 +231,7 @@ certTest("TC-S-3.1", { plan: "scenes.adoc", pics: ["S.C"], app: "all-clusters" }
                     sceneId: SCENE_ID,
                     transitionTime: TRANSITION_TIME,
                     sceneName: SCENE_NAME,
-                    extensionFieldSetStructs: [],
+                    extensionFieldSetStructs: EXTENSION_FIELD_SETS,
                 },
                 [
                     { id: 0, value: GROUP.id },
@@ -211,13 +240,31 @@ certTest("TC-S-3.1", { plan: "scenes.adoc", pics: ["S.C"], app: "all-clusters" }
                     { id: 3, value: SCENE_NAME },
                 ],
             );
+
+            await expectPayloadLines(cx, from, "AddScene ExtensionFieldSetStructs (ID 4)", {
+                chip: {
+                    ordered: [
+                        /0x4 = \[\s*$/,
+                        new RegExp(`0x0 = ${ON_OFF_CLUSTER_ID} \\(unsigned\\),`),
+                        /0x1 = \[\s*$/,
+                        new RegExp(`0x0 = ${ON_OFF_ATTRIBUTE_ID} \\(unsigned\\),`),
+                        new RegExp(`0x1 = ${SCENE_ON_OFF_VALUE} \\(unsigned\\),`),
+                    ],
+                },
+                matterjs: [
+                    new RegExp(
+                        `extensionFieldSetStructs: \\{ clusterId: ${ON_OFF_CLUSTER_ID}, attributeValueList: ` +
+                            `\\[ \\{ attributeId: ${ON_OFF_ATTRIBUTE_ID}, valueUnsigned8: ${SCENE_ON_OFF_VALUE} \\} \\]`,
+                    ),
+                ],
+            });
         }),
         {
             pics: "S.C.C00.Tx",
             expected:
                 "Test Harness receives the AddScene command from the DUT, carrying GroupID, SceneID, " +
-                "TransitionTime and SceneName. ExtensionFieldSetStructs is a list, which the log renders " +
-                "across lines rather than as one field.",
+                "TransitionTime, SceneName and an ExtensionFieldSetStructs list whose ClusterID and " +
+                "AttributeValueList the TH's log shows.",
         },
     )
     .step(
@@ -313,10 +360,9 @@ certTest("TC-S-3.1", { plan: "scenes.adoc", pics: ["S.C"], app: "all-clusters" }
         8,
         "DUT issues a CopyScene command to the Test Harness.",
         commissioned.withRef("dut", async (cx, ref) => {
-            // Mode is a bitmap, which the two logs render differently from a plain integer, so the
-            // copy's own scene and group ids carry the evidence. `copyAllScenes` is left clear, which
-            // is the case the plan's own parameter note describes as "otherwise this bit is set to 0".
-            await invokeAndCheck(
+            // `copyAllScenes` is left clear, which is the case the plan's own parameter note describes
+            // as "otherwise this bit is set to 0".
+            const { from } = await invokeAndCheck(
                 cx,
                 ref,
                 "copyScene",
@@ -334,12 +380,17 @@ certTest("TC-S-3.1", { plan: "scenes.adoc", pics: ["S.C"], app: "all-clusters" }
                     { id: 4, value: COPIED_SCENE_ID },
                 ],
             );
+
+            await expectPayloadLines(cx, from, "CopyScene Mode (ID 0) with CopyAllScenes clear", {
+                chip: [/0x0 = 0 \(unsigned\),/],
+                matterjs: [/mode: \{ copyAllScenes: false \}/],
+            });
         }),
         {
             pics: "S.C.C40.Tx",
             expected:
-                "Test Harness receives the CopyScene command from the DUT, carrying the source and destination " +
-                "group and scene ids. Mode is a bitmap, which the log renders differently from an integer.",
+                "Test Harness receives the CopyScene command from the DUT, carrying Mode with CopyAllScenes " +
+                "clear and the source and destination group and scene ids.",
         },
     )
     .finalize(cx => commissioned.decommissionAll(cx));

--- a/support/chip-testing/test/cert/TC-S-3.1.test.ts
+++ b/support/chip-testing/test/cert/TC-S-3.1.test.ts
@@ -1,0 +1,345 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Bytes } from "@matter/main";
+import { Matter } from "@matter/model";
+import type { CertNodeRef, CertStepContext } from "@matter/testing";
+import { certTest } from "@matter/testing";
+import type { CommandFieldValue } from "./tc-support.js";
+import {
+    answersWithStatus,
+    CommissionedRefs,
+    expectCommandInvoke,
+    LOG_TIMEOUT,
+    record,
+    requireId,
+    responseStatusOf,
+} from "./tc-support.js";
+
+const SCENES = Matter.clusters.require("ScenesManagement");
+const GROUP_KEY_MANAGEMENT = Matter.clusters.require("GroupKeyManagement");
+
+const SCENES_ID = requireId(SCENES.id, "ScenesManagement cluster");
+
+/** Both THs put ScenesManagement and Groups on the on/off light at endpoint 1. */
+const ENDPOINT = 1;
+
+/** GroupKeyManagement is a root-node cluster, so its interactions go to endpoint 0. */
+const ROOT_ENDPOINT = 0;
+
+/** The plan's own `GroupKeySetID` and G₁. */
+const GROUP_KEY_SET_ID = 0x01a1;
+const GROUP = { id: 0x0001, name: "gp1" };
+
+const SCENE_ID = 0x01;
+const COPIED_SCENE_ID = 0x02;
+const SCENE_NAME = "scene1";
+
+/** Well inside the field's `max 60,000,000` (§ 1.4.9.2), and small enough to leave no transition running. */
+const TRANSITION_TIME = 0;
+
+const commissioned = new CommissionedRefs();
+
+function commandId(commandName: string): number {
+    return requireId(SCENES.commands.require(commandName).id, `ScenesManagement.${commandName}`);
+}
+
+/**
+ * The key set the plan's preconditions have the DUT write. The start times are not the plan's literal
+ * 1110000/1110001: matter.js reads an `epoch-us` as a Unix timestamp and refuses one already offset to
+ * the Matter epoch (see AGENTS.md, "An `epoch-us` cannot carry the plan's literal start time"). Only
+ * their order matters here, since nothing in this TC sends group traffic.
+ */
+function groupKeySet() {
+    const start = 1_600_000_000_000_000n;
+    return {
+        groupKeySetId: GROUP_KEY_SET_ID,
+        groupKeySecurityPolicy: 0,
+        epochKey0: Bytes.fromHex("a0a1a2a3a4a5a6a7a8a9aaabacadaeaf"),
+        epochStartTime0: start,
+        epochKey1: Bytes.fromHex("b0b1b2b3b4b5b6b7b8b9babbbcbdbebf"),
+        epochStartTime1: start + 1_000_000n,
+        epochKey2: null,
+        epochStartTime2: null,
+    };
+}
+
+/**
+ * Invokes `commandName` on the TH's ScenesManagement cluster and verifies the TH's own log recorded
+ * the command with the fields the step sent.
+ *
+ * Every ScenesManagement command in this TC but `RecallScene` answers with a status inside its
+ * response payload, so an invoke that resolves has not yet said whether the cluster accepted it; that
+ * status is checked as a claim of its own.
+ */
+async function invokeAndCheck(
+    cx: CertStepContext,
+    ref: CertNodeRef,
+    commandName: string,
+    args: object,
+    fields: CommandFieldValue[],
+): Promise<unknown> {
+    const th = cx.devices.th;
+    const from = th.log.mark();
+
+    let response: unknown;
+    try {
+        response = await cx.controllers.dut.node(ref).invoke("ScenesManagement", commandName, args, ENDPOINT);
+    } catch (e) {
+        cx.recorder.check({ type: "response", verdict: "fail", detail: String(e) });
+        throw e;
+    }
+    cx.recorder.check({
+        type: "response",
+        verdict: "pass",
+        detail: response === undefined ? "status=Success" : `status=Success, response=${JSON.stringify(response)}`,
+    });
+
+    if (answersWithStatus(SCENES, commandName)) {
+        const payloadStatus = responseStatusOf(response);
+        record(
+            cx,
+            {
+                type: "response",
+                verdict: payloadStatus === 0 ? "pass" : "fail",
+                detail:
+                    payloadStatus === undefined
+                        ? `${commandName} answered ${JSON.stringify(response)}, which carries no status`
+                        : `${commandName} response status=${payloadStatus}`,
+            },
+            `ScenesManagement.${commandName} response status`,
+        );
+    }
+
+    const logCheck = await expectCommandInvoke(
+        th.log,
+        th.flavor,
+        ENDPOINT,
+        SCENES_ID,
+        commandId(commandName),
+        fields,
+        from,
+        LOG_TIMEOUT,
+    );
+    record(cx, logCheck, `CommandDataIB log for ScenesManagement.${commandName}`);
+
+    return response;
+}
+
+certTest("TC-S-3.1", { plan: "scenes.adoc", pics: ["S.C"], app: "all-clusters" })
+    .step(
+        "0",
+        "Preconditions: the DUT commissions the TH, writes the plan's group key set, binds G1 to it in " +
+            "GroupKeyMap, clears the TH's groups and adds G1.",
+        async cx => {
+            const dut = cx.controllers.dut;
+            const th = cx.devices.th;
+
+            const ref = await dut.commission({
+                passcode: th.commissioning.passcode,
+                discriminator: th.commissioning.discriminator,
+            });
+            commissioned.set("dut", ref);
+
+            const node = dut.node(ref);
+            await node.invoke("GroupKeyManagement", "keySetWrite", { groupKeySet: groupKeySet() }, ROOT_ENDPOINT);
+            await node.writeAttribute(
+                {
+                    endpoint: ROOT_ENDPOINT,
+                    cluster: requireId(GROUP_KEY_MANAGEMENT.id, "GroupKeyManagement cluster"),
+                    attribute: requireId(
+                        GROUP_KEY_MANAGEMENT.attributes.require("groupKeyMap").id,
+                        "GroupKeyManagement.groupKeyMap",
+                    ),
+                },
+                [{ groupId: GROUP.id, groupKeySetId: GROUP_KEY_SET_ID }],
+            );
+
+            await node.invoke("Groups", "removeAllGroups", {}, ENDPOINT);
+
+            // A group the fabric's GroupKeyMap does not name is refused, so this answer is what proves
+            // the binding above took — every scene command below names this group.
+            const added = await node.invoke(
+                "Groups",
+                "addGroup",
+                { groupId: GROUP.id, groupName: GROUP.name },
+                ENDPOINT,
+            );
+            const addStatus = responseStatusOf(added);
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: addStatus === 0 ? "pass" : "fail",
+                    detail:
+                        addStatus === undefined
+                            ? `AddGroup answered ${JSON.stringify(added)}, which carries no status`
+                            : `AddGroup response status=${addStatus}, group ${GROUP.id} bound to key set ` +
+                              `0x${GROUP_KEY_SET_ID.toString(16)}`,
+                },
+                `Groups.addGroup response status`,
+            );
+        },
+        {
+            expected:
+                "The TH accepts the key set, the GroupKeyMap write and AddGroup, so every scene command below " +
+                "names a group the TH actually has.",
+        },
+    )
+    .step(
+        1,
+        "DUT issues an AddScene command to the Test Harness.",
+        commissioned.withRef("dut", async (cx, ref) => {
+            await invokeAndCheck(
+                cx,
+                ref,
+                "addScene",
+                {
+                    groupId: GROUP.id,
+                    sceneId: SCENE_ID,
+                    transitionTime: TRANSITION_TIME,
+                    sceneName: SCENE_NAME,
+                    extensionFieldSetStructs: [],
+                },
+                [
+                    { id: 0, value: GROUP.id },
+                    { id: 1, value: SCENE_ID },
+                    { id: 2, value: TRANSITION_TIME },
+                    { id: 3, value: SCENE_NAME },
+                ],
+            );
+        }),
+        {
+            pics: "S.C.C00.Tx",
+            expected:
+                "Test Harness receives the AddScene command from the DUT, carrying GroupID, SceneID, " +
+                "TransitionTime and SceneName. ExtensionFieldSetStructs is a list, which the log renders " +
+                "across lines rather than as one field.",
+        },
+    )
+    .step(
+        2,
+        "DUT issues a ViewScene command to the Test Harness.",
+        commissioned.withRef("dut", async (cx, ref) => {
+            await invokeAndCheck(cx, ref, "viewScene", { groupId: GROUP.id, sceneId: SCENE_ID }, [
+                { id: 0, value: GROUP.id },
+                { id: 1, value: SCENE_ID },
+            ]);
+        }),
+        {
+            pics: "S.C.C01.Tx",
+            expected: "Test Harness receives the ViewScene command from the DUT, carrying GroupID and SceneID.",
+        },
+    )
+    .step(
+        3,
+        "DUT issues a RemoveScene command to the Test Harness.",
+        commissioned.withRef("dut", async (cx, ref) => {
+            await invokeAndCheck(cx, ref, "removeScene", { groupId: GROUP.id, sceneId: SCENE_ID }, [
+                { id: 0, value: GROUP.id },
+                { id: 1, value: SCENE_ID },
+            ]);
+        }),
+        {
+            pics: "S.C.C02.Tx",
+            expected: "Test Harness receives the RemoveScene command from the DUT, carrying GroupID and SceneID.",
+        },
+    )
+    .step(
+        4,
+        "DUT issues a RemoveAllScenes command to the Test Harness.",
+        commissioned.withRef("dut", async (cx, ref) => {
+            await invokeAndCheck(cx, ref, "removeAllScenes", { groupId: GROUP.id }, [{ id: 0, value: GROUP.id }]);
+        }),
+        {
+            pics: "S.C.C03.Tx",
+            expected: "Test Harness receives the RemoveAllScenes command from the DUT, carrying GroupID.",
+        },
+    )
+    .step(
+        5,
+        "DUT issues a StoreScene command to the Test Harness.",
+        commissioned.withRef("dut", async (cx, ref) => {
+            await invokeAndCheck(cx, ref, "storeScene", { groupId: GROUP.id, sceneId: SCENE_ID }, [
+                { id: 0, value: GROUP.id },
+                { id: 1, value: SCENE_ID },
+            ]);
+        }),
+        {
+            pics: "S.C.C04.Tx",
+            expected: "Test Harness receives the StoreScene command from the DUT, carrying GroupID and SceneID.",
+        },
+    )
+    .step(
+        6,
+        "DUT issues a RecallScene command to the Test Harness.",
+        commissioned.withRef("dut", async (cx, ref) => {
+            // TransitionTime is optional on this command; the plan asks for its type where present, so
+            // it is sent and checked rather than omitted.
+            await invokeAndCheck(
+                cx,
+                ref,
+                "recallScene",
+                { groupId: GROUP.id, sceneId: SCENE_ID, transitionTime: TRANSITION_TIME },
+                [
+                    { id: 0, value: GROUP.id },
+                    { id: 1, value: SCENE_ID },
+                    { id: 2, value: TRANSITION_TIME },
+                ],
+            );
+        }),
+        {
+            pics: "S.C.C05.Tx",
+            expected:
+                "Test Harness receives the RecallScene command from the DUT, carrying GroupID, SceneID and the " +
+                "optional TransitionTime.",
+        },
+    )
+    .step(
+        7,
+        "DUT issues a GetSceneMembership command to the Test Harness.",
+        commissioned.withRef("dut", async (cx, ref) => {
+            await invokeAndCheck(cx, ref, "getSceneMembership", { groupId: GROUP.id }, [{ id: 0, value: GROUP.id }]);
+        }),
+        {
+            pics: "S.C.C06.Tx",
+            expected: "Test Harness receives the GetSceneMembership command from the DUT, carrying GroupID.",
+        },
+    )
+    .step(
+        8,
+        "DUT issues a CopyScene command to the Test Harness.",
+        commissioned.withRef("dut", async (cx, ref) => {
+            // Mode is a bitmap, which the two logs render differently from a plain integer, so the
+            // copy's own scene and group ids carry the evidence. `copyAllScenes` is left clear, which
+            // is the case the plan's own parameter note describes as "otherwise this bit is set to 0".
+            await invokeAndCheck(
+                cx,
+                ref,
+                "copyScene",
+                {
+                    mode: {},
+                    groupIdentifierFrom: GROUP.id,
+                    sceneIdentifierFrom: SCENE_ID,
+                    groupIdentifierTo: GROUP.id,
+                    sceneIdentifierTo: COPIED_SCENE_ID,
+                },
+                [
+                    { id: 1, value: GROUP.id },
+                    { id: 2, value: SCENE_ID },
+                    { id: 3, value: GROUP.id },
+                    { id: 4, value: COPIED_SCENE_ID },
+                ],
+            );
+        }),
+        {
+            pics: "S.C.C40.Tx",
+            expected:
+                "Test Harness receives the CopyScene command from the DUT, carrying the source and destination " +
+                "group and scene ids. Mode is a bitmap, which the log renders differently from an integer.",
+        },
+    )
+    .finalize(cx => commissioned.decommissionAll(cx));

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -14,6 +14,7 @@ import {
     Seconds,
     Time,
 } from "@matter/main";
+import type { ClusterModel } from "@matter/model";
 import { Matter } from "@matter/model";
 import type {
     AttributePathSpec,
@@ -855,6 +856,25 @@ export function requireId(id: number | undefined, what: string): number {
         throw new InternalError(`${what} has no numeric id`);
     }
     return id;
+}
+
+/**
+ * The status a command's response carries in its own payload, or `undefined` where the answer has
+ * none. A cluster that answers with a status reports a refusal there rather than as an interaction
+ * status, so an invoke that resolves has told the caller nothing about it yet.
+ */
+export function responseStatusOf(response: unknown): number | undefined {
+    if (typeof response !== "object" || response === null || !("status" in response)) {
+        return undefined;
+    }
+    const { status } = response;
+    return typeof status === "number" ? status : undefined;
+}
+
+/** Whether `commandName`'s response schema makes a status part of the answer. */
+export function answersWithStatus(cluster: ClusterModel, commandName: string): boolean {
+    const response = cluster.commands.require(commandName).responseModel;
+    return response !== undefined && [...response.members].some(member => member.name === "Status");
 }
 
 /**

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -715,6 +715,23 @@ function matterjsInvokePath(endpoint: number, cluster: number, command: number):
 }
 
 /**
+ * One field value as matter.js writes it into that line. A string is written bare and the next field
+ * follows a space, so a string is bounded by what can follow it — the line's end, or the next field's
+ * `<name>:` — rather than by "not more non-space", which a value containing a space would satisfy
+ * mid-value. A value matter.js cannot write on one line, or writes indistinguishably from an absent
+ * one, has no pattern at all and is refused here rather than waiting for a line that cannot come.
+ */
+function matterjsFieldValue(value: number | bigint | string): string {
+    if (typeof value !== "string") {
+        return `${value}(?!\\d)`;
+    }
+    if (value === "" || /[\n\r]/.test(value)) {
+        throw new InternalError(`matter.js does not print "${value}" as a matchable field value`);
+    }
+    return `${literally(value)}(?=$|\\s\\w+:)`;
+}
+
+/**
  * matter.js's line for the invoked command's own payload, which names each field rather than
  * numbering it: `<name>: <value>`, in payload order, on the line that names the command.
  */
@@ -725,7 +742,7 @@ function matterjsCommandFields(cluster: number, command: number, fields: Command
         if (name === undefined) {
             throw new InternalError(`Command 0x${command.toString(16)} has no field 0x${id.toString(16)}`);
         }
-        return `${camelize(name)}: ${value}(?!\\d)`;
+        return `${camelize(name)}: ${matterjsFieldValue(value)}`;
     });
     return new RegExp(`ProtocolService Invoke «.*${matterjsElement(model?.name, command)}\\b.*${named.join(".*")}`);
 }
@@ -840,10 +857,34 @@ export function requireId(id: number | undefined, what: string): number {
     return id;
 }
 
-/** One `CommandFields` entry: a field id and its value, matched as `0x<id> = <value> (unsigned),`. */
+/**
+ * One `CommandFields` entry: a field id and its value. chip prints the TLV type after the value, so a
+ * string is matched as `0x<id> = "<value>" (<n> chars),` — where `n` counts the string's UTF-8 bytes,
+ * not its code points — and a number as `0x<id> = <value> (unsigned),`. Every numeric field any TC
+ * checks so far is unsigned; chip prints a signed one as `(signed)`, which no shape here matches.
+ */
 export interface CommandFieldValue {
     id: number;
-    value: number;
+    value: number | bigint | string;
+}
+
+/** `value` as a pattern matching itself and nothing else. */
+function literally(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * The line chip prints for one decoded `CommandFields` entry.
+ *
+ * The trailing type name is load-bearing: without it `0x0 = 2,` also matches the first two digits of
+ * `0x0 = 20,`.
+ */
+function chipCommandField({ id, value }: CommandFieldValue): RegExp {
+    const rendered =
+        typeof value === "string"
+            ? `"${literally(value)}" \\(${new TextEncoder().encode(value).length} chars\\)`
+            : `${value} \\(unsigned\\)`;
+    return new RegExp(`0x${id.toString(16)} = ${rendered},\\s*$`);
 }
 
 /**
@@ -913,8 +954,8 @@ async function matterjsCommandInvoke(
 /**
  * Confirms chip's `InvokeRequestMessage` log carries a `CommandPathIB` matching `endpoint`/`cluster`/
  * `command` as a consecutive block at or after `from` (see {@link expectAdjacentLines}), then that
- * every `fields` entry appears afterward, in order, as its own `0x<id> = <value>,` line inside
- * `CommandFields`. Field lines aren't required adjacent to the `CommandPathIB` block itself — chip
+ * every `fields` entry appears afterward, in order, as its own line inside `CommandFields` (see
+ * {@link chipCommandField}). Field lines aren't required adjacent to the `CommandPathIB` block itself — chip
  * emits a blank `CHIP:DMG:` separator line in between that isn't part of what this check verifies. A
  * search always starts at or after the previous match's own index (`log.expect`'s `from`), so this
  * can't match a field line belonging to an earlier invoke. matter.js names every command one invoke
@@ -958,12 +999,11 @@ export async function expectCommandInvoke(
         last = block.last;
         cursor = block.last.index + 1;
 
-        for (const { id, value } of fields) {
-            // Every field checked by any TC using this helper so far is an unsigned int (uint16/uint32);
-            // chip's decode dump appends the TLV type name after the value (verified against a real
-            // chip-bridge-app capture).
-            const pattern = new RegExp(`0x${id.toString(16)} = ${value} \\(unsigned\\),\\s*$`);
-            const result = await log.expect({ chip: pattern }, { flavor, timeoutMs: remaining(), from: cursor });
+        for (const field of fields) {
+            const result = await log.expect(
+                { chip: chipCommandField(field) },
+                { flavor, timeoutMs: remaining(), from: cursor },
+            );
             if (result.verdict === "unverified") {
                 return { type: "device-log", verdict: "unverified" };
             }


### PR DESCRIPTION
Opens the cluster-level client block with **TC-G-3.2**, and fixes an adapter defect the test exposed.

## The test

Four steps, one per command the plan names — GetGroupMembership, RemoveGroup, RemoveAllGroups, AddGroupIfIdentifying — each sent unicast to the TH and each proved from the TH's own log, not from what the controller got back.

The preconditions are interactions with claims of their own: the DUT writes a group key set to GroupKeyManagement, binds both group ids to it in GroupKeyMap, and adds both groups. A group the fabric's key map does not name is refused with `UnsupportedAccess`, so the two AddGroup answers are what proves the binding took. That status arrives inside the response payload rather than as an interaction status, so the step checks it as a claim separate from the invoke resolving.

Two things the plan text cannot be followed literally on:

- **Endpoint.** The CHIP YAML uses endpoint 0; matter.js's TH has no Groups on its root endpoint. Endpoint 1 is an on/off light on both THs, so it carries Groups *and* Identify — which AddGroupIfIdentifying needs, the command being a no-op on a TH that is not identifying.
- **EpochStartTime0 = 1.** matter.js reads an `epoch-us` as a Unix timestamp and refuses one already offset to the Matter epoch. The test writes Unix-microsecond start times; only their order matters, since nothing here sends group traffic.

## The defect it uncovered

chip-tool's `any command-by-id` / `any write-by-id` take their payload as a `CustomArgument`, whose parser decides a JSON number's TLV type from the number alone: jsoncpp `isUInt()`, then `isInt()`, then a double. Both predicates are 32 bits wide. So from plain JSON chip-tool reaches an unsigned integer only up to `0xffffffff` and a signed one only within int32; outside that it writes a **float**, and inside the unsigned range it writes an unsigned element whatever the field's declared type is. The peer then rejects the element — a KeySetWrite carrying a real epoch timestamp failed against matter.js with `Unexpected type 10, was expecting 4`, type 10 being float.

The codec now states the type outright, through chip-tool's own `u:` / `s:` / `f:` / `d:` prefixes, whenever the plain form would mistype the value; a value chip-tool already infers correctly stays a plain number. Two values with no correct wire form are refused with an `ImplementationError` instead of being sent: a non-integral value on an integer field, and a char string whose text begins with one of those prefixes, which chip-tool reads as a typed value rather than as a string.

This was wrong for every value outside the 32-bit window the suite could send through chip-tool — a node id, an event number, a timestamp, a negative int64, any float — not only this test's epoch keys.

## Supporting changes

- A command-field check can assert a **string** field: chip prints `0x1 = "gp3" (3 chars),` (UTF-8 bytes), matter.js prints the value bare. matter.js separates fields with a space, so a string value ends at the line's end or at the next field's name; bounding it on "no further non-space" would let `gp` match a name that reads `gp 3`. A value matter.js cannot print distinguishably — empty, or carrying a newline — is refused rather than waited out.
- Both controller PICS overlays declare the Groups client commands they send, AddGroup included. The CHIP PICS file answers 0 for these because it describes a device, and a device is not a Groups client.

## Verification

- All four matrix legs green: matter.js and chip-tool controllers × matter.js and chip-local devices.
- `cert-framework` 817/817, every cert TC 21/21, full `npm test`, `npm run build`, `format-verify`, `lint`.
- Each added branch mutation-proved: reverting the signed-forcing classification, the float prefix, the string-prefix refusal, the regex escaping, the chip and matter.js string renderings and the matter.js value boundary each turns a specific test red.

Not fixed here, and pre-existing: `support/chip-testing` imports `@matter/model` in both `src` and `test` without a `package.json` dependency or a tsconfig project reference — it resolves through workspace hoisting today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
