### PR TITLE
TC-SC-8.6 (a device-wide read answered in one oversized report)

### DIFF
--- a/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
@@ -6,7 +6,12 @@
 
 import type { CertDevice, CertStepContext, CheckRecord, Subject } from "@matter/testing";
 import { LineQueue, LogFollower, PicsFile } from "@matter/testing";
-import { recordTcpInvoke, recordTcpSession, TcpSessionRef } from "../cert/tc-sc-8-support.js";
+import {
+    recordTcpInvoke,
+    recordTcpSession,
+    wildcardReadInOneReportCheck,
+    TcpSessionRef,
+} from "../cert/tc-sc-8-support.js";
 import { CertCheckFailedError } from "../cert/tc-support.js";
 
 /** GeneralDiagnostics, and its TimeSnapshot command, which TC-SC-8.5 invokes. */
@@ -201,6 +206,81 @@ describe("recordTcpInvoke", () => {
 
     it("fails when the DUT never answered the invoke", async () => {
         const checks = await invoke([invokeRequest()]);
+
+        expect(checks[0].verdict).equal("fail");
+    });
+});
+
+describe("wildcardReadInOneReportCheck", () => {
+    const EXCHANGE = "9200";
+
+    const wildcardRead = (session = SESSION, exchange = EXCHANGE, paths = "*.*.*") =>
+        `${at(5)} DEBUG InteractionServer Read « ${session}(tcp)⇵${exchange} fabricFiltered attributes: ${paths} events: none`;
+    const reportData = (bytes: number, session = SESSION, exchange = EXCHANGE) =>
+        `${at(6)} DEBUG MessageChannel Message » for: I/ReportData suppressResponse attr: 838 id: ${session}(tcp)⇵${exchange}✉08e2433e type: 0x1/0x5 size: ${bytes} payload: 1536`;
+
+    async function report(lines: string[]) {
+        return withDut(lines, async cx => [await wildcardReadInOneReportCheck(cx, SESSION, 0)]);
+    }
+
+    it("passes for one report larger than an MRP message may be", async () => {
+        const checks = await report([wildcardRead(), reportData(27432)]);
+
+        expect(checks[0].verdict).equal("pass");
+        expect(checks[0].detail).contains("27432");
+    });
+
+    it("fails for a report an MRP session could have carried", async () => {
+        const checks = await report([wildcardRead(), reportData(1280)]);
+
+        expect(checks[0].verdict).equal("fail");
+    });
+
+    it("fails when the device chunked the report", async () => {
+        const checks = await report([wildcardRead(), reportData(20000), reportData(7432)]);
+
+        expect(checks[0].verdict).equal("fail");
+        expect(checks[0].detail).contains("2 ReportData");
+    });
+
+    it("does not take a report sent on another exchange", async () => {
+        const checks = await report([wildcardRead(), reportData(27432, SESSION, "9201")]);
+
+        expect(checks[0].verdict).equal("fail");
+    });
+
+    it("does not take a report of the same exchange on another session", async () => {
+        const checks = await report([wildcardRead(), reportData(27432, OTHER_SESSION)]);
+
+        expect(checks[0].verdict).equal("fail");
+    });
+
+    it("fails a report line that states no size", async () => {
+        const sizeless = `${at(6)} DEBUG MessageChannel Message » for: I/ReportData suppressResponse attr: 838 id: ${SESSION}(tcp)⇵${EXCHANGE}✉08e2433e type: 0x1/0x5 payload: 1536`;
+        const checks = await report([wildcardRead(), sizeless]);
+
+        expect(checks[0].verdict).equal("fail");
+    });
+
+    it("keeps the evidence short, though the report line carries its whole payload", async () => {
+        const long = `${reportData(27432)}${"ab".repeat(30000)}`;
+        const checks = await report([wildcardRead(), long]);
+
+        expect(checks[0].verdict).equal("pass");
+        expect(checks[0].matched?.length).most(300);
+    });
+
+    it("does not take a read of one attribute for the wildcard read", async () => {
+        const checks = await report([
+            wildcardRead(SESSION, EXCHANGE, "0.basicInformation.state.vendorName"),
+            reportData(27432),
+        ]);
+
+        expect(checks[0].verdict).equal("fail");
+    });
+
+    it("does not take another session's wildcard read", async () => {
+        const checks = await report([wildcardRead(OTHER_SESSION), reportData(27432, OTHER_SESSION)]);
 
         expect(checks[0].verdict).equal("fail");
     });

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -2294,9 +2294,9 @@ before activation on the chip flavors.
 **What is not yet written, and why.** `TC-SC-8.2` ("the session allows large payloads") has no witness
 distinct from 8.1's on this stack: nothing logs a session's maximum payload, and a TCP-backed session
 is large-payload-capable by construction, so the two cases would rest on the same line. Its real
-witness is behavioural and belongs to `TC-SC-8.6` — a wildcard read arriving in a single `ReportData`,
-which UDP's ~1232-byte budget could not carry. `TC-SC-8.3`/`8.4` additionally need a way to sever just
-the TCP connection mid-test.
+witness is behavioural, and `TC-SC-8.6` below now carries it — a wildcard read arriving in a single
+`ReportData`, which UDP's ~1232-byte budget could not carry. `TC-SC-8.3`/`8.4` additionally need a way
+to sever just the TCP connection mid-test.
 
 ## An interaction over the TCP session, bound to that session (`TC-SC-8.5`)
 
@@ -2332,3 +2332,31 @@ so a regex regression surfaces without docker and without a chip binary.
 Step 1's expected outcome here is the plan's "the session allows large payloads", which nothing logs —
 a TCP-backed session is large-payload-capable by construction, so this step's evidence is 8.1's and the
 distinct witness belongs to `TC-SC-8.6`, as the note above records for `TC-SC-8.2`.
+
+## The large-payload witness the earlier TCP cases lack (`TC-SC-8.6`)
+
+`TC-SC-8.6` is the case that actually observes a large payload, and it is what `TC-SC-8.2`'s note
+above defers to: step 2 reads every attribute of every cluster and requires the DUT's answer to be a
+**single** `ReportData` too large for an MRP session. Against the matter.js all-clusters device that is
+838 attributes in one report of 27432 payload bytes — twenty times the 1280-byte floor the check uses,
+which is the IPv6 minimum MTU and so conservative, MRP's own budget being smaller (~1232 bytes). The
+size on the line is the encoded message, without its framing, so the wire message is larger still.
+
+Three things the check has to get right, each covered hermetically:
+
+- **The read is identified by its own path, not by the search window.** The pattern requires
+  `attributes: *.*.*` on the session, so a read of one attribute — which commissioning itself performs
+  moments earlier — cannot stand in for it.
+- **The reports are counted, not merely found.** A device that chunked would still log a first report
+  matching any "is there a report" pattern. The check takes every report on the read's own exchange
+  between the request and a settled mark, and requires exactly one.
+- **The size is read off the message, not assumed.** matter.js prints `size: <bytes>` on the message
+  line, and anything at or below the floor — or a line stating no size at all — fails.
+
+The first report is waited for, and only then is the buffer settled and the rest counted. Settling
+alone bounds the follower's pump lag, not the device: a chunking device emits its remaining chunks
+immediately after the first, so waiting for one report is what makes counting them trustworthy.
+
+The evidence keeps only the first 300 characters of the matched line. matter.js renders a message's
+whole payload as hex, so an unbounded `matched` would put ~55 000 characters of one report into the
+evidence bundle.

--- a/support/chip-testing/test/cert/TC-SC-8.6.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-8.6.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CertStepContext } from "@matter/testing";
+import { certTest } from "@matter/testing";
+import {
+    wildcardReadInOneReportCheck,
+    TCP_FLAVORS,
+    TCP_PICS,
+    TCP_ROLES,
+    TcpSessionRef,
+    tcpSessionStep,
+    tcpStep,
+} from "./tc-sc-8-support.js";
+import { CommissionedRefs, recordAll } from "./tc-support.js";
+
+const commissioned = new CommissionedRefs<"th">();
+const session = new TcpSessionRef();
+
+/** Every attribute of every cluster of every endpoint, which is what the plan's step 2 reads. */
+const WILDCARD = {};
+
+/**
+ * What a device-wide read has to come back with before the report it produced says anything: the
+ * all-clusters device answers with hundreds of attributes across dozens of clusters, and a read that
+ * returned a handful would make a small report unremarkable rather than a failure.
+ */
+const MIN_ATTRIBUTES = 100;
+const MIN_CLUSTERS = 10;
+
+/**
+ * A wildcard read of the whole device is the interaction this case is named for: its report is far
+ * larger than an MRP message may be, so a device that answers it in one `ReportData` can only have
+ * done so over a large-payload session.
+ */
+async function readEverything(cx: CertStepContext) {
+    const node = cx.controllers.th.node(commissioned.require("th"));
+    const tag = session.require();
+
+    const dut = cx.devices.dut;
+    const from = await dut.log.markSettled();
+
+    const entries = await node.readAttributes([WILDCARD]);
+
+    const endpoints = new Set(entries.map(entry => entry.endpoint));
+    const clusters = new Set(entries.map(entry => `${entry.endpoint}/${entry.cluster}`));
+    const answered = await wildcardReadInOneReportCheck(cx, tag, from);
+
+    recordAll(cx, [
+        {
+            check: () => ({
+                type: "response",
+                verdict: entries.length > MIN_ATTRIBUTES && clusters.size > MIN_CLUSTERS ? "pass" : "fail",
+                detail: `${entries.length} attributes of ${clusters.size} clusters on ${endpoints.size} endpoints`,
+            }),
+            what: "the TH received attributes from across the DUT",
+        },
+        { check: () => answered, what: "the DUT answered the read in one large ReportData" },
+    ]);
+}
+
+certTest("TC-SC-8.6", {
+    plan: "securechannel.adoc",
+    pics: TCP_PICS,
+    app: "all-clusters",
+    transport: "tcp",
+    flavors: TCP_FLAVORS,
+    ...TCP_ROLES,
+})
+    .step(
+        1,
+        "TH initiates a CASE session establishment with DUT, requesting a session supporting large payloads",
+        tcpSessionStep(commissioned, session),
+        {
+            expected: "Verify that the session established with DUT allows large payloads.",
+        },
+    )
+    .step(2, "TH initiates a Read of all attributes of all clusters of DUT", tcpStep(readEverything), {
+        expected:
+            "Verify DUT successfully transmits all the attribute data in one ReportData message to TH. Verify " +
+            "receipt of ReportData message at TH.",
+    })
+    .finalize(async cx => {
+        session.clear();
+        await commissioned.decommissionAll(cx);
+    });

--- a/support/chip-testing/test/cert/tc-sc-8-support.ts
+++ b/support/chip-testing/test/cert/tc-sc-8-support.ts
@@ -247,6 +247,97 @@ export async function recordTcpInvoke(
     record(cx, await tcpInvokeCheck(cx, session, endpoint, cluster, command, from), what);
 }
 
+/**
+ * Above this, a report cannot have crossed an MRP session: 1280 bytes is the IPv6 minimum MTU, and
+ * MRP's own payload budget is smaller still (~1232 bytes once the headers are counted), so a payload
+ * larger than this is conservative evidence of a large-payload session either way.
+ *
+ * @see {@link MatterSpecification.v141.Core} § 4.4.4
+ */
+const LARGE_PAYLOAD_FLOOR = 1280;
+
+/** The payload size matter.js prints on a message line — the encoded message, without its framing. */
+const REPORT_SIZE = /\bsize: (\d+)\b/;
+
+/** How much of a matched line the evidence keeps; a wildcard read's report line carries its whole payload in hex. */
+const EVIDENCE_LIMIT = 300;
+
+/**
+ * Confirms the DUT answered the wildcard read that arrived on `session` with a **single**
+ * `ReportData` too large for an MRP session to have carried — the behaviour a large-payload session
+ * exists for, and the only witness of it this stack produces: nothing logs a session's maximum
+ * payload, while a report that both exceeds {@link LARGE_PAYLOAD_FLOOR} and was never chunked could
+ * not have crossed one.
+ */
+export async function wildcardReadInOneReportCheck(
+    cx: CertStepContext,
+    session: string,
+    from: number,
+): Promise<CheckRecord> {
+    const dut = cx.devices.dut;
+    const onSession = `${literally(session)}\\(tcp\\)`;
+
+    const request = await expectSequence(
+        dut.log,
+        dut.flavor,
+        `a read of every attribute on ${session}`,
+        // The path is what tells this read from any other on the session — commissioning performs a
+        // single-attribute read moments earlier
+        { matterjs: [new RegExp(`InteractionServer Read « ${onSession}⇵[0-9a-f]+ .*attributes: \\*\\.\\*\\.\\*`)] },
+        from,
+        LOG_TIMEOUT,
+    );
+    if (request.verdict !== "pass" || request.matched === undefined || request.logLine === undefined) {
+        return request;
+    }
+
+    const exchange = EXCHANGE.exec(request.matched)?.[1];
+    if (exchange === undefined) {
+        return {
+            type: "device-log",
+            verdict: "fail",
+            pattern: EXCHANGE.source,
+            detail: `the DUT's read line names no exchange: ${request.matched}`,
+            logLine: request.logLine,
+        };
+    }
+
+    const report = new RegExp(`Message » for: I/ReportData .*\\bid: ${onSession}⇵${exchange}✉`);
+    const first = await expectSequence(
+        dut.log,
+        dut.flavor,
+        `a ReportData answering the read on exchange ${exchange}`,
+        { matterjs: [report] },
+        request.logLine + 1,
+        LOG_TIMEOUT,
+    );
+    if (first.verdict !== "pass") {
+        return first;
+    }
+
+    // Waiting for the first report is what makes the count trustworthy: a device that chunks emits
+    // the rest immediately after it, and settling only bounds the pump's own lag
+    await dut.log.settled();
+    const lines = dut.log.lines;
+    const reports = lines.slice(request.logLine + 1).filter(line => !line.synthetic && report.test(line.text));
+
+    const sizes = reports.map(line => Number(REPORT_SIZE.exec(line.text)?.[1] ?? Number.NaN));
+    const single = reports.length === 1 && sizes[0] > LARGE_PAYLOAD_FLOOR;
+    return {
+        type: "device-log",
+        verdict: single ? "pass" : "fail",
+        pattern: report.source,
+        detail: `${reports.length} ReportData on exchange ${exchange}, of ${sizes.join(", ") || "no"} bytes`,
+        matched: reports[0]?.text.slice(0, EVIDENCE_LIMIT),
+        logLine: reports[0]?.index,
+    };
+}
+
+/** {@link wildcardReadInOneReportCheck}, recorded as the step's evidence. */
+export async function recordWildcardReadInOneReport(cx: CertStepContext, session: string, from: number, what: string) {
+    record(cx, await wildcardReadInOneReportCheck(cx, session, from), what);
+}
+
 /** Where a TCP case keeps the session its first step established, for the steps that follow. */
 export class TcpSessionRef {
     #tag?: string;


### PR DESCRIPTION
Adds the certification case TC-SC-8.6. This is the case that actually observes a **large payload**: the test harness reads every attribute of every cluster over a session that runs on TCP, and the device has to answer with all of it in a single `ReportData`. Against the matter.js all-clusters device that is 838 attributes in one report of 27432 payload bytes — twenty times the 1280-byte floor the check uses — so neither an MRP session nor a chunked transfer could have produced it.

That floor is the IPv6 minimum MTU, and so conservative: MRP's own payload budget is smaller still, and the size the device logs is the encoded message without its framing, so the message on the wire is larger than the number compared.

**Why it matters for the block.** TC-SC-8.1 and TC-SC-8.5 rest on the device's own session line saying the connection underneath is TCP. Nothing logs a session's maximum payload, so "the session allows large payloads" had no evidence of its own — which is exactly why TC-SC-8.2 is not written. This case supplies that evidence behaviourally.

**What the check does, and what it refuses.** The read is identified by its own path (`attributes: *.*.*`), not by when it happened — commissioning performs a single-attribute read moments earlier. The exchange is taken from that read line and required on the report. The first report is waited for and only then is the buffer settled and the rest counted, because settling alone bounds the follower's lag rather than the device. The size is read off the message line. A device that chunked, that answered small, that answered on another exchange or session, or that stated no size, fails.

The evidence keeps only the first 300 characters of the matched line: matter.js renders a message's whole payload as hex, so recording it whole would put some 55 000 characters of one report into the bundle.

**Stacked on #4357** — review that one first; this diff is the new case, one helper, its hermetic tests and an AGENTS.md section.

### Matrix legs

| Leg | Outcome |
| --- | --- |
| matter.js controller × matter.js device | passes, four checks recorded |
| chip-tool controller × matter.js device | both steps skipped, with the reason |
| either controller × chip device flavors | skipped before activation (`flavors: ["matterjs"]`) |

### Verification

Repository root:

```
npm run build          exit 0
npm run format-verify  exit 0
npm run lint           exit 0
npm test               exit 0
```

Certification suites (not covered by the root `npm test`):

```
npx matter-test --spec="test/cert/*.test.ts" --report                    exit 0, 30 cases pass
npm --prefix support/chip-testing run test-cert-framework -- --no-pull   exit 0
```

Mutation: relaxing "exactly one report, above the floor" to "at least one report" turns three hermetic tests red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)