### PR TITLE
A malformed command payload answers INVALID_COMMAND

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A mandatory command a cluster leaves unimplemented is no longer dispatched; an invoke answers `UNSUPPORTED_COMMAND`, matching what the cluster advertises in `AcceptedCommandList`
 
 - @matter/protocol
+    - Fix: A command whose payload does not match the command's schema is answered with `INVALID_COMMAND` instead of `FAILURE`
     - Enhancement: An interaction can be abandoned by the caller: `ClientRequest.abort` takes an `AbortSignal`, honored for read, write, invoke and subscribe
     - Fix: An error escaping a command handler with no defined status code answers that command with `FAILURE` inside the `InvokeResponse` instead of terminating the message with a status response, so the other commands of a batch invoke keep their results. Under `SuppressResponse` such a command now sends no response at all, as for any other generated status
     - Fix: A device that returns an empty or malformed DAC, PAI, attestation elements or Certification Declaration during commissioning now fails attestation with a finding that names the unreadable field, instead of an opaque decoder message

--- a/packages/node/test/node/CommandInvokeResponseTest.ts
+++ b/packages/node/test/node/CommandInvokeResponseTest.ts
@@ -12,7 +12,7 @@ import { Endpoint } from "#endpoint/index.js";
 import { MatterFlowError } from "@matter/general";
 import { AccessLevel } from "@matter/model";
 import { CommandInvokeResponse, Invoke, InvokeRequest, InvokeResult } from "@matter/protocol";
-import { ClusterId, CommandId, EndpointNumber, Status, StatusResponseError } from "@matter/types";
+import { ClusterId, CommandId, EndpointNumber, Status, StatusResponseError, TlvUInt8 } from "@matter/types";
 import { Chime } from "@matter/types/clusters/chime";
 import { OnOff } from "@matter/types/clusters/on-off";
 import { MockServerNode } from "./mock-server-node.js";
@@ -445,6 +445,35 @@ describe("CommandInvokeResponse", () => {
                 kind: "cmd-status",
                 path: { clusterId: Chime.Cluster.id, commandId: 0, endpointId: 1 },
                 status: Status.UnsupportedCommand,
+                clusterStatus: undefined,
+                commandRef: undefined,
+            },
+        ]);
+    });
+
+    it("reports a payload that does not match the command schema as INVALID_COMMAND", async () => {
+        const device = new Endpoint(OnOffLightDevice);
+        const node = await MockServerNode.createOnline(undefined, { device });
+
+        // OnWithTimedOff expects a structure; a bare integer cannot decode against it
+        const response = await invokeCmdRaw(node, {
+            invokeRequests: [
+                {
+                    commandPath: {
+                        endpointId: EndpointNumber(1),
+                        clusterId: ClusterId(6),
+                        commandId: CommandId(0x42),
+                    },
+                    commandFields: TlvUInt8.encodeTlv(5),
+                },
+            ],
+        });
+
+        expect(response.data).deep.equals([
+            {
+                kind: "cmd-status",
+                path: { clusterId: 6, commandId: 0x42, endpointId: 1 },
+                status: Status.InvalidCommand,
                 clusterStatus: undefined,
                 commandRef: undefined,
             },

--- a/packages/protocol/src/action/server/CommandInvokeResponse.ts
+++ b/packages/protocol/src/action/server/CommandInvokeResponse.ts
@@ -17,6 +17,7 @@ import {
     EndpointNumber,
     FabricIndex,
     Status,
+    StatusResponse,
     StatusResponseError,
     TlvSchema,
     TlvStream,
@@ -511,8 +512,20 @@ export class CommandInvokeResponse<
         if (value === undefined) {
             return undefined; // The validation will fail if the schema expected data
         }
+
+        let decoded;
+        try {
+            decoded = tlv.decodeTlv(value);
+        } catch (error) {
+            // A payload that does not match the command's schema is a fault in the request, not in this node
+            StatusResponseError.reject(error);
+            throw new StatusResponse.InvalidCommandError(
+                `Command payload does not match the command schema: ${error instanceof Error ? error.message : error}`,
+            );
+        }
+
         return tlv.injectField(
-            tlv.decodeTlv(value),
+            decoded,
             <number>FabricIndexField.id,
             this.#fabricIndex,
             () => true, // We always inject the current fabricIndex for invokes


### PR DESCRIPTION
## What this changes

When a controller sends a command whose payload does not match that command's schema — a bare integer where a structure is expected, a mis-tagged element inside a list — the device answered `FAILURE`. That tells the controller the device broke, when the fault is in the request. It now answers `INVALID_COMMAND`.

Decoding throws `UnexpectedDataError`, which extends `MatterError` rather than `StatusResponseError`, so it fell through to the generic backstop added in #4359 and took that path's `FAILURE`.

The surrounding code already distinguishes this class of fault: a `ValidationError` is deliberately remapped from `INVALID_ACTION` to `INVALID_COMMAND` a few lines below. Decoding failures simply never reached that branch. A decoding error that is already a `StatusResponseError` is passed through untouched.

## Evidence

CHIP answers a command it cannot decode with a per-command `InvalidCommand` — `CommandHandlerImpl::ProcessCommandDataIB` falls to `exit:` on a TLV read failure and calls `FallibleAddStatus(concretePath, Status::InvalidCommand)`. Its cluster implementations use the same status for payload content faults, for example `OperationalCredentialsCluster.cpp` rejecting an ill-sized `CSRNonce` or an over-long `NOCValue`.

The specification uses `INVALID_COMMAND` for malformed payloads. A worked example in the same cluster family, from the Operational Credentials cluster: "If the CSRNonce is malformed, then this command SHALL fail with an INVALID_COMMAND status code."

## Scope

Only the decode step is converted. `injectField` is left outside the conversion — a failure there indicates an internal problem rather than a bad request, and keeps the generic `FAILURE`.

This is the last item from the audit that followed #4359. That audit's result was mostly negative and worth recording: specification §8.3.1.2 makes `FAILURE` correct wherever no better status is defined, so nearly every throw reaching the invoke error path was already answered correctly once #4359 gave it a per-command envelope. Only three real defects came out of it — this one, the empty fabric label (#4363), and the envelope itself (#4359).

## Tests

One case: `OnWithTimedOff` invoked with a bare integer where the command's structure is expected answers `INVALID_COMMAND`.

Proven by reverting: without the conversion the command answers `FAILURE` and the test fails.

## Verification

```
npm run build           ✓
npm run format-verify   ✓  All matched files use the correct format.
npm run lint            ✓
npm test -p packages/protocol   ✓ 1553/1553 ESM · 1553/1553 CJS
npm test -p packages/node       ✓ 1890/1890 ESM · 1890/1890 CJS
npm test -p packages/nodejs     ✓ 340/340 ESM · 340/340 CJS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
