### PR TITLE
Accept an empty fabric label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A failure to attach a certification run's device logs fails the run instead of only warning
 
 - @matter/protocol
+    - Fix: `UpdateFabricLabel` accepts an empty label, as the specification's `max 32` constraint sets no minimum; it previously failed the command
     - Enhancement: An interaction can be abandoned by the caller: `ClientRequest.abort` takes an `AbortSignal`, honored for read, write, invoke and subscribe
     - Fix: A device that returns an empty or malformed DAC, PAI, attestation elements or Certification Declaration during commissioning now fails attestation with a finding that names the unreadable field, instead of an opaque decoder message
     - Fix: A certificate extension matter.js does not interpret is no longer decoded, so a proprietary extension can no longer fail the whole certificate; an extension matter.js does read is rejected with a `CertificateError` when its value is missing

--- a/packages/protocol/src/fabric/Fabric.ts
+++ b/packages/protocol/src/fabric/Fabric.ts
@@ -190,8 +190,8 @@ export class Fabric {
     }
 
     async setLabel(label: string) {
-        if (label.length === 0 || label.length > 32) {
-            throw new ImplementationError("Fabric label must be between 1 and 32 characters long.");
+        if (label.length > 32) {
+            throw new ImplementationError("Fabric label must be at most 32 characters long.");
         }
         if (this.#label === label) {
             return;
@@ -589,8 +589,8 @@ export class FabricBuilder {
     }
 
     setLabel(label: string) {
-        if (label.length === 0 || label.length > 32) {
-            throw new ImplementationError("Fabric label must be between 1 and 32 characters long.");
+        if (label.length > 32) {
+            throw new ImplementationError("Fabric label must be at most 32 characters long.");
         }
         this.#label = label;
         return this;

--- a/packages/protocol/test/fabric/FabricTest.ts
+++ b/packages/protocol/test/fabric/FabricTest.ts
@@ -112,7 +112,7 @@ describe("Fabric", () => {
 
     describe("setLabel", () => {
         // Spec 1.6 §11.18.6.11: the Label field is constrained to "max 32" with no minimum, and any label that does
-        // not collide with another fabric's SHALL be accepted
+        // not collide with another fabric's label SHALL be accepted
         it("accepts an empty label", async () => {
             const fabric = await TestFabric();
 

--- a/packages/protocol/test/fabric/FabricTest.ts
+++ b/packages/protocol/test/fabric/FabricTest.ts
@@ -110,6 +110,33 @@ describe("Fabric", () => {
         });
     });
 
+    describe("setLabel", () => {
+        // Spec 1.6 §11.18.6.11: the Label field is constrained to "max 32" with no minimum, and any label that does
+        // not collide with another fabric's SHALL be accepted
+        it("accepts an empty label", async () => {
+            const fabric = await TestFabric();
+
+            await fabric.setLabel("");
+
+            expect(fabric.label).equals("");
+        });
+
+        it("accepts a label of the maximum length", async () => {
+            const fabric = await TestFabric();
+            const label = "x".repeat(32);
+
+            await fabric.setLabel(label);
+
+            expect(fabric.label).equals(label);
+        });
+
+        it("rejects a label that exceeds the maximum length", async () => {
+            const fabric = await TestFabric();
+
+            await expect(fabric.setLabel("x".repeat(33))).rejectedWith(/at most 32 characters/);
+        });
+    });
+
     describe("remove from session", () => {
         it("removes all sessions when removing fabric", async () => {
             const DECRYPT_KEY = b$`bacb178b2588443d5d5b1e4559e7accc`;


### PR DESCRIPTION
## What this changes

`UpdateFabricLabel` failed the command when an administrator set an empty label. It now succeeds, as the specification requires.

The Label field is constrained to `max 32` with **no minimum**, and §11.18.6.11 gives the command exactly two outcomes:

> If the Label field is identical to a Label already in use by a Fabric within the Fabrics list that is not the accessing fabric, then an NOCResponse with a StatusCode of LabelConflict SHALL be returned […] **Otherwise, the Label field for the accessing fabric SHALL immediately be updated to reflect the Label argument provided. Following the update, an NOCResponse with a StatusCode of OK SHALL be returned.**

An empty label is not a conflict, so it falls into "otherwise" and must be accepted. `Fabric.setLabel` instead rejected it with an `ImplementationError`, which escaped the command handler and failed the whole command.

CHIP agrees: `HandleUpdateFabricLabel` rejects only `label.size() > 32`, and `FabricInfo::SetFabricLabel` checks only against the maximum. Neither has an empty-label check.

The inconsistency was internal too — a `Fabric` could already be *constructed* with an empty label (and the tests do exactly that); only `setLabel` disagreed.

The maximum-length check stays. It is unreachable for `UpdateFabricLabel`, where schema validation already rejects an over-long label with `CONSTRAINT_ERROR` before the handler runs, but it still guards local callers such as the controller's admin fabric label.

## How this was found

Auditing the throw sites that reach a command handler without being a `StatusResponseError`, as follow-up to #4359. That audit's main result is a negative one worth recording: of the sites reviewed, this is the **only** genuine defect.

Specification §8.3.1.2 makes `FAILURE` the correct status wherever no better one is defined, so a throw that represents a code error is already answered correctly once #4359 gives it a per-command envelope. Checked and found already correct:

- `FailsafeContext.createCertificateSigningRequest` — §11.18.6.5 explicitly prescribes `FAILURE` for an operational key pair that collides with an installed one
- `GeneralCommissioningServer` arming the failsafe over CASE while the commissioning window is open — the throw is caught by the handler itself and converted to an `ArmFailSafeResponse` with `BusyWithOtherAdmin`, matching both the specification and CHIP
- `OperationalCredentialsServer` on a duplicate fabric index, `AdministratorCommissioningServer` on an already-initialised window, `DeviceCommissioner` on a conflicting window state, `GroupsServer` on a missing root endpoint — all guarded upstream and reachable only through an internal state inconsistency, for which `FAILURE` is the right answer

## Tests

Three cases in `FabricTest.ts`: an empty label is accepted, a 32-character label is accepted, and a 33-character label is rejected.

Proven by reverting: restoring the `length === 0` rejection turns the empty-label and over-length tests red.

## Verification

```
npm run build           ✓
npm run format-verify   ✓  All matched files use the correct format.
npm run lint            ✓
npm test -p packages/protocol   ✓ 1556/1556 ESM · 1556/1556 CJS
npm test -p packages/node       ✓ 1883/1883 ESM · 1883/1883 CJS
npm test -p packages/nodejs     ✓ 340/340 ESM · 340/340 CJS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
