### PR TITLE
An invoke answers each command with its own status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,12 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A certification run's `result.json` no longer reports a passing verdict for a run that failed
     - Fix: A failure to attach a certification run's device logs fails the run instead of only warning
 
+- @matter/node
+    - Fix: A mandatory command a cluster leaves unimplemented is no longer dispatched; an invoke answers `UNSUPPORTED_COMMAND`, matching what the cluster advertises in `AcceptedCommandList`
+
 - @matter/protocol
     - Enhancement: An interaction can be abandoned by the caller: `ClientRequest.abort` takes an `AbortSignal`, honored for read, write, invoke and subscribe
+    - Fix: An error escaping a command handler with no defined status code answers that command with `FAILURE` inside the `InvokeResponse` instead of terminating the message with a status response, so the other commands of a batch invoke keep their results. Under `SuppressResponse` such a command now sends no response at all, as for any other generated status
     - Fix: A device that returns an empty or malformed DAC, PAI, attestation elements or Certification Declaration during commissioning now fails attestation with a finding that names the unreadable field, instead of an opaque decoder message
     - Fix: A certificate extension matter.js does not interpret is no longer decoded, so a proprietary extension can no longer fail the whole certificate; an extension matter.js does read is rejected with a `CertificateError` when its value is missing
 

--- a/packages/node/src/node/integration/ProtocolService.ts
+++ b/packages/node/src/node/integration/ProtocolService.ts
@@ -401,7 +401,7 @@ function clusterTypeProtocolOf(backing: BehaviorBacking): ClusterTypeProtocol | 
     const supportedElements = backing.endpoint.behaviors.elementsOf(behavior);
     const nonMandatorySupportedAttributes = new Set<AttributeId>();
     const nonMandatorySupportedEvents = new Set<EventId>();
-    const nonMandatorySupportedCommands = new Set<CommandId>();
+    const supportedCommands = new Set<CommandId>();
 
     let wildcardPathFlags = schema.effectiveQuality.diagnostics ? WildcardPathFlags.skipDiagnosticsClusters : 0;
     if (schema.id & 0xffff0000) {
@@ -524,11 +524,9 @@ function clusterTypeProtocolOf(backing: BehaviorBacking): ClusterTypeProtocol | 
                 break;
             }
             case "command": {
-                if (
-                    id === CommandId.NONE ||
-                    (!member.effectiveConformance.isMandatory && !supportedElements.commands.has(name)) ||
-                    !member.isRequest
-                ) {
+                // A mandatory command left unimplemented is absent from AcceptedCommandList; dispatching it anyway
+                // would answer an invoke the cluster does not advertise
+                if (id === CommandId.NONE || !supportedElements.commands.has(name) || !member.isRequest) {
                     continue;
                 }
 
@@ -545,15 +543,13 @@ function clusterTypeProtocolOf(backing: BehaviorBacking): ClusterTypeProtocol | 
 
                 commandList.push(command);
                 commands[id] = command;
-                if (!member.effectiveConformance.isMandatory) {
-                    nonMandatorySupportedCommands.add(id as CommandId);
-                }
+                supportedCommands.add(id as CommandId);
                 break;
             }
         }
     }
 
