### PR TITLE
Cert tests can ask for a TCP session, and TC-SC-8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 ## __WORK IN PROGRESS__
 
 - @matter/testing
+    - Enhancement: A certification test selects the transport its controllers use via `certTest`'s `transport` option; `"tcp"` asks for a TCP-backed session, and adapters receive it through `ControllerAdapterOptions`
     - Enhancement: A certification step whose check could not be evaluated ends `"unverified"` and fails the run, unless the check states why the claim cannot be observed
     - Enhancement: Per-step certification PICS is evaluated on chip device flavors too, and `result.json` reports how many steps their PICS excluded
     - Fix: A certification run's `result.json` no longer reports a passing verdict for a run that failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 ## __WORK IN PROGRESS__
 
 - @matter/testing
-    - Enhancement: A certification test selects the transport its controllers use via `certTest`'s `transport` option; `"tcp"` asks for a TCP-backed session, and adapters receive it through `ControllerAdapterOptions`
+    - Enhancement: A certification test requests a transport preference for its controllers via `certTest`'s `transport` option; `"tcp"` asks for a TCP-backed session where the peer supports one, and adapters receive the request through `ControllerAdapterOptions`
     - Enhancement: A certification step whose check could not be evaluated ends `"unverified"` and fails the run, unless the check states why the claim cannot be observed
     - Enhancement: Per-step certification PICS is evaluated on chip device flavors too, and `result.json` reports how many steps their PICS excluded
     - Fix: A certification run's `result.json` no longer reports a passing verdict for a run that failed

--- a/packages/testing/src/chip/cert/cert-context.ts
+++ b/packages/testing/src/chip/cert/cert-context.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Subject } from "../../device/subject.js";
+import type { ControllerTransport } from "./controller-adapter.js";
 import type { ControllerAdapter } from "./controller-adapter.js";
 import type { LogFollower } from "./log-follower.js";
 
@@ -214,4 +215,9 @@ export interface CertTestDefinition {
     steps: CertStepDefinition[];
     /** Cleanup the engine runs after the last step whatever happened to it (see `cert-dsl.ts`'s `finalize`). */
     finalize?: (cx: CertStepContext) => Promise<void>;
+    /**
+     * How this test's controllers reach their peers. A TC needing a TCP-backed session declares it
+     * here; every other test keeps the transport its evidence and timing were written against.
+     */
+    transport?: ControllerTransport;
 }

--- a/packages/testing/src/chip/cert/cert-dsl.ts
+++ b/packages/testing/src/chip/cert/cert-dsl.ts
@@ -29,6 +29,7 @@ import {
 } from "./cert-context.js";
 import { CertTest, registerCertTestFactory } from "./cert-test.js";
 import { chipImageBase, ChipDockerSubject, ChipLocalSubject, resolveChipLocalAppDir } from "./chip-app-subject.js";
+import type { ControllerTransport } from "./controller-adapter.js";
 import { ControllerAdapter, controllerPicsOverridesFor, createControllerAdapter } from "./controller-adapter.js";
 import { ControllerImplementation, resolveControllerImplementation, resolveDeviceFlavor } from "./device-config.js";
 import { EvidenceRecorder } from "./evidence.js";
@@ -60,6 +61,13 @@ export interface CertTestOptions {
     controllers?: Record<string, "dut" | "helper">;
     /** Role name → app name. Default: `{ th: options.app }`. */
     devices?: Record<string, string>;
+
+    /**
+     * How this test's controllers reach their peers. `"tcp"` asks for a TCP-backed session, which the
+     * TCP test cases are about and which a large-payload interaction requires. Omitted, a controller
+     * keeps the transport every other test's evidence and timing were written against.
+     */
+    transport?: ControllerTransport;
 }
 
 export interface CertStepOptions {
@@ -211,6 +219,7 @@ export function certTest(tc: string, options: CertTestOptions): CertTestBuilder 
         app: options.app,
         appVariant: options.appVariant,
         flavors: options.flavors,
+        transport: options.transport,
         steps: new Array<CertStepDefinition>(),
     };
 
