### PR TITLE
TC-LVL-8.1 (LevelControl commands, DUT as client)

### DIFF
--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -2033,3 +2033,49 @@ hand over just the first result of a batch. On any other controller the shortfal
 own defect, so the check stands unaccepted and fails the run. A report carrying a value nobody wrote is
 still a failure. What this gives up: a controller that delivered the values out of order is no longer
 caught, which the plan never asked about anyway.
+
+## An operator-prompted step, when the DUT is a controller the test drives (`TC-LVL-8.1`)
+
+The plan's single step reads "TH prompts the operator to make the DUT send one or more supported
+commands". There is no operator here and the DUT is a controller this suite drives, so the step
+itself is the prompt: it makes the DUT send the commands, and the TH's log is the evidence, exactly
+as in every other DUT-as-client TC.
+
+**Know what the "consistent with the attribute values reported by the TH" clause can and cannot
+buy.** The obvious reading — read `MinLevel`/`MaxLevel`, derive the commanded level from them — reads
+as strong evidence and is not: with the Lighting feature the spec *fixes* those bounds at 1 and 254
+(§ 1.6.6.4, § 1.6.6.5), both THs are lighting devices, and 1-254 is also what any hard-coded
+fallback would use. A first draft did exactly this, and hard-coding the bounds left the run passing
+with byte-identical evidence. What the reads are worth is the two claims that can actually fail:
+
+- the TH reports bounds a conforming device may report — `MinLevel` is `max 254` and `MaxLevel` is
+  `minLevel to 254`, so **0 is a legal minimum** for a device without Lighting, and only a Lighting
+  device is pinned to 1-254. A precondition demanding `min >= 1` outright would fail a legal TH;
+- the level the DUT sends stays inside what the TH reported, whatever that turns out to be.
+
+`MinLevel`/`MaxLevel` are optional in general but not for this TC: its Required Devices row asks for
+a TH "exposing all optional attributes", so an absent one fails the precondition rather than falling
+back to a constant. A fallback here would be a branch no leg exercises, reporting a provenance
+nobody checked.
+
+The check that carries the step is the **read-back**: `CurrentLevel` after the command. It is what
+catches a well-formed, successfully-acked command the TH silently ignored — swapping
+`MoveToLevelWithOnOff` for a plain `MoveToLevel` produces exactly that (a command reaching a TH that
+is off has no effect unless the Options bits say otherwise, § 1.6.4.1.3, § 1.6.6.9), and nothing else
+in the test notices. For the read-back to mean anything the commanded level must differ from the one
+the TH already holds, and `CurrentLevel` is persistent on the chip TH — so the level is chosen
+against the value read first, not fixed.
+
+Two limits worth stating rather than hiding:
+
+- Only the level is TH-derived. `Move`'s rate and `Step`'s step size are spec-legal constants; the
+  plan does not tie them to an attribute, and `DefaultMoveRate` is not read.
+- `Stop` has no fields but its Options bits, so its evidence is the command path alone — on the
+  matter.js flavor that is a single `InteractionServer Invoke` line.
+
+A bitmap attribute does not read back as a number. Both adapters decode one through the model into an
+object of named bits, so a `FeatureMap` read answers `{ onOff: true, lighting: true, frequency: false }`
+and a `& bit` test against it is always falsy — read the named bit instead.
+
+No PICS work: CHIP's register defines no per-command client keys for LevelControl, so `LVL.C` (which
+the device file already answers 1) is the only gate, and choosing which commands to send is ours.

--- a/support/chip-testing/test/cert/TC-LVL-8.1.test.ts
+++ b/support/chip-testing/test/cert/TC-LVL-8.1.test.ts
@@ -81,7 +81,7 @@ async function readsLighting(node: CertNodeApi): Promise<boolean> {
         return (value & LIGHTING_FEATURE) !== 0;
     }
     if (typeof value === "object" && value !== null && LIGHTING_PROPERTY in value) {
-        return Boolean((value as Record<string, unknown>)[LIGHTING_PROPERTY]);
+        return Boolean(value[LIGHTING_PROPERTY]);
     }
     throw new CertCheckFailedError(`TH answered FeatureMap with ${JSON.stringify(value)}, which names no features`);
 }

