### PR TITLE
fix(node): SetCredential creates its user, and reports what the specification states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A failure to attach a certification run's device logs fails the run instead of only warning
 
 - @matter/node
-    - Fix: (@Luligu) Corrects status codes returned by `DoorLockServer.setCredential` for duplicating another credential of the same type an adding an occupied credential index
+    - Fix: (@Luligu) Corrects status codes returned by `DoorLockServer.setCredential` for duplicating another credential of the same type and adding an occupied credential index
+    - Fix: `DoorLockServer.setCredential` creates the user alongside the credential when the request carries no user index
+    - Fix: `DoorLockServer.setCredential` reports `NextCredentialIndex` on a failing response as well as a successful one
+    - Fix: `DoorLockServer.setCredential` reports `OCCUPIED` when no user slot remains for a new credential
+    - Fix: `DoorLockServer.setCredential` answers `INVALID_COMMAND` when a request names a user index and also carries `UserStatus` or `UserType`, and when it would create a `ProgrammingUser` alongside a credential
     - Fix: `ClientStructure.applyWireChanges` applies the change it is given. A client node keys each member of a cluster by attribute ID, and a change from the remote API addresses members by property name, so values landed under a key reads were never served from: the update was invisible and never persisted. Values now convert as the change is applied
     - Fix: `ClientStructure.applyWireChanges` regenerates a behavior whose cluster definition changed and prunes attributes the cluster dropped, as the Matter protocol path already did
     - Fix: Validation honors the conformance and quality an element inherits, so an element overridden by an operational extension is no longer judged as if it stated neither

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: `DoorLockServer.setCredential` reports `NextCredentialIndex` on a failing response as well as a successful one
     - Fix: `DoorLockServer.setCredential` reports `OCCUPIED` when no user slot remains for a new credential
     - Fix: `DoorLockServer.setCredential` answers `INVALID_COMMAND` when the user fields a request carries do not match the use case it states
+    - Fix: `DoorLockServer` stores each enumerated field of a user or credential record as its Matter enumeration, so a value the enumeration does not define is refused rather than kept
     - Fix: Creating a struct fills in a default only for a field the cluster supports, so a field a device does not set stays absent instead of carrying the fallback its schema states. A write of a list entry that omits a feature-gated field is accepted, where it previously failed validation against the field it had filled in. Affects `Thermostat` preset names and setpoints, `Descriptor` tag labels, `MediaPlayback` track attributes and the feature-gated members of `ClosureControl`, `ClosureDimension`, `ElectricalEnergyMeasurement`, `CommodityPrice` and `CommodityTariff`
     - Fix: A struct field's default is stored in the units and shape of its datatype: a preset created without a cooling setpoint reads `2600` rather than the schema's `26°C` notation, and a bitmap default arrives decoded
     - Fix: Each struct created by a write receives its own copy of a list or bitmap default instead of sharing one instance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: `DoorLockServer.setCredential` creates the user alongside the credential when the request carries no user index
     - Fix: `DoorLockServer.setCredential` reports `NextCredentialIndex` on a failing response as well as a successful one
     - Fix: `DoorLockServer.setCredential` reports `OCCUPIED` when no user slot remains for a new credential
-    - Fix: `DoorLockServer.setCredential` answers `INVALID_COMMAND` when a request names a user index and also carries `UserStatus` or `UserType`, and when it would create a `ProgrammingUser` alongside a credential
+    - Fix: `DoorLockServer.setCredential` answers `INVALID_COMMAND` when the user fields a request carries do not match the use case it states
     - Fix: Creating a struct fills in a default only for a field the cluster supports, so a field a device does not set stays absent instead of carrying the fallback its schema states. A write of a list entry that omits a feature-gated field is accepted, where it previously failed validation against the field it had filled in. Affects `Thermostat` preset names and setpoints, `Descriptor` tag labels, `MediaPlayback` track attributes and the feature-gated members of `ClosureControl`, `ClosureDimension`, `ElectricalEnergyMeasurement`, `CommodityPrice` and `CommodityTariff`
     - Fix: A struct field's default is stored in the units and shape of its datatype: a preset created without a cooling setpoint reads `2600` rather than the schema's `26°C` notation, and a bitmap default arrives decoded
     - Fix: Each struct created by a write receives its own copy of a list or bitmap default instead of sharing one instance

--- a/packages/node/src/behaviors/door-lock/DoorLockServer.ts
+++ b/packages/node/src/behaviors/door-lock/DoorLockServer.ts
@@ -1026,9 +1026,9 @@ export class DoorLockBaseServer extends DoorLockBaseServerClass {
             return userType !== UserType.ProgrammingUser;
         }
 
