### PR TITLE
Give up on an undo that can never finish, and say why a request was refused

### DIFF
--- a/packages/node-manager/src/task/Execution.ts
+++ b/packages/node-manager/src/task/Execution.ts
@@ -37,12 +37,6 @@ export class Execution {
      */
     settled = false;
 
-    /**
-     * A cancel has been accepted and has not finished unwinding. Outlives the driver deliberately: it refuses a
-     * re-run for the whole window, and the driver reads it between phases to stop advancing.
-     */
-    cancelling = false;
-
     #phases?: TaskPhase[];
 
     constructor(record: RunRecord, bound: BoundDefinition) {

--- a/packages/node-manager/src/task/RunStore.ts
+++ b/packages/node-manager/src/task/RunStore.ts
@@ -8,9 +8,9 @@ import { ImplementationError } from "@matter/general";
 import { TaskIdentityExhaustedError } from "./errors.js";
 import { Execution } from "./Execution.js";
 import { runKey, RunRecord, TaskPersistence } from "./Task.js";
-import { RetireSeq, RunId, TaskState } from "./types.js";
+import { RetireSeq, RunId, Teardown, TaskState } from "./types.js";
 
-const TERMINAL_STATES: ReadonlySet<TaskState> = new Set<TaskState>(["completed", "failed", "cancelled"]);
+const TERMINAL_STATES: ReadonlySet<TaskState> = new Set<TaskState>(["completed", "failed", "cancelled", "abandoned"]);
 
 /** Whether a persisted record has reached a state no driver will advance. */
 export function isTerminal(state: TaskState): boolean {
@@ -26,6 +26,17 @@ export function isTerminal(state: TaskState): boolean {
  * left of the block, so identities are sparse rather than consecutive.
  */
 export const RUN_ID_RESERVATION = 64;
+
+/**
+ * One verb's exclusive hold on a run's outcome.
+ *
+ * {@link settled} resolves when the hold ends, so a second caller of the same verb waits for the decision and
+ * then answers from it rather than being refused — a duplicate cancel is owed the rollback the first created.
+ */
+export interface RunTransition {
+    readonly teardown: Teardown;
+    readonly settled: Promise<void>;
+}
 
 export interface RunStoreSnapshot {
     runs: Record<string, TaskPersistence>;
@@ -60,6 +71,16 @@ export class RunStore {
      * intents it already wrote.
      */
     readonly #executions = new Map<RunId, Execution>();
+
+    /**
+     * The verb currently taking a run's outcome away from its driver, for as long as that transition lasts.
+     *
+     * Kept here rather than on the execution because it must outlive one: a transition detaches the run it is
+     * retiring, and a claim that died with the execution would let a second verb start against the same run in
+     * the window before the first has written anything. It also answers a request for the target after the
+     * driver has stopped, which is most of the window.
+     */
+    readonly #transitions = new Map<RunId, RunTransition & { release(): void }>();
 
     /**
      * Who owns each slot. Maintained rather than derived: a slot is released at the retirement commit, and
@@ -225,6 +246,38 @@ export class RunStore {
         return holder !== undefined && holder.slotKey !== slotKey && !isTerminal(holder.state) ? holder : undefined;
     }
 
+    /**
+     * Take exclusive responsibility for `runId`'s outcome, refusing if another verb already has it.
+     *
+     * Exclusive because a transition stops the driver and then decides: two of them decide from the same
+     * pre-transition state, and the second would either write over the first's outcome or restore a second
+     * driver over the same record.
+     */
+    claimTransition(runId: RunId, teardown: Teardown): RunTransition | undefined {
+        const held = this.#transitions.get(runId);
+        if (held !== undefined) {
+            return held;
+        }
+        let release!: () => void;
+        const settled = new Promise<void>(resolve => (release = resolve));
+        this.#transitions.set(runId, { teardown, settled, release });
+        return undefined;
+    }
+
+    releaseTransition(runId: RunId): void {
+        const held = this.#transitions.get(runId);
+        if (held === undefined) {
+            return;
+        }
+        this.#transitions.delete(runId);
+        held.release();
+    }
+
+    /** The transition that currently owns `runId`'s outcome, if any. */
+    transitionOf(runId: RunId): RunTransition | undefined {
+        return this.#transitions.get(runId);
+    }
+
     /** Register a run and give it ownership of its slot. In memory only: nothing is durable yet. */
     admit(record: RunRecord, execution?: Execution): void {
         const owner = this.#slots.get(record.slotKey);
@@ -314,27 +367,43 @@ export class RunStore {
     }
 
     /**
-     * The rollback that undoes `runId`, if one exists — whether or not the run's own record names it yet.
+     * The rollback of `runId`: the live one if there is one, otherwise the one its record names.
      *
-     * Derived rather than remembered: a rollback is linked by identity from the moment it is admitted, so a
-     * second cancel racing the first finds the rollback already being prepared instead of trying to create
-     * another one.
+     * **The only way to ask.** The relation has two representations — a rollback links to its original by
+     * identity from the moment it is admitted, while the original's own link is durable but only lands with a
+     * write — so a caller that picks one of them gets a different answer inside every persistence window. Every
+     * decision about a run's rollback comes through here; `revertRunId` is read directly only to report
+     * history.
+     *
+     * Unambiguous despite two rollbacks being able to exist for one run: a rollback's target is
+     * `revert:<originalRunId>`, and a target has one owner, so only one of them is ever live.
      */
-    rollbackOf(runId: RunId): RunRecord | undefined {
-        for (const record of this.#records.values()) {
+    rollbackFor(runId: RunId): RunRecord | undefined {
+        for (const record of this.live) {
             if (record.revertOf === runId) {
                 return record;
             }
         }
-        return undefined;
+        const recorded = this.#records.get(runId)?.revertRunId;
+        return recorded === undefined ? undefined : this.#records.get(recorded);
+    }
+
+    /**
+     * The rollback that applies to `undone`'s target: the live one, otherwise the one `undone` names.
+     *
+     * A wider question than {@link rollbackFor}, and the one supersession asks: a rollback of a *later* run of
+     * the same target makes an earlier run's priors historical without that earlier run ever naming it.
+     */
+    rollbackApplyingTo(undone: RunRecord): RunRecord | undefined {
+        return this.liveRollbackOfTarget(undone.slotKey) ?? this.rollbackFor(undone.runId);
     }
 
     /**
      * A live rollback of any retired run of `slotKey`. A rollback rewrites exactly the intents a re-run would
      * re-apply, so the two must never overlap — and the rollback in flight is not necessarily undoing the most
-     * recent run of the slot.
+     * recent run of the target.
      */
-    pendingRevertOfSlot(slotKey: string): RunRecord | undefined {
+    liveRollbackOfTarget(slotKey: string): RunRecord | undefined {
         const undone = new Set<RunId>();
         for (const record of this.#records.values()) {
             if (record.slotKey === slotKey && isTerminal(record.state)) {

--- a/packages/node-manager/src/task/RunningTaskContext.ts
+++ b/packages/node-manager/src/task/RunningTaskContext.ts
@@ -15,7 +15,7 @@ import { TaskContext, TaskState } from "./types.js";
 const logger = Logger.get("TaskContext");
 
 /**
- * Lets the manager interrupt a parked gate. `aborted()` returns the abort reason (a cancel or suspend signal)
+ * Lets the manager interrupt a parked gate. `aborted()` returns the abort reason (a cancel, abandon or suspend signal)
  * once set; the gate then rejects with it. `onAbort` wakes the gate so it observes the abort even while parked
  * on peer observers.
  */

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -5,16 +5,28 @@
  */
 
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
-import { asError, ImplementationError, Lifecycle, Logger, Mutex } from "@matter/general";
+import { asError, ImplementationError, InternalError, Lifecycle, Logger, Mutex } from "@matter/general";
 import { DatatypeModel, FieldElement } from "@matter/model";
 import { Agent, Behavior, ClientNode, DesiredStateBehavior, itemMapKey, Node, ServerNode } from "@matter/node";
 import {
+    TaskAbandonedError,
+    TaskAbandonedSignal,
+    TaskAlreadyUndoneError,
     TaskCancelledSignal,
+    TaskCannotCancelRollbackError,
     TaskCapacityExceededError,
-    TaskConflictError,
+    TaskExternalIdInUseError,
     TaskManagerClosingError,
+    TaskNotARollbackError,
     TaskNotFoundError,
     TaskNotRevertibleError,
+    TaskRollbackPendingError,
+    TaskSlotAwaitingResumeError,
+    TaskSlotDrainingError,
+    TaskSlotOccupiedError,
+    TaskSlotSettlingError,
+    TaskStopSignal,
+    TaskSupersededError,
     TaskSuspendedSignal,
     TaskTypeNotRegisteredError,
 } from "./errors.js";
@@ -22,12 +34,12 @@ import { Execution, GateState } from "./Execution.js";
 import { AddNodeToGroup } from "./groups/AddNodeToGroup.js";
 import { RemoveNodeFromGroup } from "./groups/RemoveNodeFromGroup.js";
 import { RotateGroupKey } from "./groups/RotateGroupKey.js";
-import { Revert, REVERT_TYPE } from "./Revert.js";
+import { Revert } from "./Revert.js";
 import { GateControl, RunningTaskContext } from "./RunningTaskContext.js";
 import { isTerminal, RunStore } from "./RunStore.js";
 import { BoundDefinition, runKey, runLabel, RunRecord, statusOf, TaskDefinition, TaskPersistence } from "./Task.js";
 import { TaskRegistry } from "./TaskRegistry.js";
-import { PlannedChange, RunId, TaskState, TaskStatus } from "./types.js";
+import { PlannedChange, RunId, Teardown, TaskState, TaskStatus } from "./types.js";
 
 const logger = Logger.get("TaskManager");
 
@@ -50,6 +62,17 @@ interface PreparedRevert {
 
 /** The rollback of a task that has nothing to roll back: nothing to write, start or forget. */
 const NO_REVERT: PreparedRevert = { discard() {}, start() {} };
+
+/**
+ * Whether a rollback's undo has concluded: it restored the device, or it was called off before it wrote
+ * anything. Either way nothing is left to retry or to give up on.
+ *
+ * `cancelled` is reachable only from a store an earlier build wrote, when cancelling a rollback was still
+ * admitted.
+ */
+function undoConcluded(record: RunRecord): boolean {
+    return record.state === "completed" || record.state === "cancelled";
+}
 
 /** A task registered as live, and whether the caller joined a live task that is already being driven. */
 interface SpawnedExecution {
@@ -227,9 +250,9 @@ export class TaskManagerBehavior extends Behavior {
      * write that records it, so nothing is written here.
      */
     #retire(execution: Execution): void {
-        // A cancel awaiting this driver owns the run's terminal state, so it owns the retirement too: the run
-        // is still `running` here, and retiring it now would record it mid-cancel.
-        if (execution.cancelling) {
+        // A transition in flight owns this run's outcome, so it owns the retirement too: releasing the target
+        // here would admit new work while that transition is still deciding what the run's outcome is.
+        if (this.internal.runs.transitionOf(execution.runId) !== undefined) {
             return;
         }
         // A non-terminal run otherwise reaches here through shutdown, which leaves it for the next start. An
@@ -266,6 +289,15 @@ export class TaskManagerBehavior extends Behavior {
                 `Task type "${definition.type}" undoes another run and is created by cancel(), not by run()`,
             );
         }
+        // Structural, not a flag a definition has to remember: admission lets a rollback be admitted while the
+        // run it undoes still owns the target, because only cancel creates one and it has already stopped that
+        // run's driver. A caller-created undo would take that exception with the original still driving, and
+        // the two would rewrite the same intents.
+        if (bound.undoes !== undefined) {
+            throw new ImplementationError(
+                `Task type "${definition.type}" declares what it undoes, so it is created by cancel(), not by run()`,
+            );
+        }
         const { execution, joined } = this.#spawn(bound, { externalId: opts?.externalId });
         if (!joined) {
             this.#track(execution);
@@ -294,16 +326,19 @@ export class TaskManagerBehavior extends Behavior {
         //    already-written intents with no owner.
         const owner = runs.ownerOf(slotKey);
         if (owner !== undefined) {
-            const ownerExecution = runs.executionOf(owner.runId);
-            if (ownerExecution === undefined) {
-                throw new TaskConflictError(
-                    `Task ${slotKey} rejected: ${runLabel(owner.runId)} holds this slot and is awaiting resume; register its type "${owner.type}" to continue it`,
+            // Asked before the execution, because a transition outlives one: it may already have handed back
+            // this process's responsibility for the run while it is still deciding the outcome.
+            const teardown = runs.transitionOf(owner.runId)?.teardown;
+            if (teardown !== undefined) {
+                throw new TaskSlotDrainingError(
+                    `Task ${slotKey} rejected: ${teardown} of ${runLabel(owner.runId)} is still in flight`,
                     owner.runId,
                 );
             }
-            if (ownerExecution.cancelling) {
-                throw new TaskConflictError(
-                    `Task ${slotKey} rejected: a cancel of ${runLabel(owner.runId)} is still in flight`,
+            const ownerExecution = runs.executionOf(owner.runId);
+            if (ownerExecution === undefined) {
+                throw new TaskSlotAwaitingResumeError(
+                    `Task ${slotKey} rejected: ${runLabel(owner.runId)} holds this slot and nothing is driving it (type "${owner.type}")`,
                     owner.runId,
                 );
             }
@@ -311,13 +346,13 @@ export class TaskManagerBehavior extends Behavior {
             // would hand back a run nothing is advancing, and re-running would write to the peer while this one
             // is still being recorded.
             if (ownerExecution.settled) {
-                throw new TaskConflictError(
+                throw new TaskSlotSettlingError(
                     `Task ${slotKey} rejected: ${runLabel(owner.runId)} is settling and still holds this slot`,
                     owner.runId,
                 );
             }
             if (seed.externalId === undefined || seed.externalId !== owner.externalId) {
-                throw new TaskConflictError(
+                throw new TaskSlotOccupiedError(
                     `Task ${slotKey} rejected: slot held by ${runLabel(owner.runId)} (${owner.state})`,
                     owner.runId,
                 );
@@ -329,7 +364,7 @@ export class TaskManagerBehavior extends Behavior {
         if (seed.externalId !== undefined) {
             const holder = runs.conflictingExternalIdHolder(seed.externalId, slotKey);
             if (holder !== undefined) {
-                throw new TaskConflictError(
+                throw new TaskExternalIdInUseError(
                     `Task ${slotKey} rejected: external id "${seed.externalId}" names ${runLabel(holder.runId)} of slot ${holder.slotKey}`,
                     holder.runId,
                 );
@@ -338,9 +373,19 @@ export class TaskManagerBehavior extends Behavior {
 
         // 4. A rollback rewrites exactly the intents a re-run would re-apply, so the two must never overlap —
         //    and the rollback in flight need not be undoing the most recent run of the slot.
-        const pendingRevert = runs.pendingRevertOfSlot(slotKey);
+        const pendingRevert = runs.liveRollbackOfTarget(slotKey);
         if (pendingRevert !== undefined) {
-            throw new TaskConflictError(
+            // A rollback being torn down is about to release this target, so the refusal is transient.
+            // Reported here rather than at step 2 because by the time a rollback can be torn down the run it
+            // undoes has retired, so nothing owns that run's slot and step 2 never sees it.
+            const teardown = runs.transitionOf(pendingRevert.runId)?.teardown;
+            if (teardown !== undefined) {
+                throw new TaskSlotDrainingError(
+                    `Task ${slotKey} rejected: ${teardown} of rollback ${runLabel(pendingRevert.runId)} is still in flight`,
+                    pendingRevert.runId,
+                );
+            }
+            throw new TaskRollbackPendingError(
                 `Task ${slotKey} rejected: rollback ${runLabel(pendingRevert.runId)} is still in flight and would undo it again`,
                 pendingRevert.runId,
             );
@@ -354,25 +399,26 @@ export class TaskManagerBehavior extends Behavior {
             const undoneSlot = runs.get(undone)?.slotKey;
             if (undoneSlot !== undefined) {
                 const holder = runs.ownerOf(undoneSlot);
-                // A rollback is only ever prepared by cancel, which has already stopped the run's driver, so
-                // the run still holding its own slot here is expected. Any other holder is live work this
-                // rollback would rewrite underneath.
+                // A rollback reaches admission only through #prepareRevert — `run()` refuses any definition
+                // declaring `undoes` — and cancel has stopped the run's driver by then, so the run still
+                // holding its own slot here is expected. Any other holder is live work this rollback would
+                // rewrite underneath.
                 if (holder !== undefined && holder.runId !== undone) {
-                    throw new TaskConflictError(
+                    throw new TaskSlotOccupiedError(
                         `Rollback of ${runLabel(undone)} rejected: slot ${undoneSlot} is held by ${runLabel(holder.runId)}`,
                         holder.runId,
                     );
                 }
                 const superseder = runs.supersederOf(undone);
                 if (superseder !== undefined) {
-                    throw new TaskConflictError(
+                    throw new TaskSupersededError(
                         `Rollback of ${runLabel(undone)} rejected: ${runLabel(superseder.runId)} has since committed slot ${undoneSlot}, so the values this would restore are historical`,
                         superseder.runId,
                     );
                 }
-                const sibling = runs.pendingRevertOfSlot(undoneSlot);
+                const sibling = runs.liveRollbackOfTarget(undoneSlot);
                 if (sibling !== undefined) {
-                    throw new TaskConflictError(
+                    throw new TaskRollbackPendingError(
                         `Rollback of ${runLabel(undone)} rejected: rollback ${runLabel(sibling.runId)} is already undoing slot ${undoneSlot}`,
                         sibling.runId,
                     );
@@ -450,20 +496,43 @@ export class TaskManagerBehavior extends Behavior {
      * Start a fresh rollback for a run whose previous one did not finish.
      *
      * A rollback is created by {@link cancel}, so retrying one cannot be an ordinary `run`: only the manager
-     * knows the original's driver is stopped and that no other rollback of its slot is in flight. Refuses
-     * while the recorded rollback is still going, since that one may yet succeed.
+     * knows the original's driver is stopped and that no other rollback of its slot is in flight.
+     *
+     * Refuses while the recorded rollback is still going, since that one may yet succeed; while a transition
+     * owns it, since that transition decides its outcome; and once it was abandoned, since an operator
+     * declining an undo must not be undone by a retry.
      */
     async retryRollback(runId: RunId): Promise<TaskHandle> {
         const record = this.internal.runs.get(runId);
         if (record === undefined) {
             throw new TaskNotFoundError(`Cannot retry the rollback of ${runLabel(runId)}: no run answers to it`);
         }
-        const previous = record.revertRunId;
-        if (previous === undefined) {
+        const recorded = this.internal.runs.rollbackFor(runId);
+        if (recorded === undefined) {
             throw new ImplementationError(`${runLabel(runId)} has no rollback to retry`);
         }
+        const previous = recorded.runId;
+        if (recorded.state === "abandoned") {
+            throw new TaskAbandonedError(
+                `Cannot retry the rollback of ${runLabel(runId)}: ${runLabel(previous)} was abandoned`,
+            );
+        }
+        // A concluded rollback is detached, so the in-flight checks below would let a replacement through and
+        // replay priors onto a device whose undo already succeeded. Same question `abandon` asks, same answer.
+        if (undoConcluded(recorded)) {
+            throw new TaskAlreadyUndoneError(
+                `Cannot retry the rollback of ${runLabel(runId)}: ${runLabel(previous)} already concluded (${recorded.state})`,
+            );
+        }
+        const teardown = this.internal.runs.transitionOf(previous)?.teardown;
+        if (teardown !== undefined) {
+            throw new TaskRollbackPendingError(
+                `Cannot retry the rollback of ${runLabel(runId)}: ${teardown} of ${runLabel(previous)} is still in flight`,
+                previous,
+            );
+        }
         if (this.internal.runs.isAttached(previous)) {
-            throw new TaskConflictError(
+            throw new TaskRollbackPendingError(
                 `Cannot retry the rollback of ${runLabel(runId)}: ${runLabel(previous)} is still in flight`,
                 previous,
             );
@@ -489,24 +558,42 @@ export class TaskManagerBehavior extends Behavior {
      * task (parks on offline peers, resumes after restart). Does not await the revert — the caller observes it
      * via the returned handle.
      *
-     * Each outcome has exactly one meaning: a handle is the rollback, `undefined` is a run with nothing to roll
-     * back, and {@link TaskNotFoundError} is an identity no run answers to — live or retired, since a finished
-     * run keeps the changeSet its rollback needs.
+     * A handle is the rollback. `undefined` means there is nothing to roll back — either the run wrote nothing,
+     * or it was already cancelled; `status.state` tells the two apart. {@link TaskNotFoundError} is an identity
+     * no run answers to, live or retired, since a finished run keeps the changeSet its rollback needs.
+     *
+     * A rollback is not cancelled: {@link TaskCannotCancelRollbackError} points at {@link abandon}, which
+     * records that the undo was given up on rather than that nothing needed it.
      *
      * Throws {@link TaskManagerClosingError} if shutdown intervenes before the cancel can be recorded; the task
      * then keeps its non-terminal state and the cancel must be re-issued after the next start.
      */
     async cancel(runId: RunId): Promise<TaskHandle | undefined> {
+        for (let pending = this.#pendingTransition(runId); pending !== undefined;) {
+            await pending;
+            pending = this.#pendingTransition(runId);
+        }
         const record = this.internal.runs.get(runId);
         if (record === undefined) {
             throw new TaskNotFoundError(`Cannot cancel ${runLabel(runId)}: no run answers to it`);
         }
+        // A rollback is ended with `abandon`, which records that the undo was given up on. Cancelling one would
+        // leave it `cancelled` — the state a rollback nothing needed ends in — with nothing saying the device
+        // was left part-changed.
+        if (record.revertOf !== undefined) {
+            throw new TaskCannotCancelRollbackError(
+                `Cannot cancel ${runLabel(runId)}: it is the rollback of ${runLabel(record.revertOf)}; use abandon() to give up on it`,
+            );
+        }
         const execution = this.internal.runs.executionOf(runId);
 
-        // A rollback this run already recorded is the answer, wherever it now lives: reporting it as unknown
-        // would make re-cancelling fail the moment its rollback finishes.
-        if (record.revertRunId !== undefined) {
-            return this.get(record.revertRunId);
+        // The rollback this run already has is the answer, wherever it now lives and whichever representation
+        // currently carries it: reporting it as unknown would make re-cancelling fail the moment its rollback
+        // finishes, and reading only the durable link would report none while one is being created.
+        const existing = this.internal.runs.rollbackFor(runId);
+        if (existing !== undefined) {
+            this.#refuseIfProvisional(existing, `Cannot answer for the rollback of ${runLabel(runId)}`);
+            return this.#handle(existing);
         }
         if (record.state === "cancelled") {
             return undefined;
@@ -521,20 +608,17 @@ export class TaskManagerBehavior extends Behavior {
             );
         }
 
-        // Stop forward driving so the changeset is final before we revert it. `cancelling` also covers the
-        // between-phase gap the gate cannot: the driver checks it synchronously before advancing a phase.
-        if (execution !== undefined) {
-            execution.cancelling = true;
-            execution.abort(new TaskCancelledSignal(`${runLabel(record.runId)} cancelled`));
-            try {
-                await execution.promise;
-            } finally {
-                // A `cancelling` execution left behind refuses every future run of this slot for the process
-                // lifetime.
-                execution.cancelling = false;
+        return this.#transition(record, "cancel", async () => {
+            // Stop forward driving so the changeset is final before we revert it.
+            if (execution !== undefined) {
+                await this.#unwind(execution, this.#stopSignal("cancel", record.runId));
             }
-        }
+            return this.#recordCancellation(record, bound);
+        });
+    }
 
+    /** The part of a cancel that decides and writes, with this run's outcome already claimed. */
+    async #recordCancellation(record: RunRecord, bound: BoundDefinition): Promise<TaskHandle | undefined> {
         // Shutdown took over the unwind: state can no longer be persisted, so leave the task non-terminal and
         // unreverted rather than claiming a cancel that storage would contradict on the next start.
         this.#refuseIfClosing(`${runLabel(record.runId)} cannot be cancelled`);
@@ -545,13 +629,7 @@ export class TaskManagerBehavior extends Behavior {
         try {
             revert = this.#prepareRevert(record, bound);
         } catch (e) {
-            // The abort above stopped the driver. A run the manager declines to cancel keeps its state, so it
-            // must keep its driver too, or it sits non-terminal with nothing left to advance it. A run this
-            // process was never attached to never had a driver here; driving it would write reconstructed
-            // state back over whatever the record now holds.
-            if (this.internal.runs.isAttached(record.runId)) {
-                this.#redrive(record, bound);
-            }
+            this.#restoreDriver(record, bound);
             throw e;
         }
         // running/parked → cancelled; an already-terminal (completed/failed) run keeps its truthful state.
@@ -565,18 +643,14 @@ export class TaskManagerBehavior extends Behavior {
                     next: {
                         state: outcome,
                         retireSeq: this.internal.runs.nextRetirement(record),
-                        revertRunId: revert.record?.runId ?? record.revertRunId,
+                        revertRunId: revert.record?.runId,
                     },
                 },
                 ...(revert.record === undefined ? [] : [{ record: revert.record }]),
             );
         } catch (e) {
             revert.discard();
-            // A cancel that did not happen leaves the run as it was, driver included. A run this process was
-            // never attached to has no driver to restore, and driving one would overwrite the stored record.
-            if (this.internal.runs.isAttached(record.runId)) {
-                this.#redrive(record, bound);
-            }
+            this.#restoreDriver(record, bound);
             throw e;
         }
         this.internal.runs.commitRetirement(record);
@@ -585,8 +659,215 @@ export class TaskManagerBehavior extends Behavior {
         // Resolved from the rollback that exists rather than from what this call prepared: a second cancel that
         // raced this one must be told about the rollback the first created, not told there was nothing to roll
         // back — and it may reach here before the write recording the link has landed.
-        const rollback = this.internal.runs.rollbackOf(record.runId)?.runId ?? record.revertRunId;
-        return rollback === undefined ? undefined : this.get(rollback);
+        const rollback = this.internal.runs.rollbackFor(record.runId);
+        return rollback === undefined ? undefined : this.#handle(rollback);
+    }
+
+    /**
+     * Give up on a rollback whose undo cannot be completed — a node physically removed, so the rollback parks
+     * forever, and while it lives nothing new is admitted against the target of the run it undoes.
+     *
+     * Takes the *rollback's* identity, which a caller holding the original reads from `status.revertRunId`. One
+     * verb, one mutation: accepting either identity would make the same call write different records depending
+     * on which one the caller happened to hold.
+     *
+     * The rollback ends {@link TaskState} `abandoned` rather than `cancelled` or `failed`: the device is
+     * knowingly left part-changed, which is neither an undo nobody needed nor one worth retrying. Idempotent.
+     */
+    async abandon(runId: RunId, reason?: string): Promise<TaskHandle> {
+        for (let pending = this.#pendingTransition(runId); pending !== undefined;) {
+            await pending;
+            pending = this.#pendingTransition(runId);
+        }
+        const record = this.internal.runs.get(runId);
+        if (record === undefined) {
+            throw new TaskNotFoundError(`Cannot abandon ${runLabel(runId)}: no run answers to it`);
+        }
+        if (!this.#needsAbandoning(record)) {
+            return this.#handle(record);
+        }
+
+        // An abandoned tombstone of a rollback nothing recorded would outlive the transaction that was going
+        // to record it.
+        this.#refuseIfProvisional(record, `Cannot abandon ${runLabel(runId)}`);
+        const execution = this.internal.runs.executionOf(runId);
+
+        return this.#transition(record, "abandon", async () => {
+            if (execution !== undefined) {
+                await this.#unwind(execution, this.#stopSignal("abandon", runId));
+                // Its driver may have reached an outcome of its own inside that window. #retire declined to
+                // retire it because this transition owns the run, so retiring it falls here — and before the
+                // decision below, which depends on the state the driver left behind.
+                //
+                // Unconditional on the retirement order, unlike #retire: a terminal record without one is
+                // discarded at load, so nothing can resume it and holding its target buys nothing.
+                if (isTerminal(record.state)) {
+                    this.internal.runs.commitRetirement(record);
+                }
+            }
+
+            // Shutdown took over: the state cannot be persisted, so leave the rollback as it was rather than
+            // claiming an abandonment the next start would contradict.
+            this.#refuseIfClosing(`${runLabel(runId)} cannot be abandoned`);
+
+            // The check at entry answered about the run as it was before the unwind. This one is the decision.
+            if (!this.#needsAbandoning(record)) {
+                return this.#handle(record);
+            }
+
+            try {
+                await this.#commit({
+                    record,
+                    next: {
+                        state: "abandoned",
+                        // Composed rather than replaced: for a rollback that failed on its own, why it could
+                        // not finish is what an operator needs to decide what to do about the device.
+                        error: this.#abandonReason(record.error, reason),
+                        // Absent for a rollback that already retired on its own failure path, which keeps the
+                        // place it took then.
+                        retireSeq: this.internal.runs.nextRetirement(record),
+                    },
+                });
+            } catch (e) {
+                if (execution !== undefined) {
+                    this.#restoreDriver(record, execution.bound);
+                }
+                throw e;
+            }
+            this.internal.runs.commitRetirement(record);
+            return this.#handle(record);
+        });
+    }
+
+    #abandonReason(failure: string | undefined, reason?: string): string {
+        const given = reason === undefined || reason.trim() === "" ? "the undo was abandoned" : reason;
+        return failure === undefined ? given : `${failure} (abandoned: ${given})`;
+    }
+
+    /**
+     * Whether `record` still needs abandoning, throwing if it may not be.
+     *
+     * Asked twice — as an entry filter, and again after the unwind, where it is the decision, because a driver
+     * can reach an outcome of its own in between.
+     */
+    #needsAbandoning(record: RunRecord): boolean {
+        if (record.state === "abandoned") {
+            return false;
+        }
+        if (record.revertOf === undefined) {
+            const rollback = this.internal.runs.rollbackFor(record.runId)?.runId;
+            throw new TaskNotARollbackError(
+                rollback === undefined
+                    ? `Cannot abandon ${runLabel(record.runId)}: it is not a rollback`
+                    : `Cannot abandon ${runLabel(record.runId)}: it is not a rollback; its rollback is ${runLabel(rollback)}`,
+            );
+        }
+        // Another rollback applies to this target now, so abandoning this one forecloses nothing and would
+        // record that an undo still in progress was given up on.
+        const undone = this.internal.runs.get(record.revertOf);
+        const applicable = undone === undefined ? undefined : this.internal.runs.rollbackApplyingTo(undone);
+        if (applicable !== undefined && applicable.runId !== record.runId) {
+            this.#refuseIfProvisional(applicable, `Cannot abandon ${runLabel(record.runId)}`);
+            throw new TaskSupersededError(
+                `Cannot abandon ${runLabel(record.runId)}: ${runLabel(applicable.runId)} is the rollback that now applies to ${undone?.slotKey ?? "its target"}`,
+                applicable.runId,
+            );
+        }
+        if (undoConcluded(record)) {
+            throw new TaskAlreadyUndoneError(
+                `Cannot abandon ${runLabel(record.runId)}: the undo already concluded (${record.state})`,
+            );
+        }
+        return true;
+    }
+
+    /**
+     * Stop driving `execution` and wait for its driver to notice, so the caller owns what happens next.
+     *
+     * Flipping a record's state does not stop a driver: it is sitting in an `await` and will wake and keep
+     * writing. Awaiting it is the only way to know nothing is still writing to the peer when the caller decides
+     * the run's outcome.
+     */
+    async #unwind(execution: Execution, signal: TaskStopSignal): Promise<void> {
+        execution.abort(signal);
+        await execution.promise;
+    }
+
+    /**
+     * Run a transition as the exclusive owner of this run's outcome, refusing if another already owns it.
+     *
+     * Exclusive because a transition stops the driver and only then decides: two of them would decide from the
+     * same pre-transition state, and the loser would either write over the winner's outcome or restore a
+     * second driver over one record. Held for the whole transition rather than for the unwind, so a request
+     * that arrives after the driver stopped but before the write lands is still told the target is draining.
+     */
+    async #transition<T>(record: RunRecord, teardown: Teardown, body: () => Promise<T>): Promise<T> {
+        const held = this.internal.runs.claimTransition(record.runId, teardown);
+        if (held !== undefined) {
+            // Only reachable if a verb skipped #pendingTransition; claiming twice is what this exists to stop.
+            throw new InternalError(`${runLabel(record.runId)}: ${held.teardown} of it already owns its outcome`);
+        }
+        try {
+            return await body();
+        } finally {
+            this.internal.runs.releaseTransition(record.runId);
+        }
+    }
+
+    /**
+     * A transition already deciding this run's outcome, for a caller to wait out before deciding itself.
+     *
+     * A duplicate request is owed the first one's answer — a second cancel is owed the rollback the first
+     * created, a second abandon the handle — so waiting is right where refusing would make the answer depend on
+     * scheduling.
+     *
+     * Deliberately synchronous, and deliberately not a helper that awaits: a verb that awaited even when
+     * nothing was pending would yield before its own claim, which is exactly the window that lets two callers
+     * claim one run.
+     */
+    #pendingTransition(runId: RunId): Promise<void> | undefined {
+        return this.internal.runs.transitionOf(runId)?.settled;
+    }
+
+    /**
+     * Refuse a request whose answer would be a run that storage may yet contradict.
+     *
+     * A rollback is admitted before the transaction naming it lands, and that transaction can be refused — its
+     * producer then discards it as never having existed. Handing back a handle for such a run, or calling
+     * another run superseded because of it, states as fact something the next start would deny. Transient by
+     * construction: the next attempt finds it durable, or finds it gone.
+     *
+     * Asked of every answer derived from a rollback, so no call site has to remember the window.
+     */
+    #refuseIfProvisional(record: RunRecord, subject: string): void {
+        if (!record.recorded) {
+            throw new TaskSlotSettlingError(`${subject}: ${runLabel(record.runId)} is not recorded yet`, record.runId);
+        }
+    }
+
+    /** The stop a driver sees, matching the verb that took over. Never a plain error: #drive would fail the run. */
+    #stopSignal(teardown: Teardown, runId: RunId): TaskStopSignal {
+        return teardown === "cancel"
+            ? new TaskCancelledSignal(`${runLabel(runId)} cancelled`)
+            : new TaskAbandonedSignal(`${runLabel(runId)} abandoned`);
+    }
+
+    /**
+     * Give back the driver an unwind stopped, for a transition the manager then declined.
+     *
+     * A run that keeps its state must keep its driver too, or it sits non-terminal with nothing left to advance
+     * it. A run this process was never attached to never had a driver here, and driving it would write
+     * reconstructed state over whatever the record now holds.
+     */
+    #restoreDriver(record: RunRecord, bound: BoundDefinition): void {
+        // A driver started now would sit outside the dispose drain, which has already taken its snapshot of
+        // what to abort and await. The run keeps its state and the next start resumes it.
+        if (this.#isClosing) {
+            return;
+        }
+        if (this.internal.runs.isAttached(record.runId)) {
+            this.#redrive(record, bound);
+        }
     }
 
     // Teardown starts at the node, not at this behavior: `Construction.close` applies `Destroying` before it runs
@@ -609,8 +890,10 @@ export class TaskManagerBehavior extends Behavior {
         bound: BoundDefinition,
         opts?: { ignoreRecordedRollback?: boolean },
     ): PreparedRevert {
-        // A failed revert surfaces as `failed` for operator attention; reverting a revert would recurse unbounded.
-        if (record.type === REVERT_TYPE) {
+        // A failed rollback surfaces as `failed` for operator attention; rolling one back would recurse
+        // unbounded. Keyed on the link rather than on the type, so it is the same question `cancel` and
+        // `abandon` ask: any definition declaring `undoes` produces a run that undoes another.
+        if (record.revertOf !== undefined) {
             return NO_REVERT;
         }
         // Past a run's point of no return there is nothing to roll back to; suppress auto-rollback too.
@@ -622,7 +905,7 @@ export class TaskManagerBehavior extends Behavior {
         // covers the window before the write recording that link has landed, where a second cancel would
         // otherwise try to create a rollback of its own. Retrying is the one caller that means to replace it.
         if (opts?.ignoreRecordedRollback !== true) {
-            if (record.revertRunId !== undefined || this.internal.runs.rollbackOf(record.runId) !== undefined) {
+            if (this.internal.runs.rollbackFor(record.runId) !== undefined) {
                 return NO_REVERT;
             }
         }
@@ -648,7 +931,7 @@ export class TaskManagerBehavior extends Behavior {
         };
     }
 
-    /** Throw a recorded abort (cancel or shutdown) so the driver stops before persisting or mutating a peer. */
+    /** Throw a recorded abort (a cancel, an abandon or shutdown) so the driver stops before it writes. */
     #throwIfAborted(execution: Execution): void {
         const aborted = execution.gate.aborted;
         if (aborted !== undefined) {
@@ -715,8 +998,9 @@ export class TaskManagerBehavior extends Behavior {
                 await phase.run(ctx);
                 // A cancel accepted while the phase ran must leave phaseIndex on that phase: revertibility is
                 // phase-based, so advancing it can cross a task's point of no return and suppress the rollback.
-                if (execution.cancelling) {
-                    throw new TaskCancelledSignal(`Task ${runLabel(record.runId)} cancelled`);
+                const teardown = this.internal.runs.transitionOf(execution.runId)?.teardown;
+                if (teardown !== undefined) {
+                    throw this.#stopSignal(teardown, record.runId);
                 }
                 await this.#commit({ record, next: { phaseIndex: record.phaseIndex + 1 } });
             }
@@ -729,7 +1013,13 @@ export class TaskManagerBehavior extends Behavior {
             }
         } catch (e) {
             // Shutdown leaves the task non-terminal for resume; cancel is finalized by cancel() itself.
-            if (e instanceof TaskSuspendedSignal || e instanceof TaskCancelledSignal) {
+            // The signal classes are public, so a phase can throw one the manager never asked for. Honoring
+            // that would leave the run non-terminal with nothing driving it and its target held for the life of
+            // the process, so authority is what counts: the recorded abort, or a transition that owns the run.
+            if (
+                e instanceof TaskStopSignal &&
+                (e === execution.gate.aborted || this.internal.runs.transitionOf(execution.runId) !== undefined)
+            ) {
                 return;
             }
             // Teardown: neither the failure nor a rollback of it can be recorded, and the rollback's driving would

--- a/packages/node-manager/src/task/errors.ts
+++ b/packages/node-manager/src/task/errors.ts
@@ -7,60 +7,217 @@
 import { MatterError } from "@matter/general";
 import type { RunId } from "./types.js";
 
+/**
+ * Why a request was refused, as a value rather than as prose.
+ *
+ * A user interface must render a refusal in the reader's language, which a pre-formatted English message cannot
+ * survive. String values, never implicit numerics: a code is logged, and inserting a member must not renumber
+ * the rest.
+ */
+export enum TaskFindingCode {
+    /** A live run holds the target. */
+    SlotOccupied = "slotOccupied",
+
+    /** A cancel or abandon of the run holding the target is unwinding. Transient. */
+    SlotDraining = "slotDraining",
+
+    /** Nothing is advancing the run — stopped, or never started — and its outcome is not durable yet. */
+    SlotSettling = "slotSettling",
+
+    /**
+     * The target's owner exists but nothing in this process is driving it.
+     *
+     * Deliberately promises no remedy: its type may be unregistered, the resume pass may not have run yet, or
+     * the record's stored parameters may have been refused.
+     */
+    SlotAwaitingResume = "slotAwaitingResume",
+
+    /** The requested external id names a live run of a different target. */
+    ExternalIdInUse = "externalIdInUse",
+
+    /** A rollback of the target is in flight and would undo the request's own writes. */
+    RollbackPending = "rollbackPending",
+
+    /** A later run has committed the target, so what this request would restore is historical. */
+    Superseded = "superseded",
+
+    /** The run's task type is not registered, so the question cannot be answered from the record alone. */
+    TypeNotRegistered = "typeNotRegistered",
+
+    /** The manager is shutting down and cannot record an outcome. */
+    ManagerClosing = "managerClosing",
+
+    /** No run answers the given identity. */
+    NotFound = "notFound",
+
+    /** The run has passed its point of no return. */
+    NotRevertible = "notRevertible",
+
+    /** More runs were started than the durable identity reservation covers. */
+    IdentityExhausted = "identityExhausted",
+
+    /** The identity names a run that is not a rollback. */
+    NotARollback = "notARollback",
+
+    /** The undo already concluded, so there is nothing to abandon. */
+    AlreadyUndone = "alreadyUndone",
+
+    /** The rollback was abandoned; an operator declined this undo. */
+    Abandoned = "abandoned",
+
+    /** A rollback is ended with `abandon`, not with `cancel`. */
+    CannotCancelRollback = "cannotCancelRollback",
+}
+
 export class TaskError extends MatterError {}
+
+/**
+ * A request the manager refused, carrying {@link TaskFindingCode} so a caller acts on the cause rather than on
+ * the message.
+ *
+ * An error that ends a *run* is not a refusal and carries no code: nobody is waiting to be told why.
+ */
+export abstract class TaskRefusedError extends TaskError {
+    abstract readonly code: TaskFindingCode;
+}
 
 /** A task referenced a peer that is not commissioned / not present. */
 export class TaskPeerUnavailableError extends TaskError {}
 
-/** A task's forward work failed terminally; the manager spawns a revert task to roll back its changeSet. */
+/** A task's forward work failed terminally; the manager spawns a rollback to undo its changeSet. */
 export class TaskFailedError extends TaskError {}
 
 /** A task's planned changes would exceed a node's device capacity for some item kind. */
 export class TaskCapacityExceededError extends TaskError {}
 
+/** A task refused to run because a member's current intent violates a required precondition. */
+export class RotationPreconditionError extends TaskError {}
+
 /** cancel() was refused: the task passed its point of no return (e.g. a realized group-key rotation). */
-export class TaskNotRevertibleError extends TaskError {}
+export class TaskNotRevertibleError extends TaskRefusedError {
+    override readonly code = TaskFindingCode.NotRevertible;
+}
 
 /**
- * A request was refused because live work already holds the slot it targets, or the external id it asked for,
- * or is rolling that work back. {@link owner} names the run responsible, so a caller can act on it without
- * parsing the message.
+ * A request was refused because other work holds what it asked for: the target it would change, or the external
+ * id it would answer to.
+ *
+ * {@link owner} names the run responsible, so a caller can act on it without parsing the message. Which run
+ * that is follows the {@link code}: usually the one holding the target; for
+ * {@link TaskFindingCode.Superseded} the run whose outcome makes the request pointless; and for
+ * {@link TaskFindingCode.SlotSettling} the run whose outcome is not durable yet, which may be the subject of
+ * the request itself.
  */
-export class TaskConflictError extends TaskError {
+export abstract class TaskConflictError extends TaskRefusedError {
     constructor(
         message: string,
-        readonly owner?: RunId,
+        readonly owner: RunId,
     ) {
         super(message);
     }
 }
 
-/** No run answers to the given name, so there is nothing to observe or act on. */
-export class TaskNotFoundError extends TaskError {}
+/** A live run holds the target this request would change. */
+export class TaskSlotOccupiedError extends TaskConflictError {
+    override readonly code = TaskFindingCode.SlotOccupied;
+}
+
+/** A cancel or abandon of the run holding the target is still unwinding. Transient: retry. */
+export class TaskSlotDrainingError extends TaskConflictError {
+    override readonly code = TaskFindingCode.SlotDraining;
+}
+
+/** Nothing is advancing the run whose outcome the request waits on, and that outcome is not durable yet. */
+export class TaskSlotSettlingError extends TaskConflictError {
+    override readonly code = TaskFindingCode.SlotSettling;
+}
+
+/** The target's owner exists, but nothing in this process is driving it. */
+export class TaskSlotAwaitingResumeError extends TaskConflictError {
+    override readonly code = TaskFindingCode.SlotAwaitingResume;
+}
+
+/** The requested external id already names a live run of a different target. */
+export class TaskExternalIdInUseError extends TaskConflictError {
+    override readonly code = TaskFindingCode.ExternalIdInUse;
+}
+
+/** A rollback of the target is in flight; it rewrites exactly the intents this request would apply. */
+export class TaskRollbackPendingError extends TaskConflictError {
+    override readonly code = TaskFindingCode.RollbackPending;
+}
+
+/** A later run has committed the target, so the values this request would restore are historical. */
+export class TaskSupersededError extends TaskConflictError {
+    override readonly code = TaskFindingCode.Superseded;
+}
+
+/** No run answers to the given identity, so there is nothing to observe or act on. */
+export class TaskNotFoundError extends TaskRefusedError {
+    override readonly code = TaskFindingCode.NotFound;
+}
 
 /**
- * Undo of a finished run needs its task type registered, because whether a run may be rolled back is a
+ * Acting on a finished run needs its task type registered, because whether a run may be rolled back is a
  * decision of the task, not of its record.
  */
-export class TaskTypeNotRegisteredError extends TaskError {}
+export class TaskTypeNotRegisteredError extends TaskRefusedError {
+    override readonly code = TaskFindingCode.TypeNotRegistered;
+}
 
 /**
  * More runs were started than the durable identity reservation covers, before any of their records landed.
  * Handing out an unreserved identity would let the next start re-issue it, so the request is refused instead.
  */
-export class TaskIdentityExhaustedError extends TaskError {}
-
-/** A task refused to run because a member's current intent violates a required precondition. */
-export class RotationPreconditionError extends TaskError {}
+export class TaskIdentityExhaustedError extends TaskRefusedError {
+    override readonly code = TaskFindingCode.IdentityExhausted;
+}
 
 /**
- * A request was refused because the manager is shutting down and could not record its outcome. A cancelled task
- * keeps the non-terminal state it had, so the request must be re-issued after the next start.
+ * A request was refused because the manager is shutting down and could not record its outcome. The run keeps
+ * the non-terminal state it had, so the request must be re-issued after the next start.
  */
-export class TaskManagerClosingError extends TaskError {}
+export class TaskManagerClosingError extends TaskRefusedError {
+    override readonly code = TaskFindingCode.ManagerClosing;
+}
 
-/** Internal signal a running gate throws when cancel is requested, so #drive stops cleanly (not "failed"). */
-export class TaskCancelledSignal extends TaskError {}
+/** `abandon()` names the rollback to give up on, not the run it undoes. */
+export class TaskNotARollbackError extends TaskRefusedError {
+    override readonly code = TaskFindingCode.NotARollback;
+}
 
-/** Internal signal a running gate throws on shutdown so #drive stops without a state change (resume later). */
-export class TaskSuspendedSignal extends TaskError {}
+/**
+ * `abandon()` was refused because the undo already concluded: it either restored the device, or was called off
+ * before it wrote anything. Nothing is left for an operator to give up on.
+ */
+export class TaskAlreadyUndoneError extends TaskRefusedError {
+    override readonly code = TaskFindingCode.AlreadyUndone;
+}
+
+/** An operator abandoned this rollback, so it is not retried: the device is knowingly left in between. */
+export class TaskAbandonedError extends TaskRefusedError {
+    override readonly code = TaskFindingCode.Abandoned;
+}
+
+/**
+ * A rollback is not cancelled. Cancelling one would record it as called off before it mattered, which is
+ * indistinguishable from a rollback nothing needed; `abandon()` says the device is knowingly inconsistent.
+ */
+export class TaskCannotCancelRollbackError extends TaskRefusedError {
+    override readonly code = TaskFindingCode.CannotCancelRollback;
+}
+
+/**
+ * A stop the manager owns, seen by a task's phases as a thrown error. Rethrow if you catch one: swallowing it
+ * drives a run whose fate the manager has already decided.
+ */
+export class TaskStopSignal extends TaskError {}
+
+/** Thrown into a running phase when a cancel is accepted, so #drive stops cleanly (not "failed"). */
+export class TaskCancelledSignal extends TaskStopSignal {}
+
+/** Thrown into a running phase when a rollback is abandoned, so #drive stops without recording a failure. */
+export class TaskAbandonedSignal extends TaskStopSignal {}
+
+/** Thrown into a running phase on shutdown so #drive stops without a state change (resume later). */
+export class TaskSuspendedSignal extends TaskStopSignal {}

--- a/packages/node-manager/src/task/types.ts
+++ b/packages/node-manager/src/task/types.ts
@@ -39,7 +39,14 @@ export function RetireSeq(value: number): RetireSeq {
     return value as RetireSeq;
 }
 
-export type TaskState = "running" | "parked" | "completed" | "failed" | "cancelled";
+/** A verb that takes ownership of a run's outcome, stopping its driver first. */
+export type Teardown = "cancel" | "abandon";
+
+/**
+ * Where a run stands. `abandoned` belongs to rollbacks alone: an operator gave up on the undo, so the device is
+ * knowingly left part-changed and the rollback is never retried.
+ */
+export type TaskState = "running" | "parked" | "completed" | "failed" | "cancelled" | "abandoned";
 
 export interface TaskStatus {
     runId: RunId;

--- a/packages/node-manager/test/task/CancelRobustnessTest.ts
+++ b/packages/node-manager/test/task/CancelRobustnessTest.ts
@@ -5,10 +5,15 @@
  */
 
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
-import { TaskConflictError, TaskFailedError, TaskManagerClosingError } from "#task/errors.js";
+import {
+    TaskFailedError,
+    TaskManagerClosingError,
+    TaskSlotDrainingError,
+    TaskSlotSettlingError,
+} from "#task/errors.js";
 import { RunRecord } from "#task/Task.js";
 import { TaskHandle, TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
-import { TaskPhase, TaskState } from "#task/types.js";
+import { Teardown, TaskPhase, TaskState } from "#task/types.js";
 import { RunId } from "#task/types.js";
 import { CrashedDependencyError, Environment, InternalError, Lifecycle, MaybePromise } from "@matter/general";
 import { Behavior, ClientNode, ItemKind, itemMapKey } from "@matter/node";
@@ -43,9 +48,9 @@ class TestTaskManager extends TaskManagerBehavior {
         return TestTaskManager.peers.get(peerId)?.asNode();
     }
 
-    /** True once cancel() has accepted the request, before it settles. */
-    isCancelling(runId: RunId): boolean {
-        return this.internal.runs.executionOf(runId)?.cancelling === true;
+    /** The verb tearing a run down, once it has accepted the request and before it settles. */
+    teardownOf(runId: RunId): Teardown | undefined {
+        return this.internal.runs.transitionOf(runId)?.teardown;
     }
 
     /** True while a task's drive promise has not settled. */
@@ -221,8 +226,10 @@ describe("cancel robustness", () => {
 
         const cancelling = node.act(a => cancelSlot(a.get(TestTaskManager), "synthetic:pregate"));
         await pumpUntil("cancel accepted", () =>
-            node.act(a =>
-                a.get(TestTaskManager).isCancelling(runIdOfSlot(a.get(TestTaskManager), "synthetic:pregate")!),
+            node.act(
+                a =>
+                    a.get(TestTaskManager).teardownOf(runIdOfSlot(a.get(TestTaskManager), "synthetic:pregate")!) ===
+                    "cancel",
             ),
         );
         state.release();
@@ -341,7 +348,7 @@ describe("cancel robustness", () => {
         expect(handle?.status.revertOf).equals(
             requireRecordFor(node.stateOf(TestTaskManager).runs, "synthetic:cancelrerun").runId,
         );
-        expect(rerun).instanceOf(TaskConflictError);
+        expect(rerun).instanceOf(TaskSlotDrainingError);
 
         const status = await node.act(a => statusOfSlot(a.get(TestTaskManager), "synthetic:cancelrerun"));
         expect(status?.state).equals("cancelled");
@@ -420,8 +427,9 @@ describe("cancel robustness", () => {
         const cancelling = node1.act(a => cancelSlot(a.get(TestTaskManager), "synthetic:queued"));
         // The cancel is accepted before its write is enqueued, and the run adopts the cancelled state only once
         // that write lands — so acceptance, not state, is what says the window is open.
-        await pumpUntil("cancel write enqueued", () =>
-            manager.isCancelling(requireRunIdOfSlot(manager, "synthetic:queued")),
+        await pumpUntil(
+            "cancel write enqueued",
+            () => manager.teardownOf(requireRunIdOfSlot(manager, "synthetic:queued")) === "cancel",
         );
 
         const closing = node1.close();
@@ -736,8 +744,7 @@ describe("cancel robustness", () => {
                 refused = e;
             }
         });
-        expect(refused).instanceOf(TaskConflictError);
-        expect((refused as TaskConflictError).message).contains("settling");
+        expect(refused).instanceOf(TaskSlotSettlingError);
 
         await node.close();
     });

--- a/packages/node-manager/test/task/ErrorTaxonomyTest.ts
+++ b/packages/node-manager/test/task/ErrorTaxonomyTest.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as errors from "#task/errors.js";
+import {
+    RotationPreconditionError,
+    TaskAbandonedError,
+    TaskAbandonedSignal,
+    TaskAlreadyUndoneError,
+    TaskCancelledSignal,
+    TaskCannotCancelRollbackError,
+    TaskCapacityExceededError,
+    TaskConflictError,
+    TaskExternalIdInUseError,
+    TaskFailedError,
+    TaskFindingCode,
+    TaskIdentityExhaustedError,
+    TaskManagerClosingError,
+    TaskNotARollbackError,
+    TaskNotFoundError,
+    TaskNotRevertibleError,
+    TaskPeerUnavailableError,
+    TaskRefusedError,
+    TaskRollbackPendingError,
+    TaskSlotAwaitingResumeError,
+    TaskSlotDrainingError,
+    TaskSlotOccupiedError,
+    TaskSlotSettlingError,
+    TaskSupersededError,
+    TaskSuspendedSignal,
+    TaskTypeNotRegisteredError,
+} from "#task/errors.js";
+import { RunId } from "#task/types.js";
+
+const OWNER = RunId(7);
+
+/**
+ * The one place the class-to-code mapping is pinned. Every other test asserts the class it expects, which says
+ * nothing about the code a caller switches on: a code assigned to the wrong class would leave all of them green.
+ */
+const CODES: Array<[TaskRefusedError, TaskFindingCode]> = [
+    [new TaskSlotOccupiedError("", OWNER), TaskFindingCode.SlotOccupied],
+    [new TaskSlotDrainingError("", OWNER), TaskFindingCode.SlotDraining],
+    [new TaskSlotSettlingError("", OWNER), TaskFindingCode.SlotSettling],
+    [new TaskSlotAwaitingResumeError("", OWNER), TaskFindingCode.SlotAwaitingResume],
+    [new TaskExternalIdInUseError("", OWNER), TaskFindingCode.ExternalIdInUse],
+    [new TaskRollbackPendingError("", OWNER), TaskFindingCode.RollbackPending],
+    [new TaskSupersededError("", OWNER), TaskFindingCode.Superseded],
+    [new TaskNotFoundError(""), TaskFindingCode.NotFound],
+    [new TaskTypeNotRegisteredError(""), TaskFindingCode.TypeNotRegistered],
+    [new TaskNotRevertibleError(""), TaskFindingCode.NotRevertible],
+    [new TaskManagerClosingError(""), TaskFindingCode.ManagerClosing],
+    [new TaskIdentityExhaustedError(""), TaskFindingCode.IdentityExhausted],
+    [new TaskNotARollbackError(""), TaskFindingCode.NotARollback],
+    [new TaskAlreadyUndoneError(""), TaskFindingCode.AlreadyUndone],
+    [new TaskAbandonedError(""), TaskFindingCode.Abandoned],
+    [new TaskCannotCancelRollbackError(""), TaskFindingCode.CannotCancelRollback],
+];
+
+describe("task error taxonomy", () => {
+    it("gives every refusal its own code", () => {
+        for (const [error, code] of CODES) {
+            expect(error.code).equals(code);
+        }
+        // Distinct, so a caller switching on the code can tell the refusals apart.
+        expect(new Set(CODES.map(([, code]) => code)).size).equals(CODES.length);
+        // And exhaustive both ways, so neither a code without a class nor a class without an entry here can be
+        // added silently. Walking the module is what catches the second: a new class reusing an existing code
+        // satisfies the count and the distinctness check on its own.
+        expect(CODES.length).equals(Object.keys(TaskFindingCode).length);
+        const named = new Set(CODES.map(([error]) => error.constructor.name));
+        for (const [name, exported] of Object.entries(errors)) {
+            if (typeof exported !== "function" || !(exported.prototype instanceof TaskRefusedError)) {
+                continue;
+            }
+            // The two abstract bases carry no code of their own and cannot be constructed.
+            if (name === "TaskConflictError") {
+                continue;
+            }
+            expect(named).contains(name);
+        }
+    });
+
+    it("names the run a contention refusal is about", () => {
+        // Required, not optional: a field every producer sets is a field every caller has to guard for nothing.
+        for (const [error] of CODES) {
+            if (error instanceof TaskConflictError) {
+                expect(error.owner).equals(OWNER);
+            }
+        }
+    });
+
+    it("carries a code on refusals only", () => {
+        // An error that ends a run, or stops a driver, is not answering a caller's request.
+        for (const notARefusal of [
+            new TaskFailedError(""),
+            new TaskCapacityExceededError(""),
+            new TaskPeerUnavailableError(""),
+            new RotationPreconditionError(""),
+            new TaskCancelledSignal(""),
+            new TaskAbandonedSignal(""),
+            new TaskSuspendedSignal(""),
+        ]) {
+            expect(notARefusal).not.instanceOf(TaskRefusedError);
+        }
+    });
+});

--- a/packages/node-manager/test/task/RunIdentityTest.ts
+++ b/packages/node-manager/test/task/RunIdentityTest.ts
@@ -5,7 +5,16 @@
  */
 
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
-import { TaskConflictError, TaskIdentityExhaustedError, TaskTypeNotRegisteredError } from "#task/errors.js";
+import {
+    TaskConflictError,
+    TaskExternalIdInUseError,
+    TaskIdentityExhaustedError,
+    TaskRollbackPendingError,
+    TaskSlotAwaitingResumeError,
+    TaskSlotOccupiedError,
+    TaskSupersededError,
+    TaskTypeNotRegisteredError,
+} from "#task/errors.js";
 import { Revert } from "#task/Revert.js";
 import { RUN_ID_RESERVATION, RunStore } from "#task/RunStore.js";
 import { TaskDefinition, TaskPersistence } from "#task/Task.js";
@@ -276,7 +285,7 @@ describe("run identity", () => {
         });
         await settle(node, "synthetic:unwind");
 
-        expect(outcome).instanceOf(TaskConflictError);
+        expect(outcome).instanceOf(TaskSlotOccupiedError);
     });
 
     it("rolls back a run that retired before a restart", async () => {
@@ -340,7 +349,7 @@ describe("run identity", () => {
         } catch (e) {
             refusal = e;
         }
-        expect(refusal).instanceOf(TaskConflictError);
+        expect(refusal).instanceOf(TaskExternalIdInUseError);
         expect((refusal as TaskConflictError).owner).equals(held.runId);
         expect(await node.act(a => a.get(TestTaskManager).forExternalId("mine")?.runId)).equals(held.runId);
     });
@@ -378,7 +387,7 @@ describe("run identity", () => {
         } catch (e) {
             refusal = e;
         }
-        expect(refusal).instanceOf(TaskConflictError);
+        expect(refusal).instanceOf(TaskRollbackPendingError);
         expect((refusal as TaskConflictError).owner).equals(rollback?.runId);
     });
 
@@ -474,7 +483,7 @@ describe("run identity", () => {
         } catch (e) {
             refusal = e;
         }
-        expect(refusal).instanceOf(TaskConflictError);
+        expect(refusal).instanceOf(TaskSupersededError);
         expect((refusal as TaskConflictError).owner).equals(runs[1]);
 
         // The newest run of the slot is still undoable.
@@ -515,7 +524,7 @@ describe("run identity", () => {
         } catch (e) {
             refusal = e;
         }
-        expect(refusal).instanceOf(TaskConflictError);
+        expect(refusal).instanceOf(TaskSlotOccupiedError);
     });
 
     it("gives every concurrent cancel of a run the same rollback", async () => {
@@ -604,7 +613,7 @@ describe("run identity", () => {
         } catch (e) {
             refusal = e;
         }
-        expect(refusal).instanceOf(TaskConflictError);
+        expect(refusal).instanceOf(TaskExternalIdInUseError);
         expect((refusal as TaskConflictError).owner).equals(parked);
     });
 
@@ -708,7 +717,41 @@ describe("run identity", () => {
         } catch (e) {
             refusal = e;
         }
-        expect(refusal).instanceOf(TaskConflictError);
+        expect(refusal).instanceOf(TaskSlotAwaitingResumeError);
         expect((refusal as TaskConflictError).owner).equals(parked);
+    });
+
+    it("refuses to cancel a run whose stored parameters its task no longer accepts", async () => {
+        const environment = persistentEnvironment();
+
+        let parked: RunId;
+        {
+            await using node = await makeNode(environment, "cancelunbuildable");
+            UnbuildableTask.rejectConstruction = false;
+            await node.act(a => a.get(TestTaskManager).register(UnbuildableTask));
+            const handle = await node.act(a => a.get(TestTaskManager).run(UnbuildableTask, { tag: "c" }));
+            parked = handle.runId;
+            await pumpUntil(
+                "the run is recorded",
+                async () =>
+                    (await node.act(a => recordFor(a.get(TestTaskManager).state.runs, "unbuildable:c"))) !== undefined,
+            );
+        }
+
+        // Whether a run may be rolled back is the task's decision, and the task cannot be asked without its
+        // parameters. Surfacing its own refusal says which of the two failed.
+        await using node = await makeNode(environment, "cancelunbuildable");
+        UnbuildableTask.rejectConstruction = true;
+        await node.act(a => a.get(TestTaskManager).register(UnbuildableTask));
+
+        let refusal: unknown;
+        try {
+            await node.act(a => a.get(TestTaskManager).cancel(parked));
+        } catch (e) {
+            refusal = e;
+        }
+        expect(refusal).instanceOf(ImplementationError);
+        expect((refusal as Error).message).contains("malformed persisted parameters");
+        expect(await node.act(a => a.get(TestTaskManager).get(parked)?.status.state)).equals("running");
     });
 });

--- a/packages/node-manager/test/task/TaskLifecycleTest.ts
+++ b/packages/node-manager/test/task/TaskLifecycleTest.ts
@@ -5,7 +5,7 @@
  */
 
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
-import { TaskConflictError, TaskFailedError, TaskIdentityExhaustedError } from "#task/errors.js";
+import { TaskFailedError, TaskIdentityExhaustedError, TaskRollbackPendingError } from "#task/errors.js";
 import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { TaskPhase } from "#task/types.js";
 import { RunId } from "#task/types.js";
@@ -335,7 +335,7 @@ describe("Task lifecycle", () => {
             // Re-running now would re-apply exactly the intents the rollback is removing.
             await expect(
                 (async () => node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "rerun" })))(),
-            ).rejectedWith(TaskConflictError);
+            ).rejectedWith(TaskRollbackPendingError);
 
             peer.setReachable(true);
             await awaitState(

--- a/packages/node-manager/test/task/TaskManagerBehaviorTest.ts
+++ b/packages/node-manager/test/task/TaskManagerBehaviorTest.ts
@@ -5,7 +5,7 @@
  */
 
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
-import { TaskConflictError, TaskFailedError, TaskNotFoundError } from "#task/errors.js";
+import { TaskFailedError, TaskNotFoundError, TaskSlotOccupiedError } from "#task/errors.js";
 import { RotateGroupKey } from "#task/groups/RotateGroupKey.js";
 import { TaskDefinition, RunRecord } from "#task/Task.js";
 import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
@@ -175,7 +175,7 @@ describe("TaskManagerBehavior", () => {
             // `act` returns a MaybePromise, so normalize before asserting on the rejection.
             await expect(
                 (async () => node.act(a => a.get(TaskManagerBehavior).run(SyntheticTask, { tag: "dup" })))(),
-            ).rejectedWith(TaskConflictError);
+            ).rejectedWith(TaskSlotOccupiedError);
             expect(runs).equals(1);
             expect(await node.act(a => a.get(TaskManagerBehavior).tasks.length)).equals(1);
         } finally {
@@ -236,7 +236,7 @@ describe("TaskManagerBehavior", () => {
                     node.act(a =>
                         a.get(TaskManagerBehavior).run(SyntheticTask, { tag: "mine" }, { externalId: "other" }),
                     ))(),
-            ).rejectedWith(TaskConflictError);
+            ).rejectedWith(TaskSlotOccupiedError);
             expect(runs).equals(1);
             expect(await node.act(a => a.get(TaskManagerBehavior).tasks.length)).equals(1);
         } finally {
@@ -380,7 +380,7 @@ describe("TaskManagerBehavior", () => {
             async () => (await node.act(a => a.get(TracingTaskManager).tasks.length)) === 0,
         );
 
-        expect(outcome).instanceOf(TaskConflictError);
+        expect(outcome).instanceOf(TaskSlotOccupiedError);
         expect(runs).equals(1);
     });
 

--- a/packages/node-manager/test/task/TransitionsTest.ts
+++ b/packages/node-manager/test/task/TransitionsTest.ts
@@ -1,0 +1,987 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
+import {
+    TaskAbandonedError,
+    TaskAbandonedSignal,
+    TaskAlreadyUndoneError,
+    TaskCancelledSignal,
+    TaskCannotCancelRollbackError,
+    TaskManagerClosingError,
+    TaskNotARollbackError,
+    TaskNotFoundError,
+    TaskRollbackPendingError,
+    TaskSlotDrainingError,
+    TaskSlotSettlingError,
+    TaskSupersededError,
+} from "#task/errors.js";
+import { TaskDefinition } from "#task/Task.js";
+import { RunRecord } from "#task/Task.js";
+import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
+import { RunId, TaskPhase } from "#task/types.js";
+import { Environment, ImplementationError, InternalError, Lifecycle, MaybePromise } from "@matter/general";
+import { ClientNode, itemMapKey, ServerNode } from "@matter/node";
+import { MockServerNode } from "@matter/node/testing";
+import { FakePeer, liveRecord, onPersisted, SyntheticTask } from "./helpers.js";
+
+class TestTaskManager extends TaskManagerBehavior {
+    static override readonly schema = TaskManagerBehavior.schema;
+    static peers = new Map<string, FakePeer>();
+    static reconcilerPeer?: FakePeer;
+    /** Set to leave a persisted rollback with no driver, as a start before `Revert` is available would. */
+    static omitRevert = false;
+
+    protected override resolvePeerNode(peerId: string): ClientNode | undefined {
+        return TestTaskManager.peers.get(peerId)?.asNode();
+    }
+    protected override taskReconciler(): ReconcilerBehavior {
+        return TestTaskManager.reconcilerPeer as unknown as ReconcilerBehavior;
+    }
+    protected override registerBuiltins() {
+        if (!TestTaskManager.omitRevert) {
+            super.registerBuiltins();
+        }
+    }
+
+    /** What a run's driver was told to stop for, as its phases would see it. */
+    abortOf(runId: RunId) {
+        return this.internal.runs.executionOf(runId)?.gate.aborted;
+    }
+
+    /** The verb tearing a run down, while it is in charge. */
+    teardownOf(runId: RunId) {
+        return this.internal.runs.transitionOf(runId)?.teardown;
+    }
+
+    isAttached(runId: RunId) {
+        return this.internal.runs.isAttached(runId);
+    }
+
+    isDriven(runId: RunId) {
+        const execution = this.internal.runs.executionOf(runId);
+        return execution !== undefined && !execution.settled;
+    }
+
+    /** The execution object driving a run. A restored driver is a *new* one, which is what identity proves. */
+    executionOf(runId: RunId) {
+        return this.internal.runs.executionOf(runId);
+    }
+
+    resumableRunIds() {
+        return this.internal.runs.resumable.map(r => r.runId);
+    }
+
+    record(runId: RunId) {
+        return this.internal.runs.get(runId);
+    }
+
+    /**
+     * Delay the moment this run's driver *appears* to stop, so a test can act inside the window between the
+     * abort and the write that ends the run. The real driver still stops; only its observation is held.
+     */
+    holdDriverStop(runId: RunId): () => void {
+        const execution = this.internal.runs.executionOf(runId);
+        if (execution?.promise === undefined) {
+            throw new InternalError(`Run #${runId} is not driving`);
+        }
+        let release = () => {};
+        const held = new Promise<void>(resolve => (release = resolve));
+        execution.promise = execution.promise.then(() => held);
+        return release;
+    }
+
+    /**
+     * Adopt the outcome a driver would have reached, for a test that needs that to happen inside a window a
+     * driver cannot be stopped in.
+     *
+     * Adopts without writing, which the manager never does — a driver adopts only once its write has landed.
+     * That is enough here because what is under test is which decision the transition takes from the state it
+     * finds, and it reads memory; nothing in these tests asserts durability of the outcome itself.
+     */
+    reachOutcome(runId: RunId, state: "completed" | "failed", error?: string) {
+        const record = this.internal.runs.get(runId);
+        if (record === undefined) {
+            throw new InternalError(`No run #${runId}`);
+        }
+        record.retireSeq = this.internal.runs.nextRetirement(record);
+        record.state = state;
+        record.error = error;
+        return record.retireSeq;
+    }
+
+    holdPersistMutex(): () => void {
+        const mutex = this.internal.persistMutex;
+        if (mutex === undefined) {
+            throw new InternalError("The persist mutex does not exist yet; run a task first");
+        }
+        let release = () => {};
+        const held = new Promise<void>(resolve => (release = resolve));
+        mutex.run(() => held);
+        return release;
+    }
+
+    async closePersistMutex() {
+        await this.internal.persistMutex?.close();
+    }
+}
+
+const RootEndpoint = MockServerNode.RootEndpoint.with(TestTaskManager);
+
+const KEY = itemMapKey("groupMembership", "X");
+
+function testPeer(id: string) {
+    const peer = new FakePeer(id);
+    TestTaskManager.peers.set(id, peer);
+    TestTaskManager.reconcilerPeer = peer;
+    return peer;
+}
+
+async function makeNode(environment?: Environment, id = "abandon") {
+    return MockServerNode.create(RootEndpoint, { environment, id });
+}
+
+async function pumpUntil(name: string, condition: () => MaybePromise<boolean>) {
+    for (let i = 0; i < 10_000; i++) {
+        if (await condition()) {
+            return;
+        }
+        await MockTime.advance(1);
+    }
+    throw new InternalError(`Condition "${name}" never held`);
+}
+
+/** A phase that writes one intent the device never confirms, so the run parks owning its target. */
+function gatingPhase(peerId: string): TaskPhase {
+    return {
+        name: "hold",
+        run: async ctx => {
+            const peer = ctx.resolvePeer(peerId);
+            await ctx.setIntent(peer, "groupMembership", "X", { v: 2 });
+            await ctx.awaitCommitted([{ peer, kind: "groupMembership", key: "X" }]);
+        },
+    };
+}
+
+/**
+ * A run parked with an unreachable peer, cancelled so its rollback parks too.
+ *
+ * The rollback is what these tests act on, and it has to be non-terminal and driving: one that had finished
+ * would answer a different question.
+ */
+async function parkedRollback(node: ServerNode, tag: string, peer: FakePeer) {
+    SyntheticTask.phasesByTag[tag] = [gatingPhase(peer.id)];
+    await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
+    const original = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag }));
+    await pumpUntil("intent written", () => peer.items[KEY] !== undefined);
+
+    peer.setReachable(false);
+    const rollback = await node.act(a => a.get(TestTaskManager).cancel(original.runId));
+    if (rollback === undefined) {
+        throw new InternalError("cancel produced no rollback");
+    }
+    await pumpUntil("rollback parked", () =>
+        node.act(a => a.get(TestTaskManager).get(rollback.runId)?.status.state === "parked"),
+    );
+    return { original, rollback };
+}
+
+/**
+ * A run whose rollback failed: the rollback restores a prior value and the reconciler then drops the intent it
+ * is waiting for, so its gate can never commit. Only a failed rollback is out of flight and retryable.
+ */
+async function failedRollback(node: ServerNode, tag: string, peer: FakePeer) {
+    peer.setIntent("groupMembership", "X", { v: 1 });
+    SyntheticTask.phasesByTag[tag] = [gatingPhase(peer.id)];
+    await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
+    const original = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag }));
+    await pumpUntil("intent written", () => (peer.items[KEY]?.intent as { v?: number })?.v === 2);
+
+    const first = await node.act(a => a.get(TestTaskManager).cancel(original.runId));
+    if (first === undefined) {
+        throw new InternalError("cancel produced no rollback");
+    }
+    await pumpUntil("rollback restoring", () => (peer.items[KEY]?.intent as { v?: number })?.v === 1);
+    peer.dropItem("groupMembership", "X");
+    // Retired, not merely terminal: a rollback whose driver has not handed back its responsibility yet still
+    // reads as in flight, and a retry would be refused for that instead.
+    await pumpUntil("rollback failed and retired", () =>
+        node.act(a => {
+            const manager = a.get(TestTaskManager);
+            return manager.get(first.runId)?.status.state === "failed" && !manager.isAttached(first.runId);
+        }),
+    );
+    return { original, first };
+}
+
+async function statusOf(node: ServerNode, runId: RunId) {
+    return node.act(a => a.get(TestTaskManager).get(runId)?.status);
+}
+
+async function attempt<T>(node: ServerNode, fn: (manager: TestTaskManager) => Promise<T>) {
+    return node.act(async a => {
+        try {
+            return await fn(a.get(TestTaskManager));
+        } catch (e) {
+            return e;
+        }
+    });
+}
+
+/** A caller-creatable definition that declares it undoes another run, which is what makes it a rollback. */
+const UndoingTask: TaskDefinition<{ tag: string }> = {
+    type: "undoer",
+    slotKeyFor: params => `undoer:${params.tag}`,
+    phases: () => [{ name: "hold", run: () => new Promise<void>(() => {}) }],
+    // A run that no longer exists, so nothing else about admission depends on the link.
+    undoes: () => RunId(9_999),
+};
+
+let legacyRollbackId: RunId;
+
+function reset() {
+    TestTaskManager.peers.clear();
+    TestTaskManager.reconcilerPeer = undefined;
+    TestTaskManager.omitRevert = false;
+    for (const tag of Object.keys(SyntheticTask.phasesByTag)) {
+        delete SyntheticTask.phasesByTag[tag];
+    }
+}
+
+describe("abandon", () => {
+    before(() => MockTime.init());
+    beforeEach(reset);
+
+    it("ends a parked rollback, retires it, and frees the target of the run it undoes", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("free");
+        const { original, rollback } = await parkedRollback(node, "free", peer);
+
+        const handle = await node.act(a => a.get(TestTaskManager).abandon(rollback.runId, "the node was removed"));
+
+        expect(handle.status.state).equals("abandoned");
+        expect(handle.status.error).equals("the node was removed");
+        expect(handle.status.retireSeq).not.equals(undefined);
+        expect(await node.act(a => a.get(TestTaskManager).tasks.map(t => t.runId))).not.contains(rollback.runId);
+        expect(
+            await node.act(a =>
+                a
+                    .get(TestTaskManager)
+                    .history()
+                    .map(h => h.runId),
+            ),
+        ).contains(rollback.runId);
+        expect(await node.act(a => a.get(TestTaskManager).isAttached(rollback.runId))).equals(false);
+
+        // The original still names the rollback: how the undo ended is the rollback's own state to tell.
+        expect((await statusOf(node, original.runId))?.revertRunId).equals(rollback.runId);
+
+        // The point of the verb: work against that target is admissible again.
+        const rerun = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "free" }));
+        expect(rerun.status.slotKey).equals("synthetic:free");
+    });
+
+    it("leaves nothing for the next start to drive", async () => {
+        const environment = new Environment("abandon-restart");
+        let rollbackId: RunId;
+        {
+            await using first = await makeNode(environment, "restart");
+            const peer = testPeer("restart");
+            const { rollback } = await parkedRollback(first, "restart", peer);
+            rollbackId = rollback.runId;
+            await first.act(a => a.get(TestTaskManager).abandon(rollbackId));
+        }
+
+        await using node = await makeNode(environment, "restart");
+        await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
+
+        // A state the store does not count as terminal is re-slotted and resumed at load, which drives an undo
+        // the operator declined — against the device, with nothing left to refuse it.
+        expect(await node.act(a => a.get(TestTaskManager).resumableRunIds())).not.contains(rollbackId);
+        expect(await node.act(a => a.get(TestTaskManager).tasks.map(t => t.runId))).not.contains(rollbackId);
+        expect(
+            await node.act(a =>
+                a
+                    .get(TestTaskManager)
+                    .history()
+                    .map(h => h.runId),
+            ),
+        ).contains(rollbackId);
+        expect((await statusOf(node, rollbackId))?.state).equals("abandoned");
+    });
+
+    it("records nothing until the driver has stopped", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("order");
+        const { rollback } = await parkedRollback(node, "order", peer);
+
+        const written = new Array<string>();
+        await node.act(a => {
+            const manager = a.get(TestTaskManager);
+            onPersisted(liveRecord(manager, rollback.runId), snapshot => written.push(snapshot.state));
+        });
+
+        // The driver's stop is not observed until released, so anything written meanwhile was written without
+        // waiting for it.
+        const release = await node.act(a => a.get(TestTaskManager).holdDriverStop(rollback.runId));
+        const abandoning = node.act(a => a.get(TestTaskManager).abandon(rollback.runId));
+        await pumpUntil("abandon in flight", () =>
+            node.act(a => a.get(TestTaskManager).teardownOf(rollback.runId) === "abandon"),
+        );
+
+        expect(written).not.contains("abandoned");
+        // "failed" would mean the stop the driver saw was not one it recognises, so it took the failure path
+        // and raced this call's own write.
+        expect(written).not.contains("failed");
+
+        release();
+        await abandoning;
+        expect(written).contains("abandoned");
+    });
+
+    it("makes a second request wait for the first and answer from it", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("dup");
+        const { rollback } = await parkedRollback(node, "dup", peer);
+
+        let writes = 0;
+        await node.act(a => {
+            onPersisted(liveRecord(a.get(TestTaskManager), rollback.runId), snapshot => {
+                if (snapshot.state === "abandoned") {
+                    writes++;
+                }
+            });
+        });
+
+        // The first request's write is held, so the second provably arrives while the first still owns the
+        // run: overlap by construction rather than by scheduling. Refusing the loser would make the answer
+        // depend on that scheduling; two winners would put two drivers on one record.
+        const release = await node.act(a => a.get(TestTaskManager).holdPersistMutex());
+        const first = node.act(a => a.get(TestTaskManager).abandon(rollback.runId));
+        await pumpUntil("first request owns the run", () =>
+            node.act(a => a.get(TestTaskManager).teardownOf(rollback.runId) === "abandon"),
+        );
+        const second = node.act(a => a.get(TestTaskManager).abandon(rollback.runId));
+        release();
+
+        const [firstHandle, secondHandle] = await MockTime.resolve(Promise.all([first, second]), {
+            macrotasks: true,
+        });
+
+        expect(firstHandle.runId).equals(rollback.runId);
+        expect(secondHandle.runId).equals(rollback.runId);
+        expect(secondHandle.status.state).equals("abandoned");
+        expect(writes).equals(1);
+    });
+
+    it("retires and refuses a rollback that reached its own outcome inside the window", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("late");
+        const { original, rollback } = await parkedRollback(node, "late", peer);
+
+        // The driver's stop is observed only after the test has done what a completing driver would do, so the
+        // decision the abandon takes is the one made *after* the unwind.
+        const release = await node.act(a => a.get(TestTaskManager).holdDriverStop(rollback.runId));
+        const abandoning = attempt(node, m => m.abandon(rollback.runId));
+        await pumpUntil("abandon in flight", () =>
+            node.act(a => a.get(TestTaskManager).teardownOf(rollback.runId) === "abandon"),
+        );
+        await node.act(a => a.get(TestTaskManager).reachOutcome(rollback.runId, "completed"));
+        release();
+
+        expect(await abandoning).instanceOf(TaskAlreadyUndoneError);
+        expect((await statusOf(node, rollback.runId))?.state).equals("completed");
+        // Retired despite the refusal: #retire declined to, because the teardown was in charge, and a rollback
+        // left holding its target would refuse every future run of the original's target for this process.
+        expect(await node.act(a => a.get(TestTaskManager).tasks.map(t => t.runId))).not.contains(rollback.runId);
+        const rerun = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "late" }));
+        expect(rerun.status.slotKey).equals("synthetic:late");
+        expect((await statusOf(node, original.runId))?.revertRunId).equals(rollback.runId);
+    });
+
+    it("abandons a rollback that failed inside the window, keeping its order and its reason", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("failed");
+        const { rollback } = await parkedRollback(node, "failed", peer);
+
+        const release = await node.act(a => a.get(TestTaskManager).holdDriverStop(rollback.runId));
+        const abandoning = node.act(a => a.get(TestTaskManager).abandon(rollback.runId, "the node is gone"));
+        await pumpUntil("abandon in flight", () =>
+            node.act(a => a.get(TestTaskManager).teardownOf(rollback.runId) === "abandon"),
+        );
+        const retireSeq = await node.act(a =>
+            a.get(TestTaskManager).reachOutcome(rollback.runId, "failed", "device refused"),
+        );
+        release();
+
+        const handle = await abandoning;
+        expect(handle.status.state).equals("abandoned");
+        // The place it took when it failed: a second stamp would sort it after runs that finished later.
+        expect(handle.status.retireSeq).equals(retireSeq);
+        // Why the undo could not finish is what an operator needs to decide about the part-changed device, so
+        // recording the decision must not erase it.
+        expect(handle.status.error).contains("device refused");
+        expect(handle.status.error).contains("the node is gone");
+    });
+
+    it("stops the driver with a signal #drive knows, naming the abandon", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("signal");
+        const { rollback } = await parkedRollback(node, "signal", peer);
+
+        const release = await node.act(a => a.get(TestTaskManager).holdDriverStop(rollback.runId));
+        const abandoning = node.act(a => a.get(TestTaskManager).abandon(rollback.runId));
+        await pumpUntil("abandon in flight", () =>
+            node.act(a => a.get(TestTaskManager).teardownOf(rollback.runId) === "abandon"),
+        );
+
+        // A stop the driver does not recognise takes its failure path and commits `failed`, racing this call's
+        // own write; one that said "cancelled" would misreport in whatever a phase logs.
+        expect(await node.act(a => a.get(TestTaskManager).abortOf(rollback.runId))).instanceOf(TaskAbandonedSignal);
+
+        release();
+        await abandoning;
+    });
+
+    it("is idempotent and writes nothing the second time", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("twice");
+        const { rollback } = await parkedRollback(node, "twice", peer);
+
+        await node.act(a => a.get(TestTaskManager).abandon(rollback.runId));
+
+        let writes = 0;
+        await node.act(a => {
+            const record = a.get(TestTaskManager).record(rollback.runId) as RunRecord;
+            onPersisted(record, () => writes++);
+        });
+        const second = await node.act(a => a.get(TestTaskManager).abandon(rollback.runId));
+
+        expect(second.status.state).equals("abandoned");
+        // Asserted on the write, not on the state: a second write of the same value leaves the state right.
+        expect(writes).equals(0);
+    });
+
+    it("leaves the undone run's record untouched", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("untouched");
+        const { original, rollback } = await parkedRollback(node, "untouched", peer);
+
+        const persisted = () =>
+            node.act(a => JSON.stringify(a.get(TestTaskManager).state.runs[String(original.runId)]));
+        const before = await persisted();
+        await node.act(a => a.get(TestTaskManager).abandon(rollback.runId));
+        expect(await persisted()).equals(before);
+    });
+
+    it("refuses a run of the undone target while the abandon is in flight", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("drain");
+        const { rollback } = await parkedRollback(node, "drain", peer);
+
+        // The write is held, not the driver: most of an abandon's flight is *after* its driver has stopped, and
+        // a refusal that only covered the unwind would report the wrong thing for the rest of it.
+        const release = await node.act(a => a.get(TestTaskManager).holdPersistMutex());
+        const abandoning = node.act(a => a.get(TestTaskManager).abandon(rollback.runId));
+        await pumpUntil("abandon past its driver", () =>
+            node.act(a => {
+                const manager = a.get(TestTaskManager);
+                return manager.teardownOf(rollback.runId) === "abandon" && !manager.isDriven(rollback.runId);
+            }),
+        );
+
+        const refusal = await node.act(a => {
+            try {
+                return a.get(TestTaskManager).run(SyntheticTask, { tag: "drain" });
+            } catch (e) {
+                return e;
+            }
+        });
+        release();
+        await abandoning;
+
+        // Transient, and reported as such: the rollback is about to release the target. The run this rollback
+        // undoes retired when the rollback was created, so nothing owns its target and only the pending-rollback
+        // step of admission sees the transition at all.
+        expect(refusal).instanceOf(TaskSlotDrainingError);
+    });
+
+    it("refuses a rollback whose own record is not durable yet", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("settling");
+        SyntheticTask.phasesByTag["settling"] = [gatingPhase("settling")];
+        await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
+        const original = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "settling" }));
+        await pumpUntil("intent written", () => peer.items[KEY] !== undefined);
+        peer.setReachable(false);
+
+        // The cancel's write is held, so its rollback is admitted but not yet driving.
+        const release = await node.act(a => a.get(TestTaskManager).holdPersistMutex());
+        const cancelling = node.act(a => a.get(TestTaskManager).cancel(original.runId));
+        let rollbackId: RunId | undefined;
+        await pumpUntil("rollback admitted", () =>
+            node.act(a => {
+                rollbackId = a.get(TestTaskManager).tasks.find(t => t.status.revertOf === original.runId)?.runId;
+                return rollbackId !== undefined;
+            }),
+        );
+
+        const refusal = await attempt(node, m => m.abandon(rollbackId!));
+        release();
+        await cancelling;
+
+        expect(refusal).instanceOf(TaskSlotSettlingError);
+    });
+
+    it("abandons a persisted rollback that nothing is driving", async () => {
+        const environment = new Environment("abandon-unattached");
+        let rollbackId: RunId;
+        {
+            await using first = await makeNode(environment, "unattached");
+            const peer = testPeer("unattached");
+            const { rollback } = await parkedRollback(first, "unattached", peer);
+            rollbackId = rollback.runId;
+        }
+
+        // Nothing registers the rollback's type on this start, so its record has no driver at all.
+        TestTaskManager.omitRevert = true;
+        await using node = await makeNode(environment, "unattached");
+        expect(await node.act(a => a.get(TestTaskManager).isAttached(rollbackId))).equals(false);
+
+        const handle = await node.act(a => a.get(TestTaskManager).abandon(rollbackId));
+        expect(handle.status.state).equals("abandoned");
+        expect(await node.act(a => a.get(TestTaskManager).resumableRunIds())).not.contains(rollbackId);
+    });
+
+    it("leaves the rollback unfinished and driven again when its own write is refused", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("norecord");
+        const { rollback } = await parkedRollback(node, "norecord", peer);
+
+        const before = await node.act(a => a.get(TestTaskManager).executionOf(rollback.runId));
+
+        // A closed mutex rejects the write on a node that is otherwise healthy, so this is a storage failure
+        // rather than shutdown.
+        await node.act(a => a.get(TestTaskManager).closePersistMutex());
+
+        const outcome = await attempt(node, m => m.abandon(rollback.runId));
+
+        expect(outcome).instanceOf(Error);
+        expect(outcome).not.instanceOf(TaskManagerClosingError);
+        // Non-terminal, so the next start can still resume it. `running` rather than `parked` because a
+        // restored driver re-parks from live reachability rather than trusting the old note.
+        expect((await statusOf(node, rollback.runId))?.state).equals("running");
+        // The driver is given back — a rollback that keeps its state with nothing advancing it is stranded.
+        // Asserted by identity: with storage refusing every write, the restored driver stops again at once, so
+        // liveness would say nothing.
+        const after = await node.act(a => a.get(TestTaskManager).executionOf(rollback.runId));
+        expect(after).not.equals(undefined);
+        expect(after).not.equals(before);
+    });
+
+    it("refuses while the manager is shutting down, leaving the rollback unfinished", async () => {
+        const node = await makeNode(new Environment("abandon-closing"), "closing");
+        const peer = testPeer("closing");
+        const { rollback } = await parkedRollback(node, "closing", peer);
+
+        // Held from before the close: `act` on a closing node refuses on its own, which would prove nothing
+        // about the refusal under test.
+        const manager = await node.act(a => a.get(TestTaskManager));
+        const driving = manager.executionOf(rollback.runId);
+        const closing = node.close();
+        await pumpUntil("node no longer active", () => node.construction.status !== Lifecycle.Status.Active);
+        let outcome: unknown = "abandoned";
+        try {
+            await manager.abandon(rollback.runId);
+        } catch (e) {
+            outcome = e;
+        }
+        await closing;
+
+        expect(outcome).instanceOf(TaskManagerClosingError);
+        // No fresh driver: the dispose drain has already taken its snapshot of what to abort and await, so one
+        // started now would run outside it, on an endpoint that refuses every write.
+        expect(manager.executionOf(rollback.runId)).equals(driving);
+    });
+
+    it("refuses an identity nothing answers to", async () => {
+        await using node = await makeNode();
+        expect(await attempt(node, m => m.abandon(RunId(Number.MAX_SAFE_INTEGER)))).instanceOf(TaskNotFoundError);
+    });
+
+    it("refuses a run that never had a rollback", async () => {
+        await using node = await makeNode();
+        testPeer("plain");
+        SyntheticTask.phasesByTag["plain"] = [{ name: "a", run: async () => {} }];
+        await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
+        const handle = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "plain" }));
+        await pumpUntil("run finished", () =>
+            node.act(a => a.get(TestTaskManager).get(handle.runId)?.status.state === "completed"),
+        );
+
+        const outcome = await attempt(node, m => m.abandon(handle.runId));
+        expect(outcome).instanceOf(TaskNotARollbackError);
+        expect((outcome as Error).message).not.contains("its rollback is");
+    });
+
+    it("refuses a run that is not a rollback, naming the rollback it has", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("forward");
+        const { original, rollback } = await parkedRollback(node, "forward", peer);
+
+        const outcome = await attempt(node, m => m.abandon(original.runId));
+
+        expect(outcome).instanceOf(TaskNotARollbackError);
+        expect((outcome as Error).message).contains(`#${rollback.runId}`);
+    });
+
+    it("waits out a retry being admitted rather than calling the old rollback superseded", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("retryrace");
+        const { original, first } = await failedRollback(node, "retryrace", peer);
+
+        // The retry's write is held, so its replacement is admitted but the original does not name it yet.
+        // Reading that link instead of the live set is what would let this abandon through.
+        const release = await node.act(a => a.get(TestTaskManager).holdPersistMutex());
+        const retrying = node.act(a => a.get(TestTaskManager).retryRollback(original.runId));
+        await pumpUntil("replacement admitted", () =>
+            node.act(a =>
+                a.get(TestTaskManager).tasks.some(t => t.status.revertOf === original.runId && t.runId !== first.runId),
+            ),
+        );
+        expect((await statusOf(node, original.runId))?.revertRunId).equals(first.runId);
+
+        const outcome = await attempt(node, m => m.abandon(first.runId));
+        release();
+        await retrying;
+
+        // Transient, not `Superseded`: if the retry's write were refused it would be discarded and this
+        // rollback would still be the one that applies, so nothing is settled yet.
+        expect(outcome).instanceOf(TaskSlotSettlingError);
+    });
+
+    it("refuses to answer for a rollback that is not recorded yet", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("provisional");
+        const { original, first } = await failedRollback(node, "provisional", peer);
+
+        // A retry admits its replacement and holds no claim on the run it relinks, so a cancel can arrive while
+        // that replacement exists only in memory.
+        const release = await node.act(a => a.get(TestTaskManager).holdPersistMutex());
+        const retrying = node.act(a => a.get(TestTaskManager).retryRollback(original.runId));
+        await pumpUntil("replacement admitted", () =>
+            node.act(a =>
+                a.get(TestTaskManager).tasks.some(t => t.status.revertOf === original.runId && t.runId !== first.runId),
+            ),
+        );
+
+        const outcome = await attempt(node, m => m.cancel(original.runId));
+        release();
+        await retrying;
+
+        // A handle for a run the producer may still discard would be a receipt for something that never
+        // existed.
+        expect(outcome).instanceOf(TaskSlotSettlingError);
+    });
+
+    it("tells a replacement it is not driving yet, not that it was superseded", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("replacement");
+        const { original, first } = await failedRollback(node, "replacement", peer);
+
+        // Inside the retry's persistence window the original still names the rollback being replaced, so a
+        // request about the *replacement* must not read that link and conclude the replacement is the stale one.
+        const release = await node.act(a => a.get(TestTaskManager).holdPersistMutex());
+        const retrying = node.act(a => a.get(TestTaskManager).retryRollback(original.runId));
+        let replacementId: RunId | undefined;
+        await pumpUntil("replacement admitted", () =>
+            node.act(a => {
+                replacementId = a
+                    .get(TestTaskManager)
+                    .tasks.find(t => t.status.revertOf === original.runId && t.runId !== first.runId)?.runId;
+                return replacementId !== undefined;
+            }),
+        );
+        expect((await statusOf(node, original.runId))?.revertRunId).equals(first.runId);
+
+        const outcome = await attempt(node, m => m.abandon(replacementId!));
+        release();
+        await retrying;
+
+        // Transient — it is about to be driving — where `Superseded` would tell the caller to stop trying.
+        expect(outcome).instanceOf(TaskSlotSettlingError);
+    });
+
+    it("refuses a rollback whose replacement has already finished", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("finished");
+        const { original, first } = await failedRollback(node, "finished", peer);
+
+        const retry = await node.act(a => a.get(TestTaskManager).retryRollback(original.runId));
+        peer.markHas("groupMembership", "X");
+        await pumpUntil("replacement finished", () =>
+            node.act(a => {
+                const manager = a.get(TestTaskManager);
+                return (
+                    manager.get(retry.runId)?.status.state === "completed" &&
+                    !manager.tasks.some(t => t.runId === retry.runId)
+                );
+            }),
+        );
+
+        // Nothing is live now, so the recorded link is what answers — the fallback the live set cannot cover.
+        const outcome = await attempt(node, m => m.abandon(first.runId));
+        expect(outcome).instanceOf(TaskSupersededError);
+    });
+
+    it("answers a rollback an older build recorded as cancelled", async () => {
+        const environment = new Environment("abandon-legacy");
+        {
+            await using seed = await makeNode(environment, "legacy");
+            const peer = testPeer("legacy");
+            const { rollback } = await parkedRollback(seed, "legacy", peer);
+            // Ended first, so nothing is driving it and its record can be rewritten into the shape a build
+            // that still admitted `cancel` of a rollback left behind: called off, with nothing undone and
+            // nothing saying the device was left part-changed.
+            await seed.act(a => a.get(TestTaskManager).abandon(rollback.runId));
+            await seed.act(a => {
+                const manager = a.get(TestTaskManager);
+                const stored = { ...manager.state.runs };
+                stored[String(rollback.runId)] = { ...stored[String(rollback.runId)], state: "cancelled" };
+                manager.state.runs = stored;
+            });
+            legacyRollbackId = rollback.runId;
+        }
+
+        await using node = await makeNode(environment, "legacy");
+        expect((await statusOf(node, legacyRollbackId))?.state).equals("cancelled");
+        expect(await attempt(node, m => m.abandon(legacyRollbackId))).instanceOf(TaskAlreadyUndoneError);
+    });
+});
+
+describe("cancel of a rollback", () => {
+    before(() => MockTime.init());
+    beforeEach(reset);
+
+    it("is refused, and points at abandon", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("nocancel");
+        const { rollback } = await parkedRollback(node, "nocancel", peer);
+
+        const outcome = await attempt(node, m => m.cancel(rollback.runId));
+
+        expect(outcome).instanceOf(TaskCannotCancelRollbackError);
+        expect((outcome as Error).message).contains("abandon");
+        // Untouched: a refused cancel leaves the rollback driving, so it can still finish or be abandoned.
+        expect((await statusOf(node, rollback.runId))?.state).equals("parked");
+        expect(await node.act(a => a.get(TestTaskManager).isDriven(rollback.runId))).equals(true);
+    });
+});
+
+describe("stop signals", () => {
+    before(() => MockTime.init());
+    beforeEach(reset);
+
+    it("fails a run whose phase throws a stop nothing asked for", async () => {
+        await using node = await makeNode();
+        testPeer("forged");
+        SyntheticTask.phasesByTag["forged"] = [
+            {
+                name: "forge",
+                run: async () => {
+                    throw new TaskCancelledSignal("nobody cancelled anything");
+                },
+            },
+        ];
+        await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
+        const handle = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "forged" }));
+
+        // Honouring it would leave the run non-terminal with nothing driving it, holding its target for the
+        // life of the process — so the run fails, as it would for any other error out of a phase.
+        await pumpUntil("run failed and retired", () =>
+            node.act(a => {
+                const manager = a.get(TestTaskManager);
+                return (
+                    manager.get(handle.runId)?.status.state === "failed" &&
+                    !manager.tasks.some(t => t.runId === handle.runId)
+                );
+            }),
+        );
+        const rerun = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "forged" }));
+        expect(rerun.runId).not.equals(handle.runId);
+    });
+
+    it("refuses to start a definition that declares what it undoes", async () => {
+        await using node = await makeNode();
+        testPeer("undoer");
+        await node.act(a => a.get(TestTaskManager).register(UndoingTask));
+
+        // Admission lets a rollback in while the run it undoes still owns the target, on the strength of only
+        // cancel creating one. A caller-created undo would take that exception with the original still driving.
+        const outcome = await attempt(node, async m => m.run(UndoingTask, { tag: "u" }));
+        expect(outcome).instanceOf(ImplementationError);
+        expect((outcome as Error).message).contains("created by cancel()");
+        expect(await node.act(a => a.get(TestTaskManager).tasks.length)).equals(0);
+    });
+});
+
+describe("retryRollback", () => {
+    before(() => MockTime.init());
+    beforeEach(reset);
+
+    it("refuses while the recorded rollback is still in flight", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("inflight");
+        const { original } = await parkedRollback(node, "inflight", peer);
+
+        const outcome = await attempt(node, m => m.retryRollback(original.runId));
+
+        expect(outcome).instanceOf(TaskRollbackPendingError);
+    });
+
+    it("reports a rollback being created as in flight, not as absent", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("creating");
+        SyntheticTask.phasesByTag["creating"] = [gatingPhase("creating")];
+        await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
+        const original = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "creating" }));
+        await pumpUntil("intent written", () => peer.items[KEY] !== undefined);
+        peer.setReachable(false);
+
+        // The cancel's write is held, so its rollback is admitted but the original does not name it yet.
+        const release = await node.act(a => a.get(TestTaskManager).holdPersistMutex());
+        const cancelling = node.act(a => a.get(TestTaskManager).cancel(original.runId));
+        await pumpUntil("rollback admitted", () =>
+            node.act(a => a.get(TestTaskManager).tasks.some(t => t.status.revertOf === original.runId)),
+        );
+
+        const outcome = await attempt(node, m => m.retryRollback(original.runId));
+        release();
+        await cancelling;
+
+        // A rollback exists and is about to drive; answering "this run has no rollback to retry" would tell a
+        // caller to do something about a state that is not the state it is in.
+        expect(outcome).instanceOf(TaskRollbackPendingError);
+    });
+
+    it("refuses a rollback that already restored the device", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("concluded");
+        const { original, rollback } = await parkedRollback(node, "concluded", peer);
+
+        // The device takes the undo, so the rollback finishes — and a finished rollback is detached, which is
+        // what would otherwise carry it past the in-flight checks.
+        peer.markHas("groupMembership", "X");
+        peer.setReachable(true);
+        await pumpUntil("rollback completed", () =>
+            node.act(a => a.get(TestTaskManager).get(rollback.runId)?.status.state === "completed"),
+        );
+
+        const outcome = await attempt(node, m => m.retryRollback(original.runId));
+        expect(outcome).instanceOf(TaskAlreadyUndoneError);
+        // Nothing replayed: a second undo would write the run's priors back over a device already restored.
+        const rollbacks = await node.act(a =>
+            Object.values(a.get(TestTaskManager).state.runs).filter(r => r.revertOf === original.runId),
+        );
+        expect(rollbacks.map(r => r.runId)).deep.equals([rollback.runId]);
+    });
+
+    it("refuses a rollback an older build recorded as cancelled", async () => {
+        const environment = new Environment("retry-legacy");
+        let originalId: RunId;
+        {
+            await using seed = await makeNode(environment, "retrylegacy");
+            const peer = testPeer("retrylegacy");
+            const { original, rollback } = await parkedRollback(seed, "retrylegacy", peer);
+            originalId = original.runId;
+            await seed.act(a => a.get(TestTaskManager).abandon(rollback.runId));
+            await seed.act(a => {
+                const manager = a.get(TestTaskManager);
+                const stored = { ...manager.state.runs };
+                stored[String(rollback.runId)] = { ...stored[String(rollback.runId)], state: "cancelled" };
+                manager.state.runs = stored;
+            });
+        }
+
+        await using node = await makeNode(environment, "retrylegacy");
+        expect(await attempt(node, m => m.retryRollback(originalId))).instanceOf(TaskAlreadyUndoneError);
+    });
+
+    it("refuses a rollback an operator abandoned", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("noretry");
+        const { original, rollback } = await parkedRollback(node, "noretry", peer);
+        await node.act(a => a.get(TestTaskManager).abandon(rollback.runId));
+
+        expect(await attempt(node, m => m.retryRollback(original.runId))).instanceOf(TaskAbandonedError);
+    });
+
+    it("refuses to abandon a rollback a retry has replaced", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("replaced");
+        const { original, first } = await failedRollback(node, "replaced", peer);
+
+        const retry = await node.act(a => a.get(TestTaskManager).retryRollback(original.runId));
+        expect(retry.runId).not.equals(first.runId);
+        expect((await statusOf(node, original.runId))?.revertRunId).equals(retry.runId);
+
+        // The replaced rollback forecloses nothing, and recording it as abandoned would say an undo still in
+        // progress was given up on.
+        expect(await attempt(node, m => m.abandon(first.runId))).instanceOf(TaskSupersededError);
+    });
+
+    it("drives a fresh rollback for a run whose previous one failed", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("driveretry");
+        const { original, first } = await failedRollback(node, "driveretry", peer);
+
+        const retry = await node.act(a => a.get(TestTaskManager).retryRollback(original.runId));
+        expect(retry.runId).not.equals(first.runId);
+
+        // Nothing rolls back a rollback: the failed one gets no undo of its own, or the manager would recurse.
+        const undosOfTheRollback = await node.act(a =>
+            Object.values(a.get(TestTaskManager).state.runs).filter(r => r.revertOf === first.runId),
+        );
+        expect(undosOfTheRollback).length(0);
+
+        // The device takes the restore this time, so the retry finishes the undo the first one could not.
+        peer.markHas("groupMembership", "X");
+        await pumpUntil("retry completed", () =>
+            node.act(a => a.get(TestTaskManager).get(retry.runId)?.status.state === "completed"),
+        );
+        expect((peer.items[KEY]?.intent as { v?: number })?.v).equals(1);
+    });
+
+    it("refuses a run that never had a rollback", async () => {
+        await using node = await makeNode();
+        testPeer("norollback");
+        SyntheticTask.phasesByTag["norollback"] = [{ name: "a", run: async () => {} }];
+        await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
+        const handle = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "norollback" }));
+        await pumpUntil("run finished", () =>
+            node.act(a => a.get(TestTaskManager).get(handle.runId)?.status.state === "completed"),
+        );
+
+        expect(await attempt(node, m => m.retryRollback(handle.runId))).instanceOf(ImplementationError);
+    });
+
+    it("leaves the original naming the old rollback when the retry's write is refused", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("retrywrite");
+        const { original, first } = await failedRollback(node, "retrywrite", peer);
+
+        await node.act(a => a.get(TestTaskManager).closePersistMutex());
+        const outcome = await attempt(node, m => m.retryRollback(original.runId));
+
+        expect(outcome).instanceOf(Error);
+        // One transaction carries the retry's record and the link to it, so a refused write leaves neither.
+        expect((await statusOf(node, original.runId))?.revertRunId).equals(first.runId);
+        const rollbacks = await node.act(a =>
+            Object.values(a.get(TestTaskManager).state.runs).filter(r => r.revertOf === original.runId),
+        );
+        expect(rollbacks.map(r => r.runId)).deep.equals([first.runId]);
+    });
+});

