### PR TITLE
A device type states how it composes its endpoint's PartsList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A certification run's `result.json` no longer reports a passing verdict for a run that failed
     - Fix: A failure to attach a certification run's device logs fails the run instead of only warning
 
+- @matter/model
+    - Enhancement: A device type states how it composes its endpoint's `PartsList` — `DeviceTypeModel.effectiveComposition` answers `"full-family"` for the root node and an aggregator and `"tree"` for everything else, inherited from the device type a definition derives from
+
 - @matter/node
     - Fix: (@Luligu) Corrects status codes returned by `DoorLockServer.setCredential` for duplicating another credential of the same type an adding an occupied credential index
     - Fix: `ClientStructure.applyWireChanges` applies the change it is given. A client node keys each member of a cluster by attribute ID, and a change from the remote API addresses members by property name, so values landed under a key reads were never served from: the update was invisible and never persisted. Values now convert as the change is applied

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,10 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A failure to attach a certification run's device logs fails the run instead of only warning
 
 - @matter/model
-    - Fix: An endpoint's own `PartsList` names every descendant only where its device type composes one that way. A bridged node carries the same internal index a root node and an aggregator do, so a device composed below one listed its grandchildren as if they were its own parts
-    - Enhancement: A device type states how it composes its endpoint's `PartsList` — `DeviceTypeModel.effectiveComposition` answers `"full-family"` for the root node and an aggregator and `"tree"` for everything else, inherited from the device type a definition derives from
+    - Enhancement: `DeviceTypeModel.effectiveComposition` states whether a device type composes its endpoint's `PartsList` of every descendant or of its own children
 
 - @matter/node
+    - Fix: A bridged node's `PartsList` names its own children rather than every endpoint below it
     - Fix: Creating a struct fills in a default only for a field the cluster supports, so a field a device does not set stays absent instead of carrying the fallback its schema states. A write of a list entry that omits a feature-gated field is accepted, where it previously failed validation against the field it had filled in. Affects `Thermostat` preset names and setpoints, `Descriptor` tag labels, `MediaPlayback` track attributes and the feature-gated members of `ClosureControl`, `ClosureDimension`, `ElectricalEnergyMeasurement`, `CommodityPrice` and `CommodityTariff`
     - Fix: A struct field's default is stored in the units and shape of its datatype: a preset created without a cooling setpoint reads `2600` rather than the schema's `26°C` notation, and a bitmap default arrives decoded
     - Fix: Each struct created by a write receives its own copy of a list or bitmap default instead of sharing one instance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A failure to attach a certification run's device logs fails the run instead of only warning
 
 - @matter/model
+    - Fix: An endpoint's own `PartsList` names every descendant only where its device type composes one that way. A bridged node carries the same internal index a root node and an aggregator do, so a device composed below one listed its grandchildren as if they were its own parts
     - Enhancement: A device type states how it composes its endpoint's `PartsList` — `DeviceTypeModel.effectiveComposition` answers `"full-family"` for the root node and an aggregator and `"tree"` for everything else, inherited from the device type a definition derives from
 
 - @matter/node

--- a/packages/model/src/common/EndpointComposition.ts
+++ b/packages/model/src/common/EndpointComposition.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * How a device type composes the `PartsList` of the endpoint it is on.
+ *
+ * A part's parent is not on the wire — `Descriptor` has no attribute naming it — so a node
+ * reconstructing another node's endpoint tree has only these lists to go on, and what a list means
+ * depends on the device type reporting it.
+ *
+ * @see {@link MatterSpecification.v16.Core} § 9.2.3
+ */
+export enum EndpointComposition {
+    /**
+     * The `PartsList` names the endpoint's own children, so it is a parent's list of its parts.
+     *
+     * @see {@link MatterSpecification.v16.Core} § 9.2.3
+     */
+    Tree = "tree",
+
+    /**
+     * The `PartsList` names every descendant, "with no imposed hierarchy" — so it says that a part is
+     * somewhere below the endpoint and nothing about which endpoint owns it.
+     *
+     * @see {@link MatterSpecification.v16.Core} § 9.2.3
+     */
+    FullFamily = "full-family",
+}

