### PR TITLE
fix(model): remove conflicting default on CommodityTariff RandomizationType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A certification run's `result.json` no longer reports a passing verdict for a run that failed
     - Fix: A failure to attach a certification run's device logs fails the run instead of only warning
 
+- @matter/model
+    - Fix: `CommodityTariff.DayEntryStruct.RandomizationType` no longer declares a `default` value that conflicted with its own `[RNDM]` conformance gate; a `dayEntries` list entry that omits `RandomizationType` when `Randomization` is unsupported no longer fails validation for a value the write never asked to set
+
 - @matter/node
     - Fix: Validation honors the conformance and quality an element inherits, so an element overridden by an operational extension is no longer judged as if it stated neither
     - Fix: A write from local code that adds an entry to a fabric-scoped list without a `fabricIndex` now fails validation instead of storing an entry that belongs to no fabric. Writes from a peer are unaffected — the accessing fabric is supplied for them

--- a/packages/model/src/standard/elements/commodity-tariff.element.ts
+++ b/packages/model/src/standard/elements/commodity-tariff.element.ts
@@ -226,8 +226,7 @@ export const CommodityTariff = Cluster(
         Field({ name: "Duration", id: 0x2, type: "uint16", conformance: "O", constraint: "max 1500 - startTime" }),
         Field({ name: "RandomizationOffset", id: 0x3, type: "int16", conformance: "[RNDM]" }),
         Field({
-            name: "RandomizationType", id: 0x4, type: "DayEntryRandomizationTypeEnum", conformance: "[RNDM]",
-            default: 0
+            name: "RandomizationType", id: 0x4, type: "DayEntryRandomizationTypeEnum", conformance: "[RNDM]"
         })
     ),
 

--- a/packages/node/test/behaviors/commodity-tariff/CommodityTariffServerTest.ts
+++ b/packages/node/test/behaviors/commodity-tariff/CommodityTariffServerTest.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CommodityTariffServer } from "#behaviors/commodity-tariff";
+import { CommodityTariff } from "@matter/types/clusters/commodity-tariff";
+import { MockServerNode } from "../../node/mock-server-node.js";
+
+/**
+ * Regression test: DayEntryStruct.RandomizationType declares both conformance "[RNDM]" (gated behind the
+ * Randomization feature, which this endpoint does not enable — only Pricing is) and a schema default (0).
+ * Writing a `dayEntries` list entry that omits RandomizationType used to auto-fill that default and then
+ * reject the very same fill for violating the conformance gate it was never asked to violate:
+ *
+ *   Conformance "[RNDM]": Matter does not allow you to set this attribute
+ *
+ * A bare (non-list) struct attribute with the identical field shape (e.g. currentDayEntry) did not trip
+ * this — the bug was specific to validating list-of-struct entries.
+ */
+describe("CommodityTariff dayEntries write with a [FEATURE]-gated, defaulted struct field", () => {
+    async function createNode() {
+        return MockServerNode.createOnline({
+            type: MockServerNode.RootEndpoint.with(
+                CommodityTariffServer.with(CommodityTariff.Feature.Pricing).set({
+                    tariffInfo: null,
+                    tariffUnit: null,
+                    startDate: null,
+                    dayEntries: null,
+                    dayPatterns: null,
+                    calendarPeriods: null,
+                    individualDays: null,
+                    tariffComponents: null,
+                    tariffPeriods: null,
+                    currentDay: null,
+                    nextDay: null,
+                    currentDayEntry: null,
+                    currentDayEntryDate: null,
+                    nextDayEntry: null,
+                    nextDayEntryDate: null,
+                    currentTariffComponents: null,
+                    nextTariffComponents: null,
+                }),
+            ),
+        });
+    }
+
+    it("accepts a dayEntries list entry that omits RandomizationType", async () => {
+        const node = await createNode();
+
+        // setStateOf() patches via the behavior's supervisor — the same path Matterbridge's setAttribute()
+        // helper uses, and where the bug actually lives (a plain `agent.get(...).state.dayEntries = value`
+        // assignment goes through a different internal mechanism and does not reproduce it).
+        await node.setStateOf(CommodityTariffServer, { dayEntries: [{ dayEntryId: 1, startTime: 0 }] });
+
+        const dayEntries = await node.online(
+            { command: true },
+            async agent => agent.get(CommodityTariffServer).state.dayEntries,
+        );
+        expect(dayEntries?.[0]?.dayEntryId).equals(1);
+        expect(dayEntries?.[0]?.startTime).equals(0);
+        expect(dayEntries?.[0]?.randomizationType).equals(undefined);
+
+        await node.close();
+    });
+});


### PR DESCRIPTION
## Type of change

- [x] 🐛 **Fix** — corrects a defect or wrong behavior
- [ ] ✨ **Feature** — adds new functionality or capability

## Description

`CommodityTariff.DayEntryStruct.RandomizationType` declared both conformance `"[RNDM]"` (only allowed
when the `Randomization` feature is supported) and `default: 0`. Writing a `dayEntries` list entry that
omits `RandomizationType` auto-filled it with that default before validating conformance, then rejected
the very same fill:

```
Conformance "[RNDM]": Matter does not allow you to set this attribute
```

This only happens along the list-of-struct write path (`Endpoint.setStateOf` → `supervisor.patch` →
`StructManager`) — a plain state property assignment (`agent.get(...).state.dayEntries = [...]`) or a
bare, non-list struct attribute with the identical field shape (e.g. `CurrentDayEntry`) don't trip it.

Per the spec text for both `RandomizationOffset` and `RandomizationType` (Application Cluster
Specification § 9.12.5.10.4–5, as transcribed in `commodity-tariff.resource.ts`): *"If this field is not
indicated, randomization shall use the value in the Default\* attribute."* Absence is spec-meaningful
(fall back to the cluster's own `DefaultRandomizationType`), not "value is `None`". `RandomizationOffset`
already has no `default` in the model, matching that — `RandomizationType`'s `default: 0` was
inconsistent with its sibling field, and collapsed that fallback semantic even when `Randomization` was
enabled, on top of causing the conformance crash when it wasn't.

**Fix**: remove the conflicting `default: 0`.

## Backing evidence

- Related issue: #4374
- [x] This fix/change is backed by a **complete log file** — attached here or in the linked issue (not just a few quoted lines).

(Log attached on #4374, from the real-world crash in a Matterbridge plugin. This PR also adds a
self-contained regression test — `CommodityTariffServerTest.ts` — that reproduces the exact same error
via `MockServerNode` + `Endpoint.setStateOf()`, with and without the fix.)

## Checklist

- [x] I understand the code I am submitting and can explain how it works ([AI policy](https://github.com/matter-js/matter.js/blob/main/AI_POLICY.md))
- [x] Tests added or updated to cover the change
- [x] `npm test` passes — ran `@matter/model`'s build, `@matter/node`'s full `test/behaviors/**` suite (390/390, including the new regression test) and `@matter/general`'s suite (1330/1330). Could not complete a full root `npm test` in this sandbox: the browser/web test step fails on a missing Playwright browser binary, unrelated to this change.
- [x] `npm run format-verify` and `npm run lint` pass (both run at the repo root, not just on the touched files)
- [x] CHANGELOG updated