--- a/packages/node-manager/test/task/groups/RotateGroupKeyIntegrationTest.ts
+++ b/packages/node-manager/test/task/groups/RotateGroupKeyIntegrationTest.ts
@@ -5,7 +5,12 @@
  */
 
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
-import { TaskConflictError, TaskNotRevertibleError } from "#task/errors.js";
+import {
+    TaskConflictError,
+    TaskNotRevertibleError,
+    TaskRollbackPendingError,
+    TaskSlotOccupiedError,
+} from "#task/errors.js";
 import { ADD_NODE_TO_GROUP_TYPE, AddNodeToGroup, AddNodeToGroupParams } from "#task/groups/AddNodeToGroup.js";
 import { ROTATE_GROUP_KEY_TYPE, RotateGroupKey, RotateGroupKeyParams } from "#task/groups/RotateGroupKey.js";
 import { TaskDefinition } from "#task/Task.js";
@@ -656,8 +661,7 @@ describe("RotateGroupKey task integration (two members)", () => {
         } catch (e) {
             refusal = e;
         }
-        expect(refusal).instanceOf(TaskConflictError);
-        // Pinned to the holder, because one error class now covers slot, external id and rollback conflicts.
+        expect(refusal).instanceOf(TaskSlotOccupiedError);
         expect((refusal as TaskConflictError).owner).equals(
             await controller.act(a => requireRunIdOfSlot(a.get(TaskManagerBehavior), ROTATE_SLOT)),
         );
@@ -697,7 +701,7 @@ describe("RotateGroupKey task integration (two members)", () => {
                     rotationId: "r2",
                 }),
             ),