--- a/packages/model/src/common/index.ts
+++ b/packages/model/src/common/index.ts
@@ -7,6 +7,7 @@
 export * from "./DataModelPath.js";
 export * from "./DefinitionError.js";
 export * from "./DeviceClassification.js";
+export * from "./EndpointComposition.js";
 export * from "./ElementTag.js";
 export * from "./errors.js";
 export * from "./FeatureSet.js";

--- a/packages/model/src/elements/DeviceTypeElement.ts
+++ b/packages/model/src/elements/DeviceTypeElement.ts
@@ -20,8 +20,10 @@ export interface DeviceTypeElement extends BaseElement {
     classification?: `${DeviceClassification}`;
 
     /**
-     * How this device type composes its endpoint's `PartsList`. Inherited from the base device type,
-     * and {@link EndpointComposition.Tree} where neither states one.
+     * How this device type composes its endpoint's `PartsList`, where it declares this itself.
+     *
+     * A device type that declares nothing leaves this unset; `DeviceTypeModel.effectiveComposition`
+     * is what answers for one, inheritance and default included.
      */
     composition?: `${EndpointComposition}`;
 

--- a/packages/model/src/elements/DeviceTypeElement.ts
+++ b/packages/model/src/elements/DeviceTypeElement.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DeviceClassification, ElementTag } from "../common/index.js";
+import { DeviceClassification, ElementTag, EndpointComposition } from "../common/index.js";
 import { BaseElement } from "./BaseElement.js";
 import { ConditionElement } from "./ConditionElement.js";
 import { FieldElement } from "./FieldElement.js";
@@ -18,6 +18,13 @@ import { RequirementElement } from "./RequirementElement.js";
 export interface DeviceTypeElement extends BaseElement {
     tag: `${DeviceTypeElement.Tag}`;
     classification?: `${DeviceClassification}`;
+
+    /**
+     * How this device type composes its endpoint's `PartsList`. Inherited from the base device type,
+     * and {@link EndpointComposition.Tree} where neither states one.
+     */
+    composition?: `${EndpointComposition}`;
+
     category?: string;
     children?: (RequirementElement | FieldElement | ConditionElement)[];
 }

--- a/packages/model/src/logic/definition-validation/DeviceTypeValidator.ts
+++ b/packages/model/src/logic/definition-validation/DeviceTypeValidator.ts
@@ -5,6 +5,7 @@
  */
 
 import { DeviceClassification } from "../../common/DeviceClassification.js";
+import { EndpointComposition } from "../../common/EndpointComposition.js";
 import { DeviceTypeElement } from "../../elements/index.js";
 import { ConditionModel, DeviceTypeModel, FieldModel, RequirementModel } from "../../models/index.js";
 import { ModelValidator } from "./ModelValidator.js";
@@ -15,6 +16,10 @@ ModelValidator.validators[DeviceTypeElement.Tag] = class DeviceTypeValidator ext
         this.validateProperty({
             name: "classification",
             type: DeviceClassification,
+        });
+        this.validateProperty({
+            name: "composition",
+            type: EndpointComposition,
         });
 
         super.validate();

--- a/packages/model/src/models/DeviceTypeModel.ts
+++ b/packages/model/src/models/DeviceTypeModel.ts
@@ -7,6 +7,7 @@
 import { DeviceClassification } from "../common/DeviceClassification.js";
 import { EndpointComposition } from "../common/EndpointComposition.js";
 import { DeviceTypeElement } from "../elements/index.js";
+import { ModelTraversal } from "../logic/ModelTraversal.js";
 import { ConditionModel } from "./ConditionModel.js";
 import { FieldModel } from "./FieldModel.js";
 import { Model } from "./Model.js";