-        // Modifying the programming user's PIN states ProgrammingUser, which the CHIP SDK does not enforce
+        // Modifying the programming user's PIN is the one case that states a user type rather than forbidding one
         if (operationType === DataOperationType.Modify && userIndex === null) {
-            return true;
+            return userStatus === null && userType === UserType.ProgrammingUser;
         }
 
         return userStatus === null && userType === null;

--- a/packages/node/src/behaviors/door-lock/DoorLockServer.ts
+++ b/packages/node/src/behaviors/door-lock/DoorLockServer.ts
@@ -309,23 +309,28 @@ export class DoorLockBaseServer extends DoorLockBaseServerClass {
         const maxCredentials = this.#maxCredentialsForType(credential.credentialType);
         const auth = this.auth;
 
-        if (credential.credentialIndex < 0 || credential.credentialIndex > maxCredentials) {
-            return { status: Status.InvalidCommand, userIndex: null, nextCredentialIndex: null };
-        }
-
-        if (!this.#validateCredentialDataLength(credential.credentialType, credentialData)) {
-            return { status: Status.InvalidCommand, userIndex: null, nextCredentialIndex: null };
-        }
-
-        if (auth.isDuplicateCredential(credential.credentialType, credentialData, credential.credentialIndex)) {
-            return { status: DoorLock.StatusCode.Duplicate, userIndex: null, nextCredentialIndex: null };
-        }
-
+        // § 5.2.10.21.3 states NextCredentialIndex independently of the status, so every response carries it
         const nextCredentialIndex = auth.findNextAvailableCredentialIndex(
             credential.credentialType,
             credential.credentialIndex,
             maxCredentials,
         );
+
+        if (credential.credentialIndex < 0 || credential.credentialIndex > maxCredentials) {
+            return { status: Status.InvalidCommand, userIndex: null, nextCredentialIndex };
+        }
+
+        if (!this.#validateCredentialDataLength(credential.credentialType, credentialData)) {
+            return { status: Status.InvalidCommand, userIndex: null, nextCredentialIndex };
+        }
+
+        if (auth.isDuplicateCredential(credential.credentialType, credentialData, credential.credentialIndex)) {
+            return { status: DoorLock.StatusCode.Duplicate, userIndex: null, nextCredentialIndex };
+        }
+
+        if (!this.#userFieldsMatchUseCase(operationType, userIndex, userStatus, userType)) {
+            return { status: Status.InvalidCommand, userIndex: null, nextCredentialIndex };
+        }
 
         if (operationType === DataOperationType.Add) {
             const existingCred = auth.findCredential(credential.credentialType, credential.credentialIndex);
@@ -341,13 +346,13 @@ export class DoorLockBaseServer extends DoorLockBaseServerClass {
                 const newUserIndex = auth.findAvailableUserIndex(this.state.numberOfTotalUsersSupported);
                 if (newUserIndex === null) {
                     auth.removeCredential(credential.credentialType, credential.credentialIndex);
-                    return { status: Status.ResourceExhausted, userIndex: null, nextCredentialIndex };
+                    return { status: DoorLock.StatusCode.Occupied, userIndex: null, nextCredentialIndex };
                 }
 
                 auth.addUser({
                     userIndex: newUserIndex,
                     userName: "",
-                    userUniqueId: 0xffffffff,
+                    userUniqueId: null,
                     userStatus: userStatus ?? UserStatus.OccupiedEnabled,
                     userType: userType ?? UserType.UnrestrictedUser,
                     credentialRule: CredentialRule.Single,
@@ -448,7 +453,7 @@ export class DoorLockBaseServer extends DoorLockBaseServerClass {
             return { status: Status.Success, userIndex: null, nextCredentialIndex };
         }
 
-        return { status: Status.InvalidCommand, userIndex: null, nextCredentialIndex: null };
+        return { status: Status.InvalidCommand, userIndex: null, nextCredentialIndex };
     }
 
     override getCredentialStatus(request: DoorLock.GetCredentialStatusRequest): DoorLock.GetCredentialStatusResponse {
@@ -1004,6 +1009,33 @@ export class DoorLockBaseServer extends DoorLockBaseServerClass {
         if (!this.auth.findUser(userIndex)) {
             throw new StatusResponseError("User not found", Status.Failure);
         }
+    }
+
+    /**
+     * § 5.2.10.20 states the user fields each SetCredential use case carries. Only the case that creates a user
+     * alongside the credential carries any; the others state both as null.
+     */
+    #userFieldsMatchUseCase(
+        operationType: DataOperationType,
+        userIndex: number | null,
+        userStatus: UserStatus | null,
+        userType: UserType | null,
+    ): boolean {
+        if (operationType === DataOperationType.Add && userIndex === null) {
+            return (
+                (userStatus === null ||
+                    userStatus === UserStatus.OccupiedEnabled ||
+                    userStatus === UserStatus.OccupiedDisabled) &&
+                userType !== UserType.ProgrammingUser
+            );
+        }
+
+        // Modifying the programming user's PIN states ProgrammingUser, which the CHIP SDK does not enforce
+        if (operationType === DataOperationType.Modify && userIndex === null) {
+            return true;
+        }
+
+        return userStatus === null && userType === null;
     }
 
     #maxCredentialsForType(type: CredentialType): number {

--- a/packages/node/src/behaviors/door-lock/DoorLockServer.ts
+++ b/packages/node/src/behaviors/door-lock/DoorLockServer.ts
@@ -1012,8 +1012,9 @@ export class DoorLockBaseServer extends DoorLockBaseServerClass {
     }
 
     /**
-     * § 5.2.10.20 states the user fields each SetCredential use case carries. Only the case that creates a user
-     * alongside the credential carries any; the others state both as null.
+     * § 5.2.10.20 states which user fields each SetCredential use case carries. Only the case that creates a user
+     * alongside the credential carries any; the others state both as null. The values each field may hold are the
+     * command's own constraint, enforced before the request reaches us.
      */
     #userFieldsMatchUseCase(
         operationType: DataOperationType,
@@ -1022,12 +1023,7 @@ export class DoorLockBaseServer extends DoorLockBaseServerClass {
         userType: UserType | null,
     ): boolean {
         if (operationType === DataOperationType.Add && userIndex === null) {
-            return (
-                (userStatus === null ||
-                    userStatus === UserStatus.OccupiedEnabled ||
-                    userStatus === UserStatus.OccupiedDisabled) &&
-                userType !== UserType.ProgrammingUser
-            );
+            return userType !== UserType.ProgrammingUser;
         }
 
         // Modifying the programming user's PIN states ProgrammingUser, which the CHIP SDK does not enforce

--- a/packages/node/src/behaviors/door-lock/DoorLockServer.ts
+++ b/packages/node/src/behaviors/door-lock/DoorLockServer.ts
@@ -328,7 +328,7 @@ export class DoorLockBaseServer extends DoorLockBaseServerClass {
             return { status: DoorLock.StatusCode.Duplicate, userIndex: null, nextCredentialIndex };
         }
 
-        if (!this.#userFieldsMatchUseCase(operationType, userIndex, userStatus, userType)) {
+        if (!this.#requestMatchesUseCase(operationType, credential, userIndex, userStatus, userType)) {
             return { status: Status.InvalidCommand, userIndex: null, nextCredentialIndex };
         }
 
@@ -1012,12 +1012,13 @@ export class DoorLockBaseServer extends DoorLockBaseServerClass {
     }
 
     /**
-     * § 5.2.10.20 states which user fields each SetCredential use case carries. Only the case that creates a user
-     * alongside the credential carries any; the others state both as null. The values each field may hold are the
-     * command's own constraint, enforced before the request reaches us.
+     * § 5.2.10.20 states what each SetCredential use case carries. Only the case that creates a user alongside the
+     * credential carries user fields; the others state them as null. The values each field may hold are the command's
+     * own constraint, enforced before the request reaches us.
      */
-    #userFieldsMatchUseCase(
+    #requestMatchesUseCase(
         operationType: DataOperationType,
+        credential: DoorLock.Credential,
         userIndex: number | null,
         userStatus: UserStatus | null,
         userType: UserType | null,
@@ -1026,9 +1027,14 @@ export class DoorLockBaseServer extends DoorLockBaseServerClass {
             return userType !== UserType.ProgrammingUser;
         }
 
-        // Modifying the programming user's PIN is the one case that states a user type rather than forbidding one
+        // Modifying the programming user's PIN is the one case that states what it carries rather than forbidding it
         if (operationType === DataOperationType.Modify && userIndex === null) {
-            return userStatus === null && userType === UserType.ProgrammingUser;
+            return (
+                userStatus === null &&
+                userType === UserType.ProgrammingUser &&
+                credential.credentialType === CredentialType.ProgrammingPin &&
+                credential.credentialIndex === 0
+            );
         }
 
         return userStatus === null && userType === null;

--- a/packages/node/src/behaviors/door-lock/LockAuth.ts
+++ b/packages/node/src/behaviors/door-lock/LockAuth.ts
@@ -5,7 +5,17 @@
  */
 
 import { Bytes, type Cipher } from "@matter/general";
-import { fabricIdx, field, listOf, nullable, octstr, string, uint16, uint32, uint8 } from "@matter/model";
+import {
+    DoorLock as DoorLockModel,
+    fabricIdx,
+    field,
+    listOf,
+    nullable,
+    octstr,
+    string,
+    uint16,
+    uint32,
+} from "@matter/model";
 import { FabricIndex } from "@matter/types";
 import { DoorLock } from "@matter/types/clusters/door-lock";
 
@@ -20,7 +30,7 @@ export namespace LockAuth {
      * Reference to a credential by type and index.
      */
     export class CredentialRef {
-        @field(uint8)
+        @field(DoorLockModel.datatypes.require("CredentialTypeEnum"))
         credentialType!: CredentialType;
 
         @field(uint16)
@@ -41,13 +51,13 @@ export namespace LockAuth {
         @field(uint32)
         userUniqueId: number | null = null;
 
-        @field(uint8)
+        @field(DoorLockModel.datatypes.require("UserStatusEnum"))
         userStatus: DoorLock.UserStatus = DoorLock.UserStatus.Available;
 
-        @field(uint8)
+        @field(DoorLockModel.datatypes.require("UserTypeEnum"))
         userType: DoorLock.UserType = DoorLock.UserType.UnrestrictedUser;
 
-        @field(uint8)
+        @field(DoorLockModel.datatypes.require("CredentialRuleEnum"))
         credentialRule: DoorLock.CredentialRule = DoorLock.CredentialRule.Single;
 
         @field(listOf(CredentialRef))
@@ -64,7 +74,7 @@ export namespace LockAuth {
      * Stored credential record with encrypted data and fabric tracking.
      */
     export class Credential {
-        @field(uint8)
+        @field(DoorLockModel.datatypes.require("CredentialTypeEnum"))
         credentialType!: CredentialType;
 
         @field(uint16)

--- a/packages/node/test/behaviors/door-lock/DoorLockServerTest.ts
+++ b/packages/node/test/behaviors/door-lock/DoorLockServerTest.ts
@@ -12,38 +12,36 @@ import { MockServerNode } from "../../node/mock-server-node.js";
 
 const TestDoorLockDevice = DoorLockDevice.with(DoorLockServer.with("User", "PinCredential"));
 
-async function createLock() {
-    const node = await MockServerNode.createOnline(undefined, { device: undefined });
-    const endpoint = await node.add(TestDoorLockDevice, {
-        doorLock: {
-            lockState: DoorLock.LockState.Locked,
-            lockType: DoorLock.LockType.DeadBolt,
-            actuatorEnabled: true,
-            operatingMode: DoorLock.OperatingMode.Normal,
-            wrongCodeEntryLimit: 3,
-            userCodeTemporaryDisableTime: 10,
-            numberOfTotalUsersSupported: 10,
-            numberOfPinUsersSupported: 10,
-            numberOfCredentialsSupportedPerUser: 5,
-            minPinCodeLength: 4,
-            maxPinCodeLength: 8,
-            // A pre-existing user avoids the Add branch's new-user creation path (which has its own,
-            // unrelated userUniqueId bug) so the test can focus on the credential status codes.
-            users: [
-                {
-                    userIndex: 1,
-                    userName: "",
-                    userUniqueId: null,
-                    userStatus: DoorLock.UserStatus.OccupiedEnabled,
-                    userType: DoorLock.UserType.UnrestrictedUser,
-                    credentialRule: DoorLock.CredentialRule.Single,
-                    credentials: [],
-                    creatorFabricIndex: FabricIndex.NO_FABRIC,
-                    lastModifiedFabricIndex: FabricIndex.NO_FABRIC,
-                },
-            ],
+const lockState = {
+    lockState: DoorLock.LockState.Locked,
+    lockType: DoorLock.LockType.DeadBolt,
+    actuatorEnabled: true,
+    operatingMode: DoorLock.OperatingMode.Normal,
+    wrongCodeEntryLimit: 3,
+    userCodeTemporaryDisableTime: 10,
+    numberOfTotalUsersSupported: 10,
+    numberOfPinUsersSupported: 10,
+    numberOfCredentialsSupportedPerUser: 5,
+    minPinCodeLength: 4,
+    maxPinCodeLength: 8,
+    users: [
+        {
+            userIndex: 1,
+            userName: "",
+            userUniqueId: null,
+            userStatus: DoorLock.UserStatus.OccupiedEnabled,
+            userType: DoorLock.UserType.UnrestrictedUser,
+            credentialRule: DoorLock.CredentialRule.Single,
+            credentials: [],
+            creatorFabricIndex: FabricIndex.NO_FABRIC,
+            lastModifiedFabricIndex: FabricIndex.NO_FABRIC,
         },
-    });
+    ],
+};
+
+async function createLock(overrides: Partial<typeof lockState> = {}) {
+    const node = await MockServerNode.createOnline(undefined, { device: undefined });
+    const endpoint = await node.add(TestDoorLockDevice, { doorLock: { ...lockState, ...overrides } });
     return { node, endpoint, [Symbol.asyncDispose]: () => node.close() };
 }
 
@@ -105,6 +103,311 @@ describe("DoorLockServer", () => {
                 userType: null,
             });
             expect(occupied.status).equals(DoorLock.StatusCode.Occupied);
+        });
+    });
+    it("creates the user alongside the credential when no user index is given", async () => {
+        await using lock = await createLock();
+
+        await lock.node.online({}, async agent => {
+            const doorLock = lock.endpoint.agentFor(agent.context).doorLock;
+
+            const added = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                credentialData: pin("1234"),
+                userIndex: null,
+                userStatus: null,
+                userType: null,
+            });
+            expect(added.status).equals(Status.Success);
+            expect(added.userIndex).equals(2);
+
+            const user = await doorLock.getUser({ userIndex: 2 });
+            expect(user.userUniqueId).null;
+            expect(user.userStatus).equals(DoorLock.UserStatus.OccupiedEnabled);
+            expect(user.userType).equals(DoorLock.UserType.UnrestrictedUser);
+            expect(user.credentials).deep.equals([{ credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 }]);
+        });
+    });
+
+    it("reports OCCUPIED when no user slot remains for the new credential", async () => {
+        await using lock = await createLock({ numberOfTotalUsersSupported: 1 });
+
+        await lock.node.online({}, async agent => {
+            const doorLock = lock.endpoint.agentFor(agent.context).doorLock;
+
+            const exhausted = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                credentialData: pin("1234"),
+                userIndex: null,
+                userStatus: null,
+                userType: null,
+            });
+            expect(exhausted.status).equals(DoorLock.StatusCode.Occupied);
+
+            const status = await doorLock.getCredentialStatus({
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+            });
+            expect(status.credentialExists).false;
+        });
+    });
+
+    it("refuses a user status the created user may not hold", async () => {
+        await using lock = await createLock();
+
+        await lock.node.online({}, async agent => {
+            const doorLock = lock.endpoint.agentFor(agent.context).doorLock;
+
+            const refused = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                credentialData: pin("1234"),
+                userIndex: null,
+                userStatus: DoorLock.UserStatus.Available,
+                userType: null,
+            });
+            expect(refused.status).equals(Status.InvalidCommand);
+
+            const status = await doorLock.getCredentialStatus({
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+            });
+            expect(status.credentialExists).false;
+        });
+    });
+
+    it("refuses to create a programming user alongside a credential", async () => {
+        await using lock = await createLock();
+
+        await lock.node.online({}, async agent => {
+            const doorLock = lock.endpoint.agentFor(agent.context).doorLock;
+
+            const refused = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                credentialData: pin("1234"),
+                userIndex: null,
+                userStatus: null,
+                userType: DoorLock.UserType.ProgrammingUser,
+            });
+            expect(refused.status).equals(Status.InvalidCommand);
+        });
+    });
+
+    it("reports the next available credential index whatever the status", async () => {
+        await using lock = await createLock();
+
+        await lock.node.online({}, async agent => {
+            const doorLock = lock.endpoint.agentFor(agent.context).doorLock;
+
+            await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                credentialData: pin("1234"),
+                userIndex: 1,
+                userStatus: null,
+                userType: null,
+            });
+
+            const duplicate = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 2 },
+                credentialData: pin("1234"),
+                userIndex: 1,
+                userStatus: null,
+                userType: null,
+            });
+            expect(duplicate.status).equals(DoorLock.StatusCode.Duplicate);
+            expect(duplicate.nextCredentialIndex).equals(3);
+
+            const tooShort = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 2 },
+                credentialData: pin("1"),
+                userIndex: 1,
+                userStatus: null,
+                userType: null,
+            });
+            expect(tooShort.status).equals(Status.InvalidCommand);
+            expect(tooShort.nextCredentialIndex).equals(3);
+        });
+    });
+    it("refuses a credential index beyond the supported count", async () => {
+        await using lock = await createLock();
+
+        await lock.node.online({}, async agent => {
+            const doorLock = lock.endpoint.agentFor(agent.context).doorLock;
+
+            const refused = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 11 },
+                credentialData: pin("1234"),
+                userIndex: 1,
+                userStatus: null,
+                userType: null,
+            });
+            expect(refused.status).equals(Status.InvalidCommand);
+
+            // Nothing follows the last supported index, so there is no next index to report
+            expect(refused.nextCredentialIndex).null;
+        });
+    });
+
+    it("reports the next available credential index when modifying a credential", async () => {
+        await using lock = await createLock();
+
+        await lock.node.online({}, async agent => {
+            const doorLock = lock.endpoint.agentFor(agent.context).doorLock;
+
+            await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                credentialData: pin("1234"),
+                userIndex: 1,
+                userStatus: null,
+                userType: null,
+            });
+
+            const modified = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Modify,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                credentialData: pin("5678"),
+                userIndex: 1,
+                userStatus: null,
+                userType: null,
+            });
+            expect(modified.status).equals(Status.Success);
+            expect(modified.nextCredentialIndex).equals(2);
+        });
+    });
+    it("refuses user fields when the credential joins an existing user", async () => {
+        await using lock = await createLock();
+
+        await lock.node.online({}, async agent => {
+            const doorLock = lock.endpoint.agentFor(agent.context).doorLock;
+
+            const refused = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                credentialData: pin("1234"),
+                userIndex: 1,
+                userStatus: DoorLock.UserStatus.OccupiedEnabled,
+                userType: null,
+            });
+            expect(refused.status).equals(Status.InvalidCommand);
+        });
+    });
+
+    it("refuses user fields when modifying a credential", async () => {
+        await using lock = await createLock();
+
+        await lock.node.online({}, async agent => {
+            const doorLock = lock.endpoint.agentFor(agent.context).doorLock;
+
+            await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                credentialData: pin("1234"),
+                userIndex: 1,
+                userStatus: null,
+                userType: null,
+            });
+
+            const refusedStatus = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Modify,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                credentialData: pin("5678"),
+                userIndex: 1,
+                userStatus: DoorLock.UserStatus.OccupiedEnabled,
+                userType: null,
+            });
+            expect(refusedStatus.status).equals(Status.InvalidCommand);
+
+            const refusedType = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Modify,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                credentialData: pin("5678"),
+                userIndex: 1,
+                userStatus: null,
+                userType: DoorLock.UserType.UnrestrictedUser,
+            });
+            expect(refusedType.status).equals(Status.InvalidCommand);
+        });
+    });
+    it("stores the user status and type the request carries", async () => {
+        await using lock = await createLock();
+
+        await lock.node.online({}, async agent => {
+            const doorLock = lock.endpoint.agentFor(agent.context).doorLock;
+
+            const added = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                credentialData: pin("1234"),
+                userIndex: null,
+                userStatus: DoorLock.UserStatus.OccupiedDisabled,
+                userType: DoorLock.UserType.NonAccessUser,
+            });
+            expect(added.status).equals(Status.Success);
+
+            const user = await doorLock.getUser({ userIndex: 2 });
+            expect(user.userStatus).equals(DoorLock.UserStatus.OccupiedDisabled);
+            expect(user.userType).equals(DoorLock.UserType.NonAccessUser);
+        });
+    });
+
+    it("accepts the programming user type when modifying without a user index", async () => {
+        await using lock = await createLock();
+
+        await lock.node.online({}, async agent => {
+            const doorLock = lock.endpoint.agentFor(agent.context).doorLock;
+
+            await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                credentialData: pin("1234"),
+                userIndex: 1,
+                userStatus: null,
+                userType: null,
+            });
+
+            // The CHIP SDK detects this combination and proceeds, so it is accepted rather than refused
+            const modified = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Modify,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                credentialData: pin("5678"),
+                userIndex: null,
+                userStatus: null,
+                userType: DoorLock.UserType.ProgrammingUser,
+            });
+            expect(modified.status).equals(Status.Success);
+        });
+    });
+    it("reports DUPLICATE ahead of a malformed user field", async () => {
+        await using lock = await createLock();
+
+        await lock.node.online({}, async agent => {
+            const doorLock = lock.endpoint.agentFor(agent.context).doorLock;
+
+            await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                credentialData: pin("1234"),
+                userIndex: 1,
+                userStatus: null,
+                userType: null,
+            });
+
+            // The CHIP SDK scans for duplicates before it validates the user fields
+            const both = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 2 },
+                credentialData: pin("1234"),
+                userIndex: 1,
+                userStatus: DoorLock.UserStatus.OccupiedEnabled,
+                userType: null,
+            });
+            expect(both.status).equals(DoorLock.StatusCode.Duplicate);
         });
     });
 });