--- a/support/chip-testing/test/cert/TC-LVL-8.1.test.ts
+++ b/support/chip-testing/test/cert/TC-LVL-8.1.test.ts
@@ -1,0 +1,284 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Matter } from "@matter/model";
+import type { CertNodeApi, CertNodeRef, CertStepContext } from "@matter/testing";
+import { certTest } from "@matter/testing";
+import type { CommandFieldValue } from "./tc-support.js";
+import {
+    CertCheckFailedError,
+    CommissionedRefs,
+    expectCommandInvoke,
+    LOG_TIMEOUT,
+    record,
+    requireId,
+} from "./tc-support.js";
+
+const LEVEL_CONTROL = Matter.clusters.require("LevelControl");
+const LEVEL_CONTROL_ID = requireId(LEVEL_CONTROL.id, "LevelControl cluster");
+
+/** Both THs put their LevelControl on the on/off light at endpoint 1. */
+const ENDPOINT = 1;
+
+/** `FeatureMap` bit for Lighting (LT), which fixes what the level bounds may be. */
+const LIGHTING_FEATURE = 1 << 1;
+
+/** The Lighting bit's name in the decoded feature map, which both adapters render through the model. */
+const LIGHTING_PROPERTY = "lighting";
+
+/** `CurrentLevel`'s own ceiling (Matter Application Clusters § 1.6.4.2). */
+const MAX_LEVEL_CEILING = 254;
+
+/** What a Lighting device's bounds are required to be (§ 1.6.6.4, § 1.6.6.5). */
+const LIGHTING_MIN_LEVEL = 1;
+const LIGHTING_MAX_LEVEL = 254;
+
+/** Immediate, so a step reading the level back is not racing a transition. */
+const NO_TRANSITION = 0;
+
+const MOVE_RATE = 20;
+const STEP_SIZE = 10;
+
+const MOVE_MODE_UP = 0;
+const STEP_MODE_DOWN = 1;
+
+const commissioned = new CommissionedRefs();
+
+function commandId(commandName: string): number {
+    return requireId(LEVEL_CONTROL.commands.require(commandName).id, `LevelControl.${commandName}`);
+}
+
+function attributeId(attributeName: string): number {
+    return requireId(LEVEL_CONTROL.attributes.require(attributeName).id, `LevelControl.${attributeName}`);
+}
+
+async function readNumber(node: CertNodeApi, attributeName: string): Promise<number> {
+    const value = await node.readAttribute({
+        endpoint: ENDPOINT,
+        cluster: LEVEL_CONTROL_ID,
+        attribute: attributeId(attributeName),
+    });
+    if (typeof value !== "number") {
+        throw new CertCheckFailedError(`TH answered ${attributeName} with ${JSON.stringify(value)}, not a number`);
+    }
+    return value;
+}
+
+/**
+ * Whether the TH's LevelControl has the Lighting feature. A feature map is a bitmap, and both adapters
+ * decode a bitmap through the model into an object of named bits rather than the raw number.
+ */
+async function readsLighting(node: CertNodeApi): Promise<boolean> {
+    const value = await node.readAttribute({
+        endpoint: ENDPOINT,
+        cluster: LEVEL_CONTROL_ID,
+        attribute: attributeId("featureMap"),
+    });
+    if (typeof value === "number") {
+        return (value & LIGHTING_FEATURE) !== 0;
+    }
+    if (typeof value === "object" && value !== null && LIGHTING_PROPERTY in value) {
+        return Boolean((value as Record<string, unknown>)[LIGHTING_PROPERTY]);
+    }
+    throw new CertCheckFailedError(`TH answered FeatureMap with ${JSON.stringify(value)}, which names no features`);
+}
+
+/** The levels the TH says it accepts, and whether it must obey the Lighting bounds. */
+interface LevelBounds {
+    min: number;
+    max: number;
+    lighting: boolean;
+}
+
+/**
+ * This TC's TH is one that "exposes a Level Control server with all optional attributes and commands
+ * supported" (the plan's own Required Devices row), so `MinLevel`/`MaxLevel` — optional in general —
+ * are required here, and a TH without them fails the precondition rather than falling back to a
+ * constant. Which is also what keeps the bounds below the DUT's own, rather than this file's.
+ */
+async function readLevelBounds(node: CertNodeApi): Promise<LevelBounds> {
+    return {
+        min: await readNumber(node, "minLevel"),
+        max: await readNumber(node, "maxLevel"),
+        lighting: await readsLighting(node),
+    };
+}
+
+/**
+ * Whether `bounds` are ones a conforming TH may report. `MinLevel` is `max 254` and `MaxLevel` is
+ * `minLevel to 254`, so 0 is a legal minimum for a device without Lighting; with Lighting the spec
+ * fixes both (§ 1.6.6.4, § 1.6.6.5), which is the only part of this a TH can get wrong while still
+ * answering.
+ */
+function boundsConform({ min, max, lighting }: LevelBounds): string | undefined {
+    if (min > max || max > MAX_LEVEL_CEILING) {
+        return `${min}-${max} is not a range CurrentLevel can take`;
+    }
+    if (lighting && (min !== LIGHTING_MIN_LEVEL || max !== LIGHTING_MAX_LEVEL)) {
+        return `a Lighting device reports ${LIGHTING_MIN_LEVEL}-${LIGHTING_MAX_LEVEL}, not ${min}-${max}`;
+    }
+    return undefined;
+}
+
+/**
+ * A level within the bounds the TH reported that the TH is not already sitting at, so the read-back
+ * after the command shows a level the TH moved to rather than one it happened to hold. `CurrentLevel`
+ * is persistent on the chip TH, so its starting value is whatever an earlier run left.
+ */
+function levelOtherThan(current: number | null, { min, max }: LevelBounds): number {
+    const midpoint = min + Math.floor((max - min) / 2);
+    if (midpoint !== current) {
+        return midpoint;
+    }
+    return midpoint === max ? min : midpoint + 1;
+}
+
+/**
+ * Invokes `commandName` on the TH's LevelControl cluster and verifies the TH's log recorded the
+ * command with the field values the step sent.
+ *
+ * `optionsMask`/`optionsOverride` are sent because the commands require them, but are not among the
+ * checked fields: they are bitmaps, which the two logs render differently from a plain integer.
+ */
+async function invokeAndCheck(
+    cx: CertStepContext,
+    ref: CertNodeRef,
+    commandName: string,
+    args: Record<string, unknown>,
+    fields: CommandFieldValue[],
+): Promise<void> {
+    const th = cx.devices.th;
+    const from = th.log.mark();
+
+    try {
+        await cx.controllers.dut
+            .node(ref)
+            .invoke("LevelControl", commandName, { ...args, optionsMask: {}, optionsOverride: {} }, ENDPOINT);
+    } catch (e) {
+        cx.recorder.check({ type: "response", verdict: "fail", detail: String(e) });
+        throw e;
+    }
+    cx.recorder.check({ type: "response", verdict: "pass", detail: `${commandName} status=Success` });
+
+    const logCheck = await expectCommandInvoke(
+        th.log,
+        th.flavor,
+        ENDPOINT,
+        LEVEL_CONTROL_ID,
+        commandId(commandName),
+        fields,
+        from,
+        LOG_TIMEOUT,
+    );
+    record(cx, logCheck, `CommandDataIB log for LevelControl.${commandName}`);
+}
+
+let bounds: LevelBounds | undefined;
+
+certTest("TC-LVL-8.1", { plan: "levelcontrol.adoc", pics: ["LVL.C"], app: "all-clusters" })
+    .step(
+        "0",
+        "Precondition: the DUT commissions the TH and reads the levels the TH says it accepts.",
+        async cx => {
+            const dut = cx.controllers.dut;
+            const th = cx.devices.th;
+
+            const ref = await dut.commission({
+                passcode: th.commissioning.passcode,
+                discriminator: th.commissioning.discriminator,
+            });
+            commissioned.set("dut", ref);
+
+            const read = await readLevelBounds(dut.node(ref));
+            bounds = read;
+
+            const nonConformance = boundsConform(read);
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: nonConformance === undefined ? "pass" : "fail",
+                    detail:
+                        nonConformance === undefined
+                            ? `TH accepts levels ${read.min}-${read.max}${read.lighting ? " (Lighting)" : ""}`
+                            : nonConformance,
+                },
+                "the level range the DUT's commands must stay within",
+            );
+        },
+        {
+            expected:
+                "The TH reports the levels it accepts, and reports bounds a conforming device may have. The level " +
+                "the next step commands comes from these, so a level outside what the TH accepts cannot be sent.",
+        },
+    )
+    .step(
+        1,
+        "TH prompts the operator to make the DUT send one or more supported commands from the Level Control cluster",
+        commissioned.withRef("dut", async (cx, ref) => {
+            // The DUT of this suite is a controller the test drives, so the plan's operator prompt is
+            // the step itself: it makes the DUT send each command, and the TH's log is the evidence.
+            if (bounds === undefined) {
+                throw new CertCheckFailedError("step 0 did not read the TH's level bounds");
+            }
+
+            const node = cx.controllers.dut.node(ref);
+            const before = await node.readAttribute({
+                endpoint: ENDPOINT,
+                cluster: LEVEL_CONTROL_ID,
+                attribute: attributeId("currentLevel"),
+            });
+            const level = levelOtherThan(typeof before === "number" ? before : null, bounds);
+
+            // WithOnOff, so the TH is on and the level it reports afterward is the one just commanded;
+            // a command without it reaching a TH that is off has no effect unless the Options bits say
+            // otherwise (Matter Application Clusters § 1.6.4.1.3, § 1.6.6.9).
+            await invokeAndCheck(cx, ref, "moveToLevelWithOnOff", { level, transitionTime: NO_TRANSITION }, [
+                { id: 0, value: level },
+                { id: 1, value: NO_TRANSITION },
+            ]);
+
+            const reported = await readNumber(node, "currentLevel");
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: reported === level ? "pass" : "fail",
+                    detail: `CurrentLevel ${JSON.stringify(before)} -> ${reported}, commanded ${level}`,
+                },
+                "the TH moved to the level the DUT commanded",
+            );
+
+            await invokeAndCheck(cx, ref, "move", { moveMode: MOVE_MODE_UP, rate: MOVE_RATE }, [
+                { id: 0, value: MOVE_MODE_UP },
+                { id: 1, value: MOVE_RATE },
+            ]);
+
+            await invokeAndCheck(cx, ref, "stop", {}, []);
+
+            await invokeAndCheck(
+                cx,
+                ref,
+                "step",
+                { stepMode: STEP_MODE_DOWN, stepSize: STEP_SIZE, transitionTime: NO_TRANSITION },
+                [
+                    { id: 0, value: STEP_MODE_DOWN },
+                    { id: 1, value: STEP_SIZE },
+                    { id: 2, value: NO_TRANSITION },
+                ],
+            );
+        }),
+        {
+            expected:
+                "DUT transmits correctly formed commands in any order and with application achievable values which " +
+                "are within the limits allowed by the specification and consistent with the attribute values " +
+                "reported by the TH. Verify this using the TH log of these messages.",
+        },
+    )
+    .finalize(cx => {
+        bounds = undefined;
+        return commissioned.decommissionAll(cx);
+    });


