### PR TITLE
Validation honors the conformance an element inherits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A failure to attach a certification run's device logs fails the run instead of only warning
 
 - @matter/node
+    - Fix: Validation honors the conformance and quality an element inherits, so an element overridden by an operational extension is no longer judged as if it stated neither
+    - Fix: A write from local code that adds an entry to a fabric-scoped list without a `fabricIndex` now fails validation instead of storing an entry that belongs to no fabric. Writes from a peer are unaffected — the accessing fabric is supplied for them
+    - Fix: Assigning a whole list to a fabric-scoped attribute that held none merges through the managed list, so its entries are fabric-filtered and carry the accessing fabric; it previously bypassed both
+    - Fix: A `ConformanceError` names the conformance the decision was made on rather than the element's own
     - Fix: A mandatory command a cluster leaves unimplemented is no longer dispatched; an invoke answers `UNSUPPORTED_COMMAND`, matching what the cluster advertises in `AcceptedCommandList`
 
 - @matter/protocol

--- a/packages/node/src/behavior/state/managed/values/ListManager.ts
+++ b/packages/node/src/behavior/state/managed/values/ListManager.ts
@@ -184,6 +184,15 @@ class ListProxyHandler implements ProxyHandler<Val.List> {
         }
     }
 
+    /**
+     * Supply the parts of an entry the manager owns rather than the caller.
+     *
+     * Invoked before the entry is validated, because validation judges the entry as a whole.
+     */
+    protected prepareEntry(value: Val): Val {
+        return value;
+    }
+
     protected writeEntry(index: number, value: Val, location: AccessControl.Location) {
         this.config.authorizeWrite(this.session, location);
 
@@ -237,6 +246,7 @@ class ListProxyHandler implements ProxyHandler<Val.List> {
     set(_target: Val.List, property: PropertyKey, newValue: Val, receiver: Val.List) {
         if (typeof property === "string" && property.match(/^\d+/)) {
             this.#sublocation.path.id = property;
+            newValue = this.prepareEntry(newValue);
             this.config.validateEntry?.(newValue, this.session, this.#sublocation);
             this.writeEntry(Number.parseInt(property), newValue, this.#sublocation);
             return true;
@@ -326,6 +336,13 @@ class FabricFilteredListProxyHandler extends ListProxyHandler {
         return super.readEntry(this.#mapScopedToActual(index, true), location);
     }
 
+    protected override prepareEntry(value: Val) {
+        if (isObject(value)) {
+            (value as { fabricIndex?: number }).fabricIndex ??= this.session.fabric;
+        }
+        return value;
+    }
+
     protected override writeEntry(index: number, value: Val, location: AccessControl.Location) {
         if (value === undefined) {
             const valueIndex = this.#mapScopedToActual(index, false);
@@ -334,7 +351,6 @@ class FabricFilteredListProxyHandler extends ListProxyHandler {
             if (!isObject(value)) {
                 throw new WriteError(location, `Fabric scoped list value is not an object`, Status.Failure);
             }
-            (value as { fabricIndex?: number }).fabricIndex ??= this.session.fabric;
             super.writeEntry(this.#mapScopedToActual(index, false), value, location);
         }
     }

--- a/packages/node/src/behavior/state/managed/values/StructManager.ts
+++ b/packages/node/src/behavior/state/managed/values/StructManager.ts
@@ -229,7 +229,16 @@ function configureProperty(supervisor: RootSupervisor, schema: ValueModel) {
                 value = Internal.unmanage(value);
 
                 // Modify the value
-                if (isFabricScopedList && Array.isArray(value) && Array.isArray(previousValue)) {
+                if (isFabricScopedList && Array.isArray(value)) {
+                    // The merge must run through the proxy even for an absent member; it is what filters by fabric
+                    // and supplies the accessing fabric
+                    if (previousValue === undefined) {
+                        target[key] = [];
+                        if (storedKey !== undefined && storedKey !== key) {
+                            delete target[storedKey];
+                        }
+                    }
+
                     // In the case of fabric-scoped write to established list we use the managed proxy to perform update
                     // as it will sort through values and only modify those with correct fabricIndex
                     const proxy = self[memberKeyFor(pk, name, id)] as Val.List;

--- a/packages/node/src/behavior/state/managed/values/StructManager.ts
+++ b/packages/node/src/behavior/state/managed/values/StructManager.ts
@@ -228,6 +228,17 @@ function configureProperty(supervisor: RootSupervisor, schema: ValueModel) {
                 // Unwrap if incoming value (or nested children) is managed
                 value = Internal.unmanage(value);
 
+                // Undo our change on error.  Rollback will take care of this when transactional but this handles the
+                // cases of 1.) no transaction, and 2.) error is caught within transaction.  A previously absent member
+                // must not leave a slot behind — consumers enumerate slot keys to discover which members hold values
+                const undo = () => {
+                    if (previousValue === undefined) {
+                        delete target[key];
+                    } else {
+                        target[key] = previousValue;
+                    }
+                };
+
                 // Modify the value
                 if (isFabricScopedList && Array.isArray(value)) {
                     // The merge must run through the proxy even for an absent member; it is what filters by fabric
@@ -242,10 +253,15 @@ function configureProperty(supervisor: RootSupervisor, schema: ValueModel) {
                     // In the case of fabric-scoped write to established list we use the managed proxy to perform update
                     // as it will sort through values and only modify those with correct fabricIndex
                     const proxy = self[memberKeyFor(pk, name, id)] as Val.List;
-                    for (let i = 0; i < value.length; i++) {
-                        proxy[i] = value[i];
+                    try {
+                        for (let i = 0; i < value.length; i++) {
+                            proxy[i] = value[i];
+                        }
+                        proxy.length = value.length;
+                    } catch (e) {
+                        undo();
+                        throw e;
                     }
-                    proxy.length = value.length;
                 } else {
                     // Direct assignment
                     target[key] = value;
@@ -270,16 +286,7 @@ function configureProperty(supervisor: RootSupervisor, schema: ValueModel) {
                             owner: this[Internal.reference].rootOwner,
                         });
                     } catch (e) {
-                        // Undo our change on error.  Rollback will take care of this when transactional but this
-                        // handles the cases of 1.) no transaction, and 2.) error is caught within transaction.
-                        // A previously absent member must not leave a slot behind — consumers enumerate slot keys to
-                        // discover which members hold values
-                        if (previousValue === undefined) {
-                            delete target[key];
-                        } else {
-                            target[key] = previousValue;
-                        }
-
+                        undo();
                         throw e;
                     }
                 }

--- a/packages/node/src/behavior/state/validation/conformance-compiler.ts
+++ b/packages/node/src/behavior/state/validation/conformance-compiler.ts
@@ -87,7 +87,7 @@ export function astToFunction(
     supervisor: RootSupervisor,
     options?: astToFunction.Options,
 ): ValueSupervisor.Validate | undefined {
-    const ast = schema.conformance.ast;
+    const ast = schema.effectiveConformance.ast;
     const { featuresAvailable, featuresSupported } = FeatureSet.normalize(
         supervisor.featureMap,
         supervisor.supportedFeatures,
@@ -127,7 +127,7 @@ export function astToFunction(
     };
 
     // Compile the AST
-    const isNullable = schema.quality.nullable;
+    const isNullable = schema.effectiveQuality.nullable;
     const compiledNode = compile(ast);
 
     let validator: ValueSupervisor.Validate | undefined;
@@ -780,7 +780,7 @@ export function astToFunction(
             }
 
             // Enum choice indicates support for the value; it should not affect validation
-            let ast = member.conformance.ast;
+            let ast = member.effectiveConformance.ast;
             if (ast.type === Conformance.Special.Choice) {
                 ast = ast.param.expr;
             }

--- a/packages/node/test/behavior/state/managed/values/ListManagerTest.ts
+++ b/packages/node/test/behavior/state/managed/values/ListManagerTest.ts
@@ -497,6 +497,13 @@ describe("ListManager", () => {
             }, {});
         });
 
+        it("leaves a member that had no list absent when an entry is rejected", async () => {
+            await testMandatoryFabricIndex((_list, ref) => {
+                expect(() => (ref.list = [{ value: 99999 }])).throw();
+                expect(ref.list).undefined;
+            }, {});
+        });
+
         it("supplies the accessing fabric for an entry that omits it", async () => {
             await testMandatoryFabricIndex(list => {
                 list[0] = { value: 3 };

--- a/packages/node/test/behavior/state/managed/values/ListManagerTest.ts
+++ b/packages/node/test/behavior/state/managed/values/ListManagerTest.ts
@@ -6,6 +6,7 @@
 
 import { ActionContext } from "#behavior/context/ActionContext.js";
 import { MaybePromise } from "@matter/general";
+import { Val } from "@matter/protocol";
 import { FabricIndex, NodeId } from "@matter/types";
 import { MockExchange } from "../../../../node/mock-exchange.js";
 import { TestStruct, aclEndpoint, listOf, structOf } from "./value-utils.js";
@@ -20,6 +21,39 @@ export interface TwoLists {
     list2: ValueList;
     subList1: ValueSubList;
     subList2: ValueSubList;
+}
+
+/**
+ * A fabric-scoped list whose entry spells its index with the FabricIndex seed field, which states mandatory
+ * conformance.  The manager supplies the index, so a caller that omits it must still be accepted.
+ */
+export async function testMandatoryFabricIndex(
+    actor: (list: ValueList, ref: Val.Struct) => MaybePromise,
+    defaults: Val.Struct = { list: [] },
+) {
+    const struct = TestStruct(
+        {
+            list: listOf(
+                structOf({
+                    fabricIndex: "FabricIndex",
+                    value: "uint8",
+                }),
+                { access: "F" },
+            ),
+        },
+        defaults,
+    );
+
+    const cx = {
+        fabricFiltered: true,
+        exchange: new MockExchange({ fabricIndex: FabricIndex(1), nodeId: NodeId(1) }),
+        node: aclEndpoint(),
+    };
+
+    return struct.online2(cx, cx, async ({ cx1, ref1 }) => {
+        await actor(ref1.list as ValueList, ref1);
+        await cx1.transaction.commit();
+    });
 }
 
 export async function testFabricScoped(actor: (struct: TestStruct, lists: TwoLists) => MaybePromise) {
@@ -433,6 +467,41 @@ describe("ListManager", () => {
                 { fabricIndex: 1, value: 5 },
                 { fabricIndex: 1, value: 7 },
             ]);
+        });
+    });
+
+    describe("entry with mandatory fabricIndex", () => {
+        it("accepts an entry assigned by index", async () => {
+            await testMandatoryFabricIndex(list => {
+                list[0] = { value: 1 };
+            });
+        });
+
+        it("accepts an entry appended with push", async () => {
+            await testMandatoryFabricIndex(list => {
+                list.push({ value: 2 });
+            });
+        });
+
+        it("accepts a whole list assigned over an existing one", async () => {
+            await testMandatoryFabricIndex((list, ref) => {
+                list[0] = { value: 1 };
+                ref.list = [{ value: 2 }, { value: 3 }];
+            });
+        });
+
+        it("accepts a whole list assigned to a member that had none", async () => {
+            await testMandatoryFabricIndex((_list, ref) => {
+                ref.list = [{ value: 4 }];
+                expect(ref.list).deep.equals([{ fabricIndex: 1, value: 4 }]);
+            }, {});
+        });
+
+        it("supplies the accessing fabric for an entry that omits it", async () => {
+            await testMandatoryFabricIndex(list => {
+                list[0] = { value: 3 };
+                expect(list[0]).deep.equals({ fabricIndex: 1, value: 3 });
+            });
         });
     });
 });

--- a/packages/node/test/behavior/state/managed/values/ListManagerTest.ts
+++ b/packages/node/test/behavior/state/managed/values/ListManagerTest.ts
@@ -6,7 +6,7 @@
 
 import { ActionContext } from "#behavior/context/ActionContext.js";
 import { MaybePromise } from "@matter/general";
-import { Val } from "@matter/protocol";
+import { ConformanceError, Val } from "@matter/protocol";
 import { FabricIndex, NodeId } from "@matter/types";
 import { MockExchange } from "../../../../node/mock-exchange.js";
 import { TestStruct, aclEndpoint, listOf, structOf } from "./value-utils.js";
@@ -467,6 +467,78 @@ describe("ListManager", () => {
                 { fabricIndex: 1, value: 5 },
                 { fabricIndex: 1, value: 7 },
             ]);
+        });
+    });
+
+    describe("list that is not fabric-scoped", () => {
+        // The same write paths as the fabric-scoped cases, where nothing completes an entry on the caller's behalf
+        async function testPlainList(
+            actor: (list: ValueList, ref: Val.Struct) => MaybePromise,
+            defaults: Val.Struct = { list: [] },
+        ) {
+            const struct = TestStruct({ list: listOf(structOf({ value: "uint8" })) }, defaults);
+
+            await struct.online(
+                {
+                    exchange: new MockExchange({ fabricIndex: FabricIndex(1), nodeId: NodeId(1) }),
+                    node: aclEndpoint(),
+                },
+                async ref => {
+                    await actor(ref.list as ValueList, ref);
+                },
+            );
+
+            return struct;
+        }
+
+        it("accepts an entry assigned by index", async () => {
+            const struct = await testPlainList(list => {
+                list[0] = { value: 1 };
+            });
+
+            struct.expect({ list: [{ value: 1 }] });
+        });
+
+        it("accepts a whole list assigned to a member that had none", async () => {
+            const struct = await testPlainList((_list, ref) => {
+                ref.list = [{ value: 2 }];
+            }, {});
+
+            struct.expect({ list: [{ value: 2 }] });
+        });
+
+        it("rejects an invalid entry assigned by index", async () => {
+            const struct = await testPlainList(list => {
+                expect(() => (list[0] = { value: 99999 })).throw();
+            });
+
+            struct.expect({ list: [] });
+        });
+
+        it("leaves a member that had no list absent when an entry is rejected", async () => {
+            const struct = await testPlainList((_list, ref) => {
+                expect(() => (ref.list = [{ value: 99999 }])).throw();
+                expect(ref.list).undefined;
+            }, {});
+
+            expect(struct.fields.list).undefined;
+        });
+
+        it("supplies no fabric for an entry that omits a mandatory fabricIndex", async () => {
+            const struct = TestStruct(
+                { list: listOf(structOf({ fabricIndex: "FabricIndex", value: "uint8" })) },
+                { list: [] },
+            );
+
+            await struct.online(
+                {
+                    exchange: new MockExchange({ fabricIndex: FabricIndex(1), nodeId: NodeId(1) }),
+                    node: aclEndpoint(),
+                },
+                ref => {
+                    expect(() => ((ref.list as ValueList)[0] = { value: 1 })).throw(ConformanceError);
+                },
+            );
         });
     });
 

--- a/packages/node/test/behavior/state/validation/conformanceTest.ts
+++ b/packages/node/test/behavior/state/validation/conformanceTest.ts
@@ -1157,6 +1157,56 @@ describe("conformance", () => {
         });
     });
 
+    describe("operational extension", () => {
+        // An extension carries only id, name and the properties it overrides, so its conformance is the base's
+        function managerFor(extend: boolean) {
+            const gated = new FieldModel({ name: "Gated", type: "uint8", conformance: "X" });
+            const cluster = new ClusterModel({ name: "Test", children: [FeatureMap.clone(), gated] });
+            const schema = extend ? cluster.extend({}, gated.extend({ description: "overridden" })) : cluster;
+            return RootSupervisor.for(schema).get(schema);
+        }
+
+        function validate(manager: ReturnType<typeof managerFor>, record: Record<string, unknown>) {
+            manager.validate?.(record, LocalActorContext.ReadOnly, { path: new DataModelPath("Test") });
+        }
+
+        it("disallows a field its base disallows", () => {
+            expect(() => validate(managerFor(false), { gated: 42 })).throw(ConformanceError);
+        });
+
+        it("disallows a field its base disallows when the field is overridden", () => {
+            expect(() => validate(managerFor(true), { gated: 42 })).throw(ConformanceError);
+        });
+
+        it("disallows an enum value its base disallows when the member is overridden", () => {
+            const member = new FieldModel({ id: 3, name: "Disallowed", conformance: "X" });
+            const gated = new FieldModel(
+                { name: "Gated", type: "enum8" },
+                new FieldModel({ id: 1, name: "Allowed" }),
+                member,
+            );
+            const cluster = new ClusterModel({ name: "Test", children: [FeatureMap.clone(), gated] });
+            const schema = cluster.extend({}, gated.extend({}, member.extend({ description: "overridden" })));
+            const manager = RootSupervisor.for(schema).get(schema);
+
+            expect(() => validate(manager, { gated: 3 })).throw(EnumValueConformanceError);
+            expect(() => validate(manager, { gated: 1 })).not.throw();
+        });
+
+        it("treats a field its base declares nullable as nullable", () => {
+            const gated = new FieldModel({ name: "Gated", type: "uint8", conformance: "M", quality: "X" });
+            const cluster = new ClusterModel({ name: "Test", children: [FeatureMap.clone(), gated] });
+            const schema = cluster.extend({}, gated.extend({ description: "overridden" }));
+            const manager = RootSupervisor.for(schema).get(schema);
+
+            expect(() => validate(manager, {})).not.throw();
+        });
+
+        it("names the conformance it judged", () => {
+            expect(() => validate(managerFor(true), { gated: 42 })).throw('Conformance "X"');
+        });
+    });
+
     describe("revision", () => {
         function managerFor(revision: number, conformance: string) {
             const cluster = new ClusterModel({

--- a/packages/protocol/src/action/errors.ts
+++ b/packages/protocol/src/action/errors.ts
@@ -107,7 +107,7 @@ export class ConformanceError extends ValidateError {
         if (choice) {
             prefix = `Conformance choice "${choice}"`;
         } else {
-            prefix = `Conformance "${(schema as ValueModel).conformance}"`;
+            prefix = `Conformance "${(schema as ValueModel).effectiveConformance}"`;
         }
         super(path, `${prefix}: ${message}`, Status.ConstraintError);
     }


### PR DESCRIPTION
An operational extension carries only the properties it overrides — `id`, `name` and whatever it restates — and resolves everything else through the model it extends. The conformance compiler read the element's *own* conformance, so an extended element compiled as if it stated none, which is "optional", which installs no validator at all.

A discovered peer cluster overrides its elements this way (`PeerBehavior` extends attributes to record element support and the peer's cluster revision), so conformance was silently not enforced for them.

## The change

`astToFunction` now reads the effective conformance, and the effective quality alongside it — reading an element's own quality while resolving its conformance through the base would hand an extension inherited conformance but not inherited nullability. `ConformanceError` reports the effective conformance too, so the message names what the decision was made on instead of an empty string.

## What that exposed

Judging inherited conformance means a fabric-scoped list entry is now held to the mandatory `FabricIndex` the seed field states. Two places were validating an entry before it was complete:

- **The managed list supplied the accessing fabric inside `writeEntry`, after validation had already run.** Completion moves to a `prepareEntry` hook that the fabric-scoped handler overrides, invoked before validation. There is one preparation point rather than two.

- **Assigning a whole list to a fabric-scoped member that held no value assigned it directly**, bypassing the managed list and with it the fabric filtering and the accessing fabric. An absent member is now an empty list for merge purposes.

  Reachability of that second one is worth stating precisely: a member that is mandatory under the active features receives a synthesized default, so it holds `[]` rather than nothing. I verified that `AccessControl.acl` and `AccessControl.extension` (with the `Extension` feature enabled) both start as `[]` and therefore take the merge path already. So this closes a real hole in the managed-value layer, but I have not found a stock cluster that reaches it — it would need a fabric-scoped list that is optional under its active features and unset.

## Behavior change

A write from **local code** that adds an entry to a fabric-scoped list without a `fabricIndex` now fails validation instead of storing an entry that belongs to no fabric. Nothing supplies the fabric for a local actor and nothing ever did, so such an entry was already unusable to anyone reading it — this surfaces a latent data bug rather than creating one. Every in-repo writer already supplies the index.

Writes **from a peer** are unaffected: `AttributeWriteResponse` injects the accessing fabric into every decoded write before validation, and `TlvArray.injectField` recurses into each list element.

The standard model is otherwise untouched. Of the elements whose effective conformance differs from their own, the 212 `ClusterRevision`/`FeatureMap` attributes are skipped by struct validation, and the ModeBase and OperationalState members are already enforced by `ValidatedElements`, which has always read the effective conformance. All 20 elements whose effective *quality* differs state `conformance: "X"`, where nullability is never consulted.

## Testing

Five production hunks, each mutation-verified individually — revert one and its test fails, restore it and the suite is green:

- `conformanceTest.ts` gains an `operational extension` block: a field its base disallows, an enum member its base disallows, a field its base declares nullable, and the error message naming the conformance it judged.
- `ListManagerTest.ts` gains a `mandatory fabricIndex` block over five write shapes — indexed assignment, `push`, whole list over an existing one, whole list onto an absent member, and the accessing fabric being supplied. It uses `type: "FabricIndex"` (the seed field, which states `M`) rather than `fabricIndex: "fabric-idx"` as the existing fixtures do, since the raw datatype states no conformance and so cannot exercise this.

`npm run build-clean`, `npm run format-verify`, `npm run lint` and the full `npm test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
