### PR TITLE
TC-S-3.1 (ScenesManagement commands, DUT as client)

### DIFF
--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -96,6 +96,18 @@ export const CHIP_TOOL_CONTROLLER_PICS: PicsValues = {
     "G.C.C03.Tx": 1,
     "G.C.C04.Tx": 1,
     "G.C.C05.Tx": 1,
+
+    // Every ScenesManagement client command TC-S-3.1 sends. The CHIP PICS file answers 0 for the
+    // cluster and each command because it describes a device, which is not a scenes client.
+    "S.C": 1,
+    "S.C.C00.Tx": 1,
+    "S.C.C01.Tx": 1,
+    "S.C.C02.Tx": 1,
+    "S.C.C03.Tx": 1,
+    "S.C.C04.Tx": 1,
+    "S.C.C05.Tx": 1,
+    "S.C.C06.Tx": 1,
+    "S.C.C40.Tx": 1,
 };
 
 const WILDCARD_CLUSTER = 0xffffffff;

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -126,6 +126,18 @@ export const MATTERJS_CONTROLLER_PICS: PicsValues = {
     "G.C.C03.Tx": 1,
     "G.C.C04.Tx": 1,
     "G.C.C05.Tx": 1,
+
+    // Every ScenesManagement client command TC-S-3.1 sends. The CHIP PICS file answers 0 for the
+    // cluster and each command because it describes a device, which is not a scenes client.
+    "S.C": 1,
+    "S.C.C00.Tx": 1,
+    "S.C.C01.Tx": 1,
+    "S.C.C02.Tx": 1,
+    "S.C.C03.Tx": 1,
+    "S.C.C04.Tx": 1,
+    "S.C.C05.Tx": 1,
+    "S.C.C06.Tx": 1,
+    "S.C.C40.Tx": 1,
 };
 
 const adapterStreams = new Map<string, LineQueue>();

--- a/support/chip-testing/test/cert-framework/controller-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/controller-adapter.test.ts
@@ -658,6 +658,21 @@ describe("ControllerAdapter registry", () => {
         }
     });
 
