### PR TITLE
fix(protocol): a device that answers commissioning with unreadable certificate data gets a real error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,14 @@ The main work (all changes without a GitHub username in brackets in the below li
 - @matter/protocol
     - Enhancement: An interaction can be abandoned by the caller: `ClientRequest.abort` takes an `AbortSignal`, honored for read, write, invoke and subscribe
     - Fix: A device that returns an empty or malformed DAC, PAI, attestation elements or Certification Declaration during commissioning now fails attestation with a finding that names the unreadable field, instead of an opaque decoder message
-    - Fix: A certificate extension matter.js does not interpret is no longer decoded, so a proprietary extension can no longer fail the whole certificate
+    - Fix: A certificate extension matter.js does not interpret is no longer decoded, so a proprietary extension can no longer fail the whole certificate; an extension matter.js does read is rejected with a `CertificateError` when its value is missing
 
 - @project-chip/matter.js
     - Enhancement: `InteractionClient`'s read, write, invoke and subscribe options take an `abort` signal, forwarded to the interaction
 
 - @matter/general
-    - Breaking: `DataReader` throws `DataReadError` when a read would pass the end of the buffer; `readByteArray` and `readUtf8String` no longer return short data
-    - Fix: `DerCodec.decode` reports truncated input as `DerError` instead of a `RangeError`, and rejects a long-form length that overflows instead of reading a negative length
+    - Fix: `DataReader` throws `DataReadError` when a read would pass the end of the buffer; `readByteArray` and `readUtf8String` no longer return short data
+    - Fix: `DerCodec.decode` reports truncated input as `DerError` instead of a `RangeError`, and rejects a length that overflows or uses the indefinite-length encoding instead of decoding a value as present and empty
     - Fix: One unreadable record in an mDNS message no longer discards the whole message
     - Enhancement: `Transaction.lock()` takes an exclusive lock on resources without a promise where they are free, and waits instead of throwing where another transaction holds them
     - Breaking: `DnssdNames.Context.goodbyeProtectionWindow` and `DnssdNames.defaults.goodbyeProtectionWindow` are now `evictionDelay`, and `DnssdName.deleteRecord` no longer takes an `ifOlderThan` argument

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,16 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/protocol
     - Enhancement: An interaction can be abandoned by the caller: `ClientRequest.abort` takes an `AbortSignal`, honored for read, write, invoke and subscribe
+    - Fix: A device that returns an empty or malformed DAC, PAI, attestation elements or Certification Declaration during commissioning now fails attestation with a finding that names the unreadable field, instead of an opaque decoder message
+    - Fix: A certificate extension matter.js does not interpret is no longer decoded, so a proprietary extension can no longer fail the whole certificate
 
 - @project-chip/matter.js
     - Enhancement: `InteractionClient`'s read, write, invoke and subscribe options take an `abort` signal, forwarded to the interaction
 
 - @matter/general
+    - Breaking: `DataReader` throws `DataReadError` when a read would pass the end of the buffer; `readByteArray` and `readUtf8String` no longer return short data
+    - Fix: `DerCodec.decode` reports truncated input as `DerError` instead of a `RangeError`, and rejects a long-form length that overflows instead of reading a negative length
+    - Fix: One unreadable record in an mDNS message no longer discards the whole message
     - Enhancement: `Transaction.lock()` takes an exclusive lock on resources without a promise where they are free, and waits instead of throwing where another transaction holds them
     - Breaking: `DnssdNames.Context.goodbyeProtectionWindow` and `DnssdNames.defaults.goodbyeProtectionWindow` are now `evictionDelay`, and `DnssdName.deleteRecord` no longer takes an `ifOlderThan` argument
     - Enhancement: New `MatterAggregateError.settleSeries()` runs tasks in order, continuing past a failure, and reports the accumulated errors

--- a/packages/general/src/codec/DerCodec.ts
+++ b/packages/general/src/codec/DerCodec.ts
@@ -6,11 +6,14 @@
 
 import { UnexpectedDataError } from "../MatterError.js";
 import { Bytes } from "../util/Bytes.js";
-import { DataReader } from "../util/DataReader.js";
+import { DataReader, DataReadError } from "../util/DataReader.js";
 import { toHex } from "../util/Number.js";
 import { isObject } from "../util/Type.js";
 
 export class DerError extends UnexpectedDataError {}
+
+/** Longest DER long-form length we accept, keeping the decoded length a safe integer. */
+const MAX_LENGTH_BYTES = 6;
 
 export enum DerType {
     Boolean = 0x01,
@@ -271,7 +274,14 @@ export class DerCodec {
     }
 
     static decode(data: Bytes): DerNode {
-        return this.#decodeRec(new DataReader(data));
+        try {
+            return this.#decodeRec(new DataReader(data));
+        } catch (cause) {
+            if (cause instanceof DataReadError) {
+                throw new DerError(`DER data is truncated: ${cause.message}`, { cause });
+            }
+            throw cause;
+        }
     }
 
     /**
@@ -438,9 +448,12 @@ export class DerCodec {
         let length = reader.readUInt8();
         if ((length & 0x80) !== 0) {
             let lengthLength = length & 0x7f;
+            if (lengthLength > MAX_LENGTH_BYTES) {
+                throw new DerError(`DER length of ${lengthLength} bytes exceeds the ${MAX_LENGTH_BYTES} byte maximum`);
+            }
             length = 0;
             while (lengthLength > 0) {
-                length = (length << 8) + reader.readUInt8();
+                length = length * 0x100 + reader.readUInt8();
                 lengthLength--;
             }
         }

--- a/packages/general/src/codec/DerCodec.ts
+++ b/packages/general/src/codec/DerCodec.ts
@@ -448,6 +448,9 @@ export class DerCodec {
         let length = reader.readUInt8();
         if ((length & 0x80) !== 0) {
             let lengthLength = length & 0x7f;
+            if (lengthLength === 0) {
+                throw new DerError("DER forbids the indefinite-length encoding");
+            }
             if (lengthLength > MAX_LENGTH_BYTES) {
                 throw new DerError(`DER length of ${lengthLength} bytes exceeds the ${MAX_LENGTH_BYTES} byte maximum`);
             }

--- a/packages/general/src/codec/DerCodec.ts
+++ b/packages/general/src/codec/DerCodec.ts
@@ -277,10 +277,8 @@ export class DerCodec {
         try {
             return this.#decodeRec(new DataReader(data));
         } catch (cause) {
-            if (cause instanceof DataReadError) {
-                throw new DerError(`DER data is truncated: ${cause.message}`, { cause });
-            }
-            throw cause;
+            DataReadError.accept(cause);
+            throw new DerError(`DER data is truncated: ${cause.message}`, { cause });
         }
     }
 

--- a/packages/general/src/codec/DnsCodec.ts
+++ b/packages/general/src/codec/DnsCodec.ts
@@ -11,7 +11,7 @@ import { Seconds } from "#time/TimeUnit.js";
 import { isObject } from "#util/index.js";
 import { InternalError, NotImplementedError, UnexpectedDataError } from "../MatterError.js";
 import { Bytes, Endian } from "../util/Bytes.js";
-import { DataReader, DataReadError } from "../util/DataReader.js";
+import { DataReader } from "../util/DataReader.js";
 import { DataWriter } from "../util/DataWriter.js";
 import { ipv4BytesToString, ipv4ToBytes, ipv6BytesToString, ipv6ToBytes, isIPv4, isIPv6 } from "../util/Ip.js";
 
@@ -277,7 +277,7 @@ export class DnsCodec {
         try {
             value = this.decodeRecordValue(valueBytes, recordType, message);
         } catch (error) {
-            if (!(error instanceof DataReadError)) {
+            if (!(error instanceof UnexpectedDataError)) {
                 throw error;
             }
             return undefined;

--- a/packages/general/src/codec/DnsCodec.ts
+++ b/packages/general/src/codec/DnsCodec.ts
@@ -277,9 +277,7 @@ export class DnsCodec {
         try {
             value = this.decodeRecordValue(valueBytes, recordType, message);
         } catch (error) {
-            if (!(error instanceof UnexpectedDataError)) {
-                throw error;
-            }
+            UnexpectedDataError.accept(error);
             return undefined;
         }
 

--- a/packages/general/src/codec/DnsCodec.ts
+++ b/packages/general/src/codec/DnsCodec.ts
@@ -11,7 +11,7 @@ import { Seconds } from "#time/TimeUnit.js";
 import { isObject } from "#util/index.js";
 import { InternalError, NotImplementedError, UnexpectedDataError } from "../MatterError.js";
 import { Bytes, Endian } from "../util/Bytes.js";
-import { DataReader } from "../util/DataReader.js";
+import { DataReader, DataReadError } from "../util/DataReader.js";
 import { DataWriter } from "../util/DataWriter.js";
 import { ipv4BytesToString, ipv4ToBytes, ipv6BytesToString, ipv6ToBytes, isIPv4, isIPv6 } from "../util/Ip.js";
 
@@ -271,7 +271,17 @@ export class DnsCodec {
         const ttl = Seconds(reader.readUInt32());
         const valueLength = reader.readUInt16();
         const valueBytes = reader.readByteArray(valueLength);
-        const value = this.decodeRecordValue(valueBytes, recordType, message);
+
+        // The reader already stands after this record, so a record we cannot read costs only itself
+        let value: unknown;
+        try {
+            value = this.decodeRecordValue(valueBytes, recordType, message);
+        } catch (error) {
+            if (!(error instanceof DataReadError)) {
+                throw error;
+            }
+            return undefined;
+        }
 
         // Validate that the record has required fields
         if (recordType === undefined || value === undefined) {

--- a/packages/general/src/util/DataReader.ts
+++ b/packages/general/src/util/DataReader.ts
@@ -98,7 +98,7 @@ export class DataReader<E extends Endian = Endian.Big> {
 
     private getOffsetAndAdvance(size: number) {
         if (!Number.isInteger(size) || size < 0) {
-            throw new DataReadError(`Read size ${size} is not a non-negative integer`);
+            throw new DataReadError(`Read size ${size} must be zero or more whole bytes`);
         }
         const result = this.#offset;
         const end = result + size;

--- a/packages/general/src/util/DataReader.ts
+++ b/packages/general/src/util/DataReader.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { UnexpectedDataError } from "../MatterError.js";
 import { Bytes, Endian } from "./Bytes.js";
+
+/** Thrown when a read would extend past the end of the underlying buffer. */
+export class DataReadError extends UnexpectedDataError {}
 
 /** Reader that auto-increments its offset after each read. */
 export class DataReader<E extends Endian = Endian.Big> {
@@ -82,8 +86,8 @@ export class DataReader<E extends Endian = Endian.Big> {
     }
 
     set offset(offset: number) {
-        if (offset > this.#dataView.byteLength) {
-            throw new Error(`Offset ${offset} is out of bounds.`);
+        if (!Number.isInteger(offset) || offset < 0 || offset > this.#dataView.byteLength) {
+            throw new DataReadError(`Offset ${offset} is out of bounds.`);
         }
         this.#offset = offset;
     }
@@ -93,11 +97,17 @@ export class DataReader<E extends Endian = Endian.Big> {
     }
 
     private getOffsetAndAdvance(size: number) {
-        const result = this.#offset;
-        this.#offset += size;
-        if (this.#offset > this.#dataView.byteLength) {
-            this.#offset = this.#dataView.byteLength;
+        if (!Number.isInteger(size) || size < 0) {
+            throw new DataReadError(`Read size ${size} is not a non-negative integer`);
         }
+        const result = this.#offset;
+        const end = result + size;
+        if (end > this.#dataView.byteLength) {
+            throw new DataReadError(
+                `Read of ${size} bytes at offset ${result} exceeds the ${this.#dataView.byteLength} byte buffer`,
+            );
+        }
+        this.#offset = end;
         return result;
     }
 }

--- a/packages/general/test/codec/DerCodecTest.ts
+++ b/packages/general/test/codec/DerCodecTest.ts
@@ -114,6 +114,11 @@ describe("DerCodec", () => {
             expect(() => DerCodec.decode(b$`048480000000`)).throws(DerError, /DER data is truncated/);
         });
 
+        it("rejects the indefinite-length encoding", () => {
+            // OCTET STRING with the BER indefinite-length marker, which DER forbids
+            expect(() => DerCodec.decode(b$`0480ffff`)).throws(DerError, /indefinite-length/);
+        });
+
         it("rejects a long-form length longer than a safe integer", () => {
             // OCTET STRING with a 7-byte length
             expect(() => DerCodec.decode(b$`0487ffffffffffffff`)).throws(DerError, /exceeds the 6 byte maximum/);

--- a/packages/general/test/codec/DerCodecTest.ts
+++ b/packages/general/test/codec/DerCodecTest.ts
@@ -4,7 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ContextTagged, DatatypeOverride, DerBitString, DerCodec, DerRawUint, DerType } from "#codec/DerCodec.js";
+import {
+    ContextTagged,
+    DatatypeOverride,
+    DerBitString,
+    DerCodec,
+    DerError,
+    DerRawUint,
+    DerType,
+} from "#codec/DerCodec.js";
 import { X520 } from "#crypto/X520.js";
 import { X962 } from "#index.js";
 
@@ -88,6 +96,32 @@ describe("DerCodec", () => {
             expectHex(DerCodec.encode(DerRawUint(b$`0001`)), "020101");
             expectHex(DerCodec.encode(DerRawUint(b$`80`)), "02020080");
             expectHex(DerCodec.encode(DerRawUint(b$`0080`)), "02020080");
+        });
+    });
+
+    describe("decode", () => {
+        it("rejects empty data", () => {
+            expect(() => DerCodec.decode(new Uint8Array(0))).throws(DerError, /DER data is truncated/);
+        });
+
+        it("rejects data whose declared length exceeds the buffer", () => {
+            // SEQUENCE claiming 16 content bytes with only 2 present
+            expect(() => DerCodec.decode(b$`301000ff`)).throws(DerError, /DER data is truncated/);
+        });
+
+        it("rejects a long-form length whose high bit would make it negative", () => {
+            // OCTET STRING with a 4-byte length of 0x80000000
+            expect(() => DerCodec.decode(b$`048480000000`)).throws(DerError, /DER data is truncated/);
+        });
+
+        it("rejects a long-form length longer than a safe integer", () => {
+            // OCTET STRING with a 7-byte length
+            expect(() => DerCodec.decode(b$`0487ffffffffffffff`)).throws(DerError, /exceeds the 6 byte maximum/);
+        });
+
+        it("rejects a truncated nested element", () => {
+            // SEQUENCE of 2 bytes containing an INTEGER claiming 8 content bytes
+            expect(() => DerCodec.decode(b$`30020208`)).throws(DerError, /DER data is truncated/);
         });
     });
 });

--- a/packages/general/test/codec/DnsCodecTest.ts
+++ b/packages/general/test/codec/DnsCodecTest.ts
@@ -253,6 +253,30 @@ describe("DnsCodec", () => {
             expect(result?.answers[0].value).equal("192.168.1.1");
         });
 
+        it("keeps the readable records of a message whose record value has a bad name pointer", () => {
+            // A PTR record whose RDATA is a compression pointer past the end of the message, then a valid A record
+            const message = Bytes.fromHex(
+                "000084000000000200000000" +
+                    "0162056c6f63616c00" +
+                    "000c" +
+                    "0001" +
+                    "0000003c" +
+                    "0002" +
+                    "c0ff" +
+                    "0161056c6f63616c00" +
+                    "0001" +
+                    "0001" +
+                    "0000003c" +
+                    "0004" +
+                    "c0a80101",
+            );
+
+            const result = DnsCodec.decode(message);
+
+            expect(result?.answers).to.have.length(1);
+            expect(result?.answers[0].name).equal("a.local");
+        });
+
         it("decodes message with private record type", () => {
             const result = DnsCodec.decode(RESULT_WITH_PRIVATE_TYPE);
 

--- a/packages/general/test/codec/DnsCodecTest.ts
+++ b/packages/general/test/codec/DnsCodecTest.ts
@@ -228,6 +228,31 @@ describe("DnsCodec", () => {
             // that we do not support right now on encoding side
         });
 
+        it("keeps the readable records of a message that holds an unreadable one", () => {
+            // Two answers: a TXT record whose string length overruns its RDATA, then a valid A record
+            const message = Bytes.fromHex(
+                "000084000000000200000000" +
+                    "0162056c6f63616c00" +
+                    "0010" +
+                    "0001" +
+                    "0000003c" +
+                    "0003" +
+                    "054142" +
+                    "0161056c6f63616c00" +
+                    "0001" +
+                    "0001" +
+                    "0000003c" +
+                    "0004" +
+                    "c0a80101",
+            );
+
+            const result = DnsCodec.decode(message);
+
+            expect(result?.answers).to.have.length(1);
+            expect(result?.answers[0].name).equal("a.local");
+            expect(result?.answers[0].value).equal("192.168.1.1");
+        });
+
         it("decodes message with private record type", () => {
             const result = DnsCodec.decode(RESULT_WITH_PRIVATE_TYPE);
 

--- a/packages/general/test/util/DataReaderTest.ts
+++ b/packages/general/test/util/DataReaderTest.ts
@@ -412,7 +412,10 @@ describe("DataReader", () => {
         it("rejects a negative read size", () => {
             const reader = new DataReader(new Uint8Array([0x12, 0x34]));
 
-            expect(() => reader.readByteArray(-1)).throws(DataReadError, "Read size -1 is not a non-negative integer");
+            expect(() => reader.readByteArray(-1)).throws(
+                DataReadError,
+                "Read size -1 must be zero or more whole bytes",
+            );
             expect(reader.offset).equal(0);
         });
 

--- a/packages/general/test/util/DataReaderTest.ts
+++ b/packages/general/test/util/DataReaderTest.ts
@@ -5,7 +5,7 @@
  */
 
 import { Endian } from "#util/Bytes.js";
-import { DataReader } from "#util/DataReader.js";
+import { DataReader, DataReadError } from "#util/DataReader.js";
 
 describe("DataReader", () => {
     describe("constructor", () => {
@@ -357,7 +357,7 @@ describe("DataReader", () => {
 
             expect(() => {
                 reader.offset = 5;
-            }).throws(Error, "Offset 5 is out of bounds");
+            }).throws(DataReadError, "Offset 5 is out of bounds");
         });
 
         it("allows setting to buffer length", () => {
@@ -374,8 +374,71 @@ describe("DataReader", () => {
             const buffer = new Uint8Array([0x12, 0x34]);
             const reader = new DataReader(buffer);
 
-            // Reading past end throws an error
-            expect(() => reader.readUInt32()).throws();
+            expect(() => reader.readUInt32()).throws(
+                DataReadError,
+                "Read of 4 bytes at offset 0 exceeds the 2 byte buffer",
+            );
+        });
+
+        it("throws when a byte array read passes the end", () => {
+            const buffer = new Uint8Array([0x12, 0x34]);
+            const reader = new DataReader(buffer);
+
+            expect(() => reader.readByteArray(3)).throws(
+                DataReadError,
+                "Read of 3 bytes at offset 0 exceeds the 2 byte buffer",
+            );
+        });
+
+        it("throws when a string read passes the end", () => {
+            const buffer = new Uint8Array([0x41, 0x42]);
+            const reader = new DataReader(buffer);
+
+            expect(() => reader.readUtf8String(5)).throws(
+                DataReadError,
+                "Read of 5 bytes at offset 0 exceeds the 2 byte buffer",
+            );
+        });
+
+        it("throws when reading from an empty buffer", () => {
+            const reader = new DataReader(new Uint8Array(0));
+
+            expect(() => reader.readUInt8()).throws(
+                DataReadError,
+                "Read of 1 bytes at offset 0 exceeds the 0 byte buffer",
+            );
+        });
+
+        it("rejects a negative read size", () => {
+            const reader = new DataReader(new Uint8Array([0x12, 0x34]));
+
+            expect(() => reader.readByteArray(-1)).throws(DataReadError, "Read size -1 is not a non-negative integer");
+            expect(reader.offset).equal(0);
+        });
+
+        it("rejects a negative offset", () => {
+            const reader = new DataReader(new Uint8Array([0x12, 0x34]));
+
+            expect(() => {
+                reader.offset = -1;
+            }).throws(DataReadError, "Offset -1 is out of bounds");
+        });
+
+        it("leaves the offset untouched when a read fails", () => {
+            const reader = new DataReader(new Uint8Array([0x12, 0x34]));
+
+            reader.readUInt8();
+            expect(() => reader.readUInt32()).throws(DataReadError);
+            expect(reader.offset).equal(1);
+            expect(reader.remainingBytesCount).equal(1);
+        });
+
+        it("reads exactly to the end", () => {
+            const buffer = new Uint8Array([0x12, 0x34]);
+            const reader = new DataReader(buffer);
+
+            expect(reader.readByteArray(2)).deep.equal(buffer);
+            expect(reader.remainingBytesCount).equal(0);
         });
 
         it("handles reading from empty buffer", () => {

--- a/packages/node/test/node/ClientAttestationTest.ts
+++ b/packages/node/test/node/ClientAttestationTest.ts
@@ -432,7 +432,7 @@ describe("device attestation during commissioning", () => {
                 corruptCachedPaaSkid: TestCert_PAA_NoVID_SKID,
                 blockCachedPaaRefetch: true,
                 onAttestationFailure: false,
-                expectRejection: /Invalid certificate structure/,
+                expectRejection: /DER data is truncated/,
             }));
     });
 

--- a/packages/protocol/src/ble/BtpSessionHandler.ts
+++ b/packages/protocol/src/ble/BtpSessionHandler.ts
@@ -394,7 +394,9 @@ export class BtpSessionHandler {
                 } bytes from Rest of message: ${remainingMessageLength}`,
             );
 
-            const segmentPayload = currentProcessedMessage.readByteArray(this.fragmentSize - btpHeaderLength);
+            const segmentPayload = currentProcessedMessage.readByteArray(
+                Math.min(this.fragmentSize - btpHeaderLength, remainingMessageLength),
+            );
 
             const ackNumberToSend = hasAckNumber ? this.prevIncomingSequenceNumber : undefined;
             const btpPacket = {

--- a/packages/protocol/src/certificate/DeviceAttestationValidator.ts
+++ b/packages/protocol/src/certificate/DeviceAttestationValidator.ts
@@ -283,11 +283,7 @@ export namespace DeviceAttestationValidator {
 
             try {
                 await crypto.verifyEcdsa(
-                    parsePeerValue(
-                        DeviceAttestationCheck.CertificateUnparseable,
-                        "Device returned a PAI whose public key cannot be read",
-                        () => PublicKey(pai.cert.ellipticCurvePublicKey),
-                    ),
+                    PublicKey(pai.cert.ellipticCurvePublicKey),
                     dac.asUnsignedDer(),
                     dac.signature,
                 );

--- a/packages/protocol/src/certificate/DeviceAttestationValidator.ts
+++ b/packages/protocol/src/certificate/DeviceAttestationValidator.ts
@@ -4,7 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, Crypto, Diagnostic, EcdsaSignature, MaybePromise, PublicKey } from "@matter/general";
+import {
+    asError,
+    Bytes,
+    Crypto,
+    Diagnostic,
+    EcdsaSignature,
+    ImplementationError,
+    InternalError,
+    MaybePromise,
+    PublicKey,
+} from "@matter/general";
 import { MATTER_EPOCH_OFFSET_S, VendorId } from "@matter/types";
 import { TlvAttestation } from "../common/OperationalCredentialsTypes.js";
 import { DclCertificateService } from "../dcl/DclCertificateService.js";
@@ -28,6 +38,9 @@ export enum DeviceAttestationCheck {
     CertificationTypeProvisional = "CertificationTypeProvisional",
     CertificationTypeTest = "CertificationTypeTest",
     CertificateIdNotVerified = "CertificateIdNotVerified",
+    CertificateUnparseable = "CertificateUnparseable",
+    AttestationElementsUnparseable = "AttestationElementsUnparseable",
+    CertificationDeclarationUnparseable = "CertificationDeclarationUnparseable",
     CdSignerVerificationSkipped = "CdSignerVerificationSkipped",
     PaaTrustStoreTimeMismatch = "PaaTrustStoreTimeMismatch",
     DclServiceUnavailable = "DclServiceUnavailable",
@@ -54,9 +67,41 @@ export class DeviceAttestationError extends CommissioningError {
     constructor(
         readonly failure: DeviceAttestationCheck,
         message: string,
+        options?: ErrorOptions,
     ) {
-        super(message);
+        super(message, options);
     }
+}
+
+/**
+ * Decode a value the peer supplied, reporting malformed input as an attestation failure rather than letting a decoder
+ * error escape.
+ */
+function parsePeerValue<T>(check: DeviceAttestationCheck, description: string, parse: () => T): T {
+    try {
+        return parse();
+    } catch (cause) {
+        // A defect of ours is not the peer's malformed data and must not be reported as such
+        if (cause instanceof InternalError || cause instanceof ImplementationError) {
+            throw cause;
+        }
+        throw new DeviceAttestationError(check, `${description}: ${asError(cause).message}`, { cause });
+    }
+}
+
+/** Parse an attestation certificate the peer supplied, rejecting a missing certificate before the decoder sees it. */
+function parsePeerCertificate<T>(kind: string, der: Bytes, parse: (der: Bytes) => T): T {
+    if (Bytes.of(der).byteLength === 0) {
+        throw new DeviceAttestationError(
+            DeviceAttestationCheck.CertificateUnparseable,
+            `Device returned an empty ${kind} certificate`,
+        );
+    }
+    return parsePeerValue(
+        DeviceAttestationCheck.CertificateUnparseable,
+        `Device returned a ${kind} certificate that cannot be parsed`,
+        () => parse(der),
+    );
 }
 
 function idHex(id?: number) {
@@ -126,8 +171,8 @@ export namespace DeviceAttestationValidator {
         const findings = new Array<AttestationFinding>();
 
         // Step 1: Parse DAC and PAI from DER
-        const dac = Dac.fromAsn1(data.dac);
-        const pai = Pai.fromAsn1(data.pai);
+        const dac = parsePeerCertificate("DAC", data.dac, der => Dac.fromAsn1(der));
+        const pai = parsePeerCertificate("PAI", data.pai, der => Pai.fromAsn1(der));
 
         // === Local checks (always run, no DCL needed) ===
 
@@ -140,7 +185,11 @@ export namespace DeviceAttestationValidator {
         }
 
         // Step 6: AttestationNonce match
-        const attestationInfo = TlvAttestation.decode(data.attestationElements);
+        const attestationInfo = parsePeerValue(
+            DeviceAttestationCheck.AttestationElementsUnparseable,
+            "Device returned attestation elements that cannot be decoded",
+            () => TlvAttestation.decode(data.attestationElements),
+        );
         if (!Bytes.areEqual(attestationInfo.attestationNonce, data.attestationNonce)) {
             throw new DeviceAttestationError(
                 DeviceAttestationCheck.AttestationNonceMismatch,
@@ -305,7 +354,11 @@ export namespace DeviceAttestationValidator {
         // === Remaining local checks (CD validation) ===
 
         // Step 8: Certification Declaration signature verification
-        const cd = CertificationDeclaration.parse(attestationInfo.declaration);
+        const cd = parsePeerValue(
+            DeviceAttestationCheck.CertificationDeclarationUnparseable,
+            "Device returned a Certification Declaration that cannot be parsed",
+            () => CertificationDeclaration.parse(attestationInfo.declaration),
+        );
         const cdSignerSkidHex = Bytes.toHex(cd.signerSubjectKeyId);
 
         if (dclCertificateService !== undefined) {

--- a/packages/protocol/src/certificate/DeviceAttestationValidator.ts
+++ b/packages/protocol/src/certificate/DeviceAttestationValidator.ts
@@ -198,7 +198,11 @@ export namespace DeviceAttestationValidator {
         }
 
         // Step 7: Attestation Signature verification
-        const dacPublicKey = PublicKey(dac.cert.ellipticCurvePublicKey);
+        const dacPublicKey = parsePeerValue(
+            DeviceAttestationCheck.CertificateUnparseable,
+            "Device returned a DAC whose public key cannot be read",
+            () => PublicKey(dac.cert.ellipticCurvePublicKey),
+        );
         try {
             await crypto.verifyEcdsa(
                 dacPublicKey,
@@ -279,7 +283,11 @@ export namespace DeviceAttestationValidator {
 
             try {
                 await crypto.verifyEcdsa(
-                    PublicKey(pai.cert.ellipticCurvePublicKey),
+                    parsePeerValue(
+                        DeviceAttestationCheck.CertificateUnparseable,
+                        "Device returned a PAI whose public key cannot be read",
+                        () => PublicKey(pai.cert.ellipticCurvePublicKey),
+                    ),
                     dac.asUnsignedDer(),
                     dac.signature,
                 );

--- a/packages/protocol/src/certificate/DeviceAttestationValidator.ts
+++ b/packages/protocol/src/certificate/DeviceAttestationValidator.ts
@@ -281,12 +281,15 @@ export namespace DeviceAttestationValidator {
                 );
             }
 
+            // Reading the key inside the try below would relabel its failure as a chain failure
+            const paiPublicKey = parsePeerValue(
+                DeviceAttestationCheck.CertificateUnparseable,
+                "Device returned a PAI whose public key cannot be read",
+                () => PublicKey(pai.cert.ellipticCurvePublicKey),
+            );
+
             try {
-                await crypto.verifyEcdsa(
-                    PublicKey(pai.cert.ellipticCurvePublicKey),
-                    dac.asUnsignedDer(),
-                    dac.signature,
-                );
+                await crypto.verifyEcdsa(paiPublicKey, dac.asUnsignedDer(), dac.signature);
             } catch (error) {
                 throw new DeviceAttestationError(
                     DeviceAttestationCheck.CertificateChainInvalid,

--- a/packages/protocol/src/certificate/kinds/Certificate.ts
+++ b/packages/protocol/src/certificate/kinds/Certificate.ts
@@ -370,7 +370,12 @@ export namespace Certificate {
                     continue;
             }
 
-            const valueNode = DerCodec.decode(extElements[valueIndex]._bytes);
+            const value = extElements[valueIndex];
+            if (value === undefined || value._tag !== DerType.OctetString) {
+                throw new CertificateError(`Extension ${oidValue} is missing its value octet string`);
+            }
+
+            const valueNode = DerCodec.decode(value._bytes);
 
             switch (oidValue) {
                 case X509.Extensions.BASIC_CONSTRAINTS:

--- a/packages/protocol/src/certificate/kinds/Certificate.ts
+++ b/packages/protocol/src/certificate/kinds/Certificate.ts
@@ -357,8 +357,20 @@ export namespace Certificate {
                 valueIndex = 2; // Skip critical flag
             }
 
-            const valueOctetString = extElements[valueIndex]._bytes;
-            const valueNode = DerCodec.decode(valueOctetString);
+            switch (oidValue) {
+                case X509.Extensions.BASIC_CONSTRAINTS:
+                case X509.Extensions.KEY_USAGE:
+                case X509.Extensions.EXTENDED_KEY_USAGE:
+                case X509.Extensions.SUBJECT_KEY_IDENTIFIER:
+                case X509.Extensions.AUTHORITY_KEY_IDENTIFIER:
+                    break;
+
+                // An extension we do not interpret may carry any encoding, so its value never reaches the decoder
+                default:
+                    continue;
+            }
+
+            const valueNode = DerCodec.decode(extElements[valueIndex]._bytes);
 
             switch (oidValue) {
                 case X509.Extensions.BASIC_CONSTRAINTS:

--- a/packages/protocol/src/peer/ControllerCommissioningFlow.ts
+++ b/packages/protocol/src/peer/ControllerCommissioningFlow.ts
@@ -1259,6 +1259,7 @@ export class ControllerCommissioningFlow {
 
         let findings: AttestationFinding[];
         let baseError: Error | undefined;
+        let dacPublicKey: ReturnType<typeof PublicKey> | undefined;
         try {
             const result = await DeviceAttestationValidator.validate(
                 {
@@ -1277,6 +1278,7 @@ export class ControllerCommissioningFlow {
                 },
             );
             findings = result.findings;
+            dacPublicKey = result.dacPublicKey;
         } catch (error) {
             // A cancellation (e.g. shutdown/close while the DCL service is consulted) must propagate
             // cleanly rather than be downgraded to an attestation finding.
@@ -1312,8 +1314,18 @@ export class ControllerCommissioningFlow {
             logger.info("Device attestation successfully verified");
         }
 
-        // Extract DAC public key for CSR signature verification in #certificates()
-        this.#dacPublicKey = PublicKey(Dac.fromAsn1(deviceAttestation).cert.ellipticCurvePublicKey);
+        if (dacPublicKey === undefined) {
+            // Attestation failed but policy accepted it, so the key the validator would have returned is missing
+            try {
+                dacPublicKey = PublicKey(Dac.fromAsn1(deviceAttestation).cert.ellipticCurvePublicKey);
+            } catch (cause) {
+                throw new CommissioningError(
+                    "Device attestation was accepted but the DAC cannot be parsed, so the CSR signature cannot be verified",
+                    { cause },
+                );
+            }
+        }
+        this.#dacPublicKey = dacPublicKey;
 
         return {
             code: CommissioningStepResultCode.Success,

--- a/packages/protocol/test/certificate/CertificatesTest.ts
+++ b/packages/protocol/test/certificate/CertificatesTest.ts
@@ -262,6 +262,21 @@ describe("Certificates", () => {
             return reencode(cert);
         }
 
+        it("rejects a certificate whose recognized extension has no value octet string", () => {
+            // basicConstraints (2.5.29.19) marked critical but carrying no value
+            const valuelessExtension = DerCodec.decode(
+                DerCodec.encode({
+                    oid: { _tag: DerType.ObjectIdentifier as number, _bytes: Bytes.fromHex("551d13") },
+                    critical: { _tag: DerType.Boolean as number, _bytes: Bytes.fromHex("ff") },
+                }),
+            );
+
+            expect(() => Rcac.fromAsn1(withExtension(EXTERNAL_TEST_CERTIFICATES.RCAC_ASN1, valuelessExtension))).throws(
+                CertificateError,
+                /missing its value octet string/,
+            );
+        });
+
         it("parses a certificate whose unrecognized extension holds bytes that are not DER", () => {
             // OID 2.5.29.99 is not one we read, and 0xff is not a valid DER tag
             const opaqueExtension = DerCodec.decode(

--- a/packages/protocol/test/certificate/CertificatesTest.ts
+++ b/packages/protocol/test/certificate/CertificatesTest.ts
@@ -23,6 +23,7 @@ import {
     DerCodec,
     DerNode,
     DerTag,
+    DerType,
     EcdsaSignature,
     PrivateKey,
     PublicKey,
@@ -232,6 +233,48 @@ describe("Certificates", () => {
             await rcac.verify(crypto);
             await icac.verify(crypto, rcac);
             await noc.verify(crypto, rcac, icac);
+        });
+    });
+
+    describe("extensions we do not interpret", () => {
+        /** Re-encode a decoded node tree, so a spliced-in extension gets correct container lengths. */
+        function reencode(node: DerNode): Bytes {
+            if (node._elements === undefined) {
+                const bytes =
+                    node._tag === DerType.BitString
+                        ? Bytes.concat(Uint8Array.of(node._padding ?? 0), node._bytes)
+                        : node._bytes;
+                return DerCodec.encode({ _tag: node._tag, _bytes: bytes });
+            }
+            return DerCodec.encode({
+                _tag: node._tag,
+                _bytes: Bytes.concat(...node._elements.map(reencode)),
+            });
+        }
+
+        /** Append `extension` to the certificate's extension list. */
+        function withExtension(asn1: Bytes, extension: DerNode) {
+            const cert = DerCodec.decode(asn1);
+            const tbs = cert._elements![0];
+            // Extensions sit in the certificate's [3] EXPLICIT constructed tag
+            const extensionsTag = tbs._elements!.find(element => element._tag === 0xa3)!;
+            extensionsTag._elements![0]._elements!.push(extension);
+            return reencode(cert);
+        }
+
+        it("parses a certificate whose unrecognized extension holds bytes that are not DER", () => {
+            // OID 2.5.29.99 is not one we read, and 0xff is not a valid DER tag
+            const opaqueExtension = DerCodec.decode(
+                DerCodec.encode({
+                    oid: { _tag: DerType.ObjectIdentifier as number, _bytes: Bytes.fromHex("551d63") },
+                    value: { _tag: DerType.OctetString as number, _bytes: Bytes.fromHex("ffffff") },
+                }),
+            );
+
+            const rcac = Rcac.fromAsn1(withExtension(EXTERNAL_TEST_CERTIFICATES.RCAC_ASN1, opaqueExtension));
+
+            expect(rcac.cert.subject.rcacId).to.not.be.undefined;
+            expect(rcac.cert.extensions.basicConstraints.isCa).to.be.true;
         });
     });
 

--- a/packages/protocol/test/certificate/DeviceAttestationValidatorTest.ts
+++ b/packages/protocol/test/certificate/DeviceAttestationValidatorTest.ts
@@ -184,6 +184,19 @@ describe("DeviceAttestationValidator", () => {
             ).to.be.rejectedWith(DeviceAttestationError, /Device returned an empty DAC certificate/);
         });
 
+        it("throws CertificateUnparseable when the DAC parses but its public key does not", async () => {
+            const dclService = await setupDclService();
+
+            // Flip the uncompressed-point marker of the DAC's public key, leaving every DER length intact
+            const brokenKeyDac = Bytes.of(dacDer).slice();
+            const marker = Bytes.toHex(brokenKeyDac).indexOf("03420004") / 2 + 3;
+            brokenKeyDac[marker] = 0x05;
+
+            await expect(
+                DeviceAttestationValidator.validate(buildContext(dclService), buildData({ dac: brokenKeyDac })),
+            ).to.be.rejectedWith(DeviceAttestationError, /DAC whose public key cannot be read/);
+        });
+
         it("throws CertificateUnparseable when the device returns a truncated PAI", async () => {
             const dclService = await setupDclService();
 

--- a/packages/protocol/test/certificate/DeviceAttestationValidatorTest.ts
+++ b/packages/protocol/test/certificate/DeviceAttestationValidatorTest.ts
@@ -167,6 +167,65 @@ describe("DeviceAttestationValidator", () => {
         });
     });
 
+    describe("malformed peer certificates", () => {
+        it("throws CertificateUnparseable when the device returns an empty PAI", async () => {
+            const dclService = await setupDclService();
+
+            await expect(
+                DeviceAttestationValidator.validate(buildContext(dclService), buildData({ pai: new Uint8Array(0) })),
+            ).to.be.rejectedWith(DeviceAttestationError, /Device returned an empty PAI certificate/);
+        });
+
+        it("throws CertificateUnparseable when the device returns an empty DAC", async () => {
+            const dclService = await setupDclService();
+
+            await expect(
+                DeviceAttestationValidator.validate(buildContext(dclService), buildData({ dac: new Uint8Array(0) })),
+            ).to.be.rejectedWith(DeviceAttestationError, /Device returned an empty DAC certificate/);
+        });
+
+        it("throws CertificateUnparseable when the device returns a truncated PAI", async () => {
+            const dclService = await setupDclService();
+
+            const truncatedPai = Bytes.of(paiDer).slice(0, 20);
+
+            let error: DeviceAttestationError | undefined;
+            try {
+                await DeviceAttestationValidator.validate(buildContext(dclService), buildData({ pai: truncatedPai }));
+            } catch (caught) {
+                error = caught as DeviceAttestationError;
+            }
+
+            expect(error).instanceOf(DeviceAttestationError);
+            expect(error!.failure).equal(DeviceAttestationCheck.CertificateUnparseable);
+            expect(error!.message).match(/PAI certificate that cannot be parsed/);
+        });
+    });
+
+    describe("malformed attestation elements", () => {
+        it("throws AttestationElementsUnparseable when the elements are not valid TLV", async () => {
+            const dclService = await setupDclService();
+
+            await expect(
+                DeviceAttestationValidator.validate(
+                    buildContext(dclService),
+                    buildData({ attestationElements: Bytes.fromHex("15300102") }),
+                ),
+            ).to.be.rejectedWith(DeviceAttestationError, /attestation elements that cannot be decoded/);
+        });
+
+        it("throws CertificationDeclarationUnparseable when the CD field holds something else", async () => {
+            const dclService = await setupDclService();
+
+            // A device that answers with a leaked buffer in place of the Certification Declaration
+            const attestation = await buildAttestationWithCd(Bytes.fromHex("6c6f63616c686f73743a3131333131"));
+
+            await expect(
+                DeviceAttestationValidator.validate(buildContext(dclService), buildData(attestation)),
+            ).to.be.rejectedWith(DeviceAttestationError, /Certification Declaration that cannot be parsed/);
+        });
+    });
+
     describe("PAA trust store", () => {
         it("throws PaaNotTrusted when PAA is not in trust store", async () => {
             // Set up service with empty trust store

--- a/packages/protocol/test/certificate/DeviceAttestationValidatorTest.ts
+++ b/packages/protocol/test/certificate/DeviceAttestationValidatorTest.ts
@@ -5,7 +5,11 @@
  */
 
 import { AttestationCertificateManager } from "#certificate/AttestationCertificateManager.js";
-import { TestCert_PAA_NoVID_Cert } from "#certificate/ChipPAAuthorities.js";
+import {
+    TestCert_PAA_NoVID_Cert,
+    TestCert_PAA_NoVID_PrivateKey,
+    TestCert_PAA_NoVID_PublicKey,
+} from "#certificate/ChipPAAuthorities.js";
 import {
     DeviceAttestationCheck,
     DeviceAttestationError,
@@ -195,6 +199,45 @@ describe("DeviceAttestationValidator", () => {
             await expect(
                 DeviceAttestationValidator.validate(buildContext(dclService), buildData({ dac: brokenKeyDac })),
             ).to.be.rejectedWith(DeviceAttestationError, /DAC whose public key cannot be read/);
+        });
+
+        it("throws CertificateUnparseable when the PAI is signed but its public key is unreadable", async () => {
+            const dclService = await setupDclService();
+
+            // The PAA must vouch for the broken key, or PAI signature verification rejects it first
+            const source = Pai.fromAsn1(paiDer).cert;
+            const brokenKey = Bytes.of(source.ellipticCurvePublicKey).slice();
+            brokenKey[0] = 0x05;
+            const brokenPai = new Pai({
+                serialNumber: source.serialNumber,
+                signatureAlgorithm: source.signatureAlgorithm,
+                publicKeyAlgorithm: source.publicKeyAlgorithm,
+                ellipticCurveIdentifier: source.ellipticCurveIdentifier,
+                issuer: source.issuer,
+                notBefore: source.notBefore,
+                notAfter: source.notAfter,
+                subject: source.subject,
+                ellipticCurvePublicKey: brokenKey,
+                extensions: source.extensions,
+            });
+            await brokenPai.sign(
+                crypto,
+                PrivateKey(TestCert_PAA_NoVID_PrivateKey, { publicKey: TestCert_PAA_NoVID_PublicKey }),
+            );
+
+            let error: DeviceAttestationError | undefined;
+            try {
+                await DeviceAttestationValidator.validate(
+                    buildContext(dclService),
+                    buildData({ pai: brokenPai.asSignedDer() }),
+                );
+            } catch (caught) {
+                error = caught as DeviceAttestationError;
+            }
+
+            // The check must survive: reading the key inside the verification try relabels it CertificateChainInvalid
+            expect(error?.failure).equal(DeviceAttestationCheck.CertificateUnparseable);
+            expect(error!.message).match(/PAI whose public key cannot be read/);
         });
 
         it("throws CertificateUnparseable when the device returns a truncated PAI", async () => {

--- a/support/chip-testing/src/ChipToolWebSocketHandler.ts
+++ b/support/chip-testing/src/ChipToolWebSocketHandler.ts
@@ -300,8 +300,8 @@ export function parseWritePayload(value: string, what: string): unknown {
  * {@link parseNumber} both raise one, and both run inside a command handler's `try`.
  *
  * The device cannot produce any of those, so reporting them as the failure the device gave lets a step
- * that expects one pass on our bug. `RangeError` is deliberately absent: `DataReader` clamps its offset
- * rather than failing, so a truncated device message reaches `DataView` and raises one.
+ * that expects one pass on our bug. A truncated device message is not one of ours: `DataReader` raises
+ * `DataReadError`, an {@link UnexpectedDataError}.
  *
  * Cause chains are followed, as {@link StatusResponseError.of} and {@link causedBy} do for the two
  * classifications beside this one — a wrapped {@link ImplementationError} is still ours.

--- a/support/chip-testing/test/cert-framework/chip-tool-websocket-handler.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-websocket-handler.test.ts
@@ -4,7 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, ImplementationError, InternalError, NotImplementedError, UnexpectedDataError } from "@matter/main";
+import {
+    Bytes,
+    DataReadError,
+    ImplementationError,
+    InternalError,
+    NotImplementedError,
+    UnexpectedDataError,
+} from "@matter/main";
 import { Status, StatusResponseError } from "@matter/main/types";
 import { Matter } from "@matter/model";
 import { expect } from "chai";
@@ -164,8 +171,8 @@ describe("isOwnFailure", () => {
         expect(isOwnFailure(new UnexpectedDataError("the device answered something else"))).equal(false);
     });
 
-    it("leaves a RangeError alone, which a truncated device message raises through DataReader", () => {
-        expect(isOwnFailure(new RangeError("Offset is outside the bounds of the DataView"))).equal(false);
+    it("leaves the DataReadError a truncated device message raises alone", () => {
+        expect(isOwnFailure(new DataReadError("Read of 4 bytes at offset 0 exceeds the 2 byte buffer"))).equal(false);
     });
 });
 


### PR DESCRIPTION
Two devices fail commissioning against matter.js with the same unhelpful message, `Offset is outside the bounds of the DataView`:

- A **Meross MSS315** answers the request for its PAI certificate — the intermediate certificate above the per-device one — with a `certificate` field that is present but zero bytes long. Its DAC is fine and parses.
- A **Bosch BCRC1W/01** returns a valid DAC and PAI, but the Certification Declaration carried inside its attestation response holds 256 bytes of unrelated memory (an XML-RPC request) instead of a declaration.

Both are firmware faults on the device, and **neither device commissions after this change**. What changes is the report: the log now names the field it could not read instead of showing a crash inside the ASN.1 decoder, so the next person to see this can tell which device is at fault and why. The Meross case now reads `Device returned an empty PAI certificate`.

## Attestation

Validation routes every value the peer supplies — DAC, PAI, the attestation elements and the Certification Declaration — through a guard that turns a decode failure into a finding naming the field, using the new `CertificateUnparseable`, `AttestationElementsUnparseable` and `CertificationDeclarationUnparseable` checks. An `InternalError` or `ImplementationError` still propagates untouched, so a defect of ours is never reported as the device's fault.

The commissioning flow reuses the public key the validator already extracted rather than parsing the DAC a second time outside that guard, where the raw decoder error came straight back whenever the attestation policy accepted the finding.

## Decoders

`DataReader` threw a raw `RangeError` from `DataView` for fixed-width reads and, worse, returned short data without complaint from `readByteArray` and `readUtf8String`. It now throws a typed `DataReadError` in both cases.

That also closes a live hole found while reviewing the first version of this change. `DerCodec` assembled long-form lengths with a 32-bit shift, so a length with bit 31 set became negative, passed a bounds check that only compared the upper end, and decoded an OCTET STRING as *present and empty*:

```
0484ffffffff -> {"_tag":4,"_bytes":{}}                    # before
0484ffffffff -> THROW DerError : DER data is truncated…   # after
```

One nesting level deeper, the same input escaped as the very `RangeError` this change exists to remove. Lengths now use safe arithmetic with a six-byte cap, and the reader rejects negative and non-integer sizes and offsets.

## Call sites the stricter reads required

- **BTP** relied on `readByteArray` truncating to fill its final BLE fragment, and now clamps the length itself. Without this, every message whose last fragment is shorter than the fragment capacity would throw.
- **mDNS**: one unreadable record discarded every other record that shared the packet, so a single sloppy TXT encoder on the LAN could hide unrelated devices. A record that cannot be read now costs only itself.
- **Certificates**: an extension we do not interpret was decoded anyway, so a proprietary extension carrying anything but DER failed the whole certificate. Such an extension is now skipped before the decoder sees it. This reaches beyond peer data, since PAA certificates come from the DCL.

## Verification

`npm run build-clean`, `npm run format`, `npm run lint` and `npm test` all pass (12 packages, zero failures).

Every added branch has executed mutation proof — reverting the production hunk turns tests red, restoring it turns them green: the reader's bounds and negative-size guards (7 and 1 red), the DER length cap (1), the DER truncation wrap (3), the per-record mDNS recovery (1), the unknown-extension skip (1), and the attestation guards (3 and 2).

One guard is knowingly untested: the DAC-unparseable-but-policy-accepted branch in `ControllerCommissioningFlow`. `ClientAttestationTest` has no way to make the device app serve a corrupt DAC, and adding that plumbing is a larger job than the guard warrants.

Addresses matter-js/matterjs-server#1018
Addresses home-assistant/core#179664

🤖 Generated with [Claude Code](https://claude.com/claude-code)