### PR DESCRIPTION
Adds **TC-LVL-8.1**, the second case of the cluster-level client block. Independent of #4347.

## The test

The plan is a single step: "TH prompts the operator to make the DUT send one or more supported commands from the Level Control cluster." There is no operator here and the DUT is a controller this suite drives, so the step itself is the prompt — it makes the DUT send `MoveToLevelWithOnOff`, `Move`, `Stop` and `Step`, and the TH's own log is the evidence.

## What the plan's "consistent with the attribute values reported by the TH" clause is worth

The obvious reading — read `MinLevel`/`MaxLevel`, derive the commanded level from them — reads as strong evidence and is not. With the Lighting feature the specification *fixes* those bounds at 1 and 254 (§ 1.6.6.4, § 1.6.6.5), both THs are lighting devices, and 1–254 is exactly what a hard-coded fallback would use. A first draft did this; hard-coding the bounds left the run passing with byte-identical evidence.

So the precondition states the two claims that can actually fail:

- **The TH reports bounds a conforming device may report.** `MinLevel` is `max 254` and `MaxLevel` is `minLevel to 254`, so **0 is a legal minimum** for a device without Lighting, and only a Lighting device is pinned to 1–254. A precondition demanding a minimum of 1 outright would fail a legal TH.
- **The level the DUT sends stays inside what the TH reported**, whatever that turns out to be.

