### PR TITLE
TC-SWTCH-3.2, urgent event subscriptions, and operable chip test devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The main work (all changes without a GitHub username in brackets in the below li
 ## __WORK IN PROGRESS__
 
 - @matter/testing
+    - Breaking: `BackchannelCommand.SimulateLongPress` carries the switch's `featureMap`, which a chip test app requires to decide which events a press produces
+    - Enhancement: Chip certification test devices take simulation commands through the named pipe their app opens, so a step that operates the device runs against a chip app rather than skipping
+    - Enhancement: A certification step subscribing to events may ask for them urgently via `SubscribeEventOptions.urgent`, so a device reports them as they occur rather than at the subscription's maximum interval
     - Enhancement: A certification test requests a transport preference for its controllers via `certTest`'s `transport` option; `"tcp"` asks for a TCP-backed session where the peer supports one, and adapters receive the request through `ControllerAdapterOptions`
     - Enhancement: A certification step whose check could not be evaluated ends `"unverified"` and fails the run, unless the check states why the claim cannot be observed
     - Enhancement: Per-step certification PICS is evaluated on chip device flavors too, and `result.json` reports how many steps their PICS excluded

--- a/packages/testing/src/chip/cert/chip-app-subject.ts
+++ b/packages/testing/src/chip/cert/chip-app-subject.ts
@@ -473,16 +473,19 @@ class ChipLocalDevice implements CertDevice {
      * running app is waited for; there is nothing to wait for otherwise.
      */
     async #sendToPipe(json: string): Promise<void> {
-        const generation = this.#generation;
-        if (generation === undefined || generation.exited) {
-            throw new Error(
-                `Cert device ${this.id} cannot be operated while it is not running, so there is no app to ` +
-                    "send the command to",
-            );
-        }
+        const generation = this.#requireRunning();
 
         const path = this.#pipePath();
         await this.#awaitPipe(path);
+
+        // The wait can span a restart, and the successor generation creates its fifo at the same path,
+        // so a command that set out for one app must not be delivered to the next.
+        if (this.#requireRunning() !== generation) {
+            throw new Error(
+                `Cert device ${this.id} restarted while its command was waiting for the app's pipe, so the ` +
+                    "command was not sent",
+            );
+        }
 
         const pipe = await open(path, constants.O_WRONLY | constants.O_NONBLOCK).catch(cause => {
             throw new Error(
@@ -495,6 +498,18 @@ class ChipLocalDevice implements CertDevice {
         } finally {
             await pipe.close();
         }
+    }
+
+    /** The generation currently running, or a failure naming that there is none. */
+    #requireRunning(): Generation {
+        const generation = this.#generation;
+        if (generation === undefined || generation.exited) {
+            throw new Error(
+                `Cert device ${this.id} cannot be operated while it is not running, so there is no app to ` +
+                    "send the command to",
+            );
+        }
+        return generation;
     }
 
     /** Waits for the app to create its fifo, refusing a path that is there but is not one. */

--- a/packages/testing/src/chip/cert/chip-app-subject.ts
+++ b/packages/testing/src/chip/cert/chip-app-subject.ts
@@ -499,7 +499,7 @@ class ChipLocalDevice implements CertDevice {
 
     /** Waits for the app to create its fifo, refusing a path that is there but is not one. */
     async #awaitPipe(path: string): Promise<void> {
-        const deadline = Date.now() + PIPE_TIMEOUT_MS;
+        const deadline = performance.now() + PIPE_TIMEOUT_MS;
         for (;;) {
             const target = await lstat(path).catch(() => undefined);
             if (target?.isFIFO()) {
@@ -513,7 +513,7 @@ class ChipLocalDevice implements CertDevice {
                 );
             }
 
-            if (Date.now() >= deadline) {
+            if (performance.now() >= deadline) {
                 throw new Error(
                     `Cert device ${this.id} has no command pipe at ${path} after ` +
                         `${PIPE_TIMEOUT_MS}ms, so the app cannot be operated; it is not running, or was ` +
@@ -945,6 +945,10 @@ export class ChipDockerDevice implements CertDevice {
                 // for the reason ChipLocalDevice's own send documents; a shell that exits non-zero
                 // fails the step rather than reporting a command nothing received.
                 //
+                // The app creates its fifo as it starts, so a command sent just after start() waits
+                // for it rather than being refused for a pipe that is merely not there yet; a path
+                // that is there but is not a fifo is still refused at once.
+                //
                 // Opening a fifo for writing waits for a reader, so the write is bounded from outside:
                 // an app that has stopped reading ends this as a non-zero exit rather than holding the
                 // exec for as long as the container lives.
@@ -953,7 +957,7 @@ export class ChipDockerDevice implements CertDevice {
                     String(PIPE_TIMEOUT_MS / 1000),
                     "sh",
                     "-c",
-                    `test -p ${CONTAINER_APP_PIPE} && printf '%s\\n' "$0" > ${CONTAINER_APP_PIPE}`,
+                    `while [ ! -e ${CONTAINER_APP_PIPE} ]; do sleep 0.1; done; test -p ${CONTAINER_APP_PIPE} && printf '%s\\n' "$0" > ${CONTAINER_APP_PIPE}`,
                     json,
                 ]);
                 break;

--- a/packages/testing/src/chip/cert/chip-app-subject.ts
+++ b/packages/testing/src/chip/cert/chip-app-subject.ts
@@ -5,7 +5,7 @@
  */
 
 import { ChildProcess, spawn } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
+import { constants, lstat, mkdtemp, open, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { env, platform as hostPlatform } from "node:process";
@@ -35,6 +35,11 @@ const DEFAULT_PASSCODE = 20202021;
 const STOP_TIMEOUT_MS = 5_000;
 const DRAIN_TIMEOUT_MS = 5_000;
 
+// A chip app creates its command pipe as it starts, so a pipe still absent by now belongs to an app
+// that is not running or was started without one.
+const PIPE_TIMEOUT_MS = 5_000;
+const PIPE_POLL_MS = 50;
+
 // Killing a container and seeing it gone goes through the Docker daemon, so it is nothing like as
 // prompt as a SIGTERM to a local child.
 const CONTAINER_STOP_TIMEOUT_MS = 30_000;
@@ -43,6 +48,44 @@ const CONTAINER_STOP_TIMEOUT_MS = 30_000;
 // `CHIP:DMG: ReadRequestMessage = { AttributePathIB = ... }` decode dumps cert-test log checks match
 // against (see TC-IDM-2.1's AGENTS.md section) never appear at all, on any platform build.
 const TRACE_ARGS = ["--trace_log", "1", "--trace_decode", "1"];
+
+/**
+ * The simulation commands a chip app takes on the named pipe it opens for `--app-pipe`, by the app
+ * that answers them. A pipe accepts a write whatever the app makes of it, so a command an app does
+ * not implement would become a silent no-op; only what the named app's own command delegate handles
+ * is forwarded, and everything else stays unsupported.
+ */
+const PIPE_COMMANDS: Record<string, ReadonlySet<BackchannelCommand["name"]>> = {
+    "all-clusters": new Set(["simulateLatchPosition", "simulateLongPress", "simulateMultiPress", "simulateSwitchIdle"]),
+};
+
+/** Where a chip app is told to open its command pipe inside a container. */
+const CONTAINER_APP_PIPE = "/tmp/app-pipe";
+
+/** Whether `app` reads simulation commands from a pipe at all, which is what naming one is for. */
+function hasCommandPipe(app: string) {
+    return PIPE_COMMANDS[app] !== undefined;
+}
+
+/**
+ * A backchannel command as the JSON a chip app's `NamedPipeCommandDelegate` parses, or `undefined` for
+ * a command `app` does not take that way. The delegate keys off `Name` and reads each argument by its
+ * capitalized name (`examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp`).
+ */
+function namedPipeCommandFor(app: string, command: BackchannelCommand): string | undefined {
+    if (!PIPE_COMMANDS[app]?.has(command.name)) {
+        return undefined;
+    }
+
+    const fields: Record<string, unknown> = {};
+    for (const [name, value] of Object.entries(command)) {
+        if (name !== "name") {
+            fields[`${name[0].toUpperCase()}${name.slice(1)}`] = value;
+        }
+    }
+
+    return JSON.stringify({ Name: `${command.name[0].toUpperCase()}${command.name.slice(1)}`, ...fields });
+}
 
 function commissioningFor(identity?: Subject.Identity): Subject.CommissioningParameters {
     return {
@@ -224,6 +267,13 @@ class ChipLocalDevice implements CertDevice {
         const binPath = join(dir, appBinaryName(this.app, this.appVariant));
         const kvsPath = join(this.#storageDir, "chip_kvs");
 
+        // A stop leaves the storage directory, and an app killed before it could unlink its own fifo
+        // leaves that too. Chip treats a failing `mkfifo` as fatal, so a restart would report a device
+        // that will not initialize rather than one whose previous generation ended abruptly.
+        if (hasCommandPipe(this.app)) {
+            await rm(this.#pipePath(), { force: true });
+        }
+
         const args = [
             "--discriminator",
             String(this.commissioning.discriminator),
@@ -231,6 +281,7 @@ class ChipLocalDevice implements CertDevice {
             String(this.commissioning.passcode),
             "--KVS",
             kvsPath,
+            ...(hasCommandPipe(this.app) ? ["--app-pipe", this.#pipePath()] : []),
             ...TRACE_ARGS,
             ...this.#appArgs,
         ];
@@ -395,6 +446,85 @@ class ChipLocalDevice implements CertDevice {
         throwUnsupported(this.flavor, "snapshot/restore");
     }
 
+    /** The app's command pipe, which it creates itself once `--app-pipe` names it. */
+    #pipePath(): string {
+        if (this.#storageDir === undefined) {
+            throw new Error(`Cert device ${this.id} has no storage directory, so it has no command pipe`);
+        }
+        return join(this.#storageDir, "app-pipe");
+    }
+
+    /**
+     * Hands one command to the running app.
+     *
+     * Three properties this needs, none of which a plain write to the path has:
+     *
+     * The open is non-blocking, so a pipe with no reader fails with `ENXIO` here rather than waiting
+     * for one. A blocking open of a fifo waits until a reader attaches, and nothing can cancel it —
+     * an app that died holding its fifo would hang the step, and the run, with no diagnosis.
+     *
+     * It carries no `O_CREAT`, and the path is confirmed to be a fifo first: a write to a path the app
+     * has not made a fifo would leave a regular file there, which the app's own `mkfifo` then accepts
+     * as already existing, so its reader sees one stale command and ends — silently discarding every
+     * command for the rest of that app's life.
+     *
+     * And it waits for the app to create the fifo, which it does as it starts: a command sent just
+     * after `start()` would otherwise be refused for a pipe that is merely not there yet. Only a
+     * running app is waited for; there is nothing to wait for otherwise.
+     */
+    async #sendToPipe(json: string): Promise<void> {
+        const generation = this.#generation;
+        if (generation === undefined || generation.exited) {
+            throw new Error(
+                `Cert device ${this.id} cannot be operated while it is not running, so there is no app to ` +
+                    "send the command to",
+            );
+        }
+
+        const path = this.#pipePath();
+        await this.#awaitPipe(path);
+
+        const pipe = await open(path, constants.O_WRONLY | constants.O_NONBLOCK).catch(cause => {
+            throw new Error(
+                `Cert device ${this.id} could not open its command pipe at ${path}, so the app cannot be ` +
+                    `operated; it is running but has stopped reading the pipe (${cause})`,
+            );
+        });
+        try {
+            await pipe.write(`${json}\n`);
+        } finally {
+            await pipe.close();
+        }
+    }
+
+    /** Waits for the app to create its fifo, refusing a path that is there but is not one. */
+    async #awaitPipe(path: string): Promise<void> {
+        const deadline = Date.now() + PIPE_TIMEOUT_MS;
+        for (;;) {
+            const target = await lstat(path).catch(() => undefined);
+            if (target?.isFIFO()) {
+                return;
+            }
+
+            if (target !== undefined) {
+                throw new Error(
+                    `Cert device ${this.id} has a file at ${path} that the app did not create as its command ` +
+                        "pipe, so the app cannot be operated",
+                );
+            }
+
+            if (Date.now() >= deadline) {
+                throw new Error(
+                    `Cert device ${this.id} has no command pipe at ${path} after ` +
+                        `${PIPE_TIMEOUT_MS}ms, so the app cannot be operated; it is not running, or was ` +
+                        "started without one",
+                );
+            }
+
+            await new Promise(resolve => setTimeout(resolve, PIPE_POLL_MS));
+        }
+    }
+
     async backchannel(command: BackchannelCommand): Promise<void> {
         switch (command.name) {
             case "factoryReset":
@@ -423,8 +553,14 @@ class ChipLocalDevice implements CertDevice {
                 await this.start();
                 break;
 
-            default:
-                throwUnsupported(this.flavor, `the "${command.name}" backchannel command`);
+            default: {
+                const json = namedPipeCommandFor(this.app, command);
+                if (json === undefined) {
+                    throwUnsupported(this.flavor, `the "${command.name}" backchannel command`);
+                }
+                await this.#sendToPipe(json);
+                break;
+            }
         }
     }
 }
@@ -596,6 +732,7 @@ export class ChipDockerDevice implements CertDevice {
             String(this.commissioning.discriminator),
             "--passcode",
             String(this.commissioning.passcode),
+            ...(hasCommandPipe(this.app) ? ["--app-pipe", CONTAINER_APP_PIPE] : []),
             ...TRACE_ARGS,
             ...this.#appArgs,
         ];
@@ -789,8 +926,38 @@ export class ChipDockerDevice implements CertDevice {
                 await this.start();
                 break;
 
-            default:
-                throwUnsupported(this.flavor, `the "${command.name}" backchannel command`);
+            default: {
+                const json = namedPipeCommandFor(this.app, command);
+                if (json === undefined) {
+                    throwUnsupported(this.flavor, `the "${command.name}" backchannel command`);
+                }
+
+                const generation = this.#generation;
+                if (generation === undefined || generation.exited || generation.container === undefined) {
+                    throw new Error(
+                        `Cert device ${this.id} received the "${command.name}" backchannel command while it was ` +
+                            "not running, so there is no app to send it to",
+                    );
+                }
+
+                // The command travels as an argument rather than as part of the script, so nothing in
+                // it can be read as shell syntax. `test -p` refuses a path the app has not made a fifo,
+                // for the reason ChipLocalDevice's own send documents; a shell that exits non-zero
+                // fails the step rather than reporting a command nothing received.
+                //
+                // Opening a fifo for writing waits for a reader, so the write is bounded from outside:
+                // an app that has stopped reading ends this as a non-zero exit rather than holding the
+                // exec for as long as the container lives.
+                await generation.container.exec([
+                    "timeout",
+                    String(PIPE_TIMEOUT_MS / 1000),
+                    "sh",
+                    "-c",
+                    `test -p ${CONTAINER_APP_PIPE} && printf '%s\\n' "$0" > ${CONTAINER_APP_PIPE}`,
+                    json,
+                ]);
+                break;
+            }
         }
     }
 }

--- a/packages/testing/src/chip/cert/controller-adapter.ts
+++ b/packages/testing/src/chip/cert/controller-adapter.ts
@@ -125,6 +125,18 @@ export interface SubscribeEventOptions extends ReadEventOptions {
     minIntervalFloorSeconds: number;
     maxIntervalCeilingSeconds: number;
     onUpdate?: (event: EventReadEntry) => void;
+
+    /**
+     * Marks every path of the subscription urgent, which a step operating the device and then waiting
+     * for the event needs: without it the publisher holds queued events until the subscription's
+     * maximum interval elapses.
+     *
+     * Off by default because it is visible on the wire, and a step asserting the subscribe request it
+     * sent describes the request it asked for.
+     *
+     * @see {@link MatterSpecification.v16.Core} § 8.5
+     */
+    urgent?: boolean;
 }
 
 /**

--- a/packages/testing/src/device/backchannel.ts
+++ b/packages/testing/src/device/backchannel.ts
@@ -34,6 +34,14 @@ export namespace BackchannelCommand {
         buttonId: number;
         longPressDelayMillis: number;
         longPressDurationMillis: number;
+
+        /**
+         * The switch's own FeatureMap. A chip app requires it and simulates the events it implies; a
+         * matter.js test device derives them from the switch's own state and ignores it.
+         *
+         * @see {@link MatterSpecification.v16.Cluster} § 1.12.4
+         */
+        featureMap: number;
     };
 
     export type SimulateMultiPress = {

--- a/packages/testing/src/device/backchannel.ts
+++ b/packages/testing/src/device/backchannel.ts
@@ -39,7 +39,7 @@ export namespace BackchannelCommand {
          * The switch's own FeatureMap. A chip app requires it and simulates the events it implies; a
          * matter.js test device derives them from the switch's own state and ignores it.
          *
-         * @see {@link MatterSpecification.v16.Cluster} § 1.12.4
+         * @see {@link MatterSpecification.v16.Cluster} § 1.13.4
          */
         featureMap: number;
     };

--- a/support/chip-testing/src/AllClustersTestInstance.ts
+++ b/support/chip-testing/src/AllClustersTestInstance.ts
@@ -171,7 +171,7 @@ export class AllClustersTestInstance extends NodeTestInstance {
                     throw new ImplementationError(`Endpoint ${endpointId} not found`);
                 }
                 await endpoint.setStateOf(SwitchServer, { currentPosition: 0 });
-                endpoint.act(agent => agent.get(SwitchServer).resetState());
+                await endpoint.act(agent => agent.get(SwitchServer).resetState());
                 break;
             case "operationalStateChange": {
                 endpoint = findEndpoint(1);

--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -123,7 +123,7 @@ export const CHIP_TOOL_CONTROLLER_PICS: PicsValues = {
     "SWTCH.C": 1,
 
     // CHIP's PICS file has no entry for the action-switch client flag, and it answers 1 for the release
-    // flag, which the cluster forbids alongside an action switch (Application Clusters § 1.12.4). The
+    // flag, which the cluster forbids alongside an action switch (Application Clusters § 1.13.4). The
     // switch this controller observes is an action switch, so that is what it declares.
     "SWTCH.C.F02": 0,
     "SWTCH.C.F05": 1,

--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -116,6 +116,17 @@ export const CHIP_TOOL_CONTROLLER_PICS: PicsValues = {
     "G.C.C01.Tx": 1,
     "GRPKEY.C.C03.Tx": 1,
     "GRPKEY.C.C04.Tx": 1,
+
+    // The Switch client flags TC-SWTCH-3.2 rests on. The CHIP PICS file answers 0 for `SWTCH.C` and
+    // declares F00..F04 for a *device*; here the switch client is the controller, and this overlay is
+    // the DUT-as-client declaration the plan's steps 0a-0h check for self-consistency.
+    "SWTCH.C": 1,
+
+    // CHIP's PICS file has no entry for the action-switch client flag, and it answers 1 for the release
+    // flag, which the cluster forbids alongside an action switch (Application Clusters § 1.12.4). The
+    // switch this controller observes is an action switch, so that is what it declares.
+    "SWTCH.C.F02": 0,
+    "SWTCH.C.F05": 1,
 };
 
 const WILDCARD_CLUSTER = 0xffffffff;
@@ -1477,6 +1488,9 @@ export class ChipToolControllerAdapter implements ControllerAdapter {
             `any subscribe-event-by-id ${paths.map(eventClusterArg).join(",")} ${paths.map(eventArg).join(",")} ` +
             `${opts.minIntervalFloorSeconds} ${opts.maxIntervalCeilingSeconds} ${node} ` +
             `${paths.map(eventEndpointArg).join(",")} --keepSubscriptions true${largePayloadArg(this.#transport)}`;
+        if (opts.urgent) {
+            command += ` --is-urgent ${paths.map(() => "true").join(",")}`;
+        }
         if (opts.fabricFiltered === false) {
             command += " --fabric-filtered false";
         }

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -157,7 +157,7 @@ export const MATTERJS_CONTROLLER_PICS: PicsValues = {
     "SWTCH.C": 1,
 
     // CHIP's PICS file has no entry for the action-switch client flag, and it answers 1 for the release
-    // flag, which the cluster forbids alongside an action switch (Application Clusters § 1.12.4). The
+    // flag, which the cluster forbids alongside an action switch (Application Clusters § 1.13.4). The
     // switch this controller observes is an action switch, so that is what it declares.
     "SWTCH.C.F02": 0,
     "SWTCH.C.F05": 1,

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -150,6 +150,17 @@ export const MATTERJS_CONTROLLER_PICS: PicsValues = {
     "G.C.C01.Tx": 1,
     "GRPKEY.C.C03.Tx": 1,
     "GRPKEY.C.C04.Tx": 1,
+
+    // The Switch client flags TC-SWTCH-3.2 rests on. The CHIP PICS file answers 0 for `SWTCH.C` and
+    // declares F00..F04 for a *device*; here the switch client is the controller, and this overlay is
+    // the DUT-as-client declaration the plan's steps 0a-0h check for self-consistency.
+    "SWTCH.C": 1,
+
+    // CHIP's PICS file has no entry for the action-switch client flag, and it answers 1 for the release
+    // flag, which the cluster forbids alongside an action switch (Application Clusters § 1.12.4). The
+    // switch this controller observes is an action switch, so that is what it declares.
+    "SWTCH.C.F02": 0,
+    "SWTCH.C.F05": 1,
 };
 
 const adapterStreams = new Map<string, LineQueue>();
@@ -723,7 +734,7 @@ class InProcessCertNodeApi implements CertNodeApi {
             // already failed on the rejection, which is what the chip-tool adapter does too.
             let phase: "seeding" | "live" | "refused" = "seeding";
             const request = Subscribe({
-                events: paths.map(toEventIds),
+                events: paths.map(path => ({ ...toEventIds(path), isUrgent: opts.urgent })),
                 eventFilters: eventFiltersFor(opts),
                 fabricFilter: opts.fabricFiltered,
                 keepSubscriptions: true,

--- a/support/chip-testing/test/cert-framework/chip-app-subject.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-app-subject.test.ts
@@ -411,6 +411,221 @@ describe("ChipLocalSubject", () => {
         }
     });
 
+    it("hands a simulation command to the app through the pipe it opened", async function () {
+        this.timeout(15_000);
+
+        // Stands in for a chip app's own named pipe handling: the app creates the fifo the harness
+        // named and reports what it reads there, which is what the backchannel has to reach.
+        await writeFile(
+            join(appDir, "chip-all-clusters-app"),
+            [
+                "#!/bin/sh",
+                'pipe=""',
+                "while [ $# -gt 0 ]; do",
+                '    if [ "$1" = "--app-pipe" ]; then pipe="$2"; fi',
+                "    shift",
+                "done",
+                'mkfifo "$pipe"',
+                "echo ready",
+                'while read -r line < "$pipe"; do echo "pipe $line"; done',
+                "",
+            ].join("\n"),
+            { mode: 0o755 },
+        );
+
+        const device = ChipLocalSubject("all-clusters")("cert");
+        if (!isCertDevice(device)) {
+            throw new Error("Expected a CertDevice");
+        }
+
+        await device.initialize();
+        await device.start();
+
+        try {
+            const lines = device.log.follow();
+            expect(await collectLines(lines, 1, 5_000)).deep.equal(["ready"]);
+
+            await device.backchannel({ name: "simulateSwitchIdle", endpointId: 3 });
+
+            expect(await collectLines(lines, 1, 5_000)).deep.equal([
+                'pipe {"Name":"SimulateSwitchIdle","EndpointId":3}',
+            ]);
+        } finally {
+            await device.stop();
+            await device.close();
+        }
+    });
+
+    it("refuses a simulation command for an app that reads none, rather than writing where nothing listens", async function () {
+        this.timeout(15_000);
+
+        const device = ChipLocalSubject(app)("cert");
+        if (!isCertDevice(device)) {
+            throw new Error("Expected a CertDevice");
+        }
+
+        await device.initialize();
+        await device.start();
+
+        try {
+            await expect(device.backchannel({ name: "simulateSwitchIdle", endpointId: 3 })).rejectedWith(
+                "simulateSwitchIdle",
+            );
+        } finally {
+            await device.stop();
+            await device.close();
+        }
+    });
+
+    it("refuses a simulation command when the pipe path holds a file the app did not create", async function () {
+        this.timeout(15_000);
+
+        // Reports the pipe path instead of creating one, so the test can leave a plain file there
+        await writeFile(
+            join(appDir, "chip-all-clusters-app"),
+            [
+                "#!/bin/sh",
+                'pipe=""',
+                "while [ $# -gt 0 ]; do",
+                '    if [ "$1" = "--app-pipe" ]; then pipe="$2"; fi',
+                "    shift",
+                "done",
+                'echo "pipe-is $pipe"',
+                "exec sleep 300",
+                "",
+            ].join("\n"),
+            { mode: 0o755 },
+        );
+
+        const device = ChipLocalSubject("all-clusters")("cert");
+        if (!isCertDevice(device)) {
+            throw new Error("Expected a CertDevice");
+        }
+
+        await device.initialize();
+        await device.start();
+
+        try {
+            const [reported] = await collectLines(device.log.follow(), 1, 5_000);
+            const pipePath = reported.replace("pipe-is ", "");
+
+            // What a write to a path the app has not made a fifo would leave behind, and what the app's
+            // own mkfifo would then accept as already existing
+            await writeFile(pipePath, "");
+
+            await expect(device.backchannel({ name: "simulateSwitchIdle", endpointId: 3 })).rejectedWith(
+                "the app did not create",
+            );
+        } finally {
+            await device.stop();
+            await device.close();
+        }
+    });
+
+    it("clears a pipe a killed app left behind, so the next generation can create its own", async function () {
+        this.timeout(20_000);
+
+        // Chip treats a failing mkfifo as fatal, so an app that finds one already there does not start
+        await writeFile(
+            join(appDir, "chip-all-clusters-app"),
+            [
+                "#!/bin/sh",
+                'pipe=""',
+                "while [ $# -gt 0 ]; do",
+                '    if [ "$1" = "--app-pipe" ]; then pipe="$2"; fi',
+                "    shift",
+                "done",
+                'mkfifo "$pipe" || { echo pipe-already-there; exit 3; }',
+                "echo ready",
+                "exec sleep 300",
+                "",
+            ].join("\n"),
+            { mode: 0o755 },
+        );
+
+        const device = ChipLocalSubject("all-clusters")("cert");
+        if (!isCertDevice(device)) {
+            throw new Error("Expected a CertDevice");
+        }
+
+        await device.initialize();
+        await device.start();
+
+        try {
+            const lines = device.log.follow();
+            expect(await collectLines(lines, 1, 5_000)).deep.equal(["ready"]);
+
+            // A SIGKILL'd app never unlinks its own pipe, and stop() keeps the storage directory
+            await device.stop();
+            await device.start();
+
+            // The stopped generation's stream can still yield its trailing blank line, so this looks for
+            // what the second generation says rather than for the very next line
+            const restarted = await collectLines(lines, 2, 5_000);
+            expect(restarted).contains("ready");
+            expect(restarted).not.contains("pipe-already-there");
+        } finally {
+            await device.stop();
+            await device.close();
+        }
+    });
+
+    it("fails a simulation command the app has stopped reading, rather than waiting for a reader", async function () {
+        this.timeout(15_000);
+
+        // Creates the pipe and never reads it, which is what an app that died holding its fifo leaves
+        await writeFile(
+            join(appDir, "chip-all-clusters-app"),
+            [
+                "#!/bin/sh",
+                'pipe=""',
+                "while [ $# -gt 0 ]; do",
+                '    if [ "$1" = "--app-pipe" ]; then pipe="$2"; fi',
+                "    shift",
+                "done",
+                'mkfifo "$pipe"',
+                "echo ready",
+                "exec sleep 300",
+                "",
+            ].join("\n"),
+            { mode: 0o755 },
+        );
+
+        const device = ChipLocalSubject("all-clusters")("cert");
+        if (!isCertDevice(device)) {
+            throw new Error("Expected a CertDevice");
+        }
+
+        await device.initialize();
+        await device.start();
+
+        try {
+            expect(await collectLines(device.log.follow(), 1, 5_000)).deep.equal(["ready"]);
+
+            await expect(device.backchannel({ name: "simulateSwitchIdle", endpointId: 3 })).rejectedWith(
+                "stopped reading the pipe",
+            );
+        } finally {
+            await device.stop();
+            await device.close();
+        }
+    });
+
+    it("refuses a simulation command while the app is not running, rather than leaving a file where its pipe goes", async () => {
+        const device = ChipLocalSubject("all-clusters")("cert");
+        if (!isCertDevice(device)) {
+            throw new Error("Expected a CertDevice");
+        }
+
+        await device.initialize();
+
+        try {
+            await expect(device.backchannel({ name: "simulateSwitchIdle", endpointId: 3 })).rejectedWith("not running");
+        } finally {
+            await device.close();
+        }
+    });
+
     it("fails clearly at start() when MATTER_CERT_APP_DIR is unset, rather than spawning an undefined path", async () => {
         delete env.MATTER_CERT_APP_DIR;
 
@@ -495,6 +710,124 @@ describe("ChipDockerSubject", () => {
 
         expect(killed).equal(true);
         expect(await stillPending(device.exit, 100)).equal(true);
+    });
+
+    it("hands a simulation command to the app container's pipe, with the command as an argument", async function () {
+        this.timeout(5_000);
+
+        const execs = new Array<string[]>();
+        let ended!: () => void;
+        const container = fakeContainer({
+            kill: async () => ended(),
+            wait: () =>
+                new Promise<void>(resolve => {
+                    ended = resolve;
+                }),
+            exec: (async (command: string[]) => {
+                execs.push(command);
+            }) as Container["exec"],
+        });
+
+        const composition: CompositionHandle = {
+            async add(config) {
+                commands.push(...(config.command ?? []));
+                return container;
+            },
+            async close() {},
+        };
+
+        const commands = new Array<string>();
+        const docker: DockerHandle = {
+            async ensureVolume() {},
+            compose() {
+                return composition;
+            },
+            async containerStatus() {
+                return { isRunning: true };
+            },
+        };
+
+        const device = new ChipDockerDevice("all-clusters", "cert", undefined, docker);
+
+        await device.start();
+        try {
+            expect(commands).contains("--app-pipe");
+
+            await device.backchannel({ name: "simulateSwitchIdle", endpointId: 3 });
+
+            expect(execs.length).equal(1);
+            const [bound, seconds, shell, flag, script, json] = execs[0];
+            expect([bound, shell, flag]).deep.equal(["timeout", "sh", "-c"]);
+            expect(Number(seconds)).greaterThan(0);
+            expect(script).contains("test -p");
+            expect(json).equal('{"Name":"SimulateSwitchIdle","EndpointId":3}');
+
+            await device.backchannel({ name: "simulateLatchPosition", endpointId: 1, positionId: 1 });
+            expect(execs.length).equal(2);
+            expect(execs[1][execs[1].length - 1]).equal(
+                '{"Name":"SimulateLatchPosition","EndpointId":1,"PositionId":1}',
+            );
+        } finally {
+            await device.close();
+        }
+    });
+
+    it("refuses a simulation command after the container is gone", async function () {
+        this.timeout(5_000);
+
+        let ended!: () => void;
+        const container = fakeContainer({
+            kill: async () => ended(),
+            wait: () =>
+                new Promise<void>(resolve => {
+                    ended = resolve;
+                }),
+            exec: (async () => {
+                throw new Error("exec should not reach a container that is gone");
+            }) as Container["exec"],
+        });
+
+        const composition: CompositionHandle = {
+            async add() {
+                return container;
+            },
+            async close() {},
+        };
+
+        const docker: DockerHandle = {
+            async ensureVolume() {},
+            compose() {
+                return composition;
+            },
+            async containerStatus() {
+                return { isRunning: true };
+            },
+        };
+
+        const device = new ChipDockerDevice("all-clusters", "cert", undefined, docker);
+
+        await device.start();
+        await device.stop();
+
+        await expect(device.backchannel({ name: "simulateSwitchIdle", endpointId: 3 })).rejectedWith("not running");
+
+        await device.close();
+    });
+
+    it("refuses a simulation command while no container is running", async () => {
+        const docker: DockerHandle = {
+            async ensureVolume() {},
+            compose() {
+                throw new Error("compose() should not be called");
+            },
+            async containerStatus() {
+                return { isRunning: true };
+            },
+        };
+
+        const device = new ChipDockerDevice("all-clusters", "cert", undefined, docker);
+
+        await expect(device.backchannel({ name: "simulateSwitchIdle", endpointId: 3 })).rejectedWith("not running");
     });
 
     it("closes the composition when adding the app container fails", async function () {

--- a/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/chip-tool-adapter.test.ts
@@ -1296,6 +1296,17 @@ describe("ChipToolControllerAdapter", function () {
             ]);
         });
 
+        it("asks for urgent event paths only when the step asks for them", async () => {
+            const { ref, node } = await commissioned();
+
+            fake.reply = () => ({ results: [] });
+            await node.subscribeEvents([EVENT_PATH], { ...INTERVALS, urgent: true });
+
+            expect(fake.commands).deep.equal([
+                `any subscribe-event-by-id 0x28 0x0 1 10 ${ref} 0 --keepSubscriptions true --is-urgent true`,
+            ]);
+        });
+
         it("rejects a subscribe whose own event path the device rejected, and registers nothing", async () => {
             const { node } = await commissioned();
             const abandoned = new Array<unknown>();

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -2405,3 +2405,35 @@ receiver's own view of the destination, and the only place in this suite where t
 **A production change came with it.** The group invoke's diagnostic printed the address alone;
 `GroupSession.destination` now renders `[<address>]:<port>` so the log says where a message actually
 went. Steps 6 and 7 stay not-applicable: they need the Groupcast cluster, which neither TH has.
+
+## Operating a device, and observing the events it sends (`TC-SWTCH-3.2`)
+
+Three mechanics this TC needed, all reusable.
+
+**An event subscription that does not ask for urgency sees almost nothing.** A publisher may hold
+queued events until the subscription's maximum interval elapses, so a step that operates the device and
+then waits a few seconds for the event sees one report and then silence — this TC's first run saw one
+of four switch events, the rest arriving when the subscription closed. `SubscribeEventOptions.urgent`
+asks for urgent paths (`isUrgent` on each `EventPathIB`, `--is-urgent` on chip-tool). It is off by
+default because it is visible on the wire: chip's decode dump prints an `isUrgent = true` line inside
+the `EventPathIB`, which breaks a log check that matches the subscribe envelope as adjacent lines
+(`TC-IDM-6.4` does exactly that).
+
+**Count events above a boundary, and take the boundary from the subscription, not from a read.** Events
+an earlier step provoked can still be in flight when the next step starts, so a step that counts "the
+events named X" counts the step before it too. Wait until the subscription has been quiet for a moment,
+take the highest event number received, and count only above it — and fail the step if it never goes
+quiet, since then the boundary separates nothing. Do not take the boundary from `readEvents`: chip-tool
+folds a subscription report that arrives while a read is in flight into that read's reply, so the
+step's own first event lands *below* a boundary read this way. That was observed in a captured run —
+the read returned event numbers 4..8 where the subscription had delivered 4..7, and the step then
+counted three of its four events.
+
+**A backchannel command returning does not mean the device has acted.** The matter.js test device
+awaits the state change before answering; a chip app reads the command from its named pipe on its own
+thread and posts it to its event loop, so a read taken immediately afterwards can still see the old
+state. A step that operates a device and then reads should poll to a deadline rather than assert once.
+
+Beware also that a device's own idea of "idle" differs: `simulateSwitchIdle` resets the switch state on
+the matter.js device but only moves the position on a chip app, so a step that presses needs its own
+wait for the previous press cycle to close, not just the command.

--- a/support/chip-testing/test/cert/TC-SWTCH-3.2.test.ts
+++ b/support/chip-testing/test/cert/TC-SWTCH-3.2.test.ts
@@ -706,9 +706,12 @@ certTest("TC-SWTCH-3.2", {
         "TH simulates a long press, sending InitialPress, LongPress and LongRelease",
         commissioned.withRef("dut", async (cx, ref) => {
             const th = cx.devices.th;
-            const featureMap = await readNumber(cx, ref, MOMENTARY_ENDPOINT, FEATURE_MAP);
             await idleSwitch(cx, MOMENTARY_ENDPOINT);
             const boundary = await quietEventBoundary(cx);
+
+            // Read once the previous step's reports have arrived: chip-tool delivers them in whatever
+            // command reply is open, and a read whose own values are displaced by one answers nothing.
+            const featureMap = await readNumber(cx, ref, MOMENTARY_ENDPOINT, FEATURE_MAP);
             await th.backchannel({
                 name: "simulateLongPress",
                 endpointId: MOMENTARY_ENDPOINT,
@@ -778,10 +781,12 @@ certTest("TC-SWTCH-3.2", {
         "TH simulates a multi press on an action switch, sending InitialPress and MultiPressComplete",
         commissioned.withRef("dut", async (cx, ref) => {
             const th = cx.devices.th;
-            const featureMap = await readNumber(cx, ref, MOMENTARY_ENDPOINT, FEATURE_MAP);
-            const multiPressMax = await readNumber(cx, ref, MOMENTARY_ENDPOINT, MULTI_PRESS_MAX);
             await idleSwitch(cx, MOMENTARY_ENDPOINT);
             const boundary = await quietEventBoundary(cx);
+
+            // As step 4c: read only once the reports the previous step provoked have arrived
+            const featureMap = await readNumber(cx, ref, MOMENTARY_ENDPOINT, FEATURE_MAP);
+            const multiPressMax = await readNumber(cx, ref, MOMENTARY_ENDPOINT, MULTI_PRESS_MAX);
             await th.backchannel({
                 name: "simulateMultiPress",
                 endpointId: MOMENTARY_ENDPOINT,

--- a/support/chip-testing/test/cert/TC-SWTCH-3.2.test.ts
+++ b/support/chip-testing/test/cert/TC-SWTCH-3.2.test.ts
@@ -35,7 +35,7 @@ const MULTI_PRESS_MAX = attributeId("multiPressMax");
 const LATCHING_ENDPOINT = 1;
 const MOMENTARY_ENDPOINT = 3;
 
-/** `Switch` feature bits (Matter Application Clusters § 1.12.4). */
+/** `Switch` feature bits (Matter Application Clusters § 1.13.4). */
 const LS = 1 << 0;
 const MS = 1 << 1;
 const MSR = 1 << 2;
@@ -100,7 +100,7 @@ const BETWEEN_OPERATIONS_MS = 300;
 /**
  * Returns the switch to its idle position and gives the device time to close the press cycle the
  * previous step left open. A momentary switch counts presses until it goes idle (Application Clusters
- * § 1.12.8), so a step that presses without this one sees its presses counted into the cycle before it
+ * § 1.13.8), so a step that presses without this one sees its presses counted into the cycle before it
  * and reported as one multi press instead of what it simulated. How much of the cycle the command
  * itself ends is the device's own: the matter.js test device resets its switch state, a chip app only
  * moves the position, which is why the wait matters as much as the command.
@@ -447,7 +447,7 @@ certTest("TC-SWTCH-3.2", {
             expected:
                 "The DUT does not declare long press without either momentary switch release or an action " +
                 "switch. The plan's own rule here is that MSL requires MSR, which contradicts MSL's " +
-                "conformance `[MS & (MSR | AS)]` (Application Clusters § 1.12.4) and the plan's own step 0h " +
+                "conformance `[MS & (MSR | AS)]` (Application Clusters § 1.13.4) and the plan's own step 0h " +
                 "and step 3b, so this step applies the conformance instead.",
         },
     )
@@ -697,7 +697,7 @@ certTest("TC-SWTCH-3.2", {
         pics: `${PICS_MS} & ${PICS_MSR} & ${PICS_EVENTING}`,
         notApplicable:
             "This controller declares the switch it observes, which is an action switch, and one never " +
-            "generates the ShortRelease this step waits for (Application Clusters § 1.12.6.4). The plan " +
+            "generates the ShortRelease this step waits for (Application Clusters § 1.13.6.4). The plan " +
             "gates the step on the momentary switch alone, which its own step 3b contradicts by allowing " +
             "an action-switch TH; the release flag gates it here.",
     })
@@ -768,7 +768,7 @@ certTest("TC-SWTCH-3.2", {
             pics: `${PICS_MS} & ${PICS_MSL} & ${PICS_EVENTING}`,
             expected:
                 "The DUT receives InitialPress, LongPress and LongRelease. An action switch still reports " +
-                "the long-press cycle in full (Application Clusters § 1.12.8.2). This controller records " +
+                "the long-press cycle in full (Application Clusters § 1.13.8.2). This controller records " +
                 "the events rather than acting on them.",
         },
     )

--- a/support/chip-testing/test/cert/TC-SWTCH-3.2.test.ts
+++ b/support/chip-testing/test/cert/TC-SWTCH-3.2.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Duration, Millis } from "@matter/general";
+import { Duration, Millis, Time } from "@matter/general";
 import { Matter } from "@matter/model";
 import type { CertNodeRef, CertStepContext, EventReadEntry, PicsValues } from "@matter/testing";
 import {
@@ -238,7 +238,7 @@ async function readUntil(
     expected: number,
     what: string,
 ) {
-    const deadline = Date.now() + EVENT_WAIT_MS;
+    const deadline = Time.nowUs + Millis(EVENT_WAIT_MS);
     let value: number | undefined;
     let failure: unknown;
     for (;;) {
@@ -254,7 +254,7 @@ async function readUntil(
             failure = e;
         }
 
-        if (value === expected || Date.now() >= deadline) {
+        if (value === expected || Time.nowUs >= deadline) {
             break;
         }
         await pause(READ_RETRY_MS);
@@ -303,8 +303,8 @@ async function subscribeToSwitch(cx: CertStepContext, ref: CertNodeRef, endpoint
 
 /** Waits until `predicate` holds over the events received so far, or the budget runs out. */
 async function untilReceived(predicate: () => boolean): Promise<boolean> {
-    const deadline = Date.now() + EVENT_WAIT_MS;
-    while (Date.now() < deadline) {
+    const deadline = Time.nowUs + Millis(EVENT_WAIT_MS);
+    while (Time.nowUs < deadline) {
         if (predicate()) {
             return true;
         }
@@ -346,9 +346,9 @@ function nameOf(entry: EventReadEntry): string {
  * can already carry the first event of the step that is about to run.
  */
 async function quietEventBoundary(cx: CertStepContext): Promise<bigint> {
-    const deadline = Date.now() + EVENT_WAIT_MS;
+    const deadline = Time.nowUs + Millis(EVENT_WAIT_MS);
     let seen = -1;
-    while (seen !== received.length && Date.now() < deadline) {
+    while (seen !== received.length && Time.nowUs < deadline) {
         seen = received.length;
         await pause(EVENT_QUIET_MS);
     }

--- a/support/chip-testing/test/cert/TC-SWTCH-3.2.test.ts
+++ b/support/chip-testing/test/cert/TC-SWTCH-3.2.test.ts
@@ -239,23 +239,39 @@ async function readUntil(
     what: string,
 ) {
     const deadline = Date.now() + EVENT_WAIT_MS;
-    let value = await readNumber(cx, ref, endpoint, attribute);
-    while (value !== expected && Date.now() < deadline) {
+    let value: number | undefined;
+    let failure: unknown;
+    for (;;) {
+        try {
+            value = await readNumber(cx, ref, endpoint, attribute);
+            failure = undefined;
+        } catch (e) {
+            // A read whose answer does not come back is not an answer of the wrong value. chip-tool
+            // delivers a live subscription's report in whatever command reply is open, and a read whose
+            // own values were displaced by one reports nothing for its path — which this step's
+            // repeated reads meet where a single read rarely did.
+            value = undefined;
+            failure = e;
+        }
+
+        if (value === expected || Date.now() >= deadline) {
+            break;
+        }
         await pause(READ_RETRY_MS);
-        value = await readNumber(cx, ref, endpoint, attribute);
     }
 
+    const answer = failure === undefined ? `the TH answers ${value}` : `the read failed: ${failure}`;
     record(
         cx,
         {
             type: "response",
             verdict: value === expected ? "pass" : "fail",
-            detail: `${what}: the TH answers ${value}`,
+            detail: `${what}: ${answer}`,
         },
         what,
     );
     if (value !== expected) {
-        throw new CertCheckFailedError(`${what}: the TH answers ${value}`);
+        throw new CertCheckFailedError(`${what}: ${answer}`);
     }
 }
 

--- a/support/chip-testing/test/cert/TC-SWTCH-3.2.test.ts
+++ b/support/chip-testing/test/cert/TC-SWTCH-3.2.test.ts
@@ -1,0 +1,820 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Duration, Millis } from "@matter/general";
+import { Matter } from "@matter/model";
+import type { CertNodeRef, CertStepContext, EventReadEntry, PicsValues } from "@matter/testing";
+import {
+    certTest,
+    controllerPicsOverridesFor,
+    PicsUnavailableError,
+    resolveControllerImplementation,
+} from "@matter/testing";
+import { CertCheckFailedError, CommissionedRefs, describeValue, record, recordAll, requireId } from "./tc-support.js";
+
+const SWITCH = Matter.clusters.require("Switch");
+const SWITCH_ID = requireId(SWITCH.id, "Switch cluster");
+
+function attributeId(name: string): number {
+    return requireId(SWITCH.attributes.require(name).id, `Switch.${name}`);
+}
+
+function eventId(name: string): number {
+    return requireId(SWITCH.events.require(name).id, `Switch.${name}`);
+}
+
+const FEATURE_MAP = attributeId("featureMap");
+const CURRENT_POSITION = attributeId("currentPosition");
+const NUMBER_OF_POSITIONS = attributeId("numberOfPositions");
+const MULTI_PRESS_MAX = attributeId("multiPressMax");
+
+/** The TH's two switches: a latching one, and a momentary one that is also an action switch. */
+const LATCHING_ENDPOINT = 1;
+const MOMENTARY_ENDPOINT = 3;
+
+/** `Switch` feature bits (Matter Application Clusters § 1.12.4). */
+const LS = 1 << 0;
+const MS = 1 << 1;
+const MSR = 1 << 2;
+const MSL = 1 << 3;
+const MSM = 1 << 4;
+const AS = 1 << 5;
+
+/** What the plan's step 1b and step 3b require the TH to be. */
+const LATCHING_FEATURE_MAP = LS;
+const MOMENTARY_FEATURE_MAPS = [MS | MSL | MSM | AS, MS | MSR | MSL | MSM];
+
+/** The plan's own value for both switches. */
+const POSITIONS = 2;
+
+/**
+ * The DUT's own declaration of what it supports as a switch *client*, which is what steps 0a-0h check
+ * for self-consistency. It is the controller's PICS overlaid on the device file, because the DUT here
+ * is the controller.
+ */
+const PICS_LS = "SWTCH.C.F00";
+const PICS_MS = "SWTCH.C.F01";
+const PICS_MSR = "SWTCH.C.F02";
+const PICS_MSL = "SWTCH.C.F03";
+const PICS_MSM = "SWTCH.C.F04";
+const PICS_AS = "SWTCH.C.F05";
+const PICS_POLLING = "SWTCH.C.M.SwitchStatePolling";
+const PICS_EVENTING = "SWTCH.C.M.SwitchStateEventing";
+
+/** The position of the button the momentary steps press; 0 is the idle position. */
+const PRESSED_POSITION = 1;
+
+/** The plan's own multi press: two presses of 0.2s each. */
+const PRESSES = 2;
+const PRESS_MS = 200;
+
+/** The plan's own long-press timings: LongPress after 0.75s, released 2s later. */
+const LONG_PRESS_DELAY_MS = 750;
+const LONG_PRESS_DURATION_MS = 2_750;
+
+/** Between reads of a state the device may not have applied yet. */
+const READ_RETRY_MS = 100;
+
+/** A subscription that reports nothing for this long is taken to have delivered what it holds. */
+const EVENT_QUIET_MS = 750;
+
+/** After the switch is reset, before the next simulated press. */
+const SWITCH_IDLE_MS = 1_000;
+
+/** How long a simulated operation is given to reach the DUT. */
+const EVENT_WAIT_MS = 5_000;
+
+/** The plan runs each simulation for a minute; the evidence is the same after a few operations. */
+const OPERATIONS = 2;
+
+/**
+ * Between operations. The plan waits ten seconds; what the wait is *for* is that each change is its own
+ * operation — back-to-back writes reach the device as one state change and produce one event, which is
+ * the switch behaving correctly and the step observing the wrong thing.
+ */
+const BETWEEN_OPERATIONS_MS = 300;
+
+/**
+ * Returns the switch to its idle position and gives the device time to close the press cycle the
+ * previous step left open. A momentary switch counts presses until it goes idle (Application Clusters
+ * § 1.12.8), so a step that presses without this one sees its presses counted into the cycle before it
+ * and reported as one multi press instead of what it simulated. How much of the cycle the command
+ * itself ends is the device's own: the matter.js test device resets its switch state, a chip app only
+ * moves the position, which is why the wait matters as much as the command.
+ */
+async function idleSwitch(cx: CertStepContext, endpoint: number) {
+    await cx.devices.th.backchannel({ name: "simulateSwitchIdle", endpointId: endpoint });
+    await pause(SWITCH_IDLE_MS);
+}
+
+async function pause(ms: number) {
+    await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+const commissioned = new CommissionedRefs();
+const received = new Array<EventReadEntry>();
+
+/**
+ * What the DUT declares as a switch client. A device whose own PICS file is unavailable gates nothing
+ * (see `certTest`'s own handling), so the controller's declaration stands alone rather than failing the
+ * run — the consistency rules are about that declaration.
+ */
+function picsOf(cx: CertStepContext): PicsValues {
+    const overlay = controllerPicsOverridesFor(resolveControllerImplementation());
+    try {
+        return { ...cx.devices.th.pics.values, ...overlay };
+    } catch (e) {
+        if (e instanceof PicsUnavailableError) {
+            return overlay;
+        }
+        throw e;
+    }
+}
+
+function declares(pics: PicsValues, key: string): boolean {
+    return pics[key] === 1;
+}
+
+/**
+ * One of the plan's eight consistency rules, each of which names a combination the DUT's declaration
+ * must not hold. The step passes when the combination is absent, which is what "FAIL the test - ..."
+ * asks for read the other way round.
+ */
+function consistencyStep(rule: (pics: PicsValues) => boolean, violation: string) {
+    return async (cx: CertStepContext) => {
+        const pics = picsOf(cx);
+        const violated = rule(pics);
+        record(
+            cx,
+            {
+                type: "response",
+                verdict: violated ? "fail" : "pass",
+                detail: violated ? `the DUT declares ${violation}` : `the DUT's declaration does not hold ${violation}`,
+            },
+            "the DUT's switch-client declaration",
+        );
+        if (violated) {
+            throw new CertCheckFailedError(`the DUT declares ${violation}`);
+        }
+    };
+}
+
+/**
+ * Which bit each `Switch` feature holds, by the name a decoded bitmap gives it. Taken from the model
+ * rather than listed here, so a feature the cluster gains is folded back rather than silently dropped
+ * from the number this test hands the device.
+ */
+const FEATURE_BITS = new Map(
+    SWITCH.features.map(feature => {
+        const bit = feature.constraint.value;
+        if (typeof bit !== "number") {
+            throw new CertCheckFailedError(`Switch feature ${feature.name} names no bit`);
+        }
+        const title = feature.title ?? feature.name;
+        return [`${title[0].toLowerCase()}${title.slice(1)}`, 1 << bit] as const;
+    }),
+);
+
+/**
+ * A switch attribute as a number. A feature map is a bitmap, and both adapters decode a bitmap through
+ * the model into an object of named bits rather than the raw number, so the bits are folded back.
+ */
+async function readNumber(cx: CertStepContext, ref: CertNodeRef, endpoint: number, attribute: number) {
+    const value = await cx.controllers.dut.node(ref).readAttribute({ endpoint, cluster: SWITCH_ID, attribute });
+    if (typeof value === "number") {
+        return value;
+    }
+    if (attribute === FEATURE_MAP && typeof value === "object" && value !== null) {
+        const named = value as Record<string, unknown>;
+        let bits = 0;
+        for (const [name, bit] of FEATURE_BITS) {
+            if (named[name]) {
+                bits |= bit;
+            }
+        }
+        return bits;
+    }
+    throw new CertCheckFailedError(`the TH answered with ${describeValue(value)}, which is not a number`);
+}
+
+/** Reads a switch attribute and records what the TH answered against what the plan requires. */
+async function readAndCheck(
+    cx: CertStepContext,
+    ref: CertNodeRef,
+    endpoint: number,
+    attribute: number,
+    accept: (value: number) => boolean,
+    what: string,
+) {
+    const value = await readNumber(cx, ref, endpoint, attribute);
+    record(
+        cx,
+        {
+            type: "response",
+            verdict: accept(value) ? "pass" : "fail",
+            detail: `${what}: the TH answers ${value}`,
+        },
+        what,
+    );
+    if (!accept(value)) {
+        throw new CertCheckFailedError(`${what}: the TH answers ${value}`);
+    }
+    return value;
+}
+
+/**
+ * Reads `attribute` until it holds `expected`, and records what it last saw. A backchannel command
+ * returning proves the device was told, not that it has acted: a chip app reads the command from its
+ * pipe on its own thread, so the state a read finds immediately afterwards can still be the old one.
+ */
+async function readUntil(
+    cx: CertStepContext,
+    ref: CertNodeRef,
+    endpoint: number,
+    attribute: number,
+    expected: number,
+    what: string,
+) {
+    const deadline = Date.now() + EVENT_WAIT_MS;
+    let value = await readNumber(cx, ref, endpoint, attribute);
+    while (value !== expected && Date.now() < deadline) {
+        await pause(READ_RETRY_MS);
+        value = await readNumber(cx, ref, endpoint, attribute);
+    }
+
+    record(
+        cx,
+        {
+            type: "response",
+            verdict: value === expected ? "pass" : "fail",
+            detail: `${what}: the TH answers ${value}`,
+        },
+        what,
+    );
+    if (value !== expected) {
+        throw new CertCheckFailedError(`${what}: the TH answers ${value}`);
+    }
+}
+
+/**
+ * Subscribes to every event of the switch on `endpoint`, collecting what arrives for a later step.
+ *
+ * A subscription this test establishes stays established: nothing revokes the one an earlier step made,
+ * and the adapters hand an event to every subscription whose path covers it. Collecting only what this
+ * endpoint reports is what keeps two of them from counting the same event twice.
+ */
+async function subscribeToSwitch(cx: CertStepContext, ref: CertNodeRef, endpoint: number) {
+    received.length = 0;
+    await cx.controllers.dut.node(ref).subscribeEvents([{ endpoint, cluster: SWITCH_ID }], {
+        minIntervalFloorSeconds: 0,
+        maxIntervalCeilingSeconds: 30,
+        urgent: true,
+        onUpdate: event => {
+            if (event.endpoint === endpoint) {
+                received.push(event);
+            }
+        },
+    });
+    record(
+        cx,
+        { type: "response", verdict: "pass", detail: `subscribed to every Switch event on endpoint ${endpoint}` },
+        "the DUT's event subscription",
+    );
+}
+
+/** Waits until `predicate` holds over the events received so far, or the budget runs out. */
+async function untilReceived(predicate: () => boolean): Promise<boolean> {
+    const deadline = Date.now() + EVENT_WAIT_MS;
+    while (Date.now() < deadline) {
+        if (predicate()) {
+            return true;
+        }
+        await new Promise(resolve => setTimeout(resolve, 50));
+    }
+    return predicate();
+}
+
+/** One field of an event's payload, or `undefined` for an event that is absent or carries no such field. */
+function fieldOf(entry: EventReadEntry | undefined, field: string): unknown {
+    return typeof entry?.value === "object" && entry.value !== null
+        ? (entry.value as Record<string, unknown>)[field]
+        : undefined;
+}
+
+function eventsNamed(name: string, after = -1n): EventReadEntry[] {
+    const id = eventId(name);
+    return received.filter(entry => entry.event === id && entry.eventNumber > after);
+}
+
+/** Every switch event the DUT received above `after`, in the order the publisher numbered them. */
+function eventsAfter(after: bigint): EventReadEntry[] {
+    return received
+        .filter(entry => entry.eventNumber > after)
+        .sort((a, b) => (a.eventNumber < b.eventNumber ? -1 : a.eventNumber > b.eventNumber ? 1 : 0));
+}
+
+/** The `Switch` event an entry carries, by the name the cluster gives it. */
+function nameOf(entry: EventReadEntry): string {
+    return SWITCH.events.find(event => event.id === entry.event)?.name ?? `event ${entry.event}`;
+}
+
+/**
+ * The highest event number the DUT has received once the subscription has gone quiet. A step counts only
+ * the events above this, so events an earlier step provoked cannot stand in for the ones it asks for.
+ *
+ * The boundary comes from what arrived rather than from a read of the publisher's events: on chip-tool a
+ * report that arrives while a read is in flight is folded into that read's reply, so a read taken here
+ * can already carry the first event of the step that is about to run.
+ */
+async function quietEventBoundary(cx: CertStepContext): Promise<bigint> {
+    const deadline = Date.now() + EVENT_WAIT_MS;
+    let seen = -1;
+    while (seen !== received.length && Date.now() < deadline) {
+        seen = received.length;
+        await pause(EVENT_QUIET_MS);
+    }
+
+    if (seen !== received.length) {
+        // Events still arriving means the boundary cannot separate this step's from the previous one's,
+        // so what the step goes on to count would say nothing about what it simulated.
+        record(
+            cx,
+            {
+                type: "response",
+                verdict: "fail",
+                detail: `events were still arriving after ${Duration.format(Millis(EVENT_WAIT_MS))}`,
+            },
+            "the previous step's events had all arrived",
+        );
+        throw new CertCheckFailedError("the DUT was still receiving events when this step began");
+    }
+
+    return received.reduce((highest, entry) => (entry.eventNumber > highest ? entry.eventNumber : highest), -1n);
+}
+
+/**
+ * Commissions the TH, or reports the fabric it is already on. Both halves of the plan open with their
+ * own commissioning step, gated on the switch that half is about, and a DUT that declares only one of
+ * the two switches runs only that half's step — so neither may assume the other ran.
+ */
+async function commissionTh(cx: CertStepContext) {
+    const existing = commissioned.get("dut");
+    if (existing !== undefined) {
+        record(
+            cx,
+            {
+                type: "response",
+                verdict: "pass",
+                detail: `the DUT is on the TH's fabric as ${existing}, and one fabric carries both switches`,
+            },
+            "the DUT commissioned the TH",
+        );
+        return;
+    }
+
+    const th = cx.devices.th;
+    const ref = await cx.controllers.dut.commission({
+        passcode: th.commissioning.passcode,
+        discriminator: th.commissioning.discriminator,
+    });
+    commissioned.set("dut", ref);
+    record(
+        cx,
+        { type: "response", verdict: "pass", detail: `commissioned the TH as ${ref}` },
+        "the DUT commissioned the TH",
+    );
+}
+
+certTest("TC-SWTCH-3.2", {
+    plan: "cluster/switch.adoc",
+    pics: ["SWTCH.C", "MCORE.IDM.C.SubscribeEvent"],
+    app: "all-clusters",
+})
+    .step(
+        "0a",
+        "Consistency check: at least one of LS and MS has to be supported",
+        consistencyStep(
+            pics => !declares(pics, PICS_LS) && !declares(pics, PICS_MS),
+            "neither a latching nor a momentary switch",
+        ),
+        { expected: "The DUT declares support for a latching switch, a momentary switch, or both." },
+    )
+    .step(
+        "0b",
+        "Consistency check: when supporting MSR also MS must be supported",
+        consistencyStep(
+            pics => declares(pics, PICS_MSR) && !declares(pics, PICS_MS),
+            "momentary switch release without a momentary switch",
+        ),
+        { expected: "The DUT does not declare momentary switch release without the momentary switch itself." },
+    )
+    .step(
+        "0c",
+        "Consistency check: when supporting MSL also MS must be supported",
+        consistencyStep(
+            pics => declares(pics, PICS_MSL) && !declares(pics, PICS_MS),
+            "long press without a momentary switch",
+        ),
+        { expected: "The DUT does not declare long press without the momentary switch itself." },
+    )
+    .step(
+        "0d",
+        "Consistency check: when supporting MSL also MSR or AS must be supported",
+        consistencyStep(
+            pics => declares(pics, PICS_MSL) && !declares(pics, PICS_MSR) && !declares(pics, PICS_AS),
+            "long press with neither momentary switch release nor an action switch",
+        ),
+        {
+            expected:
+                "The DUT does not declare long press without either momentary switch release or an action " +
+                "switch. The plan's own rule here is that MSL requires MSR, which contradicts MSL's " +
+                "conformance `[MS & (MSR | AS)]` (Application Clusters § 1.12.4) and the plan's own step 0h " +
+                "and step 3b, so this step applies the conformance instead.",
+        },
+    )
+    .step(
+        "0e",
+        "Consistency check: when supporting MSM also MS must be supported",
+        consistencyStep(
+            pics => declares(pics, PICS_MSM) && !declares(pics, PICS_MS),
+            "multi press without a momentary switch",
+        ),
+        { expected: "The DUT does not declare multi press without the momentary switch itself." },
+    )
+    .step(
+        "0f",
+        "Consistency check: when supporting MSM also MSR or AS must be supported",
+        consistencyStep(
+            pics => declares(pics, PICS_MSM) && !declares(pics, PICS_MSR) && !declares(pics, PICS_AS),
+            "multi press with neither momentary switch release nor an action switch",
+        ),
+        {
+            expected:
+                "The DUT does not declare multi press without either momentary switch release or an action " +
+                "switch. As step 0d: MSM's conformance is `AS, [MS & MSR]`, so an action switch both permits " +
+                "and requires it.",
+        },
+    )
+    .step(
+        "0g",
+        "Consistency check: at least one of SwitchStatePolling and SwitchStateEventing must be supported",
+        consistencyStep(
+            pics => !declares(pics, PICS_POLLING) && !declares(pics, PICS_EVENTING),
+            "neither polling nor eventing of switch state",
+        ),
+        { expected: "The DUT declares that it reads switch state, receives events for it, or both." },
+    )
+    .step(
+        "0h",
+        "Consistency check: when supporting MSR the AS must not be supported",
+        consistencyStep(
+            pics => declares(pics, PICS_MSR) && declares(pics, PICS_AS),
+            "momentary switch release together with an action switch",
+        ),
+        { expected: "The DUT does not declare both momentary switch release and action switch." },
+    )
+    .step("1a", "Commission DUT to TH, and set it up so the switch state can be observed", commissionTh, {
+        pics: PICS_LS,
+        expected:
+            "The DUT is on the TH's fabric and reads the switch's state from it, which is what this " +
+            "controller observes it with — it presents no state of its own and controls no other device.",
+    })
+    .step(
+        "1b",
+        "DUT reads global attribute FeatureMap",
+        commissioned.withRef("dut", async (cx, ref) => {
+            await readAndCheck(
+                cx,
+                ref,
+                LATCHING_ENDPOINT,
+                FEATURE_MAP,
+                value => value === LATCHING_FEATURE_MAP,
+                "the latching switch's FeatureMap",
+            );
+        }),
+        { pics: PICS_LS, expected: "TH provides value 1 (LS)." },
+    )
+    .step(
+        "1c",
+        "DUT reads attribute NumberOfPositions",
+        commissioned.withRef("dut", async (cx, ref) => {
+            await readAndCheck(
+                cx,
+                ref,
+                LATCHING_ENDPOINT,
+                NUMBER_OF_POSITIONS,
+                value => value === POSITIONS,
+                "the latching switch's NumberOfPositions",
+            );
+        }),
+        { pics: PICS_LS, expected: "TH provides value 2." },
+    )
+    .step(
+        "1d",
+        "DUT sets up eventing (SwitchLatched) so it will receive events when the switch is operated",
+        commissioned.withRef("dut", async (cx, ref) => subscribeToSwitch(cx, ref, LATCHING_ENDPOINT)),
+        { pics: `${PICS_LS} & ${PICS_EVENTING}`, expected: "TH responds accordingly." },
+    )
+    .step(
+        "2a",
+        "TH simulates operation of the switch by changing CurrentPosition, and the DUT reads it regularly",
+        commissioned.withRef("dut", async (cx, ref) => {
+            const th = cx.devices.th;
+            for (let operation = 0; operation < OPERATIONS; operation++) {
+                for (const position of [1, 0]) {
+                    await th.backchannel({
+                        name: "simulateLatchPosition",
+                        endpointId: LATCHING_ENDPOINT,
+                        positionId: position,
+                    });
+                    await readUntil(
+                        cx,
+                        ref,
+                        LATCHING_ENDPOINT,
+                        CURRENT_POSITION,
+                        position,
+                        `CurrentPosition after the switch was moved to ${position}`,
+                    );
+                }
+            }
+        }),
+        {
+            pics: `${PICS_LS} & ${PICS_POLLING}`,
+            expected:
+                "When the DUT reads CurrentPosition, the TH answers with the position it was moved to. This " +
+                "controller reads the state rather than presenting it.",
+        },
+    )
+    .step(
+        "2b",
+        "TH simulates operation of the switch, sending SwitchLatched on every change",
+        commissioned.withRef("dut", async cx => {
+            const th = cx.devices.th;
+            const simulated = new Array<number>();
+            const boundary = await quietEventBoundary(cx);
+            for (let operation = 0; operation < OPERATIONS; operation++) {
+                for (const position of [1, 0]) {
+                    await th.backchannel({
+                        name: "simulateLatchPosition",
+                        endpointId: LATCHING_ENDPOINT,
+                        positionId: position,
+                    });
+                    simulated.push(position);
+                    await pause(BETWEEN_OPERATIONS_MS);
+                }
+            }
+
+            const arrived = await untilReceived(
+                () => eventsNamed("switchLatched", boundary).length >= simulated.length,
+            );
+            const latched = eventsNamed("switchLatched", boundary);
+            recordAll(cx, [
+                {
+                    check: () => ({
+                        type: "response",
+                        verdict: arrived ? "pass" : "fail",
+                        detail: `${latched.length} of ${simulated.length} SwitchLatched events reached the DUT`,
+                    }),
+                    what: "the DUT received an event for every change",
+                },
+                {
+                    check: () => {
+                        const positions = latched.map(entry => fieldOf(entry, "newPosition"));
+                        const matches =
+                            positions.length === simulated.length &&
+                            positions.every((position, index) => position === simulated[index]);
+                        return {
+                            type: "response",
+                            verdict: matches ? "pass" : "fail",
+                            detail:
+                                `the events name positions ${describeValue(positions)}, ` +
+                                `for the sequence ${describeValue(simulated)} the switch was moved through`,
+                        };
+                    },
+                    what: "the events name the positions the switch moved to, in order",
+                },
+            ]);
+        }),
+        {
+            pics: `${PICS_LS} & ${PICS_EVENTING}`,
+            expected:
+                "The DUT receives these events. This controller records them rather than presenting the state " +
+                "or controlling another device.",
+        },
+    )
+    .step("3a", "Commission DUT to TH, and set it up so the momentary switch's state can be observed", commissionTh, {
+        pics: PICS_MS,
+        expected:
+            "The DUT is on the TH's fabric. It observes the switch by reading and subscribing, and presents " +
+            "no state of its own.",
+    })
+    .step(
+        "3b",
+        "DUT reads global attribute FeatureMap",
+        commissioned.withRef("dut", async (cx, ref) => {
+            await readAndCheck(
+                cx,
+                ref,
+                MOMENTARY_ENDPOINT,
+                FEATURE_MAP,
+                value => MOMENTARY_FEATURE_MAPS.includes(value),
+                "the momentary switch's FeatureMap",
+            );
+        }),
+        { pics: PICS_MS, expected: "TH provides value 0x1E (MS, MSR, MSL, MSM) or 0x3A (MS, MSL, MSM, AS)." },
+    )
+    .step(
+        "3c",
+        "DUT reads attribute NumberOfPositions",
+        commissioned.withRef("dut", async (cx, ref) => {
+            await readAndCheck(
+                cx,
+                ref,
+                MOMENTARY_ENDPOINT,
+                NUMBER_OF_POSITIONS,
+                value => value === POSITIONS,
+                "the momentary switch's NumberOfPositions",
+            );
+        }),
+        { pics: PICS_MS, expected: "TH provides value 2." },
+    )
+    .step(
+        "3d",
+        "DUT subscribes to all switch events on the endpoint",
+        commissioned.withRef("dut", async (cx, ref) => subscribeToSwitch(cx, ref, MOMENTARY_ENDPOINT)),
+        { pics: `${PICS_MS} & ${PICS_EVENTING}`, expected: "TH responds accordingly." },
+    )
+    .step(
+        "4a",
+        "TH simulates operation of the momentary switch while the DUT reads CurrentPosition regularly",
+        commissioned.withRef("dut", async (cx, ref) => {
+            const th = cx.devices.th;
+            for (let operation = 0; operation < OPERATIONS; operation++) {
+                for (const position of [1, 0]) {
+                    await th.backchannel({
+                        name: "simulateLatchPosition",
+                        endpointId: MOMENTARY_ENDPOINT,
+                        positionId: position,
+                    });
+                    await readUntil(
+                        cx,
+                        ref,
+                        MOMENTARY_ENDPOINT,
+                        CURRENT_POSITION,
+                        position,
+                        `CurrentPosition while the button was ${position === PRESSED_POSITION ? "pressed" : "released"}`,
+                    );
+                }
+            }
+        }),
+        {
+            pics: `${PICS_MS} & ${PICS_POLLING}`,
+            expected:
+                "The TH answers with the position the button is in. This controller reads the state rather than " +
+                "presenting it.",
+        },
+    )
+    .step("4b", "TH simulates a short press, sending InitialPress and ShortRelease", async () => {}, {
+        pics: `${PICS_MS} & ${PICS_MSR} & ${PICS_EVENTING}`,
+        notApplicable:
+            "This controller declares the switch it observes, which is an action switch, and one never " +
+            "generates the ShortRelease this step waits for (Application Clusters § 1.12.6.4). The plan " +
+            "gates the step on the momentary switch alone, which its own step 3b contradicts by allowing " +
+            "an action-switch TH; the release flag gates it here.",
+    })
+    .step(
+        "4c",
+        "TH simulates a long press, sending InitialPress, LongPress and LongRelease",
+        commissioned.withRef("dut", async (cx, ref) => {
+            const th = cx.devices.th;
+            const featureMap = await readNumber(cx, ref, MOMENTARY_ENDPOINT, FEATURE_MAP);
+            await idleSwitch(cx, MOMENTARY_ENDPOINT);
+            const boundary = await quietEventBoundary(cx);
+            await th.backchannel({
+                name: "simulateLongPress",
+                endpointId: MOMENTARY_ENDPOINT,
+                buttonId: PRESSED_POSITION,
+                longPressDelayMillis: LONG_PRESS_DELAY_MS,
+                longPressDurationMillis: LONG_PRESS_DURATION_MS,
+                featureMap,
+            });
+
+            const sequence = [
+                { name: "initialPress", field: "newPosition" },
+                { name: "longPress", field: "newPosition" },
+                { name: "longRelease", field: "previousPosition" },
+            ];
+            const arrived = await untilReceived(() =>
+                sequence.every(({ name }) => eventsNamed(name, boundary).length > 0),
+            );
+            const cycle = eventsAfter(boundary);
+
+            recordAll(cx, [
+                {
+                    check: () => {
+                        const expected = sequence.map(({ name }) => eventId(name));
+                        return {
+                            type: "response",
+                            verdict:
+                                cycle.length === expected.length &&
+                                cycle.every((entry, index) => entry.event === expected[index])
+                                    ? "pass"
+                                    : "fail",
+                            detail: `the DUT received ${describeValue(cycle.map(nameOf))}${
+                                arrived ? "" : " within the wait"
+                            }`,
+                        };
+                    },
+                    what: "the DUT received the long-press cycle, once each and in order",
+                },
+                {
+                    check: () => {
+                        const positions = sequence.map(({ name, field }) =>
+                            fieldOf(eventsNamed(name, boundary)[0], field),
+                        );
+                        return {
+                            type: "response",
+                            verdict: positions.every(position => position === PRESSED_POSITION) ? "pass" : "fail",
+                            detail: `the events name positions ${describeValue(positions)}`,
+                        };
+                    },
+                    what: "each event of the cycle names the button that was pressed",
+                },
+            ]);
+        }),
+        {
+            pics: `${PICS_MS} & ${PICS_MSL} & ${PICS_EVENTING}`,
+            expected:
+                "The DUT receives InitialPress, LongPress and LongRelease. An action switch still reports " +
+                "the long-press cycle in full (Application Clusters § 1.12.8.2). This controller records " +
+                "the events rather than acting on them.",
+        },
+    )
+    .step("4d", "TH simulates a multi press on a switch that is not an action switch", async () => {}, {
+        pics: `${PICS_MS} & ${PICS_MSM} & !${PICS_AS} & ${PICS_EVENTING}`,
+        notApplicable: "The TH's momentary switch is an action switch, which this step excludes.",
+    })
+    .step(
+        "4f",
+        "TH simulates a multi press on an action switch, sending InitialPress and MultiPressComplete",
+        commissioned.withRef("dut", async (cx, ref) => {
+            const th = cx.devices.th;
+            const featureMap = await readNumber(cx, ref, MOMENTARY_ENDPOINT, FEATURE_MAP);
+            const multiPressMax = await readNumber(cx, ref, MOMENTARY_ENDPOINT, MULTI_PRESS_MAX);
+            await idleSwitch(cx, MOMENTARY_ENDPOINT);
+            const boundary = await quietEventBoundary(cx);
+            await th.backchannel({
+                name: "simulateMultiPress",
+                endpointId: MOMENTARY_ENDPOINT,
+                buttonId: PRESSED_POSITION,
+                multiPressPressedTimeMillis: PRESS_MS,
+                multiPressReleasedTimeMillis: PRESS_MS,
+                multiPressNumPresses: PRESSES,
+                featureMap,
+                multiPressMax,
+            });
+
+            const arrived = await untilReceived(() => eventsNamed("multiPressComplete", boundary).length > 0);
+            const counted = fieldOf(eventsNamed("multiPressComplete", boundary)[0], "totalNumberOfPressesCounted");
+
+            recordAll(cx, [
+                {
+                    check: () => {
+                        const presses = eventsNamed("initialPress", boundary);
+                        return {
+                            type: "response",
+                            verdict:
+                                presses.length === 1 && fieldOf(presses[0], "newPosition") === PRESSED_POSITION
+                                    ? "pass"
+                                    : "fail",
+                            detail:
+                                `${presses.length} InitialPress events reached the DUT, naming positions ` +
+                                describeValue(presses.map(press => fieldOf(press, "newPosition"))),
+                        };
+                    },
+                    what: "the DUT received one press for the sequence, as an action switch reports it",
+                },
+                {
+                    check: () => ({
+                        type: "response",
+                        verdict: arrived && counted === PRESSES ? "pass" : "fail",
+                        detail: `MultiPressComplete counted ${describeValue(counted)} presses`,
+                    }),
+                    what: "the DUT received the completed multi press, with the number of presses",
+                },
+            ]);
+        }),
+        {
+            pics: `${PICS_MS} & ${PICS_MSM} & ${PICS_AS} & ${PICS_EVENTING}`,
+            expected:
+                "The DUT receives InitialPress and a MultiPressComplete naming two presses. This controller " +
+                "records them rather than acting on them.",
+        },
+    )
+    .finalize(cx => {
+        received.length = 0;
+        return commissioned.decommissionAll(cx);
+    });


### PR DESCRIPTION
Adds the certification test TC-SWTCH-3.2, and the two pieces of harness work it needed.

**TC-SWTCH-3.2** exercises a controller that acts as a switch client: it checks that the switch-client
capabilities the controller declares are self-consistent, commissions a simulated switch, reads its
state, subscribes to its events, and then has the switch operated while it watches what arrives — a
latching switch first, then a momentary one that reports long presses and multi presses.

### A cert step can ask for an urgent event subscription

Without that flag a device may hold queued events until the subscription's maximum interval elapses,
so a step that operates the device and then waits a few seconds for the event sees almost nothing: the
first run of this test case saw one of four switch events, and the other three arrived seconds later
when the subscription closed.

Urgency is off by default rather than on for every subscription, because it is visible on the wire —
chip prints an `isUrgent` line inside the decoded event path — and TC-IDM-6.4 asserts the exact
subscribe request it sent, as adjacent log lines.

### Chip test devices can be operated, not only started and stopped

A cert step operates a device through the backchannel — moving a switch, simulating a press. The
harness's chip subjects answered only process lifecycle there, so any test that operates a device could
run against the matter.js test device alone, and its chip legs skipped what they were written to prove.
A chip app has always been able to do this: it reads commands as JSON from a named pipe whose path it
takes from `--app-pipe`. Both chip subjects now name that pipe and hand it the commands the app in
question answers — the local subject writes to the pipe, the container one through a shell inside the
container, with the command passed as an argument so nothing in it can be read as shell syntax.

Which commands travel that way is decided per app rather than per command name: a pipe accepts a write
whatever the app makes of it, so forwarding a command an app does not implement would report a delivery
that nothing acted on.

The write is guarded for the same reason, and each guard exists for a failure that was reached while
building this:

- A fifo with no reader **fails at once** instead of waiting for one. Opening a fifo for writing blocks
  until a reader attaches and nothing can cancel that open, so an app that died holding its fifo would
  hang the step and the run — and park a thread that keeps the process from exiting. The local subject
  opens non-blocking; the container one bounds the shell from outside, so the same case ends as a
  non-zero exit rather than an exec held for as long as the container lives.
- A path that is **not** a fifo is refused rather than written. An ordinary file there is one the app's
  own `mkfifo` accepts as already existing, after which its reader sees a single stale command and
  ends — silently discarding every command for the rest of that app's life.
- A pipe a killed app left behind is **cleared before the next generation starts**, since chip treats a
  failing `mkfifo` as fatal and the app would otherwise fail to initialize.

The result is that TC-SWTCH-3.2 runs whole against a real chip app rather than skipping the five steps
that operate the switch.

### Counting events a step actually caused

Steps count only the events numbered above a boundary taken once the subscription has gone quiet, so
events an earlier step provoked cannot stand in for the ones a later step asks for; a step whose
subscription never goes quiet fails rather than counting against a boundary that separates nothing.

The boundary comes from what arrived rather than from a read of the device's events, because chip-tool
folds a subscription report that arrives while a read is in flight into that read's reply. That was
observed in a captured run: the read answered event numbers 4..8 while the subscription had delivered
4..7, and the step then counted three of its four events.

A step that operates a device and then reads its state polls to a deadline. A backchannel command
returning proves the device was told, not that it has acted — a chip app reads the command from its
pipe on its own thread.

### Where this test departs from the test plan

Two of the plan's PICS consistency rules contradict the Switch cluster's conformance, so the case
applies the conformance and says so in the affected steps' expected outcome, which is what a run's
evidence then records.

The cluster (Application Clusters § 1.13.4) makes the release feature optional for a momentary switch
that is not an action switch, permits long press with *either* the release feature or an action switch,
and makes multi press mandatory for an action switch. The plan instead requires the release feature
wherever long press or multi press is declared. Read together with the plan's own rule that the release
feature and an action switch exclude each other, and with its step 3b, which lets the switch under test
be an action switch, no client of such a switch can declare a set of flags that passes. Step 4b has the
matching gap: it asks for a `ShortRelease` event while being gated on the momentary switch alone, and
an action switch never generates one.

An issue for the test plan covers both, along with the missing `SWTCH.C.F05` entry in CHIP's PICS file,
which is why the action-switch client flag comes from this repository's controller overlay.

### Also here

A swallowed promise in the test device's switch-idle backchannel is now awaited; the new steps depend
on that reset completing before they press again.

`test/cert/AGENTS.md` records the three reusable mechanics for the next test author: why urgent
subscriptions are opt-in, how to count events a step caused, and that a backchannel command returning
does not mean the device has acted.

### Verification

TC-SWTCH-3.2 passes on all four controller/device combinations — matter.js and chip-tool as the
controller, the matter.js test device and a local chip app as the device. Each leg runs 21 steps and
skips two (4b and 4d), which this controller's own declaration excludes: it declares the action switch
it observes, and those two steps are for a switch that reports releases.

`npm run test-cert` (29/29), `npm run test-cert-framework` (26/26), `npm test`, `npm run lint` and
`npm run format-verify` are clean.

The guards on the pipe write are mutation-tested: removing the non-blocking open hangs the suite
instead of failing it, removing the stale-pipe clearing fails the restart test, and breaking the
command's JSON shape fails both the local and container tests. Two gaps remain and are worth knowing:
the container path has unit tests but was not run against a built image locally (CI's docker legs are
the only real exercise, and `chip-docker` is not currently a leg in the cert workflow), and nothing
fast asserts that `urgent` reaches the in-process controller's request — that flag's effect is
evidenced by the captured cert run and by the chip-tool command assertion.
