### PR TITLE
fix(node): reserve door lock credential index 0 for the programming PIN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: `DeviceTypeModel.effectiveComposition` states whether a device type composes its endpoint's `PartsList` of every descendant or of its own children
 
 - @matter/node
+    - Fix: `DoorLockServer` reserves credential index 0 for the programming PIN, refusing it for any other credential type and refusing any other index for the programming PIN. The programming PIN counts as one credential rather than one of the PIN credentials, and reports no next index
     - Fix: (@Luligu) Corrects status codes returned by `DoorLockServer.setCredential` for duplicating another credential of the same type and adding an occupied credential index
     - Fix: `DoorLockServer.setCredential` creates the user alongside the credential when the request carries no user index
     - Fix: `DoorLockServer.setCredential` reports `NextCredentialIndex` on a failing response as well as a successful one

--- a/packages/node/src/behaviors/door-lock/DoorLockServer.ts
+++ b/packages/node/src/behaviors/door-lock/DoorLockServer.ts
@@ -306,17 +306,17 @@ export class DoorLockBaseServer extends DoorLockBaseServerClass {
     override setCredential(request: DoorLock.SetCredentialRequest): DoorLock.SetCredentialResponse {
         const { operationType, credential, credentialData, userIndex, userStatus, userType } = request;
         const fabricIndex = this.#fabricIndex;
-        const maxCredentials = this.#maxCredentialsForType(credential.credentialType);
+        const maxCredentialIndex = this.#maxCredentialIndexForType(credential.credentialType);
         const auth = this.auth;
 
         // § 5.2.10.21.3 states NextCredentialIndex independently of the status, so every response carries it
         const nextCredentialIndex = auth.findNextAvailableCredentialIndex(
             credential.credentialType,
             credential.credentialIndex,
-            maxCredentials,
+            maxCredentialIndex,
         );
 
-        if (credential.credentialIndex < 0 || credential.credentialIndex > maxCredentials) {
+        if (!this.#credentialIndexValid(credential.credentialType, credential.credentialIndex, maxCredentialIndex)) {
             return { status: Status.InvalidCommand, userIndex: null, nextCredentialIndex };
         }
 
@@ -1027,23 +1027,36 @@ export class DoorLockBaseServer extends DoorLockBaseServerClass {
             return userType !== UserType.ProgrammingUser;
         }
 
-        // Modifying the programming user's PIN is the one case that states what it carries rather than forbidding it
+        // Reached only for a credential index the type permits, so the programming PIN is already at index 0
         if (operationType === DataOperationType.Modify && userIndex === null) {
             return (
                 userStatus === null &&
                 userType === UserType.ProgrammingUser &&
-                credential.credentialType === CredentialType.ProgrammingPin &&
-                credential.credentialIndex === 0
+                credential.credentialType === CredentialType.ProgrammingPin
             );
         }
 
         return userStatus === null && userType === null;
     }
 
-    #maxCredentialsForType(type: CredentialType): number {
+    /**
+     * § 5.2.6.24.2 states index 0 for a credential type that indexes into nothing, of which the programming PIN is
+     * the only one, so every other type indexes from 1.
+     */
+    #credentialIndexValid(type: CredentialType, index: number, maxIndex: number): boolean {
+        if (type === CredentialType.ProgrammingPin) {
+            return index === 0;
+        }
+
+        return index >= 1 && index <= maxIndex;
+    }
+
+    #maxCredentialIndexForType(type: CredentialType): number {
         switch (type) {
-            case CredentialType.Pin:
+            // Indexes into nothing, so there is no slot to scan and none to report
             case CredentialType.ProgrammingPin:
+                return 0;
+            case CredentialType.Pin:
                 return this.state.numberOfPinUsersSupported;
             case CredentialType.Rfid:
                 return this.state.numberOfRfidUsersSupported;

--- a/packages/node/test/behaviors/door-lock/DoorLockServerTest.ts
+++ b/packages/node/test/behaviors/door-lock/DoorLockServerTest.ts
@@ -339,7 +339,7 @@ describe("DoorLockServer", () => {
         await lock.node.online({}, async agent => {
             const doorLock = lock.endpoint.agentFor(agent.context).doorLock;
 
-            await doorLock.setCredential({
+            const seeded = await doorLock.setCredential({
                 operationType: DoorLock.DataOperationType.Add,
                 credential: { credentialType: DoorLock.CredentialType.ProgrammingPin, credentialIndex: 0 },
                 credentialData: pin("1234"),
@@ -347,6 +347,7 @@ describe("DoorLockServer", () => {
                 userStatus: null,
                 userType: null,
             });
+            expect(seeded.status).equals(Status.Success);
 
             const modified = await doorLock.setCredential({
                 operationType: DoorLock.DataOperationType.Modify,
@@ -368,44 +369,92 @@ describe("DoorLockServer", () => {
             });
             expect(withoutType.status).equals(Status.InvalidCommand);
 
-            // Each of the two below would modify its credential were the use case not checked
-            await doorLock.setCredential({
+            const seededPin = await doorLock.setCredential({
                 operationType: DoorLock.DataOperationType.Add,
-                credential: { credentialType: DoorLock.CredentialType.ProgrammingPin, credentialIndex: 1 },
-                credentialData: pin("2345"),
-                userIndex: 1,
-                userStatus: null,
-                userType: null,
-            });
-
-            const wrongCredentialIndex = await doorLock.setCredential({
-                operationType: DoorLock.DataOperationType.Modify,
-                credential: { credentialType: DoorLock.CredentialType.ProgrammingPin, credentialIndex: 1 },
-                credentialData: pin("9012"),
-                userIndex: null,
-                userStatus: null,
-                userType: DoorLock.UserType.ProgrammingUser,
-            });
-            expect(wrongCredentialIndex.status).equals(Status.InvalidCommand);
-
-            await doorLock.setCredential({
-                operationType: DoorLock.DataOperationType.Add,
-                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 0 },
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
                 credentialData: pin("3456"),
                 userIndex: 1,
                 userStatus: null,
                 userType: null,
             });
+            expect(seededPin.status).equals(Status.Success);
 
             const wrongCredentialType = await doorLock.setCredential({
                 operationType: DoorLock.DataOperationType.Modify,
-                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 0 },
-                credentialData: pin("9012"),
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 1 },
+                credentialData: pin("7890"),
                 userIndex: null,
                 userStatus: null,
                 userType: DoorLock.UserType.ProgrammingUser,
             });
             expect(wrongCredentialType.status).equals(Status.InvalidCommand);
+        });
+    });
+
+    it("reserves credential index 0 for the programming PIN", async () => {
+        await using lock = await createLock();
+
+        await lock.node.online({}, async agent => {
+            const doorLock = lock.endpoint.agentFor(agent.context).doorLock;
+
+            const pinAtZero = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 0 },
+                credentialData: pin("1234"),
+                userIndex: 1,
+                userStatus: null,
+                userType: null,
+            });
+            expect(pinAtZero.status).equals(Status.InvalidCommand);
+
+            const pinAtMax = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 10 },
+                credentialData: pin("5678"),
+                userIndex: 1,
+                userStatus: null,
+                userType: null,
+            });
+            expect(pinAtMax.status).equals(Status.Success);
+
+            const pinPastMax = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.Pin, credentialIndex: 11 },
+                credentialData: pin("6789"),
+                userIndex: 1,
+                userStatus: null,
+                userType: null,
+            });
+            expect(pinPastMax.status).equals(Status.InvalidCommand);
+
+            const programmingPinElsewhere = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.ProgrammingPin, credentialIndex: 1 },
+                credentialData: pin("1234"),
+                userIndex: 1,
+                userStatus: null,
+                userType: null,
+            });
+            expect(programmingPinElsewhere.status).equals(Status.InvalidCommand);
+        });
+    });
+
+    it("reports no next index for the programming PIN", async () => {
+        await using lock = await createLock();
+
+        await lock.node.online({}, async agent => {
+            const doorLock = lock.endpoint.agentFor(agent.context).doorLock;
+
+            const added = await doorLock.setCredential({
+                operationType: DoorLock.DataOperationType.Add,
+                credential: { credentialType: DoorLock.CredentialType.ProgrammingPin, credentialIndex: 0 },
+                credentialData: pin("1234"),
+                userIndex: 1,
+                userStatus: null,
+                userType: null,
+            });
+            expect(added.status).equals(Status.Success);
+            expect(added.nextCredentialIndex).null;
         });
     });
 