@@ -30,12 +31,18 @@ export class DeviceTypeModel extends Model<DeviceTypeElement, DeviceTypeModel.Ch
      * type opts into (§ 9.2.3).
      */
     get effectiveComposition(): EndpointComposition {
-        for (let model: Model | undefined = this; model !== undefined; model = model.base) {
+        let composition: EndpointComposition | undefined;
+
+        // One traversal rather than a hop-by-hop walk of #base, so a definition that derives from
+        // itself through another is caught by the traversal's own cycle detection
+        new ModelTraversal().visitInheritance(this, model => {
             if (model instanceof DeviceTypeModel && model.composition !== undefined) {
-                return model.composition;
+                composition = model.composition;
+                return false;
             }
-        }
-        return EndpointComposition.Tree;
+        });
+
+        return composition ?? EndpointComposition.Tree;
     }
 
     get requirements() {

--- a/packages/model/src/models/DeviceTypeModel.ts
+++ b/packages/model/src/models/DeviceTypeModel.ts
@@ -5,6 +5,7 @@
  */
 
 import { DeviceClassification } from "../common/DeviceClassification.js";
+import { EndpointComposition } from "../common/EndpointComposition.js";
 import { DeviceTypeElement } from "../elements/index.js";
 import { ConditionModel } from "./ConditionModel.js";
 import { FieldModel } from "./FieldModel.js";
@@ -14,6 +15,28 @@ import { RequirementModel } from "./RequirementModel.js";
 export class DeviceTypeModel extends Model<DeviceTypeElement, DeviceTypeModel.Child> implements DeviceTypeElement {
     override tag: DeviceTypeElement.Tag = DeviceTypeElement.Tag;
     classification?: DeviceClassification;
+
+    /**
+     * How this device type composes its endpoint's `PartsList`, as this device type declares it.
+     * {@link effectiveComposition} answers what applies, inheritance and default included.
+     */
+    composition?: EndpointComposition;
+
+    /**
+     * How this device type composes its endpoint's `PartsList`.
+     *
+     * A device type that declares nothing takes its base's answer, and the tree pattern where no
+     * ancestor declares one either — the specification defines full-family as the exception a device
+     * type opts into (§ 9.2.3).
+     */
+    get effectiveComposition(): EndpointComposition {
+        for (let model: Model | undefined = this; model !== undefined; model = model.base) {
+            if (model instanceof DeviceTypeModel && model.composition !== undefined) {
+                return model.composition;
+            }
+        }
+        return EndpointComposition.Tree;
+    }
 
     get requirements() {
         return this.all(RequirementModel);
@@ -29,11 +52,13 @@ export class DeviceTypeModel extends Model<DeviceTypeElement, DeviceTypeModel.Ch
         super(definition, ...children);
 
         this.classification = definition.classification as DeviceClassification;
+        this.composition = definition.composition as EndpointComposition;
     }
 
     override toElement(omitResources = false, extra?: Record<string, unknown>) {
         return super.toElement(omitResources, {
             classification: this.classification,
+            composition: this.composition,
             ...extra,
         });
     }

--- a/packages/model/src/models/DeviceTypeModel.ts
+++ b/packages/model/src/models/DeviceTypeModel.ts
@@ -33,8 +33,8 @@ export class DeviceTypeModel extends Model<DeviceTypeElement, DeviceTypeModel.Ch
     get effectiveComposition(): EndpointComposition {
         let composition: EndpointComposition | undefined;
 
-        // One traversal rather than a hop-by-hop walk of #base, so a definition that derives from
-        // itself through another is caught by the traversal's own cycle detection
+        // A single traversal, whose cycle detection then spans the whole inheritance chain: a
+        // definition that derives from itself must be reported rather than followed
         new ModelTraversal().visitInheritance(this, model => {
             if (model instanceof DeviceTypeModel && model.composition !== undefined) {
                 composition = model.composition;

--- a/packages/model/src/standard/elements/aggregator.element.ts
+++ b/packages/model/src/standard/elements/aggregator.element.ts
@@ -14,7 +14,7 @@ import {
 } from "../../elements/index.js";
 
 export const AggregatorDt = DeviceType(
-    { name: "Aggregator", id: 0xe, classification: "simple" },
+    { name: "Aggregator", id: 0xe, classification: "simple", composition: "full-family" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 14, revision: 2 } ], element: "attribute" })

--- a/packages/model/src/standard/elements/root-node.element.ts
+++ b/packages/model/src/standard/elements/root-node.element.ts
@@ -14,7 +14,7 @@ import {
 } from "../../elements/index.js";
 
 export const RootNodeDt = DeviceType(
-    { name: "RootNode", id: 0x16, classification: "node" },
+    { name: "RootNode", id: 0x16, classification: "node", composition: "full-family" },
     Requirement(
         { name: "Descriptor", id: 0x1d, element: "serverCluster" },
         Requirement({ name: "DeviceTypeList", default: [ { deviceType: 22, revision: 4 } ], element: "attribute" })

--- a/packages/model/test/models/DeviceTypeModelTest.ts
+++ b/packages/model/test/models/DeviceTypeModelTest.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DeviceTypeModel, EndpointComposition, MatterModel } from "@matter/model";
+import { DeviceTypeModel, EndpointComposition, MatterModel, ValidateModel } from "@matter/model";
 
 describe("DeviceTypeModel", () => {
     describe("effectiveComposition", () => {
@@ -37,6 +37,34 @@ describe("DeviceTypeModel", () => {
 
             expect(derived.composition).undefined;
             expect(derived.effectiveComposition).equals(EndpointComposition.FullFamily);
+        });
+
+        it("refuses a definition that derives from itself rather than searching forever", () => {
+            const matter = new MatterModel({
+                name: "Test",
+                children: [
+                    { tag: "deviceType", name: "Ouroboros", id: 0xfff1, type: "Serpent" },
+                    { tag: "deviceType", name: "Serpent", id: 0xfff2, type: "Ouroboros" },
+                ],
+            });
+
+            expect(() => matter.deviceTypes.require("Ouroboros", DeviceTypeModel).effectiveComposition).throws(
+                /cycle/i,
+            );
+        });
+    });
+
+    describe("validation", () => {
+        it("rejects a composition the enumeration does not define", () => {
+            // Parsed rather than written, because the typed form of a definition cannot express this
+            // and an untyped definition is the way one arrives
+            const definition = JSON.parse(
+                '{ "name": "Test", "children": [{ "tag": "deviceType", "name": "Confused", "id": 65521, "composition": "flat" }] }',
+            );
+
+            const result = ValidateModel(new MatterModel(definition));
+
+            expect(result.errors.map(error => error.message).join("; ")).match(/composition/i);
         });
     });
 });

--- a/packages/model/test/models/DeviceTypeModelTest.ts
+++ b/packages/model/test/models/DeviceTypeModelTest.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DeviceTypeModel, EndpointComposition, MatterModel } from "@matter/model";
+
+describe("DeviceTypeModel", () => {
+    describe("effectiveComposition", () => {
+        it("answers full-family for the two device types the specification names", () => {
+            for (const name of ["RootNode", "Aggregator"]) {
+                const deviceType = MatterModel.standard.deviceTypes.require(name, DeviceTypeModel);
+                expect(deviceType.effectiveComposition, name).equals(EndpointComposition.FullFamily);
+            }
+        });
+
+        it("answers tree for a device type that declares nothing", () => {
+            const deviceType = MatterModel.standard.deviceTypes.require("OnOffLight", DeviceTypeModel);
+
+            expect(deviceType.composition).undefined;
+            expect(deviceType.effectiveComposition).equals(EndpointComposition.Tree);
+        });
+
+        it("inherits the composition of the device type it derives from", () => {
+            // A manufacturer's own aggregator composes its PartsList the way an aggregator does,
+            // without having to say so
+            const matter = new MatterModel({
+                name: "Test",
+                children: [
+                    ...MatterModel.standard.deviceTypes.map(deviceType => deviceType.toElement()),
+                    { tag: "deviceType", name: "VendorAggregator", id: 0xfff1, type: "Aggregator" },
+                ],
+            });
+
+            const derived = matter.deviceTypes.require("VendorAggregator", DeviceTypeModel);
+
+            expect(derived.composition).undefined;
+            expect(derived.effectiveComposition).equals(EndpointComposition.FullFamily);
+        });
+    });
+});

--- a/packages/node/src/behaviors/descriptor/DescriptorServer.ts
+++ b/packages/node/src/behaviors/descriptor/DescriptorServer.ts
@@ -8,7 +8,7 @@ import { IndexBehavior } from "#behavior/system/index/IndexBehavior.js";
 import { Endpoint } from "#endpoint/Endpoint.js";
 import { EndpointLifecycle } from "#endpoint/properties/EndpointLifecycle.js";
 import { ImplementationError, isDeepEqual, Logger } from "@matter/general";
-import { Matter } from "@matter/model";
+import { EndpointComposition, Matter } from "@matter/model";
 import { ClusterId, DeviceTypeId, EndpointNumber, Semtag } from "@matter/types";
 import { Descriptor } from "@matter/types/clusters/descriptor";
 import { DescriptorBehavior } from "./DescriptorBehavior.js";
@@ -209,9 +209,7 @@ export class DescriptorServer extends DescriptorBehavior {
 
         let numbers: number[];
 
-        // The presence of IndexBehavior indicates a flat namespace as required by Matter standard for root and
-        // aggregator endpoints
-        if (this.agent.has(IndexBehavior)) {
+        if (this.#composesFullFamily && this.agent.has(IndexBehavior)) {
             const index = this.agent.get(IndexBehavior);
             numbers = Object.keys(index.partsByNumber).map(n => Number.parseInt(n));
 
@@ -250,6 +248,23 @@ export class DescriptorServer extends DescriptorBehavior {
         await this.context.transaction.begin();
 
         this.state.partsList = numbers as EndpointNumber[];
+    }
+
+    /**
+     * Whether this endpoint's device type composes its `PartsList` of every descendant rather than of
+     * its own children (Matter Core § 9.2.3).
+     *
+     * {@link IndexBehavior} is how the flat list is obtained, not what decides it is wanted: the
+     * behavior is installed on bridged nodes too, which compose a tree.
+     */
+    get #composesFullFamily() {
+        const deviceTypes = this.state.deviceTypeList.length
+            ? this.state.deviceTypeList.map(entry => entry.deviceType)
+            : [this.endpoint.type.deviceType];
+
+        return deviceTypes.some(
+            deviceType => Matter.deviceTypes(deviceType)?.effectiveComposition === EndpointComposition.FullFamily,
+        );
     }
 
     /**

--- a/packages/node/test/behaviors/descriptor/DescriptorServerTest.ts
+++ b/packages/node/test/behaviors/descriptor/DescriptorServerTest.ts
@@ -13,6 +13,7 @@ import { OnOffLightSwitchDevice } from "#devices/on-off-light-switch";
 import { Endpoint } from "#endpoint/Endpoint.js";
 import { MutableEndpoint } from "#endpoint/type/MutableEndpoint.js";
 import { AggregatorEndpoint } from "#endpoints/aggregator";
+import { BridgedNodeEndpoint } from "#endpoints/bridged-node";
 import type { Node } from "#node/Node.js";
 import { ClusterId, DeviceTypeId, EndpointNumber } from "@matter/types";
 import { MockEndpointType } from "../../behavior/mock-behavior.js";
@@ -136,6 +137,45 @@ describe("DescriptorServer", () => {
             // { deviceType: 257, revision: 3 },
             // { deviceType: 256, revision: 3 },
         ]);
+    });
+
+    describe("composition", () => {
+        it("lists every descendant for an aggregator and only children for a bridged node", async () => {
+            // A bridged node carries IndexBehavior as root and aggregator do, but composes a tree
+            // (Matter Core § 9.2.3), so only its own children belong in its list
+            const node = await MockServerNode.create({
+                number: 0,
+                parts: [
+                    {
+                        type: AggregatorEndpoint,
+                        number: 1,
+                        parts: [
+                            {
+                                type: BridgedNodeEndpoint,
+                                number: 2,
+                                parts: [
+                                    {
+                                        type: OnOffLightDevice,
+                                        number: 3,
+                                        parts: [{ type: OnOffLightDevice, number: 4 }],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            });
+
+            await node.env.get(NodeActivity).inactive;
+
+            const aggregator = [...node.parts][0];
+            const bridgedNode = [...aggregator.parts][0];
+            const light = [...bridgedNode.parts][0];
+
+            expect(aggregator.stateOf(DescriptorBehavior).partsList).deep.equals([2, 3, 4]);
+            expect(bridgedNode.stateOf(DescriptorBehavior).partsList).deep.equals([3]);
+            expect(light.stateOf(DescriptorBehavior).partsList).deep.equals([4]);
+        });
     });
 
     describe("adds parts automatically with indexed grandparent and parent", () => {

--- a/support/models/src/local/EndpointCompositionOverrides.ts
+++ b/support/models/src/local/EndpointCompositionOverrides.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EndpointComposition } from "@matter/model";
+import { LocalMatter } from "../local.js";
+
+// The two device types the specification names as composing their PartsList of every descendant
+// rather than of their own children (Core § 9.2.3). It states the pattern in prose in each device
+// type's own section, which the scrape does not carry.
+for (const name of ["RootNode", "Aggregator"]) {
+    LocalMatter.children.push({
+        tag: "deviceType",
+        name,
+        composition: EndpointComposition.FullFamily,
+    });
+}

--- a/support/models/src/local/index.ts
+++ b/support/models/src/local/index.ts
@@ -21,6 +21,7 @@ import "./CommodityTariffOverrides.js";
 import "./DoorLockOverrides.js";
 import "./duration.js";
 import "./ElectricalPowerMeasurementOverrides.js";
+import "./EndpointCompositionOverrides.js";
 import "./epoch-s.js";
 import "./epoch-us.js";
 import "./FanControl.js";


### PR DESCRIPTION
A `PartsList` means one of two things depending on the device type reporting it. The tree pattern names
an endpoint's own children; the full-family pattern names every descendant *"with no imposed
hierarchy"* (Matter Core § 9.2.3, which gives the two patterns a section each). Nothing on the wire
distinguishes them — `Descriptor` carries no attribute naming a part's parent — so a node
reconstructing another node's endpoint tree has to know which pattern each endpoint uses, and until now
nothing in the model said.

`DeviceTypeModel` gains `composition` for what a device type declares, and `effectiveComposition` for
what applies: what it declares, else what the device type it derives from declares, else the tree
pattern. So a manufacturer's own aggregator declaring `type: "Aggregator"` composes its list the way an
aggregator does without having to say so — which a list of known device type ids could not do.

The specification states the pattern in prose inside each device type's own section rather than in a
table, which the scrape does not carry, so the two it names take it from a local override. That is the
first device-type override in `support/models/src/local`, and needed no change to the merge.

The declared/effective split follows the model's existing `effectiveId` / `effectiveType` /
`effectiveXref` idiom. It also matters mechanically: naming the getter `composition` shadows the stored
field when the generator round-trips a model through `toElement`, which stamped `composition: "tree"`
onto all 99 device-type element files. With the split the generated diff is the two lines it should be.

## Verification

`generate-model` reports validation successful over 8332 elements, and the regenerated output is
exactly the aggregator and root-node elements. Full suite, build, lint and format clean.

Three tests, and the inheritance one is mutation-verified — removing the base walk fails it with
`expected 'tree' to equal 'full-family'`.

## Consumer

The branch stacked on this one uses it to fix the endpoint tree a controller builds for a bridge with a
composed device, which is the defect that prompted it.

## Our own server had the same problem

`DescriptorServer` decided which endpoints report a flat `PartsList` from the presence of
`IndexBehavior`, whose own documentation says it *"should only be present on root and aggregator
parts"*. It is also installed on bridged nodes, which compose a tree — so a device composed below a
bridged node had its **grandchildren** listed among the bridged node's own parts. The device type now
decides, and the behavior is what produces the flat list rather than what asks for one.

A composition two levels deep reports the same list either way, which is why this went unnoticed. The
test goes three deep — aggregator, bridged node, light, light — and reverting the condition fails it
with `expected [ 3, 4 ] to deeply equal [ 3 ]`.

This is wire-visible for any endpoint that carries `IndexBehavior` without being a root node or an
aggregator, which today means bridged nodes.

## Copilot's two findings, both real

The composition walked `base` hop by hop, building a fresh `ModelTraversal` each time, so its cycle
guard could not span the walk and a definition deriving from itself would be followed forever. One
traversal now detects it. And `composition` reaches a model through untyped definitions where the
element's typing cannot refuse a value the enumeration does not define, so the validator checks it as
it already checks `classification` — which also removed a cast.