-        ).rejectedWith(TaskConflictError);
+        ).rejectedWith(TaskRollbackPendingError);
 
         // The revert is untouched, and the refusal means no second rotation of the slot was spawned.
         expect(["parked", "running"]).contains(
@@ -721,7 +725,7 @@ describe("RotateGroupKey task integration (two members)", () => {
         // `act` returns a MaybePromise, so normalize before asserting on the rejection.
         await expect(
             (async () => controller.act(a => a.get(TaskManagerBehavior).run(RotateGroupKey, ROTATE_PARAMS)))(),
-        ).rejectedWith(TaskConflictError);
+        ).rejectedWith(TaskSlotOccupiedError);
 
         // The owner reaches the parked rotation itself: a replacement task under the same id would answer as
         // freshly running and leave the parked one driving with nothing observing it.

--- a/packages/node-manager/test/task/helpers.ts
+++ b/packages/node-manager/test/task/helpers.ts
@@ -386,7 +386,7 @@ export async function awaitRun(
             }
             // A run turns terminal one step before it retires; a caller acting here would find the slot held.
             return (
-                !(["completed", "failed", "cancelled"] as string[]).includes(state) ||
+                !(["completed", "failed", "cancelled", "abandoned"] as string[]).includes(state) ||
                 !m.tasks.some(t => t.runId === runId)
             );
         });


