### PR TITLE
fix(model): a temperature sensor that states no range reports it as unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: The `Symbol.metadata` polyfill no longer conflicts with `lib.esnext.decorators` in the published declarations
 
 - @matter/model
+    - Fix: TemperatureMeasurement's MinMeasuredValue and MaxMeasuredValue now default to `null` ("range unavailable"), like the other measurement clusters, instead of -27315 and 32767, and carry the constraints the specification states rather than hand-written ones
     - Fix: A device type requiring several instances of one component, such as `BatteryStorage` with two electrical sensors and two power sources, no longer reports each instance as a duplicate of the others
     - Enhancement: The model build reports an instance number stated on a requirement other than a component device type, where the specification numbers nothing
     - Enhancement: A model element's `extend()` can remove an inherited quality, stated as `!N` in the quality definition; the removal survives further extension, and a definition that extends one carrying a removal may state the quality again

--- a/packages/model/src/standard/elements/temperature-measurement.element.ts
+++ b/packages/model/src/standard/elements/temperature-measurement.element.ts
@@ -18,11 +18,11 @@ export const TemperatureMeasurement = Cluster(
     }),
     Attribute({
         name: "MinMeasuredValue", id: 0x1, type: "temperature", access: "R V", conformance: "M",
-        constraint: "-27315 to maxMeasuredValue - 1", default: -27315, quality: "X F"
+        constraint: "-27315 to 32766", quality: "X F"
     }),
     Attribute({
         name: "MaxMeasuredValue", id: 0x2, type: "temperature", access: "R V", conformance: "M",
-        constraint: "minMeasuredValue + 1 to 32767", default: 32767, quality: "X F"
+        constraint: "min minMeasuredValue + 1", quality: "X F"
     }),
     Attribute({
         name: "Tolerance", id: 0x3, type: "uint16", access: "R V", conformance: "O", constraint: "max 2048",

--- a/packages/node/test/behaviors/measurement/MeasurementServersTest.ts
+++ b/packages/node/test/behaviors/measurement/MeasurementServersTest.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { FlowMeasurementServer } from "#behaviors/flow-measurement";
+import { IlluminanceMeasurementServer } from "#behaviors/illuminance-measurement";
+import { PressureMeasurementServer } from "#behaviors/pressure-measurement";
+import { RelativeHumidityMeasurementServer } from "#behaviors/relative-humidity-measurement";
+import { TemperatureMeasurementServer } from "#behaviors/temperature-measurement";
+import { FlowSensorDevice } from "#devices/flow-sensor";
+import { HumiditySensorDevice } from "#devices/humidity-sensor";
+import { LightSensorDevice } from "#devices/light-sensor";
+import { PressureSensorDevice } from "#devices/pressure-sensor";
+import { TemperatureSensorDevice } from "#devices/temperature-sensor";
+import { MockServerNode } from "../../node/mock-server-node.js";
+
+const CASES = [
+    { name: "TemperatureMeasurementServer", device: TemperatureSensorDevice, behavior: TemperatureMeasurementServer },
+    { name: "IlluminanceMeasurementServer", device: LightSensorDevice, behavior: IlluminanceMeasurementServer },
+    { name: "PressureMeasurementServer", device: PressureSensorDevice, behavior: PressureMeasurementServer },
+    { name: "FlowMeasurementServer", device: FlowSensorDevice, behavior: FlowMeasurementServer },
+    {
+        name: "RelativeHumidityMeasurementServer",
+        device: HumiditySensorDevice,
+        behavior: RelativeHumidityMeasurementServer,
+    },
+] as const;
+
+describe("measurement cluster servers", () => {
+    for (const { name, device, behavior } of CASES) {
+        it(`${name} reports an unavailable measurement range by default`, async () => {
+            await using node = await MockServerNode.createOnline(undefined, { device: undefined });
+            const ep = await node.add(device);
+
+            const state = ep.stateOf(behavior);
+            expect(state.minMeasuredValue).equals(null);
+            expect(state.maxMeasuredValue).equals(null);
+        });
+    }
+
+    describe("TemperatureMeasurementServer bounds", () => {
+        it("refuses a maximum that does not exceed the minimum", async () => {
+            await using node = await MockServerNode.createOnline(undefined, { device: undefined });
+            const ep = await node.add(TemperatureSensorDevice);
+
+            await expect(
+                ep.set({ temperatureMeasurement: { minMeasuredValue: 1000, maxMeasuredValue: 1000 } }),
+            ).rejectedWith(/min minMeasuredValue \+ 1/);
+        });
+
+        it("refuses a measurement outside a stated range", async () => {
+            await using node = await MockServerNode.createOnline(undefined, { device: undefined });
+            const ep = await node.add(TemperatureSensorDevice, {
+                temperatureMeasurement: { minMeasuredValue: -1000, maxMeasuredValue: 1000 },
+            });
+
+            await expect(ep.set({ temperatureMeasurement: { measuredValue: 1001 } })).rejectedWith(
+                /minMeasuredValue to maxMeasuredValue/,
+            );
+        });
+    });
+});

--- a/support/chip-testing/src/devices/TemperatureSensorEndpoint.ts
+++ b/support/chip-testing/src/devices/TemperatureSensorEndpoint.ts
@@ -14,7 +14,7 @@ registerDeviceType({
     async create(serverNode: ServerNode, endpoint: EndpointNumber) {
         const ep = new Endpoint(TemperatureSensorDevice, {
             number: endpoint,
-            temperatureMeasurement: { measuredValue: 2500 },
+            temperatureMeasurement: { measuredValue: 2500, minMeasuredValue: -5000, maxMeasuredValue: 10000 },
         });
         await serverNode.add(ep);
         return { endpoint: ep };

--- a/support/models/src/local/TemperatureMeasurementOverrides.ts
+++ b/support/models/src/local/TemperatureMeasurementOverrides.ts
@@ -11,25 +11,25 @@ LocalMatter.children.push({
     name: "TemperatureMeasurement",
 
     children: [
-        {
-            tag: "attribute",
-            id: 0x0,
-            name: "MeasuredValue",
-            constraint: "MinMeasuredValue to MaxMeasuredValue",
-        },
+        // The CHIP-derived model, merged for 1.1 only, states the int16 "invalid" sentinel 0x8000 as the default
+        { tag: "attribute", id: 0x1, name: "MinMeasuredValue", default: -27315, until: "1.2" },
+        { tag: "attribute", id: 0x2, name: "MaxMeasuredValue", default: 32767, until: "1.2" },
+
+        // Through 1.3 the scraped constraint names the cross-referenced attribute as "maxMeasuredValue1" /
+        // "minMeasuredValue1", which resolves to nothing
         {
             tag: "attribute",
             id: 0x1,
             name: "MinMeasuredValue",
-            default: -27315,
             constraint: "-27315 to MaxMeasuredValue-1",
+            until: "1.4",
         },
         {
             tag: "attribute",
             id: 0x2,
             name: "MaxMeasuredValue",
-            default: 32767,
             constraint: "MinMeasuredValue+1 to 32767",
+            until: "1.4",
         },
     ],
 });


### PR DESCRIPTION
## What

A `TemperatureMeasurementServer` that an application configures with no measurement range reported `MinMeasuredValue = -27315` and `MaxMeasuredValue = 32767` — "this device measures every temperature that physically exists". The specification means `null` there: "the value is not available". The four sibling measurement clusters (illuminance, pressure, flow, relative humidity) already report `null`, and so does CHIP.

## Why it was wrong

The two numbers came from a hand-written local model override added in 2023 to patch two upstream defects:

- CHIP's ZAP XML declared `0x8000` — the int16 "invalid" sentinel, not a real temperature — as the default, and matter.js's model was CHIP-derived at the time.
- The specification scrape glued a footnote marker onto the cross-referenced identifier, producing constraints like `"-27315 to maxMeasuredValue1"`, which resolves to nothing.

Both are gone. CHIP data is merged for revision 1.1 only, and the scrape reads cleanly from 1.4 onward. The override was never gated, so it kept overwriting a model that had been correct for four releases.

## What changed

`support/models/src/local/TemperatureMeasurementOverrides.ts` gates the repairs by revision rather than dropping them, so the historical models keep what they genuinely need: the defaults apply through 1.1, the constraint repair through 1.3. The `MeasuredValue` entry is dropped outright — every revision from 1.1 scrapes that constraint correctly, so it never did anything.

`packages/model/src/standard/elements/temperature-measurement.element.ts` is the regenerated result: no `default` on either attribute, and the constraints the specification itself states (`-27315 to 32766`, `min minMeasuredValue + 1`). It is now structurally identical to its four siblings.

`support/chip-testing/src/devices/TemperatureSensorEndpoint.ts` was the only consumer relying on the old defaults — every sibling sensor endpoint in that directory already states bounds explicitly, and this one did not, so it would have started advertising `null` in certification runs. It now states bounds too.

## One consequence worth knowing

`MeasuredValue`'s constraint is `minMeasuredValue to maxMeasuredValue`. While both are `null` the constraint resolves to nothing, so a value such as `-30000` (−300 °C) is accepted where the old defaults happened to refuse it. That matches the specification, the four sibling clusters and CHIP; the `temperature` datatype carries no range of its own to fall back on. An application that wants its measurements bounded states its range, which is what the attributes are for.

## Tests

New `packages/node/test/behaviors/measurement/MeasurementServersTest.ts`, the first test file for any of these five clusters.

- All five servers report `null` for both bounds by default. Only the temperature case guards this change — mutation-verified, it fails with `expected -27315 to equal null` against the previous model. **The other four are characterization tests**: they were already green before this change, and are here so the temperature expectation reads as a consistency statement rather than a lone magic value.
- Two temperature cases cover the constraints: a maximum equal to the minimum is refused, and a measurement above a stated maximum is refused.

`npm run build`, `npm run format-verify`, `npm run lint` and the full `npm test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