--- a/packages/node/test/behaviors/door-lock/DoorLockServerTest.ts
+++ b/packages/node/test/behaviors/door-lock/DoorLockServerTest.ts
@@ -153,29 +153,6 @@ describe("DoorLockServer", () => {
         });
     });
 
-    it("refuses a user status the created user may not hold", async () => {
-        await using lock = await createLock();
-
-        await lock.node.online({}, async agent => {
-            const doorLock = lock.endpoint.agentFor(agent.context).doorLock;
-
-            const refused = await doorLock.setCredential({
-                operationType: DoorLock.DataOperationType.Add,
-                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
-                credentialData: pin("1234"),
-                userIndex: null,
-                userStatus: DoorLock.UserStatus.Available,
-                userType: null,
-            });
-            expect(refused.status).equals(Status.InvalidCommand);
-
-            const status = await doorLock.getCredentialStatus({
-                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
-            });
-            expect(status.credentialExists).false;
-        });
-    });
-
     it("refuses to create a programming user alongside a credential", async () => {
         await using lock = await createLock();
 

--- a/packages/node/test/behaviors/door-lock/DoorLockServerTest.ts
+++ b/packages/node/test/behaviors/door-lock/DoorLockServerTest.ts
@@ -333,7 +333,7 @@ describe("DoorLockServer", () => {
         });
     });
 