+    it("declares the ScenesManagement client commands TC-S-3.1 sends, and the cluster itself", () => {
+        // Unlike Groups, the device file answers 0 for the cluster as well, so an undeclared S.C would
+        // make the whole test pending rather than skipping one step.
+        const scenesKeys = ["00", "01", "02", "03", "04", "05", "06", "40"].map(id => `S.C.C${id}.Tx`);
+        const asDevice = new PicsFile(["S.C=0", ...scenesKeys.map(key => `${key}=0`)]);
+
+        for (const implementation of ["matterjs", "chip-tool"] as const) {
+            const forRun = asDevice.with(controllerPicsOverridesFor(implementation));
+
+            for (const key of ["S.C", ...scenesKeys]) {
+                expect(new PicsExpression(key).evaluate(forRun), `${implementation} ${key}`).equal(true);
+            }
+        }
+    });
+
     it("declares the client-side capabilities the device's own PICS file answers for a device", () => {
         // Every command TC-ACT-3.2 gates a step on, since a declaration missing from the middle of the
         // range skips that step as quietly as one missing from either end.

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -2174,7 +2174,12 @@ group the fabric's key map must already carry. What it adds:
   (promoted to `tc-support.ts` when this became the second TC to need them) gate on it. A command
   whose schema mandates a status and answers without one fails rather than skipping the check.
 - **`EpochKey2`/`EpochStartTime2` go as null**, which the plan asks for and both adapters carry.
-- **A list or bitmap field carries no log assertion.** `AddScene`'s `ExtensionFieldSetStructs` and
-  `CopyScene`'s `Mode` are rendered across lines (chip) or as named bits (matter.js), and
-  `expectCommandInvoke` matches one line per field; the surrounding scalar fields carry the evidence.
-  Say so in the step's `expected` rather than leaving a reader to assume the whole payload was checked.
+- **A list or bitmap field needs its own lines, not a field entry.** `expectCommandInvoke` matches one
+  line per field, and neither shape is one line on both flavors: chip nests a list across lines and
+  numbers its members, while matter.js prints the whole nested value inline and names them
+  (`extensionFieldSetStructs: { clusterId: 6, attributeValueList: [ { attributeId: 0, valueUnsigned8: 1 } ] }`).
+  A bitmap diverges the same way — chip prints `0x0 = 0 (unsigned),` where matter.js prints
+  `mode: { copyAllScenes: false }`. So these go through `expectSequence` with per-flavor lines instead,
+  anchored on the mark the invoke took, which is what lets the step assert the nested `ClusterID` and
+  `AttributeValueList` the plan actually names. Sending an empty list would have been the quieter
+  mistake: the step would pass while exercising none of the shape it is about.

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -2158,3 +2158,23 @@ widest integer a Matter field can hold fits exactly (`18446744073709551615` and
 `-9223372036854775808` are 20 characters each), but a float need not — the largest finite double
 renders as 23, and `stod` on the truncated text yields a well-formed number that is not the one asked
 for. A value that would not survive is refused rather than silently changed.
+
+## The second cluster-client TC of the same shape (`TC-S-3.1`)
+
+Eight steps, each "DUT issues *command*, TH receives it", plus the same key-set / GroupKeyMap /
+AddGroup preconditions `TC-G-3.2` needs — scenes are addressed by group, so a scene command names a
+group the fabric's key map must already carry. What it adds:
+
+- **The cluster's own PICS key needs declaring, not only its commands.** CHIP's file answers `S.C=0`
+  as well as `S.C.C0x.Tx=0`, so without the overlay the *whole test* is pending rather than one step
+  being skipped — a quieter failure than the per-command case, and one a `certTest`-level `pics`
+  never announces.
+- **A response's status is a separate claim from the invoke resolving.** Every command here but
+  `RecallScene` answers with a status inside its payload, so `answersWithStatus`/`responseStatusOf`
+  (promoted to `tc-support.ts` when this became the second TC to need them) gate on it. A command
+  whose schema mandates a status and answers without one fails rather than skipping the check.
+- **`EpochKey2`/`EpochStartTime2` go as null**, which the plan asks for and both adapters carry.
+- **A list or bitmap field carries no log assertion.** `AddScene`'s `ExtensionFieldSetStructs` and
+  `CopyScene`'s `Mode` are rendered across lines (chip) or as named bits (matter.js), and
+  `expectCommandInvoke` matches one line per field; the surrounding scalar fields carry the evidence.
+  Say so in the step's `expected` rather than leaving a reader to assume the whole payload was checked.

--- a/support/chip-testing/test/cert/TC-G-3.2.test.ts
+++ b/support/chip-testing/test/cert/TC-G-3.2.test.ts
@@ -9,7 +9,15 @@ import { Matter } from "@matter/model";
 import type { CertNodeRef, CertStepContext } from "@matter/testing";
 import { certTest } from "@matter/testing";
 import type { CommandFieldValue } from "./tc-support.js";
-import { CommissionedRefs, expectCommandInvoke, LOG_TIMEOUT, record, requireId } from "./tc-support.js";
+import {
+    answersWithStatus,
+    CommissionedRefs,
+    expectCommandInvoke,
+    LOG_TIMEOUT,
+    record,
+    requireId,
+    responseStatusOf,
+} from "./tc-support.js";
 
 const GROUPS = Matter.clusters.require("Groups");
 const GROUP_KEY_MANAGEMENT = Matter.clusters.require("GroupKeyManagement");
@@ -74,11 +82,11 @@ async function invokeAndCheck(
         detail: response === undefined ? "status=Success" : `status=Success, response=${JSON.stringify(response)}`,
     });
 
-    if (answersWithStatus(commandName)) {
+    if (answersWithStatus(GROUPS, commandName)) {
         // An absent or malformed status is a failure, not a check to skip: skipping it would leave the
         // command resting on the TH's log alone, which says the request arrived and nothing about
         // whether the cluster accepted it.
-        const payloadStatus = statusOf(response);
+        const payloadStatus = responseStatusOf(response);
         record(
             cx,
             {
@@ -129,21 +137,6 @@ function groupKeySet() {
         epochKey2: Bytes.fromHex("d2d1d2d3d4d5d6d7d8d9dadbdcdddedf"),
         epochStartTime2: start + 2_000_000n,
     };
-}
-
-/** Whether `commandName`'s response schema makes a status part of the answer. */
-function answersWithStatus(commandName: string): boolean {
-    const response = GROUPS.commands.require(commandName).responseModel;
-    return response !== undefined && [...response.members].some(member => member.name === "Status");
-}
-
-/** The status a Groups response carries in its payload, or `undefined` where the answer has none. */
-function statusOf(response: unknown): number | undefined {
-    if (typeof response !== "object" || response === null || !("status" in response)) {
-        return undefined;
-    }
-    const { status } = response;
-    return typeof status === "number" ? status : undefined;
 }
 
 /** The group ids a `GetGroupMembership` response carries, whatever shape the controller decoded it into. */

--- a/support/chip-testing/test/cert/TC-S-3.1.test.ts
+++ b/support/chip-testing/test/cert/TC-S-3.1.test.ts
@@ -9,10 +9,12 @@ import { Matter } from "@matter/model";
 import type { CertNodeRef, CertStepContext } from "@matter/testing";
 import { certTest } from "@matter/testing";
 import type { CommandFieldValue } from "./tc-support.js";
+import type { LogExpectClaim } from "./tc-support.js";
 import {
     answersWithStatus,
     CommissionedRefs,
     expectCommandInvoke,
+    expectSequence,
     LOG_TIMEOUT,
     record,
     requireId,
@@ -37,6 +39,22 @@ const GROUP = { id: 0x0001, name: "gp1" };
 const SCENE_ID = 0x01;
 const COPIED_SCENE_ID = 0x02;
 const SCENE_NAME = "scene1";
+
+/**
+ * The scene's stored state, which the plan names as ID 4's shape: a list of `ExtensionFieldSetStruct`,
+ * each a `ClusterID` and an `AttributeValueList`. OnOff's `OnOff` attribute is the one both THs carry
+ * on this endpoint, so the set the DUT sends is one a TH could actually apply.
+ */
+const ON_OFF_CLUSTER_ID = requireId(Matter.clusters.require("OnOff").id, "OnOff cluster");
+const ON_OFF_ATTRIBUTE_ID = requireId(Matter.clusters.require("OnOff").attributes.require("onOff").id, "OnOff.onOff");
+const SCENE_ON_OFF_VALUE = 1;
+
+const EXTENSION_FIELD_SETS = [
+    {
+        clusterId: ON_OFF_CLUSTER_ID,
+        attributeValueList: [{ attributeId: ON_OFF_ATTRIBUTE_ID, valueUnsigned8: SCENE_ON_OFF_VALUE }],
+    },
+];
 
 /** Well inside the field's `max 60,000,000` (§ 1.4.9.2), and small enough to leave no transition running. */
 const TRANSITION_TIME = 0;
@@ -81,7 +99,7 @@ async function invokeAndCheck(
     commandName: string,
     args: object,
     fields: CommandFieldValue[],
-): Promise<unknown> {
+): Promise<{ response: unknown; from: number }> {
     const th = cx.devices.th;
     const from = th.log.mark();
 
@@ -126,7 +144,18 @@ async function invokeAndCheck(
     );
     record(cx, logCheck, `CommandDataIB log for ScenesManagement.${commandName}`);
 
-    return response;
+    return { response, from };
+}
+
+/**
+ * Checks a payload the per-field matcher cannot state: it matches one line per field, and a list or a
+ * bitmap is neither one line on chip nor a plain integer on matter.js. The two flavors are given their
+ * own lines rather than the field's value, since they do not merely format it differently — chip
+ * numbers the nested fields and matter.js names them.
+ */
+async function expectPayloadLines(cx: CertStepContext, from: number, label: string, claim: LogExpectClaim) {
+    const th = cx.devices.th;
+    record(cx, await expectSequence(th.log, th.flavor, label, claim, from, LOG_TIMEOUT), label);
 }
 
 certTest("TC-S-3.1", { plan: "scenes.adoc", pics: ["S.C"], app: "all-clusters" })
@@ -193,7 +222,7 @@ certTest("TC-S-3.1", { plan: "scenes.adoc", pics: ["S.C"], app: "all-clusters" }
         1,
         "DUT issues an AddScene command to the Test Harness.",
         commissioned.withRef("dut", async (cx, ref) => {
-            await invokeAndCheck(
+            const { from } = await invokeAndCheck(
                 cx,
                 ref,
                 "addScene",
@@ -202,7 +231,7 @@ certTest("TC-S-3.1", { plan: "scenes.adoc", pics: ["S.C"], app: "all-clusters" }
                     sceneId: SCENE_ID,
                     transitionTime: TRANSITION_TIME,
                     sceneName: SCENE_NAME,
-                    extensionFieldSetStructs: [],
+                    extensionFieldSetStructs: EXTENSION_FIELD_SETS,
                 },
                 [
                     { id: 0, value: GROUP.id },
@@ -211,13 +240,31 @@ certTest("TC-S-3.1", { plan: "scenes.adoc", pics: ["S.C"], app: "all-clusters" }
                     { id: 3, value: SCENE_NAME },
                 ],
             );
+
+            await expectPayloadLines(cx, from, "AddScene ExtensionFieldSetStructs (ID 4)", {
+                chip: {
+                    ordered: [
+                        /0x4 = \[\s*$/,
+                        new RegExp(`0x0 = ${ON_OFF_CLUSTER_ID} \\(unsigned\\),`),
+                        /0x1 = \[\s*$/,
+                        new RegExp(`0x0 = ${ON_OFF_ATTRIBUTE_ID} \\(unsigned\\),`),
+                        new RegExp(`0x1 = ${SCENE_ON_OFF_VALUE} \\(unsigned\\),`),
+                    ],
+                },
+                matterjs: [
+                    new RegExp(
+                        `extensionFieldSetStructs: \\{ clusterId: ${ON_OFF_CLUSTER_ID}, attributeValueList: ` +
+                            `\\[ \\{ attributeId: ${ON_OFF_ATTRIBUTE_ID}, valueUnsigned8: ${SCENE_ON_OFF_VALUE} \\} \\]`,
+                    ),
+                ],
+            });
         }),
         {
             pics: "S.C.C00.Tx",
             expected:
                 "Test Harness receives the AddScene command from the DUT, carrying GroupID, SceneID, " +
-                "TransitionTime and SceneName. ExtensionFieldSetStructs is a list, which the log renders " +
-                "across lines rather than as one field.",
+                "TransitionTime, SceneName and an ExtensionFieldSetStructs list whose ClusterID and " +
+                "AttributeValueList the TH's log shows.",
         },
     )
     .step(
@@ -313,10 +360,9 @@ certTest("TC-S-3.1", { plan: "scenes.adoc", pics: ["S.C"], app: "all-clusters" }
         8,
         "DUT issues a CopyScene command to the Test Harness.",
         commissioned.withRef("dut", async (cx, ref) => {
-            // Mode is a bitmap, which the two logs render differently from a plain integer, so the
-            // copy's own scene and group ids carry the evidence. `copyAllScenes` is left clear, which
-            // is the case the plan's own parameter note describes as "otherwise this bit is set to 0".
-            await invokeAndCheck(
+            // `copyAllScenes` is left clear, which is the case the plan's own parameter note describes
+            // as "otherwise this bit is set to 0".
+            const { from } = await invokeAndCheck(
                 cx,
                 ref,
                 "copyScene",
@@ -334,12 +380,17 @@ certTest("TC-S-3.1", { plan: "scenes.adoc", pics: ["S.C"], app: "all-clusters" }
                     { id: 4, value: COPIED_SCENE_ID },
                 ],
             );
+
+            await expectPayloadLines(cx, from, "CopyScene Mode (ID 0) with CopyAllScenes clear", {
+                chip: [/0x0 = 0 \(unsigned\),/],
+                matterjs: [/mode: \{ copyAllScenes: false \}/],
+            });
         }),
         {
             pics: "S.C.C40.Tx",
             expected:
-                "Test Harness receives the CopyScene command from the DUT, carrying the source and destination " +
-                "group and scene ids. Mode is a bitmap, which the log renders differently from an integer.",
+                "Test Harness receives the CopyScene command from the DUT, carrying Mode with CopyAllScenes " +
+                "clear and the source and destination group and scene ids.",
         },
     )
     .finalize(cx => commissioned.decommissionAll(cx));

--- a/support/chip-testing/test/cert/TC-S-3.1.test.ts
+++ b/support/chip-testing/test/cert/TC-S-3.1.test.ts
@@ -1,0 +1,345 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Bytes } from "@matter/main";
+import { Matter } from "@matter/model";
+import type { CertNodeRef, CertStepContext } from "@matter/testing";
+import { certTest } from "@matter/testing";
+import type { CommandFieldValue } from "./tc-support.js";
+import {
+    answersWithStatus,
+    CommissionedRefs,
+    expectCommandInvoke,
+    LOG_TIMEOUT,
+    record,
+    requireId,
+    responseStatusOf,
+} from "./tc-support.js";
+
+const SCENES = Matter.clusters.require("ScenesManagement");
+const GROUP_KEY_MANAGEMENT = Matter.clusters.require("GroupKeyManagement");
+
+const SCENES_ID = requireId(SCENES.id, "ScenesManagement cluster");
+
+/** Both THs put ScenesManagement and Groups on the on/off light at endpoint 1. */
+const ENDPOINT = 1;
+
+/** GroupKeyManagement is a root-node cluster, so its interactions go to endpoint 0. */
+const ROOT_ENDPOINT = 0;
+
+/** The plan's own `GroupKeySetID` and G₁. */
+const GROUP_KEY_SET_ID = 0x01a1;
+const GROUP = { id: 0x0001, name: "gp1" };
+
+const SCENE_ID = 0x01;
+const COPIED_SCENE_ID = 0x02;
+const SCENE_NAME = "scene1";
+
+/** Well inside the field's `max 60,000,000` (§ 1.4.9.2), and small enough to leave no transition running. */
+const TRANSITION_TIME = 0;
+
+const commissioned = new CommissionedRefs();
+
+function commandId(commandName: string): number {
+    return requireId(SCENES.commands.require(commandName).id, `ScenesManagement.${commandName}`);
+}
+
+/**
+ * The key set the plan's preconditions have the DUT write. The start times are not the plan's literal
+ * 1110000/1110001: matter.js reads an `epoch-us` as a Unix timestamp and refuses one already offset to
+ * the Matter epoch (see AGENTS.md, "An `epoch-us` cannot carry the plan's literal start time"). Only
+ * their order matters here, since nothing in this TC sends group traffic.
+ */
+function groupKeySet() {
+    const start = 1_600_000_000_000_000n;
+    return {
+        groupKeySetId: GROUP_KEY_SET_ID,
+        groupKeySecurityPolicy: 0,
+        epochKey0: Bytes.fromHex("a0a1a2a3a4a5a6a7a8a9aaabacadaeaf"),
+        epochStartTime0: start,
+        epochKey1: Bytes.fromHex("b0b1b2b3b4b5b6b7b8b9babbbcbdbebf"),
+        epochStartTime1: start + 1_000_000n,
+        epochKey2: null,
+        epochStartTime2: null,
+    };
+}
+
+/**
+ * Invokes `commandName` on the TH's ScenesManagement cluster and verifies the TH's own log recorded
+ * the command with the fields the step sent.
+ *
+ * Every ScenesManagement command in this TC but `RecallScene` answers with a status inside its
+ * response payload, so an invoke that resolves has not yet said whether the cluster accepted it; that
+ * status is checked as a claim of its own.
+ */
+async function invokeAndCheck(
+    cx: CertStepContext,
+    ref: CertNodeRef,
+    commandName: string,
+    args: object,
+    fields: CommandFieldValue[],
+): Promise<unknown> {
+    const th = cx.devices.th;
+    const from = th.log.mark();
+
+    let response: unknown;
+    try {
+        response = await cx.controllers.dut.node(ref).invoke("ScenesManagement", commandName, args, ENDPOINT);
+    } catch (e) {
+        cx.recorder.check({ type: "response", verdict: "fail", detail: String(e) });
+        throw e;
+    }
+    cx.recorder.check({
+        type: "response",
+        verdict: "pass",
+        detail: response === undefined ? "status=Success" : `status=Success, response=${JSON.stringify(response)}`,
+    });
+
+    if (answersWithStatus(SCENES, commandName)) {
+        const payloadStatus = responseStatusOf(response);
+        record(
+            cx,
+            {
+                type: "response",
+                verdict: payloadStatus === 0 ? "pass" : "fail",
+                detail:
+                    payloadStatus === undefined
+                        ? `${commandName} answered ${JSON.stringify(response)}, which carries no status`
+                        : `${commandName} response status=${payloadStatus}`,
+            },
+            `ScenesManagement.${commandName} response status`,
+        );
+    }
+
+    const logCheck = await expectCommandInvoke(
+        th.log,
+        th.flavor,
+        ENDPOINT,
+        SCENES_ID,
+        commandId(commandName),
+        fields,
+        from,
+        LOG_TIMEOUT,
+    );
+    record(cx, logCheck, `CommandDataIB log for ScenesManagement.${commandName}`);
+
+    return response;
+}
+
+certTest("TC-S-3.1", { plan: "scenes.adoc", pics: ["S.C"], app: "all-clusters" })
+    .step(
+        "0",
+        "Preconditions: the DUT commissions the TH, writes the plan's group key set, binds G1 to it in " +
+            "GroupKeyMap, clears the TH's groups and adds G1.",
+        async cx => {
+            const dut = cx.controllers.dut;
+            const th = cx.devices.th;
+
+            const ref = await dut.commission({
+                passcode: th.commissioning.passcode,
+                discriminator: th.commissioning.discriminator,
+            });
+            commissioned.set("dut", ref);
+
+            const node = dut.node(ref);
+            await node.invoke("GroupKeyManagement", "keySetWrite", { groupKeySet: groupKeySet() }, ROOT_ENDPOINT);
+            await node.writeAttribute(
+                {
+                    endpoint: ROOT_ENDPOINT,
+                    cluster: requireId(GROUP_KEY_MANAGEMENT.id, "GroupKeyManagement cluster"),
+                    attribute: requireId(
+                        GROUP_KEY_MANAGEMENT.attributes.require("groupKeyMap").id,
+                        "GroupKeyManagement.groupKeyMap",
+                    ),
+                },
+                [{ groupId: GROUP.id, groupKeySetId: GROUP_KEY_SET_ID }],
+            );
+
+            await node.invoke("Groups", "removeAllGroups", {}, ENDPOINT);
+
+            // A group the fabric's GroupKeyMap does not name is refused, so this answer is what proves
+            // the binding above took — every scene command below names this group.
+            const added = await node.invoke(
+                "Groups",
+                "addGroup",
+                { groupId: GROUP.id, groupName: GROUP.name },
+                ENDPOINT,
+            );
+            const addStatus = responseStatusOf(added);
+            record(
+                cx,
+                {
+                    type: "response",
+                    verdict: addStatus === 0 ? "pass" : "fail",
+                    detail:
+                        addStatus === undefined
+                            ? `AddGroup answered ${JSON.stringify(added)}, which carries no status`
+                            : `AddGroup response status=${addStatus}, group ${GROUP.id} bound to key set ` +
+                              `0x${GROUP_KEY_SET_ID.toString(16)}`,
+                },
+                `Groups.addGroup response status`,
+            );
+        },
+        {
+            expected:
+                "The TH accepts the key set, the GroupKeyMap write and AddGroup, so every scene command below " +
+                "names a group the TH actually has.",
+        },
+    )
+    .step(
+        1,
+        "DUT issues an AddScene command to the Test Harness.",
+        commissioned.withRef("dut", async (cx, ref) => {
+            await invokeAndCheck(
+                cx,
+                ref,
+                "addScene",
+                {
+                    groupId: GROUP.id,
+                    sceneId: SCENE_ID,
+                    transitionTime: TRANSITION_TIME,
+                    sceneName: SCENE_NAME,
+                    extensionFieldSetStructs: [],
+                },
+                [
+                    { id: 0, value: GROUP.id },
+                    { id: 1, value: SCENE_ID },
+                    { id: 2, value: TRANSITION_TIME },
+                    { id: 3, value: SCENE_NAME },
+                ],
+            );
+        }),
+        {
+            pics: "S.C.C00.Tx",
+            expected:
+                "Test Harness receives the AddScene command from the DUT, carrying GroupID, SceneID, " +
+                "TransitionTime and SceneName. ExtensionFieldSetStructs is a list, which the log renders " +
+                "across lines rather than as one field.",
+        },
+    )
+    .step(
+        2,
+        "DUT issues a ViewScene command to the Test Harness.",
+        commissioned.withRef("dut", async (cx, ref) => {
+            await invokeAndCheck(cx, ref, "viewScene", { groupId: GROUP.id, sceneId: SCENE_ID }, [
+                { id: 0, value: GROUP.id },
+                { id: 1, value: SCENE_ID },
+            ]);
+        }),
+        {
+            pics: "S.C.C01.Tx",
+            expected: "Test Harness receives the ViewScene command from the DUT, carrying GroupID and SceneID.",
+        },
+    )
+    .step(
+        3,
+        "DUT issues a RemoveScene command to the Test Harness.",
+        commissioned.withRef("dut", async (cx, ref) => {
+            await invokeAndCheck(cx, ref, "removeScene", { groupId: GROUP.id, sceneId: SCENE_ID }, [
+                { id: 0, value: GROUP.id },
+                { id: 1, value: SCENE_ID },
+            ]);
+        }),
+        {
+            pics: "S.C.C02.Tx",
+            expected: "Test Harness receives the RemoveScene command from the DUT, carrying GroupID and SceneID.",
+        },
+    )
+    .step(
+        4,
+        "DUT issues a RemoveAllScenes command to the Test Harness.",
+        commissioned.withRef("dut", async (cx, ref) => {
+            await invokeAndCheck(cx, ref, "removeAllScenes", { groupId: GROUP.id }, [{ id: 0, value: GROUP.id }]);
+        }),
+        {
+            pics: "S.C.C03.Tx",
+            expected: "Test Harness receives the RemoveAllScenes command from the DUT, carrying GroupID.",
+        },
+    )
+    .step(
+        5,
+        "DUT issues a StoreScene command to the Test Harness.",
+        commissioned.withRef("dut", async (cx, ref) => {
+            await invokeAndCheck(cx, ref, "storeScene", { groupId: GROUP.id, sceneId: SCENE_ID }, [
+                { id: 0, value: GROUP.id },
+                { id: 1, value: SCENE_ID },
+            ]);
+        }),
+        {
+            pics: "S.C.C04.Tx",
+            expected: "Test Harness receives the StoreScene command from the DUT, carrying GroupID and SceneID.",
+        },
+    )
+    .step(
+        6,
+        "DUT issues a RecallScene command to the Test Harness.",
+        commissioned.withRef("dut", async (cx, ref) => {
+            // TransitionTime is optional on this command; the plan asks for its type where present, so
+            // it is sent and checked rather than omitted.
+            await invokeAndCheck(
+                cx,
+                ref,
+                "recallScene",
+                { groupId: GROUP.id, sceneId: SCENE_ID, transitionTime: TRANSITION_TIME },
+                [
+                    { id: 0, value: GROUP.id },
+                    { id: 1, value: SCENE_ID },
+                    { id: 2, value: TRANSITION_TIME },
+                ],
+            );
+        }),
+        {
+            pics: "S.C.C05.Tx",
+            expected:
+                "Test Harness receives the RecallScene command from the DUT, carrying GroupID, SceneID and the " +
+                "optional TransitionTime.",
+        },
+    )
+    .step(
+        7,
+        "DUT issues a GetSceneMembership command to the Test Harness.",
+        commissioned.withRef("dut", async (cx, ref) => {
+            await invokeAndCheck(cx, ref, "getSceneMembership", { groupId: GROUP.id }, [{ id: 0, value: GROUP.id }]);
+        }),
+        {
+            pics: "S.C.C06.Tx",
+            expected: "Test Harness receives the GetSceneMembership command from the DUT, carrying GroupID.",
+        },
+    )
+    .step(
+        8,
+        "DUT issues a CopyScene command to the Test Harness.",
+        commissioned.withRef("dut", async (cx, ref) => {
+            // Mode is a bitmap, which the two logs render differently from a plain integer, so the
+            // copy's own scene and group ids carry the evidence. `copyAllScenes` is left clear, which
+            // is the case the plan's own parameter note describes as "otherwise this bit is set to 0".
+            await invokeAndCheck(
+                cx,
+                ref,
+                "copyScene",
+                {
+                    mode: {},
+                    groupIdentifierFrom: GROUP.id,
+                    sceneIdentifierFrom: SCENE_ID,
+                    groupIdentifierTo: GROUP.id,
+                    sceneIdentifierTo: COPIED_SCENE_ID,
+                },
+                [
+                    { id: 1, value: GROUP.id },
+                    { id: 2, value: SCENE_ID },
+                    { id: 3, value: GROUP.id },
+                    { id: 4, value: COPIED_SCENE_ID },
+                ],
+            );
+        }),
+        {
+            pics: "S.C.C40.Tx",
+            expected:
+                "Test Harness receives the CopyScene command from the DUT, carrying the source and destination " +
+                "group and scene ids. Mode is a bitmap, which the log renders differently from an integer.",
+        },
+    )
+    .finalize(cx => commissioned.decommissionAll(cx));

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -14,6 +14,7 @@ import {
     Seconds,
     Time,
 } from "@matter/main";
+import type { ClusterModel } from "@matter/model";
 import { Matter } from "@matter/model";
 import type {
     AttributePathSpec,
@@ -855,6 +856,25 @@ export function requireId(id: number | undefined, what: string): number {
         throw new InternalError(`${what} has no numeric id`);
     }
     return id;
+}
+
+/**
+ * The status a command's response carries in its own payload, or `undefined` where the answer has
+ * none. A cluster that answers with a status reports a refusal there rather than as an interaction
+ * status, so an invoke that resolves has told the caller nothing about it yet.
+ */
+export function responseStatusOf(response: unknown): number | undefined {
+    if (typeof response !== "object" || response === null || !("status" in response)) {
+        return undefined;
+    }
+    const { status } = response;
+    return typeof status === "number" ? status : undefined;
+}
+
+/** Whether `commandName`'s response schema makes a status part of the answer. */
+export function answersWithStatus(cluster: ClusterModel, commandName: string): boolean {
+    const response = cluster.commands.require(commandName).responseModel;
+    return response !== undefined && [...response.members].some(member => member.name === "Status");
 }
 
 /**


### PR DESCRIPTION
**Stacked on #4347** — it uses the string command-field check added there (`AddScene`'s `SceneName`). Review that one first; this diff is only the two files at its tip.

Third case of the cluster-level client block. Eight steps, one per command the plan names — AddScene, ViewScene, RemoveScene, RemoveAllScenes, StoreScene, RecallScene, GetSceneMembership, CopyScene — each sent to the TH and each proved from the TH's own log.

## Preconditions

Scenes are addressed by group, so these are the ones TC-G-3.2 already needs: write the plan's key set, bind G₁ to it in `GroupKeyMap`, clear the TH's groups, add G₁. `AddGroup`'s own answer is what proves the binding took — a group the fabric's key map does not name is refused. `EpochKey2`/`EpochStartTime2` go as null, as the plan asks.

The plan's literal `EpochStartTime` values can't be sent for the reason already documented for TC-G-3.2: matter.js reads an `epoch-us` as a Unix timestamp and refuses one already offset to the Matter epoch. Only their order matters here.

## What this adds over the earlier two

- **A response's payload status is a claim separate from the invoke resolving.** Every command here but `RecallScene` answers with a status inside its payload, so a command the cluster refused still resolves. The two helpers that check this moved into `tc-support.ts`, this being the second TC to need them; a command whose schema mandates a status and answers without one now fails rather than skipping the check.
- **The cluster's own PICS key needs declaring, not just its commands.** CHIP's file answers `S.C=0` as well as `S.C.C0x.Tx=0`, and an undeclared cluster key leaves the *whole test* pending rather than skipping one step — quieter than the per-command case.
- **Two fields carry no log assertion, and the steps say so.** `AddScene`'s `ExtensionFieldSetStructs` is a list and `CopyScene`'s `Mode` is a bitmap; both render across lines or as named bits, while the field check matches one line per field. The surrounding scalars carry the evidence.

## Verification

All four matrix legs green (matter.js and chip-tool controllers × matter.js and chip-local devices), `cert-framework` 818/818, all 22 cert TCs, full `npm test`, build, format-verify, lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
