### PR TITLE
TC-SC-8.7 (an ordinary interaction on the connection that is already open)

### DIFF
--- a/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { CertDevice, CertStepContext, CheckRecord, Subject } from "@matter/testing";
+import type { CertDevice, CertStepContext, CheckRecord, DeviceFlavor, Subject } from "@matter/testing";
 import { LineQueue, LogFollower, PicsFile } from "@matter/testing";
 import {
     noFurtherSessionCheck,
@@ -48,7 +48,11 @@ const invokeResponse = (session = SESSION, exchange = INVOKE_EXCHANGE) =>
     `${at(4)} DEBUG MessageChannel Message » for: I/InvokeResponse id: ${session}(tcp)⇵${exchange}✉018c0504 type: 0x1/0x9 size: 42`;
 
 /** A device whose log is exactly `lines`, and a recorder that keeps what a helper records. */
-async function withDut<T>(lines: string[], body: (cx: CertStepContext, checks: CheckRecord[]) => Promise<T>) {
+async function withDut<T>(
+    lines: string[],
+    body: (cx: CertStepContext, checks: CheckRecord[]) => Promise<T>,
+    flavor: DeviceFlavor = "matterjs",
+) {
     const source = new LineQueue();
     const log = new LogFollower(source.follow(), "dut");
     for (const text of lines) {
@@ -74,7 +78,7 @@ async function withDut<T>(lines: string[], body: (cx: CertStepContext, checks: C
         async backchannel() {},
     } satisfies Subject;
 
-    const dut: CertDevice = { ...subject, flavor: "matterjs", log, exit: new Promise(() => {}) };
+    const dut: CertDevice = { ...subject, flavor, log, exit: new Promise(() => {}) };
 
     const checks = new Array<CheckRecord>();
     const cx: CertStepContext = {
@@ -258,7 +262,7 @@ describe("wildcardReadInOneReportCheck", () => {
     });
 
     it("fails a report line that states no size", async () => {
-        const sizeless = `${at(6)} DEBUG MessageChannel Message » for: I/ReportData suppressResponse attr: 838 id: ${SESSION}(tcp)⇵${EXCHANGE}✉08e2433e type: 0x1/0x5 payload: 1536`;
+        const sizeless = `${at(6)} DEBUG MessageChannel Message » for: I/ReportData suppressResponse attr: 838 id: ${SESSION}(tcp)⇵${EXCHANGE}✉08e2433e type: 0x1/0x5`;
         const checks = await report([wildcardRead(), sizeless]);
 
         expect(checks[0].verdict).equal("fail");
@@ -289,11 +293,11 @@ describe("wildcardReadInOneReportCheck", () => {
 });
 
 describe("regularSizedRequestCheck", () => {
-    const invokeMessage = (bytes: number | undefined, session = SESSION) =>
-        `${at(2)} DEBUG MessageExchange Message « for: I/InvokeRequest id: ${session}(tcp)⇵${INVOKE_EXCHANGE}✉0ca20aa0 type: 0x1/0x8${bytes === undefined ? "" : ` size: ${bytes}`} payload: 1528`;
+    const invokeMessage = (bytes: number | undefined, session = SESSION, exchange = INVOKE_EXCHANGE) =>
+        `${at(2)} DEBUG MessageExchange Message « for: I/InvokeRequest id: ${session}(tcp)⇵${exchange}✉0ca20aa0 type: 0x1/0x8${bytes === undefined ? "" : ` size: ${bytes} payload: 1528`}`;
 
     async function sized(lines: string[]) {
-        return withDut(lines, async cx => regularSizedRequestCheck(cx, SESSION, 0));
+        return withDut(lines, async cx => regularSizedRequestCheck(cx, SESSION, INVOKE_EXCHANGE, 0));
     }
 
     it("passes for a request an MRP session could equally have carried", async () => {
@@ -303,8 +307,8 @@ describe("regularSizedRequestCheck", () => {
         expect(check.detail).contains("29 bytes");
     });
 
-    it("fails for a request no MRP session could have carried", async () => {
-        expect((await sized([invokeMessage(5000)])).verdict).equal("fail");
+    it("fails for a request larger than MRP's own payload limit, though smaller than the large-payload floor", async () => {
+        expect((await sized([invokeMessage(1250)])).verdict).equal("fail");
     });
 
     it("fails for a request line stating no size", async () => {
@@ -314,28 +318,62 @@ describe("regularSizedRequestCheck", () => {
     it("does not take another session's request", async () => {
         expect((await sized([invokeMessage(29, OTHER_SESSION)])).verdict).equal("fail");
     });
+
+    it("does not take another exchange's request", async () => {
+        expect((await sized([invokeMessage(29, SESSION, "2c58")])).verdict).equal("fail");
+    });
+
+    it("keeps the evidence short, though a request line carries its whole payload", async () => {
+        const check = await sized([`${invokeMessage(29)}${"ab".repeat(30000)}`]);
+
+        expect(check.verdict).equal("pass");
+        expect(check.matched?.length).most(300);
+    });
 });
 
 describe("noFurtherSessionCheck", () => {
     const unrelated = `${at(2)} DEBUG MessageExchange New exchange « ${SESSION}(tcp)⇵2c57 protocol: 1`;
 
-    it("passes when the DUT accepted no further connection", async () => {
-        const check = await withDut([unrelated], async cx => noFurtherSessionCheck(cx, 0));
+    it("passes when the DUT accepted no further connection while the interaction ran", async () => {
+        const check = await withDut([unrelated, unrelated], async cx => noFurtherSessionCheck(cx, 0, 1));
 
         expect(check.verdict).equal("pass");
+        expect(check.detail).contains("0 further pairing");
     });
 
     it("fails when a second session was established while the interaction ran", async () => {
-        const check = await withDut([unrelated, pairingRequest()], async cx => noFurtherSessionCheck(cx, 0));
+        const check = await withDut([unrelated, pairingRequest()], async cx => noFurtherSessionCheck(cx, 0, 1));
 
         expect(check.verdict).equal("fail");
         expect(check.detail).contains("1 further pairing");
     });
 
     it("ignores a pairing request that preceded the window", async () => {
-        const check = await withDut([pairingRequest(), unrelated], async cx => noFurtherSessionCheck(cx, 1));
+        const check = await withDut([pairingRequest(), unrelated], async cx => noFurtherSessionCheck(cx, 1, 1));
 
         expect(check.verdict).equal("pass");
+    });
+
+    it("ignores a pairing request that followed the interaction", async () => {
+        const check = await withDut([unrelated, pairingRequest()], async cx => noFurtherSessionCheck(cx, 0, 0));
+
+        expect(check.verdict).equal("pass");
+    });
+
+    it("ignores the runner's own step banner", async () => {
+        await withDut([unrelated], async (cx, _checks) => {
+            const dut = cx.devices.dut;
+            dut.log.annotate("TC-SC-8.7 — Pairing request « tcp://[fe80::1%en0]«60111");
+            await dut.log.settled();
+
+            expect((await noFurtherSessionCheck(cx, 0, dut.log.lines.length - 1)).verdict).equal("pass");
+        });
+    });
+
+    it("states the gap rather than a pass on a device whose log it cannot read", async () => {
+        const check = await withDut([pairingRequest()], async cx => noFurtherSessionCheck(cx, 0, 0), "chip-local");
+
+        expect(check.verdict).equal("unverified");
     });
 });
 

--- a/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
@@ -337,37 +337,53 @@ describe("regularSizedRequestCheck", () => {
 
 describe("noFurtherSessionCheck", () => {
     const unrelated = `${at(2)} DEBUG MessageExchange New exchange « ${SESSION}(tcp)⇵2c57 protocol: 1`;
+    const established = (session = OTHER_SESSION) =>
+        `${at(3)} INFO CaseServer ${session}(tcp) New session with @1:86c217a36142d632 2↔1 address: tcp://[fe80::2%en0]«60999`;
+    const resumed = (session = OTHER_SESSION) =>
+        `${at(3)} INFO CaseServer ${session}(tcp) Resumed session with @1:86c217a36142d632 2↔1 address: tcp://[fe80::2%en0]«60999`;
 
-    it("passes when the DUT accepted no further connection while the interaction ran", async () => {
+    it("passes when the DUT established no further session while the interaction ran", async () => {
         const check = await withDut([unrelated, unrelated], async cx => noFurtherSessionCheck(cx, 0, 1));
 
         expect(check.verdict).equal("pass");
-        expect(check.detail).contains("0 further pairing");
+        expect(check.detail).contains("0 further session");
     });
 
     it("fails when a second session was established while the interaction ran", async () => {
-        const check = await withDut([unrelated, pairingRequest()], async cx => noFurtherSessionCheck(cx, 0, 1));
+        const check = await withDut([unrelated, established()], async cx => noFurtherSessionCheck(cx, 0, 1));
 
         expect(check.verdict).equal("fail");
-        expect(check.detail).contains("1 further pairing");
+        expect(check.detail).contains("1 further session");
     });
 
-    it("ignores a pairing request that preceded the window", async () => {
-        const check = await withDut([pairingRequest(), unrelated], async cx => noFurtherSessionCheck(cx, 1, 1));
+    it("fails when a session was resumed while the interaction ran", async () => {
+        const check = await withDut([unrelated, resumed()], async cx => noFurtherSessionCheck(cx, 0, 1));
+
+        expect(check.verdict).equal("fail");
+    });
+
+    it("passes for an attempt the DUT never turned into a session", async () => {
+        const check = await withDut([unrelated, pairingRequest()], async cx => noFurtherSessionCheck(cx, 0, 1));
 
         expect(check.verdict).equal("pass");
     });
 
-    it("ignores a pairing request that followed the interaction", async () => {
-        const check = await withDut([unrelated, pairingRequest()], async cx => noFurtherSessionCheck(cx, 0, 0));
+    it("ignores a session established before the window", async () => {
+        const check = await withDut([established(), unrelated], async cx => noFurtherSessionCheck(cx, 1, 1));
+
+        expect(check.verdict).equal("pass");
+    });
+
+    it("ignores a session established after the interaction", async () => {
+        const check = await withDut([unrelated, established()], async cx => noFurtherSessionCheck(cx, 0, 0));
 
         expect(check.verdict).equal("pass");
     });
 
     it("ignores the runner's own step banner", async () => {
-        await withDut([unrelated], async (cx, _checks) => {
+        await withDut([unrelated], async cx => {
             const dut = cx.devices.dut;
-            dut.log.annotate("TC-SC-8.7 — Pairing request « tcp://[fe80::1%en0]«60111");
+            dut.log.annotate("TC-SC-8.7 — CaseServer New session with a peer");
             await dut.log.settled();
 
             expect((await noFurtherSessionCheck(cx, 0, dut.log.lines.length - 1)).verdict).equal("pass");
@@ -375,7 +391,7 @@ describe("noFurtherSessionCheck", () => {
     });
 
     it("states the gap rather than a pass on a device whose log it cannot read", async () => {
-        const check = await withDut([pairingRequest()], async cx => noFurtherSessionCheck(cx, 0, 0), "chip-local");
+        const check = await withDut([established()], async cx => noFurtherSessionCheck(cx, 0, 0), "chip-local");
 
         expect(check.verdict).equal("unverified");
     });

--- a/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
@@ -7,8 +7,10 @@
 import type { CertDevice, CertStepContext, CheckRecord, Subject } from "@matter/testing";
 import { LineQueue, LogFollower, PicsFile } from "@matter/testing";
 import {
+    noFurtherSessionCheck,
     recordTcpInvoke,
     recordTcpSession,
+    regularSizedRequestCheck,
     wildcardReadInOneReportCheck,
     TcpSessionRef,
 } from "../cert/tc-sc-8-support.js";
@@ -283,6 +285,57 @@ describe("wildcardReadInOneReportCheck", () => {
         const checks = await report([wildcardRead(OTHER_SESSION), reportData(27432, OTHER_SESSION)]);
 
         expect(checks[0].verdict).equal("fail");
+    });
+});
+
+describe("regularSizedRequestCheck", () => {
+    const invokeMessage = (bytes: number | undefined, session = SESSION) =>
+        `${at(2)} DEBUG MessageExchange Message « for: I/InvokeRequest id: ${session}(tcp)⇵${INVOKE_EXCHANGE}✉0ca20aa0 type: 0x1/0x8${bytes === undefined ? "" : ` size: ${bytes}`} payload: 1528`;
+
+    async function sized(lines: string[]) {
+        return withDut(lines, async cx => regularSizedRequestCheck(cx, SESSION, 0));
+    }
+
+    it("passes for a request an MRP session could equally have carried", async () => {
+        const check = await sized([invokeMessage(29)]);
+
+        expect(check.verdict).equal("pass");
+        expect(check.detail).contains("29 bytes");
+    });
+
+    it("fails for a request no MRP session could have carried", async () => {
+        expect((await sized([invokeMessage(5000)])).verdict).equal("fail");
+    });
+
+    it("fails for a request line stating no size", async () => {
+        expect((await sized([invokeMessage(undefined)])).verdict).equal("fail");
+    });
+
+    it("does not take another session's request", async () => {
+        expect((await sized([invokeMessage(29, OTHER_SESSION)])).verdict).equal("fail");
+    });
+});
+
+describe("noFurtherSessionCheck", () => {
+    const unrelated = `${at(2)} DEBUG MessageExchange New exchange « ${SESSION}(tcp)⇵2c57 protocol: 1`;
+
+    it("passes when the DUT accepted no further connection", async () => {
+        const check = await withDut([unrelated], async cx => noFurtherSessionCheck(cx, 0));
+
+        expect(check.verdict).equal("pass");
+    });
+
+    it("fails when a second session was established while the interaction ran", async () => {
+        const check = await withDut([unrelated, pairingRequest()], async cx => noFurtherSessionCheck(cx, 0));
+
+        expect(check.verdict).equal("fail");
+        expect(check.detail).contains("1 further pairing");
+    });
+
+    it("ignores a pairing request that preceded the window", async () => {
+        const check = await withDut([pairingRequest(), unrelated], async cx => noFurtherSessionCheck(cx, 1));
+
+        expect(check.verdict).equal("pass");
     });
 });
 

--- a/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
@@ -308,7 +308,11 @@ describe("regularSizedRequestCheck", () => {
     });
 
     it("fails for a request larger than MRP's own payload limit, though smaller than the large-payload floor", async () => {
-        expect((await sized([invokeMessage(1250)])).verdict).equal("fail");
+        expect((await sized([invokeMessage(1200)])).verdict).equal("fail");
+    });
+
+    it("passes for the largest payload MRP could still have carried", async () => {
+        expect((await sized([invokeMessage(1178)])).verdict).equal("pass");
     });
 
     it("fails for a request line stating no size", async () => {

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -2377,10 +2377,16 @@ invoke, no large payload — and the step's evidence is what distinguishes the c
   the opposite of this case.
 - **The answer came back on step 1's session**, through the same exchange-correlated check `TC-SC-8.5`
   uses.
-- **No further session was established.** `noFurtherSessionCheck` scans the window for any
-  `CaseServer … Pairing request` — over *any* transport, since the failure this guards against is the
-  controller quietly opening an MRP session for a small interaction. Without it, every other check
-  here is equally satisfied by a run that made a second session and used it.
+- **No further session was established.** `noFurtherSessionCheck` scans the interaction's own span for
+  a `CaseServer … New session with` or `… Resumed session with` — over *any* transport, since the
+  failure this guards against is the controller quietly opening an MRP session for a small
+  interaction. Without it, every other check here is equally satisfied by a run that made a second
+  session and used it.
+
+  It keys on establishment rather than on the `Pairing request` that precedes it, and the difference
+  matters twice: matter.js writes that line before it has read Sigma1, so an attempt the DUT went on to
+  reject would read as a session it accepted, and an attempt inside the span whose session forms after
+  it would be counted though its establishment falls outside the window this check bounds.
 
 Nothing in the controller expresses "either transport is usable" as a request flag: matter.js's
 `transportPreference` is set once, for the session, and the protocol layer's hard `requiredTransport`

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -2345,8 +2345,8 @@ size on the line is the encoded message, without its framing, so the wire messag
 Three things the check has to get right, each covered hermetically:
 
 - **The read is identified by its own path, not by the search window.** The pattern requires
-  `attributes: *.*.*` on the session, so a read of one attribute — which commissioning itself performs
-  moments earlier — cannot stand in for it.
+  `attributes: *.*.*` on the session, so a read of one attribute — which step 1 performs moments
+  earlier, to exercise the session it established — cannot stand in for it.
 - **The reports are counted, not merely found.** A device that chunked would still log a first report
   matching any "is there a report" pattern. The check takes every report on the read's own exchange
   between the request and a settled mark, and requires exactly one.
@@ -2360,3 +2360,25 @@ immediately after the first, so waiting for one report is what makes counting th
 The evidence keeps only the first 300 characters of the matched line. matter.js renders a message's
 whole payload as hex, so an unbounded `matched` would put ~55 000 characters of one report into the
 evidence bundle.
+
+## An interaction that could have gone either way, on the session that exists (`TC-SC-8.7`)
+
+`TC-SC-8.7` asks for something the two cases before it do not: a **regularly sized** interaction, one
+neither transport is required for, that nonetheless travels on the TCP session already established
+rather than causing a new one. The controller is therefore asked for nothing special — an ordinary
+invoke, no large payload — and the step's evidence is what distinguishes the case:
+
+- **The request is one MRP could have carried.** `regularSizedRequestCheck` reads the size off the
+  DUT's own `I/InvokeRequest` message line and requires it at or below the same floor `TC-SC-8.6`
+  requires its report to exceed. A payload only TCP could carry would prove the opposite of this case.
+- **The answer came back on step 1's session**, through the same exchange-correlated check `TC-SC-8.5`
+  uses.
+- **No further session was established.** `noFurtherSessionCheck` scans the window for any
+  `CaseServer … Pairing request` — over *any* transport, since the failure this guards against is the
+  controller quietly opening an MRP session for a small interaction. Without it, every other check
+  here is equally satisfied by a run that made a second session and used it.
+
+Nothing in the controller expresses "either transport is usable" as a request flag: matter.js's
+`transportPreference` is set once, for the session, and the protocol layer's hard `requiredTransport`
+lever is not surfaced. So the plan's step text describes what an ordinary invoke already is on this
+stack, and the case's substance lives entirely in the three checks above.

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -2379,9 +2379,12 @@ invoke, no large payload — and the step's evidence is what distinguishes the c
   uses.
 - **No further session was established.** `noFurtherSessionCheck` scans the interaction's own span for
   a `CaseServer … New session with` or `… Resumed session with` — over *any* transport, since the
-  failure this guards against is the controller quietly opening an MRP session for a small
-  interaction. Without it, every other check here is equally satisfied by a run that made a second
-  session and used it.
+  failure this guards against is the controller opening an MRP session for a small interaction.
+
+  What it adds is narrower than it looks, and worth stating exactly: the checks above are bound to
+  step 1's own session tag, so an interaction that *travelled* on a second session would already fail
+  them. This one covers the remaining case — a second session created alongside, whether or not this
+  interaction used it — which is what the plan's "use whichever one is available" rules out.
 
   It keys on establishment rather than on the `Pairing request` that precedes it, and the difference
   matters twice: matter.js writes that line before it has read Sigma1, so an attempt the DUT went on to

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -2369,8 +2369,12 @@ rather than causing a new one. The controller is therefore asked for nothing spe
 invoke, no large payload — and the step's evidence is what distinguishes the case:
 
 - **The request is one MRP could have carried.** `regularSizedRequestCheck` reads the size off the
-  DUT's own `I/InvokeRequest` message line and requires it at or below the same floor `TC-SC-8.6`
-  requires its report to exceed. A payload only TCP could carry would prove the opposite of this case.
+  DUT's own `I/InvokeRequest` message line and requires it at or below what MRP may carry. That is a
+  **different limit** from the one `TC-SC-8.6` requires its report to exceed, and the two are not
+  interchangeable: 1280 is the IPv6 MTU, so above it nothing MRP-sized fits and it serves as 8.6's
+  floor, while a request has to fit MRP's own budget — the UDP limit less Matter's header and MIC
+  overhead — before this case may call it regularly sized. A payload only TCP could carry would prove
+  the opposite of this case.
 - **The answer came back on step 1's session**, through the same exchange-correlated check `TC-SC-8.5`
   uses.
 - **No further session was established.** `noFurtherSessionCheck` scans the window for any

--- a/support/chip-testing/test/cert/TC-SC-8.5.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-8.5.test.ts
@@ -15,8 +15,9 @@ import {
     TcpSessionRef,
     tcpSessionStep,
     tcpStep,
+    timeSnapshotResponseCheck,
 } from "./tc-sc-8-support.js";
-import { CommissionedRefs, describeError, describeValue, recordAll, requireId } from "./tc-support.js";
+import { CommissionedRefs, recordAll, requireId } from "./tc-support.js";
 
 const GENERAL_DIAGNOSTICS = Matter.clusters.require("GeneralDiagnostics");
 const GENERAL_DIAGNOSTICS_ID = requireId(GENERAL_DIAGNOSTICS.id, "GeneralDiagnostics cluster");
@@ -30,15 +31,6 @@ const ROOT_ENDPOINT = 0;
 
 const commissioned = new CommissionedRefs<"th">();
 const session = new TcpSessionRef();
-
-/** `SystemTimeMs` of a `TimeSnapshotResponse`, or undefined for an answer that is not one. */
-function systemTimeMsOf(response: unknown): number | bigint | undefined {
-    if (typeof response !== "object" || response === null || !("systemTimeMs" in response)) {
-        return undefined;
-    }
-    const value = response.systemTimeMs;
-    return typeof value === "number" || typeof value === "bigint" ? value : undefined;
-}
 
 /**
  * `TimeSnapshot` is the command this case sends because it carries a response of its own and changes
@@ -60,37 +52,15 @@ async function invokeOverTcp(cx: CertStepContext) {
         refusal = e;
     }
 
-    const systemTimeMs = refusal === undefined ? systemTimeMsOf(response) : undefined;
     const invoked = await tcpInvokeCheck(cx, tag, ROOT_ENDPOINT, GENERAL_DIAGNOSTICS_ID, TIME_SNAPSHOT_ID, from);
 
     recordAll(cx, [
-        {
-            check: () => ({
-                type: "response",
-                verdict: systemTimeMs === undefined ? "fail" : "pass",
-                detail: responseDetail(response, refusal, systemTimeMs),
-            }),
-            what: "the TH received the command response",
-        },
+        { check: () => timeSnapshotResponseCheck(response, refusal), what: "the TH received the command response" },
         {
             check: () => invoked,
             what: "the DUT dispatched the command and answered it on the session step 1 established",
         },
     ]);
-}
-
-/**
- * What the response check says it saw. A refused invoke is reported as the refusal rather than as a
- * missing field: the two failures have different causes and the evidence is where they are told apart.
- */
-function responseDetail(response: unknown, refusal: unknown, systemTimeMs: number | bigint | undefined) {
-    if (refusal !== undefined) {
-        return `the DUT refused TimeSnapshot: ${describeError(refusal)}`;
-    }
-    if (systemTimeMs === undefined) {
-        return `the DUT answered TimeSnapshot with ${describeValue(response)}, which carries no SystemTimeMs`;
-    }
-    return `TimeSnapshotResponse systemTimeMs=${systemTimeMs}`;
 }
 
 certTest("TC-SC-8.5", {

--- a/support/chip-testing/test/cert/TC-SC-8.7.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-8.7.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Matter } from "@matter/model";
+import type { CertStepContext } from "@matter/testing";
+import { certTest } from "@matter/testing";
+import {
+    noFurtherSessionCheck,
+    regularSizedRequestCheck,
+    TCP_FLAVORS,
+    TCP_PICS,
+    TCP_ROLES,
+    TcpSessionRef,
+    tcpInvokeCheck,
+    tcpSessionStep,
+    tcpStep,
+} from "./tc-sc-8-support.js";
+import { CommissionedRefs, describeError, recordAll, requireId } from "./tc-support.js";
+
+const GENERAL_DIAGNOSTICS = Matter.clusters.require("GeneralDiagnostics");
+const GENERAL_DIAGNOSTICS_ID = requireId(GENERAL_DIAGNOSTICS.id, "GeneralDiagnostics cluster");
+const TIME_SNAPSHOT_ID = requireId(
+    GENERAL_DIAGNOSTICS.commands.require("timeSnapshot").id,
+    "GeneralDiagnostics.timeSnapshot",
+);
+
+const ROOT_ENDPOINT = 0;
+
+const commissioned = new CommissionedRefs<"th">();
+const session = new TcpSessionRef();
+
+/**
+ * The controller asks for nothing here beyond an ordinary invoke — no large payload, no transport of
+ * its own — which is what the plan means by a request either transport could carry. What the step
+ * then proves is that it went out on the session step 1 established rather than causing a new one.
+ */
+async function invokeOverExistingSession(cx: CertStepContext) {
+    const node = cx.controllers.th.node(commissioned.require("th"));
+    const tag = session.require();
+
+    const dut = cx.devices.dut;
+    const from = await dut.log.markSettled();
+
+    let refusal: unknown;
+    try {
+        await node.invoke("GeneralDiagnostics", "timeSnapshot", {}, ROOT_ENDPOINT);
+    } catch (e) {
+        refusal = e;
+    }
+
+    const sized = await regularSizedRequestCheck(cx, tag, from);
+    const invoked = await tcpInvokeCheck(cx, tag, ROOT_ENDPOINT, GENERAL_DIAGNOSTICS_ID, TIME_SNAPSHOT_ID, from);
+    const alone = await noFurtherSessionCheck(cx, from);
+
+    recordAll(cx, [
+        {
+            check: () => ({
+                type: "response",
+                verdict: refusal === undefined ? "pass" : "fail",
+                detail:
+                    refusal === undefined
+                        ? "the TH received the command response"
+                        : `the DUT refused TimeSnapshot: ${describeError(refusal)}`,
+            }),
+            what: "the TH received the command response",
+        },
+        { check: () => sized, what: "the request was one MRP could have carried" },
+        { check: () => invoked, what: "the DUT answered it on the session step 1 established" },
+        { check: () => alone, what: "no further session was established for it" },
+    ]);
+}
+
+certTest("TC-SC-8.7", {
+    plan: "securechannel.adoc",
+    pics: TCP_PICS,
+    app: "all-clusters",
+    transport: "tcp",
+    flavors: TCP_FLAVORS,
+    ...TCP_ROLES,
+})
+    .step(
+        1,
+        "TH initiates a CASE session establishment with DUT, requesting a session supporting large payloads",
+        tcpSessionStep(commissioned, session),
+        {
+            expected: "Verify that the session established with DUT allows large payloads.",
+        },
+    )
+    .step(
+        2,
+        "TH initiates a regularly-sized InvokeCommandRequest with DUT, specifying that either a MRP or TCP-based session is usable.",
+        tcpStep(invokeOverExistingSession),
+        {
+            expected: "Verify Command response received successfully at TH over the existing TCP-based session.",
+        },
+    )
+    .finalize(async cx => {
+        session.clear();
+        await commissioned.decommissionAll(cx);
+    });

--- a/support/chip-testing/test/cert/TC-SC-8.7.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-8.7.test.ts
@@ -14,11 +14,12 @@ import {
     TCP_PICS,
     TCP_ROLES,
     TcpSessionRef,
-    tcpInvokeCheck,
+    tcpInvokeEvidence,
     tcpSessionStep,
     tcpStep,
+    timeSnapshotResponseCheck,
 } from "./tc-sc-8-support.js";
-import { CommissionedRefs, describeError, recordAll, requireId } from "./tc-support.js";
+import { CommissionedRefs, recordAll, requireId } from "./tc-support.js";
 
 const GENERAL_DIAGNOSTICS = Matter.clusters.require("GeneralDiagnostics");
 const GENERAL_DIAGNOSTICS_ID = requireId(GENERAL_DIAGNOSTICS.id, "GeneralDiagnostics cluster");
@@ -44,32 +45,26 @@ async function invokeOverExistingSession(cx: CertStepContext) {
     const dut = cx.devices.dut;
     const from = await dut.log.markSettled();
 
+    let response: unknown;
     let refusal: unknown;
     try {
-        await node.invoke("GeneralDiagnostics", "timeSnapshot", {}, ROOT_ENDPOINT);
+        response = await node.invoke("GeneralDiagnostics", "timeSnapshot", {}, ROOT_ENDPOINT);
     } catch (e) {
         refusal = e;
     }
 
-    const sized = await regularSizedRequestCheck(cx, tag, from);
-    const invoked = await tcpInvokeCheck(cx, tag, ROOT_ENDPOINT, GENERAL_DIAGNOSTICS_ID, TIME_SNAPSHOT_ID, from);
-    const alone = await noFurtherSessionCheck(cx, from);
+    const invoked = await tcpInvokeEvidence(cx, tag, ROOT_ENDPOINT, GENERAL_DIAGNOSTICS_ID, TIME_SNAPSHOT_ID, from);
+    const sized =
+        invoked.exchange === undefined ? undefined : await regularSizedRequestCheck(cx, tag, invoked.exchange, from);
+    const alone = invoked.lastLine === undefined ? undefined : await noFurtherSessionCheck(cx, from, invoked.lastLine);
 
     recordAll(cx, [
-        {
-            check: () => ({
-                type: "response",
-                verdict: refusal === undefined ? "pass" : "fail",
-                detail:
-                    refusal === undefined
-                        ? "the TH received the command response"
-                        : `the DUT refused TimeSnapshot: ${describeError(refusal)}`,
-            }),
-            what: "the TH received the command response",
-        },
-        { check: () => sized, what: "the request was one MRP could have carried" },
-        { check: () => invoked, what: "the DUT answered it on the session step 1 established" },
-        { check: () => alone, what: "no further session was established for it" },
+        { check: () => timeSnapshotResponseCheck(response, refusal), what: "the TH received the command response" },
+        { check: () => invoked.check, what: "the DUT answered it on the session step 1 established" },
+        // Both of the remaining claims are about the interaction the invoke check identified, so
+        // neither can be settled once that check has failed to identify it
+        ...(sized === undefined ? [] : [{ check: () => sized, what: "the request was one MRP could have carried" }]),
+        ...(alone === undefined ? [] : [{ check: () => alone, what: "no further session was established for it" }]),
     ]);
 }
 

--- a/support/chip-testing/test/cert/tc-sc-8-support.ts
+++ b/support/chip-testing/test/cert/tc-sc-8-support.ts
@@ -418,9 +418,9 @@ export async function regularSizedRequestCheck(
 }
 
 /**
- * Confirms the DUT accepted no further CASE session between `from` and `until`: the case this belongs
- * to claims the interaction reused the session already established, and an interaction that caused a
- * second one would satisfy every other check just as well.
+ * Confirms the DUT established no further CASE session between `from` and `until`: the case this
+ * belongs to claims the interaction reused the session already established, and an interaction that
+ * caused a second one would satisfy every other check just as well.
  *
  * `until` is the last line of the interaction itself, so the window is the interaction's own and is
  * non-empty by construction — a scan to the end of the buffer would report a session the DUT accepted
@@ -444,7 +444,7 @@ export async function noFurtherSessionCheck(cx: CertStepContext, from: number, u
         type: "device-log",
         verdict: opened.length ? "fail" : "pass",
         pattern: FURTHER_SESSION.source,
-        detail: `${opened.length} further pairing request(s) between log lines ${from} and ${until}`,
+        detail: `${opened.length} further session(s) established between log lines ${from} and ${until}`,
         matched: opened[0]?.text.slice(0, EVIDENCE_LIMIT),
         logLine: opened[0]?.index,
     };
@@ -485,8 +485,12 @@ export function timeSnapshotResponseCheck(response: unknown, refusal: unknown): 
     };
 }
 
-/** A CASE session establishment beginning, over any transport. */
-const FURTHER_SESSION = /CaseServer .*Pairing request «/;
+/**
+ * A CASE session the DUT established, over any transport. Not the pairing request that precedes it:
+ * matter.js writes that before it has read Sigma1, so an attempt the DUT went on to reject would read
+ * as a session it accepted.
+ */
+const FURTHER_SESSION = /CaseServer .*(?:New|Resumed) session with/;
 
 /** Where a TCP case keeps the session its first step established, for the steps that follow. */
 export class TcpSessionRef {

--- a/support/chip-testing/test/cert/tc-sc-8-support.ts
+++ b/support/chip-testing/test/cert/tc-sc-8-support.ts
@@ -252,7 +252,7 @@ export async function recordTcpInvoke(
  * MRP's own payload budget is smaller still (~1232 bytes once the headers are counted), so a payload
  * larger than this is conservative evidence of a large-payload session either way.
  *
- * @see {@link MatterSpecification.v141.Core} § 4.4.4
+ * @see {@link MatterSpecification.v16.Core} § 4.4.4
  */
 const LARGE_PAYLOAD_FLOOR = 1280;
 
@@ -281,8 +281,8 @@ export async function wildcardReadInOneReportCheck(
         dut.log,
         dut.flavor,
         `a read of every attribute on ${session}`,
-        // The path is what tells this read from any other on the session — commissioning performs a
-        // single-attribute read moments earlier
+        // The path is what tells this read from any other on the session — step 1 reads a single
+        // attribute moments earlier
         { matterjs: [new RegExp(`InteractionServer Read « ${onSession}⇵[0-9a-f]+ .*attributes: \\*\\.\\*\\.\\*`)] },
         from,
         LOG_TIMEOUT,
@@ -337,6 +337,71 @@ export async function wildcardReadInOneReportCheck(
 export async function recordWildcardReadInOneReport(cx: CertStepContext, session: string, from: number, what: string) {
     record(cx, await wildcardReadInOneReportCheck(cx, session, from), what);
 }
+
+/**
+ * Confirms the request the TH sent on `session` was one an MRP session could equally have carried:
+ * the case this belongs to is about a *regularly sized* interaction choosing the TCP session that
+ * already exists, so a payload only TCP could carry would prove the wrong thing.
+ */
+export async function regularSizedRequestCheck(
+    cx: CertStepContext,
+    session: string,
+    from: number,
+): Promise<CheckRecord> {
+    const dut = cx.devices.dut;
+    const request = await expectSequence(
+        dut.log,
+        dut.flavor,
+        `an InvokeRequest received on ${session}`,
+        {
+            matterjs: [new RegExp(`Message « for: I/InvokeRequest .*\\bid: ${literally(session)}\\(tcp\\)⇵[0-9a-f]+✉`)],
+        },
+        from,
+        LOG_TIMEOUT,
+    );
+    if (request.verdict !== "pass" || request.matched === undefined) {
+        return request;
+    }
+
+    const size = Number(REPORT_SIZE.exec(request.matched)?.[1] ?? Number.NaN);
+    return {
+        type: "device-log",
+        verdict: size > 0 && size <= LARGE_PAYLOAD_FLOOR ? "pass" : "fail",
+        pattern: request.pattern,
+        detail: `the InvokeRequest carried ${size} bytes, which MRP could have carried too`,
+        matched: request.matched.slice(0, EVIDENCE_LIMIT),
+        logLine: request.logLine,
+    };
+}
+
+/**
+ * Confirms the DUT accepted no further connection or session while `from` was open: the case this
+ * belongs to claims the interaction reused the session already established, and an interaction that
+ * caused a second one would satisfy every other check just as well.
+ */
+export async function noFurtherSessionCheck(cx: CertStepContext, from: number): Promise<CheckRecord> {
+    const dut = cx.devices.dut;
+    if (dut.flavor !== "matterjs") {
+        return { type: "device-log", verdict: "unverified" };
+    }
+
+    await dut.log.settled();
+    const opened = dut.log.lines.slice(from).filter(line => !line.synthetic && FURTHER_SESSION.test(line.text));
+
+    return {
+        type: "device-log",
+        verdict: opened.length ? "fail" : "pass",
+        pattern: FURTHER_SESSION.source,
+        detail: opened.length
+            ? `the DUT accepted ${opened.length} further pairing request(s) while the interaction ran`
+            : "the DUT accepted no further pairing request while the interaction ran",
+        matched: opened[0]?.text.slice(0, EVIDENCE_LIMIT),
+        logLine: opened[0]?.index,
+    };
+}
+
+/** A CASE session establishment beginning, over any transport. */
+const FURTHER_SESSION = /CaseServer .*Pairing request «/;
 
 /** Where a TCP case keeps the session its first step established, for the steps that follow. */
 export class TcpSessionRef {

--- a/support/chip-testing/test/cert/tc-sc-8-support.ts
+++ b/support/chip-testing/test/cert/tc-sc-8-support.ts
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { MAX_UDP_MESSAGE_SIZE } from "@matter/general";
 import { Matter } from "@matter/model";
+import { MATTER_MESSAGE_OVERHEAD } from "@matter/protocol";
 import type { CertNodeRef, CertStepContext, CheckRecord, DeviceFlavor } from "@matter/testing";
 import { resolveControllerImplementation, UnsupportedByControllerError } from "@matter/testing";
 import {
@@ -366,15 +368,15 @@ export async function recordWildcardReadInOneReport(cx: CertStepContext, session
 }
 
 /**
- * What an MRP message may carry: the IPv6 minimum MTU less the headers matter.js accounts for in its
- * own UDP limit. A request at or below this is one MRP could equally have delivered, which is what a
- * case about *choosing* the existing TCP session has to establish — the floor
- * {@link LARGE_PAYLOAD_FLOOR} sets for a large payload is a different, looser number and would let a
- * request MRP could not have carried pass as one it could.
+ * What an MRP message may carry as payload, which is what a device's message line reports: the UDP
+ * channel's own budget less the Matter header and MIC the exchange subtracts from it. Derived from
+ * the constants the production path uses rather than written out, so it cannot drift from them.
  *
- * @see {@link MatterSpecification.v16.Core} § 4.4.4
+ * A different, tighter number than {@link LARGE_PAYLOAD_FLOOR}, and not interchangeable with it: that
+ * floor is the IPv6 MTU, above which nothing MRP-sized fits, while a request has to fit *this* before
+ * a case may call it one MRP could equally have carried.
  */
-const MRP_PAYLOAD_LIMIT = 1232;
+const MRP_PAYLOAD_LIMIT = MAX_UDP_MESSAGE_SIZE - MATTER_MESSAGE_OVERHEAD;
 
 /**
  * Confirms the request the DUT received on `exchange` was one an MRP session could equally have

--- a/support/chip-testing/test/cert/tc-sc-8-support.ts
+++ b/support/chip-testing/test/cert/tc-sc-8-support.ts
@@ -10,6 +10,7 @@ import { resolveControllerImplementation, UnsupportedByControllerError } from "@
 import {
     CertCheckFailedError,
     CommissionedRefs,
+    describeError,
     describeValue,
     expectSequence,
     literally,
@@ -177,6 +178,28 @@ export async function tcpInvokeCheck(
     command: number,
     from: number,
 ): Promise<CheckRecord> {
+    return (await tcpInvokeEvidence(cx, session, endpoint, cluster, command, from)).check;
+}
+
+/**
+ * What {@link tcpInvokeCheck} observed, for a step that has more to say about the same invoke: the
+ * exchange it used and the last line of it the DUT wrote, so a further check bounds itself to this
+ * interaction rather than to whatever else the log holds.
+ */
+export interface TcpInvokeEvidence {
+    check: CheckRecord;
+    exchange?: string;
+    lastLine?: number;
+}
+
+export async function tcpInvokeEvidence(
+    cx: CertStepContext,
+    session: string,
+    endpoint: number,
+    cluster: number,
+    command: number,
+    from: number,
+): Promise<TcpInvokeEvidence> {
     const dut = cx.devices.dut;
     const onSession = `${literally(session)}\\(tcp\\)`;
     const path = matterjsCommandPath(endpoint, cluster, command);
@@ -197,7 +220,7 @@ export async function tcpInvokeCheck(
         LOG_TIMEOUT,
     );
     if (invoked.verdict !== "pass" || invoked.matched === undefined || invoked.logLine === undefined) {
-        return invoked;
+        return { check: invoked };
     }
 
     // The answer has to be this invoke's own, and an exchange is what makes it so: a second invoke on
@@ -205,16 +228,18 @@ export async function tcpInvokeCheck(
     const exchange = EXCHANGE.exec(invoked.matched)?.[1];
     if (exchange === undefined) {
         return {
-            type: "device-log",
-            verdict: "fail",
-            pattern: EXCHANGE.source,
-            detail: `the DUT's invoke line names no exchange: ${invoked.matched}`,
-            logLine: invoked.logLine,
+            check: {
+                type: "device-log",
+                verdict: "fail",
+                pattern: EXCHANGE.source,
+                detail: `the DUT's invoke line names no exchange: ${invoked.matched}`,
+                logLine: invoked.logLine,
+            },
         };
     }
 
     const onExchange = `${onSession}⇵${exchange}`;
-    return expectSequence(
+    const answered = await expectSequence(
         dut.log,
         dut.flavor,
         `${what} answered with an InvokeResponse on exchange ${exchange}`,
@@ -229,6 +254,8 @@ export async function tcpInvokeCheck(
         invoked.logLine + 1,
         LOG_TIMEOUT,
     );
+
+    return { check: answered, exchange, lastLine: answered.logLine ?? invoked.logLine };
 }
 
 /** The exchange a matter.js log line names. */
@@ -257,7 +284,7 @@ export async function recordTcpInvoke(
 const LARGE_PAYLOAD_FLOOR = 1280;
 
 /** The payload size matter.js prints on a message line — the encoded message, without its framing. */
-const REPORT_SIZE = /\bsize: (\d+)\b/;
+const MESSAGE_SIZE = /\bsize: (\d+)\b/;
 
 /** How much of a matched line the evidence keeps; a wildcard read's report line carries its whole payload in hex. */
 const EVIDENCE_LIMIT = 300;
@@ -321,7 +348,7 @@ export async function wildcardReadInOneReportCheck(
     const lines = dut.log.lines;
     const reports = lines.slice(request.logLine + 1).filter(line => !line.synthetic && report.test(line.text));
 
-    const sizes = reports.map(line => Number(REPORT_SIZE.exec(line.text)?.[1] ?? Number.NaN));
+    const sizes = reports.map(line => Number(MESSAGE_SIZE.exec(line.text)?.[1] ?? Number.NaN));
     const single = reports.length === 1 && sizes[0] > LARGE_PAYLOAD_FLOOR;
     return {
         type: "device-log",
@@ -339,23 +366,37 @@ export async function recordWildcardReadInOneReport(cx: CertStepContext, session
 }
 
 /**
- * Confirms the request the TH sent on `session` was one an MRP session could equally have carried:
- * the case this belongs to is about a *regularly sized* interaction choosing the TCP session that
- * already exists, so a payload only TCP could carry would prove the wrong thing.
+ * What an MRP message may carry: the IPv6 minimum MTU less the headers matter.js accounts for in its
+ * own UDP limit. A request at or below this is one MRP could equally have delivered, which is what a
+ * case about *choosing* the existing TCP session has to establish — the floor
+ * {@link LARGE_PAYLOAD_FLOOR} sets for a large payload is a different, looser number and would let a
+ * request MRP could not have carried pass as one it could.
+ *
+ * @see {@link MatterSpecification.v16.Core} § 4.4.4
+ */
+const MRP_PAYLOAD_LIMIT = 1232;
+
+/**
+ * Confirms the request the DUT received on `exchange` was one an MRP session could equally have
+ * carried: the case this belongs to is about a *regularly sized* interaction choosing the TCP session
+ * that already exists, so a payload only TCP could carry would prove the wrong thing.
+ *
+ * `exchange` is the one {@link tcpInvokeEvidence} matched, so the size measured belongs to the invoke
+ * the step checked rather than to whatever else the session carried.
  */
 export async function regularSizedRequestCheck(
     cx: CertStepContext,
     session: string,
+    exchange: string,
     from: number,
 ): Promise<CheckRecord> {
     const dut = cx.devices.dut;
+    const pattern = new RegExp(`Message « for: I/InvokeRequest .*\\bid: ${literally(session)}\\(tcp\\)⇵${exchange}✉`);
     const request = await expectSequence(
         dut.log,
         dut.flavor,
-        `an InvokeRequest received on ${session}`,
-        {
-            matterjs: [new RegExp(`Message « for: I/InvokeRequest .*\\bid: ${literally(session)}\\(tcp\\)⇵[0-9a-f]+✉`)],
-        },
+        pattern.source,
+        { matterjs: [pattern] },
         from,
         LOG_TIMEOUT,
     );
@@ -363,40 +404,82 @@ export async function regularSizedRequestCheck(
         return request;
     }
 
-    const size = Number(REPORT_SIZE.exec(request.matched)?.[1] ?? Number.NaN);
+    const size = Number(MESSAGE_SIZE.exec(request.matched)?.[1] ?? Number.NaN);
     return {
         type: "device-log",
-        verdict: size > 0 && size <= LARGE_PAYLOAD_FLOOR ? "pass" : "fail",
-        pattern: request.pattern,
-        detail: `the InvokeRequest carried ${size} bytes, which MRP could have carried too`,
+        verdict: size > 0 && size <= MRP_PAYLOAD_LIMIT ? "pass" : "fail",
+        pattern: pattern.source,
+        detail: `the InvokeRequest carried ${size} bytes, against an MRP limit of ${MRP_PAYLOAD_LIMIT}`,
         matched: request.matched.slice(0, EVIDENCE_LIMIT),
         logLine: request.logLine,
     };
 }
 
 /**
- * Confirms the DUT accepted no further connection or session while `from` was open: the case this
- * belongs to claims the interaction reused the session already established, and an interaction that
- * caused a second one would satisfy every other check just as well.
+ * Confirms the DUT accepted no further CASE session between `from` and `until`: the case this belongs
+ * to claims the interaction reused the session already established, and an interaction that caused a
+ * second one would satisfy every other check just as well.
+ *
+ * `until` is the last line of the interaction itself, so the window is the interaction's own and is
+ * non-empty by construction — a scan to the end of the buffer would report a session the DUT accepted
+ * afterwards, and an unanchored one could pass on a log that had not arrived yet.
+ *
+ * A second TCP *connection* carrying the same session is not observable here: matter.js logs no
+ * accept, and a session re-attached to a new connection still renders `(tcp)`.
  */
-export async function noFurtherSessionCheck(cx: CertStepContext, from: number): Promise<CheckRecord> {
+export async function noFurtherSessionCheck(cx: CertStepContext, from: number, until: number): Promise<CheckRecord> {
     const dut = cx.devices.dut;
     if (dut.flavor !== "matterjs") {
         return { type: "device-log", verdict: "unverified" };
     }
 
     await dut.log.settled();
-    const opened = dut.log.lines.slice(from).filter(line => !line.synthetic && FURTHER_SESSION.test(line.text));
+    const opened = dut.log
+        .window(from, until + 1 - from)
+        .filter(line => !line.synthetic && FURTHER_SESSION.test(line.text));
 
     return {
         type: "device-log",
         verdict: opened.length ? "fail" : "pass",
         pattern: FURTHER_SESSION.source,
-        detail: opened.length
-            ? `the DUT accepted ${opened.length} further pairing request(s) while the interaction ran`
-            : "the DUT accepted no further pairing request while the interaction ran",
+        detail: `${opened.length} further pairing request(s) between log lines ${from} and ${until}`,
         matched: opened[0]?.text.slice(0, EVIDENCE_LIMIT),
         logLine: opened[0]?.index,
+    };
+}
+
+/**
+ * The `SystemTimeMs` a `TimeSnapshotResponse` carries, or undefined for an answer that is not one.
+ * `GeneralDiagnostics.TimeSnapshot` is what the TCP cases invoke: it carries a response of its own,
+ * which is what "a command response" means, and changes nothing on the DUT, so a rerun does not
+ * depend on what the previous one left behind.
+ */
+export function systemTimeMsOf(response: unknown): number | bigint | undefined {
+    if (typeof response !== "object" || response === null || !("systemTimeMs" in response)) {
+        return undefined;
+    }
+    const value = response.systemTimeMs;
+    return typeof value === "number" || typeof value === "bigint" ? value : undefined;
+}
+
+/** What a step records for the answer to a `TimeSnapshot` it invoked. */
+export function timeSnapshotResponseCheck(response: unknown, refusal: unknown): CheckRecord {
+    if (refusal !== undefined) {
+        return {
+            type: "response",
+            verdict: "fail",
+            detail: `the DUT refused TimeSnapshot: ${describeError(refusal)}`,
+        };
+    }
+
+    const systemTimeMs = systemTimeMsOf(response);
+    return {
+        type: "response",
+        verdict: systemTimeMs === undefined ? "fail" : "pass",
+        detail:
+            systemTimeMs === undefined
+                ? `the DUT answered TimeSnapshot with ${describeValue(response)}, which carries no SystemTimeMs`
+                : `TimeSnapshotResponse systemTimeMs=${systemTimeMs}`,
     };
 }
 


### PR DESCRIPTION
Adds the certification case TC-SC-8.7. It asks for something the two cases before it do not: a **regularly sized** interaction — one neither transport is required for — that nonetheless travels on the TCP session already established, rather than causing a new one. The controller is asked for nothing special (an ordinary invoke, no large payload), so the case's substance is entirely in what the step proves afterwards.

Three checks, all bound to the one interaction the invoke check identified — it hands back the exchange it matched and the last line of the interaction, and the other two take them:

- **The request is one MRP could have carried.** The size is read off the device's `I/InvokeRequest` line *on that exchange* and must be at or below MRP's own payload limit. That limit is derived from the constants the protocol uses — the UDP channel's budget less the exchange's header and MIC overhead, 1232 − 54 = 1178 — because the size a device logs is the payload alone. (Not the 1280-byte large-payload floor TC-SC-8.6 uses: 1280 is the IPv6 MTU, and comparing a payload against it would accept a request MRP could not have carried.)
- **The answer came back on step 1's session**, through the exchange-correlated check TC-SC-8.5 uses.
- **No further CASE session was established**, scanning that interaction's own span. It keys on the line the device writes once a session exists, new or resumed, rather than on the pairing request that precedes it — matter.js writes that before it has read Sigma1, so an attempt the device rejected would otherwise read as a session it accepted. Bounding the scan at both ends is what makes the window mean anything: a session established after the interaction finished is not reported as one established during it, and a window that had not been filled yet cannot read as silence.

  What this adds is narrower than it first looks. The two checks above are bound to step 1's own session tag, so an interaction that *travelled* on a second session already fails them. This one covers the remaining case — a second session created alongside, used or not — which is what the plan's "use whichever one is available" rules out.

A further TCP *connection* is deliberately not claimed: matter.js logs no accept, and a session re-attached to a new connection still renders `(tcp)`, so only a further CASE session is observable.

Nothing in the controller expresses "either transport is usable" as a per-request flag. A per-call `preferredTransport` exists at the protocol layer and is used internally by subscription re-establishment, but no cert-facing API surfaces it, and the hard `requiredTransport` lever is set only from a command's own large-payload quality. Passing nothing is therefore what "either transport is usable" means on this stack — which is what the AGENTS.md section says, rather than leaving it for the next reader.

TC-SC-8.5 now shares this case's response check, so both require the answer to carry `SystemTimeMs` rather than merely not throwing.

### Matrix legs

| Leg | Outcome |
| --- | --- |
| matter.js controller × matter.js device | passes, six checks recorded |
| chip-tool controller × matter.js device | both steps skipped, with the reason |
| either controller × chip device flavors | skipped before activation (`flavors: ["matterjs"]`) |

### Verification

Repository root:

```
npm run build          exit 0
npm run format-verify  exit 0
npm run lint           exit 0
npm test               exit 0
```

Certification suites (not covered by the root `npm test`):

```
npx matter-test --spec="test/cert/*.test.ts" --report                    exit 0
npm --prefix support/chip-testing run test-cert-framework -- --no-pull   exit 0, 37 hermetic cases for these helpers
```

Mutations: forcing `regularSizedRequestCheck` to pass turns three hermetic tests red; forcing `noFurtherSessionCheck` to pass turns one red; reverting its pattern to the pairing request turns three red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
