### PR TITLE
Certification checks that could pass without seeing what they claim

### DIFF
--- a/support/chip-testing/test/cert-framework/tc-cadmin-1.17-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-cadmin-1.17-support.test.ts
@@ -85,6 +85,15 @@ describe("TC-CADMIN-1.17's post-removal refusal predicate", () => {
         );
     });
 
+    it("does not accept a status the removal does not explain", () => {
+        expect(isPostRemovalRefusal(new StatusResponseError("writeAttribute failed", Status.ConstraintError))).equal(
+            false,
+        );
+        expect(isPostRemovalRefusal(new StatusResponseError("writeAttribute failed", Status.InvalidCommand))).equal(
+            false,
+        );
+    });
+
     it("accepts a failed connection to a device that no longer serves the fabric", () => {
         expect(isPostRemovalRefusal(new PeerCommunicationError("Cannot establish a session"))).equal(true);
     });

--- a/support/chip-testing/test/cert-framework/tc-idm-1.3-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-1.3-support.test.ts
@@ -196,11 +196,31 @@ describe("expectNoInjectedFault", () => {
 
         expect(check.verdict).equal("unverified");
     });
+
+    // Undrained on purpose: the TH announces the fault while answering the invoke, so the line is in
+    // the pump exactly when a step calls this. Counting without settling reports the window clean
+    it("settles the buffer before counting, so a fault still in the pump is not missed", async () => {
+        const check = await withFollower(
+            [...batchRequestLines(PATHS), ...faultLines(ChipFault.imInvokeSeparateResponses)],
+            follower => expectNoInjectedFault(follower, "chip-local", 0),
+        );
+
+        expect(check.verdict).equal("fail");
+    });
 });
 
 describe("expectInvokeCount", () => {
     it("passes on the expected number of invoke requests", async () => {
         const check = await withBufferedFollower([...batchRequestLines(PATHS), ...batchRequestLines(PATHS)], follower =>
+            expectInvokeCount(follower, "chip-local", 0, 2),
+        );
+
+        expect(check.verdict).equal("pass");
+    });
+
+    // Same trap as the fault counter's: the invokes are in the pump when a step calls this
+    it("settles the buffer before counting, so invokes still in the pump are counted", async () => {
+        const check = await withFollower([...batchRequestLines(PATHS), ...batchRequestLines(PATHS)], follower =>
             expectInvokeCount(follower, "chip-local", 0, 2),
         );
 

--- a/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { InternalError, Millis, Seconds } from "@matter/main";
+import { ImplementationError } from "@matter/main";
 import type {
     CertDevice,
     CertNodeApi,
@@ -242,6 +243,12 @@ async function withFixture(fixture: Fixture, body: (fixture: Fixture) => Promise
 }
 
 describe("subscribeAndModify", () => {
+    it("refuses values a write would not change, which report nothing and would time out unexplained", async () => {
+        await withFixture(new Fixture("chip-local", () => {}), async fixture => {
+            await expect(fixture.run([true, true])).rejectedWith(ImplementationError);
+        });
+    });
+
     it("completes when each write is reported twice and other subscriptions report alongside", async () => {
         const fixture = new Fixture("chip-local", (f, _index, value) => {
             // The sibling report ahead of ours carries no ack of its own: a wait that anchored on

--- a/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
@@ -216,7 +216,7 @@ class Fixture {
         this.#onUpdate?.(value);
     }
 
-    run(values: boolean[] = VALUES, timeouts: SubscribeAndModifyTimeouts = TIMEOUTS): Promise<void> {
+    run(values: unknown[] = VALUES, timeouts: SubscribeAndModifyTimeouts = TIMEOUTS): Promise<void> {
         return subscribeAndModify(this.cx, "ref", 3, PATH, values, timeouts);
     }
 
@@ -246,6 +246,17 @@ describe("subscribeAndModify", () => {
     it("refuses values a write would not change, which report nothing and would time out unexplained", async () => {
         await withFixture(new Fixture("chip-local", () => {}), async fixture => {
             await expect(fixture.run([true, true])).rejectedWith(ImplementationError);
+        });
+    });
+
+    it("refuses structurally equal values, which is what decides whether the attribute changed", async () => {
+        // Separately allocated and carrying a bigint: reference equality would let this through, and
+        // rendering the offending value with JSON.stringify would throw instead of naming it
+        await withFixture(new Fixture("chip-local", () => {}), async fixture => {
+            await expect(fixture.run([{ nodes: [1n, 2n] }, { nodes: [1n, 2n] }])).rejectedWith(
+                ImplementationError,
+                /repeats at index 1/,
+            );
         });
     });
 

--- a/support/chip-testing/test/cert-framework/tc-idm-5.1-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-5.1-support.test.ts
@@ -26,10 +26,10 @@ function line(atMs: number, text: string) {
 
 const T0 = 1786711488_000;
 
-function receipt(atMs: number, category: "S" | "U" | "G", type: string, exchange = "1r") {
+function receipt(atMs: number, category: "S" | "U" | "G", type: string, exchange = "1r", session = "2") {
     return line(
         atMs,
-        `[EM] >>> [E:${exchange} S:2 M:3] (${category}) Msg RX from 1:000000000001B669 --- Type 0001:${type}`,
+        `[EM] >>> [E:${exchange} S:${session} M:3] (${category}) Msg RX from 1:000000000001B669 --- Type 0001:${type}`,
     );
 }
 
@@ -43,10 +43,13 @@ function timedRequestLines(atMs: number, category: "S" | "U" | "G" = "S") {
     ];
 }
 
-function invokeLines(atMs: number, options: { suppressResponse?: boolean; timed?: boolean; exchange?: string } = {}) {
-    const { suppressResponse = true, timed = true, exchange = "1r" } = options;
+function invokeLines(
+    atMs: number,
+    options: { suppressResponse?: boolean; timed?: boolean; exchange?: string; session?: string } = {},
+) {
+    const { suppressResponse = true, timed = true, exchange = "1r", session = "2" } = options;
     return [
-        receipt(atMs, "S", "08 (IM:InvokeCommandRequest)", exchange),
+        receipt(atMs, "S", "08 (IM:InvokeCommandRequest)", exchange, session),
         line(atMs, "[DMG] InvokeRequestMessage ="),
         line(atMs, "[DMG] {"),
         ...(suppressResponse ? [line(atMs, "[DMG] \tsuppressResponse = false, ")] : []),
@@ -313,6 +316,14 @@ describe("expectTimedFollowUp", () => {
 
         expect(check.verdict).equal("pass");
         expect(check.detail).contains("20.0ms");
+    });
+
+    it("does not take another session's identically numbered exchange for this one", async () => {
+        // An exchange id is unique only within its session, so a second session can hold one with the
+        // same number at the same time
+        const check = await followUp([...timedRequestLines(T0), ...invokeLines(T0 + 20, { session: "3" })]);
+
+        expect(check.verdict).equal("fail");
     });
 
     it("passes when the optional suppressResponse line is absent, as a matter.js write is", async () => {

--- a/support/chip-testing/test/cert-framework/tc-idm-5.1-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-5.1-support.test.ts
@@ -26,16 +26,24 @@ function line(atMs: number, text: string) {
 
 const T0 = 1786711488_000;
 
-function receipt(atMs: number, category: "S" | "U" | "G", type: string, exchange = "1r", session = "2") {
+function receipt(
+    atMs: number,
+    category: "S" | "U" | "G",
+    type: string,
+    exchange = "1r",
+    // null omits the field, which a default parameter cannot express: passing undefined would take it
+    session: string | null = "2",
+) {
     return line(
         atMs,
-        `[EM] >>> [E:${exchange} S:${session} M:3] (${category}) Msg RX from 1:000000000001B669 --- Type 0001:${type}`,
+        `[EM] >>> [E:${exchange}${session === null ? "" : ` S:${session}`} M:3] (${category}) Msg RX from ` +
+            `1:000000000001B669 --- Type 0001:${type}`,
     );
 }
 
-function timedRequestLines(atMs: number, category: "S" | "U" | "G" = "S") {
+function timedRequestLines(atMs: number, category: "S" | "U" | "G" = "S", session: string | null = "2") {
     return [
-        receipt(atMs, category, "0a (IM:TimedRequest)"),
+        receipt(atMs, category, "0a (IM:TimedRequest)", "1r", session),
         line(atMs, "[DMG] TimedRequestMessage ="),
         line(atMs, "[DMG] {"),
         line(atMs, `[DMG] \tTimeoutMs = 0x${TIMEOUT.toString(16)},`),
@@ -45,7 +53,7 @@ function timedRequestLines(atMs: number, category: "S" | "U" | "G" = "S") {
 
 function invokeLines(
     atMs: number,
-    options: { suppressResponse?: boolean; timed?: boolean; exchange?: string; session?: string } = {},
+    options: { suppressResponse?: boolean; timed?: boolean; exchange?: string; session?: string | null } = {},
 ) {
     const { suppressResponse = true, timed = true, exchange = "1r", session = "2" } = options;
     return [
@@ -322,6 +330,13 @@ describe("expectTimedFollowUp", () => {
         // An exchange id is unique only within its session, so a second session can hold one with the
         // same number at the same time
         const check = await followUp([...timedRequestLines(T0), ...invokeLines(T0 + 20, { session: "3" })]);
+
+        expect(check.verdict).equal("fail");
+    });
+
+    it("does not attribute a follow-up when neither receive line names a session", async () => {
+        // Both sides absent compares nothing, so the check would fall back to exchange-only attribution
+        const check = await followUp([...timedRequestLines(T0, "S", null), ...invokeLines(T0 + 20, { session: null })]);
 
         expect(check.verdict).equal("fail");
     });

--- a/support/chip-testing/test/cert-framework/tc-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-support.test.ts
@@ -1207,6 +1207,73 @@ describe("command, event and subscribe checks against a matter.js TH", () => {
     });
 });
 
+describe("expectReportAck against a chip TH", () => {
+    // One subscription's report going out on its own exchange, and the acks that come back. chip
+    // prints a trace line naming the exchange, then the message's decode dump.
+    const SUBSCRIPTION_ID = 0x54c99e7e;
+
+    function reportLines(exchange: string) {
+        return [
+            `[DMG] >> to UDP:[fe80::1]:5540 | 1234 | [Interaction Model  (1) / Report Data (0x05) / Session = 2 / Exchange = ${exchange}]`,
+            "[DMG] ReportDataMessage =",
+            "[DMG] {",
+            `[DMG] \tSubscriptionId = 0x${SUBSCRIPTION_ID.toString(16)},`,
+            "[DMG] \tAttributeReportIBs =",
+        ];
+    }
+
+    function ackLines(exchange: string, status: string) {
+        return [
+            `[DMG] << from UDP:[fe80::1]:5540 | 1235 | [Interaction Model  (1) / Status Response (0x01) / Session = 2 / Exchange = ${exchange}]`,
+            "[DMG] StatusResponseMessage =",
+            "[DMG] {",
+            `[DMG] \tStatus = ${status},`,
+        ];
+    }
+
+    async function ack(lines: string[]) {
+        return withFollower(
+            lines,
+            follower =>
+                expectReportAck(
+                    follower,
+                    "chip-local",
+                    {
+                        outcome: "found",
+                        subscriptionId: SUBSCRIPTION_ID,
+                        check: { type: "device-log", verdict: "pass" },
+                    },
+                    0,
+                    Millis(200),
+                ),
+            { endSource: true },
+        );
+    }
+
+    it("reads the status out of the ack sent on the report's own exchange", async () => {
+        // A run acks one report per write per live subscription, so another subscription's rejection
+        // can sit between our report and our own ack
+        const check = await ack([
+            ...reportLines("9000"),
+            ...ackLines("9001", "0x01 (FAILURE)"),
+            ...ackLines("9000", "0x00 (SUCCESS)"),
+        ]);
+
+        expect(check.verdict).equal("pass");
+    });
+
+    it("fails on the status of our own ack, though another exchange succeeded first", async () => {
+        const check = await ack([
+            ...reportLines("9000"),
+            ...ackLines("9001", "0x00 (SUCCESS)"),
+            ...ackLines("9000", "0x01 (FAILURE)"),
+        ]);
+
+        expect(check.verdict).equal("fail");
+        expect(check.detail).contains("FAILURE");
+    });
+});
+
 describe("expectSubscriptionId and expectReportAck against a matter.js TH", () => {
     // Lines a matter.js TH writes for one subscription: the response naming the id it minted, the
     // report it then sends on that subscription, and the DUT's answer to that very report — the

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -1194,11 +1194,13 @@ What the plan asks to verify, and how each part is evidenced:
   `(U)` unencrypted unicast, `(G)` secure groupcast (`src/messaging/README.md`). `expectUnicastReceipt`
   scans *backward* from the decode dump for the nearest `Msg RX from` line, which is this message's own
   since chip logs one message at a time.
-- **The follow-up is the one this request opened** — matched by chip's own exchange id, read off both
-  messages' receive lines, not by "the next message after the timed request". A retry of this
-  interaction, or a second administrator's own timed interaction with the same TH, otherwise stands in
-  for it: the check then passes on someone else's evidence, or fails on a span measured between two
-  different interactions. This is the same rule the subscription checks follow (see "Anchor a
+- **The follow-up is the one this request opened** — matched by the session *and* exchange chip names
+  on both messages' receive lines (`[E:<exchange> S:<session> …]`), not by "the next message after the
+  timed request". A retry of this interaction, or a second administrator's own timed interaction with
+  the same TH, otherwise stands in for it: the check then passes on someone else's evidence, or fails
+  on a span measured between two different interactions. Both halves are needed because an exchange id
+  is unique only within its session, so a session that re-establishes mid-run can hold one with a
+  number a previous session already used. This is the same rule the subscription checks follow (see "Anchor a
   subscription ack on its own subscription id"), and it is why `expectUnicastReceipt` and the follow-up
   check share one receive-line lookup.
 - **The follow-up carried `timedRequest = true`** — matched by *proximity*, not adjacency: chip prints

--- a/support/chip-testing/test/cert/TC-IDM-1.3.test.ts
+++ b/support/chip-testing/test/cert/TC-IDM-1.3.test.ts
@@ -85,7 +85,7 @@ function recordResults(
 async function recordBatchRequest(cx: CertStepContext, from: number, paths: BatchPath[]) {
     const th = cx.devices.th;
     record(cx, await expectBatchRequestPaths(th.log, th.flavor, paths, from, LOG_TIMEOUT), "Invoke request paths");
-    record(cx, expectInvokeCount(th.log, th.flavor, from, 1), "Invoke request count");
+    record(cx, await expectInvokeCount(th.log, th.flavor, from, 1), "Invoke request count");
 }
 
 certTest("TC-IDM-1.3", {
@@ -167,8 +167,8 @@ certTest("TC-IDM-1.3", {
                 detail: "TH device accepted FailAtFault for chip faults 12, 13 and 14",
             });
 
-            record(cx, expectInvokeCount(th.log, th.flavor, from, 3), "Arming invoke count");
-            record(cx, expectNoInjectedFault(th.log, th.flavor, from), "No fault fired while arming");
+            record(cx, await expectInvokeCount(th.log, th.flavor, from, 3), "Arming invoke count");
+            record(cx, await expectNoInjectedFault(th.log, th.flavor, from), "No fault fired while arming");
         },
         { expected: "Each FailAtFault command's response indicates it was successful" },
     )
@@ -188,7 +188,7 @@ certTest("TC-IDM-1.3", {
                 { index: 1, status: Status.Success },
             ]);
             await recordBatchRequest(cx, from, BATCH_PATHS);
-            record(cx, expectNoInjectedFault(th.log, th.flavor, from), "No injected fault");
+            record(cx, await expectNoInjectedFault(th.log, th.flavor, from), "No injected fault");
         },
         {
             expected:
@@ -301,7 +301,7 @@ certTest("TC-IDM-1.3", {
                 detail: `single invoke of OnOff.on on endpoint ${ENDPOINT_1} succeeded`,
             });
             await recordBatchRequest(cx, from, [BATCH_PATHS[0]]);
-            record(cx, expectNoInjectedFault(th.log, th.flavor, from), "No injected fault");
+            record(cx, await expectNoInjectedFault(th.log, th.flavor, from), "No injected fault");
         },
         {
             expected: "On the TH, the received request message has the same path as provided in the command",

--- a/support/chip-testing/test/cert/tc-cadmin-1.17-support.ts
+++ b/support/chip-testing/test/cert/tc-cadmin-1.17-support.ts
@@ -6,7 +6,7 @@
 
 import { OperationalCredentials } from "@matter/main/clusters";
 import { PeerCommunicationError } from "@matter/main/protocol";
-import { StatusResponseError, ValidationError } from "@matter/main/types";
+import { Status, StatusResponseError, ValidationError } from "@matter/main/types";
 import type { LogExpectPatterns } from "@matter/testing";
 import { ChipToolCommandError } from "../../src/cert/ChipToolControllerAdapter.js";
 import { NoCommissionedPeerError } from "../../src/cert/InProcessControllerAdapter.js";
@@ -41,16 +41,24 @@ export const WINDOW_OPEN: LogExpectPatterns = {
  * ({@link StatusResponseError}). {@link ValidationError} is a {@link StatusResponseError} but is the
  * client's own encode-time rejection before anything goes on the wire, so it proves nothing here.
  * Anything else says nothing about the removal and must not pass the step.
+ *
+ * A status the device answered has to be one the removal explains. Once the fabric is gone the
+ * controller's own access is gone with it, so `UnsupportedAccess` is that status (Matter Core
+ * § 8.4.3.2); a device that answered `ConstraintError` or `InvalidCommand` processed the interaction
+ * on a fabric it still honours and refused it for a reason of its own, which is the opposite of what
+ * this step claims.
  */
 export function isPostRemovalRefusal(error: unknown): boolean {
     if (error instanceof ValidationError) {
         return false;
     }
+    if (error instanceof StatusResponseError) {
+        return error.code === Status.UnsupportedAccess;
+    }
     return (
         error instanceof NoCommissionedPeerError ||
         error instanceof PeerCommunicationError ||
-        error instanceof ChipToolCommandError ||
-        error instanceof StatusResponseError
+        error instanceof ChipToolCommandError
     );
 }
 

--- a/support/chip-testing/test/cert/tc-idm-1.3-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-1.3-support.ts
@@ -89,13 +89,17 @@ export function expectInjectedFault(
  * Records that the TH answered the invoke at or after `from` itself, with no fault substituting the
  * response — the evidence for a step the plan expects to behave normally.
  *
- * Synchronous, unlike its positive counterpart: there is no line to wait for, and the invoke whose
- * absence of a fault this asserts has already been answered by the time a step can call this.
+ * There is no line to wait for, unlike its positive counterpart — but the buffer still has to be
+ * settled first. `count` sees only what the pump has ingested, so a fault the TH announced while
+ * answering the invoke is invisible for a turn or two afterwards, and counting without settling
+ * records "no fault fired" against a window the fault line has not reached yet.
  */
-export function expectNoInjectedFault(log: LogFollower, flavor: string, from: number): CheckRecord {
+export async function expectNoInjectedFault(log: LogFollower, flavor: string, from: number): Promise<CheckRecord> {
     if (!flavor.startsWith("chip")) {
         return { type: "device-log", verdict: "unverified" };
     }
+
+    await log.settled();
 
     const count = log.count(FAULT_INJECTED_LINE, from);
     return {
@@ -115,10 +119,17 @@ export function expectNoInjectedFault(log: LogFollower, flavor: string, from: nu
  * every later step onto the wrong fault. This check is what turns that into a legible failure instead
  * of an inexplicable one, and it is why the plan forbids any other command in this window.
  */
-export function expectInvokeCount(log: LogFollower, flavor: string, from: number, expected: number): CheckRecord {
+export async function expectInvokeCount(
+    log: LogFollower,
+    flavor: string,
+    from: number,
+    expected: number,
+): Promise<CheckRecord> {
     if (!flavor.startsWith("chip")) {
         return { type: "device-log", verdict: "unverified" };
     }
+
+    await log.settled();
 
     const count = log.count(INVOKE_REQUEST_MESSAGE, from);
     return {

--- a/support/chip-testing/test/cert/tc-idm-4.1-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-4.1-support.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Duration, Millis, Seconds, Time } from "@matter/main";
+import { Duration, ImplementationError, Millis, Seconds, Time } from "@matter/main";
 import { resolveControllerImplementation } from "@matter/testing";
 import type { AttributePathSpec, CertNodeRef, CertStepContext } from "@matter/testing";
 import {
@@ -105,6 +105,17 @@ export async function subscribeAndModify<Value>(
     values: Value[],
     timeouts: SubscribeAndModifyTimeouts = {},
 ): Promise<void> {
+    // A write that does not change the attribute produces no report, so the step would wait out its
+    // report budget and fail for a reason the evidence cannot name
+    const repeated = values.findIndex((value, index) => index > 0 && values[index - 1] === value);
+    if (repeated > 0) {
+        throw new ImplementationError(
+            `subscribeAndModify needs values that differ from their predecessor; ${JSON.stringify(
+                values[repeated],
+            )} repeats at index ${repeated}`,
+        );
+    }
+
     const th = cx.devices.th;
     const node = cx.controllers.dut.node(ref);
     const establish = timeouts.establish ?? LOG_TIMEOUT;

--- a/support/chip-testing/test/cert/tc-idm-4.1-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-4.1-support.ts
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Duration, ImplementationError, Millis, Seconds, Time } from "@matter/main";
+import { Duration, ImplementationError, isDeepEqual, Millis, Seconds, Time } from "@matter/main";
 import { resolveControllerImplementation } from "@matter/testing";
 import type { AttributePathSpec, CertNodeRef, CertStepContext } from "@matter/testing";
 import {
     CertCheckFailedError,
+    describeValue,
     expectMessageWithPath,
     expectReportAck,
     expectSubscriptionId,
@@ -106,13 +107,13 @@ export async function subscribeAndModify<Value>(
     timeouts: SubscribeAndModifyTimeouts = {},
 ): Promise<void> {
     // A write that does not change the attribute produces no report, so the step would wait out its
-    // report budget and fail for a reason the evidence cannot name
-    const repeated = values.findIndex((value, index) => index > 0 && values[index - 1] === value);
+    // report budget and fail for a reason the evidence cannot name. Deep equality, because that is what
+    // decides whether the attribute changed (`Datasource`'s own report suppression)
+    const repeated = values.findIndex((value, index) => index > 0 && isDeepEqual(values[index - 1], value));
     if (repeated > 0) {
         throw new ImplementationError(
-            `subscribeAndModify needs values that differ from their predecessor; ${JSON.stringify(
-                values[repeated],
-            )} repeats at index ${repeated}`,
+            `subscribeAndModify needs values that differ from their predecessor; ` +
+                `${describeValue(values[repeated])} repeats at index ${repeated}`,
         );
     }
 

--- a/support/chip-testing/test/cert/tc-idm-5.1-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-5.1-support.ts
@@ -27,7 +27,7 @@ const TIMED_REQUEST_FLAG = /timedRequest = true,\s*$/;
  * the session it came over: `(S)` secure unicast, `(U)` unencrypted unicast, `(G)` secure groupcast
  * (`src/messaging/README.md`).
  */
-const RECEIPT_LINE = /\[E:(\d+[ir])[^\]]*\] \((S|U|G)\) Msg RX from/;
+const RECEIPT_LINE = /\[E:(\d+[ir])(?: S:(\d+))?[^\]]*\] \((S|U|G)\) Msg RX from/;
 
 // How far back from a message's decode dump its own receive line may sit. chip prints the two a
 // handful of lines apart; the bound is what stops a search that finds nothing nearby from
@@ -99,7 +99,8 @@ function receiptBefore(log: LogFollower, index: number): Receipt | undefined {
         index: line.index,
         text: line.text,
         exchange: match[1],
-        category: match[2] as Receipt["category"],
+        session: match[2],
+        category: match[3] as Receipt["category"],
         pattern: String(RECEIPT_LINE),
     };
 }
@@ -406,7 +407,10 @@ export async function expectTimedFollowUp(
             }
             cursor = block.last.index + 1;
 
-            if (receiptBefore(log, block.last.index)?.exchange !== receipt.exchange) {
+            // An exchange id is unique only within its session, so a follow-up is this timed request's
+            // only when both agree
+            const candidate = receiptBefore(log, block.last.index);
+            if (candidate?.exchange !== receipt.exchange || candidate.session !== receipt.session) {
                 continue;
             }
 

--- a/support/chip-testing/test/cert/tc-idm-5.1-support.ts
+++ b/support/chip-testing/test/cert/tc-idm-5.1-support.ts
@@ -408,9 +408,14 @@ export async function expectTimedFollowUp(
             cursor = block.last.index + 1;
 
             // An exchange id is unique only within its session, so a follow-up is this timed request's
-            // only when both agree
+            // only when both agree — and a receive line naming no session cannot establish that
             const candidate = receiptBefore(log, block.last.index);
-            if (candidate?.exchange !== receipt.exchange || candidate.session !== receipt.session) {
+            if (
+                receipt.session === undefined ||
+                candidate?.session === undefined ||
+                candidate.exchange !== receipt.exchange ||
+                candidate.session !== receipt.session
+            ) {
                 continue;
             }
 

--- a/support/chip-testing/test/cert/tc-support.ts
+++ b/support/chip-testing/test/cert/tc-support.ts
@@ -1520,6 +1520,13 @@ const REPORT_SENT_LINE = /\[DMG\] >> to UDP:.*\/ Report Data \(0x05\) \/ Session
 const READ_REQUEST_RECEIVED_LINE =
     /\[DMG\] << from UDP:.*\/ Read Request \(0x02\) \/ Session = \d+ \/ Exchange = (\d+)\]\s*$/;
 
+/**
+ * chip prints the *peer's* session id on a message it sends and its own on one it receives — a real
+ * capture has one interaction's outbound Report Data on `Session = 56179` and the inbound ack for it
+ * on `Session = 13606` — so an ack cannot be matched to the report it answers by session, only by
+ * exchange. Session scoping applies between two messages travelling the same way, which is what the
+ * timed-interaction checks compare (`tc-idm-5.1-support.ts`).
+ */
 function reportAckedOnExchange(exchange: string): RegExp {
     return new RegExp(
         `\\[DMG\\] << from UDP:.*/ Status Response \\(0x01\\) / Session = \\d+ / Exchange = ${exchange}\\]\\s*$`,


### PR DESCRIPTION
A survey of eleven suspected weak checks in the certification suite — checks that report success, or an `accepted` unverified that does not fail a run, without observing what their step claims. **Four were real; this PR fixes them.** The other seven were already fixed or were misreadings of the current code, and are listed below so the survey does not have to be repeated.

### Fixed here

**A count of what has *not* happened has to settle the buffer first.** `expectNoInjectedFault` and `expectInvokeCount` counted lines the follower had not necessarily ingested yet, so "no fault fired" was recorded against a window the fault line had not reached. Both settle first now. (This commit was written earlier and parked; it is the same class of bug as the one just fixed in the TCP block.)

**A post-removal refusal accepted any status the device answered with.** Once a fabric is removed the controller's access goes with it, so `UnsupportedAccess` is the status that follows. A device answering `ConstraintError` or `InvalidCommand` processed the interaction on a fabric it still honours and refused it for reasons of its own — the opposite of what TC-CADMIN-1.17 step 8 claims. The chip-tool branch is unchanged: its errors genuinely cannot be told apart, and that is documented where it happens.

**A timed follow-up was attributed by exchange id alone.** An exchange id is unique only within a session — which `Receipt.session`'s own documentation said while the code did not do it. chip prints the session beside the exchange on every receive line (`[E:1r S:2 M:3]`), so both are now read and compared. A test gives a second session an identically numbered exchange and requires the check to reject it.

**"N distinct writes" was described but not checked.** A repeated value changes no attribute, so it produces no report, and `subscribeAndModify` would wait out its report budget and fail for a reason its evidence could not name. The precondition is now enforced at the call, with the error naming the offending index.

**Plus a missing test, not a fix:** the report-ack check on the chip flavor binds an acknowledgement to its report's own exchange, and had no test for that binding. Two interleaved acknowledgements, one on another exchange — the check must read the status from ours. Unbinding the pattern turns it red.

### Surveyed and left alone, with reasons

| # | Item | Verdict |
| --- | --- | --- |
| 1 | mDNS probe answers from cache, so a negative check could pass on an absent TH | Already fixed — transitions now rest on the device's own log; the probe corroborates a precondition only |
| 3 | `expectReportAck` takes the status from the first StatusResponse after the ack | Already fixed — bound by exchange id; only the test was missing, added here |
| 5 | `expectUnicastReceipt` passes category "U" | Mistaken — "U" is chip's *unencrypted unicast*, and the check's claim is unicast-versus-groupcast |
| 7 | `recordVendorOutcome`'s resolved branch is an unconditional pass | Mistaken — the plan accepts either outcome, and a resolved commission means real PASE/CASE completed |
| 10 | `defineFlowQrTest` step `.a` is accepted-unverified | Mistaken — the checkable half is verified for real; only "TH not in commissioning mode", which no TH flavor here can exhibit, is accepted |
| 11 | Hard-coded passes in `recordUnpair`/`commissionByTarget` | Mistaken — each follows an `await` that would have thrown, and is followed by a real log check |

**One real gap deliberately left open (#2):** `recordDiscriminatorHonored` records an accepted unverified on chip-tool, so roughly half the flavor matrix carries no evidence for a claim later commissioning steps rest on. chip-tool funnels discovery, PASE, attestation and argument failures into one opaque error, so there is nothing honest to observe there. It is documented at the call and locked in by a test. Closing it means attempting a bounded commission for weak corroboration — which trades an honest gap for a murkier one, so it is a decision rather than an oversight.

### Verification

Repository root:

```
npm run build          exit 0
npm run format-verify  exit 0
npm run lint           exit 0
npm test               exit 0
```

Certification suites (not covered by the root `npm test`):

```
npm --prefix support/chip-testing run test-cert-framework -- --no-pull   exit 0
npx matter-test --spec="test/cert/*.test.ts" --report                    exit 0, 30 cases
MATTER_CERT_DEVICE=chip-local … --spec=test/cert/TC-IDM-5.1.test.ts      exit 0
```

The chip-local leg is the one that exercises the timed-attribution change; TC-IDM-1.3, which carries the settle fix, runs only on the chip flavors in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)