-    const elementsCacheKey = `a:${[...nonMandatorySupportedAttributes.values()].sort().join(",")},e:${[...nonMandatorySupportedEvents.values()].sort().join(",")},c:${[...nonMandatorySupportedCommands.values()].sort().join(",")}`;
+    const elementsCacheKey = `a:${[...nonMandatorySupportedAttributes.values()].sort().join(",")},e:${[...nonMandatorySupportedEvents.values()].sort().join(",")},c:${[...supportedCommands.values()].sort().join(",")}`;
     const existingCache = behaviorCache.get(behavior)?.get(elementsCacheKey);
     if (existingCache) {
         return existingCache;

--- a/packages/node/test/endpoint/server/InteractionProtocolTest.ts
+++ b/packages/node/test/endpoint/server/InteractionProtocolTest.ts
@@ -9,8 +9,10 @@
 import { AdministratorCommissioningServer } from "#behaviors/administrator-commissioning";
 import { OnOffServer } from "#behaviors/on-off";
 import { WiFiNetworkDiagnosticsServer } from "#behaviors/wi-fi-network-diagnostics";
+import { OnOffLightDevice } from "#devices/on-off-light";
+import { Endpoint } from "#endpoint/Endpoint.js";
 import { InteractionServer } from "#node/server/InteractionServer.js";
-import { Observable } from "@matter/general";
+import { MatterFlowError, Observable } from "@matter/general";
 import { Specification } from "@matter/model";
 import {
     BaseDataReport,
@@ -1112,6 +1114,12 @@ async function fillIterableDataReport(data: {
     return dataReport;
 }
 
+class ThrowingOnOffServer extends OnOffServer {
+    override on(): never {
+        throw new MatterFlowError("boom");
+    }
+}
+
 class EventedOnOffServer extends OnOffServer {
     declare events: EventedOnOffServer.Events;
 
@@ -1876,6 +1884,78 @@ describe("InteractionProtocol", () => {
             // Note: moreChunkedMessages is set by the messenger, not the handler
             expect(triggeredOn).equals(true);
             expect(triggeredOff).equals(true);
+            expect(onOffState).equals(false);
+        });
+
+        it("keeps already-sent chunks when a command on a later endpoint throws", async () => {
+            await createNode(200);
+            initilizeOnOff();
+
+            const device = new Endpoint(OnOffLightDevice.with(ThrowingOnOffServer));
+            await node.add(device);
+
+            // Fill endpoint 0 so its chunk exceeds the payload limit and is transmitted before endpoint 1 runs
+            const invokeRequests = new Array<InvokeRequest["invokeRequests"][number]>();
+            for (let i = 0; i < 100; i++) {
+                invokeRequests.push({
+                    commandPath: {
+                        endpointId: EndpointNumber(0),
+                        clusterId: ClusterId(6),
+                        commandId: CommandId(100 + i),
+                    },
+                    commandFields: TlvNoArguments.encodeTlv(undefined),
+                    commandRef: i + 1,
+                });
+            }
+            invokeRequests.push({
+                commandPath: { endpointId: EndpointNumber(1), clusterId: ClusterId(6), commandId: CommandId(1) },
+                commandFields: TlvNoArguments.encodeTlv(undefined),
+                commandRef: 101,
+            });
+
+            const exchange = await createDummyMessageExchange(node);
+            const { messenger, getResponse, getChunks } = createMockInvokeMessenger();
+
+            await interactionProtocol.handleInvokeRequest(
+                exchange,
+                { ...INVOKE_COMMAND_REQUEST_MULTI, invokeRequests },
+                messenger,
+                interaction.BarelyMockedMessage,
+            );
+
+            const chunks = getChunks();
+            expect(chunks.length).greaterThan(0);
+
+            const responses = [...chunks, getResponse()!].flatMap(result =>
+                result.invokeResponses.map(encoded => TlvInvokeResponseData.decodeTlv(encoded)),
+            );
+            expect(responses.length).equals(101);
+
+            expect(responses.find(response => response.status?.commandRef === 101)?.status?.status.status).equals(
+                Status.Failure,
+            );
+            expect(
+                chunks.flatMap(chunk => chunk.invokeResponses.map(encoded => TlvInvokeResponseData.decodeTlv(encoded)))
+                    .length,
+            ).greaterThan(0);
+        });
+
+        it("sends no response under SuppressResponse when a command throws", async () => {
+            node.eventsOf(EventedOnOffServer).onCalled.on(() => {
+                throw new MatterFlowError("boom");
+            });
+
+            const exchange = await createDummyMessageExchange(node);
+            const { messenger, getResponse, getChunks } = createMockInvokeMessenger();
+            await interactionProtocol.handleInvokeRequest(
+                exchange,
+                INVOKE_ON_OFF_SUPPRESSED,
+                messenger,
+                interaction.BarelyMockedMessage,
+            );
+
+            expect(getResponse()).equals(undefined);
+            expect(getChunks().length).equals(0);
             expect(onOffState).equals(false);
         });
 

--- a/packages/node/test/node/CommandInvokeResponseTest.ts
+++ b/packages/node/test/node/CommandInvokeResponseTest.ts
@@ -6,11 +6,14 @@
 
 import { ClientBehavior } from "#behavior/cluster/ClientBehavior.js";
 import { OnOffClient, OnOffServer } from "#behaviors/on-off";
+import { ChimeDevice } from "#devices/chime";
 import { OnOffLightDevice } from "#devices/on-off-light";
 import { Endpoint } from "#endpoint/index.js";
+import { MatterFlowError } from "@matter/general";
 import { AccessLevel } from "@matter/model";
 import { CommandInvokeResponse, Invoke, InvokeRequest, InvokeResult } from "@matter/protocol";
 import { ClusterId, CommandId, EndpointNumber, Status, StatusResponseError } from "@matter/types";
+import { Chime } from "@matter/types/clusters/chime";
 import { OnOff } from "@matter/types/clusters/on-off";
 import { MockServerNode } from "./mock-server-node.js";
 
@@ -299,6 +302,150 @@ describe("CommandInvokeResponse", () => {
                 path: { clusterId: 6, commandId: 1, endpointId: 1 },
                 status: Status.Failure,
                 clusterStatus: 0x42,
+                commandRef: undefined,
+            },
+        ]);
+    });
+
+    it("reports an error with no defined status code as a per-command FAILURE", async () => {
+        class ThrowingOnOffServer extends OnOffServer {
+            override on(): never {
+                throw new MatterFlowError("boom");
+            }
+        }
+        const device = new Endpoint(OnOffLightDevice.with(ThrowingOnOffServer));
+        const node = await MockServerNode.createOnline(undefined, { device });
+        const response = await invokeCmd(
+            node,
+            Invoke.ConcreteCommandRequest({
+                endpoint: device,
+                cluster: OnOff,
+                command: "on",
+            }),
+        );
+
+        expect(response.data).deep.equals([
+            {
+                kind: "cmd-status",
+                path: { clusterId: 6, commandId: 1, endpointId: 1 },
+                status: Status.Failure,
+                clusterStatus: undefined,
+                commandRef: undefined,
+            },
+        ]);
+        expect(response.counts).deep.equals({ status: 1, success: 0, existent: 1 });
+    });
+
+    it("reports a plain Error escaping a handler as a per-command FAILURE", async () => {
+        class ThrowingOnOffServer extends OnOffServer {
+            override on(): never {
+                throw new Error("boom");
+            }
+        }
+        const device = new Endpoint(OnOffLightDevice.with(ThrowingOnOffServer));
+        const node = await MockServerNode.createOnline(undefined, { device });
+        const response = await invokeCmd(
+            node,
+            Invoke.ConcreteCommandRequest({
+                endpoint: device,
+                cluster: OnOff,
+                command: "on",
+            }),
+        );
+
+        expect(response.data).deep.equals([
+            {
+                kind: "cmd-status",
+                path: { clusterId: 6, commandId: 1, endpointId: 1 },
+                status: Status.Failure,
+                clusterStatus: undefined,
+                commandRef: undefined,
+            },
+        ]);
+        expect(response.counts).deep.equals({ status: 1, success: 0, existent: 1 });
+    });
+
+    it("keeps sibling results and continues the batch when one command throws", async () => {
+        let thrown = false;
+        class ThrowingOnOffServer extends OnOffServer {
+            override on() {
+                if (thrown) {
+                    return super.on();
+                }
+                thrown = true;
+                throw new MatterFlowError("boom");
+            }
+        }
+        const device = new Endpoint(OnOffLightDevice.with(ThrowingOnOffServer));
+        const node = await MockServerNode.createOnline(undefined, { device });
+
+        const response = await invokeCmdRaw(node, {
+            invokeRequests: [
+                {
+                    commandPath: { endpointId: EndpointNumber(1), clusterId: ClusterId(6), commandId: CommandId(0) },
+                    commandRef: 1,
+                },
+                {
+                    commandPath: { endpointId: EndpointNumber(1), clusterId: ClusterId(6), commandId: CommandId(1) },
+                    commandRef: 2,
+                },
+                {
+                    commandPath: { endpointId: EndpointNumber(1), clusterId: ClusterId(6), commandId: CommandId(2) },
+                    commandRef: 3,
+                },
+            ],
+        });
+
+        expect(response.data).deep.equals([
+            {
+                kind: "cmd-status",
+                path: { clusterId: 6, commandId: 0, endpointId: 1 },
+                status: Status.Success,
+                clusterStatus: undefined,
+                commandRef: 1,
+            },
+            {
+                kind: "cmd-status",
+                path: { clusterId: 6, commandId: 1, endpointId: 1 },
+                status: Status.Failure,
+                clusterStatus: undefined,
+                commandRef: 2,
+            },
+            {
+                kind: "cmd-status",
+                path: { clusterId: 6, commandId: 2, endpointId: 1 },
+                status: Status.Success,
+                clusterStatus: undefined,
+                commandRef: 3,
+            },
+        ]);
+        expect(response.counts).deep.equals({ status: 1, success: 2, existent: 3 });
+        expect(device.state.onOff.onOff).equals(true);
+    });
+
+    it("reports an unimplemented mandatory command as UNSUPPORTED_COMMAND and omits it from AcceptedCommandList", async () => {
+        const device = new Endpoint(ChimeDevice, {
+            chime: { installedChimeSounds: [{ chimeId: 0, name: "Ding" }], selectedChime: 0 },
+        });
+        const node = await MockServerNode.createOnline(undefined, { device });
+
+        expect(device.globalsOf("chime").acceptedCommandList).deep.equals([]);
+
+        const response = await invokeCmd(
+            node,
+            Invoke.ConcreteCommandRequest({
+                endpoint: device,
+                cluster: Chime.Cluster,
+                command: "playChimeSound",
+            }),
+        );
+
+        expect(response.data).deep.equals([
+            {
+                kind: "cmd-status",
+                path: { clusterId: Chime.Cluster.id, commandId: 0, endpointId: 1 },
+                status: Status.UnsupportedCommand,
+                clusterStatus: undefined,
                 commandRef: undefined,
             },
         ]);

--- a/packages/protocol/src/action/server/CommandInvokeResponse.ts
+++ b/packages/protocol/src/action/server/CommandInvokeResponse.ts
@@ -476,12 +476,20 @@ export class CommandInvokeResponse<
             try {
                 const sre = StatusResponseError.of(error);
 
+                if (sre !== undefined) {
+                    status = sre.code;
+                    clusterStatus = sre.clusterCode;
+                    if (sre instanceof ValidationError && status === Status.InvalidAction) {
+                        status = Status.InvalidCommand;
+                    }
+                }
+
+                // Discarding the command's state must not be contingent on logging succeeding
+                await this.session.transaction?.rollback();
+
                 if (sre === undefined) {
                     logger.error(`Unhandled error invoking command ${this.node.inspectPath(path)}:`, error);
                 } else {
-                    status = sre.code;
-                    clusterStatus = sre.clusterCode;
-
                     const errorLogText = `Error ${Diagnostic.hex(status)}${
                         clusterStatus !== undefined ? `/${Diagnostic.hex(clusterStatus)}` : ""
                     } while invoking command: ${sre.message}`;
@@ -490,15 +498,10 @@ export class CommandInvokeResponse<
                         logger.info(
                             `Validation-${errorLogText}${sre.fieldName !== undefined ? ` in field ${sre.fieldName}` : ""}`,
                         );
-                        if (status === Status.InvalidAction) {
-                            status = Status.InvalidCommand;
-                        }
                     } else {
                         logger.info(errorLogText);
                     }
                 }
-
-                await this.session.transaction?.rollback();
             } catch (secondary) {
                 logger.error("Secondary error handling invoke failure:", secondary);
             }

--- a/packages/protocol/src/action/server/CommandInvokeResponse.ts
+++ b/packages/protocol/src/action/server/CommandInvokeResponse.ts
@@ -469,27 +469,20 @@ export class CommandInvokeResponse<
             }
         } catch (error) {
             // Spec 1.6 §8.8.3.2.1: Invoke Execution yields only a CommandStatusIB or a CommandDataIB, so this command
-            // owes a status however classification, logging or rollback themselves fare
+            // owes a status even if handling the error itself fails
             let status = Status.Failure;
             let clusterStatus: number | undefined;
 
             try {
-                const sre = StatusResponseError.of(error);
-
-                if (sre !== undefined) {
-                    status = sre.code;
-                    clusterStatus = sre.clusterCode;
-                    if (sre instanceof ValidationError && status === Status.InvalidAction) {
-                        status = Status.InvalidCommand;
-                    }
-                }
-
-                // Discarding the command's state must not be contingent on logging succeeding
                 await this.session.transaction?.rollback();
 
+                const sre = StatusResponseError.of(error);
                 if (sre === undefined) {
                     logger.error(`Unhandled error invoking command ${this.node.inspectPath(path)}:`, error);
                 } else {
+                    status = sre.code;
+                    clusterStatus = sre.clusterCode;
+
                     const errorLogText = `Error ${Diagnostic.hex(status)}${
                         clusterStatus !== undefined ? `/${Diagnostic.hex(clusterStatus)}` : ""
                     } while invoking command: ${sre.message}`;
@@ -498,6 +491,9 @@ export class CommandInvokeResponse<
                         logger.info(
                             `Validation-${errorLogText}${sre.fieldName !== undefined ? ` in field ${sre.fieldName}` : ""}`,
                         );
+                        if (status === Status.InvalidAction) {
+                            status = Status.InvalidCommand;
+                        }
                     } else {
                         logger.info(errorLogText);
                     }

--- a/packages/protocol/src/action/server/CommandInvokeResponse.ts
+++ b/packages/protocol/src/action/server/CommandInvokeResponse.ts
@@ -447,10 +447,13 @@ export class CommandInvokeResponse<
                 requestTlv.validate(request);
             }
             const response = await invoker(request, this.session);
+
+            // A response the schema cannot represent must roll back with its command rather than leave state
+            // committed behind a failure status
+            const encodedResponse = responseTlv.encodeTlv(response);
             await this.session.transaction?.commit();
 
             this.#successCount++;
-            const encodedResponse = responseTlv.encodeTlv(response);
             if (encodedResponse.length === 0) {
                 this.#addStatus(path, commandRef, Status.Success);
             } else {
@@ -465,31 +468,43 @@ export class CommandInvokeResponse<
                 });
             }
         } catch (error) {
-            await this.session.transaction?.rollback();
-            const sre = StatusResponseError.of(error);
-            if (sre) {
-                this.#errorCount++;
+            // Spec 1.6 §8.8.3.2.1: Invoke Execution yields only a CommandStatusIB or a CommandDataIB, so this command
+            // owes a status however classification, logging or rollback themselves fare
+            let status = Status.Failure;
+            let clusterStatus: number | undefined;
 
-                let errorCode = sre.code;
-                const errorLogText = `Error ${Diagnostic.hex(errorCode)}${
-                    sre.clusterCode !== undefined ? `/${Diagnostic.hex(sre.clusterCode)}` : ""
-                } while invoking command: ${sre.message}`;
+            try {
+                const sre = StatusResponseError.of(error);
 
-                if (sre instanceof ValidationError) {
-                    logger.info(
-                        `Validation-${errorLogText}${sre.fieldName !== undefined ? ` in field ${sre.fieldName}` : ""}`,
-                    );
-                    if (errorCode === Status.InvalidAction) {
-                        errorCode = Status.InvalidCommand;
-                    }
+                if (sre === undefined) {
+                    logger.error(`Unhandled error invoking command ${this.node.inspectPath(path)}:`, error);
                 } else {
-                    logger.info(errorLogText);
+                    status = sre.code;
+                    clusterStatus = sre.clusterCode;
+
+                    const errorLogText = `Error ${Diagnostic.hex(status)}${
+                        clusterStatus !== undefined ? `/${Diagnostic.hex(clusterStatus)}` : ""
+                    } while invoking command: ${sre.message}`;
+
+                    if (sre instanceof ValidationError) {
+                        logger.info(
+                            `Validation-${errorLogText}${sre.fieldName !== undefined ? ` in field ${sre.fieldName}` : ""}`,
+                        );
+                        if (status === Status.InvalidAction) {
+                            status = Status.InvalidCommand;
+                        }
+                    } else {
+                        logger.info(errorLogText);
+                    }
                 }
 
-                this.#addStatus(path, commandRef, errorCode, sre.clusterCode);
-                return;
+                await this.session.transaction?.rollback();
+            } catch (secondary) {
+                logger.error("Secondary error handling invoke failure:", secondary);
             }
-            throw error;
+
+            this.#errorCount++;
+            this.#addStatus(path, commandRef, status, clusterStatus);
         }
     }
 

--- a/packages/protocol/src/common/FailsafeContext.ts
+++ b/packages/protocol/src/common/FailsafeContext.ts
@@ -176,7 +176,7 @@ export abstract class FailsafeContext {
      */
     createCertificateSigningRequest(isForUpdateNoc: boolean, sessionId: number) {
         if (this.#fabrics.findByKeypair(this.#builder.keyPair)) {
-            throw new MatterFlowError("Key pair already exists."); // becomes Failure as StatusResponse
+            throw new MatterFlowError("Key pair already exists.");
         }
 
         const result = this.#builder.createCertificateSigningRequest();


### PR DESCRIPTION
## What this changes

When a controller invokes a command, the device answers each command in the request individually. Two paths broke that and answered the whole *message* with a single failure instead.

**1. An error escaping a command handler.** A handler that threw anything other than a `StatusResponseError` — an internal error, an implementation error, a plain `Error` — terminated the entire message with a status response. In a batch invoke that is destructive: the commands that already ran had their results discarded, while their side effects stayed committed, because each command commits independently and nothing rolls them back.

Matter 1.6 §8.8 lists the message-level terminations exhaustively, and every one of them happens *before* any command executes. From that point on, §8.8.3.2.1 requires every outcome to be a `CommandStatusIB` or a `CommandDataIB` inside the `InvokeResponse`. So an error the cluster specification gives no status code for is `FAILURE` **on that one command**, not on the message. §8.3.1.2 ("if there is no well-defined Status Code for an error or exception, the Status Code of FAILURE SHALL be used") settles the code; it was only the envelope that was wrong.

**2. A mandatory command left unimplemented.** A cluster that leaves a mandatory command as the unimplemented stub already withholds it from `AcceptedCommandList` — but it was still registered for dispatch, so invoking it threw `NotImplementedError` and produced that same message-level failure. A controller was told the command is unsupported and then got a device-level error for using it. Dispatch now follows the advertised set, so such a command answers `UNSUPPORTED_COMMAND`, which is what CHIP does.

### Also in here

- The error path emits its status from a **single point**, so a failure while classifying, logging, or rolling back cannot displace the status the command is owed. `Tx.rollback()` can itself throw (it asserts the transaction is available), and in the previous shape that threw straight past the code meant to answer the command.
- A response is **encoded before the transaction commits**, so a response the schema cannot represent rolls back with its command instead of leaving state committed behind a failure status. This also stops such a command being counted as both a success and an error.

### Behaviour changes worth calling out

- Under `SuppressResponse`, a command that fails this way now sends no response at all, consistent with every other generated status. Previously the escaping error produced a message-level status response despite the suppression request.
- A rollback that leaves a participant's state neither committed nor restored is now reported as an ordinary per-command `FAILURE` and the batch continues. Previously it aborted the message, which at least signalled to the controller that node state was untrustworthy.

## Scope of change 2

I swept every exported device type and endpoint type and compared what gets registered for dispatch against what `ValidatedElements` accepts. The delta is **98 distinct cluster/command pairs, and every one of them is an unimplemented stub** — no implemented command loses wire reachability. It spans `DiagnosticLogs`, `TimeSynchronization`, `Chime`, `EnergyEvse`, `WaterHeaterManagement`, `ClosureControl`, `ThreadBorderRouterManagement`, the camera and WebRTC clusters and others; all of them already advertised an empty or reduced `AcceptedCommandList`, so this is convergence rather than a regression.

Startup feedback is unchanged: `ValidatedElements` still warns that the mandatory command is missing an implementation.

## Not in this PR

- **The per-site status audit.** Several throw sites would be better served by a specific status than by the generic `FAILURE` — `DeviceCommissioner`'s "commissioning window already open" has a cluster-specific `Busy`, a fabric label length violation is a constraint error, and a malformed TLV command payload should be `INVALID_COMMAND` rather than `FAILURE`. Each needs its own reading of the specification, so they follow separately. Nothing regresses by waiting: a per-command `FAILURE` is already an improvement on the message-level one they produce today. Where a throw genuinely represents a code error rather than an expected condition, `FAILURE` is the correct final answer and stays.
- **A transaction-unusable short circuit.** If `rollback()` fails *before* the transaction resets, the failed command's participants stay joined and a later command in the same batch could commit its writes. I could not construct a reachable trace for this, so it is filed as a question rather than fixed here; the reachable variants are contained.

## Tests

Six new cases, each proven by reverting the corresponding production change and confirming it goes red:

- an error with no defined status code, and a plain `Error`, each answered as a per-command `FAILURE`
- a batch where one command throws: the siblings before and after it keep their results and still execute
- a batch spanning two endpoints where the command on the second throws, driven through `InteractionServer.handleInvokeRequest` so a chunk is genuinely transmitted before the throw
- `SuppressResponse` with a throwing command sends nothing
- an unimplemented mandatory command answers `UNSUPPORTED_COMMAND` and agrees with `AcceptedCommandList`

Reverting the status emission turns 6 tests red; restoring the dispatch of unadvertised mandatory commands turns the `UNSUPPORTED_COMMAND` test red.

Two branches are argued statically rather than proven by a test, and I would rather say so than imply coverage: the rollback-failure catch (needs a destroyed or read-only transaction under a throwing handler) and the encode-before-commit ordering (needs a handler returning a response the schema cannot encode).

One test deliberately throws a plain `Error` rather than a typed `MatterError`. That is the subject under test — the point is that an untyped error is answered correctly — not a lapse in the error-type convention.

## Verification

```
npm run build-clean     ✓
npm run format-verify   ✓  All matched files use the correct format.
npm run lint            ✓
npm test -p packages/protocol   ✓ 1553/1553 ESM · 1553/1553 CJS
npm test -p packages/node       ✓ 1889/1889 ESM · 1889/1889 CJS
npm test -p packages/matter.js  ✓ 5/5 ESM · 5/5 CJS
npm test -p packages/nodejs     ✓ 340/340 ESM · 340/340 CJS
```

`support/chip-testing` and `support/tests` were not run: they are blocked in this environment (chip-tool PASE timeout, multicast on VPN tunnel interfaces), not by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