### PR DESCRIPTION
`CredentialIndex` was validated only against its upper bound:

```ts
if (credential.credentialIndex < 0 || credential.credentialIndex > maxCredentials) {
```

`credentialIndex` is a `uint16` on the wire, so the negative half never fired there, and the reserved index was not checked at all. A PIN could occupy index 0, and a programming PIN any index up to the maximum.

§ 5.2.6.24.2 states the rule for the `CredentialIndex` field of `CredentialStruct`: it "shall be set to 0 if CredentialType is ProgrammingPIN or does not correspond to a list that can be indexed into". The programming PIN is the only credential type today that indexes into nothing — every other type, the Aliro keys included, has a `NumberOf…Supported` attribute and an indexed list — so index 0 belongs to it and nothing else, and every other type indexes from 1.

The CHIP SDK enforces both directions in `credentialIndexValid` (`door-lock-server.cpp:1601-1616`).

## The programming PIN has no indexable slot

It no longer draws its bound from `NumberOfPINUsersSupported`, which the specification scopes to PIN credentials. Its bound is the highest index that can be scanned, which for a type that indexes into nothing is none — so the scan for the next available index finds nothing and the response reports no next index. The CHIP SDK reaches the same result by decrementing its count of 1 to 0 before scanning, and sends the field as null.

That also let the store stay index-agnostic: `findNextAvailableCredentialIndex` keeps no knowledge of the rule, which matters because `LockAuth.Store` is replaceable through the `auth` override.

## Consequence for a lock that already stored one

Credentials are nonvolatile and this storage shipped in 0.17.0, so a lock may hold a credential at an index now refused — only if a controller sent one, since a conforming controller does not. Such a credential stays readable, still operates the lock, and stays removable: a PIN at index 0 through `ClearCredential`, a programming PIN through `ClearUser` on its user, which removes credentials by the user's own references regardless of index. What it loses is `Modify`. No migration is included: silently dropping a stored credential on upgrade is worse than the narrow case it would address.

## Test plan

Sixteen tests. Each rule mutation-checked by reverting the production hunk alone:

| reverted | failure |
| --- | --- |
| the reserved-index rule | `expected +0 to equal 133` |
| the programming PIN's bound | `expected 1 to be null` |

Both boundaries of the surviving range are covered — index 10 (`NumberOfPINUsersSupported`) succeeds, index 11 is refused — alongside index 0 refused for a PIN and index 1 refused for a programming PIN.

## Verification

```
npm run build-clean   # Type check + Transpile, clean
npm run format        # 2373 files, no rewrites
npm run lint          # oxlint --type-aware, clean
npm test              # all packages green, ESM/CJS/Web, 0 failures
```
