### PR TITLE
Pin the one path that reaches an absent fabric-scoped list

### DIFF
--- a/packages/node/test/behavior/state/managed/values/ListManagerTest.ts
+++ b/packages/node/test/behavior/state/managed/values/ListManagerTest.ts
@@ -5,6 +5,7 @@
  */
 
 import { ActionContext } from "#behavior/context/ActionContext.js";
+import { LocalActorContext } from "#behavior/context/server/LocalActorContext.js";
 import { MaybePromise } from "@matter/general";
 import { ConformanceError, Val } from "@matter/protocol";
 import { FabricIndex, NodeId } from "@matter/types";
@@ -574,6 +575,22 @@ describe("ListManager", () => {
                 expect(() => (ref.list = [{ value: 99999 }])).throw();
                 expect(ref.list).undefined;
             }, {});
+        });
+
+        // A behavior populating a fabric-scoped attribute at startup has no session, so nothing supplies the fabric
+        it("refuses an entry stored with no session to supply the fabric", async () => {
+            const struct = TestStruct(
+                { list: listOf(structOf({ fabricIndex: "FabricIndex", value: "uint8" }), { access: "F" }) },
+                {},
+            );
+
+            await LocalActorContext.act("test", async cx => {
+                const ref = struct.reference(cx);
+                expect(() => (ref.list = [{ value: 1 }])).throw(ConformanceError);
+                expect(ref.list).undefined;
+            });
+
+            expect(struct.fields.list).undefined;
         });
 
         it("supplies the accessing fabric for an entry that omits it", async () => {


### PR DESCRIPTION
Follow-up test for #4369, which made validation honor the conformance an element inherits. That change means a fabric-scoped list entry is held to the mandatory `FabricIndex` the seed field states. This pins the one way that rule can actually be reached, which nothing covered.

## Why there is only one path

A remote write cannot reach it. `ValidatedElements` decides support by whether state holds a value (`ValidatedElements.ts:211`), so an optional attribute holding `undefined` stays out of `AttributeList` (`ServerBehaviorBacking.ts:105`) and a peer write is declined as unsupported before it reaches the managed-value layer.

That leaves the server's own code writing into the member — a behavior populating a fabric-scoped attribute at startup, which has no session to supply the fabric.

Before #4369 such a write was accepted and stored an entry belonging to no fabric, unusable to anyone reading it. It is now refused and the member is left absent.

## Why the fixture is synthetic

No standard cluster states an *officially* optional fabric-scoped list. Of the 23 fabric-scoped list attributes in the model, the mandatory ones receive a synthesized default and the feature-gated ones become mandatory once their feature is selected, so neither is ever absent. The three that read as optional — `AccessControl.AuxiliaryAcl`, `GroupKeyManagement.GroupcastAdoption`, `Groupcast.Membership` — are optional only because they are provisional, and their conformance becomes mandatory-under-feature once that lifts. They are also refused outright today by the provisional guards.

So the fixture declares the shape directly rather than borrowing a cluster that does not exist.

## Testing

Mutation-verified in both directions: reverting `astToFunction` to the element's own conformance fails this test with `expected [Function] to throw ConformanceError`; restoring it passes.

`npm run format-verify`, `npm run lint` and the full `npm test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)