### PR TITLE
One regex-escape helper for the cert tests, not three

### DIFF
--- a/support/chip-testing/test/cert/tc-idm-1.3-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-1.3-support.ts
@@ -8,7 +8,13 @@ import { Duration, ImplementationError } from "@matter/main";
 import type { CheckRecord, LogFollower } from "@matter/testing";
 import { CertLogClosedError, CertLogTimeoutError } from "@matter/testing";
 import { ChipFault } from "./fault-injection.js";
-import { commandPathIBSequence, expectAdjacentLines, expectSequence, INVOKE_REQUEST_MESSAGE } from "./tc-support.js";
+import {
+    commandPathIBSequence,
+    expectAdjacentLines,
+    expectSequence,
+    INVOKE_REQUEST_MESSAGE,
+    literally,
+} from "./tc-support.js";
 
 /** A concrete command path of a batched invoke. */
 export interface BatchPath {
@@ -43,10 +49,6 @@ const FAULT_DESCRIPTIONS = new Map<number, string>([
     [ChipFault.imInvokeSkipSecondResponse, "Single InvokeResponseMessages. Dropping response to second request"],
 ]);
 
-function escapeForPattern(text: string) {
-    return text.replace(/[.*+?^${}()|[\]\\]/g, match => `\\${match}`);
-}
-
 function descriptionOf(fault: number) {
     const description = FAULT_DESCRIPTIONS.get(fault);
     if (description === undefined) {
@@ -60,10 +62,7 @@ function descriptionOf(fault: number) {
  * description of the response it substitutes.
  */
 export function injectedFaultSequence(fault: number): RegExp[] {
-    return [
-        FAULT_INJECTED_LINE,
-        new RegExp(`Injecting the following response:${escapeForPattern(descriptionOf(fault))}`),
-    ];
+    return [FAULT_INJECTED_LINE, new RegExp(`Injecting the following response:${literally(descriptionOf(fault))}`)];
 }
 
 /**

--- a/support/chip-testing/test/cert/tc-idm-5.1-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-5.1-support.ts
@@ -7,7 +7,7 @@
 import { Duration, InternalError, Millis, Seconds, Time } from "@matter/main";
 import type { CheckRecord, LogFollower, LogLine } from "@matter/testing";
 import { CertLogClosedError, CertLogTimeoutError, forFlavor } from "@matter/testing";
-import { expectAdjacentLines, INVOKE_REQUEST_MESSAGE, WRITE_REQUEST_MESSAGE } from "./tc-support.js";
+import { expectAdjacentLines, INVOKE_REQUEST_MESSAGE, literally, WRITE_REQUEST_MESSAGE } from "./tc-support.js";
 
 // TC-IDM-5.1's own checks live beside the test case rather than inside it because a `TC-*.test.ts`
 // registers a device-driven mocha test at import time, so the cert-framework spec set cannot import
@@ -283,7 +283,7 @@ const MATTERJS_FOLLOW_UPS: Record<TimedInteraction, string> = {
 
 /** matter.js's own line for the message of `interaction` that arrived on `session`'s `exchange`. */
 function matterjsFollowUpPattern(interaction: TimedInteraction, session: string, exchange: string): RegExp {
-    return new RegExp(`Message « for: I/${MATTERJS_FOLLOW_UPS[interaction]} id: ${escaped(session)}⇵${exchange}✉`);
+    return new RegExp(`Message « for: I/${MATTERJS_FOLLOW_UPS[interaction]} id: ${literally(session)}⇵${exchange}✉`);
 }
 
 // matter.js clears the timed interaction a message consumed, naming the exchange in decimal where the
@@ -292,13 +292,8 @@ function matterjsFollowUpPattern(interaction: TimedInteraction, session: string,
 // matter.js does not print at all), present for both kinds.
 function matterjsTimedClearedPattern(session: string, exchange: string): RegExp {
     return new RegExp(
-        `Clearing timed interaction exId: ${parseInt(exchange, 16)}(?!\\d) via: ${escaped(session)}(?![0-9a-f])`,
+        `Clearing timed interaction exId: ${parseInt(exchange, 16)}(?!\\d) via: ${literally(session)}(?![0-9a-f])`,
     );
-}
-
-/** A captured log token used as a literal inside a larger pattern. */
-function escaped(text: string): string {
-    return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /** As {@link expectTimedFollowUp} against a matter.js TH. */


### PR DESCRIPTION
Two certification support modules each carried their own copy of the same helper: "escape this captured log token so it matches itself inside a larger pattern". A third copy already lived in `tc-support.ts` and is now exported; both callers use it.

No behaviour change — all three escaped the same character set the same way (`escapeForPattern` spelled the replacement as a callback, the other two as `"\\$&"`).

**Stacked on #4357**, which is where `literally` is exported from. Review that one first; this diff is two files.

### Verification

Repository root:

```
npm run build          exit 0
npm run format-verify  exit 0
npm run lint           exit 0
```

Certification suites (not covered by the root `npm test`):

```
npm --prefix support/chip-testing run test-cert-framework -- --no-pull   exit 0
npx matter-test --spec=test/cert/TC-IDM-1.3.test.ts --report            exit 0
npx matter-test --spec=test/cert/TC-IDM-5.1.test.ts --report            exit 0
```

The two cert cases are the ones whose helpers changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)