### PR TITLE
Give a task run its own identity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12437,7 +12437,9 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@matter/general": "*",
+                "@matter/model": "*",
                 "@matter/node": "*",
+                "@matter/protocol": "*",
                 "@matter/types": "*"
             },
             "devDependencies": {

--- a/packages/node-manager/package.json
+++ b/packages/node-manager/package.json
@@ -27,7 +27,9 @@
     },
     "dependencies": {
         "@matter/general": "*",
+        "@matter/model": "*",
         "@matter/node": "*",
+        "@matter/protocol": "*",
         "@matter/types": "*"
     },
     "devDependencies": {

--- a/packages/node-manager/src/reconcile/executeActions.ts
+++ b/packages/node-manager/src/reconcile/executeActions.ts
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Logger } from "@matter/general";
 import type { ClientNode } from "@matter/node";
-import { ItemKindRegistry, ItemState, ManagedItem } from "@matter/node";
+import { ItemKindRegistry, ItemState, ManagedItem, UnknownItemKindError } from "@matter/node";
 import { PlannedAction } from "./planActions.js";
+
+const logger = Logger.get("Reconciler");
 
 /**
  * Interface for the I/O operations the executor needs to perform on a peer's desired state.
@@ -50,9 +53,10 @@ export async function executeActions(
             case "apply":
             case "retry":
                 try {
-                    if (kind !== undefined) {
-                        await kind.apply(target.node, item);
+                    if (kind === undefined) {
+                        throw new UnknownItemKindError(`No item kind registered for "${item.kind}"`);
                     }
+                    await kind.apply(target.node, item);
                     // A revert that flipped the intent to delete during this apply must win: a status
                     // write here would resurrect the item the revert is trying to remove.
                     if (target.currentState(item.kind, item.key) === "deletePending") {
@@ -62,6 +66,9 @@ export async function executeActions(
                 } catch (e) {
                     if (target.currentState(item.kind, item.key) === "deletePending") {
                         break;
+                    }
+                    if (e instanceof UnknownItemKindError) {
+                        logger.warn(`${item.kind}:${item.key} on ${target.node.id} will not commit:`, e);
                     }
                     await target.updateStatus(item.kind, item.key, "commitFailed", extractStatusCode(e));
                 }

--- a/packages/node-manager/src/task/Revert.ts
+++ b/packages/node-manager/src/task/Revert.ts
@@ -32,6 +32,10 @@ export class Revert extends Task<RevertParams> {
         this.revertOf ??= params.originalRunId;
     }
 
+    static override get callerCreatable(): boolean {
+        return false;
+    }
+
     static override undoes(params: RevertParams): RunId {
         return params.originalRunId;
     }

--- a/packages/node-manager/src/task/Revert.ts
+++ b/packages/node-manager/src/task/Revert.ts
@@ -5,7 +5,7 @@
  */
 
 import { ClientNode } from "@matter/node";
-import { Task } from "./Task.js";
+import { Task, TaskPersistence } from "./Task.js";
 import { ChangeEntry, RunId, TaskContext, TaskPhase } from "./types.js";
 
 export const REVERT_TYPE = "revert";
