### PR TITLE
TC-SC-8.5 (a command invoked over a TCP-based CASE session)

### DIFF
--- a/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
@@ -1,0 +1,191 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CertDevice, CertStepContext, CheckRecord, PicsFile, Subject } from "@matter/testing";
+import { LineQueue, LogFollower } from "@matter/testing";
+import { recordTcpInvoke, recordTcpSession, TcpSessionRef } from "../cert/tc-sc-8-support.js";
+import { CertCheckFailedError } from "../cert/tc-support.js";
+
+/** GeneralDiagnostics, and its TimeSnapshot command, which TC-SC-8.5 invokes. */
+const CLUSTER = 0x33;
+const COMMAND = 0x1;
+const ENDPOINT = 0;
+
+const SESSION = "@1:86c217a36142d632•c8b8";
+const OTHER_SESSION = "@1:86c217a36142d632•9f2c";
+
+function at(millis: number) {
+    const iso = new Date(1786711488_000 + millis).toISOString();
+    return `${iso.slice(0, 10)} ${iso.slice(11, 23)}`;
+}
+
+const pairingRequest = (session = SESSION) =>
+    `${at(0)} INFO CaseServer •unsecured#${session}(tcp)⇵2c56 Pairing request « tcp://[fe80::1%en0]«60111`;
+const newSession = (session = SESSION) =>
+    `${at(1)} INFO CaseServer ${session}(tcp) New session with @1:86c217a36142d632 2↔1 address: tcp://[fe80::1%en0]«60111`;
+
+const invokeRequest = (session = SESSION, path = "0.generalDiagnostics.timeSnapshot", flags = "") =>
+    `${at(2)} INFO InteractionServer Invoke « ${session}(tcp)⇵2c57 ${flags}invokes: ${path}`;
+const invokeFinal = (session = SESSION, commands = 1) =>
+    `${at(3)} DEBUG InteractionServer Invoke (final) » ${session}(tcp)⇵2c57 commands: ${commands}`;
+const invokeResponse = (session = SESSION) =>
+    `${at(4)} DEBUG MessageChannel Message » for: I/InvokeResponse id: ${session}(tcp)⇵2c57✉018c0504 type: 0x1/0x9 size: 42`;
+
+/** A device whose log is exactly `lines`, and a recorder that keeps what a helper records. */
+async function withDut<T>(lines: string[], body: (cx: CertStepContext, checks: CheckRecord[]) => Promise<T>) {
+    const source = new LineQueue();
+    const log = new LogFollower(source.follow(), "dut");
+    for (const text of lines) {
+        source.push(text);
+    }
+    // The log ends where these lines do, so a pattern that cannot match fails at once rather than
+    // waiting out the follower's budget
+    source.close();
+
+    const subject = {
+        id: "dut",
+        app: "all-clusters",
+        commissioning: { kind: "on-network", passcode: 20202021, discriminator: 3840, qrPairingCode: "" },
+        pics: undefined as unknown as PicsFile,
+        async initialize() {},
+        async start() {},
+        async stop() {},
+        async close() {},
+        async snapshot() {
+            return {};
+        },
+        async restore() {},
+        async backchannel() {},
+    } satisfies Subject;
+
+    const dut: CertDevice = { ...subject, flavor: "matterjs", log, exit: new Promise(() => {}) };
+
+    const checks = new Array<CheckRecord>();
+    const cx: CertStepContext = {
+        controllers: {},
+        devices: { dut },
+        recorder: {
+            beginStep() {},
+            check(record) {
+                checks.push(record);
+            },
+            endStep() {
+                return [];
+            },
+            async flush() {
+                return "";
+            },
+        },
+    };
+
+    try {
+        return await body(cx, checks);
+    } finally {
+        await log.close();
+    }
+}
+
+describe("recordTcpSession", () => {
+    it("returns the session tag the DUT's own line names", async () => {
+        await withDut([pairingRequest(), newSession()], async (cx, checks) => {
+            expect(await recordTcpSession(cx, 0, "runs over TCP")).equal(SESSION);
+            expect(checks).length(1);
+            expect(checks[0].verdict).equal("pass");
+        });
+    });
+
+    it("records a failing check, rather than only throwing, for a session line naming no session", async () => {
+        const anonymous = `${at(1)} INFO CaseServer (tcp) New session with a peer`;
+
+        await withDut([pairingRequest(), anonymous], async (cx, checks) => {
+            await expect(recordTcpSession(cx, 0, "runs over TCP")).rejectedWith(CertCheckFailedError);
+            expect(checks.map(check => check.verdict)).deep.equal(["pass", "fail"]);
+        });
+    });
+});
+
+describe("recordTcpInvoke", () => {
+    async function invoke(lines: string[], session = SESSION) {
+        return withDut(lines, async (cx, checks) => {
+            await recordTcpInvoke(cx, session, ENDPOINT, CLUSTER, COMMAND, 0, "invoked over TCP").catch(() => {});
+            return checks;
+        });
+    }
+
+    it("passes for an invoke dispatched and answered on the session", async () => {
+        const checks = await invoke([invokeRequest(), invokeFinal(), invokeResponse()]);
+
+        expect(checks).length(1);
+        expect(checks[0].verdict).equal("pass");
+    });
+
+    it("passes for a timed invoke, whose flags matter.js writes before the path", async () => {
+        const checks = await invoke([
+            invokeRequest(SESSION, "0.generalDiagnostics.timeSnapshot", "timedRequest "),
+            invokeFinal(),
+            invokeResponse(),
+        ]);
+
+        expect(checks[0].verdict).equal("pass");
+    });
+
+    it("fails for the same command on another session", async () => {
+        const checks = await invoke([
+            invokeRequest(OTHER_SESSION),
+            invokeFinal(OTHER_SESSION),
+            invokeResponse(OTHER_SESSION),
+        ]);
+
+        expect(checks[0].verdict).equal("fail");
+    });
+
+    it("fails for another command on the session", async () => {
+        const checks = await invoke([
+            invokeRequest(SESSION, "0.generalDiagnostics.testEventTrigger"),
+            invokeFinal(),
+            invokeResponse(),
+        ]);
+
+        expect(checks[0].verdict).equal("fail");
+    });
+
+    it("fails for the same command on another endpoint", async () => {
+        const checks = await invoke([
+            invokeRequest(SESSION, "1.generalDiagnostics.timeSnapshot"),
+            invokeFinal(),
+            invokeResponse(),
+        ]);
+
+        expect(checks[0].verdict).equal("fail");
+    });
+
+    it("does not take a response carrying more commands than the one invoked", async () => {
+        const checks = await invoke([invokeRequest(), invokeFinal(SESSION, 12), invokeResponse()]);
+
+        expect(checks[0].verdict).equal("fail");
+    });
+
+    it("fails when the DUT never answered the invoke", async () => {
+        const checks = await invoke([invokeRequest()]);
+
+        expect(checks[0].verdict).equal("fail");
+    });
+});
+
+describe("TcpSessionRef", () => {
+    it("refuses to answer before a session was captured", () => {
+        expect(() => new TcpSessionRef().require()).throw(CertCheckFailedError);
+    });
+
+    it("forgets the session a finalizer cleared", () => {
+        const session = new TcpSessionRef();
+        session.set(SESSION);
+        expect(session.require()).equal(SESSION);
+
+        session.clear();
+        expect(() => session.require()).throw(CertCheckFailedError);
+    });
+});

--- a/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
@@ -27,12 +27,18 @@ const pairingRequest = (session = SESSION) =>
 const newSession = (session = SESSION) =>
     `${at(1)} INFO CaseServer ${session}(tcp) New session with @1:86c217a36142d632 2↔1 address: tcp://[fe80::1%en0]«60111`;
 
