### PR TITLE
A discovered peer cluster keeps the revision the peer reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/node
     - Fix: A mandatory command a cluster leaves unimplemented is no longer dispatched; an invoke answers `UNSUPPORTED_COMMAND`, matching what the cluster advertises in `AcceptedCommandList`
+    - Fix: A discovered peer cluster records the `ClusterRevision` the peer reports rather than the standard cluster's, and peers differing only in revision no longer share a behavior
 
 - @matter/protocol
     - Fix: A command whose payload does not match the command's schema is answered with `INVALID_COMMAND` instead of `FAILURE`

--- a/packages/node/src/node/client/ClientStructure.ts
+++ b/packages/node/src/node/client/ClientStructure.ts
@@ -561,6 +561,12 @@ export class ClientStructure {
             this.#pruneDroppedAttributes(cluster, newAttributes, attrs.values);
         }
 
+        if (cluster.behavior && attrs.values.has(ClusterRevision.id)) {
+            if (cluster.revision !== attrs.values.get(ClusterRevision.id)) {
+                cluster.behavior = undefined;
+            }
+        }
+
         if (cluster.behavior && attrs.values.has(FeatureMap.id)) {
             if (!isDeepEqual(cluster.features, attrs.values.get(FeatureMap.id))) {
                 cluster.behavior = undefined;

--- a/packages/node/src/node/client/PeerBehavior.ts
+++ b/packages/node/src/node/client/PeerBehavior.ts
@@ -11,6 +11,7 @@ import { camelize, InternalError } from "@matter/general";
 import {
     AttributeModel,
     ClusterModel,
+    ClusterRevision,
     CommandModel,
     Conformance,
     EncodedBitmap,
@@ -72,7 +73,11 @@ export namespace PeerBehavior {
     export interface DiscoveredClusterShape {
         kind: "discovered";
         id: ClusterId;
-        revision: number;
+
+        /**
+         * The cluster revision the peer reports.  Undefined if the peer did not report {@link ClusterRevision}.
+         */
+        revision?: number;
         features?: FeatureBitmap | number;
         attributes?: AttributeId[];
         commands?: CommandId[];
@@ -220,14 +225,23 @@ function generateDiscoveredType(
 
     // If the schema does not match what the device actually returned, further augment the schema
     // with unknown attributes and/or commands
+    const { revisionOverride } = analysis;
     if (
-        schema.revision !== analysis.shape.revision ||
+        revisionOverride !== undefined ||
         extraAttrs.size ||
         extraCommands.size ||
         attrSupportOverrides.size ||
         commandSupportOverrides.size
     ) {
         extendSchema();
+
+        if (revisionOverride !== undefined) {
+            const base = schema.attributes(ClusterRevision.id);
+            if (base === undefined) {
+                throw new InternalError(`Cluster ${schema.name} states no ClusterRevision to override`);
+            }
+            schema.children.push(base.extend({ default: revisionOverride }));
+        }
 
         if (attrSupportOverrides.size) {
             for (const [attr, isSupported] of attrSupportOverrides.entries()) {
@@ -275,6 +289,10 @@ function generateDiscoveredType(
  */
 function createFingerprint(analysis: DiscoveredShapeAnalysis) {
     const fingerprint = [analysis.shape.id] as (number | string | bigint)[];
+
+    if (analysis.revisionOverride !== undefined) {
+        fingerprint.push("r", analysis.revisionOverride);
+    }
 
     if (analysis.featureBitmap) {
         fingerprint.push("f", analysis.featureBitmap);
@@ -367,6 +385,12 @@ interface DiscoveredShapeAnalysis {
     schema: ClusterModel & { id: ClusterId };
     featureBitmap: number | bigint;
     shape: PeerBehavior.DiscoveredClusterShape;
+
+    /**
+     * The revision to record on the schema, present only where it differs from the revision the schema already states.
+     */
+    revisionOverride?: number;
+
     attrSupportOverrides: Map<AttributeModel, boolean>;
     extraAttrs: Set<number>;
     commandSupportOverrides: Map<CommandModel, boolean>;
@@ -381,9 +405,14 @@ function DiscoveredShapeAnalysis(
     matter: MatterModel = Matter,
 ): DiscoveredShapeAnalysis {
     const standardCluster = matter.clusters(shape.id);
-    const schema =
-        standardCluster ??
-        new ClusterModel({ id: shape.id, name: createUnknownName("Cluster", shape.id), revision: shape.revision });
+    const schema = standardCluster ?? new ClusterModel({ id: shape.id, name: createUnknownName("Cluster", shape.id) });
+
+    // The specification constrains ClusterRevision to "min 1", so anything else is not a revision the peer holds
+    const { revision } = shape;
+    const revisionOverride =
+        typeof revision === "number" && Number.isInteger(revision) && revision >= 1 && revision !== schema.revision
+            ? revision
+            : undefined;
 
     let featureBitmap: bigint | number;
     if (typeof shape.features === "number") {
@@ -410,6 +439,7 @@ function DiscoveredShapeAnalysis(
         schema: schema as ClusterModel & { id: ClusterId },
         featureBitmap,
         shape,
+        revisionOverride,
         attrSupportOverrides,
         extraAttrs,
         commandSupportOverrides,

--- a/packages/node/test/node/ClientNodeTest.ts
+++ b/packages/node/test/node/ClientNodeTest.ts
@@ -2620,6 +2620,15 @@ describe("ClientNode", () => {
             ];
         }
 
+        // Like neoReports but at revision 2 — same featureMap, attribute list and command lists.
+        function neoReportsAtRevision2(version: number): ReadResult.Report[] {
+            return neoReports(version).map(report =>
+                report.kind === "attr-value" && report.path.attributeId === ClusterRevision.id
+                    ? { ...report, value: 2 }
+                    : report,
+            );
+        }
+
         // Like neoReports but with an accepted command (1) added — same featureMap and attribute list.
         function neoReportsWithExtraCommand(version: number): ReadResult.Report[] {
             return [
@@ -2792,6 +2801,35 @@ describe("ClientNode", () => {
             const after = neoType();
             expect(after, "NEO should remain active").not.undefined;
             expect(after, "behavior must be rebuilt to reflect the new attribute set").not.equals(before);
+        });
+
+        it("rebuilds a cluster when the peer changes its revision without a feature change", async () => {
+            await using site = new MockSite();
+            const { controller } = await site.addCommissionedPair();
+            const peer1 = await subscribedPeer(controller, "peer1");
+            const structure = (peer1.env.get(EndpointInitializer) as ClientEndpointInitializer).structure;
+            const request = Read({ attributes: [{}], fabricFilter: structure.subscribedFabricFiltered });
+
+            const neoType = () => {
+                const endpoint = structure.endpointFor(EP1);
+                return endpoint === undefined
+                    ? undefined
+                    : (Object.values(endpoint.behaviors.supported).find(
+                          type => (type as ClusterBehavior.Type).cluster?.id === NEO,
+                      ) as ClusterBehavior.Type | undefined);
+            };
+
+            await drain(structure.mutate(request, readResult(descriptorServerListWithNeoReport(10), neoReports(10))));
+            const before = neoType();
+            expect(before?.cluster.revision, "NEO should report the revision the peer sent").equals(1);
+
+            // Same featureMap, attribute list and command lists, but the peer now reports revision 2.
+            await drain(
+                structure.mutate(request, readResult(descriptorServerListWithNeoReport(11), neoReportsAtRevision2(11))),
+            );
+            const after = neoType();
+            expect(after, "behavior must be rebuilt to reflect the new revision").not.equals(before);
+            expect(after?.cluster.revision, "NEO must report the new revision").equals(2);
         });
 
         it("rebuilds a cluster when the peer changes its accepted command list without a feature change", async () => {

--- a/packages/node/test/node/PeerBehaviorTest.ts
+++ b/packages/node/test/node/PeerBehaviorTest.ts
@@ -4,8 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { LocalActorContext } from "#behavior/context/server/LocalActorContext.js";
+import { RootSupervisor } from "#behavior/supervision/RootSupervisor.js";
 import { PeerBehavior } from "#node/client/PeerBehavior.js";
-import { ClusterModel, Matter } from "@matter/model";
+import { AttributeModel, ClusterModel, DataModelPath, FeatureMap, Matter } from "@matter/model";
+import { ConformanceError } from "@matter/protocol";
 import { AttributeId, ClusterId, CommandId } from "@matter/types";
 
 // NetworkCommissioning (0x31) with the EthernetNetworkInterface feature (bit 2).
@@ -16,6 +19,22 @@ const ETHERNET_FEATURE = 4;
 const MALFORMED_MEI = ClusterId(0xfff10001, false);
 
 const UNKNOWN_CLUSTER = ClusterId(0xfff1fc01);
+
+const LEVEL_CONTROL = ClusterId(0x8);
+
+// A custom cluster at revision 3 with one attribute the specification would only introduce at that revision
+const REV_GATED = ClusterId(0xfff1fc02);
+const REV_GATED_MODEL = Matter.withClusters(
+    new ClusterModel({
+        id: REV_GATED,
+        name: "RevGated",
+        children: [
+            FeatureMap.clone(),
+            new AttributeModel({ id: 0xfffd, name: "ClusterRevision", type: "uint16", default: 3 }),
+            new AttributeModel({ id: 1, name: "Gated", type: "uint8", conformance: "[Rev >= v3]" }),
+        ],
+    }),
+);
 
 describe("PeerBehavior", () => {
     describe("discovered schema generation", () => {
@@ -99,6 +118,117 @@ describe("PeerBehavior", () => {
             expect(first).not.equals(second);
             expect(Object.keys(first.cluster.attributes ?? {})).deep.equals(["attr$1"]);
             expect(Object.keys(second.cluster.attributes ?? {})).deep.equals(["attr$21"]);
+        });
+
+        it("reports the revision the peer sent", () => {
+            const behaviorType = PeerBehavior({
+                kind: "discovered",
+                id: LEVEL_CONTROL,
+                revision: 5,
+                attributes: [0, 65528, 65529, 65531, 65532, 65533].map(n => AttributeId(n)),
+                commands: new Array<CommandId>(),
+            });
+
+            expect(behaviorType.cluster.revision).equals(5);
+        });
+
+        it("judges a revision-conformant element against the revision the peer sent", () => {
+            const validateFor = (revision: number) => {
+                const { schema } = PeerBehavior({
+                    kind: "discovered",
+                    id: REV_GATED,
+                    revision,
+                    attributes: [0xfffc, 0xfffd].map(n => AttributeId(n)),
+                    commands: new Array<CommandId>(),
+                    matter: REV_GATED_MODEL,
+                });
+                const supervisor = RootSupervisor.for(schema).get(schema);
+                return () =>
+                    supervisor.validate?.({ gated: 1 }, LocalActorContext.ReadOnly, {
+                        path: new DataModelPath("RevGated"),
+                    });
+            };
+
+            expect(validateFor(3)).not.throw();
+            expect(validateFor(2)).throw(ConformanceError);
+        });
+
+        it("leaves a revision-conformant element to the peer on a write from a client node", () => {
+            const { schema } = PeerBehavior({
+                kind: "discovered",
+                id: REV_GATED,
+                revision: 2,
+                attributes: [0xfffc, 0xfffd].map(n => AttributeId(n)),
+                commands: new Array<CommandId>(),
+                matter: REV_GATED_MODEL,
+            });
+            const supervisor = RootSupervisor.for(schema).get(schema);
+            const session = { ...LocalActorContext.ReadOnly, clientPeerContext: {} };
+
+            expect(() =>
+                supervisor.validate?.({ gated: 1 }, session, { path: new DataModelPath("RevGated") }),
+            ).not.throw();
+        });
+
+        it("reports a revision the standard cluster does not yet define", () => {
+            const behaviorType = PeerBehavior({
+                kind: "discovered",
+                id: REV_GATED,
+                revision: 4,
+                attributes: [0xfffc, 0xfffd].map(n => AttributeId(n)),
+                commands: new Array<CommandId>(),
+                matter: REV_GATED_MODEL,
+            });
+
+            expect(behaviorType.cluster.revision).equals(4);
+        });
+
+        it("reports the revision an unknown cluster sent", () => {
+            const behaviorType = PeerBehavior({
+                kind: "discovered",
+                id: UNKNOWN_CLUSTER,
+                revision: 4,
+                attributes: [AttributeId(3)],
+                commands: new Array<CommandId>(),
+            });
+
+            expect(behaviorType.cluster.revision).equals(4);
+        });
+
+        it("distinguishes shapes that differ only in revision", () => {
+            const shapeFor = (revision: number): PeerBehavior.DiscoveredClusterShape => ({
+                kind: "discovered",
+                id: UNKNOWN_CLUSTER,
+                revision,
+                attributes: [AttributeId(1)],
+                commands: new Array<CommandId>(),
+            });
+
+            expect(PeerBehavior(shapeFor(2))).not.equals(PeerBehavior(shapeFor(3)));
+        });
+
+        it("shares a behavior with a peer that reports the standard revision", () => {
+            const shapeFor = (revision?: number): PeerBehavior.DiscoveredClusterShape => ({
+                kind: "discovered",
+                id: REV_GATED,
+                revision,
+                attributes: [0xfffc, 0xfffd].map(n => AttributeId(n)),
+                commands: new Array<CommandId>(),
+                matter: REV_GATED_MODEL,
+            });
+
+            expect(PeerBehavior(shapeFor(3))).equals(PeerBehavior(shapeFor()));
+        });
+
+        it("tolerates a peer that does not report a revision", () => {
+            const behaviorType = PeerBehavior({
+                kind: "discovered",
+                id: UNKNOWN_CLUSTER,
+                attributes: [AttributeId(2)],
+                commands: new Array<CommandId>(),
+            });
+
+            expect(behaviorType.cluster.revision).equals(1);
         });
     });
 });


### PR DESCRIPTION
A client node builds a behavior for each cluster it discovers on a peer. The revision the peer reports in `ClusterRevision` was passed to the `ClusterModel` constructor, which has no such property, so it was silently dropped — the behavior reported the revision of the *standard* cluster instead. A peer running revision 1 of a cluster matter.js models at revision 7 therefore claimed revision 7.

The reported revision is now recorded as a `ClusterRevision` default on the discovered schema.

## Coupled changes

Two things follow from making the revision a schema input, and neither is optional:

**The behavior-type cache key gains the revision.** Without it, two peers of one cluster differing only in revision would share a behavior, and whichever was seen first would decide the revision both report. The key uses the *effective* override, so a peer reporting exactly the standard revision still shares the standard behavior rather than getting a second, structurally identical type.

**A peer that changes its revision now rebuilds its behavior.** Revision joins `FeatureMap`, `AttributeList` and `AcceptedCommandList` as an input the discovered schema is built from, so a change to it has to invalidate the behavior the same way the others do. Without this, a revision bump that left the other three untouched would leave the old revision reported for the life of the process. This was latent before — revision wasn't a schema input, so there was nothing to invalidate.

A revision below 1 is ignored, matching the `min 1` constraint the specification places on `ClusterRevision`.

## On conformance

`Rev >= vN` conformance is resolved at compile time from the cluster's revision, so it now resolves against the peer's number. That has no practical effect on a client node: `forwardValidationToPeer` sends conformance verdicts to the device rather than raising them locally, and every `act()` under a client-node root carries the `clientPeerContext` that enables it. A test pins both halves — the verdict is judged against the peer's revision, and a write from a client node is left to the peer.

## Testing

Every added branch is mutation-verified against the reverted hunk:

- Reverting the schema push fails "reports the revision the peer sent" (LevelControl reports the standard 7, not the peer's 5).
- Reverting the fingerprint component fails "distinguishes shapes that differ only in revision" — both shapes hit one cache entry.
- Reverting the `ClientStructure` invalidation fails "rebuilds a cluster when the peer changes its revision".

`npm run build-clean`, `npm run format-verify`, `npm run lint` and the full `npm test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)