@@ -638,7 +647,7 @@ class WiredCertTest extends CertTest {
             const controllerImplementation = resolveControllerImplementation();
 
             for (const name of Object.keys(this.#controllerRoles)) {
-                const controller = createControllerAdapter(name);
+                const controller = createControllerAdapter(name, { transport: this.definition.transport });
                 controllers[name] = controller;
                 this.#openControllers = controllers;
                 await controller.start();

--- a/packages/testing/src/chip/cert/controller-adapter.ts
+++ b/packages/testing/src/chip/cert/controller-adapter.ts
@@ -451,7 +451,19 @@ export interface ManualPairingCodeFields {
 /**
  * Builds a {@link ControllerAdapter} for the given id (e.g. "dut", "th_cr2").
  */
-export type ControllerAdapterFactory = (id: string) => ControllerAdapter;
+/**
+ * How a controller reaches its peers. `"tcp"` asks for a TCP-backed session, which a large-payload
+ * interaction requires; omitted, a controller keeps the transport every other TC's evidence and
+ * timing were written against.
+ */
+export type ControllerTransport = "tcp";
+
+/** What a test asks of the controller before it starts. */
+export interface ControllerAdapterOptions {
+    transport?: ControllerTransport;
+}
+
+export type ControllerAdapterFactory = (id: string, options?: ControllerAdapterOptions) => ControllerAdapter;
 
 const factories = new Map<ControllerImplementation, ControllerAdapterFactory>();
 const controllerPics = new Map<ControllerImplementation, PicsValues>();
@@ -500,7 +512,7 @@ export function controllerPicsOverridesFor(implementation: ControllerImplementat
  * Constructs a {@link ControllerAdapter} for `role`, via the factory registered for the run's
  * {@link resolveControllerImplementation | selected implementation}.
  */
-export function createControllerAdapter(role: string): ControllerAdapter {
+export function createControllerAdapter(role: string, options?: ControllerAdapterOptions): ControllerAdapter {
     const implementation = resolveControllerImplementation();
     const factory = factories.get(implementation);
     if (!factory) {
@@ -510,7 +522,7 @@ export function createControllerAdapter(role: string): ControllerAdapter {
                 "before running a cert test",
         );
     }
-    return factory(role);
+    return factory(role, options);
 }
 
 /**

--- a/packages/testing/src/chip/cert/controller-adapter.ts
+++ b/packages/testing/src/chip/cert/controller-adapter.ts
@@ -449,9 +449,6 @@ export interface ManualPairingCodeFields {
 }
 
 /**
- * Builds a {@link ControllerAdapter} for the given id (e.g. "dut", "th_cr2").
- */
-/**
  * How a controller reaches its peers. `"tcp"` asks for a TCP-backed session, which a large-payload
  * interaction requires; omitted, a controller keeps the transport every other TC's evidence and
  * timing were written against.
@@ -463,6 +460,9 @@ export interface ControllerAdapterOptions {
     transport?: ControllerTransport;
 }
 
+/**
+ * Builds a {@link ControllerAdapter} for the given id (e.g. "dut", "th_cr2").
+ */
 export type ControllerAdapterFactory = (id: string, options?: ControllerAdapterOptions) => ControllerAdapter;
 
 const factories = new Map<ControllerImplementation, ControllerAdapterFactory>();

--- a/packages/testing/src/chip/index.ts
+++ b/packages/testing/src/chip/index.ts
@@ -56,6 +56,8 @@ export type {
     CommissioningTarget,
     ControllerAdapter,
     ControllerAdapterFactory,
+    ControllerAdapterOptions,
+    ControllerTransport,
     EventPathSpec,
     EventReadEntry,
     ManualPairingCodeFields,

--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -39,7 +39,7 @@ import type {
     SubscribeOptions,
     TimedInteractionOptions,
 } from "@matter/testing";
-import type { PicsValues } from "@matter/testing";
+import type { ControllerAdapterOptions, ControllerTransport, PicsValues } from "@matter/testing";
 import { LineQueue, LogFollower, UnsupportedByControllerError } from "@matter/testing";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -176,6 +176,16 @@ function quoteArg(value: string) {
 }
 
 /** chip-tool's own name for the timed-interaction timeout, on `command-by-id` and `write-by-id` alike. */
+/**
+ * chip-tool decides a session's transport at CASE setup: `--allow-large-payload 1` makes it ask for a
+ * TCP-backed one, which it can only get where the peer advertises a TCP server
+ * (`OperationalSessionSetup`). The flag lives on chip-tool's shared model-command base, so it applies
+ * to read, write and invoke alike.
+ */
+function largePayloadArg(transport?: ControllerTransport) {
+    return transport === "tcp" ? " --allow-large-payload 1" : "";
+}
+
 function timedArg(options?: TimedInteractionOptions) {
     const timeout = timedInteractionTimeoutOf(options);
     return timeout === undefined ? "" : ` --timedInteractionTimeoutMs ${timeout}`;
@@ -768,7 +778,7 @@ class ChipToolCertNodeApi implements CertNodeApi {
 
         const reply = await this.#adapter.execute(
             `any command-by-id ${hex(clusterId)} ${hex(commandModel.id)} ${quoteArg(fields)} ` +
-                `${this.#node} ${endpoint}${timedArg(options)}`,
+                `${this.#node} ${endpoint}${timedArg(options)}${largePayloadArg(this.#adapter.transport)}`,
         );
 
         const operation = `invoke ${clusterModel.name}.${commandModel.name}`;
@@ -1157,6 +1167,7 @@ export class ChipToolControllerAdapter implements ControllerAdapter {
     readonly #subscriptions = new Array<LiveSubscription>();
     readonly #eventSubscriptions = new Array<LiveEventSubscription>();
     readonly #commissionerName: ChipToolCommissionerName;
+    readonly #transport?: ControllerTransport;
     #storageDirectory?: string;
     #client?: ChipToolClient;
     #nextNodeId = FIRST_NODE_ID;
@@ -1164,7 +1175,7 @@ export class ChipToolControllerAdapter implements ControllerAdapter {
     readonly #globalFabricIds = new Map<string, Promise<GlobalFabricId>>();
     #closed = false;
 
-    constructor(id: string) {
+    constructor(id: string, options?: ControllerAdapterOptions) {
         const commissionerName = COMMISSIONER_NAMES.find(name => !claimedCommissioners.has(name));
         if (commissionerName === undefined) {
             throw new InternalError(
@@ -1176,9 +1187,15 @@ export class ChipToolControllerAdapter implements ControllerAdapter {
         }
 
         this.id = id;
+        this.#transport = options?.transport;
         this.#commissionerName = commissionerName;
         claimedCommissioners.set(commissionerName, this);
         this.log = new LogFollower(this.#logStream.follow(), id);
+    }
+
+    /** How this adapter's sessions reach their peers, which a model command states per invocation. */
+    get transport() {
+        return this.#transport;
     }
 
     /** The commissioner identity this adapter's chip-tool process was launched with. */

--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -1,14 +1,4 @@
 /**
- * chip-tool decides a session's transport at CASE setup: `--allow-large-payload 1` makes it ask for a
- * TCP-backed one, which it can only get where the peer advertises a TCP server
- * (`OperationalSessionSetup`). The flag lives on chip-tool's shared model-command base, so it applies
- * to read, write and invoke alike.
- */
-function largePayloadArg(transport?: ControllerTransport) {
-    return transport === "tcp" ? " --allow-large-payload 1" : "";
-}
-
-/**
  * @license
  * Copyright 2022-2026 Matter.js Authors
  * SPDX-License-Identifier: Apache-2.0
@@ -183,6 +173,16 @@ function quoteArg(value: string) {
         return value;
     }
     return `'${value.replace(/[\\']/g, match => `\\${match}`)}'`;
+}
+
+/**
+ * chip-tool decides a session's transport when it establishes one, so every interaction a test might
+ * begin with carries this: `--allow-large-payload 1` asks for a TCP-backed session, which chip-tool
+ * can only get where the peer advertises a TCP server (`OperationalSessionSetup`). The flag lives on
+ * chip-tool's shared model-command base, so read, write, invoke, event read and subscribe all take it.
+ */
+function largePayloadArg(transport?: ControllerTransport) {
+    return transport === "tcp" ? " --allow-large-payload 1" : "";
 }
 
 /** chip-tool's own name for the timed-interaction timeout, on `command-by-id` and `write-by-id` alike. */

--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -1194,7 +1194,11 @@ export class ChipToolControllerAdapter implements ControllerAdapter {
         this.log = new LogFollower(this.#logStream.follow(), id);
     }
 
-    /** How this adapter's sessions reach their peers, which a model command states per invocation. */
+    /**
+     * The transport this adapter's test *asked* for, which each model command states per invocation.
+     * Not what the sessions do: chip-tool keeps using the session commissioning established, so this
+     * reads `"tcp"` while the interactions still travel over that UDP session.
+     */
     get transport() {
         return this.#transport;
     }

--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -1,4 +1,14 @@
 /**
+ * chip-tool decides a session's transport at CASE setup: `--allow-large-payload 1` makes it ask for a
+ * TCP-backed one, which it can only get where the peer advertises a TCP server
+ * (`OperationalSessionSetup`). The flag lives on chip-tool's shared model-command base, so it applies
+ * to read, write and invoke alike.
+ */
+function largePayloadArg(transport?: ControllerTransport) {
+    return transport === "tcp" ? " --allow-large-payload 1" : "";
+}
+
+/**
  * @license
  * Copyright 2022-2026 Matter.js Authors
  * SPDX-License-Identifier: Apache-2.0
@@ -176,16 +186,6 @@ function quoteArg(value: string) {
 }
 
 /** chip-tool's own name for the timed-interaction timeout, on `command-by-id` and `write-by-id` alike. */
-/**
- * chip-tool decides a session's transport at CASE setup: `--allow-large-payload 1` makes it ask for a
- * TCP-backed one, which it can only get where the peer advertises a TCP server
- * (`OperationalSessionSetup`). The flag lives on chip-tool's shared model-command base, so it applies
- * to read, write and invoke alike.
- */
-function largePayloadArg(transport?: ControllerTransport) {
-    return transport === "tcp" ? " --allow-large-payload 1" : "";
-}
-
 function timedArg(options?: TimedInteractionOptions) {
     const timeout = timedInteractionTimeoutOf(options);
     return timeout === undefined ? "" : ` --timedInteractionTimeoutMs ${timeout}`;
@@ -985,7 +985,7 @@ class ChipToolCertNodeApi implements CertNodeApi {
         // chip-tool zips its cluster/event/endpoint id lists element-wise, as it does for attributes
         let command =
             `any read-event-by-id ${paths.map(eventClusterArg).join(",")} ${paths.map(eventArg).join(",")} ` +
-            `${this.#node} ${paths.map(eventEndpointArg).join(",")}`;
+            `${this.#node} ${paths.map(eventEndpointArg).join(",")}${largePayloadArg(this.#adapter.transport)}`;
         if (options?.fabricFiltered === false) {
             command += " --fabric-filtered false";
         }
@@ -1078,7 +1078,7 @@ class ChipToolCertNodeApi implements CertNodeApi {
         // (`InteractionModelConfig::GetAttributePaths`), so equal-length lists express any path set.
         let command =
             `any read-by-id ${paths.map(clusterArg).join(",")} ${paths.map(attributeArg).join(",")} ` +
-            `${this.#node} ${paths.map(endpointArg).join(",")}`;
+            `${this.#node} ${paths.map(endpointArg).join(",")}${largePayloadArg(this.#adapter.transport)}`;
         if (options?.fabricFiltered === false) {
             command += " --fabric-filtered false";
         }
@@ -1112,6 +1112,7 @@ class ChipToolCertNodeApi implements CertNodeApi {
             command += ` --data-version ${versions.join(",")}`;
         }
         command += timedArg(options);
+        command += largePayloadArg(this.#adapter.transport);
 
         return this.#adapter.execute(command, { attributes: entries.map(({ path }) => path) });
     }
@@ -1357,7 +1358,7 @@ export class ChipToolControllerAdapter implements ControllerAdapter {
         const reply = await this.execute(
             `any subscribe-by-id ${clusterArg(path)} ${attributeArg(path)} ` +
                 `${opts.minIntervalFloorSeconds} ${opts.maxIntervalCeilingSeconds} ${node} ` +
-                `${endpointArg(path)} --keepSubscriptions true`,
+                `${endpointArg(path)} --keepSubscriptions true${largePayloadArg(this.#transport)}`,
             { attributes: [path] },
         );
         assertNoFailure(reply, `subscribe ${JSON.stringify(path)}`);
@@ -1390,7 +1391,7 @@ export class ChipToolControllerAdapter implements ControllerAdapter {
         let command =
             `any subscribe-event-by-id ${paths.map(eventClusterArg).join(",")} ${paths.map(eventArg).join(",")} ` +
             `${opts.minIntervalFloorSeconds} ${opts.maxIntervalCeilingSeconds} ${node} ` +
-            `${paths.map(eventEndpointArg).join(",")} --keepSubscriptions true`;
+            `${paths.map(eventEndpointArg).join(",")} --keepSubscriptions true${largePayloadArg(this.#transport)}`;
         if (opts.fabricFiltered === false) {
             command += " --fabric-filtered false";
         }

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -901,9 +901,11 @@ export class InProcessControllerAdapter implements ControllerAdapter {
                 network: {
                     autoStartCommissionedPeers: false,
 
-                    // A TC that needs TCP asks for it; every other run keeps the transport its
-                    // evidence and timing were written against.
-                    ...(this.#transport === "tcp" ? { tcp: true, transportPreference: "tcp" as const } : {}),
+                    // Outgoing only: this controller is a TCP client, and `tcp: true` would also have it
+                    // listen and advertise as a TCP server, which no cert test asks of a controller.
+                    ...(this.#transport === "tcp"
+                        ? { tcp: { outgoing: true }, transportPreference: "tcp" as const }
+                        : {}),
                 },
                 subscriptions: { persistenceEnabled: false },
             });

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -66,6 +66,8 @@ import type {
     CertNodeRef,
     CommissioningTarget,
     ControllerAdapter,
+    ControllerAdapterOptions,
+    ControllerTransport,
     EventPathSpec,
     EventReadEntry,
     ManualPairingCodeFields,
@@ -855,8 +857,9 @@ export class InProcessControllerAdapter implements ControllerAdapter {
     readonly #logStream = new LineQueue();
     #controller?: ServerNode;
     #fabric?: Fabric;
+    readonly #transport?: ControllerTransport;
 
-    constructor(id: string) {
+    constructor(id: string, options?: ControllerAdapterOptions) {
         if (adapterStreams.has(id)) {
             throw new InternalError(
                 `InProcessControllerAdapter "${id}" is already registered; two live adapters with the same id ` +
@@ -866,6 +869,7 @@ export class InProcessControllerAdapter implements ControllerAdapter {
         }
 
         this.id = id;
+        this.#transport = options?.transport;
         this.#env = new Environment(`cert-${id}`, Environment.default);
         new MockStorageService(this.#env);
         this.log = new LogFollower(this.#logStream.follow(), id);
@@ -894,7 +898,13 @@ export class InProcessControllerAdapter implements ControllerAdapter {
                 id: this.id,
                 commissioning: { enabled: false },
                 controller: { adminFabricLabel: this.id },
-                network: { autoStartCommissionedPeers: false },
+                network: {
+                    autoStartCommissionedPeers: false,
+
+                    // A TC that needs TCP asks for it; every other run keeps the transport its
+                    // evidence and timing were written against.
+                    ...(this.#transport === "tcp" ? { tcp: true, transportPreference: "tcp" as const } : {}),
+                },
                 subscriptions: { persistenceEnabled: false },
             });
             this.#controller = controller;

--- a/support/chip-testing/src/cert/index.ts
+++ b/support/chip-testing/src/cert/index.ts
@@ -24,8 +24,16 @@ import { NodeTestInstance } from "../NodeTestInstance.js";
 import { CHIP_TOOL_CONTROLLER_PICS, ChipToolControllerAdapter } from "./ChipToolControllerAdapter.js";
 import { InProcessControllerAdapter, MATTERJS_CONTROLLER_PICS } from "./InProcessControllerAdapter.js";
 
-registerControllerAdapterFactory("matterjs", id => new InProcessControllerAdapter(id), MATTERJS_CONTROLLER_PICS);
-registerControllerAdapterFactory("chip-tool", id => new ChipToolControllerAdapter(id), CHIP_TOOL_CONTROLLER_PICS);
+registerControllerAdapterFactory(
+    "matterjs",
+    (id, options) => new InProcessControllerAdapter(id, options),
+    MATTERJS_CONTROLLER_PICS,
+);
+registerControllerAdapterFactory(
+    "chip-tool",
+    (id, options) => new ChipToolControllerAdapter(id, options),
+    CHIP_TOOL_CONTROLLER_PICS,
+);
 
 // EvidenceRecorder (packages/testing, generic) has no knowledge of this package's own directory
 // layout; this is the seam cert-dsl.ts documents for choosing an outDir. matter-test's working

--- a/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
@@ -178,16 +178,16 @@ describe("ChipToolControllerAdapter", function () {
         }
     });
 
-    async function start() {
-        const started = new ChipToolControllerAdapter("dut");
+    async function start(options?: { transport?: "tcp" }) {
+        const started = new ChipToolControllerAdapter("dut", options);
         adapter = started;
         await started.start();
         return started;
     }
 
     /** Commissions a node and clears the recorded frames, so a test asserts only on its own command. */
-    async function commissioned(): Promise<{ ref: string; node: CertNodeApi }> {
-        const started = await start();
+    async function commissioned(options?: { transport?: "tcp" }): Promise<{ ref: string; node: CertNodeApi }> {
+        const started = await start(options);
         const ref = await started.commission({ passcode: 20202021, discriminator: 3840 });
         fake.commands.splice(0);
         fake.frames.splice(0);
@@ -388,6 +388,50 @@ describe("ChipToolControllerAdapter", function () {
         expect(await node.readAttribute({ endpoint: 0, cluster: BASIC_INFORMATION.id, attribute: VENDOR_ID.id })).equal(
             0xfff1,
         );
+        expect(fake.commands).deep.equal([`any read-by-id 0x28 0x2 ${ref} 0`]);
+    });
+
+    it("asks for a large-payload session on every interaction when the test requested TCP", async () => {
+        // chip-tool decides a session's transport when it establishes one, so a test that begins with
+        // a read must carry the flag as much as one that begins with an invoke.
+        const { ref, node } = await commissioned({ transport: "tcp" });
+
+        fake.reply = () => ({
+            results: [
+                {
+                    clusterId: BASIC_INFORMATION.id,
+                    endpointId: 0,
+                    attributeId: requireId(VENDOR_ID.id, "vendorId"),
+                    value: 0xfff1,
+                },
+            ],
+        });
+        await node.readAttribute({ endpoint: 0, cluster: BASIC_INFORMATION.id, attribute: VENDOR_ID.id });
+
+        fake.reply = () => ({ results: [] });
+        await node.invoke("OnOff", "on", {}, 1);
+
+        expect(fake.commands).deep.equal([
+            `any read-by-id 0x28 0x2 ${ref} 0 --allow-large-payload 1`,
+            `any command-by-id 0x6 0x1 {} ${ref} 1 --allow-large-payload 1`,
+        ]);
+    });
+
+    it("sends no large-payload flag for a test that did not ask for TCP", async () => {
+        const { ref, node } = await commissioned();
+
+        fake.reply = () => ({
+            results: [
+                {
+                    clusterId: BASIC_INFORMATION.id,
+                    endpointId: 0,
+                    attributeId: requireId(VENDOR_ID.id, "vendorId"),
+                    value: 0xfff1,
+                },
+            ],
+        });
+        await node.readAttribute({ endpoint: 0, cluster: BASIC_INFORMATION.id, attribute: VENDOR_ID.id });
+
         expect(fake.commands).deep.equal([`any read-by-id 0x28 0x2 ${ref} 0`]);
     });
 

--- a/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
@@ -391,30 +391,41 @@ describe("ChipToolControllerAdapter", function () {
         expect(fake.commands).deep.equal([`any read-by-id 0x28 0x2 ${ref} 0`]);
     });
 
-    it("asks for a large-payload session on every interaction when the test requested TCP", async () => {
-        // chip-tool decides a session's transport when it establishes one, so a test that begins with
-        // a read must carry the flag as much as one that begins with an invoke.
+    it("asks for a large-payload session on every interaction a test might begin with", async () => {
+        // chip-tool decides a session's transport when it establishes one, so whichever interaction a
+        // test starts with has to carry the flag. This asserts the commands, not the replies: each call
+        // is allowed to reject, since a builder is what is under test here.
         const { ref, node } = await commissioned({ transport: "tcp" });
-
-        fake.reply = () => ({
-            results: [
-                {
-                    clusterId: BASIC_INFORMATION.id,
-                    endpointId: 0,
-                    attributeId: requireId(VENDOR_ID.id, "vendorId"),
-                    value: 0xfff1,
-                },
-            ],
-        });
-        await node.readAttribute({ endpoint: 0, cluster: BASIC_INFORMATION.id, attribute: VENDOR_ID.id });
+        const attribute = {
+            endpoint: 0,
+            cluster: BASIC_INFORMATION.id,
+            attribute: requireId(VENDOR_ID.id, "vendorId"),
+        };
+        const event = { endpoint: 0, cluster: BASIC_INFORMATION.id, event: 0 };
+        const intervals = { minIntervalFloorSeconds: 1, maxIntervalCeilingSeconds: 10 };
 
         fake.reply = () => ({ results: [] });
-        await node.invoke("OnOff", "on", {}, 1);
 
-        expect(fake.commands).deep.equal([
-            `any read-by-id 0x28 0x2 ${ref} 0 --allow-large-payload 1`,
-            `any command-by-id 0x6 0x1 {} ${ref} 1 --allow-large-payload 1`,
-        ]);
+        const interactions: [string, () => Promise<unknown>][] = [
+            ["read-by-id", () => node.readAttribute(attribute)],
+            ["write-by-id", () => node.writeAttribute(attribute, 1)],
+            ["command-by-id", () => node.invoke("OnOff", "on", {}, 1)],
+            ["read-event-by-id", () => node.readEvents([event])],
+            ["subscribe-by-id", () => node.subscribe(attribute, intervals)],
+            ["subscribe-event-by-id", () => node.subscribeEvents([event], intervals)],
+        ];
+
+        for (const [, interaction] of interactions) {
+            await interaction().catch(() => undefined);
+        }
+
+        expect(fake.commands.length).equal(interactions.length);
+        for (const [index, [builder]] of interactions.entries()) {
+            const command = fake.commands[index];
+            expect(command, builder).contains(`any ${builder} `);
+            expect(command.endsWith(" --allow-large-payload 1"), `${builder}: ${command}`).equal(true);
+        }
+        expect(fake.commands[0]).equal(`any read-by-id 0x28 0x2 ${ref} 0 --allow-large-payload 1`);
     });
 
     it("sends no large-payload flag for a test that did not ask for TCP", async () => {

--- a/support/chip-testing/test/cert-framework/controller-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/controller-adapter.test.ts
@@ -719,6 +719,33 @@ describe("ControllerAdapter registry", () => {
         }
     });
 
+    it("hands a test's transport request to the factory", () => {
+        // A TC that needs TCP declares it, and the adapter must see it before it starts — a controller
+        // cannot change a session's transport afterwards.
+        env.MATTER_CERT_CONTROLLER = "chip-tool";
+        resetControllerAdapterFactoryForTesting("chip-tool");
+
+        const seen = new Array<unknown>();
+        try {
+            registerControllerAdapterFactory("chip-tool", (id, options) => {
+                seen.push(options?.transport);
+                return fakeControllerAdapter(id);
+            });
+
+            createControllerAdapter("with-tcp", { transport: "tcp" });
+            createControllerAdapter("without");
+
+            expect(seen).deep.equal(["tcp", undefined]);
+        } finally {
+            resetControllerAdapterFactoryForTesting("chip-tool");
+            registerControllerAdapterFactory(
+                "chip-tool",
+                (id, options) => new ChipToolControllerAdapter(id, options),
+                CHIP_TOOL_CONTROLLER_PICS,
+            );
+        }
+    });
+
     it("reports no declarations for an implementation registered without them", () => {
         resetControllerAdapterFactoryForTesting("chip-tool");
 

--- a/support/chip-testing/test/cert-framework/controller-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/controller-adapter.test.ts
@@ -622,7 +622,7 @@ describe("ControllerAdapter registry", () => {
             resetControllerAdapterFactoryForTesting("chip-tool");
             registerControllerAdapterFactory(
                 "chip-tool",
-                id => new ChipToolControllerAdapter(id),
+                (id, options) => new ChipToolControllerAdapter(id, options),
                 CHIP_TOOL_CONTROLLER_PICS,
             );
         }
@@ -756,7 +756,7 @@ describe("ControllerAdapter registry", () => {
             resetControllerAdapterFactoryForTesting("chip-tool");
             registerControllerAdapterFactory(
                 "chip-tool",
-                id => new ChipToolControllerAdapter(id),
+                (id, options) => new ChipToolControllerAdapter(id, options),
                 CHIP_TOOL_CONTROLLER_PICS,
             );
         }

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -2273,7 +2273,9 @@ What each side does with the request:
   falls back to UDP otherwise. The hard `requiredTransport` lever exists in the protocol layer but is
   not surfaced, so a test cannot yet assert "TCP or fail" — which is why the evidence below is the
   device's, not the controller's.
-- **chip-tool** gets `--allow-large-payload 1` on its model commands, and it is **not enough**: chip-tool
+- **chip-tool** gets `--allow-large-payload 1` on every model command it builds — read, write, invoke,
+  event read and both subscribes, since it decides a session's transport when it establishes one and a
+  test may begin with any of them — and it is **not enough**: chip-tool
   keeps using the session commissioning established, so the flag reaches the DUT over that UDP session
   and no TCP connection is set up. The support module refuses the case up front with
   `UnsupportedByControllerError`, so a chip-tool leg is recorded skipped with that reason instead of

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -2252,3 +2252,46 @@ So the open question is which witness to build, and it is a decision rather than
 
 Until one of those exists, a TC written here could claim "the TH received this on a group session"
 and nothing about the addressing the step is actually about.
+
+## The TCP cases invert the topology, and a controller must be asked for TCP before it starts
+
+`TC-SC-8.x` is the first block where the **DUT is the device** — the plan's preconditions say "DUT is a
+TCP server, TH is a TCP client" — so these tests name their roles the plan's way
+(`controllers: { th: … }`, `devices: { dut: … }`) and read `cx.devices.dut`'s log. Nothing else in the
+DSL changes: the controller still commissions the device, which is the same direction as always. The
+role *kind* (`"dut"`/`"helper"`) is only a label; nothing consumes it.
+
+**A transport is a property of the session, so it is requested before the controller starts.**
+`certTest`'s `transport: "tcp"` reaches the adapter through the factory (`ControllerAdapterOptions`),
+because a controller cannot change a session's transport afterwards. Only a test that needs TCP asks
+for it — every other test keeps the transport its evidence and timing were written against.
+
+What each side does with the request:
+
+- **matter.js controller** gets `network: { tcp: true, transportPreference: "tcp" }`, a *soft*
+  preference: it uses TCP where the peer's `SUPPORTED_TRANSPORTS.tcpServer` says it can, and silently
+  falls back to UDP otherwise. The hard `requiredTransport` lever exists in the protocol layer but is
+  not surfaced, so a test cannot yet assert "TCP or fail" — which is why the evidence below is the
+  device's, not the controller's.
+- **chip-tool** gets `--allow-large-payload 1` on its model commands, and it is **not enough**: chip-tool
+  keeps using the session commissioning established, so the flag reaches the DUT over that UDP session
+  and no TCP connection is set up. The support module refuses the case up front with
+  `UnsupportedByControllerError`, so a chip-tool leg is recorded skipped with that reason instead of
+  passing on a transport nobody used.
+
+**The evidence is the DUT's own session line.** matter.js renders a session's transport in its tag and
+names the channel the peer connected on, so `CaseServer …(tcp) … Pairing request « tcp://…` followed by
+`New session with …` is the device saying the connection underneath is TCP. Removing `transport: "tcp"`
+from the test makes that check time out, which is the mutation that proves it.
+
+**Only the matterjs device flavor can host these cases today.** chip's all-clusters app as built here
+does not advertise TCP support, so even a TCP-preferring controller falls back to UDP against it and
+the case would claim a transport nobody used. `flavors: ["matterjs"]` states that, and the test skips
+before activation on the chip flavors.
+
+**What is not yet written, and why.** `TC-SC-8.2` ("the session allows large payloads") has no witness
+distinct from 8.1's on this stack: nothing logs a session's maximum payload, and a TCP-backed session
+is large-payload-capable by construction, so the two cases would rest on the same line. Its real
+witness is behavioural and belongs to `TC-SC-8.6` — a wildcard read arriving in a single `ReportData`,
+which UDP's ~1232-byte budget could not carry. `TC-SC-8.3`/`8.4` additionally need a way to sever just
+the TCP connection mid-test.

--- a/support/chip-testing/test/cert/TC-SC-8.1.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-8.1.test.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { certTest } from "@matter/testing";
+import { TCP_FLAVORS, TCP_PICS, TCP_ROLES, tcpSessionStep } from "./tc-sc-8-support.js";
+import { CommissionedRefs } from "./tc-support.js";
+
+const commissioned = new CommissionedRefs<"th">();
+
+certTest("TC-SC-8.1", {
+    plan: "securechannel.adoc",
+    pics: TCP_PICS,
+    app: "all-clusters",
+    transport: "tcp",
+    flavors: TCP_FLAVORS,
+    ...TCP_ROLES,
+})
+    .step(
+        1,
+        "TH initiates a CASE session establishment with DUT, requesting a session supporting large payloads",
+        tcpSessionStep(commissioned),
+        {
+            expected: "Verify that a session is set up with an underlying TCP connection established with DUT.",
+        },
+    )
+    .finalize(cx => commissioned.decommissionAll(cx));

--- a/support/chip-testing/test/cert/tc-sc-8-support.ts
+++ b/support/chip-testing/test/cert/tc-sc-8-support.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Matter } from "@matter/model";
+import type { CertNodeRef, CertStepContext, DeviceFlavor } from "@matter/testing";
+import { resolveControllerImplementation, UnsupportedByControllerError } from "@matter/testing";
+import { CommissionedRefs, expectSequence, LOG_TIMEOUT, record, requireId } from "./tc-support.js";
+
+const BASIC_INFORMATION = Matter.clusters.require("BasicInformation");
+const BASIC_INFORMATION_ID = requireId(BASIC_INFORMATION.id, "BasicInformation cluster");
+const VENDOR_NAME_ID = requireId(BASIC_INFORMATION.attributes.require("vendorName").id, "BasicInformation.vendorName");
+
+/**
+ * The TCP cases invert this suite's usual topology: the **DUT is the device** (a TCP server) and the
+ * **TH is the controller** (a TCP client), so a step drives `cx.controllers.th` and reads
+ * `cx.devices.dut`'s log.
+ *
+ * Only a device that advertises TCP gets a TCP-backed session — matter.js's controller requires the
+ * peer's `SUPPORTED_TRANSPORTS.tcpServer` before it will use one. chip's all-clusters app as built
+ * here does not advertise it, and a run against it silently uses UDP instead, which would leave these
+ * cases claiming a transport nobody used.
+ */
+export const TCP_FLAVORS: DeviceFlavor[] = ["matterjs"];
+
+export const TCP_PICS = ["MCORE.SC.TCP"];
+
+/** Role wiring for a TCP case, named for the roles the plan gives them rather than this suite's usual pair. */
+export const TCP_ROLES = {
+    controllers: { th: "helper" },
+    devices: { dut: "all-clusters" },
+} as const;
+
+/**
+ * Commissions the DUT and then uses the session, which is what the plan's "initiates a CASE session
+ * establishment ... requesting a session supporting large payloads" amounts to for each controller:
+ * matter.js prefers TCP for every session once asked, while chip-tool decides per interaction, so its
+ * TCP session is the one the first large-payload-capable read establishes. Commissioning alone would
+ * leave the chip-tool leg on the UDP session pairing set up.
+ */
+export async function commissionOverTcp(cx: CertStepContext, commissioned: CommissionedRefs<"th">) {
+    requireTcpCapableController();
+
+    const dut = cx.devices.dut;
+    const from = dut.log.mark();
+
+    const th = cx.controllers.th;
+    const ref = await th.commission({
+        passcode: dut.commissioning.passcode,
+        discriminator: dut.commissioning.discriminator,
+    });
+    commissioned.set("th", ref);
+
+    await th.node(ref).readAttribute({ endpoint: 0, cluster: BASIC_INFORMATION_ID, attribute: VENDOR_NAME_ID });
+
+    return { ref, from };
+}
+
+/**
+ * chip-tool decides a session's transport when it establishes one, and it keeps using the session
+ * pairing already made — so `--allow-large-payload` on a later interaction reaches the DUT over that
+ * existing UDP session and no TCP connection is ever set up. The refusal comes before the step acts,
+ * so the case is recorded as skipped rather than failing on evidence the controller could not produce.
+ */
+function requireTcpCapableController() {
+    const implementation = resolveControllerImplementation();
+    if (implementation !== "matterjs") {
+        throw new UnsupportedByControllerError(
+            "a session established over TCP",
+            implementation,
+            "chip-tool reuses the session commissioning established, so a large-payload interaction " +
+                "does not cause it to establish a TCP-backed one",
+        );
+    }
+}
+
+/**
+ * Confirms the DUT's own log shows the CASE session it just accepted running over TCP: matter.js
+ * renders a session's transport in the session tag and names the channel the peer connected on, so
+ * `(tcp)` beside a `tcp://` address is the device saying the connection underneath is a TCP one.
+ */
+export async function recordTcpSession(cx: CertStepContext, from: number, what: string) {
+    const dut = cx.devices.dut;
+    record(
+        cx,
+        await expectSequence(
+            dut.log,
+            dut.flavor,
+            "CASE session established over a TCP connection",
+            {
+                matterjs: {
+                    ordered: [
+                        /CaseServer .*\(tcp\).*Pairing request « tcp:\/\//,
+                        /CaseServer .*\(tcp\).*New session with/,
+                    ],
+                },
+            },
+            from,
+            LOG_TIMEOUT,
+        ),
+        what,
+    );
+}
+
+/** Every TCP case starts the same way, so its first step is shared rather than copied. */
+export function tcpSessionStep(commissioned: CommissionedRefs<"th">) {
+    return async (cx: CertStepContext) => {
+        const { from } = await commissionOverTcp(cx, commissioned);
+        await recordTcpSession(cx, from, "the session the TH established with the DUT runs over TCP");
+    };
+}
+
+export type TcpRef = CertNodeRef;

--- a/support/chip-testing/test/cert/tc-sc-8-support.ts
+++ b/support/chip-testing/test/cert/tc-sc-8-support.ts
@@ -35,10 +35,10 @@ export const TCP_ROLES = {
 
 /**
  * Commissions the DUT and then uses the session, which is what the plan's "initiates a CASE session
- * establishment ... requesting a session supporting large payloads" amounts to for each controller:
- * matter.js prefers TCP for every session once asked, while chip-tool decides per interaction, so its
- * TCP session is the one the first large-payload-capable read establishes. Commissioning alone would
- * leave the chip-tool leg on the UDP session pairing set up.
+ * establishment ... requesting a session supporting large payloads" amounts to here: matter.js
+ * prefers TCP for every session once asked, so commissioning establishes the session this case is
+ * about and the read exercises it. Only matter.js reaches this point — see
+ * {@link requireTcpCapableController}.
  */
 export async function commissionOverTcp(cx: CertStepContext, commissioned: CommissionedRefs<"th">) {
     requireTcpCapableController();


### PR DESCRIPTION
Opens the TCP block: the framework change that lets a certification test run over TCP, and the first case that uses it.

## The topology inverts here

`TC-SC-8.x` is the first block whose **DUT is the device** — the plan's preconditions read "DUT is a TCP server, TH is a TCP client". So this test names its roles the plan's way (`controllers: { th: … }`, `devices: { dut: … }`) and reads the DUT device's log. Nothing else in the DSL changes: the controller still commissions the device, which is the same direction as always, and the role *kind* is only a label.

## Asking for a transport

A transport is a property of the session, so it must be requested before the controller starts — a controller cannot change it afterwards. `certTest`'s new `transport: "tcp"` reaches the adapter through the factory (`ControllerAdapterOptions`). Only a test that needs TCP asks for it; every other test keeps the transport its evidence and timing were written against.

The two controllers answer differently, and only one can carry the case today:

- **matter.js** takes `network: { tcp: true, transportPreference: "tcp" }` and establishes CASE over TCP where the peer advertises support. Its device log then names the transport in the session tag and the channel the peer connected on — `CaseServer …(tcp) … Pairing request « tcp://…` then `New session with …` — which *is* the plan's "a session is set up with an underlying TCP connection established with DUT".
- **chip-tool** takes `--allow-large-payload 1` on its model commands, and that turns out **not to be enough**: it keeps using the session commissioning established, so the flag travels over that UDP session and no TCP connection is ever set up. The case refuses up front with `UnsupportedByControllerError`, so a chip-tool leg is recorded skipped *with that reason* rather than passing on a transport nobody used.

## Device flavor

Only the matterjs device can host these cases: chip's all-clusters app as built here does not advertise TCP support, so even a TCP-preferring controller falls back to UDP against it. `flavors: ["matterjs"]` states that, and the test skips before activation on the chip flavors.

## Verification

- matterjs leg passes; removing `transport: "tcp"` makes the check time out, which is the mutation that proves it is not asserting something incidental.
- chip-tool leg records the skip with its reason; chip-local device leg skips before activation.
- `cert-framework` 821/821 (including a new test that the transport request reaches the factory), all 24 cert TCs, full `npm test`, build, format-verify, lint.

## What is deliberately not in this PR

- **TC-SC-8.2** ("the session allows large payloads") has no witness distinct from 8.1's on this stack: nothing logs a session's maximum payload, and a TCP-backed session is large-payload-capable by construction, so both cases would rest on the same line. Its real witness is behavioural and belongs to **TC-SC-8.6** — a wildcard read arriving in a single `ReportData`, which UDP's ~1232-byte budget could not carry.
- **TC-SC-8.3 / 8.4** need a way to sever just the TCP connection mid-test.
- **TC-SC-8.5** (an invoke over the session) is straightforward on top of this and is the natural next one.

Also worth knowing: matter.js exposes only a *soft* transport preference above the protocol layer. The hard `requiredTransport` lever exists internally, so a test cannot yet assert "TCP or fail" — which is why the evidence here is the device's log rather than the controller's own claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