-const invokeRequest = (session = SESSION, path = "0.generalDiagnostics.timeSnapshot", flags = "") =>
-    `${at(2)} INFO InteractionServer Invoke « ${session}(tcp)⇵2c57 ${flags}invokes: ${path}`;
-const invokeFinal = (session = SESSION, commands = 1) =>
-    `${at(3)} DEBUG InteractionServer Invoke (final) » ${session}(tcp)⇵2c57 commands: ${commands}`;
-const invokeResponse = (session = SESSION) =>
-    `${at(4)} DEBUG MessageChannel Message » for: I/InvokeResponse id: ${session}(tcp)⇵2c57✉018c0504 type: 0x1/0x9 size: 42`;
+const INVOKE_EXCHANGE = "2c57";
+
+const invokeRequest = (
+    session = SESSION,
+    path = "0.generalDiagnostics.timeSnapshot",
+    flags = "",
+    exchange = INVOKE_EXCHANGE,
+) => `${at(2)} INFO InteractionServer Invoke « ${session}(tcp)⇵${exchange} ${flags}invokes: ${path}`;
+const invokeFinal = (session = SESSION, commands = 1, exchange = INVOKE_EXCHANGE) =>
+    `${at(3)} DEBUG InteractionServer Invoke (final) » ${session}(tcp)⇵${exchange} commands: ${commands}`;
+const invokeResponse = (session = SESSION, exchange = INVOKE_EXCHANGE) =>
+    `${at(4)} DEBUG MessageChannel Message » for: I/InvokeResponse id: ${session}(tcp)⇵${exchange}✉018c0504 type: 0x1/0x9 size: 42`;
 
 /** A device whose log is exactly `lines`, and a recorder that keeps what a helper records. */
 async function withDut<T>(lines: string[], body: (cx: CertStepContext, checks: CheckRecord[]) => Promise<T>) {
@@ -92,17 +98,25 @@ describe("recordTcpSession", () => {
     it("returns the session tag the DUT's own line names", async () => {
         await withDut([pairingRequest(), newSession()], async (cx, checks) => {
             expect(await recordTcpSession(cx, 0, "runs over TCP")).equal(SESSION);
-            expect(checks).length(1);
-            expect(checks[0].verdict).equal("pass");
+            expect(checks.map(check => check.verdict)).deep.equal(["pass", "pass"]);
+        });
+    });
+
+    it("does not pair the pairing request with another connection's session line", async () => {
+        const other = `${at(1)} INFO CaseServer @1:86c217a36142d632•9f2c(tcp) New session with @1:86c217a36142d632 2↔1 address: tcp://[fe80::2%en0]«60999`;
+
+        await withDut([pairingRequest(), other], async (cx, checks) => {
+            await expect(recordTcpSession(cx, 0, "runs over TCP")).rejectedWith(CertCheckFailedError);
+            expect(checks.map(check => check.verdict)).deep.equal(["pass", "fail"]);
         });
     });
 
     it("records a failing check, rather than only throwing, for a session line naming no session", async () => {
-        const anonymous = `${at(1)} INFO CaseServer (tcp) New session with a peer`;
+        const anonymous = `${at(1)} INFO CaseServer (tcp) New session with a peer 2↔1 address: tcp://[fe80::1%en0]«60111`;
 
         await withDut([pairingRequest(), anonymous], async (cx, checks) => {
             await expect(recordTcpSession(cx, 0, "runs over TCP")).rejectedWith(CertCheckFailedError);
-            expect(checks.map(check => check.verdict)).deep.equal(["pass", "fail"]);
+            expect(checks.map(check => check.verdict)).deep.equal(["pass", "pass", "fail"]);
         });
     });
 });
@@ -171,6 +185,16 @@ describe("recordTcpInvoke", () => {
 
     it("does not take a response carrying more commands than the one invoked", async () => {
         const checks = await invoke([invokeRequest(), invokeFinal(SESSION, 12), invokeResponse()]);
+
+        expect(checks[0].verdict).equal("fail");
+    });
+
+    it("does not take another exchange's answer for this invoke's", async () => {
+        const checks = await invoke([
+            invokeRequest(),
+            invokeFinal(SESSION, 1, "2c58"),
+            invokeResponse(SESSION, "2c58"),
+        ]);
 
         expect(checks[0].verdict).equal("fail");
     });

--- a/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
@@ -6,7 +6,12 @@
 
 import type { CertDevice, CertStepContext, CheckRecord, Subject } from "@matter/testing";
 import { LineQueue, LogFollower, PicsFile } from "@matter/testing";
-import { recordTcpInvoke, recordTcpSession, TcpSessionRef } from "../cert/tc-sc-8-support.js";
+import {
+    recordTcpInvoke,
+    recordTcpSession,
+    wildcardReadInOneReportCheck,
+    TcpSessionRef,
+} from "../cert/tc-sc-8-support.js";
 import { CertCheckFailedError } from "../cert/tc-support.js";
 
 /** GeneralDiagnostics, and its TimeSnapshot command, which TC-SC-8.5 invokes. */
@@ -201,6 +206,81 @@ describe("recordTcpInvoke", () => {
 
     it("fails when the DUT never answered the invoke", async () => {
         const checks = await invoke([invokeRequest()]);
+
+        expect(checks[0].verdict).equal("fail");
+    });
+});
+
+describe("wildcardReadInOneReportCheck", () => {
+    const EXCHANGE = "9200";
+
+    const wildcardRead = (session = SESSION, exchange = EXCHANGE, paths = "*.*.*") =>
+        `${at(5)} DEBUG InteractionServer Read « ${session}(tcp)⇵${exchange} fabricFiltered attributes: ${paths} events: none`;
+    const reportData = (bytes: number, session = SESSION, exchange = EXCHANGE) =>
+        `${at(6)} DEBUG MessageChannel Message » for: I/ReportData suppressResponse attr: 838 id: ${session}(tcp)⇵${exchange}✉08e2433e type: 0x1/0x5 size: ${bytes} payload: 1536`;
+
+    async function report(lines: string[]) {
+        return withDut(lines, async cx => [await wildcardReadInOneReportCheck(cx, SESSION, 0)]);
+    }
+
+    it("passes for one report larger than an MRP message may be", async () => {
+        const checks = await report([wildcardRead(), reportData(27432)]);
+
+        expect(checks[0].verdict).equal("pass");
+        expect(checks[0].detail).contains("27432");
+    });
+
+    it("fails for a report an MRP session could have carried", async () => {
+        const checks = await report([wildcardRead(), reportData(1280)]);
+
+        expect(checks[0].verdict).equal("fail");
+    });
+
+    it("fails when the device chunked the report", async () => {
+        const checks = await report([wildcardRead(), reportData(20000), reportData(7432)]);
+
+        expect(checks[0].verdict).equal("fail");
+        expect(checks[0].detail).contains("2 ReportData");
+    });
+
+    it("does not take a report sent on another exchange", async () => {
+        const checks = await report([wildcardRead(), reportData(27432, SESSION, "9201")]);
+
+        expect(checks[0].verdict).equal("fail");
+    });
+
+    it("does not take a report of the same exchange on another session", async () => {
+        const checks = await report([wildcardRead(), reportData(27432, OTHER_SESSION)]);
+
+        expect(checks[0].verdict).equal("fail");
+    });
+
+    it("fails a report line that states no size", async () => {
+        const sizeless = `${at(6)} DEBUG MessageChannel Message » for: I/ReportData suppressResponse attr: 838 id: ${SESSION}(tcp)⇵${EXCHANGE}✉08e2433e type: 0x1/0x5 payload: 1536`;
+        const checks = await report([wildcardRead(), sizeless]);
+
+        expect(checks[0].verdict).equal("fail");
+    });
+
+    it("keeps the evidence short, though the report line carries its whole payload", async () => {
+        const long = `${reportData(27432)}${"ab".repeat(30000)}`;
+        const checks = await report([wildcardRead(), long]);
+
+        expect(checks[0].verdict).equal("pass");
+        expect(checks[0].matched?.length).most(300);
+    });
+
+    it("does not take a read of one attribute for the wildcard read", async () => {
+        const checks = await report([
+            wildcardRead(SESSION, EXCHANGE, "0.basicInformation.state.vendorName"),
+            reportData(27432),
+        ]);
+
+        expect(checks[0].verdict).equal("fail");
+    });
+
+    it("does not take another session's wildcard read", async () => {
+        const checks = await report([wildcardRead(OTHER_SESSION), reportData(27432, OTHER_SESSION)]);
 
         expect(checks[0].verdict).equal("fail");
     });

--- a/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { CertDevice, CertStepContext, CheckRecord, PicsFile, Subject } from "@matter/testing";
-import { LineQueue, LogFollower } from "@matter/testing";
+import type { CertDevice, CertStepContext, CheckRecord, Subject } from "@matter/testing";
+import { LineQueue, LogFollower, PicsFile } from "@matter/testing";
 import { recordTcpInvoke, recordTcpSession, TcpSessionRef } from "../cert/tc-sc-8-support.js";
 import { CertCheckFailedError } from "../cert/tc-support.js";
 
@@ -49,7 +49,7 @@ async function withDut<T>(lines: string[], body: (cx: CertStepContext, checks: C
         id: "dut",
         app: "all-clusters",
         commissioning: { kind: "on-network", passcode: 20202021, discriminator: 3840, qrPairingCode: "" },
-        pics: undefined as unknown as PicsFile,
+        pics: new PicsFile([]),
         async initialize() {},
         async start() {},
         async stop() {},
@@ -110,7 +110,14 @@ describe("recordTcpSession", () => {
 describe("recordTcpInvoke", () => {
     async function invoke(lines: string[], session = SESSION) {
         return withDut(lines, async (cx, checks) => {
-            await recordTcpInvoke(cx, session, ENDPOINT, CLUSTER, COMMAND, 0, "invoked over TCP").catch(() => {});
+            try {
+                await recordTcpInvoke(cx, session, ENDPOINT, CLUSTER, COMMAND, 0, "invoked over TCP");
+            } catch (e) {
+                // A failing check is what several of these cases assert; anything else is a real error
+                if (!(e instanceof CertCheckFailedError)) {
+                    throw e;
+                }
+            }
             return checks;
         });
     }

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -2294,9 +2294,9 @@ before activation on the chip flavors.
 **What is not yet written, and why.** `TC-SC-8.2` ("the session allows large payloads") has no witness
 distinct from 8.1's on this stack: nothing logs a session's maximum payload, and a TCP-backed session
 is large-payload-capable by construction, so the two cases would rest on the same line. Its real
-witness is behavioural and belongs to `TC-SC-8.6` — a wildcard read arriving in a single `ReportData`,
-which UDP's ~1232-byte budget could not carry. `TC-SC-8.3`/`8.4` additionally need a way to sever just
-the TCP connection mid-test.
+witness is behavioural, and `TC-SC-8.6` below now carries it — a wildcard read arriving in a single
+`ReportData`, which UDP's ~1232-byte budget could not carry. `TC-SC-8.3`/`8.4` additionally need a way
+to sever just the TCP connection mid-test.
 
 ## An interaction over the TCP session, bound to that session (`TC-SC-8.5`)
 
@@ -2332,3 +2332,31 @@ so a regex regression surfaces without docker and without a chip binary.
 Step 1's expected outcome here is the plan's "the session allows large payloads", which nothing logs —
 a TCP-backed session is large-payload-capable by construction, so this step's evidence is 8.1's and the
 distinct witness belongs to `TC-SC-8.6`, as the note above records for `TC-SC-8.2`.
+
+## The large-payload witness the earlier TCP cases lack (`TC-SC-8.6`)
+
+`TC-SC-8.6` is the case that actually observes a large payload, and it is what `TC-SC-8.2`'s note
+above defers to: step 2 reads every attribute of every cluster and requires the DUT's answer to be a
+**single** `ReportData` too large for an MRP session. Against the matter.js all-clusters device that is
+838 attributes in one report of 27432 payload bytes — twenty times the 1280-byte floor the check uses,
+which is the IPv6 minimum MTU and so conservative, MRP's own budget being smaller (~1232 bytes). The
+size on the line is the encoded message, without its framing, so the wire message is larger still.
+
+Three things the check has to get right, each covered hermetically:
+
+- **The read is identified by its own path, not by the search window.** The pattern requires
+  `attributes: *.*.*` on the session, so a read of one attribute — which commissioning itself performs
+  moments earlier — cannot stand in for it.
+- **The reports are counted, not merely found.** A device that chunked would still log a first report
+  matching any "is there a report" pattern. The check takes every report on the read's own exchange
+  between the request and a settled mark, and requires exactly one.
+- **The size is read off the message, not assumed.** matter.js prints `size: <bytes>` on the message
+  line, and anything at or below the floor — or a line stating no size at all — fails.
+
+The first report is waited for, and only then is the buffer settled and the rest counted. Settling
+alone bounds the follower's pump lag, not the device: a chunking device emits its remaining chunks
+immediately after the first, so waiting for one report is what makes counting them trustworthy.
+
+The evidence keeps only the first 300 characters of the matched line. matter.js renders a message's
+whole payload as hex, so an unbounded `matched` would put ~55 000 characters of one report into the
+evidence bundle.

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -2297,3 +2297,38 @@ is large-payload-capable by construction, so the two cases would rest on the sam
 witness is behavioural and belongs to `TC-SC-8.6` — a wildcard read arriving in a single `ReportData`,
 which UDP's ~1232-byte budget could not carry. `TC-SC-8.3`/`8.4` additionally need a way to sever just
 the TCP connection mid-test.
+
+## An interaction over the TCP session, bound to that session (`TC-SC-8.5`)
+
+`TC-SC-8.5` adds one step to `TC-SC-8.1`'s: an invoke over the session step 1 established. Three
+things make that step's evidence say more than "an invoke happened".
+
+**The step binds its evidence to the session, not to the transport.** `recordTcpSession` returns the
+DUT's own tag for the session it matched (`@<fabric>:<node>•<id>`, which `(tcp)` follows) and the test
+keeps it in a `TcpSessionRef`; `recordTcpInvoke` then builds every pattern around that literal tag. A
+pattern that only asked for `(tcp)` would be satisfied by any TCP-backed session, which is the claim
+the plan does *not* make.
+
+**The command is `GeneralDiagnostics.TimeSnapshot`.** It carries a response of its own — the plan asks
+for a command *response*, not a status — and changes nothing on the DUT, so a rerun does not depend on
+what the previous run left behind.
+
+**Every step of a TCP case owes the controller refusal, not just the first**, so `tcpStep()` wraps a
+step's body with it rather than each step's author remembering. Without the refusal, the chip-tool leg
+skipped step 1 and then *failed* step 2 on `th has no active commissioned node ref` — a failed run
+whose real cause is that the controller cannot establish a TCP session at all. A step that depends on
+a skipped step has to refuse for the same reason the skipped one did.
+
+Mutations that prove the step: pass a command id one higher (`TIME_SNAPSHOT_ID + 1`) and the log check
+times out with the response check still passing; substitute a bogus session tag and it times out on the
+invoke line. The controller-side response check (`TimeSnapshotResponse` carrying a `systemTimeMs`) is
+what proves the response reached the TH.
+
+`test/cert-framework/tc-sc-8-support.test.ts` covers the helpers hermetically — the session-tag
+extraction, and each way `recordTcpInvoke`'s patterns can be satisfied by the wrong thing (another
+session, another command, another endpoint, a response carrying more commands, no answer at all) —
+so a regex regression surfaces without docker and without a chip binary.
+
+Step 1's expected outcome here is the plan's "the session allows large payloads", which nothing logs —
+a TCP-backed session is large-payload-capable by construction, so this step's evidence is 8.1's and the
+distinct witness belongs to `TC-SC-8.6`, as the note above records for `TC-SC-8.2`.

--- a/support/chip-testing/test/cert/TC-SC-6.1.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-6.1.test.ts
@@ -13,6 +13,7 @@ import {
     answersWithStatus,
     CertCheckFailedError,
     CommissionedRefs,
+    describeValue,
     expectCommandInvoke,
     expectMessageWithPath,
     LOG_TIMEOUT,
@@ -48,14 +49,6 @@ const PRIVILEGE_OPERATE = 3;
 const AUTH_MODE_GROUP = 3;
 
 const commissioned = new CommissionedRefs();
-
-/**
- * A value as evidence text. `JSON.stringify` throws on a `bigint`, and a key set's epoch start times
- * are `epoch-us`, so a step reporting what the TH answered would otherwise fail on its own evidence.
- */
-function describe(value: unknown): string {
-    return JSON.stringify(value, (_key, member) => (typeof member === "bigint" ? `${member}` : member)) ?? "undefined";
-}
 
 function attributeId(cluster: typeof GROUP_KEY_MANAGEMENT, attributeName: string): number {
     return requireId(cluster.attributes.require(attributeName).id, `${cluster.name}.${attributeName}`);
@@ -107,7 +100,7 @@ async function invokeAndCheck(
     cx.recorder.check({
         type: "response",
         verdict: "pass",
-        detail: response === undefined ? "status=Success" : `status=Success, response=${describe(response)}`,
+        detail: response === undefined ? "status=Success" : `status=Success, response=${describeValue(response)}`,
     });
 
     if (answersWithStatus(cluster, commandName)) {
@@ -119,7 +112,7 @@ async function invokeAndCheck(
                 verdict: payloadStatus === 0 ? "pass" : "fail",
                 detail:
                     payloadStatus === undefined
-                        ? `${commandName} answered ${describe(response)}, which carries no status`
+                        ? `${commandName} answered ${describeValue(response)}, which carries no status`
                         : `${commandName} response status=${payloadStatus}`,
             },
             `${cluster.name}.${commandName} response status`,
@@ -157,7 +150,9 @@ async function keepsGroupNames(node: CertNodeApi): Promise<boolean> {
     if (typeof value === "object" && value !== null && GROUP_NAMES_PROPERTY in value) {
         return Boolean(value[GROUP_NAMES_PROPERTY]);
     }
-    throw new CertCheckFailedError(`TH answered Groups FeatureMap with ${describe(value)}, which names no features`);
+    throw new CertCheckFailedError(
+        `TH answered Groups FeatureMap with ${describeValue(value)}, which names no features`,
+    );
 }
 
 /** The ACL the TH already holds for this fabric, which a new entry is appended to rather than replacing. */
@@ -168,7 +163,7 @@ async function readAcl(node: CertNodeApi): Promise<unknown[]> {
         attribute: attributeId(ACCESS_CONTROL, "acl"),
     });
     if (!Array.isArray(value)) {
-        throw new CertCheckFailedError(`TH answered its ACL with ${describe(value)}, not a list`);
+        throw new CertCheckFailedError(`TH answered its ACL with ${describeValue(value)}, not a list`);
     }
     return value;
 }
@@ -329,7 +324,7 @@ certTest("TC-SC-6.1", {
                 {
                     type: "response",
                     verdict: bound ? "pass" : "fail",
-                    detail: `GroupKeyMap reads back as ${describe(readBack)}`,
+                    detail: `GroupKeyMap reads back as ${describeValue(readBack)}`,
                 },
                 "the binding the TH kept",
             );
@@ -393,7 +388,7 @@ certTest("TC-SC-6.1", {
                     type: "response",
                     verdict: Number(groupId) === GROUP.id && named ? "pass" : "fail",
                     detail:
-                        `ViewGroupResponse answers for group ${describe(groupId)} named ${describe(groupName)}; ` +
+                        `ViewGroupResponse answers for group ${describeValue(groupId)} named ${describeValue(groupName)}; ` +
                         `the TH ${keepsNames ? "keeps" : "does not keep"} group names`,
                 },
                 "the group the TH reports, and its name",
@@ -438,7 +433,7 @@ certTest("TC-SC-6.1", {
                 {
                     type: "response",
                     verdict: read?.groupKeySetId === GROUP_KEY_SET_ID ? "pass" : "fail",
-                    detail: `KeySetReadResponse carries key set ${describe(read?.groupKeySetId)}`,
+                    detail: `KeySetReadResponse carries key set ${describeValue(read?.groupKeySetId)}`,
                 },
                 "the key set the TH reports back",
             );
@@ -499,7 +494,7 @@ certTest("TC-SC-6.1", {
                     type: "response",
                     verdict: onlyIpk ? "pass" : "fail",
                     detail:
-                        `KeySetReadAllIndicesResponse lists ${describe(indices)}; after removing ` +
+                        `KeySetReadAllIndicesResponse lists ${describeValue(indices)}; after removing ` +
                         `${GROUP_KEY_SET_ID} only the IPK's ${IPK_KEY_SET_ID} may remain`,
                 },
                 "the indices the TH reports after the removal",

--- a/support/chip-testing/test/cert/TC-SC-8.1.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-8.1.test.ts
@@ -5,10 +5,13 @@
  */
 
 import { certTest } from "@matter/testing";
-import { TCP_FLAVORS, TCP_PICS, TCP_ROLES, tcpSessionStep } from "./tc-sc-8-support.js";
+import { TCP_FLAVORS, TCP_PICS, TCP_ROLES, TcpSessionRef, tcpSessionStep } from "./tc-sc-8-support.js";
 import { CommissionedRefs } from "./tc-support.js";
 
 const commissioned = new CommissionedRefs<"th">();
+
+/** This case makes no use of the session beyond establishing it, but the step captures one regardless. */
+const session = new TcpSessionRef();
 
 certTest("TC-SC-8.1", {
     plan: "securechannel.adoc",
@@ -21,9 +24,12 @@ certTest("TC-SC-8.1", {
     .step(
         1,
         "TH initiates a CASE session establishment with DUT, requesting a session supporting large payloads",
-        tcpSessionStep(commissioned),
+        tcpSessionStep(commissioned, session),
         {
             expected: "Verify that a session is set up with an underlying TCP connection established with DUT.",
         },
     )
-    .finalize(cx => commissioned.decommissionAll(cx));
+    .finalize(async cx => {
+        session.clear();
+        await commissioned.decommissionAll(cx);
+    });

--- a/support/chip-testing/test/cert/TC-SC-8.5.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-8.5.test.ts
@@ -16,7 +16,7 @@ import {
     tcpSessionStep,
     tcpStep,
 } from "./tc-sc-8-support.js";
-import { CommissionedRefs, describeValue, recordAll, requireId } from "./tc-support.js";
+import { CommissionedRefs, describeError, describeValue, recordAll, requireId } from "./tc-support.js";
 
 const GENERAL_DIAGNOSTICS = Matter.clusters.require("GeneralDiagnostics");
 const GENERAL_DIAGNOSTICS_ID = requireId(GENERAL_DIAGNOSTICS.id, "GeneralDiagnostics cluster");
@@ -52,9 +52,15 @@ async function invokeOverTcp(cx: CertStepContext) {
     const dut = cx.devices.dut;
     const from = await dut.log.markSettled();
 
-    const response = await node.invoke("GeneralDiagnostics", "timeSnapshot", {}, ROOT_ENDPOINT);
+    let response: unknown;
+    let refusal: unknown;
+    try {
+        response = await node.invoke("GeneralDiagnostics", "timeSnapshot", {}, ROOT_ENDPOINT);
+    } catch (e) {
+        refusal = e;
+    }
 
-    const systemTimeMs = systemTimeMsOf(response);
+    const systemTimeMs = refusal === undefined ? systemTimeMsOf(response) : undefined;
     const invoked = await tcpInvokeCheck(cx, tag, ROOT_ENDPOINT, GENERAL_DIAGNOSTICS_ID, TIME_SNAPSHOT_ID, from);
 
     recordAll(cx, [
@@ -62,10 +68,7 @@ async function invokeOverTcp(cx: CertStepContext) {
             check: () => ({
                 type: "response",
                 verdict: systemTimeMs === undefined ? "fail" : "pass",
-                detail:
-                    systemTimeMs === undefined
-                        ? `the DUT answered TimeSnapshot with ${describeValue(response)}, which carries no SystemTimeMs`
-                        : `TimeSnapshotResponse systemTimeMs=${systemTimeMs}`,
+                detail: responseDetail(response, refusal, systemTimeMs),
             }),
             what: "the TH received the command response",
         },
@@ -74,6 +77,20 @@ async function invokeOverTcp(cx: CertStepContext) {
             what: "the DUT dispatched the command and answered it on the session step 1 established",
         },
     ]);
+}
+
+/**
+ * What the response check says it saw. A refused invoke is reported as the refusal rather than as a
+ * missing field: the two failures have different causes and the evidence is where they are told apart.
+ */
+function responseDetail(response: unknown, refusal: unknown, systemTimeMs: number | bigint | undefined) {
+    if (refusal !== undefined) {
+        return `the DUT refused TimeSnapshot: ${describeError(refusal)}`;
+    }
+    if (systemTimeMs === undefined) {
+        return `the DUT answered TimeSnapshot with ${describeValue(response)}, which carries no SystemTimeMs`;
+    }
+    return `TimeSnapshotResponse systemTimeMs=${systemTimeMs}`;
 }
 
 certTest("TC-SC-8.5", {

--- a/support/chip-testing/test/cert/TC-SC-8.5.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-8.5.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Matter } from "@matter/model";
+import type { CertStepContext } from "@matter/testing";
+import { certTest } from "@matter/testing";
+import {
+    recordTcpInvoke,
+    TCP_FLAVORS,
+    TCP_PICS,
+    TCP_ROLES,
+    TcpSessionRef,
+    tcpSessionStep,
+    tcpStep,
+} from "./tc-sc-8-support.js";
+import { CommissionedRefs, record, requireId } from "./tc-support.js";
+
+const GENERAL_DIAGNOSTICS = Matter.clusters.require("GeneralDiagnostics");
+const GENERAL_DIAGNOSTICS_ID = requireId(GENERAL_DIAGNOSTICS.id, "GeneralDiagnostics cluster");
+const TIME_SNAPSHOT_ID = requireId(
+    GENERAL_DIAGNOSTICS.commands.require("timeSnapshot").id,
+    "GeneralDiagnostics.timeSnapshot",
+);
+
+/** GeneralDiagnostics is a root-node cluster. */
+const ROOT_ENDPOINT = 0;
+
+const commissioned = new CommissionedRefs<"th">();
+const session = new TcpSessionRef();
+
+/** `SystemTimeMs` of a `TimeSnapshotResponse`, or undefined for an answer that is not one. */
+function systemTimeMsOf(response: unknown): number | bigint | undefined {
+    if (typeof response !== "object" || response === null || !("systemTimeMs" in response)) {
+        return undefined;
+    }
+    const value = response.systemTimeMs;
+    return typeof value === "number" || typeof value === "bigint" ? value : undefined;
+}
+
+/**
+ * `TimeSnapshot` is the command this case sends because it carries a response of its own and changes
+ * nothing on the DUT: the plan asks only that a command response comes back, and a command that also
+ * mutates the device would make a retry of this case depend on the state the previous one left.
+ */
+async function invokeOverTcp(cx: CertStepContext) {
+    const node = cx.controllers.th.node(commissioned.require("th"));
+    const tag = session.require();
+
+    const dut = cx.devices.dut;
+    const from = await dut.log.markSettled();
+
+    const response = await node.invoke("GeneralDiagnostics", "timeSnapshot", {}, ROOT_ENDPOINT);
+
+    const systemTimeMs = systemTimeMsOf(response);
+    record(
+        cx,
+        {
+            type: "response",
+            verdict: systemTimeMs === undefined ? "fail" : "pass",
+            detail:
+                systemTimeMs === undefined
+                    ? `the DUT answered TimeSnapshot with ${JSON.stringify(response)}, which carries no SystemTimeMs`
+                    : `TimeSnapshotResponse systemTimeMs=${systemTimeMs}`,
+        },
+        "the TH received the command response",
+    );
+
+    await recordTcpInvoke(
+        cx,
+        tag,
+        ROOT_ENDPOINT,
+        GENERAL_DIAGNOSTICS_ID,
+        TIME_SNAPSHOT_ID,
+        from,
+        "the DUT dispatched the command and answered it on the session step 1 established",
+    );
+}
+
+certTest("TC-SC-8.5", {
+    plan: "securechannel.adoc",
+    pics: TCP_PICS,
+    app: "all-clusters",
+    transport: "tcp",
+    flavors: TCP_FLAVORS,
+    ...TCP_ROLES,
+})
+    .step(
+        1,
+        "TH initiates a CASE session establishment with DUT, requesting a session supporting large payloads",
+        tcpSessionStep(commissioned, session),
+        {
+            expected: "Verify that the session established with DUT allows large payloads.",
+        },
+    )
+    .step(2, "TH initiates an InvokeCommandRequest with DUT over the established session", tcpStep(invokeOverTcp), {
+        expected: "Verify Command response received successfully at TH.",
+    })
+    .finalize(async cx => {
+        session.clear();
+        await commissioned.decommissionAll(cx);
+    });

--- a/support/chip-testing/test/cert/TC-SC-8.5.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-8.5.test.ts
@@ -8,7 +8,7 @@ import { Matter } from "@matter/model";
 import type { CertStepContext } from "@matter/testing";
 import { certTest } from "@matter/testing";
 import {
-    recordTcpInvoke,
+    tcpInvokeCheck,
     TCP_FLAVORS,
     TCP_PICS,
     TCP_ROLES,
@@ -16,7 +16,7 @@ import {
     tcpSessionStep,
     tcpStep,
 } from "./tc-sc-8-support.js";
-import { CommissionedRefs, record, requireId } from "./tc-support.js";
+import { CommissionedRefs, describeValue, recordAll, requireId } from "./tc-support.js";
 
 const GENERAL_DIAGNOSTICS = Matter.clusters.require("GeneralDiagnostics");
 const GENERAL_DIAGNOSTICS_ID = requireId(GENERAL_DIAGNOSTICS.id, "GeneralDiagnostics cluster");
@@ -55,28 +55,25 @@ async function invokeOverTcp(cx: CertStepContext) {
     const response = await node.invoke("GeneralDiagnostics", "timeSnapshot", {}, ROOT_ENDPOINT);
 
     const systemTimeMs = systemTimeMsOf(response);
-    record(
-        cx,
-        {
-            type: "response",
-            verdict: systemTimeMs === undefined ? "fail" : "pass",
-            detail:
-                systemTimeMs === undefined
-                    ? `the DUT answered TimeSnapshot with ${JSON.stringify(response)}, which carries no SystemTimeMs`
-                    : `TimeSnapshotResponse systemTimeMs=${systemTimeMs}`,
-        },
-        "the TH received the command response",
-    );
+    const invoked = await tcpInvokeCheck(cx, tag, ROOT_ENDPOINT, GENERAL_DIAGNOSTICS_ID, TIME_SNAPSHOT_ID, from);
 
-    await recordTcpInvoke(
-        cx,
-        tag,
-        ROOT_ENDPOINT,
-        GENERAL_DIAGNOSTICS_ID,
-        TIME_SNAPSHOT_ID,
-        from,
-        "the DUT dispatched the command and answered it on the session step 1 established",
-    );
+    recordAll(cx, [
+        {
+            check: () => ({
+                type: "response",
+                verdict: systemTimeMs === undefined ? "fail" : "pass",
+                detail:
+                    systemTimeMs === undefined
+                        ? `the DUT answered TimeSnapshot with ${describeValue(response)}, which carries no SystemTimeMs`
+                        : `TimeSnapshotResponse systemTimeMs=${systemTimeMs}`,
+            }),
+            what: "the TH received the command response",
+        },
+        {
+            check: () => invoked,
+            what: "the DUT dispatched the command and answered it on the session step 1 established",
+        },
+    ]);
 }
 
 certTest("TC-SC-8.5", {

--- a/support/chip-testing/test/cert/TC-SC-8.6.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-8.6.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CertStepContext } from "@matter/testing";
+import { certTest } from "@matter/testing";
+import {
+    wildcardReadInOneReportCheck,
+    TCP_FLAVORS,
+    TCP_PICS,
+    TCP_ROLES,
+    TcpSessionRef,
+    tcpSessionStep,
+    tcpStep,
+} from "./tc-sc-8-support.js";
+import { CommissionedRefs, recordAll } from "./tc-support.js";
+
+const commissioned = new CommissionedRefs<"th">();
+const session = new TcpSessionRef();
+
+/** Every attribute of every cluster of every endpoint, which is what the plan's step 2 reads. */
+const WILDCARD = {};
+
+/**
+ * What a device-wide read has to come back with before the report it produced says anything: the
+ * all-clusters device answers with hundreds of attributes across dozens of clusters, and a read that
+ * returned a handful would make a small report unremarkable rather than a failure.
+ */
+const MIN_ATTRIBUTES = 100;
+const MIN_CLUSTERS = 10;
+
+/**
+ * A wildcard read of the whole device is the interaction this case is named for: its report is far
+ * larger than an MRP message may be, so a device that answers it in one `ReportData` can only have
+ * done so over a large-payload session.
+ */
+async function readEverything(cx: CertStepContext) {
+    const node = cx.controllers.th.node(commissioned.require("th"));
+    const tag = session.require();
+
+    const dut = cx.devices.dut;
+    const from = await dut.log.markSettled();
+
+    const entries = await node.readAttributes([WILDCARD]);
+
+    const endpoints = new Set(entries.map(entry => entry.endpoint));
+    const clusters = new Set(entries.map(entry => `${entry.endpoint}/${entry.cluster}`));
+    const answered = await wildcardReadInOneReportCheck(cx, tag, from);
+
+    recordAll(cx, [
+        {
+            check: () => ({
+                type: "response",
+                verdict: entries.length > MIN_ATTRIBUTES && clusters.size > MIN_CLUSTERS ? "pass" : "fail",
+                detail: `${entries.length} attributes of ${clusters.size} clusters on ${endpoints.size} endpoints`,
+            }),
+            what: "the TH received attributes from across the DUT",
+        },
+        { check: () => answered, what: "the DUT answered the read in one large ReportData" },
+    ]);
+}
+
+certTest("TC-SC-8.6", {
+    plan: "securechannel.adoc",
+    pics: TCP_PICS,
+    app: "all-clusters",
+    transport: "tcp",
+    flavors: TCP_FLAVORS,
+    ...TCP_ROLES,
+})
+    .step(
+        1,
+        "TH initiates a CASE session establishment with DUT, requesting a session supporting large payloads",
+        tcpSessionStep(commissioned, session),
+        {
+            expected: "Verify that the session established with DUT allows large payloads.",
+        },
+    )
+    .step(2, "TH initiates a Read of all attributes of all clusters of DUT", tcpStep(readEverything), {
+        expected:
+            "Verify DUT successfully transmits all the attribute data in one ReportData message to TH. Verify " +
+            "receipt of ReportData message at TH.",
+    })
+    .finalize(async cx => {
+        session.clear();
+        await commissioned.decommissionAll(cx);
+    });

--- a/support/chip-testing/test/cert/tc-idm-1.3-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-1.3-support.ts
@@ -8,7 +8,13 @@ import { Duration, ImplementationError } from "@matter/main";
 import type { CheckRecord, LogFollower } from "@matter/testing";
 import { CertLogClosedError, CertLogTimeoutError } from "@matter/testing";
 import { ChipFault } from "./fault-injection.js";
-import { commandPathIBSequence, expectAdjacentLines, expectSequence, INVOKE_REQUEST_MESSAGE } from "./tc-support.js";
+import {
+    commandPathIBSequence,
+    expectAdjacentLines,
+    expectSequence,
+    INVOKE_REQUEST_MESSAGE,
+    literally,
+} from "./tc-support.js";
 
 /** A concrete command path of a batched invoke. */
 export interface BatchPath {
@@ -43,10 +49,6 @@ const FAULT_DESCRIPTIONS = new Map<number, string>([
     [ChipFault.imInvokeSkipSecondResponse, "Single InvokeResponseMessages. Dropping response to second request"],
 ]);
 
-function escapeForPattern(text: string) {
-    return text.replace(/[.*+?^${}()|[\]\\]/g, match => `\\${match}`);
-}
-
 function descriptionOf(fault: number) {
     const description = FAULT_DESCRIPTIONS.get(fault);
     if (description === undefined) {
@@ -60,10 +62,7 @@ function descriptionOf(fault: number) {
  * description of the response it substitutes.
  */
 export function injectedFaultSequence(fault: number): RegExp[] {
-    return [
-        FAULT_INJECTED_LINE,
-        new RegExp(`Injecting the following response:${escapeForPattern(descriptionOf(fault))}`),
-    ];
+    return [FAULT_INJECTED_LINE, new RegExp(`Injecting the following response:${literally(descriptionOf(fault))}`)];
 }
 
 /**

--- a/support/chip-testing/test/cert/tc-idm-5.1-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-5.1-support.ts
@@ -7,7 +7,7 @@
 import { Duration, InternalError, Millis, Seconds, Time } from "@matter/main";
 import type { CheckRecord, LogFollower, LogLine } from "@matter/testing";
 import { CertLogClosedError, CertLogTimeoutError, forFlavor } from "@matter/testing";
-import { expectAdjacentLines, INVOKE_REQUEST_MESSAGE, WRITE_REQUEST_MESSAGE } from "./tc-support.js";
+import { expectAdjacentLines, INVOKE_REQUEST_MESSAGE, literally, WRITE_REQUEST_MESSAGE } from "./tc-support.js";
 
 // TC-IDM-5.1's own checks live beside the test case rather than inside it because a `TC-*.test.ts`
 // registers a device-driven mocha test at import time, so the cert-framework spec set cannot import
@@ -283,7 +283,7 @@ const MATTERJS_FOLLOW_UPS: Record<TimedInteraction, string> = {
 
 /** matter.js's own line for the message of `interaction` that arrived on `session`'s `exchange`. */
 function matterjsFollowUpPattern(interaction: TimedInteraction, session: string, exchange: string): RegExp {
-    return new RegExp(`Message « for: I/${MATTERJS_FOLLOW_UPS[interaction]} id: ${escaped(session)}⇵${exchange}✉`);
+    return new RegExp(`Message « for: I/${MATTERJS_FOLLOW_UPS[interaction]} id: ${literally(session)}⇵${exchange}✉`);
 }
 
 // matter.js clears the timed interaction a message consumed, naming the exchange in decimal where the
@@ -292,13 +292,8 @@ function matterjsFollowUpPattern(interaction: TimedInteraction, session: string,
 // matter.js does not print at all), present for both kinds.
 function matterjsTimedClearedPattern(session: string, exchange: string): RegExp {
     return new RegExp(
-        `Clearing timed interaction exId: ${parseInt(exchange, 16)}(?!\\d) via: ${escaped(session)}(?![0-9a-f])`,
+        `Clearing timed interaction exId: ${parseInt(exchange, 16)}(?!\\d) via: ${literally(session)}(?![0-9a-f])`,
     );
-}
-
-/** A captured log token used as a literal inside a larger pattern. */
-function escaped(text: string): string {
-    return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /** As {@link expectTimedFollowUp} against a matter.js TH. */

--- a/support/chip-testing/test/cert/tc-sc-8-support.ts
+++ b/support/chip-testing/test/cert/tc-sc-8-support.ts
@@ -10,6 +10,7 @@ import { resolveControllerImplementation, UnsupportedByControllerError } from "@
 import {
     CertCheckFailedError,
     CommissionedRefs,
+    describeValue,
     expectSequence,
     literally,
     LOG_TIMEOUT,
@@ -95,34 +96,62 @@ export function requireTcpCapableController() {
  */
 export async function recordTcpSession(cx: CertStepContext, from: number, what: string): Promise<string> {
     const dut = cx.devices.dut;
-    const check = await expectSequence(
+
+    const pairing = await expectSequence(
         dut.log,
         dut.flavor,
-        "CASE session established over a TCP connection",
-        {
-            matterjs: {
-                ordered: [/CaseServer .*\(tcp\).*Pairing request « tcp:\/\//, /CaseServer .*\(tcp\).*New session with/],
-            },
-        },
+        "a pairing request over a TCP connection",
+        { matterjs: [/CaseServer .*\(tcp\).*Pairing request « (tcp:\/\/\S+)/] },
         from,
         LOG_TIMEOUT,
     );
-    record(cx, check, what);
+    record(cx, pairing, `${what}: the DUT accepted a TCP connection`);
+    if (pairing.verdict !== "pass" || pairing.matched === undefined || pairing.logLine === undefined) {
+        throw new CertCheckFailedError(`the DUT's pairing request is not on the record: ${describeValue(pairing)}`);
+    }
 
-    const tag = check.matched === undefined ? undefined : SESSION_TAG.exec(check.matched)?.[1];
+    // The peer's own address is the only token both lines carry, and without it a second CASE
+    // establishment on this device supplies the session line and the wrong session is captured
+    const channel = PEER_CHANNEL.exec(pairing.matched)?.[1];
+    if (channel === undefined) {
+        throw failedCheck(
+            cx,
+            PEER_CHANNEL.source,
+            `the pairing request names no channel: ${pairing.matched}`,
+            pairing.logLine,
+        );
+    }
+
+    const established = await expectSequence(
+        dut.log,
+        dut.flavor,
+        `a CASE session established over the TCP connection from ${channel}`,
+        { matterjs: [new RegExp(`CaseServer .*\\(tcp\\).*New session with .*address: ${literally(channel)}(?!\\S)`)] },
+        pairing.logLine + 1,
+        LOG_TIMEOUT,
+    );
+    record(cx, established, what);
+    if (established.verdict !== "pass" || established.matched === undefined) {
+        throw new CertCheckFailedError(`the DUT's session line is not on the record: ${describeValue(established)}`);
+    }
+
+    const tag = SESSION_TAG.exec(established.matched)?.[1];
     if (tag === undefined) {
-        const detail = `the DUT's session line names no TCP session: ${check.matched}`;
-        cx.recorder.check({
-            type: "device-log",
-            verdict: "fail",
-            pattern: SESSION_TAG.source,
-            detail,
-            logLine: check.logLine,
-        });
-        throw new CertCheckFailedError(detail);
+        throw failedCheck(
+            cx,
+            SESSION_TAG.source,
+            `the DUT's session line names no TCP session: ${established.matched}`,
+            established.logLine,
+        );
     }
 
     return tag;
+}
+
+/** Records `detail` as a failed device-log check and returns the error a caller throws. */
+function failedCheck(cx: CertStepContext, pattern: string, detail: string, logLine?: number) {
+    cx.recorder.check({ type: "device-log", verdict: "fail", pattern, detail, logLine });
+    return new CertCheckFailedError(detail);
 }
 
 /**
@@ -130,6 +159,9 @@ export async function recordTcpSession(cx: CertStepContext, from: number, what: 
  * `(tcp)` follows.
  */
 const SESSION_TAG = /(@[0-9a-f]+:[0-9a-f]+•[0-9a-f]+)\(tcp\)/;
+
+/** The channel a peer connected on, as both the pairing line and the session line render it. */
+const PEER_CHANNEL = /(tcp:\/\/\S+)/;
 
 /**
  * Confirms the DUT dispatched `endpoint`/`cluster`/`command` on `session` and answered it there: the
@@ -146,27 +178,61 @@ export async function tcpInvokeCheck(
     from: number,
 ): Promise<CheckRecord> {
     const dut = cx.devices.dut;
-    const onSession = `${literally(session)}\\(tcp\\)⇵[0-9a-f]+`;
+    const onSession = `${literally(session)}\\(tcp\\)`;
     const path = matterjsCommandPath(endpoint, cluster, command);
-    return expectSequence(
+    const what = `an invoke of ${endpoint}/${cluster}/${command} on ${session}`;
+
+    const invoked = await expectSequence(
         dut.log,
         dut.flavor,
-        `an invoke of ${endpoint}/${cluster}/${command} answered with an InvokeResponse on ${session}`,
+        what,
         {
-            matterjs: {
-                ordered: [
-                    // The invoke line carries the timed/suppress-response flags between the session
-                    // and its path, and drops them when neither is set
-                    new RegExp(`InteractionServer Invoke « ${onSession}.*invokes: .*?${path}`),
-                    new RegExp(`InteractionServer Invoke \\(final\\) » ${onSession} commands: 1(?!\\d)`),
-                    new RegExp(`Message » for: I/InvokeResponse id: ${onSession}`),
-                ],
-            },
+            matterjs: [
+                // The invoke line carries the timed/suppress-response flags between the session and
+                // its path, and drops them when neither is set
+                new RegExp(`InteractionServer Invoke « ${onSession}⇵[0-9a-f]+.*invokes: .*?${path}`),
+            ],
         },
         from,
         LOG_TIMEOUT,
     );
+    if (invoked.verdict !== "pass" || invoked.matched === undefined || invoked.logLine === undefined) {
+        return invoked;
+    }
+
+    // The answer has to be this invoke's own, and an exchange is what makes it so: a second invoke on
+    // the same session would otherwise supply the response lines
+    const exchange = EXCHANGE.exec(invoked.matched)?.[1];
+    if (exchange === undefined) {
+        return {
+            type: "device-log",
+            verdict: "fail",
+            pattern: EXCHANGE.source,
+            detail: `the DUT's invoke line names no exchange: ${invoked.matched}`,
+            logLine: invoked.logLine,
+        };
+    }
+
+    const onExchange = `${onSession}⇵${exchange}`;
+    return expectSequence(
+        dut.log,
+        dut.flavor,
+        `${what} answered with an InvokeResponse on exchange ${exchange}`,
+        {
+            matterjs: {
+                ordered: [
+                    new RegExp(`InteractionServer Invoke \\(final\\) » ${onExchange} commands: 1(?!\\d)`),
+                    new RegExp(`Message » for: I/InvokeResponse .*\\bid: ${onExchange}✉`),
+                ],
+            },
+        },
+        invoked.logLine + 1,
+        LOG_TIMEOUT,
+    );
 }
+
+/** The exchange a matter.js log line names. */
+const EXCHANGE = /⇵([0-9a-f]+)/;
 
 /** {@link tcpInvokeCheck}, recorded as the step's evidence. */
 export async function recordTcpInvoke(

--- a/support/chip-testing/test/cert/tc-sc-8-support.ts
+++ b/support/chip-testing/test/cert/tc-sc-8-support.ts
@@ -7,7 +7,16 @@
 import { Matter } from "@matter/model";
 import type { CertNodeRef, CertStepContext, DeviceFlavor } from "@matter/testing";
 import { resolveControllerImplementation, UnsupportedByControllerError } from "@matter/testing";
-import { CommissionedRefs, expectSequence, LOG_TIMEOUT, record, requireId } from "./tc-support.js";
+import {
+    CertCheckFailedError,
+    CommissionedRefs,
+    expectSequence,
+    literally,
+    LOG_TIMEOUT,
+    matterjsCommandPath,
+    record,
+    requireId,
+} from "./tc-support.js";
 
 const BASIC_INFORMATION = Matter.clusters.require("BasicInformation");
 const BASIC_INFORMATION_ID = requireId(BASIC_INFORMATION.id, "BasicInformation cluster");
@@ -64,7 +73,7 @@ export async function commissionOverTcp(cx: CertStepContext, commissioned: Commi
  * existing UDP session and no TCP connection is ever set up. The refusal comes before the step acts,
  * so the case is recorded as skipped rather than failing on evidence the controller could not produce.
  */
-function requireTcpCapableController() {
+export function requireTcpCapableController() {
     const implementation = resolveControllerImplementation();
     if (implementation !== "matterjs") {
         throw new UnsupportedByControllerError(
@@ -80,20 +89,80 @@ function requireTcpCapableController() {
  * Confirms the DUT's own log shows the CASE session it just accepted running over TCP: matter.js
  * renders a session's transport in the session tag and names the channel the peer connected on, so
  * `(tcp)` beside a `tcp://` address is the device saying the connection underneath is a TCP one.
+ *
+ * Returns the DUT's own tag for that session, so a later step can bind its evidence to this session
+ * rather than to any session that happens to be a TCP one.
  */
-export async function recordTcpSession(cx: CertStepContext, from: number, what: string) {
+export async function recordTcpSession(cx: CertStepContext, from: number, what: string): Promise<string> {
     const dut = cx.devices.dut;
+    const check = await expectSequence(
+        dut.log,
+        dut.flavor,
+        "CASE session established over a TCP connection",
+        {
+            matterjs: {
+                ordered: [/CaseServer .*\(tcp\).*Pairing request « tcp:\/\//, /CaseServer .*\(tcp\).*New session with/],
+            },
+        },
+        from,
+        LOG_TIMEOUT,
+    );
+    record(cx, check, what);
+
+    const tag = check.matched === undefined ? undefined : SESSION_TAG.exec(check.matched)?.[1];
+    if (tag === undefined) {
+        const detail = `the DUT's session line names no TCP session: ${check.matched}`;
+        cx.recorder.check({
+            type: "device-log",
+            verdict: "fail",
+            pattern: SESSION_TAG.source,
+            detail,
+            logLine: check.logLine,
+        });
+        throw new CertCheckFailedError(detail);
+    }
+
+    return tag;
+}
+
+/**
+ * The session part of a matter.js session tag — `@<fabric>:<node>•<id>`, which the transport marker
+ * `(tcp)` follows.
+ */
+const SESSION_TAG = /(@[0-9a-f]+:[0-9a-f]+•[0-9a-f]+)\(tcp\)/;
+
+/**
+ * Confirms the DUT dispatched `endpoint`/`cluster`/`command` on `session` and answered it there: the
+ * request line names the command the TH sent, the dispatch line says the DUT finished it, and the
+ * message line is the `InvokeResponse` going back out. Every one of them carries the session tag,
+ * which is what makes this the session step 1 established rather than any TCP-backed one.
+ */
+export async function recordTcpInvoke(
+    cx: CertStepContext,
+    session: string,
+    endpoint: number,
+    cluster: number,
+    command: number,
+    from: number,
+    what: string,
+) {
+    const dut = cx.devices.dut;
+    const onSession = `${literally(session)}\\(tcp\\)⇵[0-9a-f]+`;
+    const path = matterjsCommandPath(endpoint, cluster, command);
     record(
         cx,
         await expectSequence(
             dut.log,
             dut.flavor,
-            "CASE session established over a TCP connection",
+            `an invoke of ${endpoint}/${cluster}/${command} answered with an InvokeResponse on ${session}`,
             {
                 matterjs: {
                     ordered: [
-                        /CaseServer .*\(tcp\).*Pairing request « tcp:\/\//,
-                        /CaseServer .*\(tcp\).*New session with/,
+                        // The invoke line carries the timed/suppress-response flags between the session
+                        // and its path, and drops them when neither is set
+                        new RegExp(`InteractionServer Invoke « ${onSession}.*invokes: .*?${path}`),
+                        new RegExp(`InteractionServer Invoke \\(final\\) » ${onSession} commands: 1(?!\\d)`),
+                        new RegExp(`Message » for: I/InvokeResponse id: ${onSession}`),
                     ],
                 },
             },
@@ -104,11 +173,50 @@ export async function recordTcpSession(cx: CertStepContext, from: number, what: 
     );
 }
 
+/** Where a TCP case keeps the session its first step established, for the steps that follow. */
+export class TcpSessionRef {
+    #tag?: string;
+
+    set(tag: string) {
+        this.#tag = tag;
+    }
+
+    require(): string {
+        if (this.#tag === undefined) {
+            throw new CertCheckFailedError("no TCP session was captured");
+        }
+        return this.#tag;
+    }
+
+    clear() {
+        this.#tag = undefined;
+    }
+}
+
+/**
+ * Applies {@link requireTcpCapableController} to a step, which every step of a TCP case owes: a step
+ * that skipped it refuses on the commissioning an earlier step never did instead, and reports a
+ * failure where the truth is that the controller cannot establish such a session at all.
+ */
+export function tcpStep(run: (cx: CertStepContext) => Promise<void>) {
+    return async (cx: CertStepContext) => {
+        requireTcpCapableController();
+        await run(cx);
+    };
+}
+
 /** Every TCP case starts the same way, so its first step is shared rather than copied. */
-export function tcpSessionStep(commissioned: CommissionedRefs<"th">) {
+export function tcpSessionStep(commissioned: CommissionedRefs<"th">, session?: TcpSessionRef) {
     return async (cx: CertStepContext) => {
         const { from } = await commissionOverTcp(cx, commissioned);
-        await recordTcpSession(cx, from, "the session the TH established with the DUT runs over TCP");
+
+        // The session evidence is recorded whether or not the case captures the tag
+        const tag = await recordTcpSession(
+            cx,
+            from,
+            "the session the TH established with the DUT runs over TCP, which is what makes it large-payload-capable",
+        );
+        session?.set(tag);
     };
 }
 

--- a/support/chip-testing/test/cert/tc-sc-8-support.ts
+++ b/support/chip-testing/test/cert/tc-sc-8-support.ts
@@ -5,7 +5,7 @@
  */
 
 import { Matter } from "@matter/model";
-import type { CertNodeRef, CertStepContext, DeviceFlavor } from "@matter/testing";
+import type { CertNodeRef, CertStepContext, CheckRecord, DeviceFlavor } from "@matter/testing";
 import { resolveControllerImplementation, UnsupportedByControllerError } from "@matter/testing";
 import {
     CertCheckFailedError,
@@ -137,6 +137,38 @@ const SESSION_TAG = /(@[0-9a-f]+:[0-9a-f]+•[0-9a-f]+)\(tcp\)/;
  * message line is the `InvokeResponse` going back out. Every one of them carries the session tag,
  * which is what makes this the session step 1 established rather than any TCP-backed one.
  */
+export async function tcpInvokeCheck(
+    cx: CertStepContext,
+    session: string,
+    endpoint: number,
+    cluster: number,
+    command: number,
+    from: number,
+): Promise<CheckRecord> {
+    const dut = cx.devices.dut;
+    const onSession = `${literally(session)}\\(tcp\\)⇵[0-9a-f]+`;
+    const path = matterjsCommandPath(endpoint, cluster, command);
+    return expectSequence(
+        dut.log,
+        dut.flavor,
+        `an invoke of ${endpoint}/${cluster}/${command} answered with an InvokeResponse on ${session}`,
+        {
+            matterjs: {
+                ordered: [
+                    // The invoke line carries the timed/suppress-response flags between the session
+                    // and its path, and drops them when neither is set
+                    new RegExp(`InteractionServer Invoke « ${onSession}.*invokes: .*?${path}`),
+                    new RegExp(`InteractionServer Invoke \\(final\\) » ${onSession} commands: 1(?!\\d)`),
+                    new RegExp(`Message » for: I/InvokeResponse id: ${onSession}`),
+                ],
+            },
+        },
+        from,
+        LOG_TIMEOUT,
+    );
+}
+
+/** {@link tcpInvokeCheck}, recorded as the step's evidence. */
 export async function recordTcpInvoke(
     cx: CertStepContext,
     session: string,
@@ -146,31 +178,7 @@ export async function recordTcpInvoke(
     from: number,
     what: string,
 ) {
-    const dut = cx.devices.dut;
-    const onSession = `${literally(session)}\\(tcp\\)⇵[0-9a-f]+`;
-    const path = matterjsCommandPath(endpoint, cluster, command);
-    record(
-        cx,
-        await expectSequence(
-            dut.log,
-            dut.flavor,
-            `an invoke of ${endpoint}/${cluster}/${command} answered with an InvokeResponse on ${session}`,
-            {
-                matterjs: {
-                    ordered: [
-                        // The invoke line carries the timed/suppress-response flags between the session
-                        // and its path, and drops them when neither is set
-                        new RegExp(`InteractionServer Invoke « ${onSession}.*invokes: .*?${path}`),
-                        new RegExp(`InteractionServer Invoke \\(final\\) » ${onSession} commands: 1(?!\\d)`),
-                        new RegExp(`Message » for: I/InvokeResponse id: ${onSession}`),
-                    ],
-                },
-            },
-            from,
-            LOG_TIMEOUT,
-        ),
-        what,
-    );
+    record(cx, await tcpInvokeCheck(cx, session, endpoint, cluster, command, from), what);
 }
 
 /** Where a TCP case keeps the session its first step established, for the steps that follow. */
@@ -206,17 +214,16 @@ export function tcpStep(run: (cx: CertStepContext) => Promise<void>) {
 }
 
 /** Every TCP case starts the same way, so its first step is shared rather than copied. */
-export function tcpSessionStep(commissioned: CommissionedRefs<"th">, session?: TcpSessionRef) {
+export function tcpSessionStep(commissioned: CommissionedRefs<"th">, session: TcpSessionRef) {
     return async (cx: CertStepContext) => {
         const { from } = await commissionOverTcp(cx, commissioned);
-
-        // The session evidence is recorded whether or not the case captures the tag
-        const tag = await recordTcpSession(
-            cx,
-            from,
-            "the session the TH established with the DUT runs over TCP, which is what makes it large-payload-capable",
+        session.set(
+            await recordTcpSession(
+                cx,
+                from,
+                "the session the TH established with the DUT runs over TCP, which is what makes it large-payload-capable",
+            ),
         );
-        session?.set(tag);
     };
 }
 

--- a/support/chip-testing/test/cert/tc-sc-8-support.ts
+++ b/support/chip-testing/test/cert/tc-sc-8-support.ts
@@ -247,6 +247,97 @@ export async function recordTcpInvoke(
     record(cx, await tcpInvokeCheck(cx, session, endpoint, cluster, command, from), what);
 }
 
+/**
+ * Above this, a report cannot have crossed an MRP session: 1280 bytes is the IPv6 minimum MTU, and
+ * MRP's own payload budget is smaller still (~1232 bytes once the headers are counted), so a payload
+ * larger than this is conservative evidence of a large-payload session either way.
+ *
+ * @see {@link MatterSpecification.v141.Core} § 4.4.4
+ */
+const LARGE_PAYLOAD_FLOOR = 1280;
+
+/** The payload size matter.js prints on a message line — the encoded message, without its framing. */
+const REPORT_SIZE = /\bsize: (\d+)\b/;
+
+/** How much of a matched line the evidence keeps; a wildcard read's report line carries its whole payload in hex. */
+const EVIDENCE_LIMIT = 300;
+
+/**
+ * Confirms the DUT answered the wildcard read that arrived on `session` with a **single**
+ * `ReportData` too large for an MRP session to have carried — the behaviour a large-payload session
+ * exists for, and the only witness of it this stack produces: nothing logs a session's maximum
+ * payload, while a report that both exceeds {@link LARGE_PAYLOAD_FLOOR} and was never chunked could
+ * not have crossed one.
+ */
+export async function wildcardReadInOneReportCheck(
+    cx: CertStepContext,
+    session: string,
+    from: number,
+): Promise<CheckRecord> {
+    const dut = cx.devices.dut;
+    const onSession = `${literally(session)}\\(tcp\\)`;
+
+    const request = await expectSequence(
+        dut.log,
+        dut.flavor,
+        `a read of every attribute on ${session}`,
+        // The path is what tells this read from any other on the session — commissioning performs a
+        // single-attribute read moments earlier
+        { matterjs: [new RegExp(`InteractionServer Read « ${onSession}⇵[0-9a-f]+ .*attributes: \\*\\.\\*\\.\\*`)] },
+        from,
+        LOG_TIMEOUT,
+    );
+    if (request.verdict !== "pass" || request.matched === undefined || request.logLine === undefined) {
+        return request;
+    }
+
+    const exchange = EXCHANGE.exec(request.matched)?.[1];
+    if (exchange === undefined) {
+        return {
+            type: "device-log",
+            verdict: "fail",
+            pattern: EXCHANGE.source,
+            detail: `the DUT's read line names no exchange: ${request.matched}`,
+            logLine: request.logLine,
+        };
+    }
+
+    const report = new RegExp(`Message » for: I/ReportData .*\\bid: ${onSession}⇵${exchange}✉`);
+    const first = await expectSequence(
+        dut.log,
+        dut.flavor,
+        `a ReportData answering the read on exchange ${exchange}`,
+        { matterjs: [report] },
+        request.logLine + 1,
+        LOG_TIMEOUT,
+    );
+    if (first.verdict !== "pass") {
+        return first;
+    }
+
+    // Waiting for the first report is what makes the count trustworthy: a device that chunks emits
+    // the rest immediately after it, and settling only bounds the pump's own lag
+    await dut.log.settled();
+    const lines = dut.log.lines;
+    const reports = lines.slice(request.logLine + 1).filter(line => !line.synthetic && report.test(line.text));
+
+    const sizes = reports.map(line => Number(REPORT_SIZE.exec(line.text)?.[1] ?? Number.NaN));
+    const single = reports.length === 1 && sizes[0] > LARGE_PAYLOAD_FLOOR;
+    return {
+        type: "device-log",
+        verdict: single ? "pass" : "fail",
+        pattern: report.source,
+        detail: `${reports.length} ReportData on exchange ${exchange}, of ${sizes.join(", ") || "no"} bytes`,
+        matched: reports[0]?.text.slice(0, EVIDENCE_LIMIT),
+        logLine: reports[0]?.index,
+    };
+}
+
+/** {@link wildcardReadInOneReportCheck}, recorded as the step's evidence. */
+export async function recordWildcardReadInOneReport(cx: CertStepContext, session: string, from: number, what: string) {
+    record(cx, await wildcardReadInOneReportCheck(cx, session, from), what);
+}
+
 /** Where a TCP case keeps the session its first step established, for the steps that follow. */
 export class TcpSessionRef {
     #tag?: string;

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -126,7 +126,8 @@ export async function runCleanups(...cleanups: (() => Promise<void>)[]): Promise
     }
 }
 
-function describeError(e: unknown): string {
+/** An error as evidence text, naming its class as well as its message. */
+export function describeError(e: unknown): string {
     return e instanceof Error ? `${e.constructor.name}: ${e.message}` : String(e);
 }
 

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -706,13 +706,21 @@ export function sameMessageFrom(flavor: string, earlier: CheckRecord, mark: numb
  * command itself — a command path has no `state.` segment (`resolvePathForNode`).
  */
 function matterjsInvokePath(endpoint: number, cluster: number, command: number): RegExp {
+    return new RegExp(`InteractionServer Invoke «.*invokes: .*?${matterjsCommandPath(endpoint, cluster, command)}`);
+}
+
+/**
+ * The command path itself, bounded so it cannot match as part of a longer path, for a caller building
+ * its own line around it.
+ */
+export function matterjsCommandPath(endpoint: number, cluster: number, command: number): string {
     const model = Matter.clusters(cluster);
     const path = [
         `${endpoint}`,
         matterjsElement(model?.name, cluster),
         matterjsElement(model?.commands(command)?.name, command),
     ].join("\\.");
-    return new RegExp(`InteractionServer Invoke «.*invokes: .*?${MATTERJS_PATH_START}${path}${MATTERJS_PATH_END}`);
+    return `${MATTERJS_PATH_START}${path}${MATTERJS_PATH_END}`;
 }
 
 /**
@@ -889,7 +897,7 @@ export interface CommandFieldValue {
 }
 
 /** `value` as a pattern matching itself and nothing else. */
-function literally(value: string): string {
+export function literally(value: string): string {
     return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -896,6 +896,15 @@ export interface CommandFieldValue {
     value: number | bigint | string;
 }
 
+/**
+ * `value` as evidence text. `JSON.stringify` throws on a `bigint`, and Matter carries plenty of them
+ * (an `epoch-us`, a node id, a `systime-ms`), so a step reporting what a device answered would
+ * otherwise fail on its own evidence.
+ */
+export function describeValue(value: unknown): string {
+    return JSON.stringify(value, (_key, member) => (typeof member === "bigint" ? `${member}` : member)) ?? "undefined";
+}
+
 /** `value` as a pattern matching itself and nothing else. */
 export function literally(value: string): string {
     return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");


### PR DESCRIPTION
Adds the certification case TC-SC-8.5: a test harness establishes a CASE session that runs over TCP with the device under test, sends one command over that session, and confirms the command response comes back.

Step 1 is TC-SC-8.1's step, reused unchanged in what it asserts. Step 2 invokes `GeneralDiagnostics.TimeSnapshot` — a command that carries a response of its own and changes nothing on the device, so re-running the case does not depend on what a previous run left behind — and checks both what the controller received and what the device logged.

**The evidence is bound to the session, not just to the transport.** Step 1 now returns the device's own name for the session it matched (matter.js prints it as `@<fabric>:<node>•<id>(tcp)`), and step 2 builds every log pattern around that name. A pattern asking only for `(tcp)` would be satisfied by any TCP-backed session, which is not what the plan claims.

**Every step of a TCP case has to refuse a controller that cannot establish such a session, not only the first.** Without that, the chip-tool leg skipped step 1 and then *failed* step 2 on the commissioning that never happened — a failed run whose real cause is a controller capability gap. `tcpStep()` now applies the refusal, so a future case in this block gets it by construction.

A hermetic test (`test/cert-framework/tc-sc-8-support.test.ts`, 11 cases, no docker and no chip binary needed) covers the new helpers: the session-name extraction, and each way the invoke patterns could be satisfied by the wrong thing — another session, another command, another endpoint, a response carrying more commands than were sent, no answer at all.

No CHANGELOG entry: this touches only the private `@matter/chip-testing` test package, as TC-SC-6.1 did.

### Evidence that the checks are not vacuous

- Naming a command id one higher than `TimeSnapshot`'s: the device-log check times out and fails while the controller-side response check still passes.
- Substituting a bogus session name for the captured one: the same, failing on the invoke line.
- Dropping the `commands: 1(?!\d)` bound, or the tolerance for the timed/suppress-response flags matter.js prints between the session name and the command path: two of the hermetic tests go red.

### Matrix legs

| Leg | Outcome |
| --- | --- |
| matter.js controller × matter.js device | passes, three checks recorded |
| chip-tool controller × matter.js device | both steps skipped, with the reason |
| either controller × chip device flavors | skipped before activation (`flavors: ["matterjs"]`) |

### Verification

Run from the repository root:

```
npm run build          exit 0
npm run format-verify  exit 0   All matched files use the correct format.
npm run lint           exit 0
npm test               exit 0
```

Certification suites (not covered by the root `npm test`):

```
npx matter-test --spec="test/cert/*.test.ts" --report            exit 0, 29 cases pass
npm --prefix support/chip-testing run test-cert-framework -- --no-pull   exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)