### PR TITLE
Exclude IDM 1.5 test for ReportDelay feature

### DIFF
--- a/support/chip-testing/test/core/IDM.test.ts
+++ b/support/chip-testing/test/core/IDM.test.ts
@@ -12,7 +12,7 @@ describe("IDM", () => {
         "IDM/10.4",
         // Our AllClustersApp has extra clusters on endpoints for testing; pass fail_on_extra_clusters:False below
         "IDM/10.5",
-        // IDM 1.5. tests the ReportDelay feature added in Matter 1.7
+        // IDM 1.5 tests the ReportDelay feature added in Matter 1.7
         "IDM/1.5",
     );
     chip("IDM/*/run1").exclude(

--- a/support/chip-testing/test/core/IDM.test.ts
+++ b/support/chip-testing/test/core/IDM.test.ts
@@ -12,6 +12,8 @@ describe("IDM", () => {
         "IDM/10.4",
         // Our AllClustersApp has extra clusters on endpoints for testing; pass fail_on_extra_clusters:False below
         "IDM/10.5",
+        // IDM 1.5. tests the ReportDelay feature added in Matter 1.7
+        "IDM/1.5",
     );
     chip("IDM/*/run1").exclude(
         // Spec issues for DoorLock, see https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/11712


### PR DESCRIPTION
Excluded test case for ReportDelay feature in IDM 1.5 for now