-    it("accepts the programming user type when modifying without a user index", async () => {
+    it("requires the programming user type when modifying without a user index", async () => {
         await using lock = await createLock();
 
         await lock.node.online({}, async agent => {
@@ -348,7 +348,6 @@ describe("DoorLockServer", () => {
                 userType: null,
             });
 
-            // The CHIP SDK detects this combination and proceeds, so it is accepted rather than refused
             const modified = await doorLock.setCredential({
                 operationType: DoorLock.DataOperationType.Modify,
                 credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
@@ -358,6 +357,16 @@ describe("DoorLockServer", () => {
                 userType: DoorLock.UserType.ProgrammingUser,
             });
             expect(modified.status).equals(Status.Success);
+
+            const withoutType = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Modify,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                credentialData: pin("9012"),
+                userIndex: null,
+                userStatus: null,
+                userType: null,
+            });
+            expect(withoutType.status).equals(Status.InvalidCommand);
         });
     });
     it("reports DUPLICATE ahead of a malformed user field", async () => {

--- a/packages/node/test/behaviors/door-lock/DoorLockServerTest.ts
+++ b/packages/node/test/behaviors/door-lock/DoorLockServerTest.ts
@@ -333,7 +333,7 @@ describe("DoorLockServer", () => {
         });
     });
 
-    it("requires the programming user type when modifying without a user index", async () => {
+    it("modifies the programming PIN only as the specification states that use case", async () => {
         await using lock = await createLock();
 
         await lock.node.online({}, async agent => {
@@ -341,7 +341,7 @@ describe("DoorLockServer", () => {
 
             await doorLock.setCredential({
                 operationType: DoorLock.DataOperationType.Add,
-                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                credential: { credentialType: DoorLock.CredentialType.ProgrammingPin, credentialIndex: 0 },
                 credentialData: pin("1234"),
                 userIndex: 1,
                 userStatus: null,
@@ -350,7 +350,7 @@ describe("DoorLockServer", () => {
 
             const modified = await doorLock.setCredential({
                 operationType: DoorLock.DataOperationType.Modify,
-                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                credential: { credentialType: DoorLock.CredentialType.ProgrammingPin, credentialIndex: 0 },
                 credentialData: pin("5678"),
                 userIndex: null,
                 userStatus: null,
@@ -360,15 +360,55 @@ describe("DoorLockServer", () => {
 
             const withoutType = await doorLock.setCredential({
                 operationType: DoorLock.DataOperationType.Modify,
-                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                credential: { credentialType: DoorLock.CredentialType.ProgrammingPin, credentialIndex: 0 },
                 credentialData: pin("9012"),
                 userIndex: null,
                 userStatus: null,
                 userType: null,
             });
             expect(withoutType.status).equals(Status.InvalidCommand);
+
+            // Each of the two below would modify its credential were the use case not checked
+            await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.ProgrammingPin, credentialIndex: 1 },
+                credentialData: pin("2345"),
+                userIndex: 1,
+                userStatus: null,
+                userType: null,
+            });
+
+            const wrongCredentialIndex = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Modify,
+                credential: { credentialType: DoorLock.CredentialType.ProgrammingPin, credentialIndex: 1 },
+                credentialData: pin("9012"),
+                userIndex: null,
+                userStatus: null,
+                userType: DoorLock.UserType.ProgrammingUser,
+            });
+            expect(wrongCredentialIndex.status).equals(Status.InvalidCommand);
+
+            await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 0 },
+                credentialData: pin("3456"),
+                userIndex: 1,
+                userStatus: null,
+                userType: null,
+            });
+
+            const wrongCredentialType = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Modify,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 0 },
+                credentialData: pin("9012"),
+                userIndex: null,
+                userStatus: null,
+                userType: DoorLock.UserType.ProgrammingUser,
+            });
+            expect(wrongCredentialType.status).equals(Status.InvalidCommand);
         });
     });
+
     it("reports DUPLICATE ahead of a malformed user field", async () => {
         await using lock = await createLock();
 

--- a/packages/node/test/behaviors/door-lock/DoorLockServerTest.ts
+++ b/packages/node/test/behaviors/door-lock/DoorLockServerTest.ts
@@ -436,4 +436,27 @@ describe("DoorLockServer", () => {
             expect(both.status).equals(DoorLock.StatusCode.Duplicate);
         });
     });
+    it("refuses to store a user type Matter does not define", async () => {
+        await using lock = await createLock();
+
+        await lock.node.online({}, async agent => {
+            const doorLock = lock.endpoint.agentFor(agent.context).doorLock;
+
+            // The command's own constraint covers a request from a peer; this is the local caller's path
+            let message: string | undefined;
+            try {
+                await doorLock.setCredential({
+                    operationType: DoorLock.DataOperationType.Add,
+                    credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                    credentialData: pin("1234"),
+                    userIndex: null,
+                    userStatus: null,
+                    userType: 99 as DoorLock.UserType,
+                });
+            } catch (e) {
+                message = (e as Error).message;
+            }
+            expect(message).match(/does not define the enum value 99/);
+        });
+    });
 });


### PR DESCRIPTION
## SetCredential could not create a user

Specification § 5.2.10.20 lists "create a new credential and a new user" as the first SetCredential use case: a client sends a credential with a null `UserIndex` and the lock creates both. That never worked. Creating the user stored a `userUniqueId` of `0xffffffff`, and a nullable uint32 reserves that value for null (Core Specification § 7.19.2, and `TlvNullable` implements the rule by binding the maximum one lower), so writing the user failed validation and the command reported an error every time. `SetUser` already stored `null` here; only this path did not.

## The user fields that path can now reach

Repairing it made the `UserStatus` and `UserType` a client sends reachable for the first time, and
running them showed both were stored: `UserStatus: Available` created a user reported as a free slot
while owning a credential, and `UserType: ProgrammingUser` created a programming user, which
§ 5.2.10.20 forbids for a user created alongside a credential.

Rather than guard those two values where they were found, the four use cases § 5.2.10.20 defines are
now checked as a table, since they differ only in which user fields they carry:

| use case | UserIndex | UserStatus | UserType |
| --- | --- | --- | --- |
| create the credential and its user | null | null, or Occupied{Enabled,Disabled} | null, or any but ProgrammingUser |
| add the credential to an existing user | set | null | null |
| modify a credential of an existing user | set | null | null |
| modify the programming PIN (ProgrammingPIN at index 0) | null | null | ProgrammingUser |

Carrying a user field on a use case that does not state one now answers `INVALID_COMMAND` instead of
being ignored. The CHIP SDK enforces the same for the middle two cases
(`door-lock-server.cpp:2564` and `:2677`, "when modifying a credential, userStatus and userType shall
both be NULL").

All four rows are enforced, including the credential the last one states. The CHIP SDK detects a
violation of that row's user fields, logs "Unable to modify programming PIN: invalid argument", and
then modifies the PIN anyway — the branch assigns no status and does not return — and it checks
neither the credential type nor the index. That reads as an omission rather than a decision, so this
follows the specification instead. Filed to raise upstream.

The field check also sits after duplicate detection rather than before it, so a request that is both
a duplicate and malformed reports `DUPLICATE`. That is the CHIP SDK's order too — it scans for
duplicates at `door-lock-server.cpp:764` and validates `UserStatus` at `:779` — and the
specification states no precedence between the two, so the reference implementation decides it.

## Two status details

`NextCredentialIndex` is stated independently of the status (§ 5.2.10.21.3), so it is computed before the guards that report a failure and carried by every response rather than only successful ones. The CHIP SDK computes it in the same position.

No free user slot for a new credential reports `OCCUPIED`. The specification's status list does not cover that case; this follows the CHIP SDK, which returns `kOccupied` from `createNewCredentialAndUser`.

On the out-of-range-index path the reported value is `null` either way, since no index follows the last supported one — that line is made uniform rather than made observable.

## Test plan

Thirteen tests, each new branch mutation-checked by reverting the production hunk alone:

| reverted | failure |
| --- | --- |
| `userUniqueId: null` | `Value 4294967295 is above the nullable uint32 maximum of 4294967294` |
| `OCCUPIED` for exhausted slots | `expected 137 to equal 3` |
| `nextCredentialIndex` on failures | `expected null to equal 3` |
| `nextCredentialIndex` on Modify | `expected null to equal 2` |
| the use-case table entirely | `expected +0 to equal 133` |
| only the null-fields rule for the middle two cases | `expected +0 to equal 133`, twice |
| requiring ProgrammingUser on the programming-PIN row | `expected +0 to equal 133` |
| using the request's UserStatus/UserType rather than the defaults | `expected 1 to equal 3` |
| rollback of the credential on an exhausted slot | `expected true to be false` |

The Modify path had no coverage at all before this; it shares the moved computation, so it gets a test.

## Verification

```
npm run build-clean   # Type check + Transpile, clean
npm run format        # 2367 files, no rewrites
npm run lint          # oxlint --type-aware, clean
npm test              # all packages green, ESM/CJS/Web, 0 failures
```

## Not included

Credential comparison (`LockAuth.isDuplicateCredential`, and PIN verification in `DoorLockServer`) uses `Bytes.areEqual`, which is not constant time; the CHIP SDK uses a constant-time compare deliberately. Closing that means adding a timing-safe primitive to `@matter/general`, which does not have one. Reachability is theoretical — the timing difference is nanoseconds against millisecond transport jitter, and the sender must already be commissioned with invoke rights — so it is raised rather than fixed here.