@@ -23,6 +23,14 @@ export interface RevertParams {
  */
 export class Revert extends Task<RevertParams> {
     readonly type = REVERT_TYPE;
+
+    constructor(runId: RunId, slotKey: string, params: RevertParams, persisted?: Partial<TaskPersistence>) {
+        super(runId, slotKey, params, persisted);
+        // The link to the run being undone comes from the params, so a rollback started or retried through the
+        // public `run` path carries it too. Exclusion of a re-run matches on this link; a rollback without one
+        // would let the forward work it is undoing start again underneath it.
+        this.revertOf ??= params.originalRunId;
+    }
 
     static override slotKeyFor(params: RevertParams): string {
         return `revert:${params.originalRunId}`;

--- a/packages/node-manager/src/task/Revert.ts
+++ b/packages/node-manager/src/task/Revert.ts
@@ -32,6 +32,10 @@ export class Revert extends Task<RevertParams> {
         this.revertOf ??= params.originalRunId;
     }
 
+    static override undoes(params: RevertParams): RunId {
+        return params.originalRunId;
+    }
+
     static override slotKeyFor(params: RevertParams): string {
         return `revert:${params.originalRunId}`;
     }

--- a/packages/node-manager/src/task/Revert.ts
+++ b/packages/node-manager/src/task/Revert.ts
@@ -6,12 +6,12 @@
 
 import { ClientNode } from "@matter/node";
 import { Task } from "./Task.js";
-import { ChangeEntry, TaskContext, TaskPhase } from "./types.js";
+import { ChangeEntry, RunId, TaskContext, TaskPhase } from "./types.js";
 
 export const REVERT_TYPE = "revert";
 
 export interface RevertParams {
-    originalId: string;
+    originalRunId: RunId;
     entries: ChangeEntry[];
 }
 
@@ -24,8 +24,8 @@ export interface RevertParams {
 export class Revert extends Task<RevertParams> {
     readonly type = REVERT_TYPE;
 
-    static override idFor(params: RevertParams): string {
-        return `revert:${params.originalId}`;
+    static override slotKeyFor(params: RevertParams): string {
+        return `revert:${params.originalRunId}`;
     }
 
     get phases(): TaskPhase[] {

--- a/packages/node-manager/src/task/RunStore.ts
+++ b/packages/node-manager/src/task/RunStore.ts
@@ -22,11 +22,11 @@ export interface RunStoreSnapshot {
 }
 
 /**
- * The run table: identity allocation, the live slot index, retired records and tombstones.
+ * The run table: identity allocation, the live slot index and retired records.
  *
- * Deliberately free of any dependency on a node, a gate or a clock, so the invariants that four review rounds
- * kept breaking — allocation monotonicity, one owner per slot, ordering by retirement rather than by start —
- * are testable without driving a task. The manager owns persistence and calls {@link snapshot} to write.
+ * Deliberately free of any dependency on a node, a gate or a clock, so its invariants — allocation
+ * monotonicity, one owner per slot, ordering by retirement rather than by start — are testable without
+ * driving a task. The manager owns persistence and calls {@link snapshot} to write.
  */
 export class RunStore {
     #nextRunId = 1;

--- a/packages/node-manager/src/task/RunStore.ts
+++ b/packages/node-manager/src/task/RunStore.ts
@@ -15,6 +15,16 @@ export function isTerminal(state: TaskState): boolean {
     return TERMINAL_STATES.has(state);
 }
 
+/**
+ * How far ahead of itself the identity counter is persisted.
+ *
+ * `run()` is synchronous, so a run's identity is handed out before any write. Persisting the counter this far
+ * ahead means an identity is already durable when it is issued, and a process that stops before the run's
+ * first record lands cannot re-issue it to unrelated work. The cost is that a restart abandons whatever is
+ * left of the block, so identities are sparse rather than consecutive.
+ */
+export const RUN_ID_RESERVATION = 64;
+
 export interface RunStoreSnapshot {
     runs: Record<string, TaskPersistence>;
     nextRunId: number;
@@ -34,6 +44,12 @@ export class RunStore {
     readonly #live = new Map<RunId, Task>();
     readonly #slots = new Map<string, RunId>();
     readonly #retired = new Map<RunId, TaskPersistence>();
+    /**
+     * Persisted non-terminal runs this start has not instantiated yet, because nothing has registered their
+     * type. They are work in progress, so they answer lookups and hold their slot: a record that were invisible
+     * could have its slot taken by new work and would then never resume, orphaning the intents it already wrote.
+     */
+    readonly #pending = new Map<RunId, TaskPersistence>();
 
     /**
      * Load persisted state. `externalId` is not persisted as an index of its own: it is derived from the
@@ -55,6 +71,7 @@ export class RunStore {
             if (isTerminal(record.state)) {
                 this.#retired.set(record.runId, record);
             } else {
+                this.#pending.set(record.runId, record);
                 resumable.push(record);
             }
         }
@@ -81,10 +98,35 @@ export class RunStore {
         return RunId(this.#nextRunId++);
     }
 
+    /** The counter as it must be recorded: far enough ahead that issued identities are already durable. */
+    get reservedRunId(): number {
+        return this.#nextRunId + RUN_ID_RESERVATION;
+    }
+
     /** The run that currently owns `slotKey`, if any. */
     ownerOf(slotKey: string): Task | undefined {
         const runId = this.#slots.get(slotKey);
         return runId === undefined ? undefined : this.#live.get(runId);
+    }
+
+    /** A persisted run awaiting resume that holds `slotKey`. */
+    pendingOwnerOf(slotKey: string): TaskPersistence | undefined {
+        for (const record of this.#pending.values()) {
+            if (record.slotKey === slotKey) {
+                return record;
+            }
+        }
+        return undefined;
+    }
+
+    /** Records awaiting resume, in ascending runId — the only order defined for resume. */
+    get pending(): TaskPersistence[] {
+        return [...this.#pending.values()].sort((a, b) => a.runId - b.runId);
+    }
+
+    /** Take a record out of the pending tier once resume has decided what to do with it. */
+    resolvePending(runId: RunId): void {
+        this.#pending.delete(runId);
     }
 
     /** Register a run as live and give it ownership of its slot. */
@@ -163,11 +205,21 @@ export class RunStore {
         return this.#retired.get(runId);
     }
 
+    pendingRun(runId: RunId): TaskPersistence | undefined {
+        return this.#pending.get(runId);
+    }
+
     /** The run a caller-supplied external id names, preferring a live holder over a retired one. */
     findByExternalId(externalId: string): { runId: RunId; live?: Task } | undefined {
         for (const task of this.#live.values()) {
             if (task.externalId === externalId) {
                 return { runId: task.runId, live: task };
+            }
+        }
+        // Before retired records: a run awaiting resume is unfinished work, and its name still belongs to it.
+        for (const record of this.#pending.values()) {
+            if (record.externalId === externalId) {
+                return { runId: record.runId };
             }
         }
         let newest: TaskPersistence | undefined;
@@ -185,11 +237,21 @@ export class RunStore {
         return undefined;
     }
 
-    /** A live run holding `externalId` whose slot is not `slotKey`, which no request may take that name from. */
-    conflictingExternalIdHolder(externalId: string, slotKey: string): Task | undefined {
+    /**
+     * A run holding `externalId` whose slot is not `slotKey`, which no request may take that name from.
+     *
+     * Includes runs awaiting resume: they are unfinished work whose name still belongs to them, and letting a
+     * different slot take it would leave the resumed run answering to nothing.
+     */
+    conflictingExternalIdHolder(externalId: string, slotKey: string): { runId: RunId; slotKey: string } | undefined {
         for (const task of this.#live.values()) {
             if (task.externalId === externalId && task.slotKey !== slotKey) {
                 return task;
+            }
+        }
+        for (const record of this.#pending.values()) {
+            if (record.externalId === externalId && record.slotKey !== slotKey) {
+                return record;
             }
         }
         return undefined;
@@ -221,6 +283,9 @@ export class RunStore {
             runs[runKey(task.runId)] = task.toPersistence();
         }
         for (const [runId, record] of this.#retired) {
+            runs[runKey(runId)] = record;
+        }
+        for (const [runId, record] of this.#pending) {
             runs[runKey(runId)] = record;
         }
         return { runs, nextRunId: this.#nextRunId, nextRetireSeq: this.#nextRetireSeq };

--- a/packages/node-manager/src/task/RunStore.ts
+++ b/packages/node-manager/src/task/RunStore.ts
@@ -5,6 +5,7 @@
  */
 
 import { ImplementationError } from "@matter/general";
+import { TaskIdentityExhaustedError } from "./errors.js";
 import { runKey, Task, TaskPersistence } from "./Task.js";
 import { RetireSeq, RunId, TaskState } from "./types.js";
 
@@ -40,6 +41,8 @@ export interface RunStoreSnapshot {
  */
 export class RunStore {
     #nextRunId = 1;
+    /** Identities below this are durable: the persisted counter is at least this high. */
+    #reservedBelow = 1;
     #nextRetireSeq = 1;
     readonly #live = new Map<RunId, Task>();
     readonly #slots = new Map<string, RunId>();
@@ -78,6 +81,8 @@ export class RunStore {
         // The persisted counter is a high-water mark, so it is authoritative where present; seeding above the
         // highest surviving id covers a store whose counter predates this scheme.
         this.#nextRunId = Math.max(snapshot?.nextRunId ?? 1, highest + 1);
+        // Whatever the last start persisted is what is durable; anything beyond it must be reserved again.
+        this.#reservedBelow = Math.max(snapshot?.nextRunId ?? 1, this.#nextRunId);
         this.#nextRetireSeq = Math.max(
             snapshot?.nextRetireSeq ?? 1,
             ...[...this.#retired.values()].map(r => (r.retireSeq ?? 0) + 1),
@@ -93,14 +98,29 @@ export class RunStore {
         return this.#nextRetireSeq;
     }
 
-    /** Claim the next identity. Callers allocate only after a request has passed admission. */
+    /**
+     * Claim the next identity. Callers allocate only after a request has passed admission.
+     *
+     * Refuses rather than hand out an identity the last write did not cover: an unreserved identity is one the
+     * next start can give to different work, which is the whole hazard the reservation exists to remove.
+     */
     allocate(): RunId {
+        if (this.#nextRunId >= this.#reservedBelow) {
+            throw new TaskIdentityExhaustedError(
+                `No durable run identity available: ${this.#nextRunId} is beyond the reservation ${this.#reservedBelow}. Retry once a record has been written.`,
+            );
+        }
         return RunId(this.#nextRunId++);
     }
 
-    /** The counter as it must be recorded: far enough ahead that issued identities are already durable. */
+    /** The counter as it must be recorded to cover the identities this store will hand out next. */
     get reservedRunId(): number {
         return this.#nextRunId + RUN_ID_RESERVATION;
+    }
+
+    /** Note that a reservation has been recorded, so identities below it may now be issued. */
+    noteReserved(through: number): void {
+        this.#reservedBelow = Math.max(this.#reservedBelow, through);
     }
 
     /** The run that currently owns `slotKey`, if any. */

--- a/packages/node-manager/src/task/RunStore.ts
+++ b/packages/node-manager/src/task/RunStore.ts
@@ -1,0 +1,228 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ImplementationError } from "@matter/general";
+import { runKey, Task, TaskPersistence } from "./Task.js";
+import { RetireSeq, RunId, TaskState } from "./types.js";
+
+const TERMINAL_STATES: ReadonlySet<TaskState> = new Set<TaskState>(["completed", "failed", "cancelled"]);
+
+/** Whether a persisted record has reached a state no driver will advance. */
+export function isTerminal(state: TaskState): boolean {
+    return TERMINAL_STATES.has(state);
+}
+
+export interface RunStoreSnapshot {
+    runs: Record<string, TaskPersistence>;
+    nextRunId: number;
+    nextRetireSeq: number;
+}
+
+/**
+ * The run table: identity allocation, the live slot index, retired records and tombstones.
+ *
+ * Deliberately free of any dependency on a node, a gate or a clock, so the invariants that four review rounds
+ * kept breaking — allocation monotonicity, one owner per slot, ordering by retirement rather than by start —
+ * are testable without driving a task. The manager owns persistence and calls {@link snapshot} to write.
+ */
+export class RunStore {
+    #nextRunId = 1;
+    #nextRetireSeq = 1;
+    readonly #live = new Map<RunId, Task>();
+    readonly #slots = new Map<string, RunId>();
+    readonly #retired = new Map<RunId, TaskPersistence>();
+
+    /**
+     * Load persisted state. `externalId` is not persisted as an index of its own: it is derived from the
+     * records that carry it, so it cannot drift from them.
+     */
+    load(snapshot: Partial<RunStoreSnapshot> | undefined): { resumable: TaskPersistence[]; discarded: number } {
+        const resumable = new Array<TaskPersistence>();
+        let discarded = 0;
+        let highest = 0;
+
+        for (const record of Object.values(snapshot?.runs ?? {})) {
+            // Pre-runId records name their slot where a runId now goes; they cannot be resumed under an
+            // identity they never had.
+            if (typeof record?.runId !== "number") {
+                discarded++;
+                continue;
+            }
+            highest = Math.max(highest, record.runId);
+            if (isTerminal(record.state)) {
+                this.#retired.set(record.runId, record);
+            } else {
+                resumable.push(record);
+            }
+        }
+        // The persisted counter is a high-water mark, so it is authoritative where present; seeding above the
+        // highest surviving id covers a store whose counter predates this scheme.
+        this.#nextRunId = Math.max(snapshot?.nextRunId ?? 1, highest + 1);
+        this.#nextRetireSeq = Math.max(
+            snapshot?.nextRetireSeq ?? 1,
+            ...[...this.#retired.values()].map(r => (r.retireSeq ?? 0) + 1),
+        );
+        return { resumable, discarded };
+    }
+
+    get nextRunId(): number {
+        return this.#nextRunId;
+    }
+
+    get nextRetireSeq(): number {
+        return this.#nextRetireSeq;
+    }
+
+    /** Claim the next identity. Callers allocate only after a request has passed admission. */
+    allocate(): RunId {
+        return RunId(this.#nextRunId++);
+    }
+
+    /** The run that currently owns `slotKey`, if any. */
+    ownerOf(slotKey: string): Task | undefined {
+        const runId = this.#slots.get(slotKey);
+        return runId === undefined ? undefined : this.#live.get(runId);
+    }
+
+    /** Register a run as live and give it ownership of its slot. */
+    admit(task: Task): void {
+        const owner = this.#slots.get(task.slotKey);
+        if (owner !== undefined && owner !== task.runId) {
+            throw new ImplementationError(
+                `Run ${task.runId} cannot take slot ${task.slotKey}: run ${owner} still owns it`,
+            );
+        }
+        this.#live.set(task.runId, task);
+        this.#slots.set(task.slotKey, task.runId);
+    }
+
+    /**
+     * Stamp a settled run's place in the retirement order, without moving it. Retirement is only real once the
+     * record carrying it is durable, so the caller writes first and then {@link commitRetirement}: nothing but
+     * this one field is staged, and {@link abandonRetirement} undoes it if the write is refused.
+     */
+    stampRetirement(task: Task): void {
+        if (this.#live.has(task.runId) && task.retireSeq === undefined) {
+            task.retireSeq = RetireSeq(this.#nextRetireSeq++);
+        }
+    }
+
+    /** Hand back a stamped run's slot and move its record to the retired tier. */
+    commitRetirement(task: Task): void {
+        if (!this.#live.has(task.runId)) {
+            return;
+        }
+        this.#live.delete(task.runId);
+        if (this.#slots.get(task.slotKey) === task.runId) {
+            this.#slots.delete(task.slotKey);
+        }
+        this.#retired.set(task.runId, task.toPersistence());
+    }
+
+    /** Drop a retirement whose record never landed. The run keeps its slot and stays exactly as it was. */
+    abandonRetirement(task: Task): void {
+        task.retireSeq = undefined;
+    }
+
+    /** Re-read a retired run's record from its task, for a change made after it retired. */
+    refresh(task: Task): void {
+        if (this.#retired.has(task.runId)) {
+            this.#retired.set(task.runId, task.toPersistence());
+        }
+    }
+
+    /** Forget a run that was never persisted, so a refused write leaves nothing for a later resume to find. */
+    discard(task: Task): void {
+        this.#live.delete(task.runId);
+        if (this.#slots.get(task.slotKey) === task.runId) {
+            this.#slots.delete(task.slotKey);
+        }
+    }
+
+    get live(): Task[] {
+        return [...this.#live.values()];
+    }
+
+    isLive(runId: RunId): boolean {
+        return this.#live.has(runId);
+    }
+
+    liveRun(runId: RunId): Task | undefined {
+        return this.#live.get(runId);
+    }
+
+    /** Retired records, newest retirement first. Ordered by `retireSeq`, never by `runId` or insertion. */
+    get retired(): TaskPersistence[] {
+        return [...this.#retired.values()].sort((a, b) => (b.retireSeq ?? 0) - (a.retireSeq ?? 0));
+    }
+
+    retiredRun(runId: RunId): TaskPersistence | undefined {
+        return this.#retired.get(runId);
+    }
+
+    /** The run a caller-supplied external id names, preferring a live holder over a retired one. */
+    findByExternalId(externalId: string): { runId: RunId; live?: Task } | undefined {
+        for (const task of this.#live.values()) {
+            if (task.externalId === externalId) {
+                return { runId: task.runId, live: task };
+            }
+        }
+        let newest: TaskPersistence | undefined;
+        for (const record of this.retired) {
+            if (
+                record.externalId === externalId &&
+                (newest === undefined || (record.retireSeq ?? 0) > (newest.retireSeq ?? 0))
+            ) {
+                newest = record;
+            }
+        }
+        if (newest !== undefined) {
+            return { runId: newest.runId };
+        }
+        return undefined;
+    }
+
+    /** A live run holding `externalId` whose slot is not `slotKey`, which no request may take that name from. */
+    conflictingExternalIdHolder(externalId: string, slotKey: string): Task | undefined {
+        for (const task of this.#live.values()) {
+            if (task.externalId === externalId && task.slotKey !== slotKey) {
+                return task;
+            }
+        }
+        return undefined;
+    }
+
+    /**
+     * A live rollback of any retired run of `slotKey`. A rollback rewrites exactly the intents a re-run would
+     * re-apply, so the two must never overlap — and the rollback in flight is not necessarily undoing the most
+     * recent run of the slot.
+     */
+    pendingRevertOfSlot(slotKey: string): Task | undefined {
+        const undone = new Set<RunId>();
+        for (const [runId, record] of this.#retired) {
+            if (record.slotKey === slotKey) {
+                undone.add(runId);
+            }
+        }
+        for (const task of this.#live.values()) {
+            if (task.revertOf !== undefined && undone.has(task.revertOf)) {
+                return task;
+            }
+        }
+        return undefined;
+    }
+
+    snapshot(): RunStoreSnapshot {
+        const runs: Record<string, TaskPersistence> = {};
+        for (const task of this.#live.values()) {
+            runs[runKey(task.runId)] = task.toPersistence();
+        }
+        for (const [runId, record] of this.#retired) {
+            runs[runKey(runId)] = record;
+        }
+        return { runs, nextRunId: this.#nextRunId, nextRetireSeq: this.#nextRetireSeq };
+    }
+}

--- a/packages/node-manager/src/task/RunStore.ts
+++ b/packages/node-manager/src/task/RunStore.ts
@@ -278,6 +278,26 @@ export class RunStore {
     }
 
     /**
+     * A retired run of the same slot that finished after `runId`, if there is one.
+     *
+     * Undoing a run restores the values it found, so a later run of the same slot having since committed its
+     * own makes those values historical: applying them would overwrite an outcome nobody asked to undo.
+     */
+    supersederOf(runId: RunId): TaskPersistence | undefined {
+        const record = this.#retired.get(runId);
+        if (record === undefined) {
+            return undefined;
+        }
+        const retiredAt = record.retireSeq ?? 0;
+        for (const other of this.#retired.values()) {
+            if (other.slotKey === record.slotKey && (other.retireSeq ?? 0) > retiredAt) {
+                return other;
+            }
+        }
+        return undefined;
+    }
+
+    /**
      * A live rollback of any retired run of `slotKey`. A rollback rewrites exactly the intents a re-run would
      * re-apply, so the two must never overlap — and the rollback in flight is not necessarily undoing the most
      * recent run of the slot.

--- a/packages/node-manager/src/task/RunStore.ts
+++ b/packages/node-manager/src/task/RunStore.ts
@@ -41,7 +41,11 @@ export interface RunStoreSnapshot {
  */
 export class RunStore {
     #nextRunId = 1;
-    /** Identities below this are durable: the persisted counter is at least this high. */
+    /**
+     * Identities below this are durable. Advanced only by {@link noteReserved}, which the manager calls once
+     * the write carrying the counter has landed — never before it, or a refused write leaves a boundary
+     * standing that storage does not back and the next start re-issues everything beyond it.
+     */
     #reservedBelow = 1;
     #nextRetireSeq = 1;
     readonly #live = new Map<RunId, Task>();
@@ -71,6 +75,14 @@ export class RunStore {
                 continue;
             }
             highest = Math.max(highest, record.runId);
+            // A terminal record carries its place in the retirement order, because the write that records an
+            // outcome stamps it. One without is from a build that wrote the outcome and the order separately;
+            // it has no position, so it would sort ahead of every sequenced run of its slot and let an older
+            // run's rollback overwrite it.
+            if (isTerminal(record.state) && record.retireSeq === undefined) {
+                discarded++;
+                continue;
+            }
             if (isTerminal(record.state)) {
                 this.#retired.set(record.runId, record);
             } else {
@@ -113,14 +125,14 @@ export class RunStore {
         return RunId(this.#nextRunId++);
     }
 
+    /** Note that a reservation is now durable, so identities below it may be issued. */
+    noteReserved(through: number): void {
+        this.#reservedBelow = Math.max(this.#reservedBelow, through);
+    }
+
     /** The counter as it must be recorded to cover the identities this store will hand out next. */
     get reservedRunId(): number {
         return this.#nextRunId + RUN_ID_RESERVATION;
-    }
-
-    /** Note that a reservation has been recorded, so identities below it may now be issued. */
-    noteReserved(through: number): void {
-        this.#reservedBelow = Math.max(this.#reservedBelow, through);
     }
 
     /** The run that currently owns `slotKey`, if any. */
@@ -162,9 +174,14 @@ export class RunStore {
     }
 
     /**
-     * Stamp a settled run's place in the retirement order, without moving it. Retirement is only real once the
-     * record carrying it is durable, so the caller writes first and then {@link commitRetirement}: nothing but
-     * this one field is staged, and {@link abandonRetirement} undoes it if the write is refused.
+     * Stamp a settled run's place in the retirement order, without moving it.
+     *
+     * Called as the state becomes terminal, so the write that records the outcome carries the order with it. A
+     * terminal record that reached storage without one would sort ahead of every sequenced run of its slot, and
+     * {@link supersederOf} would then let an older run's rollback overwrite it.
+     *
+     * {@link abandonRetirement} undoes the stamp if that write is refused, and {@link commitRetirement} hands
+     * back the slot once it lands.
      */
     stampRetirement(task: Task): void {
         if (this.#live.has(task.runId) && task.retireSeq === undefined) {

--- a/packages/node-manager/src/task/RunningTaskContext.ts
+++ b/packages/node-manager/src/task/RunningTaskContext.ts
@@ -9,7 +9,7 @@ import { asError, Logger, ObserverGroup } from "@matter/general";
 import { ClientNode, DesiredStateBehavior, itemMapKey, ItemMode, ManagedItem, NetworkClient } from "@matter/node";
 import { SustainedSubscription } from "@matter/protocol";
 import { TaskFailedError, TaskPeerUnavailableError } from "./errors.js";
-import { Task } from "./Task.js";
+import { runLabel, Task } from "./Task.js";
 import { TaskContext, TaskState } from "./types.js";
 
 const logger = Logger.get("TaskContext");
@@ -41,7 +41,7 @@ export class RunningTaskContext implements TaskContext {
     resolvePeer(peerId: string): ClientNode {
         const peer = this.peerResolver(peerId);
         if (peer === undefined) {
-            throw new TaskPeerUnavailableError(`Task ${this.task.id}: peer "${peerId}" is not available`);
+            throw new TaskPeerUnavailableError(`Task ${runLabel(this.task.runId)}: peer "${peerId}" is not available`);
         }
         return peer;
     }
@@ -76,7 +76,7 @@ export class RunningTaskContext implements TaskContext {
 
     async removeIntentIfUnreferenced(peer: ClientNode, kind: string, key: string): Promise<boolean> {
         if (this.reconciler.itemKind(kind)?.isReferenced?.(peer, key)) {
-            logger.debug(`Task ${this.task.id}: keep ${kind}:${key} on ${peer.id} (still referenced)`);
+            logger.debug(`Task ${runLabel(this.task.runId)}: keep ${kind}:${key} on ${peer.id} (still referenced)`);
             return false;
         }
         await this.removeIntent(peer, kind, key);
@@ -99,7 +99,7 @@ export class RunningTaskContext implements TaskContext {
         const gone = items.find(i => this.#itemState(i.peer, i.kind, i.key) === undefined);
         if (gone !== undefined) {
             throw new TaskFailedError(
-                `Task ${this.task.id}: awaited intent ${gone.kind}:${gone.key} on ${gone.peer.id} is gone — ` +
+                `Task ${runLabel(this.task.runId)}: awaited intent ${gone.kind}:${gone.key} on ${gone.peer.id} is gone — ` +
                     `the reconciler dropped it, so it can no longer commit`,
             );
         }
@@ -124,7 +124,10 @@ export class RunningTaskContext implements TaskContext {
                     // A reconcile that rejects from an already-coalesced recheck after the gate settled
                     // still represents a real failure; surface it rather than dropping it silently.
                     if (err !== undefined) {
-                        logger.warn(`Task ${this.task.id}: ignoring late gate-evaluation error after settle:`, err);
+                        logger.warn(
+                            `Task ${runLabel(this.task.runId)}: ignoring late gate-evaluation error after settle:`,
+                            err,
+                        );
                     }
                     return;
                 }

--- a/packages/node-manager/src/task/Task.ts
+++ b/packages/node-manager/src/task/Task.ts
@@ -5,9 +5,13 @@
  */
 
 import { ImplementationError } from "@matter/general";
-import { ChangeEntry, PlannedChange, TaskPhase, TaskState, TaskStatus } from "./types.js";
+import { ChangeEntry, PlannedChange, RetireSeq, RunId, TaskPhase, TaskState, TaskStatus } from "./types.js";
 
 export interface TaskPersistence {
+    /** Identity of this run. Unique for the manager's lifetime; a re-run of the same slot gets a new one. */
+    runId: RunId;
+    /** The target this run intends to change. At most one run may own a slot at a time. */
+    slotKey: string;
     type: string;
     params: unknown;
     phaseIndex: number;
@@ -15,15 +19,28 @@ export interface TaskPersistence {
     externalId?: string;
     changeSet: ChangeEntry[];
     error?: string;
-    revertTaskId?: string;
-    revertOf?: string;
+    /** Order in which runs retired. The only ordering key for history and eviction; never use `runId`. */
+    retireSeq?: RetireSeq;
+    revertRunId?: RunId;
+    revertOf?: RunId;
+}
+
+/** How a run reads in a log or an error. A display convention, never an address. */
+export function runLabel(runId: RunId): string {
+    return `run #${runId}`;
+}
+
+/** Storage key for a run's record. Object keys must be strings; the run table holds nothing else. */
+export function runKey(runId: RunId): string {
+    return String(runId);
 }
 
 export abstract class Task<P = unknown> {
     abstract readonly type: string;
     abstract readonly phases: TaskPhase[];
 
-    readonly id: string;
+    readonly runId: RunId;
+    readonly slotKey: string;
     readonly params: P;
 
     /** Id the caller of `run` asked for this task under, so it can observe and cancel the work it asked for. */
@@ -32,29 +49,40 @@ export abstract class Task<P = unknown> {
     progress: { phaseIndex: number; state: TaskState };
     changeSet: ChangeEntry[];
     error?: string;
-    revertTaskId?: string;
-    revertOf?: string;
+    retireSeq?: RetireSeq;
+    revertRunId?: RunId;
+    revertOf?: RunId;
 
-    constructor(id: string, params: P, persisted?: Partial<TaskPersistence>) {
-        this.id = id;
+    constructor(runId: RunId, slotKey: string, params: P, persisted?: Partial<TaskPersistence>) {
+        this.runId = runId;
+        this.slotKey = slotKey;
         this.params = params;
         this.externalId = persisted?.externalId;
         this.progress = { phaseIndex: persisted?.phaseIndex ?? 0, state: persisted?.state ?? "running" };
         this.changeSet = persisted?.changeSet ?? new Array<ChangeEntry>();
         this.error = persisted?.error;
-        this.revertTaskId = persisted?.revertTaskId;
+        this.retireSeq = persisted?.retireSeq;
+        this.revertRunId = persisted?.revertRunId;
         this.revertOf = persisted?.revertOf;
+    }
+
+    toString(): string {
+        return runLabel(this.runId);
     }
 
     get status(): TaskStatus {
         return {
+            runId: this.runId,
+            slotKey: this.slotKey,
             type: this.type,
             state: this.progress.state,
             phaseIndex: this.progress.phaseIndex,
             externalId: this.externalId,
             error: this.error,
-            revertTaskId: this.revertTaskId,
+            retireSeq: this.retireSeq,
+            revertRunId: this.revertRunId,
             revertOf: this.revertOf,
+            detail: "full",
         };
     }
 
@@ -77,22 +105,18 @@ export abstract class Task<P = unknown> {
         return new Array<PlannedChange>();
     }
 
-    /** Deterministic internal id from type + params. Subclasses override with their own key. */
-    static idFor(_params: unknown): string {
-        throw new ImplementationError("idFor must be implemented by the Task subclass");
-    }
-
     /**
-     * While a task is live and non-terminal, no other task sharing the same non-undefined resourceKey may start —
-     * mutual exclusion over a resource the reconciler cannot let two tasks mutate concurrently. Default undefined =
-     * no exclusivity.
+     * The target this task intends to change, derived from type and params. At most one non-terminal run may
+     * exist per slot key. Subclasses override with their own key.
      */
-    resourceKey(): string | undefined {
-        return undefined;
+    static slotKeyFor(_params: unknown): string {
+        throw new ImplementationError("slotKeyFor must be implemented by the Task subclass");
     }
 
     toPersistence(): TaskPersistence {
         return {
+            runId: this.runId,
+            slotKey: this.slotKey,
             type: this.type,
             params: this.params,
             phaseIndex: this.progress.phaseIndex,
@@ -100,7 +124,8 @@ export abstract class Task<P = unknown> {
             externalId: this.externalId,
             changeSet: this.changeSet,
             error: this.error,
-            revertTaskId: this.revertTaskId,
+            retireSeq: this.retireSeq,
+            revertRunId: this.revertRunId,
             revertOf: this.revertOf,
         };
     }

--- a/packages/node-manager/src/task/Task.ts
+++ b/packages/node-manager/src/task/Task.ts
@@ -106,6 +106,14 @@ export abstract class Task<P = unknown> {
     }
 
     /**
+     * The run this task undoes, if it is a rollback. A rollback rewrites the intents of that run, so it
+     * contends for *that* run's slot rather than for its own, and the manager excludes it there.
+     */
+    static undoes(_params: unknown): RunId | undefined {
+        return undefined;
+    }
+
+    /**
      * The target this task intends to change, derived from type and params. At most one non-terminal run may
      * exist per slot key. Subclasses override with their own key.
      */

--- a/packages/node-manager/src/task/Task.ts
+++ b/packages/node-manager/src/task/Task.ts
@@ -106,6 +106,16 @@ export abstract class Task<P = unknown> {
     }
 
     /**
+     * Whether a caller may start this type through {@link TaskManagerBehavior.run}.
+     *
+     * A rollback is false: it exists to undo a specific run, and only the manager knows that the run's driver
+     * has been stopped first. A caller able to conjure one could start it against work still in flight.
+     */
+    static get callerCreatable(): boolean {
+        return true;
+    }
+
+    /**
      * The run this task undoes, if it is a rollback. A rollback rewrites the intents of that run, so it
      * contends for *that* run's slot rather than for its own, and the manager excludes it there.
      */

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -252,6 +252,11 @@ export class TaskManagerBehavior extends Behavior {
      * The `externalId` is also the id the caller can {@link get} and {@link cancel} its task under.
      */
     run(type: string, params: unknown, opts?: { externalId?: string }): TaskHandle {
+        if (!this.internal.registry.callerCreatable(type)) {
+            throw new ImplementationError(
+                `Task type "${type}" undoes another run and is created by cancel(), not by run()`,
+            );
+        }
         const { task, joined } = this.#spawn(type, params, { externalId: opts?.externalId });
         if (!joined) {
             this.#track(task);
@@ -329,10 +334,12 @@ export class TaskManagerBehavior extends Behavior {
         //    that now owns the slot, rewrite the same intents at once.
         const undone = this.internal.registry.undoes(type, params);
         if (undone !== undefined) {
-            const undoneSlot = (runs.liveRun(undone) ?? runs.retiredRun(undone))?.slotKey;
+            const undoneSlot = (runs.liveRun(undone) ?? runs.retiredRun(undone) ?? runs.pendingRun(undone))?.slotKey;
             if (undoneSlot !== undefined) {
                 const holder = runs.ownerOf(undoneSlot);
-                // The run being undone still owns its slot while its own cancel prepares this rollback.
+                // A rollback is only ever prepared by cancel, which has already stopped the run's driver, so
+                // the run still holding its own slot here is expected. Any other holder is live work this
+                // rollback would rewrite underneath.
                 if (holder !== undefined && holder.runId !== undone) {
                     throw new TaskConflictError(
                         `Rollback of ${runLabel(undone)} rejected: slot ${undoneSlot} is held by ${runLabel(holder.runId)}`,
@@ -420,6 +427,58 @@ export class TaskManagerBehavior extends Behavior {
     }
 
     /**
+     * Start a fresh rollback for a run whose previous one did not finish.
+     *
+     * A rollback is created by {@link cancel}, so retrying one cannot be an ordinary `run`: only the manager
+     * knows the original's driver is stopped and that no other rollback of its slot is in flight. Refuses
+     * while the recorded rollback is still going, since that one may yet succeed.
+     */
+    async retryRollback(runId: RunId): Promise<TaskHandle> {
+        const live = this.internal.runs.liveRun(runId);
+        const retired = this.internal.runs.retiredRun(runId);
+        if (live === undefined && retired === undefined) {
+            throw new TaskNotFoundError(`Cannot retry the rollback of ${runLabel(runId)}: no run answers to it`);
+        }
+        const previous = live?.revertRunId ?? retired?.revertRunId;
+        if (previous === undefined) {
+            throw new ImplementationError(`${runLabel(runId)} has no rollback to retry`);
+        }
+        const inFlight = this.internal.runs.liveRun(previous);
+        if (inFlight !== undefined) {
+            throw new TaskConflictError(
+                `Cannot retry the rollback of ${runLabel(runId)}: ${runLabel(previous)} is still in flight`,
+                previous,
+            );
+        }
+
+        const original = live ?? this.#reconstitute(retired!);
+        original.revertRunId = undefined;
+        const revert = this.#prepareRevert(original);
+        if (revert.task === undefined) {
+            throw new ImplementationError(`${runLabel(runId)} has nothing to roll back`);
+        }
+        try {
+            await this.#persist(original, revert.task);
+        } catch (e) {
+            original.revertRunId = previous;
+            revert.discard();
+            throw e;
+        }
+        revert.start();
+        return this.#handle(revert.task);
+    }
+
+    /** Rebuild a retired run from its record, which undo needs because revertibility is the task's decision. */
+    #reconstitute(record: TaskPersistence): Task {
+        if (!this.internal.registry.has(record.type)) {
+            throw new TaskTypeNotRegisteredError(
+                `Cannot act on ${runLabel(record.runId)}: task type "${record.type}" is not registered`,
+            );
+        }
+        return this.internal.registry.create(record.type, record.runId, record.slotKey, record.params, record);
+    }
+
+    /**
      * Cancel a task: stop forward driving, then spawn a revert task that rolls back the changeSet as an ordinary
      * task (parks on offline peers, resumes after restart). Does not await the revert — the caller observes it
      * via the returned handle.
@@ -450,12 +509,7 @@ export class TaskManagerBehavior extends Behavior {
             if (retired.state === "cancelled") {
                 return undefined;
             }
-            if (!this.internal.registry.has(retired.type)) {
-                throw new TaskTypeNotRegisteredError(
-                    `Cannot cancel ${runLabel(runId)}: task type "${retired.type}" is not registered`,
-                );
-            }
-            task = this.internal.registry.create(retired.type, retired.runId, retired.slotKey, retired.params, retired);
+            task = this.#reconstitute(retired);
         }
         // A rollback this run already recorded is the answer, wherever it now lives: reporting it as unknown
         // would make re-cancelling fail the moment its rollback finishes.

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -176,10 +176,12 @@ export class TaskManagerBehavior extends Behavior {
                 logger.warn(`Not resuming run ${record.runId}: slot ${record.slotKey} is owned by run ${owner.runId}`);
                 continue;
             }
-            this.internal.runs.resolvePending(record.runId);
             try {
                 const task = this.internal.registry.create(type, record.runId, record.slotKey, record.params, record);
                 this.internal.runs.admit(task);
+                // Dropped from pending only now: a record whose task could not be built is still unfinished
+                // work, and forgetting it here would free its slot and hide it from lookup for this process.
+                this.internal.runs.resolvePending(record.runId);
                 this.#redrive(task);
             } catch (e) {
                 logger.error(`Cannot resume run ${record.runId}`, e);
@@ -344,6 +346,13 @@ export class TaskManagerBehavior extends Behavior {
                     throw new TaskConflictError(
                         `Rollback of ${runLabel(undone)} rejected: slot ${undoneSlot} is held by ${runLabel(holder.runId)}`,
                         holder.runId,
+                    );
+                }
+                const superseder = runs.supersederOf(undone);
+                if (superseder !== undefined) {
+                    throw new TaskConflictError(
+                        `Rollback of ${runLabel(undone)} rejected: ${runLabel(superseder.runId)} has since committed slot ${undoneSlot}, so the values this would restore are historical`,
+                        superseder.runId,
                     );
                 }
                 const sibling = runs.pendingRevertOfSlot(undoneSlot);

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -85,12 +85,11 @@ export class TaskManagerBehavior extends Behavior {
         this.internal.registry = new TaskRegistry();
         this.internal.runs = new RunStore();
         this.internal.gates = new Map();
-        const { resumable, discarded } = this.internal.runs.load({
+        const { discarded } = this.internal.runs.load({
             runs: this.state.runs,
             nextRunId: this.state.nextRunId,
             nextRetireSeq: this.state.nextRetireSeq,
         });
-        this.internal.resumable = resumable;
         if (discarded > 0) {
             logger.warn(`Discarded ${discarded} task record(s) predating per-run identity`);
         }
@@ -111,12 +110,7 @@ export class TaskManagerBehavior extends Behavior {
 
     /** Records still awaiting resume, in ascending runId — the only order defined for resume. */
     get #resumable(): TaskPersistence[] {
-        return [...this.internal.resumable].sort((a, b) => a.runId - b.runId);
-    }
-
-    /** Forget a record once resume has taken its decision, so no later pass reconsiders it. */
-    #resumed(record: TaskPersistence): void {
-        this.internal.resumable = this.internal.resumable.filter(r => r.runId !== record.runId);
+        return this.internal.runs.pending;
     }
 
     /** Built-in task types registered before the resume pass. */
@@ -170,7 +164,7 @@ export class TaskManagerBehavior extends Behavior {
                 logger.warn(`Not resuming run ${record.runId}: slot ${record.slotKey} is owned by run ${owner.runId}`);
                 continue;
             }
-            this.#resumed(record);
+            this.internal.runs.resolvePending(record.runId);
             try {
                 const task = this.internal.registry.create(type, record.runId, record.slotKey, record.params, record);
                 this.internal.runs.admit(task);
@@ -269,7 +263,17 @@ export class TaskManagerBehavior extends Behavior {
         // 1. Driving started now would outlive the dispose drain and write to peers after close.
         this.#refuseIfClosing(`Task ${slotKey} cannot start`);
 
-        // 2. The slot's owner joins the caller that already asked for this work, and refuses everyone else.
+        // 2. A persisted run awaiting resume still owns its slot. Letting new work take it would leave that
+        //    run unresumable and its already-written intents with no owner.
+        const awaiting = runs.pendingOwnerOf(slotKey);
+        if (awaiting !== undefined) {
+            throw new TaskConflictError(
+                `Task ${slotKey} rejected: ${runLabel(awaiting.runId)} holds this slot and is awaiting resume; register its type "${awaiting.type}" to continue it`,
+                awaiting.runId,
+            );
+        }
+
+        // 3. The slot's owner joins the caller that already asked for this work, and refuses everyone else.
         const owner = runs.ownerOf(slotKey);
         if (owner !== undefined) {
             if (this.internal.cancelling.has(owner.runId)) {
@@ -287,7 +291,7 @@ export class TaskManagerBehavior extends Behavior {
             return { task: owner, joined: true };
         }
 
-        // 3. An external id is one-to-one: a live run of another slot must not lose the name it answers to.
+        // 4. An external id is one-to-one: a live run of another slot must not lose the name it answers to.
         if (seed.externalId !== undefined) {
             const holder = runs.conflictingExternalIdHolder(seed.externalId, slotKey);
             if (holder !== undefined) {
@@ -298,7 +302,7 @@ export class TaskManagerBehavior extends Behavior {
             }
         }
 
-        // 4. A rollback rewrites exactly the intents a re-run would re-apply, so the two must never overlap —
+        // 5. A rollback rewrites exactly the intents a re-run would re-apply, so the two must never overlap —
         //    and the rollback in flight need not be undoing the most recent run of the slot.
         const pendingRevert = runs.pendingRevertOfSlot(slotKey);
         if (pendingRevert !== undefined) {
@@ -308,7 +312,7 @@ export class TaskManagerBehavior extends Behavior {
             );
         }
 
-        // 5. A rollback contends for the slot of the run it undoes, not for its own: its slot is unique per
+        // 6. A rollback contends for the slot of the run it undoes, not for its own: its slot is unique per
         //    run, so checking that alone would let two rollbacks of one slot, or a rollback and the newer run
         //    that now owns the slot, rewrite the same intents at once.
         const undone = this.internal.registry.undoes(type, params);
@@ -344,7 +348,7 @@ export class TaskManagerBehavior extends Behavior {
         if (live !== undefined) {
             return this.#handle(live);
         }
-        const record = this.internal.runs.retiredRun(runId);
+        const record = this.internal.runs.retiredRun(runId) ?? this.internal.runs.pendingRun(runId);
         return record === undefined ? undefined : this.#recordHandle(record);
     }
 
@@ -510,7 +514,10 @@ export class TaskManagerBehavior extends Behavior {
         this.internal.runs.commitRetirement(task);
         // The rollback mutates peers, so it may not drive before the record that names it is durable.
         revert.start();
-        return revert.task === undefined ? undefined : this.#handle(revert.task);
+        // Resolved from the run's own link rather than from what this call prepared: a second cancel that
+        // raced this one finds the rollback already recorded, and must be told about it rather than told
+        // there was nothing to roll back.
+        return task.revertRunId === undefined ? undefined : this.get(task.revertRunId);
     }
 
     // Teardown starts at the node, not at this behavior: `Construction.close` applies `Destroying` before it runs
@@ -758,7 +765,8 @@ export class TaskManagerBehavior extends Behavior {
         // other runs' uncommitted in-flight state as though it were durable.
         const written = paired === undefined ? [task] : [task, paired];
         const records = written.map(t => [runKey(t.runId), t.toPersistence()] as const);
-        const { nextRunId, nextRetireSeq } = this.internal.runs.snapshot();
+        const { nextRetireSeq } = this.internal.runs.snapshot();
+        const reservedRunId = this.internal.runs.reservedRunId;
         await this.endpoint.act(agent => {
             const self = agent.get(TaskManagerBehavior);
             const runs = { ...self.state.runs };
@@ -768,7 +776,7 @@ export class TaskManagerBehavior extends Behavior {
             self.state.runs = runs;
             // High-water marks: never `consumed + 1`, or a write that lands out of allocation order lowers the
             // counter below a durable identity and a crash re-issues it.
-            self.state.nextRunId = Math.max(self.state.nextRunId, nextRunId);
+            self.state.nextRunId = Math.max(self.state.nextRunId, reservedRunId);
             self.state.nextRetireSeq = Math.max(self.state.nextRetireSeq, nextRetireSeq);
         });
         // Only now: a retired record refreshed before the write would keep a change the write never made, and
@@ -804,11 +812,6 @@ export namespace TaskManagerBehavior {
     export class Internal {
         registry!: TaskRegistry;
         runs!: RunStore;
-        /**
-         * Persisted non-terminal records this start has not resumed yet, because their type is registered
-         * later. Held here rather than re-read from state, which no longer contains what has not been loaded.
-         */
-        resumable: TaskPersistence[] = [];
         gates!: Map<RunId, GateState>;
         driving = new Map<RunId, Promise<void>>();
         cancelling = new Set<RunId>();

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -399,6 +399,15 @@ export class TaskManagerBehavior extends Behavior {
             // Undo of finished work reads the retained changeSet, so the run has to be reconstituted:
             // `revertible` is a subclass decision (a realized rotation declines it) and a record cannot
             // answer it.
+            // A run that already recorded a rollback, or that was already cancelled with none, is answered by
+            // its record. Only deciding on a NEW rollback needs the task, because revertibility is the task's
+            // decision — so registration is required there and nowhere else.
+            if (retired.revertRunId !== undefined) {
+                return this.get(retired.revertRunId);
+            }
+            if (retired.state === "cancelled") {
+                return undefined;
+            }
             if (!this.internal.registry.has(retired.type)) {
                 throw new TaskTypeNotRegisteredError(
                     `Cannot cancel ${runLabel(runId)}: task type "${retired.type}" is not registered`,
@@ -717,9 +726,6 @@ export class TaskManagerBehavior extends Behavior {
         // other runs' uncommitted in-flight state as though it were durable.
         const written = paired === undefined ? [task] : [task, paired];
         const records = written.map(t => [runKey(t.runId), t.toPersistence()] as const);
-        for (const t of written) {
-            this.internal.runs.refresh(t);
-        }
         const { nextRunId, nextRetireSeq } = this.internal.runs.snapshot();
         await this.endpoint.act(agent => {
             const self = agent.get(TaskManagerBehavior);
@@ -733,6 +739,11 @@ export class TaskManagerBehavior extends Behavior {
             self.state.nextRunId = Math.max(self.state.nextRunId, nextRunId);
             self.state.nextRetireSeq = Math.max(self.state.nextRetireSeq, nextRetireSeq);
         });
+        // Only now: a retired record refreshed before the write would keep a change the write never made, and
+        // a run would go on naming a rollback that does not exist.
+        for (const t of written) {
+            this.internal.runs.refresh(t);
+        }
     }
 
     override async [Symbol.asyncDispose]() {

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -134,6 +134,7 @@ export class TaskManagerBehavior extends Behavior {
         if (this.state.nextRunId < reservedRunId) {
             this.state.nextRunId = reservedRunId;
         }
+        // Written in this same transaction, so the boundary it establishes is durable with it.
         this.internal.runs.noteReserved(this.state.nextRunId);
     }
 
@@ -210,14 +211,14 @@ export class TaskManagerBehavior extends Behavior {
     }
 
     /**
-     * Release a settled run: drop its bookkeeping, stamp its retirement and record it.
+     * Release a settled run: hand back its slot and drop its bookkeeping.
      *
      * The slot is released here rather than when the state turned terminal, because a task is terminal before
      * its driver stops: a re-run admitted any earlier would start writing to the peer while this run's unwind
-     * is still in flight. The record is written as part of the same step, so `retireSeq` — which orders history
-     * and eviction — is durable rather than living only in memory until the next unrelated write.
+     * is still in flight. The retirement order is stamped when the outcome is assigned and travels with the
+     * write that records it, so nothing is written here.
      */
-    async #retire(task: Task): Promise<void> {
+    #retire(task: Task): void {
         try {
             // A cancel awaiting this driver owns the run's terminal state, so it owns the retirement too: the
             // run is still `running` here, and retiring it now would record it mid-cancel.
@@ -225,17 +226,9 @@ export class TaskManagerBehavior extends Behavior {
                 return;
             }
             // A non-terminal run otherwise reaches here through shutdown, which leaves it for the next start.
-            if (!isTerminal(task.progress.state)) {
-                return;
-            }
-            // Stamped, written, and only then moved. The run keeps its slot for the whole of the write, so a
-            // re-run cannot be admitted against a retirement that never landed.
-            this.internal.runs.stampRetirement(task);
-            try {
-                await this.#persist(task);
-            } catch (e) {
-                this.internal.runs.abandonRetirement(task);
-                logger.warn(`Cannot record retirement of ${runLabel(task.runId)}`, e);
+            // An outcome whose write was refused carries no stamp, so the run keeps its slot rather than
+            // retiring behind a record storage does not have.
+            if (!isTerminal(task.progress.state) || task.retireSeq === undefined) {
                 return;
             }
             this.internal.runs.commitRetirement(task);
@@ -732,7 +725,13 @@ export class TaskManagerBehavior extends Behavior {
             }
             if (task.progress.state === "running") {
                 task.progress.state = "completed";
-                await this.#persist(task);
+                this.internal.runs.stampRetirement(task);
+                try {
+                    await this.#persist(task);
+                } catch (e) {
+                    this.internal.runs.abandonRetirement(task);
+                    throw e;
+                }
             }
         } catch (e) {
             // Shutdown leaves the task non-terminal for resume; cancel is finalized by cancel() itself.
@@ -759,9 +758,11 @@ export class TaskManagerBehavior extends Behavior {
             } catch (revertError) {
                 logger.error(`${runLabel(task.runId)}: cannot roll back`, revertError);
             }
+            this.internal.runs.stampRetirement(task);
             try {
                 await this.#persist(task, revert.task);
             } catch (persistError) {
+                this.internal.runs.abandonRetirement(task);
                 revert.discard();
                 logger.error(`${runLabel(task.runId)}: failed to persist failure state`, persistError);
                 return;
@@ -842,7 +843,6 @@ export class TaskManagerBehavior extends Behavior {
         const records = written.map(t => [runKey(t.runId), t.toPersistence()] as const);
         const { nextRetireSeq } = this.internal.runs.snapshot();
         const reservedRunId = this.internal.runs.reservedRunId;
-        this.internal.runs.noteReserved(reservedRunId);
         await this.endpoint.act(agent => {
             const self = agent.get(TaskManagerBehavior);
             const runs = { ...self.state.runs };
@@ -855,8 +855,11 @@ export class TaskManagerBehavior extends Behavior {
             self.state.nextRunId = Math.max(self.state.nextRunId, reservedRunId);
             self.state.nextRetireSeq = Math.max(self.state.nextRetireSeq, nextRetireSeq);
         });
-        // Only now: a retired record refreshed before the write would keep a change the write never made, and
-        // a run would go on naming a rollback that does not exist.
+        // Only now, and for the same reason in both cases: a value advanced before the write survives a write
+        // that never landed. A retired record refreshed early would keep a change storage does not have, and a
+        // reservation noted early would let the next identity be issued beyond what storage covers — which the
+        // next start would then re-issue to different work.
+        this.internal.runs.noteReserved(reservedRunId);
         for (const t of written) {
             this.internal.runs.refresh(t);
         }

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -93,6 +93,9 @@ export class TaskManagerBehavior extends Behavior {
         if (discarded > 0) {
             logger.warn(`Discarded ${discarded} task record(s) predating per-run identity`);
         }
+        // Reserved here rather than on the first record write: on a fresh store nothing has been written yet,
+        // so without this the very first identity would be handed out uncovered.
+        this.#reserveIdentities();
         this.#registerBuiltins();
         // Driving acts on the node, so the resume pass must wait until the node is online.
         if (this.#rootNode.lifecycle.isOnline) {
@@ -123,6 +126,15 @@ export class TaskManagerBehavior extends Behavior {
 
     #registerBuiltins(): void {
         this.registerBuiltins();
+    }
+
+    /** Record how far identities are reserved, so allocation may run ahead of the next record write. */
+    #reserveIdentities(): void {
+        const reservedRunId = this.internal.runs.reservedRunId;
+        if (this.state.nextRunId < reservedRunId) {
+            this.state.nextRunId = reservedRunId;
+        }
+        this.internal.runs.noteReserved(this.state.nextRunId);
     }
 
     get #rootNode(): ServerNode {
@@ -767,6 +779,7 @@ export class TaskManagerBehavior extends Behavior {
         const records = written.map(t => [runKey(t.runId), t.toPersistence()] as const);
         const { nextRetireSeq } = this.internal.runs.snapshot();
         const reservedRunId = this.internal.runs.reservedRunId;
+        this.internal.runs.noteReserved(reservedRunId);
         await this.endpoint.act(agent => {
             const self = agent.get(TaskManagerBehavior);
             const runs = { ...self.state.runs };

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -5,7 +5,7 @@
  */
 
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
-import { asError, Lifecycle, Logger, Mutex, Observable } from "@matter/general";
+import { asError, ImplementationError, Lifecycle, Logger, Mutex, Observable } from "@matter/general";
 import { DatatypeModel, FieldElement } from "@matter/model";
 import { Agent, Behavior, ClientNode, DesiredStateBehavior, itemMapKey, Node, ServerNode } from "@matter/node";
 import {
@@ -16,22 +16,24 @@ import {
     TaskNotFoundError,
     TaskNotRevertibleError,
     TaskSuspendedSignal,
+    TaskTypeNotRegisteredError,
 } from "./errors.js";
 import { ADD_NODE_TO_GROUP_TYPE, AddNodeToGroup } from "./groups/AddNodeToGroup.js";
 import { REMOVE_NODE_FROM_GROUP_TYPE, RemoveNodeFromGroup } from "./groups/RemoveNodeFromGroup.js";
 import { ROTATE_GROUP_KEY_TYPE, RotateGroupKey } from "./groups/RotateGroupKey.js";
 import { Revert, REVERT_TYPE } from "./Revert.js";
 import { GateControl, RunningTaskContext } from "./RunningTaskContext.js";
-import { Task, TaskPersistence } from "./Task.js";
+import { isTerminal, RunStore } from "./RunStore.js";
+import { runKey, runLabel, Task, TaskPersistence } from "./Task.js";
 import { TaskCtor, TaskRegistry } from "./TaskRegistry.js";
-import { PlannedChange, TaskState, TaskStatus } from "./types.js";
-
-const TERMINAL_STATES: ReadonlySet<TaskState> = new Set<TaskState>(["completed", "failed", "cancelled"]);
+import { PlannedChange, RunId, TaskState, TaskStatus } from "./types.js";
 
 const logger = Logger.get("TaskManager");
 
 export interface TaskHandle {
-    readonly id: string;
+    /** The run this handle names. Pass it directly to {@link TaskManagerBehavior.cancel} and friends. */
+    readonly runId: RunId;
+    /** Read through to the run, so a held handle keeps answering as the run progresses and retires. */
     readonly status: TaskStatus;
 }
 
@@ -61,24 +63,37 @@ export class TaskManagerBehavior extends Behavior {
     declare readonly state: TaskManagerBehavior.State;
     declare internal: TaskManagerBehavior.Internal;
 
+    // Nonvolatility comes from the schema member's `N` quality, not from the State property, so a counter
+    // added to State alone would silently reset to 0 on every restart and re-issue live identities.
     static override readonly schema = new DatatypeModel({
         name: "TaskManager",
         type: "struct",
         children: [
             FieldElement({
-                name: "tasks",
+                name: "runs",
                 type: "any",
                 quality: "N",
                 default: { type: "properties", properties: {} },
             }),
+            FieldElement({ name: "nextRunId", type: "uint32", quality: "N", default: 1 }),
+            FieldElement({ name: "nextRetireSeq", type: "uint32", quality: "N", default: 1 }),
         ],
     });
 
     override async initialize() {
         this.endpoint.behaviors.require(ReconcilerBehavior);
         this.internal.registry = new TaskRegistry();
-        this.internal.live = new Map();
+        this.internal.runs = new RunStore();
         this.internal.gates = new Map();
+        const { resumable, discarded } = this.internal.runs.load({
+            runs: this.state.runs,
+            nextRunId: this.state.nextRunId,
+            nextRetireSeq: this.state.nextRetireSeq,
+        });
+        this.internal.resumable = resumable;
+        if (discarded > 0) {
+            logger.warn(`Discarded ${discarded} task record(s) predating per-run identity`);
+        }
         this.#registerBuiltins();
         // Driving acts on the node, so the resume pass must wait until the node is online.
         if (this.#rootNode.lifecycle.isOnline) {
@@ -89,9 +104,19 @@ export class TaskManagerBehavior extends Behavior {
     }
 
     #resumePersisted(): void {
-        for (const type of new Set(Object.values(this.state.tasks).map(p => p.type))) {
+        for (const type of new Set(this.#resumable.map(r => r.type))) {
             this.#resumeType(type);
         }
+    }
+
+    /** Records still awaiting resume, in ascending runId — the only order defined for resume. */
+    get #resumable(): TaskPersistence[] {
+        return [...this.internal.resumable].sort((a, b) => a.runId - b.runId);
+    }
+
+    /** Forget a record once resume has taken its decision, so no later pass reconsiders it. */
+    #resumed(record: TaskPersistence): void {
+        this.internal.resumable = this.internal.resumable.filter(r => r.runId !== record.runId);
     }
 
     /** Built-in task types registered before the resume pass. */
@@ -125,18 +150,34 @@ export class TaskManagerBehavior extends Behavior {
         this.#resumeType(type);
     }
 
-    /** Resume persisted, non-terminal, not-yet-live tasks of a registered type. */
+    /**
+     * Resume persisted, non-terminal, not-yet-live runs of a registered type.
+     *
+     * Records are per-run now, so two records can name one slot where the id-keyed store admitted only one.
+     * Resume therefore consults the slot index, and each record resumes inside its own boundary so one that
+     * cannot be resumed does not strand every record after it.
+     */
     #resumeType(type: string): void {
         if (!this.internal.registry.has(type)) {
             return;
         }
-        for (const [id, p] of Object.entries(this.state.tasks)) {
-            if (p.type !== type || TERMINAL_STATES.has(p.state) || this.internal.live.has(id)) {
+        for (const record of this.#resumable) {
+            if (record.type !== type) {
                 continue;
             }
-            const task = this.internal.registry.create(type, id, p.params, p);
-            this.internal.live.set(id, task);
-            this.#redrive(task);
+            const owner = this.internal.runs.ownerOf(record.slotKey);
+            if (owner !== undefined) {
+                logger.warn(`Not resuming run ${record.runId}: slot ${record.slotKey} is owned by run ${owner.runId}`);
+                continue;
+            }
+            this.#resumed(record);
+            try {
+                const task = this.internal.registry.create(type, record.runId, record.slotKey, record.params, record);
+                this.internal.runs.admit(task);
+                this.#redrive(task);
+            } catch (e) {
+                logger.error(`Cannot resume run ${record.runId}`, e);
+            }
         }
     }
 
@@ -155,18 +196,47 @@ export class TaskManagerBehavior extends Behavior {
     // arriving before the first phase builds its gate would otherwise be discarded. It is created fresh so an abort
     // recorded for an earlier run of this id cannot carry over.
     #track(task: Task): void {
-        this.internal.gates.set(task.id, { wake: new Observable() });
-        const drivePromise: Promise<void> = this.#drive(task).finally(() => {
-            // A task turns terminal before its drive promise settles, so a re-run may already own this id's
-            // bookkeeping; only its current owner may clear it.
-            if (this.internal.driving.get(task.id) !== drivePromise) {
+        this.internal.gates.set(task.runId, { wake: new Observable() });
+        const drivePromise: Promise<void> = this.#drive(task).finally(() => this.#retire(task));
+        this.internal.driving.set(task.runId, drivePromise);
+    }
+
+    /**
+     * Release a settled run: drop its bookkeeping, stamp its retirement and record it.
+     *
+     * The slot is released here rather than when the state turned terminal, because a task is terminal before
+     * its driver stops: a re-run admitted any earlier would start writing to the peer while this run's unwind
+     * is still in flight. The record is written as part of the same step, so `retireSeq` — which orders history
+     * and eviction — is durable rather than living only in memory until the next unrelated write.
+     */
+    async #retire(task: Task): Promise<void> {
+        try {
+            // A cancel awaiting this driver owns the run's terminal state, so it owns the retirement too: the
+            // run is still `running` here, and retiring it now would record it mid-cancel.
+            if (this.internal.cancelling.has(task.runId)) {
                 return;
             }
-            this.internal.driving.delete(task.id);
-            this.internal.gates.delete(task.id);
-            this.internal.cancelling.delete(task.id);
-        });
-        this.internal.driving.set(task.id, drivePromise);
+            // A non-terminal run otherwise reaches here through shutdown, which leaves it for the next start.
+            if (!isTerminal(task.progress.state)) {
+                return;
+            }
+            // Stamped, written, and only then moved. The run keeps its slot for the whole of the write, so a
+            // re-run cannot be admitted against a retirement that never landed.
+            this.internal.runs.stampRetirement(task);
+            try {
+                await this.#persist(task);
+            } catch (e) {
+                this.internal.runs.abandonRetirement(task);
+                logger.warn(`Cannot record retirement of ${runLabel(task.runId)}`, e);
+                return;
+            }
+            this.internal.runs.commitRetirement(task);
+        } finally {
+            // Cleared last: a run is not settled until its retirement is, and an observer that watches the
+            // driver would otherwise see it finish while the slot is still momentarily released.
+            this.internal.driving.delete(task.runId);
+            this.internal.gates.delete(task.runId);
+        }
     }
 
     /**
@@ -189,95 +259,121 @@ export class TaskManagerBehavior extends Behavior {
      * peer starts with {@link #track} once the write lands.
      */
     #spawn(type: string, params: unknown, seed: Partial<TaskPersistence>): SpawnedTask {
-        const id = this.internal.registry.idFor(type, params);
-        // Driving started now would outlive the dispose drain and write to peers after close, with no way to
-        // record what it did.
-        this.#refuseIfClosing(`Task ${id} cannot start`);
-        // A cancel of this id is mid-flight: joining would hand the caller a task that is being torn down, and
-        // replacing it would take over bookkeeping the cancel is still waiting on.
-        if (this.internal.cancelling.has(id)) {
-            throw new TaskConflictError(`Task ${id} rejected: a cancel of this task is still in flight`);
-        }
-        const existing = this.internal.live.get(id);
-        if (existing !== undefined && !TERMINAL_STATES.has(existing.progress.state)) {
-            if (seed.externalId === undefined || seed.externalId !== existing.externalId) {
+        const slotKey = this.internal.registry.slotKeyFor(type, params);
+        const runs = this.internal.runs;
+
+        // Steps run in a fixed order because the order decides which refusal a caller sees, and because a
+        // slot check that ran before the externalId lookup would turn every join into a conflict. No await
+        // anywhere below, so there is no window between the checks and the admission that follows them.
+
+        // 1. Driving started now would outlive the dispose drain and write to peers after close.
+        this.#refuseIfClosing(`Task ${slotKey} cannot start`);
+
+        // 2. The slot's owner joins the caller that already asked for this work, and refuses everyone else.
+        const owner = runs.ownerOf(slotKey);
+        if (owner !== undefined) {
+            if (this.internal.cancelling.has(owner.runId)) {
                 throw new TaskConflictError(
-                    `Task ${id} rejected: this id is held by a live task (${existing.progress.state})`,
+                    `Task ${slotKey} rejected: a cancel of ${runLabel(owner.runId)} is still in flight`,
+                    owner.runId,
                 );
             }
-            return { task: existing, joined: true };
+            if (seed.externalId === undefined || seed.externalId !== owner.externalId) {
+                throw new TaskConflictError(
+                    `Task ${slotKey} rejected: slot held by ${runLabel(owner.runId)} (${owner.progress.state})`,
+                    owner.runId,
+                );
+            }
+            return { task: owner, joined: true };
         }
-        const pendingRevert = this.#pendingRevertFor(id);
-        if (pendingRevert !== undefined) {
-            throw new TaskConflictError(
-                `Task ${id} rejected: rollback ${pendingRevert.id} is still in flight and would undo it again`,
-            );
-        }
-        const task = this.internal.registry.create(type, id, params, seed);
-        // Synchronous exclusivity check: no await between reading `live` and live.set below, so there is no TOCTOU
-        // window. The just-created task is discarded on throw (never tracked or persisted).
-        const rk = task.resourceKey();
-        if (rk !== undefined) {
-            for (const t of this.internal.live.values()) {
-                if (t.id !== task.id && !TERMINAL_STATES.has(t.progress.state) && this.#occupies(t, rk)) {
-                    throw new TaskConflictError(
-                        `Task ${task.id} rejected: resource ${rk} is in use by live task ${t.id}; wait until it reaches a terminal state`,
-                    );
-                }
+
+        // 3. An external id is one-to-one: a live run of another slot must not lose the name it answers to.
+        if (seed.externalId !== undefined) {
+            const holder = runs.conflictingExternalIdHolder(seed.externalId, slotKey);
+            if (holder !== undefined) {
+                throw new TaskConflictError(
+                    `Task ${slotKey} rejected: external id "${seed.externalId}" names ${runLabel(holder.runId)} of slot ${holder.slotKey}`,
+                    holder.runId,
+                );
             }
         }
-        this.internal.live.set(id, task);
+
+        // 4. A rollback rewrites exactly the intents a re-run would re-apply, so the two must never overlap —
+        //    and the rollback in flight need not be undoing the most recent run of the slot.
+        const pendingRevert = runs.pendingRevertOfSlot(slotKey);
+        if (pendingRevert !== undefined) {
+            throw new TaskConflictError(
+                `Task ${slotKey} rejected: rollback ${runLabel(pendingRevert.runId)} is still in flight and would undo it again`,
+                pendingRevert.runId,
+            );
+        }
+
+        const task = this.internal.registry.create(type, runs.allocate(), slotKey, params, seed);
+        runs.admit(task);
         return { task, joined: false };
     }
 
-    /** A rollback rewrites exactly the intents a re-run would re-apply, so the two must never overlap. */
-    #pendingRevertFor(id: string): Task | undefined {
-        for (const t of this.internal.live.values()) {
-            if (t.revertOf === id && !TERMINAL_STATES.has(t.progress.state)) {
-                return t;
-            }
+    /** Resolve a run across every tier: live, then retired, then tombstone. */
+    get(runId: RunId): TaskHandle | undefined {
+        const live = this.internal.runs.liveRun(runId);
+        if (live !== undefined) {
+            return this.#handle(live);
         }
-        return undefined;
+        const record = this.internal.runs.retiredRun(runId);
+        return record === undefined ? undefined : this.#recordHandle(record);
     }
 
-    // A revert has no resourceKey of its own (so it is never rejected), but it rewrites the intents in its
-    // changeSet, so it occupies those resources against a new exclusive task. Resource key format is
-    // `${kind}:${key}`, matching each task's resourceKey().
-    #occupies(t: Task, rk: string): boolean {
-        if (t.resourceKey() === rk) {
-            return true;
-        }
-        return t instanceof Revert && t.params.entries.some(e => `${e.kind}:${e.key}` === rk);
+    /**
+     * Resolve the run a caller's own id names. Separate from {@link get} so no call site has to encode which
+     * namespace a string belongs to — the mistake a single polymorphic lookup makes easy to write and
+     * impossible for the compiler to catch.
+     */
+    forExternalId(externalId: string): TaskHandle | undefined {
+        const found = this.internal.runs.findByExternalId(externalId);
+        return found === undefined ? undefined : this.get(found.runId);
     }
 
-    get(idOrExternalId: string): TaskHandle | undefined {
-        const task = this.#find(idOrExternalId);
-        return task && this.#handle(task);
-    }
-
+    /** Runs that still own their slot. A retired run answers {@link get} but is not live work. */
     get tasks(): TaskHandle[] {
-        return [...this.internal.live.values()].map(t => this.#handle(t));
+        return this.internal.runs.live.map(t => this.#handle(t));
     }
 
-    #find(idOrExternalId: string): Task | undefined {
-        const byId = this.internal.live.get(idOrExternalId);
-        if (byId !== undefined) {
-            return byId;
+    /** Retired records, newest retirement first. */
+    history(limit?: number): TaskHandle[] {
+        if (limit !== undefined && !Number.isInteger(limit)) {
+            throw new ImplementationError(`history limit must be an integer, got ${limit}`);
         }
-        for (const t of this.internal.live.values()) {
-            if (t.externalId === idOrExternalId) {
-                return t;
-            }
-        }
-        return undefined;
+        const records = this.internal.runs.retired;
+        return (limit === undefined ? records : records.slice(0, Math.max(0, limit))).map(r => this.#recordHandle(r));
     }
 
     #handle(task: Task): TaskHandle {
         // A held handle must keep answering for the task it names; a snapshot would freeze at creation time.
         return {
-            id: task.id,
+            runId: task.runId,
             get status() {
                 return task.status;
+            },
+        };
+    }
+
+    #recordHandle(record: TaskPersistence): TaskHandle {
+        return {
+            runId: record.runId,
+            get status(): TaskStatus {
+                return {
+                    runId: record.runId,
+                    slotKey: record.slotKey,
+                    type: record.type,
+                    state: record.state,
+                    phaseIndex: record.phaseIndex,
+                    externalId: record.externalId,
+                    error: record.error,
+                    retireSeq: record.retireSeq,
+                    revertRunId: record.revertRunId,
+                    revertOf: record.revertOf,
+                    detail: "full",
+                };
             },
         };
     }
@@ -293,36 +389,52 @@ export class TaskManagerBehavior extends Behavior {
      * Throws {@link TaskManagerClosingError} if shutdown intervenes before the cancel can be recorded; the task
      * then keeps its non-terminal state and the cancel must be re-issued after the next start.
      */
-    async cancel(idOrExternalId: string): Promise<TaskHandle | undefined> {
-        const task = this.#find(idOrExternalId);
+    async cancel(runId: RunId): Promise<TaskHandle | undefined> {
+        let task = this.internal.runs.liveRun(runId);
         if (task === undefined) {
-            throw new TaskNotFoundError(`Cannot cancel "${idOrExternalId}": no live task answers to that id`);
+            const retired = this.internal.runs.retiredRun(runId);
+            if (retired === undefined) {
+                throw new TaskNotFoundError(`Cannot cancel ${runLabel(runId)}: no run answers to it`);
+            }
+            // Undo of finished work reads the retained changeSet, so the run has to be reconstituted:
+            // `revertible` is a subclass decision (a realized rotation declines it) and a record cannot
+            // answer it.
+            if (!this.internal.registry.has(retired.type)) {
+                throw new TaskTypeNotRegisteredError(
+                    `Cannot cancel ${runLabel(runId)}: task type "${retired.type}" is not registered`,
+                );
+            }
+            task = this.internal.registry.create(retired.type, retired.runId, retired.slotKey, retired.params, retired);
+        }
+        // A rollback this run already recorded is the answer, wherever it now lives: reporting it as unknown
+        // would make re-cancelling fail the moment its rollback finishes.
+        if (task.revertRunId !== undefined) {
+            return this.get(task.revertRunId);
         }
         if (task.progress.state === "cancelled") {
-            const revert = this.#revertOf(task);
-            return revert === undefined ? undefined : this.#handle(revert);
+            return undefined;
         }
 
         // A task past its point of no return declines cancel with zero side effects (gate untouched, state kept).
         if (!task.revertible) {
-            throw new TaskNotRevertibleError(`Task ${task.id} is not revertible: ${task.notRevertibleReason}`);
+            throw new TaskNotRevertibleError(`${runLabel(task.runId)} is not revertible: ${task.notRevertibleReason}`);
         }
 
         // Stop forward driving so the changeset is final before we revert it. The flag also covers the
         // between-phase gap the gate cannot: the driver checks it synchronously before advancing a phase.
-        this.internal.cancelling.add(task.id);
-        this.#abortGate(task.id, new TaskCancelledSignal(`Task ${task.id} cancelled`));
+        this.internal.cancelling.add(task.runId);
+        this.#abortGate(task.runId, new TaskCancelledSignal(`${runLabel(task.runId)} cancelled`));
         try {
-            await this.internal.driving.get(task.id);
+            await this.internal.driving.get(task.runId);
         } finally {
-            // A `cancelling` entry left behind refuses every future run of this id for the process lifetime.
-            this.internal.gates.delete(task.id);
-            this.internal.cancelling.delete(task.id);
+            // A `cancelling` entry left behind refuses every future run of this slot for the process lifetime.
+            this.internal.gates.delete(task.runId);
+            this.internal.cancelling.delete(task.runId);
         }
 
         // Shutdown took over the unwind: state can no longer be persisted, so leave the task non-terminal and
         // unreverted rather than claiming a cancel that storage would contradict on the next start.
-        this.#refuseIfClosing(`Task ${task.id} cannot be cancelled`);
+        this.#refuseIfClosing(`${runLabel(task.runId)} cannot be cancelled`);
 
         // Prepared before the state changes: a refused rollback must leave the task as it was, not cancelled in
         // memory and unchanged in storage.
@@ -340,13 +452,21 @@ export class TaskManagerBehavior extends Behavior {
         if (stateBeforeCancel === "running" || stateBeforeCancel === "parked") {
             task.progress.state = "cancelled";
         }
+        // Stamped before the write so one transaction carries the cancelled state, the retirement order and
+        // the rollback that undoes it; the slot moves only once that write is durable.
+        this.internal.runs.stampRetirement(task);
         try {
             await this.#persist(task, revert.task);
         } catch (e) {
             task.progress.state = stateBeforeCancel;
+            this.internal.runs.abandonRetirement(task);
             revert.discard();
+            // A cancel that did not happen leaves the task as it was, driver included, or it sits non-terminal
+            // with nothing left to advance it.
+            this.#redrive(task);
             throw e;
         }
+        this.internal.runs.commitRetirement(task);
         // The rollback mutates peers, so it may not drive before the record that names it is durable.
         revert.start();
         return revert.task === undefined ? undefined : this.#handle(revert.task);
@@ -376,18 +496,22 @@ export class TaskManagerBehavior extends Behavior {
         if (!task.revertible) {
             return NO_REVERT;
         }
-        if (task.revertTaskId !== undefined) {
-            return { task: this.#revertOf(task), discard() {}, start() {} };
+        // Already rolled back once: cancel resolves the recorded rollback itself, so there is nothing to
+        // prepare, write or start here.
+        if (task.revertRunId !== undefined) {
+            return NO_REVERT;
         }
         if (task.changeSet.length === 0) {
             return NO_REVERT;
         }
+        // `revertOf` is seeded on every rollback the manager creates, retries included: it is the identity
+        // link that refuses a re-run of the original, and a rollback that lacks it excludes nothing.
         const { task: revert, joined } = this.#spawn(
             REVERT_TYPE,
-            { originalId: task.id, entries: task.changeSet },
-            { revertOf: task.id },
+            { originalRunId: task.runId, entries: task.changeSet },
+            { revertOf: task.runId },
         );
-        task.revertTaskId = revert.id;
+        task.revertRunId = revert.runId;
         // A joined rollback is already live and driving, so it is not ours to start or to forget.
         if (joined) {
             return { task: revert, discard() {}, start() {} };
@@ -395,27 +519,14 @@ export class TaskManagerBehavior extends Behavior {
         return {
             task: revert,
             discard: () => {
-                task.revertTaskId = undefined;
-                this.internal.live.delete(revert.id);
+                task.revertRunId = undefined;
+                this.internal.runs.discard(revert);
             },
             start: () => this.#track(revert),
         };
     }
 
-    /** The rollback a task recorded, or undefined if it never had one. */
-    #revertOf(task: Task): Task | undefined {
-        if (task.revertTaskId === undefined) {
-            return undefined;
-        }
-        const revert = this.#find(task.revertTaskId);
-        // `undefined` means "nothing to roll back", so a rollback that cannot be resolved must not read as that.
-        if (revert === undefined) {
-            throw new TaskNotFoundError(`Task ${task.id} names rollback ${task.revertTaskId}, which is not live`);
-        }
-        return revert;
-    }
-
-    #abortGate(id: string, reason: unknown): void {
+    #abortGate(id: RunId, reason: unknown): void {
         const gate = this.internal.gates.get(id);
         if (gate === undefined) {
             return;
@@ -426,7 +537,7 @@ export class TaskManagerBehavior extends Behavior {
 
     /** Throw a recorded abort (cancel or shutdown) so the driver stops before persisting or mutating a peer. */
     #throwIfAborted(task: Task): void {
-        const aborted = this.internal.gates.get(task.id)?.aborted;
+        const aborted = this.internal.gates.get(task.runId)?.aborted;
         if (aborted !== undefined) {
             throw asError(aborted);
         }
@@ -469,7 +580,7 @@ export class TaskManagerBehavior extends Behavior {
             const added = group.filter(pc => items[itemMapKey(pc.kind, pc.key)] === undefined).length;
             if (capacity.used + added > capacity.limit) {
                 throw new TaskCapacityExceededError(
-                    `Task ${task.id}: ${kind} on ${peerId} exceeds capacity — needs ${added} slot(s) but only ${capacity.limit - capacity.used} free`,
+                    `${runLabel(task.runId)}: ${kind} on ${peerId} exceeds capacity — needs ${added} slot(s) but only ${capacity.limit - capacity.used} free`,
                 );
             }
         }
@@ -490,8 +601,8 @@ export class TaskManagerBehavior extends Behavior {
                 await phase.run(ctx);
                 // A cancel accepted while the phase ran must leave phaseIndex on that phase: revertibility is
                 // phase-based, so advancing it can cross a task's point of no return and suppress the rollback.
-                if (this.internal.cancelling.has(task.id)) {
-                    throw new TaskCancelledSignal(`Task ${task.id} cancelled`);
+                if (this.internal.cancelling.has(task.runId)) {
+                    throw new TaskCancelledSignal(`Task ${runLabel(task.runId)} cancelled`);
                 }
                 task.progress.phaseIndex += 1;
                 await this.#persist(task);
@@ -509,27 +620,27 @@ export class TaskManagerBehavior extends Behavior {
             // outlive the dispose drain. Leave the task as the next start can resume it.
             if (this.#isClosing) {
                 logger.warn(
-                    `Task ${task.id} interrupted by shutdown; its persisted state is left for the next start`,
+                    `${runLabel(task.runId)} interrupted by shutdown; its persisted state is left for the next start`,
                     e,
                 );
                 return;
             }
             task.progress.state = "failed";
             task.error = e instanceof Error ? e.message : String(e);
-            logger.error(`Task ${task.id} failed`, e);
+            logger.error(`${runLabel(task.runId)} failed`, e);
             // Neither a rollback this manager refuses nor a failing persist may re-reject the (otherwise handled)
             // drive promise: that turns into an unhandled rejection and a cancel awaiting this task throws.
             let revert = NO_REVERT;
             try {
                 revert = this.#prepareRevert(task);
             } catch (revertError) {
-                logger.error(`Task ${task.id}: cannot roll back`, revertError);
+                logger.error(`${runLabel(task.runId)}: cannot roll back`, revertError);
             }
             try {
                 await this.#persist(task, revert.task);
             } catch (persistError) {
                 revert.discard();
-                logger.error(`Task ${task.id}: failed to persist failure state`, persistError);
+                logger.error(`${runLabel(task.runId)}: failed to persist failure state`, persistError);
                 return;
             }
             // The rollback mutates peers, so it may not drive before the record that names it is durable.
@@ -554,12 +665,12 @@ export class TaskManagerBehavior extends Behavior {
             id => this.resolvePeerNode(id),
             reconciler,
             setState,
-            this.#gateFor(task.id),
+            this.#gateFor(task.runId),
             () => [...this.#rootNode.peers],
         );
     }
 
-    #gateStateFor(id: string): TaskManagerBehavior.GateState {
+    #gateStateFor(id: RunId): TaskManagerBehavior.GateState {
         let gate = this.internal.gates.get(id);
         if (gate === undefined) {
             gate = { wake: new Observable() };
@@ -569,7 +680,7 @@ export class TaskManagerBehavior extends Behavior {
     }
 
     /** Per-task gate control: cancel/shutdown set `aborted`; `onAbort` wakes a parked gate to observe it. */
-    #gateFor(id: string): GateControl {
+    #gateFor(id: RunId): GateControl {
         const gate = this.#gateStateFor(id);
         return {
             aborted: () => gate.aborted,
@@ -600,22 +711,34 @@ export class TaskManagerBehavior extends Behavior {
     // between the two loses the rollback while the forward record still promises it.
     async #writeRecord(task: Task, paired?: Task): Promise<void> {
         // Serialized with the write, so a shutdown that began while this queued behind the mutex cannot slip past.
-        this.#refuseIfClosing(`Task ${task.id} state cannot be recorded`);
-        const records = (paired === undefined ? [task] : [task, paired]).map(t => [t.id, t.toPersistence()] as const);
+        this.#refuseIfClosing(`${runLabel(task.runId)} state cannot be recorded`);
+        // Only the named runs are written. Republishing the whole table from memory would erase records this
+        // process never loaded — a persisted run whose type nothing has registered yet — and would publish
+        // other runs' uncommitted in-flight state as though it were durable.
+        const written = paired === undefined ? [task] : [task, paired];
+        const records = written.map(t => [runKey(t.runId), t.toPersistence()] as const);
+        for (const t of written) {
+            this.internal.runs.refresh(t);
+        }
+        const { nextRunId, nextRetireSeq } = this.internal.runs.snapshot();
         await this.endpoint.act(agent => {
             const self = agent.get(TaskManagerBehavior);
-            const tasks = { ...self.state.tasks };
-            for (const [id, record] of records) {
-                tasks[id] = record;
+            const runs = { ...self.state.runs };
+            for (const [key, record] of records) {
+                runs[key] = record;
             }
-            self.state.tasks = tasks;
+            self.state.runs = runs;
+            // High-water marks: never `consumed + 1`, or a write that lands out of allocation order lowers the
+            // counter below a durable identity and a crash re-issues it.
+            self.state.nextRunId = Math.max(self.state.nextRunId, nextRunId);
+            self.state.nextRetireSeq = Math.max(self.state.nextRetireSeq, nextRetireSeq);
         });
     }
 
     override async [Symbol.asyncDispose]() {
         // Suspend in-flight gates so parked tasks stop cleanly (non-terminal, resumable) instead of hanging close.
         for (const id of this.internal.gates.keys()) {
-            this.#abortGate(id, new TaskSuspendedSignal(`Task ${id} suspended on shutdown`));
+            this.#abortGate(id, new TaskSuspendedSignal(`${runLabel(id)} suspended on shutdown`));
         }
         await Promise.allSettled([...this.internal.driving.values()]);
         await this.internal.persistMutex?.close();
@@ -625,7 +748,9 @@ export class TaskManagerBehavior extends Behavior {
 
 export namespace TaskManagerBehavior {
     export class State {
-        tasks: Record<string, TaskPersistence> = {};
+        runs: Record<string, TaskPersistence> = {};
+        nextRunId = 1;
+        nextRetireSeq = 1;
     }
 
     export interface GateState {
@@ -635,10 +760,15 @@ export namespace TaskManagerBehavior {
 
     export class Internal {
         registry!: TaskRegistry;
-        live!: Map<string, Task>;
-        gates!: Map<string, GateState>;
-        driving = new Map<string, Promise<void>>();
-        cancelling = new Set<string>();
+        runs!: RunStore;
+        /**
+         * Persisted non-terminal records this start has not resumed yet, because their type is registered
+         * later. Held here rather than re-read from state, which no longer contains what has not been loaded.
+         */
+        resumable: TaskPersistence[] = [];
+        gates!: Map<RunId, GateState>;
+        driving = new Map<RunId, Promise<void>>();
+        cancelling = new Set<RunId>();
         persistMutex?: Mutex;
     }
 

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -308,6 +308,31 @@ export class TaskManagerBehavior extends Behavior {
             );
         }
 
+        // 5. A rollback contends for the slot of the run it undoes, not for its own: its slot is unique per
+        //    run, so checking that alone would let two rollbacks of one slot, or a rollback and the newer run
+        //    that now owns the slot, rewrite the same intents at once.
+        const undone = this.internal.registry.undoes(type, params);
+        if (undone !== undefined) {
+            const undoneSlot = (runs.liveRun(undone) ?? runs.retiredRun(undone))?.slotKey;
+            if (undoneSlot !== undefined) {
+                const holder = runs.ownerOf(undoneSlot);
+                // The run being undone still owns its slot while its own cancel prepares this rollback.
+                if (holder !== undefined && holder.runId !== undone) {
+                    throw new TaskConflictError(
+                        `Rollback of ${runLabel(undone)} rejected: slot ${undoneSlot} is held by ${runLabel(holder.runId)}`,
+                        holder.runId,
+                    );
+                }
+                const sibling = runs.pendingRevertOfSlot(undoneSlot);
+                if (sibling !== undefined) {
+                    throw new TaskConflictError(
+                        `Rollback of ${runLabel(undone)} rejected: rollback ${runLabel(sibling.runId)} is already undoing slot ${undoneSlot}`,
+                        sibling.runId,
+                    );
+                }
+            }
+        }
+
         const task = this.internal.registry.create(type, runs.allocate(), slotKey, params, seed);
         runs.admit(task);
         return { task, joined: false };
@@ -383,8 +408,9 @@ export class TaskManagerBehavior extends Behavior {
      * task (parks on offline peers, resumes after restart). Does not await the revert — the caller observes it
      * via the returned handle.
      *
-     * Each outcome has exactly one meaning: a handle is the rollback, `undefined` is a task with nothing to roll
-     * back, and {@link TaskNotFoundError} is an id no live task answers to.
+     * Each outcome has exactly one meaning: a handle is the rollback, `undefined` is a run with nothing to roll
+     * back, and {@link TaskNotFoundError} is an identity no run answers to — live or retired, since a finished
+     * run keeps the changeSet its rollback needs.
      *
      * Throws {@link TaskManagerClosingError} if shutdown intervenes before the cancel can be recorded; the task
      * then keeps its non-terminal state and the cancel must be re-issued after the next start.
@@ -451,9 +477,13 @@ export class TaskManagerBehavior extends Behavior {
         try {
             revert = this.#prepareRevert(task);
         } catch (e) {
-            // The abort above stopped the driver and dropped its gate. A task the manager declines to cancel keeps
-            // its state, so it must keep its driver too, or it sits non-terminal with nothing left to advance it.
-            this.#redrive(task);
+            // The abort above stopped the driver and dropped its gate. A task the manager declines to cancel
+            // keeps its state, so it must keep its driver too, or it sits non-terminal with nothing left to
+            // advance it. A retired run was reconstituted from its record and never had a driver here; driving
+            // it would write that reconstituted state back over whatever the record now holds.
+            if (this.internal.runs.isLive(task.runId)) {
+                this.#redrive(task);
+            }
             throw e;
         }
         const stateBeforeCancel = task.progress.state;
@@ -470,9 +500,11 @@ export class TaskManagerBehavior extends Behavior {
             task.progress.state = stateBeforeCancel;
             this.internal.runs.abandonRetirement(task);
             revert.discard();
-            // A cancel that did not happen leaves the task as it was, driver included, or it sits non-terminal
-            // with nothing left to advance it.
-            this.#redrive(task);
+            // A cancel that did not happen leaves the task as it was, driver included. A retired run has no
+            // driver to restore, and driving its reconstituted copy would overwrite the stored record.
+            if (this.internal.runs.isLive(task.runId)) {
+                this.#redrive(task);
+            }
             throw e;
         }
         this.internal.runs.commitRetirement(task);

--- a/packages/node-manager/src/task/TaskRegistry.ts
+++ b/packages/node-manager/src/task/TaskRegistry.ts
@@ -6,10 +6,11 @@
 
 import { ImplementationError } from "@matter/general";
 import { Task, TaskPersistence } from "./Task.js";
+import { RunId } from "./types.js";
 
 export interface TaskCtor {
-    new (id: string, params: any, persisted?: Partial<TaskPersistence>): Task;
-    idFor(params: any): string;
+    new (runId: RunId, slotKey: string, params: any, persisted?: Partial<TaskPersistence>): Task;
+    slotKeyFor(params: any): string;
 }
 
 export class TaskRegistry {
@@ -23,12 +24,12 @@ export class TaskRegistry {
         return this.#ctors.has(type);
     }
 
-    idFor(type: string, params: unknown): string {
-        return this.#ctorFor(type).idFor(params);
+    slotKeyFor(type: string, params: unknown): string {
+        return this.#ctorFor(type).slotKeyFor(params);
     }
 
-    create(type: string, id: string, params: unknown, persisted?: Partial<TaskPersistence>): Task {
-        return new (this.#ctorFor(type))(id, params, persisted);
+    create(type: string, runId: RunId, slotKey: string, params: unknown, persisted?: Partial<TaskPersistence>): Task {
+        return new (this.#ctorFor(type))(runId, slotKey, params, persisted);
     }
 
     #ctorFor(type: string): TaskCtor {

--- a/packages/node-manager/src/task/TaskRegistry.ts
+++ b/packages/node-manager/src/task/TaskRegistry.ts
@@ -11,6 +11,7 @@ import { RunId } from "./types.js";
 export interface TaskCtor {
     new (runId: RunId, slotKey: string, params: any, persisted?: Partial<TaskPersistence>): Task;
     slotKeyFor(params: any): string;
+    undoes(params: any): RunId | undefined;
 }
 
 export class TaskRegistry {
@@ -26,6 +27,10 @@ export class TaskRegistry {
 
     slotKeyFor(type: string, params: unknown): string {
         return this.#ctorFor(type).slotKeyFor(params);
+    }
+
+    undoes(type: string, params: unknown): RunId | undefined {
+        return this.#ctorFor(type).undoes(params);
     }
 
     create(type: string, runId: RunId, slotKey: string, params: unknown, persisted?: Partial<TaskPersistence>): Task {

--- a/packages/node-manager/src/task/TaskRegistry.ts
+++ b/packages/node-manager/src/task/TaskRegistry.ts
@@ -12,6 +12,7 @@ export interface TaskCtor {
     new (runId: RunId, slotKey: string, params: any, persisted?: Partial<TaskPersistence>): Task;
     slotKeyFor(params: any): string;
     undoes(params: any): RunId | undefined;
+    readonly callerCreatable: boolean;
 }
 
 export class TaskRegistry {
@@ -31,6 +32,10 @@ export class TaskRegistry {
 
     undoes(type: string, params: unknown): RunId | undefined {
         return this.#ctorFor(type).undoes(params);
+    }
+
+    callerCreatable(type: string): boolean {
+        return this.#ctorFor(type).callerCreatable;
     }
 
     create(type: string, runId: RunId, slotKey: string, params: unknown, persisted?: Partial<TaskPersistence>): Task {

--- a/packages/node-manager/src/task/errors.ts
+++ b/packages/node-manager/src/task/errors.ts
@@ -44,6 +44,12 @@ export class TaskNotFoundError extends TaskError {}
  */
 export class TaskTypeNotRegisteredError extends TaskError {}
 
+/**
+ * More runs were started than the durable identity reservation covers, before any of their records landed.
+ * Handing out an unreserved identity would let the next start re-issue it, so the request is refused instead.
+ */
+export class TaskIdentityExhaustedError extends TaskError {}
+
 /** A task refused to run because a member's current intent violates a required precondition. */
 export class RotationPreconditionError extends TaskError {}
 

--- a/packages/node-manager/src/task/errors.ts
+++ b/packages/node-manager/src/task/errors.ts
@@ -5,6 +5,7 @@
  */
 
 import { MatterError } from "@matter/general";
+import type { RunId } from "./types.js";
 
 export class TaskError extends MatterError {}
 
@@ -20,11 +21,28 @@ export class TaskCapacityExceededError extends TaskError {}
 /** cancel() was refused: the task passed its point of no return (e.g. a realized group-key rotation). */
 export class TaskNotRevertibleError extends TaskError {}
 
-/** A new task was rejected because live work already holds its id, its rollback or an exclusive resource. */
-export class TaskConflictError extends TaskError {}
+/**
+ * A request was refused because live work already holds the slot it targets, or the external id it asked for,
+ * or is rolling that work back. {@link owner} names the run responsible, so a caller can act on it without
+ * parsing the message.
+ */
+export class TaskConflictError extends TaskError {
+    constructor(
+        message: string,
+        readonly owner?: RunId,
+    ) {
+        super(message);
+    }
+}
 
-/** No live task answers to the given id or external id, so there is nothing to observe or act on. */
+/** No run answers to the given name, so there is nothing to observe or act on. */
 export class TaskNotFoundError extends TaskError {}
+
+/**
+ * Undo of a finished run needs its task type registered, because whether a run may be rolled back is a
+ * decision of the task, not of its record.
+ */
+export class TaskTypeNotRegisteredError extends TaskError {}
 
 /** A task refused to run because a member's current intent violates a required precondition. */
 export class RotationPreconditionError extends TaskError {}

--- a/packages/node-manager/src/task/groups/AddNodeToGroup.ts
+++ b/packages/node-manager/src/task/groups/AddNodeToGroup.ts
@@ -31,7 +31,7 @@ export interface AddNodeToGroupParams {
 export class AddNodeToGroup extends Task<AddNodeToGroupParams> {
     readonly type = ADD_NODE_TO_GROUP_TYPE;
 
-    static override idFor(params: AddNodeToGroupParams): string {
+    static override slotKeyFor(params: AddNodeToGroupParams): string {
         return `${ADD_NODE_TO_GROUP_TYPE}:${params.peerId}:${params.groupId}:${params.endpoint}`;
     }
 

--- a/packages/node-manager/src/task/groups/RemoveNodeFromGroup.ts
+++ b/packages/node-manager/src/task/groups/RemoveNodeFromGroup.ts
@@ -25,7 +25,7 @@ export interface RemoveNodeFromGroupParams {
 export class RemoveNodeFromGroup extends Task<RemoveNodeFromGroupParams> {
     readonly type = REMOVE_NODE_FROM_GROUP_TYPE;
 
-    static override idFor(p: RemoveNodeFromGroupParams): string {
+    static override slotKeyFor(p: RemoveNodeFromGroupParams): string {
         return `${REMOVE_NODE_FROM_GROUP_TYPE}:${p.peerId}:${p.groupId}:${p.endpoint}`;
     }
 

--- a/packages/node-manager/src/task/groups/RotateGroupKey.ts
+++ b/packages/node-manager/src/task/groups/RotateGroupKey.ts
@@ -50,13 +50,11 @@ const ACTIVATE_INDEX = 1;
 export class RotateGroupKey extends Task<RotateGroupKeyParams> {
     readonly type = ROTATE_GROUP_KEY_TYPE;
 
-    static override idFor(params: RotateGroupKeyParams): string {
-        return `${ROTATE_GROUP_KEY_TYPE}:${params.groupKeySetId}:${params.rotationId}`;
-    }
-
-    // Independent of rotationId: different rotationIds on the same key set must be mutually exclusive.
-    override resourceKey(): string {
-        return `groupKey:${this.params.groupKeySetId}`;
+    // Keyed on the key set alone, so one-live-run-per-slot is what makes rotations of a key set mutually
+    // exclusive: two concurrent rotations would race the single shared groupKey slot, each observing the
+    // other's committed state and advancing on the wrong struct.
+    static override slotKeyFor(params: RotateGroupKeyParams): string {
+        return `${ROTATE_GROUP_KEY_TYPE}:${params.groupKeySetId}`;
     }
 
     override get revertible(): boolean {

--- a/packages/node-manager/src/task/groups/RotateGroupKey.ts
+++ b/packages/node-manager/src/task/groups/RotateGroupKey.ts
@@ -18,9 +18,11 @@ export interface RotateGroupKeyParams {
     groupKeySetId: number;
     newEpochKey: Uint8Array;
     /**
-     * Unique per rotation operation: a new `rotationId` starts a new rotation. Re-issuing a live one is refused
-     * unless the request carries the `externalId` that rotation was started under; once it is terminal, the same
-     * `rotationId` may be run again.
+     * Operator-facing label for this rotation, carried into its record and its log lines.
+     *
+     * It takes no part in identity: a key set has one slot, so any rotation of it conflicts with a live one
+     * whatever this says, and once that run retires the next rotation may reuse this label or change it. To
+     * correlate a rotation with a request, pass `externalId` to `run`.
      */
     rotationId: string;
     groupKeySecurityPolicy?: GroupKeyManagement.GroupKeySecurityPolicy;

--- a/packages/node-manager/src/task/types.ts
+++ b/packages/node-manager/src/task/types.ts
@@ -4,19 +4,63 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Branded, ImplementationError } from "@matter/general";
 import type { ClientNode, ItemMode, ManagedItem } from "@matter/node";
+
+/**
+ * Identity of one run of a task. A re-run of the same target is a different run with a different id, so no
+ * record is ever overwritten.
+ *
+ * Branded because this layer carries several bare counters side by side — {@link RetireSeq} above all — and
+ * ordering by the wrong one is the defect class the retirement order exists to prevent.
+ */
+export type RunId = Branded<number, "RunId">;
+
+export function RunId(value: number): RunId {
+    if (!Number.isSafeInteger(value) || value < 1) {
+        throw new ImplementationError(`Invalid run id ${value}`);
+    }
+    return value as RunId;
+}
+
+/**
+ * Order in which runs retired: the only ordering key for history and for eviction.
+ *
+ * Deliberately a different type from {@link RunId}. A run id orders by *start*, and since a parked run may
+ * finish long after runs that started later, ordering retirement by run id evicts the most recently finished
+ * work first.
+ */
+export type RetireSeq = Branded<number, "RetireSeq">;
+
+export function RetireSeq(value: number): RetireSeq {
+    if (!Number.isSafeInteger(value) || value < 1) {
+        throw new ImplementationError(`Invalid retirement sequence ${value}`);
+    }
+    return value as RetireSeq;
+}
 
 export type TaskState = "running" | "parked" | "completed" | "failed" | "cancelled";
 
 export interface TaskStatus {
+    runId: RunId;
+    /**
+     * The target this run intends to change. Visible so a caller can tell which work it joined, but not an
+     * address: there is no lookup by slot, because "the run for this slot" is well defined only for live runs
+     * and answering it for retired ones needs a preference rule.
+     */
+    slotKey: string;
     type: string;
     state: TaskState;
-    phaseIndex: number;
+    phaseIndex?: number;
     /** Id the caller of `run` asked for this task under, if it supplied one. */
     externalId?: string;
     error?: string;
-    revertTaskId?: string;
-    revertOf?: string;
+    /** Set once the run retired. */
+    retireSeq?: RetireSeq;
+    revertRunId?: RunId;
+    revertOf?: RunId;
+    /** Whether the answering record still carries everything, or only what a tombstone keeps. */
+    detail: "full" | "tombstone";
 }
 
 export interface ChangeEntry {

--- a/packages/node-manager/src/tsconfig.json
+++ b/packages/node-manager/src/tsconfig.json
@@ -7,7 +7,13 @@
             "path": "../../general/src"
         },
         {
+            "path": "../../model/src"
+        },
+        {
             "path": "../../node/src"
+        },
+        {
+            "path": "../../protocol/src"
         },
         {
             "path": "../../testing/src"

--- a/packages/node-manager/test/task/AdmissionTest.ts
+++ b/packages/node-manager/test/task/AdmissionTest.ts
@@ -9,7 +9,7 @@ import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { Environment } from "@matter/general";
 import { CapacityInfo, ClientNode, ItemKind, ServerNode } from "@matter/node";
 import { MockServerNode } from "@matter/node/testing";
-import { FakePeer, SyntheticTask } from "./helpers.js";
+import { FakePeer, recordFor, requireRecordFor, SyntheticTask } from "./helpers.js";
 
 class TestTaskManager extends TaskManagerBehavior {
     static override readonly schema = TaskManagerBehavior.schema;
@@ -27,8 +27,13 @@ const RootEndpoint = MockServerNode.RootEndpoint.with(TestTaskManager);
 
 async function awaitState(node: ServerNode, id: string, ...states: string[]): Promise<void> {
     for (let i = 0; i < 10_000; i++) {
-        const state = await node.act(a => a.get(TestTaskManager).state.tasks[id]?.state);
-        if (state !== undefined && states.includes(state)) return;
+        const state = await node.act(a => recordFor(a.get(TestTaskManager).state.runs, id)?.state);
+        if (state !== undefined && states.includes(state)) {
+            const settled =
+                !(["completed", "failed", "cancelled"] as string[]).includes(state) ||
+                (await node.act(a => !a.get(TestTaskManager).tasks.some(t => t.status.slotKey === id)));
+            if (settled) return;
+        }
         await MockTime.advance(1);
     }
     throw new Error(`Task ${id} did not reach state ${states.join("|")}`);
@@ -69,10 +74,10 @@ describe("capacity admission", () => {
         await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "over" }));
 
         await awaitState(node, "synthetic:over", "failed");
-        const rec = node.stateOf(TestTaskManager).tasks["synthetic:over"];
+        const rec = requireRecordFor(node.stateOf(TestTaskManager).runs, "synthetic:over");
         expect(rec.error).contains("capacity");
         expect(rec.changeSet.length).equals(0);
-        expect(rec.revertTaskId).equals(undefined);
+        expect(rec.revertRunId).equals(undefined);
         expect(ran).equals(false);
         await node.close();
     });

--- a/packages/node-manager/test/task/CancelRobustnessTest.ts
+++ b/packages/node-manager/test/task/CancelRobustnessTest.ts
@@ -714,4 +714,42 @@ describe("cancel robustness", () => {
 
         await node.close();
     });
+
+    it("leaves a retired run unchanged when its cancel cannot be recorded", async () => {
+        const environment = new Environment("test");
+        const peer = new FakePeer("rw");
+        TestTaskManager.peers.set("rw", peer);
+        TestTaskManager.reconcilerPeer = peer;
+
+        // Completes on its own, so the run retires with a changeSet a later cancel can act on.
+        SyntheticTask.phasesByTag["retiredwrite"] = [
+            {
+                name: "touch",
+                run: async ctx => {
+                    await ctx.setIntent(ctx.resolvePeer("rw"), "groupMembership", "R", {});
+                },
+            },
+        ];
+
+        const node = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-retired-write" });
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+        let manager!: TestTaskManager;
+        await node.act(a => {
+            manager = a.get(TestTaskManager);
+        });
+        const handle = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "retiredwrite" }));
+        await pumpUntil("the run retires", () => manager.tasks.length === 0);
+
+        // The node crashes, so the write fails inside the state transaction — after the point where the record
+        // for a retired run is re-read. A closed mutex fails earlier and would not exercise this at all.
+        node.construction.setStatus(Lifecycle.Status.Crashed);
+        await expect(MockTime.resolve(manager.cancel(handle.runId))).rejected;
+
+        // The rollback was staged and then discarded, so the run must not go on naming it: a record pointing
+        // at a rollback nothing created could never be rolled back again.
+        expect(manager.get(handle.runId)?.status.revertRunId).equals(undefined);
+        expect(manager.get(handle.runId)?.status.state).equals("completed");
+
+        await node.close();
+    });
 });

--- a/packages/node-manager/test/task/CancelRobustnessTest.ts
+++ b/packages/node-manager/test/task/CancelRobustnessTest.ts
@@ -9,10 +9,22 @@ import { TaskConflictError, TaskFailedError, TaskManagerClosingError } from "#ta
 import { TaskPersistence } from "#task/Task.js";
 import { TaskHandle, TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { TaskPhase, TaskState } from "#task/types.js";
+import { RunId } from "#task/types.js";
 import { CrashedDependencyError, Environment, Lifecycle, MaybePromise } from "@matter/general";
 import { Behavior, ClientNode, ItemKind, itemMapKey } from "@matter/node";
 import { MockServerNode } from "@matter/node/testing";
-import { FakePeer, SyntheticTask } from "./helpers.js";
+import {
+    cancelSlot,
+    FakePeer,
+    recordFor,
+    requireRecordFor,
+    requireRunIdOfSlot,
+    requireStatusOfSlot,
+    revertRecordOf,
+    runIdOfSlot,
+    statusOfSlot,
+    SyntheticTask,
+} from "./helpers.js";
 
 class TestTaskManager extends TaskManagerBehavior {
     static override readonly schema = TaskManagerBehavior.schema;
@@ -30,13 +42,21 @@ class TestTaskManager extends TaskManagerBehavior {
     }
 
     /** True once cancel() has accepted the request, before it settles. */
-    isCancelling(id: string): boolean {
-        return this.internal.cancelling.has(id);
+    isCancelling(runId: RunId): boolean {
+        return this.internal.cancelling.has(runId);
     }
 
     /** True while a task's drive promise has not settled. */
-    isDriven(id: string): boolean {
-        return this.internal.driving.has(id);
+    isDriven(runId: RunId): boolean {
+        return this.internal.driving.has(runId);
+    }
+
+    /**
+     * Refuse every further write, with the node otherwise healthy. Distinct from shutdown: this is the storage
+     * failure a cancel can hit while the manager is running normally.
+     */
+    async closePersistMutex(): Promise<void> {
+        await this.internal.persistMutex?.close();
     }
 
     /** Occupy the persist mutex so the next persist queues behind the returned release. */
@@ -69,8 +89,8 @@ class TracedTask extends SyntheticTask {
     /** The state of every record written for this task, in order. */
     readonly persistedStates = new Array<TaskState>();
 
-    constructor(id: string, params: { tag: string }, persisted?: Partial<TaskPersistence>) {
-        super(id, params, persisted);
+    constructor(runId: RunId, slotKey: string, params: { tag: string }, persisted?: Partial<TaskPersistence>) {
+        super(runId, slotKey, params, persisted);
         TracedTask.instances.push(this);
     }
 
@@ -79,8 +99,8 @@ class TracedTask extends SyntheticTask {
         this.persistedStates.push(record.state);
         return record;
     }
-    static instance(id: string): TracedTask {
-        const found = TracedTask.instances.filter(t => t.id === id);
+    static instance(slotKey: string): TracedTask {
+        const found = TracedTask.instances.filter(t => t.slotKey === slotKey);
         expect(found.length).equals(1);
         return found[0];
     }
@@ -188,9 +208,11 @@ describe("cancel robustness", () => {
         await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "pregate" }));
         await pumpUntil("admission in flight", () => state.entered);
 
-        const cancelling = node.act(a => a.get(TestTaskManager).cancel("synthetic:pregate"));
+        const cancelling = node.act(a => cancelSlot(a.get(TestTaskManager), "synthetic:pregate"));
         await pumpUntil("cancel accepted", () =>
-            node.act(a => a.get(TestTaskManager).isCancelling("synthetic:pregate")),
+            node.act(a =>
+                a.get(TestTaskManager).isCancelling(runIdOfSlot(a.get(TestTaskManager), "synthetic:pregate")!),
+            ),
         );
         state.release();
 
@@ -200,13 +222,14 @@ describe("cancel robustness", () => {
         expect(peer.items[itemMapKey("groupMembership", "X")]).equals(undefined);
         expect(handle).equals(undefined);
 
-        const status = await node.act(a => a.get(TestTaskManager).get("synthetic:pregate")?.status);
+        const status = await node.act(a => statusOfSlot(a.get(TestTaskManager), "synthetic:pregate"));
         expect(status?.state).equals("cancelled");
-        expect(node.stateOf(TestTaskManager).tasks["synthetic:pregate"].state).equals("cancelled");
+        expect(requireRecordFor(node.stateOf(TestTaskManager).runs, "synthetic:pregate").state).equals("cancelled");
 
-        // The only record ever written is the cancelled one: a task whose cancel is already accepted must not be
-        // stored as running, which a crash before the cancel completes would resume.
-        expect(TracedTask.instance("synthetic:pregate").persistedStates).deep.equals(["cancelled"]);
+        // The only state ever written is the cancelled one: a task whose cancel is already accepted must not be
+        // stored as running, which a crash before the cancel completes would resume. Asserted on the distinct
+        // states rather than the sequence, because retirement re-reads the record it just wrote.
+        expect([...new Set(TracedTask.instance("synthetic:pregate").persistedStates)]).deep.equals(["cancelled"]);
 
         await node.close();
     });
@@ -225,7 +248,7 @@ describe("cancel robustness", () => {
         let cancelling: Promise<TaskHandle | undefined> | undefined;
         TestTaskManager.atContext = manager => {
             TestTaskManager.atContext = undefined;
-            cancelling = manager.cancel("synthetic:ctxrace");
+            cancelling = cancelSlot(manager, "synthetic:ctxrace");
         };
         try {
             await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "ctxrace" }));
@@ -238,7 +261,7 @@ describe("cancel robustness", () => {
 
         expect(peer.items[itemMapKey("groupMembership", "Z")]).equals(undefined);
         expect(handle).equals(undefined);
-        const status = await node.act(a => a.get(TestTaskManager).get("synthetic:ctxrace")?.status);
+        const status = await node.act(a => statusOfSlot(a.get(TestTaskManager), "synthetic:ctxrace"));
         expect(status?.state).equals("cancelled");
 
         await node.close();
@@ -257,17 +280,19 @@ describe("cancel robustness", () => {
         await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
         await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "durable" }));
         await pumpUntil("task complete", async () => {
-            const state = await node.act(a => a.get(TestTaskManager).state.tasks["synthetic:durable"]?.state);
+            const state = await node.act(a => recordFor(a.get(TestTaskManager).state.runs, "synthetic:durable")?.state);
             return state === "completed";
         });
 
-        const handle = await MockTime.resolve(node.act(a => a.get(TestTaskManager).cancel("synthetic:durable")));
-        expect(handle?.id).equals("revert:synthetic:durable");
+        const handle = await MockTime.resolve(node.act(a => cancelSlot(a.get(TestTaskManager), "synthetic:durable")));
+        expect(handle?.status.revertOf).equals(
+            requireRecordFor(node.stateOf(TestTaskManager).runs, "synthetic:durable").runId,
+        );
 
         // A promised revert that is not yet durable is lost to a crash while the forward record already names it.
-        const persisted = node.stateOf(TestTaskManager).tasks;
-        expect(persisted["synthetic:durable"].revertTaskId).equals("revert:synthetic:durable");
-        expect(persisted["revert:synthetic:durable"]).not.equals(undefined);
+        const persisted = node.stateOf(TestTaskManager).runs;
+        expect(requireRecordFor(persisted, "synthetic:durable").revertRunId).equals(handle?.runId);
+        expect(persisted[String(handle!.runId)]).not.equals(undefined);
 
         await node.close();
     });
@@ -299,11 +324,15 @@ describe("cancel robustness", () => {
         await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "cancelrerun" }, { externalId: "own" }));
         await pumpUntil("intent written", () => peer.items[itemMapKey("groupMembership", "C")] !== undefined);
 
-        const handle = await MockTime.resolve(node.act(a => a.get(TestTaskManager).cancel("synthetic:cancelrerun")));
-        expect(handle?.id).equals("revert:synthetic:cancelrerun");
+        const handle = await MockTime.resolve(
+            node.act(a => cancelSlot(a.get(TestTaskManager), "synthetic:cancelrerun")),
+        );
+        expect(handle?.status.revertOf).equals(
+            requireRecordFor(node.stateOf(TestTaskManager).runs, "synthetic:cancelrerun").runId,
+        );
         expect(rerun).instanceOf(TaskConflictError);
 
-        const status = await node.act(a => a.get(TestTaskManager).get("synthetic:cancelrerun")?.status);
+        const status = await node.act(a => statusOfSlot(a.get(TestTaskManager), "synthetic:cancelrerun"));
         expect(status?.state).equals("cancelled");
         await node.close();
     });
@@ -330,7 +359,7 @@ describe("cancel robustness", () => {
         await pumpUntil("intent written", () => peer.items[itemMapKey("groupMembership", "S")] !== undefined);
 
         // Cancel is accepted while the node is still up, then shutdown takes over the unwind.
-        const cancelling = node1.act(a => a.get(TestTaskManager).cancel("synthetic:shutrace"));
+        const cancelling = node1.act(a => cancelSlot(a.get(TestTaskManager), "synthetic:shutrace"));
         await pumpUntil("cancel observed by the gate", () => unwindReached);
 
         const closing = node1.close();
@@ -343,14 +372,14 @@ describe("cancel robustness", () => {
         // The task keeps a resumable state: nothing claims the cancel took effect.
         const task = TracedTask.instance("synthetic:shutrace");
         expect(task.progress.state).equals("running");
-        expect(task.revertTaskId).equals(undefined);
+        expect(task.revertRunId).equals(undefined);
 
         // Storage must agree: non-terminal, no dangling revert.
         const node2 = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-shutrace" });
-        const persisted = node2.stateOf(TestTaskManager).tasks;
-        expect(persisted["synthetic:shutrace"].state).equals("running");
-        expect(persisted["synthetic:shutrace"].revertTaskId).equals(undefined);
-        expect(persisted["revert:synthetic:shutrace"]).equals(undefined);
+        const persisted = node2.stateOf(TestTaskManager).runs;
+        expect(requireRecordFor(persisted, "synthetic:shutrace").state).equals("running");
+        expect(requireRecordFor(persisted, "synthetic:shutrace").revertRunId).equals(undefined);
+        expect(revertRecordOf(persisted, "synthetic:shutrace")).equals(undefined);
         await node2.close();
     });
 
@@ -374,8 +403,11 @@ describe("cancel robustness", () => {
         // Hold the mutex so the cancel's write cannot run when it is enqueued, then start shutdown in that window:
         // a synchronous check before the enqueue cannot see the shutdown that begins after it.
         const release = await node1.act(a => a.get(TestTaskManager).holdPersistMutex());
-        const cancelling = node1.act(a => a.get(TestTaskManager).cancel("synthetic:queued"));
-        await pumpUntil("cancel write enqueued", () => manager.get("synthetic:queued")?.status.state === "cancelled");
+        const cancelling = node1.act(a => cancelSlot(a.get(TestTaskManager), "synthetic:queued"));
+        await pumpUntil(
+            "cancel write enqueued",
+            () => requireStatusOfSlot(manager, "synthetic:queued").state === "cancelled",
+        );
 
         const closing = node1.close();
         await pumpUntil("node no longer active", () => node1.construction.status !== Lifecycle.Status.Active);
@@ -387,15 +419,15 @@ describe("cancel robustness", () => {
         // The refused write leaves no trace: state as it was, no rollback linked, none live, nothing rolled back.
         const task = TracedTask.instance("synthetic:queued");
         expect(task.progress.state).equals("running");
-        expect(task.revertTaskId).equals(undefined);
-        expect(manager.tasks.map(t => t.id)).deep.equals(["synthetic:queued"]);
+        expect(task.revertRunId).equals(undefined);
+        expect(manager.tasks.map(t => t.status.slotKey)).deep.equals(["synthetic:queued"]);
         expect(peer.removeOrder).deep.equals([]);
 
         const node2 = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-queued" });
-        const persisted = node2.stateOf(TestTaskManager).tasks;
-        expect(persisted["synthetic:queued"].state).equals("running");
-        expect(persisted["synthetic:queued"].revertTaskId).equals(undefined);
-        expect(persisted["revert:synthetic:queued"]).equals(undefined);
+        const persisted = node2.stateOf(TestTaskManager).runs;
+        expect(requireRecordFor(persisted, "synthetic:queued").state).equals("running");
+        expect(requireRecordFor(persisted, "synthetic:queued").revertRunId).equals(undefined);
+        expect(revertRecordOf(persisted, "synthetic:queued")).equals(undefined);
         await node2.close();
     });
 
@@ -416,14 +448,14 @@ describe("cancel robustness", () => {
         });
         await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "crashed" }));
         await pumpUntil("task complete", async () => {
-            const state = await node.act(a => a.get(TestTaskManager).state.tasks["synthetic:crashed"]?.state);
+            const state = await node.act(a => recordFor(a.get(TestTaskManager).state.runs, "synthetic:crashed")?.state);
             return state === "completed";
         });
 
         // A crashed manager cannot record a cancel either, but it is not shutting down and a re-issue after the
         // next start is not the remedy — so it must not claim it is.
         node.construction.setStatus(Lifecycle.Status.Crashed);
-        await expect(MockTime.resolve(manager.cancel("synthetic:crashed"))).rejectedWith(CrashedDependencyError);
+        await expect(MockTime.resolve(cancelSlot(manager, "synthetic:crashed"))).rejectedWith(CrashedDependencyError);
 
         await node.close();
     });
@@ -463,12 +495,12 @@ describe("cancel robustness", () => {
 
         const task = TracedTask.instance("synthetic:shutfail");
         expect(task.progress.state).equals("running");
-        expect(task.revertTaskId).equals(undefined);
+        expect(task.revertRunId).equals(undefined);
 
         const node2 = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-shutfail" });
-        const persisted = node2.stateOf(TestTaskManager).tasks;
-        expect(persisted["synthetic:shutfail"].state).equals("running");
-        expect(persisted["revert:synthetic:shutfail"]).equals(undefined);
+        const persisted = node2.stateOf(TestTaskManager).runs;
+        expect(requireRecordFor(persisted, "synthetic:shutfail").state).equals("running");
+        expect(revertRecordOf(persisted, "synthetic:shutfail")).equals(undefined);
         await node2.close();
     });
 
@@ -505,13 +537,13 @@ describe("cancel robustness", () => {
         // The task fails against a crashed node, so neither the failure nor a rollback of it can be recorded.
         node.construction.setStatus(Lifecycle.Status.Crashed);
         releasePhase();
-        await pumpUntil("drive settled", () => !manager.isDriven("synthetic:failwrite"));
-        expect(manager.get("synthetic:failwrite")?.status.state).equals("failed");
+        await pumpUntil("drive settled", () => !manager.isDriven(requireRunIdOfSlot(manager, "synthetic:failwrite")));
+        expect(requireStatusOfSlot(manager, "synthetic:failwrite").state).equals("failed");
 
         // A rollback the record does not name must not exist: it would block every future run of the id, and
         // nothing would ever drive it.
-        expect(manager.get("synthetic:failwrite")?.status.revertTaskId).equals(undefined);
-        expect(manager.tasks.map(t => t.id)).deep.equals(["synthetic:failwrite"]);
+        expect(requireStatusOfSlot(manager, "synthetic:failwrite").revertRunId).equals(undefined);
+        expect(manager.tasks.map(t => t.status.slotKey)).deep.equals(["synthetic:failwrite"]);
         expect(peer.removeOrder).deep.equals([]);
 
         await node.close();
@@ -546,7 +578,7 @@ describe("cancel robustness", () => {
         expect(peer.items[itemMapKey("groupMembership", "B")]).equals(undefined);
 
         const node2 = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-shutstart" });
-        expect(node2.stateOf(TestTaskManager).tasks["synthetic:shutstart"]).equals(undefined);
+        expect(recordFor(node2.stateOf(TestTaskManager).runs, "synthetic:shutstart")).equals(undefined);
         await node2.close();
     });
 
@@ -562,8 +594,10 @@ describe("cancel robustness", () => {
         const node = await MockServerNode.create(RegistrarRootEndpoint, { environment, id: "cancel-shutresume" });
         await node.act(a => {
             // A persisted task of a type this start never registers, so nothing resumes it before shutdown.
-            a.get(TestTaskManager).state.tasks = {
-                "synthetic:shutresume": {
+            a.get(TestTaskManager).state.runs = {
+                "1": {
+                    runId: RunId(1),
+                    slotKey: "synthetic:shutresume",
                     type: "synthetic",
                     params: { tag: "shutresume" },
                     phaseIndex: 0,
@@ -598,7 +632,9 @@ describe("cancel robustness", () => {
         const node2 = await MockServerNode.create(RegistrarRootEndpoint, { environment, id: "cancel-shutresume" });
         await node2.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
         await pumpUntil("resumed task complete", async () => {
-            const state = await node2.act(a => a.get(TestTaskManager).state.tasks["synthetic:shutresume"]?.state);
+            const state = await node2.act(
+                a => recordFor(a.get(TestTaskManager).state.runs, "synthetic:shutresume")?.state,
+            );
             return state === "completed";
         });
         await node2.close();
@@ -635,7 +671,47 @@ describe("cancel robustness", () => {
         // Shutdown cannot write state, so a task that never got that far is lost either way — but it must not be
         // recorded as failed.
         const node2 = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-predispose" });
-        expect(node2.stateOf(TestTaskManager).tasks["synthetic:predispose"]).equals(undefined);
+        expect(recordFor(node2.stateOf(TestTaskManager).runs, "synthetic:predispose")).equals(undefined);
         await node2.close();
+    });
+
+    it("keeps a task driveable when the write recording its cancel is refused", async () => {
+        const environment = new Environment("test");
+        const peer = new FakePeer("cw");
+        TestTaskManager.peers.set("cw", peer);
+        TestTaskManager.reconcilerPeer = peer;
+
+        SyntheticTask.phasesByTag["cancelwrite"] = [gatePhase("cw", "groupMembership", "W")];
+
+        const node = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-write-refused" });
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+        let manager!: TestTaskManager;
+        await node.act(a => {
+            manager = a.get(TestTaskManager);
+        });
+        const handle = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "cancelwrite" }));
+
+        // Wait until the phase has touched the peer, so the cancel has a changeSet to roll back.
+        for (let i = 0; i < 10_000 && peer.items[itemMapKey("groupMembership", "W")] === undefined; i++) {
+            await MockTime.advance(1);
+        }
+
+        // Storage refuses from here on, with the node still running: not shutdown, just a failed write.
+        await node.act(a => a.get(TestTaskManager).closePersistMutex());
+
+        await expect((async () => node.act(a => a.get(TestTaskManager).cancel(handle.runId)))()).rejected;
+
+        // A cancel that was never recorded must leave the task exactly as it was — including its driver. The
+        // abort stopped the driver and dropped the gate, so without giving both back the task would sit
+        // non-terminal with nothing left to advance it, and never reach any outcome at all.
+        expect(manager.get(handle.runId)?.status.state).does.not.equal("cancelled");
+        expect(manager.get(handle.runId)?.status.revertRunId).equals(undefined);
+
+        await pumpUntil("the redriven task reaches an outcome", () => {
+            const state = manager.get(handle.runId)?.status.state;
+            return state === "failed" || state === "completed";
+        });
+
+        await node.close();
     });
 });

--- a/packages/node-manager/test/task/ChangesetTest.ts
+++ b/packages/node-manager/test/task/ChangesetTest.ts
@@ -7,6 +7,7 @@
 import { RunningTaskContext } from "#task/RunningTaskContext.js";
 import { Task } from "#task/Task.js";
 import { TaskState } from "#task/types.js";
+import { RunId } from "#task/types.js";
 import { FakePeer } from "./helpers.js";
 
 class CsTask extends Task {
@@ -17,7 +18,7 @@ class CsTask extends Task {
 }
 
 function makeContext(peer: FakePeer) {
-    const task = new CsTask("cs-test:1", {});
+    const task = new CsTask(RunId(1), "cs-test:1", {});
     const setState = (s: TaskState) => {
         task.progress.state = s;
     };

--- a/packages/node-manager/test/task/PeersWithIntentTest.ts
+++ b/packages/node-manager/test/task/PeersWithIntentTest.ts
@@ -8,6 +8,7 @@ import { ReconcilerSurface } from "#reconcile/ReconcilerSurface.js";
 import { RunningTaskContext } from "#task/RunningTaskContext.js";
 import { Task } from "#task/Task.js";
 import { TaskState } from "#task/types.js";
+import { RunId } from "#task/types.js";
 import { FakePeer } from "./helpers.js";
 
 /** peersWithIntent never touches the reconciler; a no-op stand-in avoids depending on the whole behavior. */
@@ -36,7 +37,7 @@ describe("peersWithIntent", () => {
         e.addItem("groupKey", "43", "committed"); // live, but a different key
 
         const all = [a, b, c, d, e];
-        const task = new PwiTask("pwi-test:1", {});
+        const task = new PwiTask(RunId(1), "pwi-test:1", {});
         const ctx = new RunningTaskContext(
             task,
             id => all.find(p => p.id === id)?.asNode(),

--- a/packages/node-manager/test/task/RemoveIntentTest.ts
+++ b/packages/node-manager/test/task/RemoveIntentTest.ts
@@ -7,6 +7,7 @@
 import { RunningTaskContext } from "#task/RunningTaskContext.js";
 import { Task } from "#task/Task.js";
 import { TaskState } from "#task/types.js";
+import { RunId } from "#task/types.js";
 import { itemMapKey } from "@matter/node";
 import { FakePeer } from "./helpers.js";
 
@@ -18,7 +19,7 @@ class CtxTask extends Task {
 }
 
 function makeContext(peer: FakePeer, referenced: boolean) {
-    const task = new CtxTask("ctx-test:1", {});
+    const task = new CtxTask(RunId(1), "ctx-test:1", {});
     const setState = (s: TaskState) => {
         task.progress.state = s;
     };

--- a/packages/node-manager/test/task/RevertTaskTest.ts
+++ b/packages/node-manager/test/task/RevertTaskTest.ts
@@ -7,11 +7,12 @@
 import { Revert, RevertParams } from "#task/Revert.js";
 import { RunningTaskContext } from "#task/RunningTaskContext.js";
 import { TaskState } from "#task/types.js";
+import { RunId } from "#task/types.js";
 import { itemMapKey } from "@matter/node";
 import { FakePeer } from "./helpers.js";
 
 function runRevert(peer: FakePeer, params: RevertParams, referenced = new Set<string>()) {
-    const task = new Revert("revert:orig", params);
+    const task = new Revert(RunId(1), "revert:1", params);
     const setState = (s: TaskState) => {
         task.progress.state = s;
     };
@@ -29,7 +30,7 @@ describe("Revert task", () => {
         const peer = new FakePeer("p1");
         peer.addItem("groupKey", "42", "committed");
         await MockTime.resolve(
-            runRevert(peer, { originalId: "orig", entries: [{ peerId: "p1", kind: "groupKey", key: "42" }] }),
+            runRevert(peer, { originalRunId: RunId(1), entries: [{ peerId: "p1", kind: "groupKey", key: "42" }] }),
         );
         expect(peer.items[itemMapKey("groupKey", "42")]).equals(undefined);
     });
@@ -40,7 +41,7 @@ describe("Revert task", () => {
         peer.markHas("groupKeyMap", "257");
         await MockTime.resolve(
             runRevert(peer, {
-                originalId: "orig",
+                originalRunId: RunId(1),
                 entries: [
                     {
                         peerId: "p1",
@@ -61,7 +62,7 @@ describe("Revert task", () => {
         await MockTime.resolve(
             runRevert(
                 peer,
-                { originalId: "orig", entries: [{ peerId: "p1", kind: "groupKey", key: "42" }] },
+                { originalRunId: RunId(1), entries: [{ peerId: "p1", kind: "groupKey", key: "42" }] },
                 new Set(["groupKey:42"]),
             ),
         );

--- a/packages/node-manager/test/task/RollbackIntegrationTest.ts
+++ b/packages/node-manager/test/task/RollbackIntegrationTest.ts
@@ -10,7 +10,15 @@ import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { Environment } from "@matter/general";
 import { ClientNode, itemMapKey, ServerNode } from "@matter/node";
 import { MockServerNode } from "@matter/node/testing";
-import { FakePeer, SyntheticTask } from "./helpers.js";
+import {
+    FakePeer,
+    recordFor,
+    requireRecordFor,
+    revertRecordOf,
+    revertRecordsOf,
+    revertSlotOf,
+    SyntheticTask,
+} from "./helpers.js";
 
 class TestTaskManager extends TaskManagerBehavior {
     static override readonly schema = TaskManagerBehavior.schema;
@@ -28,8 +36,13 @@ const RootEndpoint = MockServerNode.RootEndpoint.with(TestTaskManager);
 
 async function awaitState(node: ServerNode, id: string, ...states: string[]): Promise<void> {
     for (let i = 0; i < 10_000; i++) {
-        const state = await node.act(a => a.get(TestTaskManager).state.tasks[id]?.state);
-        if (state !== undefined && states.includes(state)) return;
+        const state = await node.act(a => recordFor(a.get(TestTaskManager).state.runs, id)?.state);
+        if (state !== undefined && states.includes(state)) {
+            const settled =
+                !(["completed", "failed", "cancelled"] as string[]).includes(state) ||
+                (await node.act(a => !a.get(TestTaskManager).tasks.some(t => t.status.slotKey === id)));
+            if (settled) return;
+        }
         await MockTime.advance(1);
     }
     throw new Error(`Task ${id} did not reach state ${states.join("|")}`);
@@ -60,10 +73,16 @@ describe("auto-rollback", () => {
         await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "boom" }));
 
         await awaitState(node, "synthetic:boom", "failed");
-        const original = node.stateOf(TestTaskManager).tasks["synthetic:boom"];
-        expect(original.revertTaskId).equals("revert:synthetic:boom");
+        const original = requireRecordFor(node.stateOf(TestTaskManager).runs, "synthetic:boom");
+        expect(original.revertRunId).equals(
+            revertRecordOf(node.stateOf(TestTaskManager).runs, "synthetic:boom")?.runId,
+        );
 
-        await awaitState(node, "revert:synthetic:boom", "completed");
+        await awaitState(
+            node,
+            (await node.act(a => revertSlotOf(a.get(TestTaskManager).state.runs, "synthetic:boom")))!,
+            "completed",
+        );
         expect(peer.items[itemMapKey("groupKey", "42")]).equals(undefined);
         await node.close();
     });
@@ -99,11 +118,20 @@ describe("auto-rollback", () => {
         await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "boom2" }));
 
         await awaitState(node, "synthetic:boom2", "failed");
-        const original = node.stateOf(TestTaskManager).tasks["synthetic:boom2"];
-        expect(original.revertTaskId).equals("revert:synthetic:boom2");
+        const original = requireRecordFor(node.stateOf(TestTaskManager).runs, "synthetic:boom2");
+        expect(original.revertRunId).equals(
+            revertRecordOf(node.stateOf(TestTaskManager).runs, "synthetic:boom2")?.runId,
+        );
 
-        await awaitState(node, "revert:synthetic:boom2", "failed");
-        expect(node.stateOf(TestTaskManager).tasks["revert:revert:synthetic:boom2"]).equals(undefined);
+        await awaitState(
+            node,
+            (await node.act(a => revertSlotOf(a.get(TestTaskManager).state.runs, "synthetic:boom2")))!,
+            "failed",
+        );
+        // No rollback of the rollback: asserted against the failed rollback's own run, since a key built from
+        // the original's slot is unreachable under per-run identity and would make this check dead.
+        const failedRevert = requireRecordFor(node.stateOf(TestTaskManager).runs, `revert:${original.runId}`);
+        expect(revertRecordsOf(node.stateOf(TestTaskManager).runs, failedRevert.slotKey)).length(0);
         await node.close();
     });
 });

--- a/packages/node-manager/test/task/RunIdentityTest.ts
+++ b/packages/node-manager/test/task/RunIdentityTest.ts
@@ -1,0 +1,368 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
+import { TaskConflictError, TaskTypeNotRegisteredError } from "#task/errors.js";
+import { TaskPersistence } from "#task/Task.js";
+import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
+import { RunId, TaskPhase } from "#task/types.js";
+import { Environment } from "@matter/general";
+import { ClientNode, itemMapKey, ServerNode } from "@matter/node";
+import { MockServerNode } from "@matter/node/testing";
+import { FakePeer, SyntheticTask } from "./helpers.js";
+
+/** Resolves peers to fakes, so a phase records a real changeSet and its rollback has something to undo. */
+class TestTaskManager extends TaskManagerBehavior {
+    static override readonly schema = TaskManagerBehavior.schema;
+    static peers = new Map<string, FakePeer>();
+    static reconcilerPeer?: FakePeer;
+    protected override resolvePeerNode(peerId: string): ClientNode | undefined {
+        return TestTaskManager.peers.get(peerId)?.asNode();
+    }
+    protected override taskReconciler(): ReconcilerBehavior {
+        return TestTaskManager.reconcilerPeer as unknown as ReconcilerBehavior;
+    }
+}
+
+const RootEndpoint = MockServerNode.RootEndpoint.with(TestTaskManager);
+
+/** A peer that never reports the item as present, so a task parks with its changeSet recorded. */
+function touchingPeer(id: string) {
+    const peer = new FakePeer(id);
+    TestTaskManager.peers.set(id, peer);
+    TestTaskManager.reconcilerPeer = peer;
+    return peer;
+}
+
+/** A phase that records one intent and returns, so the run completes with a non-empty changeSet. */
+function touchPhase(peerId: string): TaskPhase {
+    return {
+        name: "touch",
+        run: async ctx => {
+            await ctx.setIntent(ctx.resolvePeer(peerId), "groupMembership", "X", {});
+        },
+    };
+}
+
+/** Fires while a terminal record is being serialized — after the task is terminal, before its driver settles. */
+class UnwindHookedTask extends SyntheticTask {
+    static atTerminalWrite?: () => void;
+
+    override toPersistence(): TaskPersistence {
+        const record = super.toPersistence();
+        if (record.state === "completed") {
+            const hook = UnwindHookedTask.atTerminalWrite;
+            UnwindHookedTask.atTerminalWrite = undefined;
+            hook?.();
+        }
+        return record;
+    }
+}
+
+async function makeNode(environment?: Environment, id = "run-identity") {
+    return MockServerNode.create(RootEndpoint, { environment, id });
+}
+
+/** An environment with its own storage so a node can be closed and recreated over the same records. */
+function persistentEnvironment() {
+    return new Environment("run-identity");
+}
+
+async function records(node: ServerNode): Promise<Record<string, TaskPersistence>> {
+    return node.act(a => ({ ...a.get(TestTaskManager).state.runs }));
+}
+
+/**
+ * Wait until no run owns `slotKey` any more. A run turns terminal one step before it retires, so waiting for
+ * the record to read terminal would let a test act while the slot is still held.
+ */
+async function settle(node: ServerNode, slotKey: string) {
+    for (let i = 0; i < 10_000; i++) {
+        const retired = await node.act(a => {
+            const manager = a.get(TestTaskManager);
+            const owned = manager.tasks.some(t => t.status.slotKey === slotKey);
+            return !owned && manager.history().some(h => h.status.slotKey === slotKey);
+        });
+        if (retired) {
+            return;
+        }
+        await MockTime.advance(1);
+    }
+    throw new Error(`No run of slot ${slotKey} retired`);
+}
+
+describe("run identity", () => {
+    before(() => MockTime.init());
+
+    it("gives a re-run of a terminal slot a new runId and leaves the prior record intact", async () => {
+        await using node = await makeNode();
+        SyntheticTask.phasesByTag["rerun"] = [{ name: "a", run: async () => {} }];
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+
+        const first = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "rerun" }));
+        await settle(node, "synthetic:rerun");
+        const firstRunId = first.status.runId;
+
+        const second = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "rerun" }));
+        await settle(node, "synthetic:rerun");
+
+        expect(second.status.runId).not.equals(firstRunId);
+        expect(second.runId).not.equals(first.runId);
+
+        // Both runs are on record: the re-run must not have overwritten its predecessor.
+        const all = Object.values(await records(node)).filter(r => r.slotKey === "synthetic:rerun");
+        expect(all.map(r => r.runId).sort()).deep.equals([firstRunId, second.status.runId].sort());
+    });
+
+    it("keeps every record of cancel, re-run, cancel", async () => {
+        await using node = await makeNode();
+        touchingPeer("churn");
+        // A changeSet is what makes a cancel produce a rollback record, so the phase must really touch a peer.
+        SyntheticTask.phasesByTag["churn"] = [touchPhase("churn")];
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+
+        const peer = TestTaskManager.peers.get("churn")!;
+        const runIds = new Array<number>();
+        for (let round = 0; round < 2; round++) {
+            const handle = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "churn" }));
+            runIds.push(handle.runId);
+
+            // Cancel only once the phase has actually touched the peer: a run with an empty changeSet has
+            // nothing to roll back, and cancelling it would prove nothing about record retention.
+            for (let i = 0; i < 10_000 && peer.items[itemMapKey("groupMembership", "X")] === undefined; i++) {
+                await MockTime.advance(1);
+            }
+            const revert = await node.act(a => a.get(TestTaskManager).cancel(handle.runId));
+            expect(revert).not.equals(undefined);
+            runIds.push(revert!.runId);
+
+            // Let the rollback finish and release the slot, so the next round is a genuine re-run of it.
+            await settle(node, `revert:${handle.runId}`);
+            peer.dropItem("groupMembership", "X");
+        }
+
+        const persisted = await records(node);
+        // Two forward runs and two rollbacks, all four distinct and all four still readable: the defect this
+        // replaces overwrote both the first run's record and its rollback's.
+        expect(runIds).length(4);
+        expect(new Set(runIds).size).equals(4);
+        for (const runId of runIds) {
+            expect(Object.keys(persisted)).includes(String(runId));
+        }
+        const cancelled = Object.values(persisted).filter(r => r.state === "cancelled");
+        expect(cancelled).length(2);
+        // Each rollback is linked to the forward run it undoes, so the audit trail of both cancels survives.
+        const rollbacks = Object.values(persisted).filter(r => r.revertOf !== undefined);
+        expect(rollbacks.map(r => r.revertOf).sort()).deep.equals(cancelled.map(r => r.runId).sort());
+    });
+
+    it("lists only non-terminal runs in tasks", async () => {
+        await using node = await makeNode();
+        SyntheticTask.phasesByTag["retire"] = [{ name: "a", run: async () => {} }];
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+
+        await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "retire" }));
+        await settle(node, "synthetic:retire");
+
+        expect(await node.act(a => a.get(TestTaskManager).tasks.length)).equals(0);
+    });
+
+    it("answers for a run that retired before a restart", async () => {
+        const environment = persistentEnvironment();
+        SyntheticTask.phasesByTag["survive"] = [{ name: "a", run: async () => {} }];
+
+        let runId: RunId;
+        {
+            await using node = await makeNode(environment, "restart");
+            await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+            const handle = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "survive" }));
+            runId = handle.status.runId;
+            await settle(node, "synthetic:survive");
+        }
+
+        await using node = await makeNode(environment, "restart");
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+        const status = await node.act(a => a.get(TestTaskManager).get(runId)?.status);
+        expect(status?.state).equals("completed");
+    });
+
+    it("never re-issues a runId across a restart", async () => {
+        const environment = persistentEnvironment();
+        SyntheticTask.phasesByTag["counter"] = [{ name: "a", run: async () => {} }];
+
+        let firstRunId: number;
+        {
+            await using node = await makeNode(environment, "counter");
+            await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+            const handle = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "counter" }));
+            firstRunId = handle.status.runId;
+            await settle(node, "synthetic:counter");
+        }
+
+        await using node = await makeNode(environment, "counter");
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+        const handle = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "counter" }));
+        expect(handle.status.runId).greaterThan(firstRunId);
+    });
+
+    it("refuses a re-run of a slot while the previous run's driver is still unwinding", async () => {
+        await using node = await makeNode(undefined, "unwind");
+        UnwindHookedTask.phasesByTag["unwind"] = [{ name: "a", run: async () => {} }];
+        await node.act(a => a.get(TestTaskManager).register("synthetic", UnwindHookedTask));
+
+        let manager!: TaskManagerBehavior;
+        await node.act(a => {
+            manager = a.get(TestTaskManager);
+        });
+
+        // The re-run is attempted from inside the first run's terminal write: it is terminal there, but its
+        // driver has not settled, so it still owns the slot and the re-run must be refused.
+        let outcome: unknown = "hook never ran";
+        UnwindHookedTask.atTerminalWrite = () => {
+            try {
+                manager.run("synthetic", { tag: "unwind" });
+                outcome = "admitted";
+            } catch (e) {
+                outcome = e;
+            }
+        };
+        try {
+            await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "unwind" }));
+            await settle(node, "synthetic:unwind");
+        } finally {
+            UnwindHookedTask.atTerminalWrite = undefined;
+        }
+
+        expect(outcome).instanceOf(TaskConflictError);
+    });
+
+    it("rolls back a run that retired before a restart", async () => {
+        const environment = persistentEnvironment();
+        touchingPeer("undo");
+        SyntheticTask.phasesByTag["undo"] = [touchPhase("undo")];
+
+        let runId: RunId;
+        {
+            await using node = await makeNode(environment, "undo");
+            await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+            const handle = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "undo" }));
+            runId = handle.runId;
+            await settle(node, "synthetic:undo");
+        }
+
+        // The undo path for finished work reads the retained changeSet, so it has to survive the restart and
+        // the run has to be reconstituted to answer whether it may be rolled back at all.
+        await using node = await makeNode(environment, "undo");
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+        const rollback = await node.act(a => a.get(TestTaskManager).cancel(runId));
+        expect(rollback?.status.revertOf).equals(runId);
+    });
+
+    it("refuses to roll back a retired run whose type nothing has registered", async () => {
+        const environment = persistentEnvironment();
+        touchingPeer("unregistered");
+        SyntheticTask.phasesByTag["unregistered"] = [touchPhase("unregistered")];
+
+        let runId: RunId;
+        {
+            await using node = await makeNode(environment, "unregistered");
+            await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+            const handle = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "unregistered" }));
+            runId = handle.runId;
+            await settle(node, "synthetic:unregistered");
+        }
+
+        // Observing a retired run needs no task; rolling one back does, because revertibility is the task's
+        // decision and a record cannot answer it.
+        await using node = await makeNode(environment, "unregistered");
+        expect(await node.act(a => a.get(TestTaskManager).get(runId)?.status.state)).equals("completed");
+        await expect((async () => node.act(a => a.get(TestTaskManager).cancel(runId)))()).rejectedWith(
+            TaskTypeNotRegisteredError,
+        );
+    });
+
+    it("refuses an external id a live run of another slot already answers to", async () => {
+        await using node = await makeNode(undefined, "extid");
+        SyntheticTask.phasesByTag["holder"] = [{ name: "a", run: async () => new Promise<void>(() => {}) }];
+        SyntheticTask.phasesByTag["other"] = [{ name: "a", run: async () => {} }];
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+
+        const held = await node.act(a =>
+            a.get(TestTaskManager).run("synthetic", { tag: "holder" }, { externalId: "mine" }),
+        );
+
+        // An external id is one-to-one, so a different slot may not take the name a live run answers to.
+        let refusal: unknown;
+        try {
+            await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "other" }, { externalId: "mine" }));
+        } catch (e) {
+            refusal = e;
+        }
+        expect(refusal).instanceOf(TaskConflictError);
+        expect((refusal as TaskConflictError).owner).equals(held.runId);
+        expect(await node.act(a => a.get(TestTaskManager).forExternalId("mine")?.runId)).equals(held.runId);
+    });
+
+    it("refuses a re-run while a rollback of an older run of the slot is still live", async () => {
+        await using node = await makeNode(undefined, "older");
+        const peer = touchingPeer("older");
+        SyntheticTask.phasesByTag["older"] = [touchPhase("older")];
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+
+        // Two completed runs of one slot, so the rollback in flight is not the newest run's.
+        const first = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "older" }));
+        for (let i = 0; i < 10_000 && peer.items[itemMapKey("groupMembership", "X")] === undefined; i++) {
+            await MockTime.advance(1);
+        }
+        await settle(node, "synthetic:older");
+        peer.dropItem("groupMembership", "X");
+
+        const second = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "older" }));
+        for (let i = 0; i < 10_000 && peer.items[itemMapKey("groupMembership", "X")] === undefined; i++) {
+            await MockTime.advance(1);
+        }
+        await settle(node, "synthetic:older");
+        expect(second.runId).not.equals(first.runId);
+
+        // The rollback of the OLDER run parks on an unreachable peer, so it stays live.
+        peer.setReachable(false);
+        const rollback = await node.act(a => a.get(TestTaskManager).cancel(first.runId));
+        expect(rollback?.status.revertOf).equals(first.runId);
+
+        // A rollback rewrites exactly the intents a re-run would re-apply, whichever run of the slot it undoes.
+        let refusal: unknown;
+        try {
+            await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "older" }));
+        } catch (e) {
+            refusal = e;
+        }
+        expect(refusal).instanceOf(TaskConflictError);
+        expect((refusal as TaskConflictError).owner).equals(rollback?.runId);
+    });
+
+    it("answers a repeated cancel with the rollback it recorded, once that rollback has finished", async () => {
+        await using node = await makeNode(undefined, "recancel");
+        const peer = touchingPeer("recancel");
+        SyntheticTask.phasesByTag["recancel"] = [touchPhase("recancel")];
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+
+        const handle = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "recancel" }));
+        for (let i = 0; i < 10_000 && peer.items[itemMapKey("groupMembership", "X")] === undefined; i++) {
+            await MockTime.advance(1);
+        }
+        const rollback = await node.act(a => a.get(TestTaskManager).cancel(handle.runId));
+        expect(rollback).not.equals(undefined);
+
+        // Let the rollback finish and retire, so it no longer answers as live work.
+        await settle(node, `revert:${handle.runId}`);
+
+        // Cancelling again is idempotent and must keep naming the same rollback. Resolving only live runs here
+        // would make the answer depend on whether the rollback happens to have finished yet.
+        const again = await node.act(a => a.get(TestTaskManager).cancel(handle.runId));
+        expect(again?.runId).equals(rollback?.runId);
+        expect(again?.status.revertOf).equals(handle.runId);
+    });
+});

--- a/packages/node-manager/test/task/RunIdentityTest.ts
+++ b/packages/node-manager/test/task/RunIdentityTest.ts
@@ -53,6 +53,24 @@ async function pumpUntil(name: string, condition: () => Promise<boolean>) {
     throw new Error(`Condition "${name}" never held`);
 }
 
+/** Refuses to be rebuilt from its persisted parameters, as a custom task validating them might. */
+class UnbuildableTask extends Task<{ tag: string }> {
+    static rejectConstruction = false;
+    override readonly type = "unbuildable";
+    override get phases(): TaskPhase[] {
+        return [];
+    }
+    static override slotKeyFor(params: { tag: string }) {
+        return `unbuildable:${params.tag}`;
+    }
+    constructor(runId: RunId, slotKey: string, params: { tag: string }, persisted?: Partial<TaskPersistence>) {
+        super(runId, slotKey, params, persisted);
+        if (UnbuildableTask.rejectConstruction) {
+            throw new ImplementationError("malformed persisted parameters");
+        }
+    }
+}
+
 /** A second type, so a request for a different slot can try to take a pending run's external id. */
 class OtherTask extends Task<{ tag: string }> {
     override readonly type = "other";
@@ -345,7 +363,7 @@ describe("run identity", () => {
         expect(await node.act(a => a.get(TestTaskManager).forExternalId("mine")?.runId)).equals(held.runId);
     });
 
-    it("refuses a re-run while a rollback of an older run of the slot is still live", async () => {
+    it("refuses a re-run while a rollback of that slot is still live", async () => {
         await using node = await makeNode(undefined, "older");
         const peer = touchingPeer("older");
         SyntheticTask.phasesByTag["older"] = [touchPhase("older")];
@@ -366,10 +384,10 @@ describe("run identity", () => {
         await settle(node, "synthetic:older");
         expect(second.runId).not.equals(first.runId);
 
-        // The rollback of the OLDER run parks on an unreachable peer, so it stays live.
+        // The rollback parks on an unreachable peer, so it stays live while the re-run is attempted.
         peer.setReachable(false);
-        const rollback = await node.act(a => a.get(TestTaskManager).cancel(first.runId));
-        expect(rollback?.status.revertOf).equals(first.runId);
+        const rollback = await node.act(a => a.get(TestTaskManager).cancel(second.runId));
+        expect(rollback?.status.revertOf).equals(second.runId);
 
         // A rollback rewrites exactly the intents a re-run would re-apply, whichever run of the slot it undoes.
         let refusal: unknown;
@@ -449,37 +467,38 @@ describe("run identity", () => {
         expect(again?.runId).equals(rollbackId);
     });
 
-    it("refuses a second rollback of a slot another rollback is already undoing", async () => {
-        await using node = await makeNode(undefined, "tworollbacks");
-        const peer = touchingPeer("tworollbacks");
-        SyntheticTask.phasesByTag["tworollbacks"] = [touchPhase("tworollbacks")];
+    it("refuses to undo a run a later run of its slot has superseded", async () => {
+        await using node = await makeNode(undefined, "superseded");
+        const peer = touchingPeer("superseded");
+        SyntheticTask.phasesByTag["superseded"] = [touchPhase("superseded")];
         await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
 
         const runs = new Array<RunId>();
         for (let round = 0; round < 2; round++) {
-            const handle = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "tworollbacks" }));
+            const handle = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "superseded" }));
             for (let i = 0; i < 10_000 && peer.items[itemMapKey("groupMembership", "X")] === undefined; i++) {
                 await MockTime.advance(1);
             }
-            await settle(node, "synthetic:tworollbacks");
+            await settle(node, "synthetic:superseded");
             peer.dropItem("groupMembership", "X");
             runs.push(handle.runId);
         }
 
-        // Each rollback has a slot of its own, so nothing about their own slots keeps them apart. They rewrite
-        // the same intents, so the second must be refused against the slot they both undo.
-        peer.setReachable(false);
-        const first = await node.act(a => a.get(TestTaskManager).cancel(runs[0]));
-        expect(first).not.equals(undefined);
-
+        // Undoing a run restores the values it found. A later run of the slot has committed its own since, so
+        // restoring the older run's would overwrite an outcome nobody asked to undo.
         let refusal: unknown;
         try {
-            await node.act(a => a.get(TestTaskManager).cancel(runs[1]));
+            await node.act(a => a.get(TestTaskManager).cancel(runs[0]));
         } catch (e) {
             refusal = e;
         }
         expect(refusal).instanceOf(TaskConflictError);
-        expect((refusal as TaskConflictError).owner).equals(first?.runId);
+        expect((refusal as TaskConflictError).owner).equals(runs[1]);
+
+        // The newest run of the slot is still undoable.
+        peer.setReachable(false);
+        const rollback = await node.act(a => a.get(TestTaskManager).cancel(runs[1]));
+        expect(rollback?.status.revertOf).equals(runs[1]);
     });
 
     it("refuses a rollback of a retired run whose slot a newer run now owns", async () => {
@@ -647,5 +666,40 @@ describe("run identity", () => {
             }
         });
         expect(exhausted).instanceOf(TaskIdentityExhaustedError);
+    });
+
+    it("keeps a run pending when its task cannot be rebuilt from its record", async () => {
+        const environment = persistentEnvironment();
+
+        let parked: RunId;
+        {
+            await using node = await makeNode(environment, "unbuildable");
+            UnbuildableTask.rejectConstruction = false;
+            await node.act(a => a.get(TestTaskManager).register("unbuildable", UnbuildableTask));
+            const handle = await node.act(a => a.get(TestTaskManager).run("unbuildable", { tag: "u" }));
+            parked = handle.runId;
+            await pumpUntil(
+                "the run is recorded",
+                async () =>
+                    (await node.act(a => recordFor(a.get(TestTaskManager).state.runs, "unbuildable:u"))) !== undefined,
+            );
+        }
+
+        // The record survives but its task refuses to be rebuilt. It is still unfinished work that has been
+        // written down, so forgetting it here would free its slot and hide it for the rest of this process.
+        await using node = await makeNode(environment, "unbuildable");
+        UnbuildableTask.rejectConstruction = true;
+        await node.act(a => a.get(TestTaskManager).register("unbuildable", UnbuildableTask));
+
+        expect(await node.act(a => a.get(TestTaskManager).get(parked)?.status.slotKey)).equals("unbuildable:u");
+        UnbuildableTask.rejectConstruction = false;
+        let refusal: unknown;
+        try {
+            await node.act(a => a.get(TestTaskManager).run("unbuildable", { tag: "u" }));
+        } catch (e) {
+            refusal = e;
+        }
+        expect(refusal).instanceOf(TaskConflictError);
+        expect((refusal as TaskConflictError).owner).equals(parked);
     });
 });

--- a/packages/node-manager/test/task/RunIdentityTest.ts
+++ b/packages/node-manager/test/task/RunIdentityTest.ts
@@ -6,7 +6,7 @@
 
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
 import { TaskConflictError, TaskIdentityExhaustedError, TaskTypeNotRegisteredError } from "#task/errors.js";
-import { RUN_ID_RESERVATION } from "#task/RunStore.js";
+import { RUN_ID_RESERVATION, RunStore } from "#task/RunStore.js";
 import { Task, TaskPersistence } from "#task/Task.js";
 import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { RunId, TaskPhase } from "#task/types.js";
@@ -644,6 +644,33 @@ describe("run identity", () => {
         await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
         const next = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "fresh" }));
         expect(next.runId).greaterThan(issued);
+    });
+
+    it("discards a terminal record that reached storage without its place in the retirement order", () => {
+        const store = new RunStore();
+        const { resumable, discarded } = store.load({
+            runs: {
+                // Written by a build that recorded the outcome and the order separately, and stopped between
+                // the two. It has no position, so it would sort ahead of every sequenced run of its slot.
+                "run:1": { runId: 1, slotKey: "synthetic:a", type: "synthetic", state: "completed", changeSet: [] },
+                "run:2": {
+                    runId: 2,
+                    slotKey: "synthetic:a",
+                    type: "synthetic",
+                    state: "completed",
+                    retireSeq: 1,
+                    changeSet: [],
+                },
+            } as unknown as Record<string, TaskPersistence>,
+            nextRunId: 3,
+            nextRetireSeq: 2,
+        });
+
+        expect(discarded).equals(1);
+        expect(resumable.length).equals(0);
+        // Only the sequenced run survives, so nothing in the table can be misordered against it.
+        expect(store.retiredRun(RunId(1))).equals(undefined);
+        expect(store.retiredRun(RunId(2))?.retireSeq).equals(1);
     });
 
     it("refuses an identity the reservation does not cover rather than issuing it", async () => {

--- a/packages/node-manager/test/task/RunIdentityTest.ts
+++ b/packages/node-manager/test/task/RunIdentityTest.ts
@@ -10,7 +10,7 @@ import { RUN_ID_RESERVATION } from "#task/RunStore.js";
 import { Task, TaskPersistence } from "#task/Task.js";
 import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { RunId, TaskPhase } from "#task/types.js";
-import { Environment } from "@matter/general";
+import { Environment, ImplementationError } from "@matter/general";
 import { ClientNode, itemMapKey, ServerNode } from "@matter/node";
 import { MockServerNode } from "@matter/node/testing";
 import { FakePeer, recordFor, SyntheticTask } from "./helpers.js";
@@ -405,35 +405,23 @@ describe("run identity", () => {
         expect(again?.status.revertOf).equals(handle.runId);
     });
 
-    it("refuses a re-run against a rollback started through the public run path", async () => {
-        await using node = await makeNode(undefined, "publicrevert");
-        const peer = touchingPeer("publicrevert");
-        SyntheticTask.phasesByTag["publicrevert"] = [touchPhase("publicrevert")];
+    it("refuses to start a rollback through run(), which only cancel may create", async () => {
+        await using node = await makeNode(undefined, "norun");
+        touchingPeer("norun");
+        SyntheticTask.phasesByTag["norun"] = [touchPhase("norun")];
         await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
 
-        const forward = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "publicrevert" }));
-        for (let i = 0; i < 10_000 && peer.items[itemMapKey("groupMembership", "X")] === undefined; i++) {
-            await MockTime.advance(1);
-        }
-        await settle(node, "synthetic:publicrevert");
+        const forward = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "norun" }));
 
-        // A rollback issued through the public API — how a failed one is retried — must exclude a re-run of the
-        // work it is undoing just as the manager's own does. It parks on an unreachable peer so it stays live.
-        peer.setReachable(false);
-        await node.act(a =>
-            a.get(TestTaskManager).run("revert", {
-                originalRunId: forward.runId,
-                entries: [{ peerId: "publicrevert", kind: "groupMembership", key: "X" }],
-            }),
-        );
-
+        // Only cancel knows the run's driver has been stopped. A caller able to conjure a rollback could start
+        // one against work still writing to a peer, which no admission check can tell from a prepared one.
         let refusal: unknown;
         try {
-            await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "publicrevert" }));
+            await node.act(a => a.get(TestTaskManager).run("revert", { originalRunId: forward.runId, entries: [] }));
         } catch (e) {
             refusal = e;
         }
-        expect(refusal).instanceOf(TaskConflictError);
+        expect(refusal).instanceOf(ImplementationError);
     });
 
     it("answers a repeated cancel from the record when the task type is not registered", async () => {

--- a/packages/node-manager/test/task/RunIdentityTest.ts
+++ b/packages/node-manager/test/task/RunIdentityTest.ts
@@ -5,7 +5,8 @@
  */
 
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
-import { TaskConflictError, TaskTypeNotRegisteredError } from "#task/errors.js";
+import { TaskConflictError, TaskIdentityExhaustedError, TaskTypeNotRegisteredError } from "#task/errors.js";
+import { RUN_ID_RESERVATION } from "#task/RunStore.js";
 import { Task, TaskPersistence } from "#task/Task.js";
 import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { RunId, TaskPhase } from "#task/types.js";
@@ -616,5 +617,47 @@ describe("run identity", () => {
         }
         expect(refusal).instanceOf(TaskConflictError);
         expect((refusal as TaskConflictError).owner).equals(parked);
+    });
+
+    it("reserves the very first identity of a fresh store", async () => {
+        const environment = persistentEnvironment();
+        touchingPeer("fresh");
+        SyntheticTask.phasesByTag["fresh"] = [touchPhase("fresh")];
+
+        let issued: RunId;
+        {
+            // Nothing has ever been written here, so without a reservation at startup the first identity
+            // would be handed out uncovered and the next start would give it to different work.
+            await using node = await makeNode(environment, "fresh");
+            await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+            issued = await node.act(a => a.get(TestTaskManager).internalRunStore.allocate());
+        }
+
+        await using node = await makeNode(environment, "fresh");
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+        const next = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "fresh" }));
+        expect(next.runId).greaterThan(issued);
+    });
+
+    it("refuses an identity the reservation does not cover rather than issuing it", async () => {
+        await using node = await makeNode(undefined, "burst");
+        touchingPeer("burst");
+        SyntheticTask.phasesByTag["burst"] = [touchPhase("burst")];
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+
+        // Exhaust the block without letting any record land. An identity beyond it is one the next start can
+        // re-issue, so allocation refuses instead of handing out something it cannot promise.
+        let exhausted: unknown;
+        await node.act(a => {
+            const store = a.get(TestTaskManager).internalRunStore;
+            try {
+                for (let i = 0; i < RUN_ID_RESERVATION + 5; i++) {
+                    store.allocate();
+                }
+            } catch (e) {
+                exhausted = e;
+            }
+        });
+        expect(exhausted).instanceOf(TaskIdentityExhaustedError);
     });
 });

--- a/packages/node-manager/test/task/RunIdentityTest.ts
+++ b/packages/node-manager/test/task/RunIdentityTest.ts
@@ -365,4 +365,60 @@ describe("run identity", () => {
         expect(again?.runId).equals(rollback?.runId);
         expect(again?.status.revertOf).equals(handle.runId);
     });
+
+    it("refuses a re-run against a rollback started through the public run path", async () => {
+        await using node = await makeNode(undefined, "publicrevert");
+        const peer = touchingPeer("publicrevert");
+        SyntheticTask.phasesByTag["publicrevert"] = [touchPhase("publicrevert")];
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+
+        const forward = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "publicrevert" }));
+        for (let i = 0; i < 10_000 && peer.items[itemMapKey("groupMembership", "X")] === undefined; i++) {
+            await MockTime.advance(1);
+        }
+        await settle(node, "synthetic:publicrevert");
+
+        // A rollback issued through the public API — how a failed one is retried — must exclude a re-run of the
+        // work it is undoing just as the manager's own does. It parks on an unreachable peer so it stays live.
+        peer.setReachable(false);
+        await node.act(a =>
+            a.get(TestTaskManager).run("revert", {
+                originalRunId: forward.runId,
+                entries: [{ peerId: "publicrevert", kind: "groupMembership", key: "X" }],
+            }),
+        );
+
+        let refusal: unknown;
+        try {
+            await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "publicrevert" }));
+        } catch (e) {
+            refusal = e;
+        }
+        expect(refusal).instanceOf(TaskConflictError);
+    });
+
+    it("answers a repeated cancel from the record when the task type is not registered", async () => {
+        const environment = persistentEnvironment();
+        touchingPeer("norereg");
+        SyntheticTask.phasesByTag["norereg"] = [touchPhase("norereg")];
+
+        let runId: RunId;
+        let rollbackId: RunId;
+        {
+            await using node = await makeNode(environment, "norereg");
+            await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+            const handle = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "norereg" }));
+            runId = handle.runId;
+            await settle(node, "synthetic:norereg");
+            const rollback = await node.act(a => a.get(TestTaskManager).cancel(runId));
+            rollbackId = rollback!.runId;
+            await settle(node, `revert:${runId}`);
+        }
+
+        // Nothing registers the type on this start. Deciding on a NEW rollback would need the task, because
+        // revertibility is the task's decision — but a run that already recorded one is answered by its record.
+        await using node = await makeNode(environment, "norereg");
+        const again = await node.act(a => a.get(TestTaskManager).cancel(runId));
+        expect(again?.runId).equals(rollbackId);
+    });
 });

--- a/packages/node-manager/test/task/RunIdentityTest.ts
+++ b/packages/node-manager/test/task/RunIdentityTest.ts
@@ -37,6 +37,18 @@ function touchingPeer(id: string) {
     return peer;
 }
 
+/** A phase that records one intent and never settles, so the run stays live and owns its slot. */
+function gateForever(peerId: string): TaskPhase {
+    return {
+        name: "hold",
+        run: async ctx => {
+            const peer = ctx.resolvePeer(peerId);
+            await ctx.setIntent(peer, "groupMembership", "X", {});
+            await ctx.awaitCommitted([{ peer, kind: "groupMembership", key: "X" }]);
+        },
+    };
+}
+
 /** A phase that records one intent and returns, so the run completes with a non-empty changeSet. */
 function touchPhase(peerId: string): TaskPhase {
     return {
@@ -420,5 +432,66 @@ describe("run identity", () => {
         await using node = await makeNode(environment, "norereg");
         const again = await node.act(a => a.get(TestTaskManager).cancel(runId));
         expect(again?.runId).equals(rollbackId);
+    });
+
+    it("refuses a second rollback of a slot another rollback is already undoing", async () => {
+        await using node = await makeNode(undefined, "tworollbacks");
+        const peer = touchingPeer("tworollbacks");
+        SyntheticTask.phasesByTag["tworollbacks"] = [touchPhase("tworollbacks")];
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+
+        const runs = new Array<RunId>();
+        for (let round = 0; round < 2; round++) {
+            const handle = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "tworollbacks" }));
+            for (let i = 0; i < 10_000 && peer.items[itemMapKey("groupMembership", "X")] === undefined; i++) {
+                await MockTime.advance(1);
+            }
+            await settle(node, "synthetic:tworollbacks");
+            peer.dropItem("groupMembership", "X");
+            runs.push(handle.runId);
+        }
+
+        // Each rollback has a slot of its own, so nothing about their own slots keeps them apart. They rewrite
+        // the same intents, so the second must be refused against the slot they both undo.
+        peer.setReachable(false);
+        const first = await node.act(a => a.get(TestTaskManager).cancel(runs[0]));
+        expect(first).not.equals(undefined);
+
+        let refusal: unknown;
+        try {
+            await node.act(a => a.get(TestTaskManager).cancel(runs[1]));
+        } catch (e) {
+            refusal = e;
+        }
+        expect(refusal).instanceOf(TaskConflictError);
+        expect((refusal as TaskConflictError).owner).equals(first?.runId);
+    });
+
+    it("refuses a rollback of a retired run whose slot a newer run now owns", async () => {
+        await using node = await makeNode(undefined, "reverseorder");
+        const peer = touchingPeer("reverseorder");
+        SyntheticTask.phasesByTag["reverseorder"] = [touchPhase("reverseorder")];
+        SyntheticTask.phasesByTag["holdit"] = [gateForever("reverseorder")];
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+
+        const older = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "reverseorder" }));
+        for (let i = 0; i < 10_000 && peer.items[itemMapKey("groupMembership", "X")] === undefined; i++) {
+            await MockTime.advance(1);
+        }
+        await settle(node, "synthetic:reverseorder");
+        peer.dropItem("groupMembership", "X");
+
+        // A newer run takes the slot and stays live. Undoing the older run now would rewrite the intents the
+        // newer one is working on.
+        const newer = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "reverseorder" }));
+        expect(newer.runId).not.equals(older.runId);
+
+        let refusal: unknown;
+        try {
+            await node.act(a => a.get(TestTaskManager).cancel(older.runId));
+        } catch (e) {
+            refusal = e;
+        }
+        expect(refusal).instanceOf(TaskConflictError);
     });
 });

--- a/packages/node-manager/test/task/RunIdentityTest.ts
+++ b/packages/node-manager/test/task/RunIdentityTest.ts
@@ -6,13 +6,13 @@
 
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
 import { TaskConflictError, TaskTypeNotRegisteredError } from "#task/errors.js";
-import { TaskPersistence } from "#task/Task.js";
+import { Task, TaskPersistence } from "#task/Task.js";
 import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { RunId, TaskPhase } from "#task/types.js";
 import { Environment } from "@matter/general";
 import { ClientNode, itemMapKey, ServerNode } from "@matter/node";
 import { MockServerNode } from "@matter/node/testing";
-import { FakePeer, SyntheticTask } from "./helpers.js";
+import { FakePeer, recordFor, SyntheticTask } from "./helpers.js";
 
 /** Resolves peers to fakes, so a phase records a real changeSet and its rollback has something to undo. */
 class TestTaskManager extends TaskManagerBehavior {
@@ -25,6 +25,11 @@ class TestTaskManager extends TaskManagerBehavior {
     protected override taskReconciler(): ReconcilerBehavior {
         return TestTaskManager.reconcilerPeer as unknown as ReconcilerBehavior;
     }
+
+    /** Hands out an identity without running anything, to reproduce a stop before the first record. */
+    get internalRunStore() {
+        return this.internal.runs;
+    }
 }
 
 const RootEndpoint = MockServerNode.RootEndpoint.with(TestTaskManager);
@@ -35,6 +40,27 @@ function touchingPeer(id: string) {
     TestTaskManager.peers.set(id, peer);
     TestTaskManager.reconcilerPeer = peer;
     return peer;
+}
+
+async function pumpUntil(name: string, condition: () => Promise<boolean>) {
+    for (let i = 0; i < 10_000; i++) {
+        if (await condition()) {
+            return;
+        }
+        await MockTime.advance(1);
+    }
+    throw new Error(`Condition "${name}" never held`);
+}
+
+/** A second type, so a request for a different slot can try to take a pending run's external id. */
+class OtherTask extends Task<{ tag: string }> {
+    override readonly type = "other";
+    override get phases(): TaskPhase[] {
+        return [];
+    }
+    static override slotKeyFor(params: { tag: string }) {
+        return `other:${params.tag}`;
+    }
 }
 
 /** A phase that records one intent and never settles, so the run stays live and owns its slot. */
@@ -471,7 +497,6 @@ describe("run identity", () => {
         await using node = await makeNode(undefined, "reverseorder");
         const peer = touchingPeer("reverseorder");
         SyntheticTask.phasesByTag["reverseorder"] = [touchPhase("reverseorder")];
-        SyntheticTask.phasesByTag["holdit"] = [gateForever("reverseorder")];
         await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
 
         const older = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "reverseorder" }));
@@ -481,10 +506,18 @@ describe("run identity", () => {
         await settle(node, "synthetic:reverseorder");
         peer.dropItem("groupMembership", "X");
 
-        // A newer run takes the slot and stays live. Undoing the older run now would rewrite the intents the
-        // newer one is working on.
+        // A newer run takes the slot and is held live on a gate that never settles, so reaching the conflict
+        // does not depend on scheduling. Swapped only now, so the older run above still completes and retires.
+        SyntheticTask.phasesByTag["reverseorder"] = [gateForever("reverseorder")];
         const newer = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "reverseorder" }));
         expect(newer.runId).not.equals(older.runId);
+        await pumpUntil(
+            "the newer run owns the slot",
+            async () => (await node.act(a => a.get(TestTaskManager).tasks.some(t => t.runId === newer.runId))) === true,
+        );
+        // Asserted rather than assumed: the conflict this test is about exists only while the newer run holds
+        // the slot, so a setup that quietly let it finish would prove nothing.
+        expect(await node.act(a => a.get(TestTaskManager).tasks.map(t => t.runId))).contains(newer.runId);
 
         let refusal: unknown;
         try {
@@ -493,5 +526,95 @@ describe("run identity", () => {
             refusal = e;
         }
         expect(refusal).instanceOf(TaskConflictError);
+    });
+
+    it("gives every concurrent cancel of a run the same rollback", async () => {
+        await using node = await makeNode(undefined, "racecancel");
+        const peer = touchingPeer("racecancel");
+        SyntheticTask.phasesByTag["racecancel"] = [touchPhase("racecancel")];
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+
+        const handle = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "racecancel" }));
+        for (let i = 0; i < 10_000 && peer.items[itemMapKey("groupMembership", "X")] === undefined; i++) {
+            await MockTime.advance(1);
+        }
+        peer.setReachable(false);
+
+        // Both callers pass the "already has a rollback" check before either creates one. The loser must be
+        // told about the rollback that was created, not told there was nothing to roll back.
+        const [first, second] = await MockTime.resolve(
+            Promise.all([
+                node.act(a => a.get(TestTaskManager).cancel(handle.runId)),
+                node.act(a => a.get(TestTaskManager).cancel(handle.runId)),
+            ]),
+            { macrotasks: true },
+        );
+        expect(first).not.equals(undefined);
+        expect(second).not.equals(undefined);
+        expect(second?.runId).equals(first?.runId);
+    });
+
+    it("does not re-issue an identity handed out before its run was ever recorded", async () => {
+        const environment = persistentEnvironment();
+        touchingPeer("reserve");
+        SyntheticTask.phasesByTag["reserve"] = [touchPhase("reserve")];
+
+        let issued: RunId;
+        {
+            await using node = await makeNode(environment, "reserve");
+            await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+            const first = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "reserve" }));
+            await settle(node, "synthetic:reserve");
+
+            // A second identity is handed out and the process stops before its run is ever recorded — the
+            // window `run()` being synchronous creates.
+            issued = await node.act(a => a.get(TestTaskManager).internalRunStore.allocate());
+            expect(issued).greaterThan(first.runId);
+        }
+
+        await using node = await makeNode(environment, "reserve");
+        await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+        const next = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "reserve" }));
+        // The identity was durable when it was issued, so unrelated work cannot be given it after a restart.
+        expect(next.runId).greaterThan(issued);
+    });
+
+    it("keeps a run awaiting resume in charge of the name it answers to", async () => {
+        const environment = persistentEnvironment();
+        touchingPeer("awaiting");
+        SyntheticTask.phasesByTag["awaiting"] = [gateForever("awaiting")];
+
+        let parked: RunId;
+        {
+            await using node = await makeNode(environment, "awaiting");
+            await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+            const handle = await node.act(a =>
+                a.get(TestTaskManager).run("synthetic", { tag: "awaiting" }, { externalId: "held" }),
+            );
+            parked = handle.runId;
+            await pumpUntil(
+                "the run records its intent",
+                async () =>
+                    (await node.act(a => recordFor(a.get(TestTaskManager).state.runs, "synthetic:awaiting"))) !==
+                    undefined,
+            );
+        }
+
+        // Nothing registers "synthetic" on this start, so that run cannot be instantiated yet. It is still
+        // unfinished work that has already written to a peer: it answers lookups, and a different slot may not
+        // take the name it answers to, or the run would come back answering to nothing.
+        await using node = await makeNode(environment, "awaiting");
+        await node.act(a => a.get(TestTaskManager).register("other", OtherTask));
+        expect(await node.act(a => a.get(TestTaskManager).get(parked)?.status.slotKey)).equals("synthetic:awaiting");
+        expect(await node.act(a => a.get(TestTaskManager).forExternalId("held")?.runId)).equals(parked);
+
+        let refusal: unknown;
+        try {
+            await node.act(a => a.get(TestTaskManager).run("other", { tag: "awaiting" }, { externalId: "held" }));
+        } catch (e) {
+            refusal = e;
+        }
+        expect(refusal).instanceOf(TaskConflictError);
+        expect((refusal as TaskConflictError).owner).equals(parked);
     });
 });

--- a/packages/node-manager/test/task/TaskContextGateTest.ts
+++ b/packages/node-manager/test/task/TaskContextGateTest.ts
@@ -8,6 +8,7 @@ import { TaskCancelledSignal, TaskFailedError } from "#task/errors.js";
 import { GateControl, RunningTaskContext } from "#task/RunningTaskContext.js";
 import { Task } from "#task/Task.js";
 import { TaskState } from "#task/types.js";
+import { RunId } from "#task/types.js";
 import { Observable } from "@matter/general";
 import { ClientNode, itemMapKey } from "@matter/node";
 import { FakePeer } from "./helpers.js";
@@ -20,7 +21,7 @@ class GateTask extends Task {
 }
 
 function makeContext(peer: FakePeer, gate?: GateControl, setState?: (state: TaskState) => void) {
-    const task = new GateTask("gate-test:1", {});
+    const task = new GateTask(RunId(1), "gate-test:1", {});
     const states = new Array<TaskState>();
     const record =
         setState ??

--- a/packages/node-manager/test/task/TaskLifecycleTest.ts
+++ b/packages/node-manager/test/task/TaskLifecycleTest.ts
@@ -43,7 +43,10 @@ class TestTaskManager extends TaskManagerBehavior {
      * Consume every identity the reservation covers, so the next rollback the manager tries to prepare is
      * refused. Reaches the preparation-failure path on a healthy node, which shutdown otherwise hides.
      */
-    exhaustIdentities(): void {
+    async exhaustIdentities(): Promise<void> {
+        // A write still in flight opens the reservation further when it lands, so drain them first: exhausting
+        // against a boundary that is about to move leaves an identity the manager can still allocate.
+        await this.internal.persistMutex;
         for (;;) {
             try {
                 this.internal.runs.allocate();

--- a/packages/node-manager/test/task/TaskLifecycleTest.ts
+++ b/packages/node-manager/test/task/TaskLifecycleTest.ts
@@ -8,10 +8,22 @@ import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
 import { TaskConflictError, TaskFailedError } from "#task/errors.js";
 import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { TaskPhase } from "#task/types.js";
+import { RunId } from "#task/types.js";
 import { Environment } from "@matter/general";
 import { ClientNode, itemMapKey, ServerNode } from "@matter/node";
 import { MockServerNode } from "@matter/node/testing";
-import { FakePeer, SyntheticTask } from "./helpers.js";
+import {
+    cancelSlot,
+    FakePeer,
+    recordFor,
+    requireRecordFor,
+    requireStatusOfSlot,
+    revertRecordOf,
+    revertSlotOf,
+    runIdOfSlot,
+    statusOfSlot,
+    SyntheticTask,
+} from "./helpers.js";
 
 /**
  * TaskManager subclass that resolves peers + reconciler from an in-memory table so cancel-revert and gate
@@ -29,8 +41,8 @@ class TestTaskManager extends TaskManagerBehavior {
     }
 
     /** True while a drive of `id` owns this id's gate and driving entries. */
-    isDriven(id: string): boolean {
-        return this.internal.driving.has(id) && this.internal.gates.has(id);
+    isDriven(runId: RunId): boolean {
+        return this.internal.driving.has(runId) && this.internal.gates.has(runId);
     }
 }
 
@@ -42,8 +54,13 @@ async function makeNode(environment: Environment) {
 
 async function awaitState(node: ServerNode, id: string, ...states: string[]): Promise<void> {
     for (let i = 0; i < 10_000; i++) {
-        const state = await node.act(a => a.get(TestTaskManager).state.tasks[id]?.state);
-        if (state !== undefined && states.includes(state)) return;
+        const state = await node.act(a => recordFor(a.get(TestTaskManager).state.runs, id)?.state);
+        if (state !== undefined && states.includes(state)) {
+            const settled =
+                !(["completed", "failed", "cancelled"] as string[]).includes(state) ||
+                (await node.act(a => !a.get(TestTaskManager).tasks.some(t => t.status.slotKey === id)));
+            if (settled) return;
+        }
         await MockTime.advance(1);
     }
     throw new Error(`Task ${id} did not reach state ${states.join("|")}`);
@@ -51,7 +68,7 @@ async function awaitState(node: ServerNode, id: string, ...states: string[]): Pr
 
 async function awaitPhase(node: ServerNode, id: string, phaseIndex: number): Promise<void> {
     for (let i = 0; i < 10_000; i++) {
-        const p = await node.act(a => a.get(TestTaskManager).state.tasks[id]);
+        const p = await node.act(a => recordFor(a.get(TestTaskManager).state.runs, id));
         if (p !== undefined && p.phaseIndex >= phaseIndex && (p.state === "running" || p.state === "parked")) return;
         await MockTime.advance(1);
     }
@@ -90,7 +107,7 @@ describe("Task lifecycle", () => {
 
             // Phase 0 completes, then phase 1 gates (device does not "have" the item yet) and suspends.
             await awaitPhase(node1, "synthetic:resume", 1);
-            const persisted = node1.stateOf(TestTaskManager).tasks["synthetic:resume"];
+            const persisted = requireRecordFor(node1.stateOf(TestTaskManager).runs, "synthetic:resume");
             expect(["running", "parked"]).contains(persisted.state);
             expect(persisted.phaseIndex).equals(1);
             await node1.close();
@@ -98,7 +115,7 @@ describe("Task lifecycle", () => {
             // Recreate the node with the same environment + id. The type is not registered until the app does so;
             // register() must trigger resume of the persisted, non-terminal task.
             const node2 = await makeNode(environment);
-            const beforeRegister = node2.stateOf(TestTaskManager).tasks["synthetic:resume"].state;
+            const beforeRegister = requireRecordFor(node2.stateOf(TestTaskManager).runs, "synthetic:resume").state;
             expect(["running", "parked"]).contains(beforeRegister);
 
             // Re-attach the in-memory peer and let the device "have" the item so the resumed gate can pass.
@@ -109,7 +126,7 @@ describe("Task lifecycle", () => {
 
             await node2.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
             await awaitState(node2, "synthetic:resume", "completed");
-            const status = await node2.act(a => a.get(TestTaskManager).get("synthetic:resume")?.status);
+            const status = await node2.act(a => statusOfSlot(a.get(TestTaskManager), "synthetic:resume"));
             expect(status?.state).equals("completed");
             await node2.close();
         });
@@ -126,7 +143,7 @@ describe("Task lifecycle", () => {
             await node1.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
             await node1.act(a => a.get(TestTaskManager).run("synthetic", { tag: "parked" }));
             await awaitState(node1, "synthetic:parked", "parked");
-            expect(node1.stateOf(TestTaskManager).tasks["synthetic:parked"].state).equals("parked");
+            expect(requireRecordFor(node1.stateOf(TestTaskManager).runs, "synthetic:parked").state).equals("parked");
             await node1.close();
 
             const node2 = await makeNode(environment);
@@ -152,12 +169,14 @@ describe("Task lifecycle", () => {
             await node1.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
             await node1.act(a => a.get(TestTaskManager).run("synthetic", { tag: "alias" }, { externalId: "owner" }));
             await awaitState(node1, "synthetic:alias", "parked");
-            expect(node1.stateOf(TestTaskManager).tasks["synthetic:alias"].externalId).equals("owner");
+            expect(requireRecordFor(node1.stateOf(TestTaskManager).runs, "synthetic:alias").externalId).equals("owner");
             await node1.close();
 
             const node2 = await makeNode(environment);
             await node2.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
-            expect(await node2.act(a => a.get(TestTaskManager).get("owner")?.id)).equals("synthetic:alias");
+            expect(await node2.act(a => a.get(TestTaskManager).forExternalId("owner")?.status.slotKey)).equals(
+                "synthetic:alias",
+            );
             await node2.close();
         });
     });
@@ -201,11 +220,17 @@ describe("Task lifecycle", () => {
             await peer.reconcile(peer.asNode(), { verify: true });
 
             await awaitState(node, "synthetic:reject", "failed");
-            const status = await node.act(a => a.get(TestTaskManager).get("synthetic:reject")?.status);
+            const status = await node.act(a => statusOfSlot(a.get(TestTaskManager), "synthetic:reject"));
             expect(status?.error).contains("groupMembership:R");
-            expect(status?.revertTaskId).equals("revert:synthetic:reject");
+            expect(status?.revertRunId).equals(
+                revertRecordOf(node.stateOf(TestTaskManager).runs, "synthetic:reject")?.runId,
+            );
 
-            await awaitState(node, "revert:synthetic:reject", "completed");
+            await awaitState(
+                node,
+                (await node.act(a => revertSlotOf(a.get(TestTaskManager).state.runs, "synthetic:reject")))!,
+                "completed",
+            );
             expect(peer.items[itemMapKey("groupMembership", "OK")]).equals(undefined);
             await node.close();
         });
@@ -219,11 +244,14 @@ describe("Task lifecycle", () => {
             TestTaskManager.peers.set("rb", peer);
             TestTaskManager.reconcilerPeer = peer;
 
+            let failNow!: () => void;
+            const held = new Promise<void>(resolve => (failNow = resolve));
             SyntheticTask.phasesByTag["blockedrollback"] = [
                 {
                     name: "touch",
                     run: async ctx => {
                         await ctx.setIntent(ctx.resolvePeer("rb"), "groupMembership", "B", {});
+                        await held;
                         throw new TaskFailedError("forced failure");
                     },
                 },
@@ -232,22 +260,23 @@ describe("Task lifecycle", () => {
             const node = await makeNode(environment);
             await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
 
-            // A rollback of this id is already in flight for a different changeSet, and parks on the offline peer.
+            // The rollback slot belongs to the run, so the run has to exist before anything can occupy it. Its
+            // failure is held until a rollback of exactly that run is already in flight on the offline peer.
+            const handle = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "blockedrollback" }));
             await node.act(a =>
                 a.get(TestTaskManager).run("revert", {
-                    originalId: "synthetic:blockedrollback",
+                    originalRunId: handle.runId,
                     entries: [{ peerId: "rb", kind: "groupMembership", key: "A" }],
                 }),
             );
-            await awaitState(node, "revert:synthetic:blockedrollback", "parked", "running");
-
-            await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "blockedrollback" }));
+            await awaitState(node, `revert:${handle.runId}`, "parked", "running");
+            failNow();
 
             // The refused rollback must not cost the task its recorded outcome.
             await awaitState(node, "synthetic:blockedrollback", "failed");
-            const status = await node.act(a => a.get(TestTaskManager).get("synthetic:blockedrollback")?.status);
+            const status = await node.act(a => statusOfSlot(a.get(TestTaskManager), "synthetic:blockedrollback"));
             expect(status?.error).contains("forced failure");
-            expect(status?.revertTaskId).equals(undefined);
+            expect(status?.revertRunId).equals(undefined);
             await node.close();
         });
 
@@ -262,31 +291,37 @@ describe("Task lifecycle", () => {
 
             const node = await makeNode(environment);
             await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
-            await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "blockedcancel" }));
+            const handle = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "blockedcancel" }));
             await awaitState(node, "synthetic:blockedcancel", "parked");
 
-            // A rollback of this id is already in flight for a different changeSet, and parks on the offline peer.
+            // A rollback of this run is already in flight for a different changeSet, and parks on the offline peer.
             await node.act(a =>
                 a.get(TestTaskManager).run("revert", {
-                    originalId: "synthetic:blockedcancel",
+                    originalRunId: handle.runId,
                     entries: [{ peerId: "cr2", kind: "groupMembership", key: "OTHER" }],
                 }),
             );
-            await awaitState(node, "revert:synthetic:blockedcancel", "parked", "running");
+            await awaitState(node, `revert:${handle.runId}`, "parked", "running");
 
-            await expect(
-                (async () => node.act(a => a.get(TestTaskManager).cancel("synthetic:blockedcancel")))(),
-            ).rejectedWith(TaskConflictError);
+            await expect((async () => node.act(a => a.get(TestTaskManager).cancel(handle.runId)))()).rejectedWith(
+                TaskConflictError,
+            );
 
             // Memory must not claim a cancel that storage never saw. Liveness bookkeeping may differ transiently:
             // a declined cancel re-drives the task, and the driver re-persists parked/running as it goes.
-            const status = await node.act(a => a.get(TestTaskManager).get("synthetic:blockedcancel")?.status);
+            const status = await node.act(a => statusOfSlot(a.get(TestTaskManager), "synthetic:blockedcancel"));
             expect(status?.state).does.not.equal("cancelled");
-            expect(node.stateOf(TestTaskManager).tasks["synthetic:blockedcancel"].state).does.not.equal("cancelled");
+            expect(
+                requireRecordFor(node.stateOf(TestTaskManager).runs, "synthetic:blockedcancel").state,
+            ).does.not.equal("cancelled");
 
             // The abort stopped the driver and dropped the gate; declining the cancel must give both back, or the
             // task sits non-terminal with nothing left to advance it until a restart.
-            expect(await node.act(a => a.get(TestTaskManager).isDriven("synthetic:blockedcancel"))).equals(true);
+            expect(
+                await node.act(a =>
+                    a.get(TestTaskManager).isDriven(runIdOfSlot(a.get(TestTaskManager), "synthetic:blockedcancel")!),
+                ),
+            ).equals(true);
 
             // ...and it still converges once the device has the item, which it cannot do without a driver.
             peer.markHas("groupMembership", "K");
@@ -321,9 +356,15 @@ describe("Task lifecycle", () => {
             await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "cancel" }));
             await awaitState(node, "synthetic:cancel", "completed");
 
-            const handle = await node.act(a => a.get(TestTaskManager).cancel("synthetic:cancel"));
-            expect(handle?.id).equals("revert:synthetic:cancel");
-            await awaitState(node, "revert:synthetic:cancel", "completed");
+            const handle = await node.act(a => cancelSlot(a.get(TestTaskManager), "synthetic:cancel"));
+            expect(handle?.status.revertOf).equals(
+                requireStatusOfSlot(await node.act(a => a.get(TestTaskManager)), "synthetic:cancel").runId,
+            );
+            await awaitState(
+                node,
+                (await node.act(a => revertSlotOf(a.get(TestTaskManager).state.runs, "synthetic:cancel")))!,
+                "completed",
+            );
 
             // Items are removed in REVERSE add order (B added last → reverted first).
             expect(peer.removeOrder).deep.equals([
@@ -333,9 +374,9 @@ describe("Task lifecycle", () => {
             expect(peer.items[itemMapKey("groupMembership", "A")]).equals(undefined);
             expect(peer.items[itemMapKey("groupMembership", "B")]).equals(undefined);
             // Cancelling an already-completed task spawns the revert but leaves the original's truthful state.
-            const status = await node.act(a => a.get(TestTaskManager).get("synthetic:cancel")?.status);
+            const status = await node.act(a => statusOfSlot(a.get(TestTaskManager), "synthetic:cancel"));
             expect(status?.state).equals("completed");
-            expect(status?.revertTaskId).equals("revert:synthetic:cancel");
+            expect(status?.revertRunId).equals(handle?.runId);
             await node.close();
         });
 
@@ -355,9 +396,16 @@ describe("Task lifecycle", () => {
 
             // The peer goes away, so the rollback parks instead of finishing.
             peer.setReachable(false);
-            const revert = await node.act(a => a.get(TestTaskManager).cancel("synthetic:rerun"));
-            expect(revert?.id).equals("revert:synthetic:rerun");
-            await awaitState(node, "revert:synthetic:rerun", "parked", "running");
+            const revert = await node.act(a => cancelSlot(a.get(TestTaskManager), "synthetic:rerun"));
+            expect(revert?.status.slotKey).equals(
+                `revert:${requireStatusOfSlot(await node.act(a => a.get(TestTaskManager)), "synthetic:rerun").runId}`,
+            );
+            await awaitState(
+                node,
+                (await node.act(a => revertSlotOf(a.get(TestTaskManager).state.runs, "synthetic:rerun")))!,
+                "parked",
+                "running",
+            );
 
             // Re-running now would re-apply exactly the intents the rollback is removing.
             await expect(
@@ -365,7 +413,11 @@ describe("Task lifecycle", () => {
             ).rejectedWith(TaskConflictError);
 
             peer.setReachable(true);
-            await awaitState(node, "revert:synthetic:rerun", "completed");
+            await awaitState(
+                node,
+                (await node.act(a => revertSlotOf(a.get(TestTaskManager).state.runs, "synthetic:rerun")))!,
+                "completed",
+            );
             await node.close();
         });
 
@@ -387,13 +439,23 @@ describe("Task lifecycle", () => {
                 await MockTime.advance(1);
             }
 
-            // The caller's own id must reach its work, all the way to rolling it back.
-            const handle = await node.act(a => a.get(TestTaskManager).cancel("owner"));
-            expect(handle?.id).equals("revert:synthetic:aliascancel");
-            const status = await node.act(a => a.get(TestTaskManager).get("owner")?.status);
+            // The caller's own id must reach its work, all the way to rolling it back. Resolving it first is
+            // the contract: the caller sees which run its name names before acting on it.
+            const handle = await node.act(a => {
+                const manager = a.get(TestTaskManager);
+                return manager.cancel(manager.forExternalId("owner")!.runId);
+            });
+            expect(handle?.status.revertOf).equals(
+                requireStatusOfSlot(await node.act(a => a.get(TestTaskManager)), "synthetic:aliascancel").runId,
+            );
+            const status = await node.act(a => a.get(TestTaskManager).forExternalId("owner")?.status);
             expect(status?.state).equals("cancelled");
 
-            await awaitState(node, "revert:synthetic:aliascancel", "completed");
+            await awaitState(
+                node,
+                (await node.act(a => revertSlotOf(a.get(TestTaskManager).state.runs, "synthetic:aliascancel")))!,
+                "completed",
+            );
             expect(peer.items[itemMapKey("groupMembership", "X")]).equals(undefined);
             await node.close();
         });
@@ -416,14 +478,20 @@ describe("Task lifecycle", () => {
             }
             expect(peer.items[itemMapKey("groupMembership", "X")]?.status.state).equals("pending");
 
-            const handle = await node.act(a => a.get(TestTaskManager).cancel("synthetic:inflight"));
-            expect(handle?.id).equals("revert:synthetic:inflight");
+            const handle = await node.act(a => cancelSlot(a.get(TestTaskManager), "synthetic:inflight"));
+            expect(handle?.status.revertOf).equals(
+                requireStatusOfSlot(await node.act(a => a.get(TestTaskManager)), "synthetic:inflight").runId,
+            );
 
-            const status = await node.act(a => a.get(TestTaskManager).get("synthetic:inflight")?.status);
+            const status = await node.act(a => statusOfSlot(a.get(TestTaskManager), "synthetic:inflight"));
             expect(status?.state).equals("cancelled");
             expect(status?.error).equals(undefined);
 
-            await awaitState(node, "revert:synthetic:inflight", "completed");
+            await awaitState(
+                node,
+                (await node.act(a => revertSlotOf(a.get(TestTaskManager).state.runs, "synthetic:inflight")))!,
+                "completed",
+            );
             expect(peer.items[itemMapKey("groupMembership", "X")]).equals(undefined);
             await node.close();
         });

--- a/packages/node-manager/test/task/TaskLifecycleTest.ts
+++ b/packages/node-manager/test/task/TaskLifecycleTest.ts
@@ -5,7 +5,7 @@
  */
 
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
-import { TaskConflictError } from "#task/errors.js";
+import { TaskConflictError, TaskFailedError, TaskIdentityExhaustedError } from "#task/errors.js";
 import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { TaskPhase } from "#task/types.js";
 import { RunId } from "#task/types.js";
@@ -37,6 +37,23 @@ class TestTaskManager extends TaskManagerBehavior {
     }
     protected override taskReconciler(): ReconcilerBehavior {
         return TestTaskManager.reconcilerPeer as unknown as ReconcilerBehavior;
+    }
+
+    /**
+     * Consume every identity the reservation covers, so the next rollback the manager tries to prepare is
+     * refused. Reaches the preparation-failure path on a healthy node, which shutdown otherwise hides.
+     */
+    exhaustIdentities(): void {
+        for (;;) {
+            try {
+                this.internal.runs.allocate();
+            } catch (e) {
+                if (e instanceof TaskIdentityExhaustedError) {
+                    return;
+                }
+                throw e;
+            }
+        }
     }
 
     /** True while a drive of `id` owns this id's gate and driving entries. */
@@ -397,6 +414,81 @@ describe("Task lifecycle", () => {
                 "completed",
             );
             expect(peer.items[itemMapKey("groupMembership", "X")]).equals(undefined);
+            await node.close();
+        });
+    });
+
+    describe("rollback refusal", () => {
+        it("records a failure whose rollback the manager refuses", async () => {
+            const environment = new Environment("test");
+            const peer = new FakePeer("rb");
+            TestTaskManager.peers.set("rb", peer);
+            TestTaskManager.reconcilerPeer = peer;
+
+            let failNow!: () => void;
+            const held = new Promise<void>(resolve => (failNow = resolve));
+            SyntheticTask.phasesByTag["blockedrollback"] = [
+                {
+                    name: "touch",
+                    run: async ctx => {
+                        await ctx.setIntent(ctx.resolvePeer("rb"), "groupMembership", "B", {});
+                        await held;
+                        throw new TaskFailedError("forced failure");
+                    },
+                },
+            ];
+
+            const node = await makeNode(environment);
+            await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+            const handle = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "blockedrollback" }));
+
+            // No identity is left for a rollback, so the manager cannot prepare one when this run fails.
+            await node.act(a => a.get(TestTaskManager).exhaustIdentities());
+            failNow();
+
+            // The refused rollback must not cost the task its recorded outcome, and must not escape the driver
+            // as an unhandled rejection.
+            await awaitState(node, "synthetic:blockedrollback", "failed");
+            const status = await node.act(a => a.get(TestTaskManager).get(handle.runId)?.status);
+            expect(status?.error).contains("forced failure");
+            expect(status?.revertRunId).equals(undefined);
+            await node.close();
+        });
+
+        it("leaves a task untouched when its cancel cannot spawn a rollback", async () => {
+            const environment = new Environment("test");
+            const peer = new FakePeer("cr2");
+            peer.setReachable(false);
+            TestTaskManager.peers.set("cr2", peer);
+            TestTaskManager.reconcilerPeer = peer;
+
+            SyntheticTask.phasesByTag["blockedcancel"] = [gatePhase("cr2", "groupMembership", "K")];
+
+            const node = await makeNode(environment);
+            await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
+            const handle = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "blockedcancel" }));
+            await awaitState(node, "synthetic:blockedcancel", "parked");
+
+            await node.act(a => a.get(TestTaskManager).exhaustIdentities());
+            await expect((async () => node.act(a => a.get(TestTaskManager).cancel(handle.runId)))()).rejectedWith(
+                TaskIdentityExhaustedError,
+            );
+
+            // Memory must not claim a cancel that storage never saw.
+            const status = await node.act(a => a.get(TestTaskManager).get(handle.runId)?.status);
+            expect(status?.state).does.not.equal("cancelled");
+            expect(
+                requireRecordFor(node.stateOf(TestTaskManager).runs, "synthetic:blockedcancel").state,
+            ).does.not.equal("cancelled");
+
+            // The abort stopped the driver and dropped the gate; declining the cancel must give both back, or
+            // the task sits non-terminal with nothing left to advance it until a restart.
+            expect(await node.act(a => a.get(TestTaskManager).isDriven(handle.runId))).equals(true);
+
+            // ...and it still converges once the device has the item, which it cannot do without a driver.
+            peer.markHas("groupMembership", "K");
+            peer.setReachable(true);
+            await awaitState(node, "synthetic:blockedcancel", "completed");
             await node.close();
         });
     });

--- a/packages/node-manager/test/task/TaskLifecycleTest.ts
+++ b/packages/node-manager/test/task/TaskLifecycleTest.ts
@@ -5,7 +5,7 @@
  */
 
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
-import { TaskConflictError, TaskFailedError } from "#task/errors.js";
+import { TaskConflictError } from "#task/errors.js";
 import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { TaskPhase } from "#task/types.js";
 import { RunId } from "#task/types.js";
@@ -20,7 +20,6 @@ import {
     requireStatusOfSlot,
     revertRecordOf,
     revertSlotOf,
-    runIdOfSlot,
     statusOfSlot,
     SyntheticTask,
 } from "./helpers.js";
@@ -232,101 +231,6 @@ describe("Task lifecycle", () => {
                 "completed",
             );
             expect(peer.items[itemMapKey("groupMembership", "OK")]).equals(undefined);
-            await node.close();
-        });
-    });
-
-    describe("rollback refusal", () => {
-        it("records a failure whose rollback the manager refuses", async () => {
-            const environment = new Environment("test");
-            const peer = new FakePeer("rb");
-            peer.setReachable(false);
-            TestTaskManager.peers.set("rb", peer);
-            TestTaskManager.reconcilerPeer = peer;
-
-            let failNow!: () => void;
-            const held = new Promise<void>(resolve => (failNow = resolve));
-            SyntheticTask.phasesByTag["blockedrollback"] = [
-                {
-                    name: "touch",
-                    run: async ctx => {
-                        await ctx.setIntent(ctx.resolvePeer("rb"), "groupMembership", "B", {});
-                        await held;
-                        throw new TaskFailedError("forced failure");
-                    },
-                },
-            ];
-
-            const node = await makeNode(environment);
-            await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
-
-            // The rollback slot belongs to the run, so the run has to exist before anything can occupy it. Its
-            // failure is held until a rollback of exactly that run is already in flight on the offline peer.
-            const handle = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "blockedrollback" }));
-            await node.act(a =>
-                a.get(TestTaskManager).run("revert", {
-                    originalRunId: handle.runId,
-                    entries: [{ peerId: "rb", kind: "groupMembership", key: "A" }],
-                }),
-            );
-            await awaitState(node, `revert:${handle.runId}`, "parked", "running");
-            failNow();
-
-            // The refused rollback must not cost the task its recorded outcome.
-            await awaitState(node, "synthetic:blockedrollback", "failed");
-            const status = await node.act(a => statusOfSlot(a.get(TestTaskManager), "synthetic:blockedrollback"));
-            expect(status?.error).contains("forced failure");
-            expect(status?.revertRunId).equals(undefined);
-            await node.close();
-        });
-
-        it("leaves a task untouched when its cancel cannot spawn a rollback", async () => {
-            const environment = new Environment("test");
-            const peer = new FakePeer("cr2");
-            peer.setReachable(false);
-            TestTaskManager.peers.set("cr2", peer);
-            TestTaskManager.reconcilerPeer = peer;
-
-            SyntheticTask.phasesByTag["blockedcancel"] = [gatePhase("cr2", "groupMembership", "K")];
-
-            const node = await makeNode(environment);
-            await node.act(a => a.get(TestTaskManager).register("synthetic", SyntheticTask));
-            const handle = await node.act(a => a.get(TestTaskManager).run("synthetic", { tag: "blockedcancel" }));
-            await awaitState(node, "synthetic:blockedcancel", "parked");
-
-            // A rollback of this run is already in flight for a different changeSet, and parks on the offline peer.
-            await node.act(a =>
-                a.get(TestTaskManager).run("revert", {
-                    originalRunId: handle.runId,
-                    entries: [{ peerId: "cr2", kind: "groupMembership", key: "OTHER" }],
-                }),
-            );
-            await awaitState(node, `revert:${handle.runId}`, "parked", "running");
-
-            await expect((async () => node.act(a => a.get(TestTaskManager).cancel(handle.runId)))()).rejectedWith(
-                TaskConflictError,
-            );
-
-            // Memory must not claim a cancel that storage never saw. Liveness bookkeeping may differ transiently:
-            // a declined cancel re-drives the task, and the driver re-persists parked/running as it goes.
-            const status = await node.act(a => statusOfSlot(a.get(TestTaskManager), "synthetic:blockedcancel"));
-            expect(status?.state).does.not.equal("cancelled");
-            expect(
-                requireRecordFor(node.stateOf(TestTaskManager).runs, "synthetic:blockedcancel").state,
-            ).does.not.equal("cancelled");
-
-            // The abort stopped the driver and dropped the gate; declining the cancel must give both back, or the
-            // task sits non-terminal with nothing left to advance it until a restart.
-            expect(
-                await node.act(a =>
-                    a.get(TestTaskManager).isDriven(runIdOfSlot(a.get(TestTaskManager), "synthetic:blockedcancel")!),
-                ),
-            ).equals(true);
-
-            // ...and it still converges once the device has the item, which it cannot do without a driver.
-            peer.markHas("groupMembership", "K");
-            peer.setReachable(true);
-            await awaitState(node, "synthetic:blockedcancel", "completed");
             await node.close();
         });
     });

--- a/packages/node-manager/test/task/TaskManagerBehaviorTest.ts
+++ b/packages/node-manager/test/task/TaskManagerBehaviorTest.ts
@@ -10,10 +10,20 @@ import { RotateGroupKey } from "#task/groups/RotateGroupKey.js";
 import { Task, TaskPersistence } from "#task/Task.js";
 import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { TaskPhase } from "#task/types.js";
+import { RetireSeq, RunId } from "#task/types.js";
 import { Environment } from "@matter/general";
 import { ServerNode } from "@matter/node";
 import { MockServerNode } from "@matter/node/testing";
-import { SyntheticTask } from "./helpers.js";
+import {
+    cancelSlot,
+    handleOfSlot,
+    recordFor,
+    requireRecordFor,
+    requireStatusOfSlot,
+    revertRecordOf,
+    statusOfSlot,
+    SyntheticTask,
+} from "./helpers.js";
 
 const RootEndpoint = MockServerNode.RootEndpoint.with(TaskManagerBehavior);
 
@@ -22,8 +32,8 @@ class TracingTaskManager extends TaskManagerBehavior {
     static override readonly schema = TaskManagerBehavior.schema;
 
     /** True while a drive of `id` owns this id's gate and driving entries. */
-    isDriven(id: string): boolean {
-        return this.internal.driving.has(id) && this.internal.gates.has(id);
+    isDriven(runId: RunId): boolean {
+        return this.internal.driving.has(runId) && this.internal.gates.has(runId);
     }
 }
 
@@ -62,17 +72,25 @@ async function pumpUntil(name: string, condition: () => boolean | Promise<boolea
 }
 
 /**
- * Advances MockTime until the persisted state for the task reaches a terminal state.
- * Polling persisted state (state.tasks[id]) ensures #drive's final #persist has completed.
+ * Advances MockTime until no run owns `slotKey` any more.
+ *
+ * A run turns terminal one step before it retires, so waiting for the record to read terminal would let a
+ * caller act while the slot is still held — and a re-run of that slot would then be refused.
  */
-async function awaitTaskDone(node: ServerNode, id: string): Promise<void> {
+async function awaitTaskDone(node: ServerNode, slotKey: string): Promise<void> {
     // Bound the poll loop so a never-terminating task fails clearly instead of spinning.
     for (let i = 0; i < 10_000; i++) {
-        const state = await node.act(a => a.get(TaskManagerBehavior).state.tasks[id]?.state);
-        if (state === "completed" || state === "failed") return;
+        const retired = await node.act(a => {
+            const manager = a.get(TaskManagerBehavior);
+            return (
+                !manager.tasks.some(t => t.status.slotKey === slotKey) &&
+                recordFor(manager.state.runs, slotKey) !== undefined
+            );
+        });
+        if (retired) return;
         await MockTime.advance(1);
     }
-    throw new Error(`Task ${id} did not reach a terminal state`);
+    throw new Error(`No run of slot ${slotKey} retired`);
 }
 
 describe("TaskManagerBehavior", () => {
@@ -106,7 +124,7 @@ describe("TaskManagerBehavior", () => {
         await node.act(agent => agent.get(TaskManagerBehavior).run("synthetic", { tag: "ok" }));
         await awaitTaskDone(node, "synthetic:ok");
         expect(ran).deep.equals(["a", "b"]);
-        const status = await node.act(a => a.get(TaskManagerBehavior).get("synthetic:ok")?.status);
+        const status = await node.act(a => statusOfSlot(a.get(TaskManagerBehavior), "synthetic:ok"));
         expect(status?.state).equals("completed");
     });
 
@@ -158,10 +176,11 @@ describe("TaskManagerBehavior", () => {
 
         // A terminal task does not hold its id, so the request runs again under it.
         const h3 = await node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "dup" }));
-        expect(h3.id).equals(h1.id);
+        expect(h3.runId).not.equals(h1.runId);
+        expect(h3.status.slotKey).equals(h1.status.slotKey);
         await pumpUntil("re-run in flight", () => runs === 2);
         await pumpUntil("re-run complete", async () => {
-            const state = await node.act(a => a.get(TaskManagerBehavior).get("synthetic:dup")?.status.state);
+            const state = await node.act(a => requireStatusOfSlot(a.get(TaskManagerBehavior), "synthetic:dup").state);
             return state === "completed";
         });
         expect(await node.act(a => a.get(TaskManagerBehavior).tasks.length)).equals(1);
@@ -192,7 +211,7 @@ describe("TaskManagerBehavior", () => {
             const again = await node.act(a =>
                 a.get(TaskManagerBehavior).run("synthetic", { tag: "mine" }, { externalId: "owner" }),
             );
-            expect(again.id).equals(first.id);
+            expect(again.runId).equals(first.runId);
             expect(await node.act(a => a.get(TaskManagerBehavior).tasks.length)).equals(1);
             // The join must reach the running task, not replace it under its id: a replacement would drive the
             // phases a second time against the same peers.
@@ -223,14 +242,15 @@ describe("TaskManagerBehavior", () => {
         await node.act(a => a.get(TaskManagerBehavior).register("synthetic", SyntheticTask));
         await node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "ext" }, { externalId: "myref" }));
         await awaitTaskDone(node, "synthetic:ext");
-        const found = await node.act(a => a.get(TaskManagerBehavior).get("myref"));
+        const found = await node.act(a => a.get(TaskManagerBehavior).forExternalId("myref"));
         expect(found?.status.externalId).equals("myref");
     });
 
     it("marks a rotation non-revertible once activate begins; tasks are revertible by default", () => {
         const rotatableAt = (phaseIndex: number) =>
             new RotateGroupKey(
-                "rotateGroupKey:42:r1",
+                RunId(1),
+                "rotateGroupKey:42",
                 { groupKeySetId: 42, newEpochKey: new Uint8Array(16), rotationId: "r1" },
                 { phaseIndex, state: "running" },
             ).revertible;
@@ -239,12 +259,14 @@ describe("TaskManagerBehavior", () => {
         expect(rotatableAt(2)).equals(false); // cleanup in flight
         expect(rotatableAt(3)).equals(false); // completed
 
-        expect(new SyntheticTask("synthetic:x", { tag: "x" }).revertible).equals(true);
+        expect(new SyntheticTask(RunId(1), "synthetic:x", { tag: "x" }).revertible).equals(true);
 
         // The generic decline reason must not leak a specific task type's domain language.
-        expect(new SyntheticTask("synthetic:x", { tag: "x" }).notRevertibleReason).does.not.contain("rotation");
+        expect(new SyntheticTask(RunId(1), "synthetic:x", { tag: "x" }).notRevertibleReason).does.not.contain(
+            "rotation",
+        );
         expect(
-            new RotateGroupKey("rotateGroupKey:42:r1", {
+            new RotateGroupKey(RunId(1), "rotateGroupKey:42", {
                 groupKeySetId: 42,
                 newEpochKey: new Uint8Array(16),
                 rotationId: "r1",
@@ -271,7 +293,7 @@ describe("TaskManagerBehavior", () => {
                     },
                 ];
             }
-            static override idFor(params: { tag: string }) {
+            static override slotKeyFor(params: { tag: string }) {
                 return `hardFail:${params.tag}`;
             }
         }
@@ -280,32 +302,34 @@ describe("TaskManagerBehavior", () => {
 
         await node.act(a => a.get(TaskManagerBehavior).run("hardFail", { tag: "revertible", revertible: true }));
         await awaitTaskDone(node, "hardFail:revertible");
-        const revertible = await node.act(a => a.get(TaskManagerBehavior).get("hardFail:revertible")?.status);
+        const revertible = await node.act(a => statusOfSlot(a.get(TaskManagerBehavior), "hardFail:revertible"));
         expect(revertible?.state).equals("failed");
-        expect(revertible?.revertTaskId).equals("revert:hardFail:revertible");
+        // A rollback was created, and it is a rollback OF this run — not merely "some record exists", which
+        // would pass identically when nothing was rolled back at all.
+        const revertRunId = revertible?.revertRunId;
+        expect(typeof revertRunId).equals("number");
+        const rollback = await node.act(a => a.get(TaskManagerBehavior).get(revertRunId!)?.status);
+        expect(rollback?.revertOf).equals(revertible?.runId);
+        expect(rollback?.slotKey).equals(`revert:${revertible?.runId}`);
 
         await node.act(a => a.get(TaskManagerBehavior).run("hardFail", { tag: "final", revertible: false }));
         await awaitTaskDone(node, "hardFail:final");
-        const nonRevertible = await node.act(a => a.get(TaskManagerBehavior).get("hardFail:final")?.status);
+        const nonRevertible = await node.act(a => statusOfSlot(a.get(TaskManagerBehavior), "hardFail:final"));
         expect(nonRevertible?.state).equals("failed");
-        expect(nonRevertible?.revertTaskId).equals(undefined);
-        expect(await node.act(a => a.get(TaskManagerBehavior).state.tasks["revert:hardFail:final"])).equals(undefined);
+        expect(nonRevertible?.revertRunId).equals(undefined);
+        expect(await node.act(a => revertRecordOf(a.get(TaskManagerBehavior).state.runs, "hardFail:final"))).equals(
+            undefined,
+        );
     });
 
-    it("keeps driver bookkeeping of a re-run started while the previous drive still settles", async () => {
+    it("refuses a re-run of a slot while the previous run's driver is still unwinding", async () => {
         await using node = await MockServerNode.create(TracingRootEndpoint, { id: "tm-rerun-race" });
-        let release!: () => void;
-        const blocked = new Promise<void>(resolve => (release = resolve));
-        let holding = false;
         let runs = 0;
         SyntheticTask.phasesByTag["race"] = [
             {
                 name: "a",
                 run: async () => {
-                    if (++runs > 1) {
-                        holding = true;
-                        await blocked;
-                    }
+                    runs++;
                 },
             },
         ];
@@ -315,17 +339,30 @@ describe("TaskManagerBehavior", () => {
             manager = a.get(TracingTaskManager);
         });
 
-        // Re-run from inside the terminal write of the first run: its drive promise has not settled yet.
-        HookedTask.atTerminalWrite = () => manager.run("synthetic", { tag: "race" });
+        // A run turns terminal before its driver settles, and it keeps its slot until it does. A re-run
+        // admitted in that window would start writing to the peer while the previous unwind is still in
+        // flight, so it is refused rather than queued.
+        let outcome: unknown = "hook never ran";
+        HookedTask.atTerminalWrite = () => {
+            try {
+                manager.run("synthetic", { tag: "race" });
+                outcome = "admitted";
+            } catch (e) {
+                outcome = e;
+            }
+        };
         try {
             await node.act(a => a.get(TracingTaskManager).run("synthetic", { tag: "race" }));
-            await pumpUntil("re-run in flight", () => holding);
-
-            expect(await node.act(a => a.get(TracingTaskManager).isDriven("synthetic:race"))).equals(true);
+            await pumpUntil(
+                "first run retired",
+                async () => (await node.act(a => a.get(TracingTaskManager).tasks.length)) === 0,
+            );
         } finally {
             HookedTask.atTerminalWrite = undefined;
-            release();
         }
+
+        expect(outcome).instanceOf(TaskConflictError);
+        expect(runs).equals(1);
     });
 
     it("distinguishes an id no live task answers to from a task with nothing to roll back", async () => {
@@ -337,22 +374,28 @@ describe("TaskManagerBehavior", () => {
         await awaitTaskDone(node, "synthetic:nothing");
 
         // A task that touched nothing has nothing to roll back, and says so.
-        expect(await node.act(a => a.get(TaskManagerBehavior).cancel("synthetic:nothing"))).equals(undefined);
+        expect(await node.act(a => cancelSlot(a.get(TaskManagerBehavior), "synthetic:nothing"))).equals(undefined);
 
         // An id nobody is holding work under is a different answer, not the same one.
         await expect(
-            (async () => node.act(a => a.get(TaskManagerBehavior).cancel("synthetic:never-existed")))(),
+            (async () => node.act(a => cancelSlot(a.get(TaskManagerBehavior), "synthetic:never-existed")))(),
         ).rejectedWith(TaskNotFoundError);
-        expect(await node.act(a => a.get(TaskManagerBehavior).get("synthetic:never-existed"))).equals(undefined);
+        expect(await node.act(a => handleOfSlot(a.get(TaskManagerBehavior), "synthetic:never-existed"))).equals(
+            undefined,
+        );
 
-        // So is a terminal record from a previous start: it is not resumed, so no live task answers to its id.
+        // A run that retired before a restart still answers. This is the contract this increment changes: it
+        // used to vanish, because only non-terminal records were resumed and lookup read only the live table.
         await node.act(a => {
-            a.get(TaskManagerBehavior).state.tasks = {
-                "synthetic:orphan": {
+            a.get(TaskManagerBehavior).state.runs = {
+                "7": {
+                    runId: RunId(7),
+                    slotKey: "synthetic:orphan",
                     type: "synthetic",
                     params: { tag: "orphan" },
                     phaseIndex: 1,
                     state: "cancelled",
+                    retireSeq: RetireSeq(1),
                     changeSet: [],
                 },
             };
@@ -361,9 +404,13 @@ describe("TaskManagerBehavior", () => {
 
         const node2 = await MockServerNode.create(RootEndpoint, { environment, id: "tm-cancel-unknown" });
         await node2.act(a => a.get(TaskManagerBehavior).register("synthetic", SyntheticTask));
-        await expect(
-            (async () => node2.act(a => a.get(TaskManagerBehavior).cancel("synthetic:orphan")))(),
-        ).rejectedWith(TaskNotFoundError);
+
+        expect(await node2.act(a => a.get(TaskManagerBehavior).get(RunId(7))?.status.state)).equals("cancelled");
+        // Its changeSet is empty, so there is nothing to roll back — a different answer from "never existed".
+        expect(await node2.act(a => a.get(TaskManagerBehavior).cancel(RunId(7)))).equals(undefined);
+        await expect((async () => node2.act(a => a.get(TaskManagerBehavior).cancel(RunId(999))))()).rejectedWith(
+            TaskNotFoundError,
+        );
         await node2.close();
     });
 
@@ -373,8 +420,10 @@ describe("TaskManagerBehavior", () => {
         await node.act(a => a.get(TaskManagerBehavior).register("synthetic", SyntheticTask));
         await node.act(a => a.get(TaskManagerBehavior).run("synthetic", { tag: "persist" }));
         await awaitTaskDone(node, "synthetic:persist");
-        const persisted = node.stateOf(TaskManagerBehavior).tasks;
-        expect(Object.keys(persisted)).deep.equals(["synthetic:persist"]);
-        expect(persisted["synthetic:persist"].state).equals("completed");
+        const persisted = node.stateOf(TaskManagerBehavior).runs;
+        const record = requireRecordFor(persisted, "synthetic:persist");
+        // One record, stored under the identity of the run that wrote it.
+        expect(Object.keys(persisted)).deep.equals([String(record.runId)]);
+        expect(record.state).equals("completed");
     });
 });

--- a/packages/node-manager/test/task/UnregisteredItemKindTest.ts
+++ b/packages/node-manager/test/task/UnregisteredItemKindTest.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Task } from "#task/Task.js";
+import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
+import { TaskContext, TaskPhase } from "#task/types.js";
+import { ClientNode, DesiredStateBehavior, itemMapKey } from "@matter/node";
+import { MockServerNode, MockSite, subscribedPeer } from "@matter/node/testing";
+import { awaitRun } from "./helpers.js";
+
+const TYPO_TYPE = "typoIntent";
+const PEER_ID = "peer1";
+
+/** Sets an intent under an unregistered kind name (as a caller-side typo would), then waits for it to commit. */
+class TypoIntentTask extends Task<{ peerId: string }> {
+    readonly type = TYPO_TYPE;
+
+    static override slotKeyFor(params: { peerId: string }): string {
+        return `${TYPO_TYPE}:${params.peerId}`;
+    }
+
+    get phases(): TaskPhase[] {
+        return [{ name: "set-typo-intent", run: ctx => this.#run(ctx) }];
+    }
+
+    async #run(ctx: TaskContext): Promise<void> {
+        const peer = ctx.resolvePeer(this.params.peerId);
+        await ctx.setIntent(peer, "groupKy", "1", {});
+        await ctx.awaitCommitted([{ peer, kind: "groupKy", key: "1" }]);
+    }
+}
+
+const ControllerRoot = MockServerNode.RootEndpoint.with(TaskManagerBehavior);
+
+function itemState(peer: ClientNode) {
+    return peer.stateOf(DesiredStateBehavior).items[itemMapKey("groupKy", "1")]?.status.state;
+}
+
+describe("an item whose kind is not registered", () => {
+    before(() => {
+        MockTime.init();
+    });
+
+    it("fails the task instead of reporting success", async () => {
+        await using site = new MockSite();
+        const { controller } = await site.addCommissionedPair({ controller: { type: ControllerRoot } });
+        const peer = await subscribedPeer(controller, PEER_ID);
+
+        await controller.act(agent => agent.get(TaskManagerBehavior).register(TYPO_TYPE, TypoIntentTask));
+        const handle = await controller.act(agent =>
+            agent.get(TaskManagerBehavior).run(TYPO_TYPE, { peerId: PEER_ID }),
+        );
+
+        await awaitRun(controller, TaskManagerBehavior, handle.runId, "failed");
+        expect(itemState(peer)).equals(undefined);
+    });
+});

--- a/packages/node-manager/test/task/groups/AddNodeToGroupIntegrationTest.ts
+++ b/packages/node-manager/test/task/groups/AddNodeToGroupIntegrationTest.ts
@@ -16,6 +16,7 @@ import { MockServerNode, MockSite, subscribedPeer } from "@matter/node/testing";
 import { SustainedSubscription } from "@matter/protocol";
 import { EndpointNumber, GroupId } from "@matter/types";
 import { GroupKeyManagement } from "@matter/types/clusters/group-key-management";
+import { cancelSlot, recordFor, requireRecordFor, revertRecordOf, revertSlotOf, statusOfSlot } from "../helpers.js";
 
 const { TrustFirst } = GroupKeyManagement.GroupKeySecurityPolicy;
 
@@ -55,9 +56,16 @@ function itemState(
 /** Pump virtual time + macrotasks until the persisted task state is one of `states` (else throw). */
 async function awaitState(node: ServerNode, id: string, ...states: string[]): Promise<void> {
     for (let i = 0; i < 2_000; i++) {
-        const state = await node.act(a => a.get(TaskManagerBehavior).state.tasks[id]?.state);
+        const state = await node.act(a => recordFor(a.get(TaskManagerBehavior).state.runs, id)?.state);
         if (state !== undefined && states.includes(state)) {
-            return;
+            // A run turns terminal one step before it retires, so a caller that acts here would find the
+            // slot still held.
+            const settled =
+                !(["completed", "failed", "cancelled"] as string[]).includes(state) ||
+                (await node.act(a => !a.get(TaskManagerBehavior).tasks.some(t => t.status.slotKey === id)));
+            if (settled) {
+                return;
+            }
         }
         await MockTime.advance(100);
         await MockTime.macrotask;
@@ -124,22 +132,30 @@ describe("AddNodeToGroup task integration (single peer)", () => {
         expect(isMember(device)).equals(true);
 
         const handle = await MockTime.resolve(
-            controller.act(agent => agent.get(TaskManagerBehavior).cancel(TASK_ID)),
+            controller.act(agent => cancelSlot(agent.get(TaskManagerBehavior), TASK_ID)),
             {
                 macrotasks: true,
             },
         );
-        expect(handle?.id).equals(`revert:${TASK_ID}`);
-        await awaitState(controller, `revert:${TASK_ID}`, "completed");
+        expect(handle?.status.revertOf).equals(
+            requireRecordFor(controller.stateOf(TaskManagerBehavior).runs, TASK_ID).runId,
+        );
+        await awaitState(
+            controller,
+            (await controller.act(a => revertSlotOf(a.get(TaskManagerBehavior).state.runs, TASK_ID)))!,
+            "completed",
+        );
 
         expect(itemState(peer, "groupKey", String(GROUP_KEY_SET_ID))).equals(undefined);
         expect(itemState(peer, "groupKeyMap", String(GROUP))).equals(undefined);
         expect(itemState(peer, "endpointGroupMembership", MEMBERSHIP_KEY)).equals(undefined);
         expect(isMember(device)).equals(false);
         // Cancelling an already-completed task spawns the revert but leaves the original's truthful state.
-        const status = await controller.act(agent => agent.get(TaskManagerBehavior).get(TASK_ID)?.status);
+        const status = await controller.act(agent => statusOfSlot(agent.get(TaskManagerBehavior), TASK_ID));
         expect(status?.state).equals("completed");
-        expect(status?.revertTaskId).equals(`revert:${TASK_ID}`);
+        expect(status?.revertRunId).equals(
+            revertRecordOf(controller.stateOf(TaskManagerBehavior).runs, TASK_ID)?.runId,
+        );
     });
 
     it("resumes a parked task across a controller restart", async () => {
@@ -162,7 +178,9 @@ describe("AddNodeToGroup task integration (single peer)", () => {
         // Recreate the controller from the same storage (keyed by id) on the same network host (index 1).
         // The persisted parked task resumes once the node is online and the peer subscription re-establishes.
         const controller2 = await site.addNode(ControllerRoot, { id, index: 1 });
-        const resumed = await controller2.act(agent => agent.get(TaskManagerBehavior).state.tasks[TASK_ID]?.state);
+        const resumed = await controller2.act(
+            agent => recordFor(agent.get(TaskManagerBehavior).state.runs, TASK_ID)?.state,
+        );
         expect(["running", "parked"]).contains(resumed);
 
         await subscribedPeer(controller2, "peer1");

--- a/packages/node-manager/test/task/groups/RemoveNodeFromGroupIntegrationTest.ts
+++ b/packages/node-manager/test/task/groups/RemoveNodeFromGroupIntegrationTest.ts
@@ -15,6 +15,7 @@ import { OnOffLightSwitchDevice } from "@matter/node/devices/on-off-light-switch
 import { MockServerNode, MockSite, subscribedPeer } from "@matter/node/testing";
 import { EndpointNumber, GroupId } from "@matter/types";
 import { GroupKeyManagement } from "@matter/types/clusters/group-key-management";
+import { recordFor } from "../helpers.js";
 
 const { TrustFirst } = GroupKeyManagement.GroupKeySecurityPolicy;
 
@@ -57,9 +58,16 @@ function itemState(
 /** Pump virtual time + macrotasks until the persisted task state is one of `states` (else throw). */
 async function awaitState(node: ServerNode, id: string, ...states: string[]): Promise<void> {
     for (let i = 0; i < 2_000; i++) {
-        const state = await node.act(a => a.get(TaskManagerBehavior).state.tasks[id]?.state);
+        const state = await node.act(a => recordFor(a.get(TaskManagerBehavior).state.runs, id)?.state);
         if (state !== undefined && states.includes(state)) {
-            return;
+            // A run turns terminal one step before it retires, so a caller that acts here would find the
+            // slot still held.
+            const settled =
+                !(["completed", "failed", "cancelled"] as string[]).includes(state) ||
+                (await node.act(a => !a.get(TaskManagerBehavior).tasks.some(t => t.status.slotKey === id)));
+            if (settled) {
+                return;
+            }
         }
         await MockTime.advance(100);
         await MockTime.macrotask;
@@ -149,7 +157,9 @@ describe("RemoveNodeFromGroup task integration (single peer)", () => {
         await controller.act(a => a.get(TaskManagerBehavior).run("addNodeToGroup", addParams(overGroup, 50 + limit)));
         await awaitState(controller, addTaskId(overGroup), "failed");
 
-        const error = await controller.act(a => a.get(TaskManagerBehavior).state.tasks[addTaskId(overGroup)]?.error);
+        const error = await controller.act(
+            a => recordFor(a.get(TaskManagerBehavior).state.runs, addTaskId(overGroup))?.error,
+        );
         expect(error).contains("capacity");
 
         // Admission rejects before any node mutation: no new group, no leftover intent.

--- a/packages/node-manager/test/task/groups/RemoveNodeFromGroupTest.ts
+++ b/packages/node-manager/test/task/groups/RemoveNodeFromGroupTest.ts
@@ -7,6 +7,7 @@
 import { RemoveNodeFromGroup, RemoveNodeFromGroupParams } from "#task/groups/RemoveNodeFromGroup.js";
 import { RunningTaskContext } from "#task/RunningTaskContext.js";
 import { TaskState } from "#task/types.js";
+import { RunId } from "#task/types.js";
 import { itemMapKey } from "@matter/node";
 import { FakePeer } from "../helpers.js";
 
@@ -40,7 +41,7 @@ function wireItemKind(peer: FakePeer) {
 }
 
 function runRemove(peer: FakePeer, params: RemoveNodeFromGroupParams) {
-    const task = new RemoveNodeFromGroup(RemoveNodeFromGroup.idFor(params), params);
+    const task = new RemoveNodeFromGroup(RunId(1), RemoveNodeFromGroup.slotKeyFor(params), params);
     const setState = (s: TaskState) => {
         task.progress.state = s;
     };

--- a/packages/node-manager/test/task/groups/RollbackIntegrationTest.ts
+++ b/packages/node-manager/test/task/groups/RollbackIntegrationTest.ts
@@ -17,6 +17,15 @@ import { MockServerNode, MockSite, subscribedPeer } from "@matter/node/testing";
 import { SustainedSubscription } from "@matter/protocol";
 import { EndpointNumber, GroupId } from "@matter/types";
 import { GroupKeyManagement } from "@matter/types/clusters/group-key-management";
+import {
+    cancelSlot,
+    recordFor,
+    requireRecordFor,
+    requireStatusOfSlot,
+    revertRecordOf,
+    revertSlotOf,
+    statusOfSlot,
+} from "../helpers.js";
 
 const { TrustFirst } = GroupKeyManagement.GroupKeySecurityPolicy;
 
@@ -47,7 +56,7 @@ const FAILING_ID = `${FAILING_TYPE}:peer1:${0x101}`;
 class FailingProvision extends Task<AddNodeToGroupParams> {
     readonly type = FAILING_TYPE;
 
-    static override idFor(params: AddNodeToGroupParams): string {
+    static override slotKeyFor(params: AddNodeToGroupParams): string {
         return `${FAILING_TYPE}:${params.peerId}:${params.groupId}`;
     }
 
@@ -117,9 +126,16 @@ function itemState(
 /** Pump virtual time + macrotasks until the persisted task state is one of `states` (else throw). */
 async function awaitState(node: ServerNode, id: string, ...states: string[]): Promise<void> {
     for (let i = 0; i < 2_000; i++) {
-        const state = await node.act(a => a.get(TaskManagerBehavior).state.tasks[id]?.state);
+        const state = await node.act(a => recordFor(a.get(TaskManagerBehavior).state.runs, id)?.state);
         if (state !== undefined && states.includes(state)) {
-            return;
+            // A run turns terminal one step before it retires, so a caller that acts here would find the
+            // slot still held.
+            const settled =
+                !(["completed", "failed", "cancelled"] as string[]).includes(state) ||
+                (await node.act(a => !a.get(TaskManagerBehavior).tasks.some(t => t.status.slotKey === id)));
+            if (settled) {
+                return;
+            }
         }
         await MockTime.advance(100);
         await MockTime.macrotask;
@@ -145,17 +161,23 @@ describe("Rollback task integration (single peer)", () => {
         await awaitState(controller, FAILING_ID, "failed");
 
         const revertId = await controller.act(
-            agent => agent.get(TaskManagerBehavior).get(FAILING_ID)?.status.revertTaskId,
+            agent => requireStatusOfSlot(agent.get(TaskManagerBehavior), FAILING_ID).revertRunId,
         );
-        expect(revertId).equals(`revert:${FAILING_ID}`);
+        expect(revertId).equals(
+            await controller.act(a => revertRecordOf(a.get(TaskManagerBehavior).state.runs, FAILING_ID)?.runId),
+        );
 
         // revertOf is part of the revert's persisted seed, so it's readable before the revert has run at all.
         const revertOf = await controller.act(
-            agent => agent.get(TaskManagerBehavior).state.tasks[`revert:${FAILING_ID}`]?.revertOf,
+            agent => revertRecordOf(agent.get(TaskManagerBehavior).state.runs, FAILING_ID)?.revertOf,
         );
-        expect(revertOf).equals(FAILING_ID);
+        expect(revertOf).equals(requireRecordFor(controller.stateOf(TaskManagerBehavior).runs, FAILING_ID).runId);
 
-        await awaitState(controller, `revert:${FAILING_ID}`, "completed");
+        await awaitState(
+            controller,
+            (await controller.act(a => revertSlotOf(a.get(TaskManagerBehavior).state.runs, FAILING_ID)))!,
+            "completed",
+        );
 
         expect(itemState(peer, "groupKey", String(GROUP_KEY_SET_ID))).equals(undefined);
         expect(itemState(peer, "groupKeyMap", String(GROUP))).equals(undefined);
@@ -176,25 +198,31 @@ describe("Rollback task integration (single peer)", () => {
         expect(isMember(device)).equals(true);
 
         const handle = await MockTime.resolve(
-            controller.act(agent => agent.get(TaskManagerBehavior).cancel(TASK_ID)),
+            controller.act(agent => cancelSlot(agent.get(TaskManagerBehavior), TASK_ID)),
             { macrotasks: true },
         );
-        expect(handle?.id).equals(`revert:${TASK_ID}`);
+        expect(handle?.status.revertOf).equals(
+            requireRecordFor(controller.stateOf(TaskManagerBehavior).runs, TASK_ID).runId,
+        );
 
         // revertOf is part of the revert's persisted seed, so it's readable before the revert has run at all.
         const revertOf = await controller.act(
-            agent => agent.get(TaskManagerBehavior).state.tasks[`revert:${TASK_ID}`]?.revertOf,
+            agent => revertRecordOf(agent.get(TaskManagerBehavior).state.runs, TASK_ID)?.revertOf,
         );
-        expect(revertOf).equals(TASK_ID);
+        expect(revertOf).equals(requireRecordFor(controller.stateOf(TaskManagerBehavior).runs, TASK_ID).runId);
 
-        await awaitState(controller, `revert:${TASK_ID}`, "completed");
+        await awaitState(
+            controller,
+            (await controller.act(a => revertSlotOf(a.get(TaskManagerBehavior).state.runs, TASK_ID)))!,
+            "completed",
+        );
 
         expect(itemState(peer, "groupKey", String(GROUP_KEY_SET_ID))).equals(undefined);
         expect(itemState(peer, "groupKeyMap", String(GROUP))).equals(undefined);
         expect(itemState(peer, "endpointGroupMembership", `${GROUP}:${PARAMS.endpoint}`)).equals(undefined);
         expect(isMember(device)).equals(false);
 
-        const status = await controller.act(agent => agent.get(TaskManagerBehavior).get(TASK_ID)?.status);
+        const status = await controller.act(agent => statusOfSlot(agent.get(TaskManagerBehavior), TASK_ID));
         expect(status?.state).equals("completed");
     });
 
@@ -251,7 +279,11 @@ describe("Rollback task integration (single peer)", () => {
         await controller.act(agent => agent.get(TaskManagerBehavior).register(FAILING_TYPE, FailingProvision));
         await controller.act(agent => agent.get(TaskManagerBehavior).run(FAILING_TYPE, PARAMS));
         await awaitState(controller, FAILING_ID, "failed");
-        await awaitState(controller, `revert:${FAILING_ID}`, "parked");
+        await awaitState(
+            controller,
+            (await controller.act(a => revertSlotOf(a.get(TaskManagerBehavior).state.runs, FAILING_ID)))!,
+            "parked",
+        );
 
         const id = controller.id;
         await MockTime.resolve(controller.close(), { macrotasks: true });
@@ -259,12 +291,16 @@ describe("Rollback task integration (single peer)", () => {
         const controller2 = await site.addNode(ControllerRoot, { id, index: 1 });
         await controller2.act(agent => agent.get(TaskManagerBehavior).register(FAILING_TYPE, FailingProvision));
         const resumed = await controller2.act(
-            agent => agent.get(TaskManagerBehavior).state.tasks[`revert:${FAILING_ID}`]?.state,
+            agent => revertRecordOf(agent.get(TaskManagerBehavior).state.runs, FAILING_ID)?.state,
         );
         expect(["running", "parked"]).contains(resumed);
 
         const peer2 = await subscribedPeer(controller2, "peer1");
-        await awaitState(controller2, `revert:${FAILING_ID}`, "completed");
+        await awaitState(
+            controller2,
+            (await controller2.act(a => revertSlotOf(a.get(TaskManagerBehavior).state.runs, FAILING_ID)))!,
+            "completed",
+        );
 
         expect(itemState(peer2, "groupKey", String(GROUP_KEY_SET_ID))).equals(undefined);
         expect(itemState(peer2, "groupKeyMap", String(GROUP))).equals(undefined);
@@ -299,12 +335,16 @@ describe("Rollback task integration (single peer)", () => {
         await awaitState(controller, idEp2, "completed");
 
         await MockTime.resolve(
-            controller.act(agent => agent.get(TaskManagerBehavior).cancel(idEp1)),
+            controller.act(agent => cancelSlot(agent.get(TaskManagerBehavior), idEp1)),
             {
                 macrotasks: true,
             },
         );
-        await awaitState(controller, `revert:${idEp1}`, "completed");
+        await awaitState(
+            controller,
+            (await controller.act(a => revertSlotOf(a.get(TaskManagerBehavior).state.runs, idEp1)))!,
+            "completed",
+        );
 
         expect(itemState(peer, "endpointGroupMembership", `${GROUP}:1`)).equals(undefined);
         expect(itemState(peer, "endpointGroupMembership", `${GROUP}:2`)).equals("committed");

--- a/packages/node-manager/test/task/groups/RotateGroupKeyIntegrationTest.ts
+++ b/packages/node-manager/test/task/groups/RotateGroupKeyIntegrationTest.ts
@@ -19,6 +19,18 @@ import { MockServerNode, MockSite, subscribedPeer } from "@matter/node/testing";
 import { FabricManager, SustainedSubscription } from "@matter/protocol";
 import { FabricId } from "@matter/types";
 import { GroupKeyManagement } from "@matter/types/clusters/group-key-management";
+import {
+    awaitRun,
+    cancelSlot,
+    recordFor,
+    recordsFor,
+    requireRecordFor,
+    requireRunIdOfSlot,
+    requireStatusOfSlot,
+    revertRecordOf,
+    revertSlotOf,
+    statusOfSlot,
+} from "../helpers.js";
 
 const { TrustFirst } = GroupKeyManagement.GroupKeySecurityPolicy;
 
@@ -34,8 +46,7 @@ const ROTATE_PARAMS: RotateGroupKeyParams = {
     newEpochKey: NEW_KEY,
     rotationId: ROTATION_ID,
 };
-const rotateId = (rotationId: string) => `${ROTATE_GROUP_KEY_TYPE}:${GROUP_KEY_SET_ID}:${rotationId}`;
-const ROTATE_ID = rotateId(ROTATION_ID);
+const ROTATE_SLOT = `${ROTATE_GROUP_KEY_TYPE}:${GROUP_KEY_SET_ID}`;
 
 const ControllerRoot = MockServerNode.RootEndpoint.with(TaskManagerBehavior);
 const MEMBER_DEVICE = OnOffLightSwitchDevice.with(GroupsServer);
@@ -162,9 +173,16 @@ function subscriptionOf(peer: ClientNode): SustainedSubscription {
 /** Pump virtual time + macrotasks until the persisted task state is one of `states` (else throw). */
 async function awaitState(node: ServerNode, id: string, ...states: string[]): Promise<void> {
     for (let i = 0; i < 2_000; i++) {
-        const state = await node.act(a => a.get(TaskManagerBehavior).state.tasks[id]?.state);
+        const state = await node.act(a => recordFor(a.get(TaskManagerBehavior).state.runs, id)?.state);
         if (state !== undefined && states.includes(state)) {
-            return;
+            // A run turns terminal one step before it retires, so a caller that acts here would find the
+            // slot still held.
+            const settled =
+                !(["completed", "failed", "cancelled"] as string[]).includes(state) ||
+                (await node.act(a => !a.get(TaskManagerBehavior).tasks.some(t => t.status.slotKey === id)));
+            if (settled) {
+                return;
+            }
         }
         await MockTime.advance(100);
         await MockTime.macrotask;
@@ -178,7 +196,7 @@ async function awaitState(node: ServerNode, id: string, ...states: string[]): Pr
  */
 async function awaitParkedInPhase(node: ServerNode, id: string, phaseIndex: number): Promise<void> {
     for (let i = 0; i < 2_000; i++) {
-        const p = await node.act(a => a.get(TaskManagerBehavior).state.tasks[id]);
+        const p = await node.act(a => recordFor(a.get(TaskManagerBehavior).state.runs, id));
         if (p?.state === "parked" && p.phaseIndex === phaseIndex) {
             return;
         }
@@ -256,7 +274,7 @@ describe("RotateGroupKey task integration (two members)", () => {
         writesA.length = writesB.length = 0;
 
         await controller.act(a => a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS));
-        await awaitState(controller, ROTATE_ID, "completed");
+        await awaitState(controller, ROTATE_SLOT, "completed");
 
         // Cleanup back-dates the sole surviving key to the ORIGINAL op start, so the final device start-set is
         // indistinguishable from the pre-rotation set (material is unreadable). The per-phase writes are the
@@ -284,16 +302,16 @@ describe("RotateGroupKey task integration (two members)", () => {
         // Park the rotation at distribute so the second member can join the key set mid-rotation.
         await MockTime.resolve(subscriptionOf(peerA).active.emit(false), { macrotasks: true });
         await controller.act(a => a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS));
-        await awaitParkedInPhase(controller, ROTATE_ID, 0);
+        await awaitParkedInPhase(controller, ROTATE_SLOT, 0);
 
         writesA.length = writesB.length = 0;
         await controller.act(a => a.get(TaskManagerBehavior).run("addNodeToGroup", addParamsFor(peerB.id)));
         await awaitState(controller, addTaskId(peerB.id), "completed");
 
         await MockTime.resolve(subscriptionOf(peerA).active.emit(true), { macrotasks: true });
-        await awaitState(controller, ROTATE_ID, "failed");
+        await awaitState(controller, ROTATE_SLOT, "failed");
 
-        const status = await controller.act(a => a.get(TaskManagerBehavior).get(ROTATE_ID)?.status);
+        const status = await controller.act(a => statusOfSlot(a.get(TaskManagerBehavior), ROTATE_SLOT));
         expect(status?.error).contains("joined the key set after the distribute phase");
 
         // A saw distribute only (2 starts, the new key future-dated and dormant); neither member was activated.
@@ -319,16 +337,16 @@ describe("RotateGroupKey task integration (two members)", () => {
         };
 
         await controller.act(a => a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS));
-        await awaitParkedInPhase(controller, ROTATE_ID, 1);
+        await awaitParkedInPhase(controller, ROTATE_SLOT, 1);
 
         writesA.length = writesB.length = 0;
         await controller.act(a => a.get(TaskManagerBehavior).run("addNodeToGroup", addParamsFor(peerB.id)));
         await awaitState(controller, addTaskId(peerB.id), "completed");
 
         await MockTime.resolve(subscriptionA.active.emit(true), { macrotasks: true });
-        await awaitState(controller, ROTATE_ID, "failed");
+        await awaitState(controller, ROTATE_SLOT, "failed");
 
-        const status = await controller.act(a => a.get(TaskManagerBehavior).get(ROTATE_ID)?.status);
+        const status = await controller.act(a => statusOfSlot(a.get(TaskManagerBehavior), ROTATE_SLOT));
         expect(status?.error).contains("during the activate phase");
 
         // Cleanup never ran, so no member lost the old key: A holds the 3-key activate struct, B only its own
@@ -341,19 +359,19 @@ describe("RotateGroupKey task integration (two members)", () => {
         expect(Bytes.areEqual(deviceKey0(deviceB, GROUP_KEY_SET_ID), OP_KEY)).equals(true);
 
         // The rotation stopped at its point of no return, so it is not rolled back.
-        expect(status?.revertTaskId).equals(undefined);
+        expect(status?.revertRunId).equals(undefined);
 
         // The remedy the failure prescribes must work: rotating to a DIFFERENT key is refused while the members
         // still carry the dormant one, so only the same key can finish what this rotation started.
-        await controller.act(a =>
+        const other = await controller.act(a =>
             a.get(TaskManagerBehavior).run("rotateGroupKey", {
                 groupKeySetId: GROUP_KEY_SET_ID,
                 newEpochKey: new Uint8Array(16).fill(0xef),
                 rotationId: "rOther",
             }),
         );
-        await awaitState(controller, rotateId("rOther"), "failed");
-        const otherStatus = await controller.act(a => a.get(TaskManagerBehavior).get(rotateId("rOther"))?.status);
+        await awaitRun(controller, TaskManagerBehavior, other.runId, "failed");
+        const otherStatus = await controller.act(a => a.get(TaskManagerBehavior).get(other.runId)?.status);
         expect(otherStatus?.error).contains("single-key steady state");
 
         // Re-issued with the same new key, distribute covers the whole current member set, so the late member is
@@ -361,7 +379,7 @@ describe("RotateGroupKey task integration (two members)", () => {
         await controller.act(a =>
             a.get(TaskManagerBehavior).run("rotateGroupKey", { ...ROTATE_PARAMS, rotationId: "r2" }),
         );
-        await awaitState(controller, rotateId("r2"), "completed");
+        await awaitState(controller, ROTATE_SLOT, "completed");
         for (const device of [deviceA, deviceB]) {
             expect(deviceStarts(device, GROUP_KEY_SET_ID)).deep.equals([OP_START]);
             expect(Bytes.areEqual(deviceKey0(device, GROUP_KEY_SET_ID), NEW_KEY)).equals(true);
@@ -377,7 +395,7 @@ describe("RotateGroupKey task integration (two members)", () => {
         await MockTime.resolve(subscriptionB.active.emit(false), { macrotasks: true });
 
         await controller.act(a => a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS));
-        await awaitState(controller, ROTATE_ID, "parked");
+        await awaitState(controller, ROTATE_SLOT, "parked");
 
         // Let any reachable-peer work settle; the barrier still cannot advance past distribute while B is offline.
         for (let i = 0; i < 50; i++) {
@@ -387,14 +405,16 @@ describe("RotateGroupKey task integration (two members)", () => {
 
         // The rotation is stuck at distribute: A's desired state holds the 2-key distribute struct, never the
         // 1-key cleanup struct that drops the old key, so the still-online member keeps its old key.
-        expect(await controller.act(a => a.get(TaskManagerBehavior).state.tasks[ROTATE_ID]?.state)).equals("parked");
+        expect(await controller.act(a => recordFor(a.get(TaskManagerBehavior).state.runs, ROTATE_SLOT)?.state)).equals(
+            "parked",
+        );
         expect(intentStarts(peerA, GROUP_KEY_SET_ID).length).equals(2);
         expect(deviceStarts(deviceA, GROUP_KEY_SET_ID)).contains(OP_START);
         expect(deviceStarts(deviceB, GROUP_KEY_SET_ID)).deep.equals([OP_START]);
 
         // Bring B back; the subscription wake re-drives the gate through the full rotation on both members.
         await MockTime.resolve(subscriptionB.active.emit(true), { macrotasks: true });
-        await awaitState(controller, ROTATE_ID, "completed");
+        await awaitState(controller, ROTATE_SLOT, "completed");
 
         // Both members were driven through all three phases once B returned (last three writes per device).
         expect(writesA.map(s => s.length).slice(-3)).deep.equals([2, 3, 1]);
@@ -412,19 +432,21 @@ describe("RotateGroupKey task integration (two members)", () => {
         // Park the rotation (member B offline), then close the controller mid-rotation.
         await MockTime.resolve(subscriptionOf(peerB).active.emit(false), { macrotasks: true });
         await controller.act(a => a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS));
-        await awaitState(controller, ROTATE_ID, "parked");
+        await awaitState(controller, ROTATE_SLOT, "parked");
         const id = controller.id;
         await MockTime.resolve(controller.close(), { macrotasks: true });
 
         // Recreate from the same storage on the same network host; the persisted parked task resumes.
         const controller2 = await site.addNode(ControllerRoot, { id, index: 1 });
-        const resumed = await controller2.act(a => a.get(TaskManagerBehavior).state.tasks[ROTATE_ID]?.state);
+        const resumed = await controller2.act(
+            a => recordFor(a.get(TaskManagerBehavior).state.runs, ROTATE_SLOT)?.state,
+        );
         expect(["running", "parked"]).contains(resumed);
 
         // Fresh subscriptions to both members re-establish; write-if-set-differs makes the re-drive idempotent.
         await subscribedPeer(controller2, peerAId);
         await subscribedPeer(controller2, peerBId);
-        await awaitState(controller2, ROTATE_ID, "completed");
+        await awaitState(controller2, ROTATE_SLOT, "completed");
 
         expect(deviceStarts(deviceA, GROUP_KEY_SET_ID)).deep.equals([OP_START]);
         expect(deviceStarts(deviceB, GROUP_KEY_SET_ID)).deep.equals([OP_START]);
@@ -435,7 +457,7 @@ describe("RotateGroupKey task integration (two members)", () => {
         const { controller, deviceA, peerA } = await twoMemberGroup(site);
 
         await controller.act(a => a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS));
-        await awaitState(controller, ROTATE_ID, "completed");
+        await awaitState(controller, ROTATE_SLOT, "completed");
         expect(deviceStarts(deviceA, GROUP_KEY_SET_ID)).deep.equals([OP_START]);
 
         // Drain the post-rotation verify pass before mutating so the drift below is what verify next observes.
@@ -479,32 +501,40 @@ describe("RotateGroupKey task integration (two members)", () => {
         await MockTime.resolve(subscriptionB.active.emit(false), { macrotasks: true });
 
         await controller.act(a => a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS));
-        await awaitState(controller, ROTATE_ID, "parked");
+        await awaitState(controller, ROTATE_SLOT, "parked");
 
         // Distribute has pushed the 2-key struct to the still-online member A; activate has not begun.
         expect(intentStarts(peerA, GROUP_KEY_SET_ID).length).equals(2);
-        const phaseIndex = await controller.act(a => a.get(TaskManagerBehavior).state.tasks[ROTATE_ID]?.phaseIndex);
+        const phaseIndex = await controller.act(
+            a => recordFor(a.get(TaskManagerBehavior).state.runs, ROTATE_SLOT)?.phaseIndex,
+        );
         expect(phaseIndex).equals(0);
 
         // Cancel is accepted in the safe window and returns a revert handle.
         const handle = await MockTime.resolve(
-            controller.act(a => a.get(TaskManagerBehavior).cancel(ROTATE_ID)),
+            controller.act(a => cancelSlot(a.get(TaskManagerBehavior), ROTATE_SLOT)),
             {
                 macrotasks: true,
             },
         );
-        expect(handle?.id).equals(`revert:${ROTATE_ID}`);
+        expect(handle?.status.revertOf).equals(
+            requireRecordFor(controller.stateOf(TaskManagerBehavior).runs, ROTATE_SLOT).runId,
+        );
 
         // Bring B back so the revert converges on both members.
         await MockTime.resolve(subscriptionB.active.emit(true), { macrotasks: true });
-        await awaitState(controller, `revert:${ROTATE_ID}`, "completed");
+        await awaitState(
+            controller,
+            (await controller.act(a => revertSlotOf(a.get(TaskManagerBehavior).state.runs, ROTATE_SLOT)))!,
+            "completed",
+        );
 
         // Both members restored to the single OLD key (old material); the dormant new key is dropped.
         for (const device of [deviceA, deviceB]) {
             expect(deviceStarts(device, GROUP_KEY_SET_ID)).deep.equals([OP_START]);
             expect(Bytes.areEqual(deviceKey0(device, GROUP_KEY_SET_ID), OP_KEY)).equals(true);
         }
-        const state = await controller.act(a => a.get(TaskManagerBehavior).get(ROTATE_ID)?.status.state);
+        const state = await controller.act(a => requireStatusOfSlot(a.get(TaskManagerBehavior), ROTATE_SLOT).state);
         expect(state).equals("cancelled");
         expect(intentStarts(peerA, GROUP_KEY_SET_ID)).deep.equals([OP_START]);
     });
@@ -528,12 +558,14 @@ describe("RotateGroupKey task integration (two members)", () => {
             await MockTime.macrotask;
         }
         expect(releaseDistribute).not.equals(undefined);
-        expect(await controller.act(a => a.get(TaskManagerBehavior).state.tasks[ROTATE_ID]?.phaseIndex)).equals(0);
+        expect(
+            await controller.act(a => recordFor(a.get(TaskManagerBehavior).state.runs, ROTATE_SLOT)?.phaseIndex),
+        ).equals(0);
         expect(writesA.map(s => s.length)).deep.equals([2]); // distribute wrote 2 slots; activate (3) has not run
         expect(writesB.map(s => s.length)).deep.equals([2]);
 
         // Request cancel while paused between phases; its flag is set synchronously (blocked on the drive promise).
-        const cancelPromise = controller.act(a => a.get(TaskManagerBehavior).cancel(ROTATE_ID));
+        const cancelPromise = controller.act(a => cancelSlot(a.get(TaskManagerBehavior), ROTATE_SLOT));
         for (let i = 0; i < 5; i++) {
             await MockTime.macrotask;
         }
@@ -543,8 +575,14 @@ describe("RotateGroupKey task integration (two members)", () => {
         releaseDistribute = undefined;
 
         const handle = await MockTime.resolve(cancelPromise, { macrotasks: true });
-        expect(handle?.id).equals(`revert:${ROTATE_ID}`);
-        await awaitState(controller, `revert:${ROTATE_ID}`, "completed");
+        expect(handle?.status.revertOf).equals(
+            requireRecordFor(controller.stateOf(TaskManagerBehavior).runs, ROTATE_SLOT).runId,
+        );
+        await awaitState(
+            controller,
+            (await controller.act(a => revertSlotOf(a.get(TaskManagerBehavior).state.runs, ROTATE_SLOT)))!,
+            "completed",
+        );
 
         // Forbidden outcome ruled out: no activate write (never a 3-slot struct), no sentinel; both members back
         // on the OLD key material with the single original start time.
@@ -554,7 +592,7 @@ describe("RotateGroupKey task integration (two members)", () => {
             expect(deviceStarts(device, GROUP_KEY_SET_ID)).deep.equals([OP_START]);
             expect(Bytes.areEqual(deviceKey0(device, GROUP_KEY_SET_ID), OP_KEY)).equals(true);
         }
-        const state = await controller.act(a => a.get(TaskManagerBehavior).get(ROTATE_ID)?.status.state);
+        const state = await controller.act(a => requireStatusOfSlot(a.get(TaskManagerBehavior), ROTATE_SLOT).state);
         expect(state).equals("cancelled");
         expect(intentStarts(peerA, GROUP_KEY_SET_ID)).deep.equals([OP_START]);
     });
@@ -566,28 +604,29 @@ describe("RotateGroupKey task integration (two members)", () => {
         const KEY_A = new Uint8Array(16).fill(0xa1);
         const KEY_B = new Uint8Array(16).fill(0xb2);
 
-        await controller.act(a =>
+        const first = await controller.act(a =>
             a.get(TaskManagerBehavior).run("rotateGroupKey", {
                 groupKeySetId: GROUP_KEY_SET_ID,
                 newEpochKey: KEY_A,
                 rotationId: "r1",
             }),
         );
-        await awaitState(controller, rotateId("r1"), "completed");
+        await awaitRun(controller, TaskManagerBehavior, first.runId, "completed");
         for (const device of [deviceA, deviceB]) {
             expect(Bytes.areEqual(deviceKey0(device, GROUP_KEY_SET_ID), KEY_A)).equals(true);
         }
 
-        // A distinct rotationId is a distinct task id, so the recovery path — rotating a bad key to another —
-        // runs as its own task with its own record.
-        await controller.act(a =>
+        // The recovery path — rotating a bad key to another — is a second run of the same slot, admitted once
+        // the first has retired. Each run keeps its own record; waiting on the slot would match the first.
+        const second = await controller.act(a =>
             a.get(TaskManagerBehavior).run("rotateGroupKey", {
                 groupKeySetId: GROUP_KEY_SET_ID,
                 newEpochKey: KEY_B,
                 rotationId: "r2",
             }),
         );
-        await awaitState(controller, rotateId("r2"), "completed");
+        expect(second.runId).not.equals(first.runId);
+        await awaitRun(controller, TaskManagerBehavior, second.runId, "completed");
         for (const device of [deviceA, deviceB]) {
             expect(Bytes.areEqual(deviceKey0(device, GROUP_KEY_SET_ID), KEY_B)).equals(true);
         }
@@ -600,24 +639,31 @@ describe("RotateGroupKey task integration (two members)", () => {
         // Park r1 non-terminal (member B offline during distribute).
         await MockTime.resolve(subscriptionOf(peerB).active.emit(false), { macrotasks: true });
         await controller.act(a => a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS));
-        await awaitState(controller, ROTATE_ID, "parked");
+        await awaitState(controller, ROTATE_SLOT, "parked");
 
         const OTHER_KEY = new Uint8Array(16).fill(0xef);
-        await expect(
-            controller.act(async a =>
+        let refusal: unknown;
+        try {
+            await controller.act(async a =>
                 a.get(TaskManagerBehavior).run("rotateGroupKey", {
                     groupKeySetId: GROUP_KEY_SET_ID,
                     newEpochKey: OTHER_KEY,
                     rotationId: "r2",
                 }),
-            ),
-        ).rejectedWith(TaskConflictError);
+            );
+        } catch (e) {
+            refusal = e;
+        }
+        expect(refusal).instanceOf(TaskConflictError);
+        // Pinned to the holder, because one error class now covers slot, external id and rollback conflicts.
+        expect((refusal as TaskConflictError).owner).equals(
+            await controller.act(a => requireRunIdOfSlot(a.get(TaskManagerBehavior), ROTATE_SLOT)),
+        );
 
-        // r1 is untouched and no r2 task was spawned.
-        const r1State = await controller.act(a => a.get(TaskManagerBehavior).state.tasks[ROTATE_ID]?.state);
-        expect(r1State).equals("parked");
-        expect(await controller.act(a => a.get(TaskManagerBehavior).state.tasks[rotateId("r2")])).equals(undefined);
-        expect(await controller.act(a => a.get(TaskManagerBehavior).get(rotateId("r2")))).equals(undefined);
+        // r1 is untouched, and the refusal means the slot still holds exactly one run.
+        const runs = await controller.act(a => recordsFor(a.get(TaskManagerBehavior).state.runs, ROTATE_SLOT));
+        expect(runs.length).equals(1);
+        expect(runs[0].state).equals("parked");
     });
 
     it("rejects a new rotation while a revert of the same key set is still live", async () => {
@@ -628,12 +674,17 @@ describe("RotateGroupKey task integration (two members)", () => {
         // offline), so a live non-terminal revert now holds the key set.
         await MockTime.resolve(subscriptionOf(peerB).active.emit(false), { macrotasks: true });
         await controller.act(a => a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS));
-        await awaitState(controller, ROTATE_ID, "parked");
+        await awaitState(controller, ROTATE_SLOT, "parked");
         await MockTime.resolve(
-            controller.act(a => a.get(TaskManagerBehavior).cancel(ROTATE_ID)),
+            controller.act(a => cancelSlot(a.get(TaskManagerBehavior), ROTATE_SLOT)),
             { macrotasks: true },
         );
-        await awaitState(controller, `revert:${ROTATE_ID}`, "parked", "running");
+        await awaitState(
+            controller,
+            (await controller.act(a => revertSlotOf(a.get(TaskManagerBehavior).state.runs, ROTATE_SLOT)))!,
+            "parked",
+            "running",
+        );
 
         const OTHER_KEY = new Uint8Array(16).fill(0xef);
         await expect(
@@ -646,11 +697,11 @@ describe("RotateGroupKey task integration (two members)", () => {
             ),
         ).rejectedWith(TaskConflictError);
 
-        // The revert is untouched and no r2 task was spawned.
+        // The revert is untouched, and the refusal means no second rotation of the slot was spawned.
         expect(["parked", "running"]).contains(
-            await controller.act(a => a.get(TaskManagerBehavior).state.tasks[`revert:${ROTATE_ID}`]?.state),
+            await controller.act(a => revertRecordOf(a.get(TaskManagerBehavior).state.runs, ROTATE_SLOT)?.state),
         );
-        expect(await controller.act(a => a.get(TaskManagerBehavior).state.tasks[rotateId("r2")])).equals(undefined);
+        expect(await controller.act(a => recordsFor(a.get(TaskManagerBehavior).state.runs, ROTATE_SLOT))).length(1);
     });
 
     it("refuses a re-issue of a live rotationId, and joins the caller that owns it", async () => {
@@ -662,8 +713,8 @@ describe("RotateGroupKey task integration (two members)", () => {
         const first = await controller.act(a =>
             a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS, { externalId: "nightly" }),
         );
-        expect(first.id).equals(ROTATE_ID);
-        await awaitState(controller, ROTATE_ID, "parked");
+        expect(first.status.slotKey).equals(ROTATE_SLOT);
+        await awaitState(controller, ROTATE_SLOT, "parked");
 
         // `act` returns a MaybePromise, so normalize before asserting on the rejection.
         await expect(
@@ -676,7 +727,7 @@ describe("RotateGroupKey task integration (two members)", () => {
         const again = await controller.act(a =>
             a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS, { externalId: "nightly" }),
         );
-        expect(again.id).equals(ROTATE_ID);
+        expect(again.runId).equals(first.runId);
         expect(again.status.state).equals("parked");
         expect(again.status.phaseIndex).equals(0);
         expect(await controller.act(a => a.get(TaskManagerBehavior).tasks.length)).equals(before);
@@ -698,7 +749,7 @@ describe("RotateGroupKey task integration (two members)", () => {
         };
 
         await controller.act(a => a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS));
-        await awaitParkedInPhase(controller, ROTATE_ID, 1); // parked in activate, not distribute
+        await awaitParkedInPhase(controller, ROTATE_SLOT, 1); // parked in activate, not distribute
 
         // Distribute committed the 2-key struct on both members (old key still present); activate never wrote.
         const parkedStartsA = deviceStarts(deviceA, GROUP_KEY_SET_ID);
@@ -707,14 +758,14 @@ describe("RotateGroupKey task integration (two members)", () => {
         expect(parkedStartsB.length).equals(2);
 
         // Cancel is declined with zero side effects: no revert spawned, task stays parked, devices untouched.
-        await expect(controller.act(a => a.get(TaskManagerBehavior).cancel(ROTATE_ID))).rejectedWith(
+        await expect(controller.act(a => cancelSlot(a.get(TaskManagerBehavior), ROTATE_SLOT))).rejectedWith(
             TaskNotRevertibleError,
             "forward-only",
         );
-        const status = await controller.act(a => a.get(TaskManagerBehavior).get(ROTATE_ID)?.status);
+        const status = await controller.act(a => statusOfSlot(a.get(TaskManagerBehavior), ROTATE_SLOT));
         expect(status?.state).equals("parked");
-        expect(status?.revertTaskId).equals(undefined);
-        expect(await controller.act(a => a.get(TaskManagerBehavior).state.tasks[`revert:${ROTATE_ID}`])).equals(
+        expect(status?.revertRunId).equals(undefined);
+        expect(await controller.act(a => revertRecordOf(a.get(TaskManagerBehavior).state.runs, ROTATE_SLOT))).equals(
             undefined,
         );
 
@@ -730,7 +781,7 @@ describe("RotateGroupKey task integration (two members)", () => {
         const { controller, deviceA, deviceB } = await twoMemberGroup(site);
 
         await controller.act(a => a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS));
-        await awaitState(controller, ROTATE_ID, "completed");
+        await awaitState(controller, ROTATE_SLOT, "completed");
 
         // The rotation realized the NEW key on both members (start-set matches the original, material does not).
         for (const device of [deviceA, deviceB]) {
@@ -738,16 +789,16 @@ describe("RotateGroupKey task integration (two members)", () => {
             expect(Bytes.areEqual(deviceKey0(device, GROUP_KEY_SET_ID), NEW_KEY)).equals(true);
         }
 
-        await expect(controller.act(a => a.get(TaskManagerBehavior).cancel(ROTATE_ID))).rejectedWith(
+        await expect(controller.act(a => cancelSlot(a.get(TaskManagerBehavior), ROTATE_SLOT))).rejectedWith(
             TaskNotRevertibleError,
             "forward-only",
         );
 
         // Declined with zero side effects: no revert spawned, task stays completed, both devices keep the new key.
-        const status = await controller.act(a => a.get(TaskManagerBehavior).get(ROTATE_ID)?.status);
+        const status = await controller.act(a => statusOfSlot(a.get(TaskManagerBehavior), ROTATE_SLOT));
         expect(status?.state).equals("completed");
-        expect(status?.revertTaskId).equals(undefined);
-        expect(await controller.act(a => a.get(TaskManagerBehavior).state.tasks[`revert:${ROTATE_ID}`])).equals(
+        expect(status?.revertRunId).equals(undefined);
+        expect(await controller.act(a => revertRecordOf(a.get(TaskManagerBehavior).state.runs, ROTATE_SLOT))).equals(
             undefined,
         );
         for (const device of [deviceA, deviceB]) {

--- a/packages/node-manager/test/task/groups/RotateGroupKeyTest.ts
+++ b/packages/node-manager/test/task/groups/RotateGroupKeyTest.ts
@@ -14,6 +14,7 @@ import { GroupsServer } from "@matter/node/behaviors/groups";
 import { OnOffLightSwitchDevice } from "@matter/node/devices/on-off-light-switch";
 import { MockServerNode, MockSite, subscribedPeer } from "@matter/node/testing";
 import { GroupKeyManagement } from "@matter/types/clusters/group-key-management";
+import { recordFor, statusOfSlot } from "../helpers.js";
 
 const { TrustFirst } = GroupKeyManagement.GroupKeySecurityPolicy;
 
@@ -44,7 +45,7 @@ const ROTATE_PARAMS: RotateGroupKeyParams = {
 };
 
 const ADD_ID = `${ADD_NODE_TO_GROUP_TYPE}:peer1:${0x101}:1`;
-const ROTATE_ID = `${ROTATE_GROUP_KEY_TYPE}:${GROUP_KEY_SET_ID}:${ROTATION_ID}`;
+const ROTATE_SLOT = `${ROTATE_GROUP_KEY_TYPE}:${GROUP_KEY_SET_ID}`;
 
 /** Snapshot of a keySetWrite, captured before the server mutates the request (MAX-sentinel nulling). */
 type WriteSnapshot = GroupKeyManagement.GroupKeySet;
@@ -64,9 +65,16 @@ const DeviceRoot = MockServerNode.RootEndpoint.with(RecordingGroupKeyManagementS
 
 async function awaitState(node: ServerNode, id: string, ...states: string[]): Promise<void> {
     for (let i = 0; i < 2_000; i++) {
-        const state = await node.act(a => a.get(TaskManagerBehavior).state.tasks[id]?.state);
+        const state = await node.act(a => recordFor(a.get(TaskManagerBehavior).state.runs, id)?.state);
         if (state !== undefined && states.includes(state)) {
-            return;
+            // A run turns terminal one step before it retires, so a caller that acts here would find the
+            // slot still held.
+            const settled =
+                !(["completed", "failed", "cancelled"] as string[]).includes(state) ||
+                (await node.act(a => !a.get(TaskManagerBehavior).tasks.some(t => t.status.slotKey === id)));
+            if (settled) {
+                return;
+            }
         }
         await MockTime.advance(100);
         await MockTime.macrotask;
@@ -107,7 +115,7 @@ describe("RotateGroupKey task integration (single member)", () => {
 
         writes.length = 0; // ignore the provisioning write; record only the rotation
         await controller.act(a => a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS));
-        await awaitState(controller, ROTATE_ID, "completed");
+        await awaitState(controller, ROTATE_SLOT, "completed");
 
         // Three phases, each a distinct start-time set that write-if-set-differs actually wrote.
         expect(writes.length).equals(3);
@@ -184,9 +192,9 @@ describe("RotateGroupKey task integration (single member)", () => {
 
         writes.length = 0;
         await controller.act(a => a.get(TaskManagerBehavior).run("rotateGroupKey", ROTATE_PARAMS));
-        await awaitState(controller, ROTATE_ID, "failed");
+        await awaitState(controller, ROTATE_SLOT, "failed");
 
-        const status = await controller.act(a => a.get(TaskManagerBehavior).get(ROTATE_ID)?.status);
+        const status = await controller.act(a => statusOfSlot(a.get(TaskManagerBehavior), ROTATE_SLOT));
         expect(status?.error).contains("single-key steady state");
 
         // Nothing was mutated: no device write, and the seeded intent object is untouched (reference-equal).
@@ -208,7 +216,7 @@ describe("RotateGroupKey task integration (single member)", () => {
         await controller.act(a =>
             a.get(TaskManagerBehavior).run("rotateGroupKey", { ...ROTATE_PARAMS, groupKeySetId: 99 }),
         );
-        await awaitState(controller, `${ROTATE_GROUP_KEY_TYPE}:99:${ROTATION_ID}`, "completed");
+        await awaitState(controller, `${ROTATE_GROUP_KEY_TYPE}:99`, "completed");
         expect(writes.length).equals(0);
     });
 });

--- a/packages/node-manager/test/task/helpers.ts
+++ b/packages/node-manager/test/task/helpers.ts
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Task } from "#task/Task.js";
-import { PlannedChange, TaskPhase } from "#task/types.js";
-import { Observable } from "@matter/general";
+import { Task, TaskPersistence } from "#task/Task.js";
+import { TaskHandle, TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
+import { PlannedChange, RunId, TaskPhase, TaskStatus } from "#task/types.js";
+import { Immutable, Observable } from "@matter/general";
 import { ClientNode, DesiredStateBehavior, ItemKind, ItemMode, ItemState, ManagedItem, itemMapKey } from "@matter/node";
 import { Status } from "@matter/types";
 
@@ -26,7 +27,7 @@ export class SyntheticTask extends Task<{ tag: string }> {
     override plannedChanges(): PlannedChange[] {
         return SyntheticTask.plannedChangesByTag[this.params.tag] ?? new Array<PlannedChange>();
     }
-    static override idFor(params: { tag: string }) {
+    static override slotKeyFor(params: { tag: string }) {
         return `synthetic:${params.tag}`;
     }
 }
@@ -218,4 +219,140 @@ export class FakePeer {
     asNode(): ClientNode {
         return this as unknown as ClientNode;
     }
+}
+
+/** Behavior state reaches a test through the project's deep-immutable view, so helpers read that shape. */
+type RunRecords = Immutable<Record<string, TaskPersistence>>;
+type RunRecord = Immutable<TaskPersistence>;
+
+/**
+ * Persisted records for a slot, newest run first. Records are per-run now, so a slot can hold several; a test
+ * that means "the record for this slot" wants {@link recordFor}, and one that means a specific attempt should
+ * name its runId.
+ */
+export function recordsFor(runs: RunRecords, slotKey: string): readonly RunRecord[] {
+    return Object.values(runs)
+        .filter(r => r.slotKey === slotKey)
+        .sort((a, b) => b.runId - a.runId);
+}
+
+/** The newest persisted record for a slot, or undefined if no run of it was ever recorded. */
+export function recordFor(runs: RunRecords, slotKey: string): RunRecord | undefined {
+    return recordsFor(runs, slotKey)[0];
+}
+
+/** The newest record for a slot, failing with the slot name when there is none. */
+export function requireRecordFor(runs: RunRecords, slotKey: string): RunRecord {
+    const record = recordFor(runs, slotKey);
+    if (record === undefined) {
+        throw new Error(`No persisted run of slot ${slotKey}`);
+    }
+    return record;
+}
+
+/**
+ * The persisted rollback the newest run of `slotKey` *recorded*, resolved through that run's own
+ * `revertRunId`.
+ *
+ * Deliberately not `find(r => r.revertOf === original.runId)`: an assertion on the result's `revertOf` would
+ * then be checking the predicate that selected it, which is how a migration ends up with a test that cannot
+ * fail. Resolving through the forward link keeps the two sides independent.
+ */
+export function revertRecordOf(runs: RunRecords, slotKey: string): RunRecord | undefined {
+    const revertRunId = recordFor(runs, slotKey)?.revertRunId;
+    return revertRunId === undefined ? undefined : runs[String(revertRunId)];
+}
+
+/** Every persisted rollback of any run of `slotKey`, for asserting that none exists. */
+export function revertRecordsOf(runs: RunRecords, slotKey: string): readonly RunRecord[] {
+    const undone = new Set(recordsFor(runs, slotKey).map(r => r.runId));
+    return Object.values(runs).filter(r => r.revertOf !== undefined && undone.has(r.revertOf));
+}
+
+/**
+ * The newest run of a slot, live or retired. Lookup is by run identity now, so a test that names a slot has to
+ * resolve it — and resolving it here keeps each assertion about the thing it was always about.
+ */
+export function requireRunIdOfSlot(manager: TaskManagerBehavior, slotKey: string): RunId {
+    const runId = runIdOfSlot(manager, slotKey);
+    if (runId === undefined) {
+        throw new Error(`No run answers to slot ${slotKey}`);
+    }
+    return runId;
+}
+
+export function runIdOfSlot(manager: TaskManagerBehavior, slotKey: string): RunId | undefined {
+    const live = manager.tasks.find(t => t.status.slotKey === slotKey);
+    if (live !== undefined) {
+        return live.runId;
+    }
+    return manager.history().find(h => h.status.slotKey === slotKey)?.runId;
+}
+
+/** The handle for the newest run of a slot. */
+export function handleOfSlot(manager: TaskManagerBehavior, slotKey: string): TaskHandle | undefined {
+    const runId = runIdOfSlot(manager, slotKey);
+    return runId === undefined ? undefined : manager.get(runId);
+}
+
+/** The status of the newest run of a slot. */
+export function statusOfSlot(manager: TaskManagerBehavior, slotKey: string): TaskStatus | undefined {
+    return handleOfSlot(manager, slotKey)?.status;
+}
+
+/** The status of the newest run of a slot, failing with the slot name when nothing answers to it. */
+export function requireStatusOfSlot(manager: TaskManagerBehavior, slotKey: string): TaskStatus {
+    const status = statusOfSlot(manager, slotKey);
+    if (status === undefined) {
+        throw new Error(`No run answers to slot ${slotKey}`);
+    }
+    return status;
+}
+
+/** Cancel the newest run of a slot, or report that nothing answers to it. */
+export function cancelSlot(manager: TaskManagerBehavior, slotKey: string): Promise<TaskHandle | undefined> {
+    const runId = runIdOfSlot(manager, slotKey);
+    if (runId === undefined) {
+        // Mirrors cancel() of a run nothing answers to, so a test asserting that outcome still exercises it.
+        return manager.cancel(RunId(Number.MAX_SAFE_INTEGER));
+    }
+    return manager.cancel(runId);
+}
+
+/** The slot key of the rollback of the newest run of `slotKey`, or undefined if none was recorded. */
+export function revertSlotOf(runs: RunRecords, slotKey: string): string | undefined {
+    return revertRecordOf(runs, slotKey)?.slotKey;
+}
+
+/**
+ * Wait for one specific run to reach one of `states`. A slot can hold several runs, so waiting on the slot
+ * would match a previous run that is already in the state the caller is waiting for.
+ */
+export async function awaitRun(
+    node: { act<T>(fn: (agent: { get(t: unknown): unknown }) => T): Promise<T> },
+    manager: { new (...args: never[]): unknown },
+    runId: RunId,
+    ...states: string[]
+): Promise<void> {
+    for (let i = 0; i < 2_000; i++) {
+        const settled = await node.act(a => {
+            const m = a.get(manager) as TaskManagerBehavior;
+            const state = m.get(runId)?.status.state;
+            if (state === undefined || !states.includes(state)) {
+                return false;
+            }
+            // A run turns terminal one step before it retires; a caller acting here would find the slot held.
+            return (
+                !(["completed", "failed", "cancelled"] as string[]).includes(state) ||
+                !m.tasks.some(t => t.runId === runId)
+            );
+        });
+        if (settled) {
+            return;
+        }
+        // Integration gates settle on macrotasks, not on time alone, so both have to be pumped.
+        await MockTime.advance(100);
+        await MockTime.macrotask;
+    }
+    throw new Error(`Run #${runId} did not reach state ${states.join("|")}`);
 }

--- a/packages/node-manager/test/tsconfig.json
+++ b/packages/node-manager/test/tsconfig.json
@@ -12,7 +12,13 @@
             "path": "../../general/src"
         },
         {
+            "path": "../../model/src"
+        },
+        {
             "path": "../../node/src"
+        },
+        {
+            "path": "../../protocol/src"
         },
         {
             "path": "../../testing/src"


### PR DESCRIPTION
A task run had no identity of its own. One string, derived from a task's parameters, served as the name of the
run, the storage key, the history key, the basis for refusing concurrent work, and the link from an undo back
to the work it undoes. Three consequences, each verified against the code before this change:

- **Re-running work destroyed the previous run's record.** `cancel → re-run → cancel` overwrote both the first
  run's record and its undo's, so the history of the first cancel was gone.
- **A finished run vanished at the next restart.** Only unfinished records were loaded back, and lookup read
  only live work, so `get()` returned nothing and `cancel()` threw for every completed, failed or cancelled run
  from the previous start — at zero unrelated load.
- **An undo retry excluded nothing.** A retried undo carried no link to the work it undoes, so a re-run of the
  original was admitted while that retry was still in flight.

## Each run now has its own identity

A `RunId` names one attempt. A **slot key** names what the attempt intends to change. A caller's `externalId`
is a separate one-to-one index. At most one run owns a slot, and it keeps that slot until its **driver
settles** rather than until its state turns terminal — a task is terminal before its driver stops, so releasing
the slot earlier admits a re-run that writes to a device while the previous attempt is still unwinding.

Records are written per run and **merged** into what is stored. Nothing is overwritten, and a stored run whose
task type has not been registered yet is no longer erased by an unrelated write.

Retirement is **staged, written, then applied**. Only the intent to retire is held in memory before the write,
so a refused write leaves the run exactly as it was — slot, state and driver included. Every path that stages a
change now unwinds symmetrically.

## Typed identity

`RunId` and the retirement order are branded numbers following the `NodeId` idiom, minted only inside the run
store. Lookup splits into `get(runId)` and `forExternalId(externalId)`, so no call site has to encode which
namespace a string belongs to.

That removes a reserved `#` prefix that a single string lookup needed in order to tell run names from caller
ids, and with it a parser in which `#01` and `#1e3` resolved as aliases for other runs. `TaskHandle.id` becomes
`TaskHandle.runId`, so the number → string → parse round trip where those accidents lived is gone. `#42`
survives only as a log rendering.

`slotKey` and `externalId` stay plain strings, and that is a constraint rather than a preference: `Immutable<T>`
has pass-through branches for `number` and `bigint` but none for `string`, so a branded string inside behavior
state is mangled.

## Exclusion between concurrent runs

`RotateGroupKey`'s slot is keyed on the key set alone, so **one live rotation per key set** follows from slot
uniqueness and `Task.resourceKey` is deleted. `rotationId` no longer takes part in identity.

An undo is linked to the work it undoes by identity, and that link is now seeded on retries too. The check
considers an undo of **any** retired run of the slot, not only the most recent one, so a later run of a slot
cannot have its outcome overwritten by an older run's undo.

## A task that writes an unknown item kind now fails

Separately, and independent of the identity work: a task that named an item kind no registered kind matched — a
typo in the kind name, or a kind whose registration had not happened — reported success having written nothing
to the device. The item was skipped when actions were applied and then marked committed anyway, so the gate the
task waits on resolved and the task completed green. Nothing was written, nothing failed, nothing was logged.

An unregistered kind now fails the item, which drops it and fails the task through the path that already exists
for work that cannot converge. The reason is logged where the error is otherwise reduced to a status code, so
the failure names the kind that could not be resolved rather than only reporting that an item disappeared.

## Scope

`packages/node-manager` declares `@matter/model` and `@matter/protocol`, which it imports but was receiving
transitively through `@matter/node`; the tsconfig references were regenerated with `nacho-build tsconfigs`.

## Tests

Six existing tests changed contract: a run that retired before a restart now answers; a re-run during the
previous run's unwind is refused rather than tracked; storage keys and the rotation slot changed shape.

Six defects in the identity work were found by running the tests rather than by compiling, and the fixes are
mutation-proven — each production hunk reverted, the failure observed, then restored. Three of those proofs
initially stayed green, which is how the missing coverage for the older-run undo check, repeated cancel across
tiers, and the refused-cancel-write redrive was found. The unknown-kind fix is mutation-proven the same way:
with the hunk reverted the new test's task reaches `completed` instead of `failed`.

Gate: `build-clean`, `format-verify`, `lint` and the full suite all clean.