### PR DESCRIPTION
Step 4 of the node-manager task-layer redesign, on top of `node-manager`.

## What this adds

**A way out of an undo that can never finish.** When a task is cancelled or fails, the manager creates a rollback that returns the device to the state it found. If that device is physically gone, the rollback waits for it forever, and while it waits no new work is admitted against that device — new work would fight the rollback over the same settings. There was no way to end that.

`abandon(runId)` names the rollback, stops it, records that the undo was given up on, and releases the device. The device is knowingly left part-changed, so the rollback ends in a state of its own, `abandoned` — not `cancelled`, which means an undo nobody needed, and not `failed`, which invites a retry. `retryRollback` refuses an abandoned rollback, and `abandon` refuses one that a retry has already replaced.

**Cancelling a rollback is now refused** and points at `abandon`. It used to be accepted, leaving the rollback looking like one nothing had needed, with nothing recording that a device was left inconsistent. "Is a rollback" now means one thing everywhere — the run declares what it undoes — so a task type declaring that is treated consistently whatever it is called.

**A refusal now says which cause applied.** One error class covered ten distinct reasons a request could be turned down, distinguishable only by reading the message — so a caller could not tell "someone else is using this device, decide whether to stop them" from "this clears on its own, retry" from "register the task type first". Each cause has its own class carrying a code from one enumeration (`TaskFindingCode`), which a user interface can translate and a caller can branch on. `TaskConflictError` becomes abstract and its `owner` required. A programming error (`ImplementationError`) deliberately carries no code: it reports a caller mistake, not a state to render.