`MinLevel`/`MaxLevel` are optional in general but not for this case, whose Required Devices row asks for a TH "exposing all optional attributes" — so an absent one fails the precondition rather than falling back to a constant nobody checked.

## The check that carries the step

The read-back of `CurrentLevel`. It is what catches a well-formed, acknowledged command the TH silently ignored — which is precisely what a plain `MoveToLevel` produces against a TH that is off (§ 1.6.4.1.3, § 1.6.6.9), and nothing else in the test notices. For the read-back to mean anything the commanded level must differ from the level the TH already holds, and `CurrentLevel` persists on the chip TH, so the level is chosen against the value read first rather than fixed.

## Limits stated rather than hidden

- Only the level is TH-derived; `Move`'s rate and `Step`'s step size are spec-legal constants, and the plan ties neither to an attribute.
- `Stop` has no fields but its Options bits, so its evidence is the command path alone.
- `OptionsMask`/`OptionsOverride` are sent but not asserted — they are bitmaps, which the two logs render differently from a plain integer.

## Verification

All four matrix legs green (matter.js and chip-tool controllers × matter.js and chip-local devices), plus `cert-framework` 817/817, every cert TC, full `npm test`, build, format-verify and lint.

No PICS work needed: CHIP's register defines no per-command client keys for LevelControl, so `LVL.C` — already 1 in the device file — is the only gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