**A stop the manager never asked for no longer ends a run quietly.** The signal classes are public, and honouring one thrown from inside a task's own phase left the run unfinished with nothing driving it and its device held for the life of the process.

## How the ordering is kept in one place

Recording an outcome does not stop the code driving a run: it is waiting on the device and will wake and keep writing. So a verb that ends a run must stop the driver, **wait** for it, decide from the state it left behind, and only then release the device. Cancel already did all of that, earned over several review rounds.

Rather than write it a second time, a verb now takes an **exclusive claim on a run's outcome** for the length of its transition. A second request for the same run waits for that claim and answers from what it recorded, so a duplicate cancel is still told about the rollback the first created rather than being refused. The claim is held with the run, not with the code driving it, because a transition hands that code back part-way through — anything watching only the driver would see the run as free while the decision was still in flight.

A claim is per run, so it says nothing about the relation *between* runs. Retrying a rollback rewrites the link on the run being undone and admits the replacement before the write that records it, so an abandon asks which rollbacks are live rather than which one the record names — otherwise it records an abandonment while a fresh rollback is driving the device.

## Tests

`packages/node-manager` goes from 206 to 239 tests, green in ESM, CJS and Web. `retryRollback` had none before and its block now holds six.

Every branch this adds was mutation-tested — the production hunk removed or inverted, the suite run, the named test red — with one exception recorded below. Two cases worth naming:

- three tests fail if the new state is left out of the store's terminal set (history, resumability, restart); the restart one is the failure that matters, because its mode is driving a declined undo against the device;
- the drain refusal holds the *write*, not the driver, because most of a transition happens after its driver has stopped, and a refusal covering only the unwind would report the wrong cause for the rest of it.

## Reviews this went through

The design was attacked twice before implementation and the shipped code once after, which changed it three times. Both design rounds and one code round each produced findings with a single root cause, recorded in §9 of `docs/superpowers/specs/2026-09-01-node-manager-step4-transitions.md` rather than patched symptom by symptom. The last of those is worth flagging for a reviewer: the round-2 fix for "a terminal record with no retirement order is a dead end" was itself the round-3 finding, so that branch was **deleted** rather than patched again — such a record cannot be resumed, so releasing its target unconditionally is simply correct.

## Not in this change

- No `CHANGELOG` entry: `packages/node-manager` does not exist on `main`, nothing depends on it, and steps 1–3 added none. One entry announcing the package belongs with the umbrella PR leaving draft.
- Dropping a rollback's recorded changes (and the key material in them) when the manager stops owing the device anything is step 5's single rule; splitting it across two steps would give one rule two implementations. An abandoned rollback keeps its changes until then. The step-5 design is written and awaiting decisions.
- A downgrade to a build that predates this would treat an `abandoned` record as unfinished and drive the undo again. Harmless while the package is unreleased with no dependents; noted so it is a decision rather than a surprise.
- `#retire`'s claim guard has no test — the one mutation that left the suite green. Its real trigger is a driver reaching its own terminal outcome inside the transition window, which is not constructible from the public surface: a transition claims before it aborts, so the post-phase check stops the driver before it can commit anything. The guard is kept because removing it lets the device be released mid-cancel, after which new work can take it and the cancel's own rollback is then refused — reasoned from the code, not executed.
- `nextRetirement` returning `undefined` for two different reasons lets a run discarded by one path be written back terminal-but-unordered by another, which is the one shape `load` discards. Pre-existing on the cancel path and not made reachable by this change; filed rather than fixed here.
