### PR TITLE
feat(node-manager): stop keeping a finished task's parameters, and only cancel work still in flight

### DIFF
--- a/packages/node-manager/src/task/RunStore.ts
+++ b/packages/node-manager/src/task/RunStore.ts
@@ -28,6 +28,15 @@ export function isTerminal(state: TaskState): boolean {
 export const RUN_ID_RESERVATION = 64;
 
 /**
+ * Schema version of the persisted run table.
+ *
+ * Bumped whenever a build changes what a record means rather than merely what it contains, so a later build
+ * can refuse a table it would misread. It cannot protect against a *downgrade* — an older build has no check —
+ * so this buys detection from here on, not backward safety.
+ */
+export const RUN_STORE_VERSION = 2;
+
+/**
  * One verb's exclusive hold on a run's outcome.
  *
  * {@link settled} resolves when the hold ends, so a second caller of the same verb waits for the decision and
@@ -42,6 +51,7 @@ export interface RunStoreSnapshot {
     runs: Record<string, TaskPersistence>;
     nextRunId: number;
     nextRetireSeq: number;
+    runsVersion: number;
 }
 
 /**
@@ -49,7 +59,8 @@ export interface RunStoreSnapshot {
  *
  * Deliberately free of any dependency on a node, a gate or a clock, so its invariants — allocation
  * monotonicity, one owner per slot, ordering by retirement rather than by start — are testable without
- * driving a task. The manager owns persistence and calls {@link snapshot} to write.
+ * driving a task. The manager owns persistence: it writes the records a transaction names
+ * rather than republishing this table, so a run this process never loaded is never erased by one that did.
  */
 export class RunStore {
     #nextRunId = 1;
@@ -60,6 +71,7 @@ export class RunStore {
      */
     #reservedBelow = 1;
     #nextRetireSeq = 1;
+    #unreadable = false;
 
     /** Every run this process knows, in every phase. One table, so no verb can look in the wrong one. */
     readonly #records = new Map<RunId, RunRecord>();
@@ -98,6 +110,15 @@ export class RunStore {
         let discarded = 0;
         let highest = 0;
 
+        const version = snapshot?.runsVersion ?? 1;
+        if (version > RUN_STORE_VERSION) {
+            // Not loading is not enough on its own: the records stay in storage, so admitting work would drive
+            // targets they own. Every verb refuses while this is set, rather than answering "no such run" for
+            // runs that demonstrably exist in the table.
+            this.#unreadable = true;
+            return { resumable, discarded };
+        }
+
         for (const stored of Object.values(snapshot?.runs ?? {})) {
             // Pre-runId records name their slot where a runId now goes; they cannot be resumed under an
             // identity they never had.
@@ -131,6 +152,13 @@ export class RunStore {
             ...[...this.#records.values()].map(r => (r.retireSeq ?? 0) + 1),
         );
         return { resumable, discarded };
+    }
+
+    /**
+     * Whether the stored table was written by a newer build, so nothing was loaded and nothing may be admitted.
+     */
+    get unreadable(): boolean {
+        return this.#unreadable;
     }
 
     get nextRunId(): number {
@@ -278,6 +306,31 @@ export class RunStore {
         return this.#transitions.get(runId);
     }
 
+    /**
+     * A retired run of the same slot that finished after `runId`, if there is one.
+     *
+     * Undoing a run restores the values it found, so a later run of the same slot having since committed its
+     * own makes those values historical: applying them would overwrite an outcome nobody asked to undo.
+     */
+    supersederOf(runId: RunId): RunRecord | undefined {
+        const record = this.#records.get(runId);
+        if (record === undefined || !isTerminal(record.state)) {
+            return undefined;
+        }
+        const retiredAt = record.retireSeq ?? 0;
+        for (const other of this.#records.values()) {
+            if (
+                other.runId !== runId &&
+                other.slotKey === record.slotKey &&
+                isTerminal(other.state) &&
+                (other.retireSeq ?? 0) > retiredAt
+            ) {
+                return other;
+            }
+        }
+        return undefined;
+    }
+
     /** Register a run and give it ownership of its slot. In memory only: nothing is durable yet. */
     admit(record: RunRecord, execution?: Execution): void {
         const owner = this.#slots.get(record.slotKey);
@@ -313,9 +366,9 @@ export class RunStore {
      * already has one.
      *
      * Allocated for the write that records the outcome, so the two land together: a terminal record that
-     * reached storage without an order would sort ahead of every sequenced run of its slot, and
-     * {@link supersederOf} would then let an older run's rollback overwrite it. A refused write leaves a gap in
-     * the sequence, which costs nothing — the order only ever has to be increasing.
+     * reached storage without an order is discarded at load, because it has no position among the runs of its
+     * slot. A refused write leaves a gap in the sequence, which costs nothing — the order only ever has to be
+     * increasing.
      */
     nextRetirement(record: RunRecord): RetireSeq | undefined {
         if (this.#slots.get(record.slotKey) !== record.runId || record.retireSeq !== undefined) {
@@ -339,31 +392,6 @@ export class RunStore {
         if (this.#slots.get(record.slotKey) === record.runId) {
             this.#slots.delete(record.slotKey);
         }
-    }
-
-    /**
-     * A retired run of the same slot that finished after `runId`, if there is one.
-     *
-     * Undoing a run restores the values it found, so a later run of the same slot having since committed its
-     * own makes those values historical: applying them would overwrite an outcome nobody asked to undo.
-     */
-    supersederOf(runId: RunId): RunRecord | undefined {
-        const record = this.#records.get(runId);
-        if (record === undefined || !isTerminal(record.state)) {
-            return undefined;
-        }
-        const retiredAt = record.retireSeq ?? 0;
-        for (const other of this.#records.values()) {
-            if (
-                other.runId !== runId &&
-                other.slotKey === record.slotKey &&
-                isTerminal(other.state) &&
-                (other.retireSeq ?? 0) > retiredAt
-            ) {
-                return other;
-            }
-        }
-        return undefined;
     }
 
     /**
@@ -418,11 +446,21 @@ export class RunStore {
         return undefined;
     }
 
+    /**
+     * The whole table as storage would hold it. Not how the manager writes — it records the runs a transaction
+     * names, so a run this process never loaded is not erased by one that did — so this exists for a caller
+     * that wants the table as a value.
+     */
     snapshot(): RunStoreSnapshot {
         const runs: Record<string, TaskPersistence> = {};
         for (const [runId, record] of this.#records) {
             runs[runKey(runId)] = record.toPersistence();
         }
-        return { runs, nextRunId: this.#nextRunId, nextRetireSeq: this.#nextRetireSeq };
+        return {
+            runs,
+            nextRunId: this.#nextRunId,
+            nextRetireSeq: this.#nextRetireSeq,
+            runsVersion: RUN_STORE_VERSION,
+        };
     }
 }

--- a/packages/node-manager/src/task/Task.ts
+++ b/packages/node-manager/src/task/Task.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { InternalError } from "@matter/general";
 import { ChangeEntry, PlannedChange, RetireSeq, RunId, TaskPhase, TaskState, TaskStatus } from "./types.js";
 
 export interface TaskPersistence {
@@ -12,17 +13,37 @@ export interface TaskPersistence {
     /** The target this run intends to change. At most one run may own a slot at a time. */
     slotKey: string;
     type: string;
-    params: unknown;
+    /**
+     * Absent once the run is terminal: params exist to re-drive phases on resume, and some carry raw key
+     * material that must not outlive the work.
+     */
+    params?: unknown;
     phaseIndex: number;
     state: TaskState;
     externalId?: string;
     changeSet: ChangeEntry[];
     error?: string;
-    /** Order in which runs retired. The only ordering key for history and eviction; never use `runId`. */
+    /** Order in which runs retired. The only ordering key for history; never use `runId`. */
     retireSeq?: RetireSeq;
     revertRunId?: RunId;
     revertOf?: RunId;
 }
+
+/**
+ * Fields a write may remove outright, as opposed to leaving unchanged.
+ *
+ * One member today because `params` is the only thing a retirement stops carrying. Retention of the values a
+ * rollback would restore is decided per *target* rather than per run, so what else becomes droppable belongs
+ * with that.
+ */
+export type DroppableField = "params";
+
+/**
+ * Fields a record may legitimately not have. Enumerated rather than derived from the values present, so the
+ * strip cannot reach a required field: `params` is typed `unknown`, which widens the indexed type enough that
+ * deleting `runId` or `state` would type-check.
+ */
+const OPTIONAL_FIELDS = ["params", "externalId", "error", "retireSeq", "revertRunId", "revertOf"] as const;
 
 /** Reason a cancel is declined when a definition states none of its own. */
 export const NOT_REVERTIBLE_REASON = "it has passed its point of no return";
@@ -77,13 +98,14 @@ export class RunRecord implements RunView {
     }
 
     /**
-     * A snapshot for storage, optionally carrying state this run has not adopted yet.
+     * A snapshot for storage, optionally carrying state this run has not adopted yet, and fields the write
+     * removes outright.
      *
      * The one place a snapshot is produced, so what a write carries and what an observer sees are the same
      * thing. `changeSet` is copied rather than shared: a snapshot taken for one write would otherwise alias an
      * array a running phase appends to, and the write would carry entries it never intended.
      */
-    toPersistence(next?: Partial<TaskPersistence>): TaskPersistence {
+    toPersistence(next?: Partial<TaskPersistence>, drop?: ReadonlyArray<DroppableField>): TaskPersistence {
         const persisted: TaskPersistence = {
             runId: this.runId,
             slotKey: this.slotKey,
@@ -106,7 +128,42 @@ export class RunRecord implements RunView {
                 Object.assign(persisted, { [key]: value });
             }
         }
+        // Removal is a separate list for that reason: `undefined` in `next` cannot express it.
+        for (const field of drop ?? []) {
+            // A write that both sets a field and removes it has two intentions for one field, and the order
+            // the two lists are applied in would decide silently which wins.
+            if (next?.[field] !== undefined) {
+                throw new InternalError(
+                    `${runLabel(this.runId)}: write both sets and drops "${field}"; a field is one or the other`,
+                );
+            }
+            delete persisted[field];
+        }
+        // A field the run does not have is absent, not present holding `undefined`. Otherwise a write that
+        // drops a field removes the key and the *next* write of the same record puts it back empty, so
+        // "storage omits it" would hold for exactly one write.
+        for (const key of OPTIONAL_FIELDS) {
+            if (persisted[key] === undefined) {
+                delete persisted[key];
+            }
+        }
         return persisted;
+    }
+
+    /** Apply a write's removals to the in-memory run, once that write has landed. */
+    adoptDrop(drop: ReadonlyArray<DroppableField>): void {
+        for (const field of drop) {
+            switch (field) {
+                case "params":
+                    this.params = undefined;
+                    break;
+                default:
+                    // A field storage drops that memory does not is the drift no assertion would catch, and a
+                    // `switch` with neither this arm nor a `never` check compiles happily when a member is
+                    // added.
+                    throw new InternalError(`${runLabel(this.runId)}: no in-memory removal for "${field}"`);
+            }
+        }
     }
 }
 
@@ -264,6 +321,5 @@ export function statusOf(record: RunView): TaskStatus {
         retireSeq: record.retireSeq,
         revertRunId: record.revertRunId,
         revertOf: record.revertOf,
-        detail: "full",
     };
 }

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -17,8 +17,10 @@ import {
     TaskCapacityExceededError,
     TaskExternalIdInUseError,
     TaskManagerClosingError,
+    TaskNoRollbackError,
     TaskNotARollbackError,
     TaskNotFoundError,
+    TaskNotInFlightError,
     TaskNotRevertibleError,
     TaskRollbackPendingError,
     TaskSlotAwaitingResumeError,
@@ -26,6 +28,7 @@ import {
     TaskSlotOccupiedError,
     TaskSlotSettlingError,
     TaskStopSignal,
+    TaskStoreVersionError,
     TaskSupersededError,
     TaskSuspendedSignal,
     TaskTypeNotRegisteredError,
@@ -36,10 +39,19 @@ import { RemoveNodeFromGroup } from "./groups/RemoveNodeFromGroup.js";
 import { RotateGroupKey } from "./groups/RotateGroupKey.js";
 import { Revert } from "./Revert.js";
 import { GateControl, RunningTaskContext } from "./RunningTaskContext.js";
-import { isTerminal, RunStore } from "./RunStore.js";
-import { BoundDefinition, runKey, runLabel, RunRecord, statusOf, TaskDefinition, TaskPersistence } from "./Task.js";
+import { isTerminal, RUN_STORE_VERSION, RunStore } from "./RunStore.js";
+import {
+    BoundDefinition,
+    DroppableField,
+    runKey,
+    runLabel,
+    RunRecord,
+    statusOf,
+    TaskDefinition,
+    TaskPersistence,
+} from "./Task.js";
 import { TaskRegistry } from "./TaskRegistry.js";
-import { PlannedChange, RunId, Teardown, TaskState, TaskStatus } from "./types.js";
+import { PlannedChange, RunId, TaskState, TaskStatus, Teardown } from "./types.js";
 
 const logger = Logger.get("TaskManager");
 
@@ -64,6 +76,12 @@ interface PreparedRevert {
 const NO_REVERT: PreparedRevert = { discard() {}, start() {} };
 
 /**
+ * What a run stops carrying at any retirement. Parameters exist to re-drive phases on resume, and some carry
+ * raw key material; a rollback replays the changeSet's priors, never params.
+ */
+const RETIRE: ReadonlyArray<DroppableField> = ["params"];
+
+/**
  * Whether a rollback's undo has concluded: it restored the device, or it was called off before it wrote
  * anything. Either way nothing is left to retry or to give up on.
  *
@@ -80,10 +98,15 @@ interface SpawnedExecution {
     joined: boolean;
 }
 
-/** One run's intended next durable state, applied to the run only once the write carrying it has landed. */
+/** One record's part in a write: state to merge in, and fields to remove outright. */
 interface RunChange {
     record: RunRecord;
     next?: Partial<TaskPersistence>;
+    /**
+     * Fields to remove. Separate from {@link RunChange.next}, where `undefined` means "unchanged" — an
+     * intended-state merge that expressed removal as `undefined` erased a retirement order once already.
+     */
+    drop?: ReadonlyArray<DroppableField>;
 }
 
 export class TaskManagerBehavior extends Behavior {
@@ -107,6 +130,10 @@ export class TaskManagerBehavior extends Behavior {
             }),
             FieldElement({ name: "nextRunId", type: "uint32", quality: "N", default: 1 }),
             FieldElement({ name: "nextRetireSeq", type: "uint32", quality: "N", default: 1 }),
+            // Default 1, not the current version: nonvolatile state records what a transaction *changed*, so a
+            // member defaulted to the reading build's own version would never differ from it, never be written,
+            // and never tell a later build what wrote the table.
+            FieldElement({ name: "runsVersion", type: "uint32", quality: "N", default: 1 }),
         ],
     });
 
@@ -118,14 +145,23 @@ export class TaskManagerBehavior extends Behavior {
             runs: this.state.runs,
             nextRunId: this.state.nextRunId,
             nextRetireSeq: this.state.nextRetireSeq,
+            runsVersion: this.state.runsVersion,
         });
         if (discarded > 0) {
             logger.warn(`Discarded ${discarded} task record(s) predating per-run identity`);
         }
+        // Registered either way, so the surface a caller sees does not depend on the store: an unreadable
+        // store refuses at `run`, with a reason, rather than by claiming a type was never registered.
+        this.#registerBuiltins();
+        if (this.internal.runs.unreadable) {
+            logger.error(
+                `Task records are at schema version ${this.state.runsVersion}, newer than this build's ${RUN_STORE_VERSION}: no run was loaded and no task will be admitted. Nothing is written to the table either, so the newer build can still read it.`,
+            );
+            return;
+        }
         // Reserved here rather than on the first record write: on a fresh store nothing has been written yet,
         // so without this the very first identity would be handed out uncovered.
         this.#reserveIdentities();
-        this.#registerBuiltins();
         // Driving acts on the node, so the resume pass must wait until the node is online.
         if (this.#rootNode.lifecycle.isOnline) {
             this.#resumePersisted();
@@ -269,8 +305,15 @@ export class TaskManagerBehavior extends Behavior {
      * it: a caller that passes an `externalId` re-issues its own request idempotently, and any other request for
      * an id a live task already holds is refused rather than silently resolving onto work it did not ask for.
      * The `externalId` is also the id the caller can {@link get} and {@link cancel} its task under.
+     *
+     * **`externalId` is a correlation key, not an idempotence token.** Only a *live* run holds a name: once a
+     * run finishes, re-issuing its name starts the work again. A consumer that needs idempotence keeps its own
+     * receipt.
      */
     run<P>(definition: TaskDefinition<P>, params: P, opts?: { externalId?: string }): TaskHandle {
+        // Records this build did not read still own their targets, so admitting work would drive a target one
+        // of them holds and a later upgrade would then resume it and replay stale values over the result.
+        this.#refuseIfUnreadable(`Cannot run "${definition.type}"`);
         // The definition must be the registered one, not merely share its name. Identity is what makes the
         // parameter type mean anything: a different definition of the same name would type its caller's params
         // and then hand them to the registered definition, which declares its own. It is also what stops a
@@ -503,13 +546,17 @@ export class TaskManagerBehavior extends Behavior {
      * declining an undo must not be undone by a retry.
      */
     async retryRollback(runId: RunId): Promise<TaskHandle> {
+        this.#refuseIfUnreadable(`Cannot retry the rollback of ${runLabel(runId)}`);
         const record = this.internal.runs.get(runId);
         if (record === undefined) {
             throw new TaskNotFoundError(`Cannot retry the rollback of ${runLabel(runId)}: no run answers to it`);
         }
         const recorded = this.internal.runs.rollbackFor(runId);
         if (recorded === undefined) {
-            throw new ImplementationError(`${runLabel(runId)} has no rollback to retry`);
+            // A state a caller cannot always know rather than a mistake it made: a run may never have produced
+            // an undo, and a rollback record that reached storage without a retirement order is discarded at
+            // load, leaving the original naming one nothing holds.
+            throw new TaskNoRollbackError(`Cannot retry the rollback of ${runLabel(runId)}: it has none`);
         }
         const previous = recorded.runId;
         if (recorded.state === "abandoned") {
@@ -538,10 +585,13 @@ export class TaskManagerBehavior extends Behavior {
             );
         }
 
-        const bound = this.#boundFor(record, this.internal.runs.executionOf(runId));
-        const revert = this.#prepareRevert(record, bound, { ignoreRecordedRollback: true });
+        // Deliberately not through #boundFor: revertibility was decided when the first rollback was created,
+        // and asking again would need the original's params, which a retirement drops. A replacement is built
+        // from the changeSet alone.
+        const revert = this.#spawnRevert(record);
         if (revert.record === undefined) {
-            throw new ImplementationError(`${runLabel(runId)} has nothing to roll back`);
+            // Cannot happen: a run with a rollback wrote something, and nothing removes a changeSet.
+            throw new InternalError(`${runLabel(runId)} has a rollback but nothing to roll back`);
         }
         try {
             await this.#commit({ record, next: { revertRunId: revert.record.runId } }, { record: revert.record });
@@ -558,9 +608,13 @@ export class TaskManagerBehavior extends Behavior {
      * task (parks on offline peers, resumes after restart). Does not await the revert — the caller observes it
      * via the returned handle.
      *
-     * A handle is the rollback. `undefined` means there is nothing to roll back — either the run wrote nothing,
-     * or it was already cancelled; `status.state` tells the two apart. {@link TaskNotFoundError} is an identity
-     * no run answers to, live or retired, since a finished run keeps the changeSet its rollback needs.
+     * Applies to work that is still in flight. A run that already finished is refused with
+     * {@link TaskNotInFlightError}: its changes are not rewound, because restoring the values it found would
+     * overwrite whatever has legitimately happened since — reversing a finished change is a new task the caller
+     * starts. A run whose rollback already exists is answered with that rollback, whatever its state.
+     *
+     * A handle is the rollback. `undefined` means there is nothing to roll back — the run wrote nothing, or it
+     * was already cancelled with nothing to undo. {@link TaskNotFoundError} is an identity no run answers to.
      *
      * A rollback is not cancelled: {@link TaskCannotCancelRollbackError} points at {@link abandon}, which
      * records that the undo was given up on rather than that nothing needed it.
@@ -573,6 +627,7 @@ export class TaskManagerBehavior extends Behavior {
             await pending;
             pending = this.#pendingTransition(runId);
         }
+        this.#refuseIfUnreadable(`Cannot cancel ${runLabel(runId)}`);
         const record = this.internal.runs.get(runId);
         if (record === undefined) {
             throw new TaskNotFoundError(`Cannot cancel ${runLabel(runId)}: no run answers to it`);
@@ -598,6 +653,14 @@ export class TaskManagerBehavior extends Behavior {
         if (record.state === "cancelled") {
             return undefined;
         }
+        // A finished run is not stopped, and its changes are not rewound: restoring the values it found would
+        // overwrite whatever has legitimately happened since, so reversing a successful change is a new action
+        // the caller starts.
+        if (isTerminal(record.state)) {
+            throw new TaskNotInFlightError(
+                `Cannot cancel ${runLabel(runId)}: it already finished (${record.state}). Reversing a finished change is a new task, not a cancel.`,
+            );
+        }
 
         // Deciding on a NEW rollback is the run's decision, so this is the one place an unattached run's type
         // must be registered.
@@ -619,6 +682,20 @@ export class TaskManagerBehavior extends Behavior {
 
     /** The part of a cancel that decides and writes, with this run's outcome already claimed. */
     async #recordCancellation(record: RunRecord, bound: BoundDefinition): Promise<TaskHandle | undefined> {
+        // The entry check answered about the run as it was before the unwind. Its driver may have reached an
+        // outcome of its own inside the transition window — the loop consults the claim only between phases —
+        // and a run that finished is not undone, whichever side of the window it finished on. `abandon` asks
+        // the same question at the same point, and for the same reason.
+        if (isTerminal(record.state)) {
+            const rollback = this.internal.runs.rollbackFor(record.runId);
+            if (rollback !== undefined) {
+                return this.#handle(rollback);
+            }
+            throw new TaskNotInFlightError(
+                `Cannot cancel ${runLabel(record.runId)}: it finished (${record.state}) while the cancel was being accepted`,
+            );
+        }
+
         // Shutdown took over the unwind: state can no longer be persisted, so leave the task non-terminal and
         // unreverted rather than claiming a cancel that storage would contradict on the next start.
         this.#refuseIfClosing(`${runLabel(record.runId)} cannot be cancelled`);
@@ -632,8 +709,6 @@ export class TaskManagerBehavior extends Behavior {
             this.#restoreDriver(record, bound);
             throw e;
         }
-        // running/parked → cancelled; an already-terminal (completed/failed) run keeps its truthful state.
-        const outcome = record.state === "running" || record.state === "parked" ? "cancelled" : record.state;
         // One transaction carries the cancelled state, the retirement order and the rollback that undoes it;
         // the slot moves only once that write is durable.
         try {
@@ -641,10 +716,13 @@ export class TaskManagerBehavior extends Behavior {
                 {
                     record,
                     next: {
-                        state: outcome,
+                        // Unconditional: the terminal check above is what makes it true, so a run reaching its
+                        // own outcome inside the window is refused rather than recorded as cancelled.
+                        state: "cancelled",
                         retireSeq: this.internal.runs.nextRetirement(record),
                         revertRunId: revert.record?.runId,
                     },
+                    drop: RETIRE,
                 },
                 ...(revert.record === undefined ? [] : [{ record: revert.record }]),
             );
@@ -679,6 +757,7 @@ export class TaskManagerBehavior extends Behavior {
             await pending;
             pending = this.#pendingTransition(runId);
         }
+        this.#refuseIfUnreadable(`Cannot abandon ${runLabel(runId)}`);
         const record = this.internal.runs.get(runId);
         if (record === undefined) {
             throw new TaskNotFoundError(`Cannot abandon ${runLabel(runId)}: no run answers to it`);
@@ -727,6 +806,7 @@ export class TaskManagerBehavior extends Behavior {
                         // place it took then.
                         retireSeq: this.internal.runs.nextRetirement(record),
                     },
+                    drop: RETIRE,
                 });
             } catch (e) {
                 if (execution !== undefined) {
@@ -885,11 +965,7 @@ export class TaskManagerBehavior extends Behavior {
     }
 
     /** Create (or reuse) the revert task for `record`, linking both directions, without driving it. */
-    #prepareRevert(
-        record: RunRecord,
-        bound: BoundDefinition,
-        opts?: { ignoreRecordedRollback?: boolean },
-    ): PreparedRevert {
+    #prepareRevert(record: RunRecord, bound: BoundDefinition): PreparedRevert {
         // A failed rollback surfaces as `failed` for operator attention; rolling one back would recurse
         // unbounded. Keyed on the link rather than on the type, so it is the same question `cancel` and
         // `abandon` ask: any definition declaring `undoes` produces a run that undoes another.
@@ -903,12 +979,20 @@ export class TaskManagerBehavior extends Behavior {
         // Already rolled back once, or being rolled back right now: cancel resolves that rollback itself, so
         // there is nothing to prepare, write or start here. Asking the table rather than the run's own link
         // covers the window before the write recording that link has landed, where a second cancel would
-        // otherwise try to create a rollback of its own. Retrying is the one caller that means to replace it.
-        if (opts?.ignoreRecordedRollback !== true) {
-            if (this.internal.runs.rollbackFor(record.runId) !== undefined) {
-                return NO_REVERT;
-            }
+        // otherwise try to create a rollback of its own.
+        if (this.internal.runs.rollbackFor(record.runId) !== undefined) {
+            return NO_REVERT;
         }
+        return this.#spawnRevert(record);
+    }
+
+    /**
+     * Build the rollback of `record` from its changeSet alone.
+     *
+     * The half of a rollback that needs nothing but the record: what a replacement rollback needs, and what a
+     * retirement's dropped params must not stand in the way of.
+     */
+    #spawnRevert(record: RunRecord): PreparedRevert {
         if (record.changeSet.length === 0) {
             return NO_REVERT;
         }
@@ -1009,6 +1093,7 @@ export class TaskManagerBehavior extends Behavior {
                 await this.#commit({
                     record,
                     next: { state: "completed", retireSeq: this.internal.runs.nextRetirement(record) },
+                    drop: RETIRE,
                 });
             }
         } catch (e) {
@@ -1054,6 +1139,7 @@ export class TaskManagerBehavior extends Behavior {
                             retireSeq: this.internal.runs.nextRetirement(record),
                             revertRunId: revert.record?.runId,
                         },
+                        drop: RETIRE,
                     },
                     ...(revert.record === undefined ? [] : [{ record: revert.record }]),
                 );
@@ -1120,6 +1206,22 @@ export class TaskManagerBehavior extends Behavior {
         return this.#rootNode.peers.get(peerId);
     }
 
+    /**
+     * Refuse while the stored table was written by a newer build.
+     *
+     * Every verb that would *write*, not only `run`: nothing was loaded, so `cancel` of a run that
+     * demonstrably exists in storage would otherwise answer "no run answers to it" — a wrong answer where a
+     * refusal naming the cause is available. The read verbs still answer from an empty table; they cannot
+     * invent a record, but they cannot explain themselves either.
+     */
+    #refuseIfUnreadable(subject: string): void {
+        if (this.internal.runs.unreadable) {
+            throw new TaskStoreVersionError(
+                `${subject}: the stored run table is at schema version ${this.state.runsVersion}, newer than this build's ${RUN_STORE_VERSION}`,
+            );
+        }
+    }
+
     // Serialized through the mutex: a spawned revert drives (and persists) concurrently with the original's
     // own persist, so direct concurrent state writes would conflict on the synchronous transaction lock.
     /**
@@ -1146,7 +1248,7 @@ export class TaskManagerBehavior extends Behavior {
         // Built here rather than at the call site: a snapshot taken before this write queued would carry state
         // an earlier transition has since superseded.
         const records = changes.map(
-            change => [runKey(change.record.runId), change.record.toPersistence(change.next)] as const,
+            change => [runKey(change.record.runId), change.record.toPersistence(change.next, change.drop)] as const,
         );
         const nextRetireSeq = this.internal.runs.nextRetireSeq;
         const reservedRunId = this.internal.runs.reservedRunId;
@@ -1161,6 +1263,9 @@ export class TaskManagerBehavior extends Behavior {
             // counter below a durable identity and a crash re-issues it.
             self.state.nextRunId = Math.max(self.state.nextRunId, reservedRunId);
             self.state.nextRetireSeq = Math.max(self.state.nextRetireSeq, nextRetireSeq);
+            // Stamped with every write rather than once at start: the table and the version that describes it
+            // then land together, so no crash leaves records a later build reads under the wrong version.
+            self.state.runsVersion = RUN_STORE_VERSION;
         });
         // Only now: a value adopted before the write survives a write that never landed. The reservation would
         // let the next identity be issued beyond what storage covers, and a run would carry state its record
@@ -1176,6 +1281,7 @@ export class TaskManagerBehavior extends Behavior {
                     Object.assign(change.record, { [key]: value });
                 }
             }
+            change.record.adoptDrop(change.drop ?? []);
         }
     }
 
@@ -1196,6 +1302,7 @@ export namespace TaskManagerBehavior {
         runs: Record<string, TaskPersistence> = {};
         nextRunId = 1;
         nextRetireSeq = 1;
+        runsVersion = 1;
     }
 
     export class Internal {

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -180,9 +180,13 @@ export class TaskManagerBehavior extends Behavior {
      * so the upgrade has to.
      *
      * Over the stored table rather than only the loaded one: a record `load` discarded still occupies storage,
-     * and its parameters are just as durable. The loaded record loses them too — a snapshot carries every field
-     * the record holds, so the next write of a migrated run would put them straight back, and the version
-     * stamp means this pass would never run again to take them off.
+     * and its parameters are just as durable.
+     *
+     * Each record is rebuilt through the same drop-and-snapshot path every ordinary write uses, rather than by
+     * editing the stored object. That is what keeps the two senses of "gone" from diverging: the loaded record
+     * must lose the field as well, or the next write of a migrated run puts it straight back and the version
+     * stamp means this pass never runs again to take it off; and the *key* must go, not merely its value,
+     * because a snapshot from the previous build materialised every key including the undefined ones.
      */
     #retireStoredParams(): void {
         if (this.state.runsVersion >= RUN_STORE_VERSION) {
@@ -191,20 +195,27 @@ export class TaskManagerBehavior extends Behavior {
         const runs = { ...this.state.runs };
         let retired = 0;
         for (const [key, persisted] of Object.entries(runs)) {
-            if (persisted?.params === undefined || !isTerminal(persisted.state)) {
+            // A record with no usable identity is one `load` discards; rebuilding it would invent a run.
+            if (typeof persisted?.runId !== "number" || !isTerminal(persisted.state)) {
                 continue;
             }
-            const { params, ...rest } = persisted;
-            void params;
-            runs[key] = rest as TaskPersistence;
-            this.internal.runs.get(persisted.runId)?.adoptDrop(RETIRE);
+            const record = this.internal.runs.get(persisted.runId) ?? RunRecord.fromPersistence(persisted);
+            const migrated = record.toPersistence(undefined, RETIRE);
+            // Compared by key rather than by value, and never by serializing: a stored record from the previous
+            // build carries keys holding `undefined`, and `JSON.stringify` drops exactly those — so a
+            // serialized comparison reports "nothing changed" for the one shape this pass exists to remove.
+            if (!Object.keys(persisted).some(field => !(field in migrated))) {
+                continue;
+            }
+            record.adoptDrop(RETIRE);
+            runs[key] = migrated;
             retired++;
         }
         if (retired > 0) {
             this.state.runs = runs;
-            logger.info(`Dropped stored parameters of ${retired} finished task record(s) on upgrade`);
+            logger.info(`Rewrote ${retired} finished task record(s) without their parameters on upgrade`);
         }
-        // Stamped even when nothing needed dropping, so the scan runs once rather than on every start.
+        // Stamped even when nothing needed rewriting, so the scan runs once rather than on every start.
         this.state.runsVersion = RUN_STORE_VERSION;
     }
 

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -179,14 +179,17 @@ export class TaskManagerBehavior extends Behavior {
      * storing, including the raw epoch keys the group tasks take. Nothing else will ever touch those records,
      * so the upgrade has to.
      *
-     * Over the stored table rather than only the loaded one: a record `load` discarded still occupies storage,
-     * and its parameters are just as durable.
+     * Over the stored table, not the loaded one, and by key rather than by value. Three things follow from
+     * that, each of which was wrong first:
      *
-     * Each record is rebuilt through the same drop-and-snapshot path every ordinary write uses, rather than by
-     * editing the stored object. That is what keeps the two senses of "gone" from diverging: the loaded record
-     * must lose the field as well, or the next write of a migrated run puts it straight back and the version
-     * stamp means this pass never runs again to take it off; and the *key* must go, not merely its value,
-     * because a snapshot from the previous build materialised every key including the undefined ones.
+     * - A record `load` discarded — one from before per-run identity, which it leaves in storage under a key
+     *   that is not a run id — is exactly a record nothing will ever rewrite. It has no in-memory twin, so it
+     *   is edited in place; anything that needed a {@link RunRecord} would skip it and keep its keys forever.
+     * - The *key* goes, not its value: a snapshot from the previous build materialised every field it knew,
+     *   including the empty ones, so a finished task that ran without parameters carries an empty `params`.
+     * - A record this process did load has a twin in memory, and that twin has to lose the field too, or the
+     *   next write of it puts the field straight back — and the version stamp means this pass never runs
+     *   again to take it off.
      */
     #retireStoredParams(): void {
         if (this.state.runsVersion >= RUN_STORE_VERSION) {
@@ -195,27 +198,28 @@ export class TaskManagerBehavior extends Behavior {
         const runs = { ...this.state.runs };
         let retired = 0;
         for (const [key, persisted] of Object.entries(runs)) {
-            // A record with no usable identity is one `load` discards; rebuilding it would invent a run.
-            if (typeof persisted?.runId !== "number" || !isTerminal(persisted.state)) {
+            if (persisted === undefined || !isTerminal(persisted.state)) {
                 continue;
             }
-            const record = this.internal.runs.get(persisted.runId) ?? RunRecord.fromPersistence(persisted);
-            const migrated = record.toPersistence(undefined, RETIRE);
-            // Compared by key rather than by value, and never by serializing: a stored record from the previous
-            // build carries keys holding `undefined`, and `JSON.stringify` drops exactly those — so a
-            // serialized comparison reports "nothing changed" for the one shape this pass exists to remove.
-            if (!Object.keys(persisted).some(field => !(field in migrated))) {
+            const stale = RETIRE.filter(field => field in persisted);
+            if (stale.length === 0) {
                 continue;
             }
-            record.adoptDrop(RETIRE);
+            const migrated = { ...persisted };
+            for (const field of stale) {
+                delete migrated[field];
+            }
             runs[key] = migrated;
+            if (typeof persisted.runId === "number") {
+                this.internal.runs.get(persisted.runId)?.adoptDrop(stale);
+            }
             retired++;
         }
         if (retired > 0) {
             this.state.runs = runs;
-            logger.info(`Rewrote ${retired} finished task record(s) without their parameters on upgrade`);
+            logger.info(`Dropped the stored parameters of ${retired} finished task record(s) on upgrade`);
         }
-        // Stamped even when nothing needed rewriting, so the scan runs once rather than on every start.
+        // Stamped even when nothing needed dropping, so the scan runs once rather than on every start.
         this.state.runsVersion = RUN_STORE_VERSION;
     }
 

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -179,8 +179,10 @@ export class TaskManagerBehavior extends Behavior {
      * storing, including the raw epoch keys the group tasks take. Nothing else will ever touch those records,
      * so the upgrade has to.
      *
-     * Over the stored table rather than the loaded one: a record `load` discarded still occupies storage, and
-     * its parameters are just as durable.
+     * Over the stored table rather than only the loaded one: a record `load` discarded still occupies storage,
+     * and its parameters are just as durable. The loaded record loses them too — a snapshot carries every field
+     * the record holds, so the next write of a migrated run would put them straight back, and the version
+     * stamp means this pass would never run again to take them off.
      */
     #retireStoredParams(): void {
         if (this.state.runsVersion >= RUN_STORE_VERSION) {
@@ -195,6 +197,7 @@ export class TaskManagerBehavior extends Behavior {
             const { params, ...rest } = persisted;
             void params;
             runs[key] = rest as TaskPersistence;
+            this.internal.runs.get(persisted.runId)?.adoptDrop(RETIRE);
             retired++;
         }
         if (retired > 0) {

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -159,6 +159,7 @@ export class TaskManagerBehavior extends Behavior {
             );
             return;
         }
+        this.#retireStoredParams();
         // Reserved here rather than on the first record write: on a fresh store nothing has been written yet,
         // so without this the very first identity would be handed out uncovered.
         this.#reserveIdentities();
@@ -168,6 +169,40 @@ export class TaskManagerBehavior extends Behavior {
         } else {
             this.reactTo(this.#rootNode.lifecycle.online, this.#resumePersisted);
         }
+    }
+
+    /**
+     * Drop `params` from records an older build left finished.
+     *
+     * A write replaces only the records its own transaction names, so a run that was already terminal when
+     * this build first ran is never rewritten — and would keep the parameters this version exists to stop
+     * storing, including the raw epoch keys the group tasks take. Nothing else will ever touch those records,
+     * so the upgrade has to.
+     *
+     * Over the stored table rather than the loaded one: a record `load` discarded still occupies storage, and
+     * its parameters are just as durable.
+     */
+    #retireStoredParams(): void {
+        if (this.state.runsVersion >= RUN_STORE_VERSION) {
+            return;
+        }
+        const runs = { ...this.state.runs };
+        let retired = 0;
+        for (const [key, persisted] of Object.entries(runs)) {
+            if (persisted?.params === undefined || !isTerminal(persisted.state)) {
+                continue;
+            }
+            const { params, ...rest } = persisted;
+            void params;
+            runs[key] = rest as TaskPersistence;
+            retired++;
+        }
+        if (retired > 0) {
+            this.state.runs = runs;
+            logger.info(`Dropped stored parameters of ${retired} finished task record(s) on upgrade`);
+        }
+        // Stamped even when nothing needed dropping, so the scan runs once rather than on every start.
+        this.state.runsVersion = RUN_STORE_VERSION;
     }
 
     #resumePersisted(): void {
@@ -687,6 +722,10 @@ export class TaskManagerBehavior extends Behavior {
         // and a run that finished is not undone, whichever side of the window it finished on. `abandon` asks
         // the same question at the same point, and for the same reason.
         if (isTerminal(record.state)) {
+            // `#retire` declined to release the target because this transition owns the run, so retiring it
+            // falls here — before answering, and whichever answer that is. Without this the finished run keeps
+            // its target for the life of the process and every later task for it is refused.
+            this.internal.runs.commitRetirement(record);
             const rollback = this.internal.runs.rollbackFor(record.runId);
             if (rollback !== undefined) {
                 return this.#handle(rollback);
@@ -1153,6 +1192,9 @@ export class TaskManagerBehavior extends Behavior {
                 if (!record.recorded) {
                     record.state = "failed";
                     record.error = error;
+                    // The handle its caller holds closes over this record, so the drop a retirement write would
+                    // have carried has to happen here too: nothing else will, and some params are raw keys.
+                    record.adoptDrop(RETIRE);
                     this.internal.runs.discard(record);
                 }
                 return;

--- a/packages/node-manager/src/task/errors.ts
+++ b/packages/node-manager/src/task/errors.ts
@@ -67,6 +67,15 @@ export enum TaskFindingCode {
 
     /** A rollback is ended with `abandon`, not with `cancel`. */
     CannotCancelRollback = "cannotCancelRollback",
+
+    /** The run already finished, so there is nothing to stop. */
+    NotInFlight = "notInFlight",
+
+    /** The stored run table was written by a newer build than this one. */
+    StoreVersion = "storeVersion",
+
+    /** The run has no undo to retry. */
+    NoRollback = "noRollback",
 }
 
 export class TaskError extends MatterError {}
@@ -158,8 +167,10 @@ export class TaskNotFoundError extends TaskRefusedError {
 }
 
 /**
- * Acting on a finished run needs its task type registered, because whether a run may be rolled back is a
- * decision of the task, not of its record.
+ * Deciding on a *new* rollback needs the run's task type registered, because whether a run may be rolled back
+ * is a decision of the task, not of its record. Reached by `cancel` of a run awaiting resume — one whose record
+ * outlived the process that registered its type. Retrying an existing rollback asks nothing of the task and so
+ * needs no registration.
  */
 export class TaskTypeNotRegisteredError extends TaskRefusedError {
     override readonly code = TaskFindingCode.TypeNotRegistered;
@@ -205,6 +216,35 @@ export class TaskAbandonedError extends TaskRefusedError {
  */
 export class TaskCannotCancelRollbackError extends TaskRefusedError {
     override readonly code = TaskFindingCode.CannotCancelRollback;
+}
+
+/**
+ * `cancel()` stops work that is still in flight. A finished run is not stopped, and its changes are not
+ * rewound: reversing a change that succeeded is a new action a caller starts, because restoring the values the
+ * run found would overwrite whatever has legitimately happened since.
+ */
+export class TaskNotInFlightError extends TaskRefusedError {
+    override readonly code = TaskFindingCode.NotInFlight;
+}
+
+/**
+ * There is no undo of this run to retry: it never produced one — nothing was written, or the task declined to
+ * be reverted — or the record of the one it had did not survive a restart.
+ *
+ * Ordinary state rather than a caller's mistake, and reachable more often since a cleanly completed run no
+ * longer gets a rollback at all.
+ */
+export class TaskNoRollbackError extends TaskRefusedError {
+    override readonly code = TaskFindingCode.NoRollback;
+}
+
+/**
+ * The stored run table carries a schema version this build does not know, so its records were not loaded and
+ * no new work is admitted: driving new runs against targets those records own would write over work this build
+ * cannot see, and a later upgrade would then resume them and replay stale values.
+ */
+export class TaskStoreVersionError extends TaskRefusedError {
+    override readonly code = TaskFindingCode.StoreVersion;
 }
 
 /**

--- a/packages/node-manager/src/task/types.ts
+++ b/packages/node-manager/src/task/types.ts
@@ -24,7 +24,7 @@ export function RunId(value: number): RunId {
 }
 
 /**
- * Order in which runs retired: the only ordering key for history and for eviction.
+ * Order in which runs retired: the only ordering key for history.
  *
  * Deliberately a different type from {@link RunId}. A run id orders by *start*, and since a parked run may
  * finish long after runs that started later, ordering retirement by run id evicts the most recently finished
@@ -66,8 +66,6 @@ export interface TaskStatus {
     retireSeq?: RetireSeq;
     revertRunId?: RunId;
     revertOf?: RunId;
-    /** Whether the answering record still carries everything, or only what a tombstone keeps. */
-    detail: "full" | "tombstone";
 }
 
 export interface ChangeEntry {

--- a/packages/node-manager/test/task/AdmissionTest.ts
+++ b/packages/node-manager/test/task/AdmissionTest.ts
@@ -76,7 +76,7 @@ describe("capacity admission", () => {
         await awaitState(node, "synthetic:over", "failed");
         const rec = requireRecordFor(node.stateOf(TestTaskManager).runs, "synthetic:over");
         expect(rec.error).contains("capacity");
-        expect(rec.changeSet.length).equals(0);
+        expect(rec.changeSet).deep.equals([]);
         expect(rec.revertRunId).equals(undefined);
         expect(ran).equals(false);
         await node.close();

--- a/packages/node-manager/test/task/CancelRobustnessTest.ts
+++ b/packages/node-manager/test/task/CancelRobustnessTest.ts
@@ -879,6 +879,12 @@ describe("cancel robustness", () => {
         expect(manager.get(handle.runId)?.status.revertRunId).equals(undefined);
         expect(revertRecordOf(node.stateOf(TestTaskManager).runs, "synthetic:inwindow")).equals(undefined);
 
+        // `#retire` declined to release the target because the transition owned the run, so the refusal has to
+        // release it. Otherwise the finished run holds its target for the life of the process.
+        expect(manager.tasks.map(t => t.runId)).deep.equals([]);
+        const next = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "inwindow" }));
+        expect(next.runId).not.equals(handle.runId);
+
         await node.close();
     });
 

--- a/packages/node-manager/test/task/CancelRobustnessTest.ts
+++ b/packages/node-manager/test/task/CancelRobustnessTest.ts
@@ -8,6 +8,7 @@ import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
 import {
     TaskFailedError,
     TaskManagerClosingError,
+    TaskNotInFlightError,
     TaskSlotDrainingError,
     TaskSlotSettlingError,
 } from "#task/errors.js";
@@ -290,17 +291,15 @@ describe("cancel robustness", () => {
         const peer = new FakePeer("dp");
         TestTaskManager.peers.set("dp", peer);
         TestTaskManager.reconcilerPeer = peer;
-        peer.markHas("groupMembership", "D");
 
+        // The peer never commits, so the run is still in flight with its intent written — which is what cancel
+        // applies to, and what gives the rollback something to undo.
         SyntheticTask.phasesByTag["durable"] = [gatePhase("dp", "groupMembership", "D")];
 
         const node = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-durable" });
         await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
         await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "durable" }));
-        await pumpUntil("task complete", async () => {
-            const state = await node.act(a => recordFor(a.get(TestTaskManager).state.runs, "synthetic:durable")?.state);
-            return state === "completed";
-        });
+        await pumpUntil("intent written", () => peer.items[itemMapKey("groupMembership", "D")] !== undefined);
 
         const handle = await MockTime.resolve(node.act(a => cancelSlot(a.get(TestTaskManager), "synthetic:durable")));
         expect(handle?.status.revertOf).equals(
@@ -459,8 +458,9 @@ describe("cancel robustness", () => {
         const peer = new FakePeer("cd");
         TestTaskManager.peers.set("cd", peer);
         TestTaskManager.reconcilerPeer = peer;
-        peer.markHas("groupMembership", "C");
 
+        // In flight, with its intent written: cancel has to reach the write it cannot make. A finished run
+        // would be refused before the crash ever mattered, and the test would prove nothing.
         SyntheticTask.phasesByTag["crashed"] = [gatePhase("cd", "groupMembership", "C")];
 
         const node = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-crashed" });
@@ -470,10 +470,7 @@ describe("cancel robustness", () => {
             manager = a.get(TestTaskManager);
         });
         await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "crashed" }));
-        await pumpUntil("task complete", async () => {
-            const state = await node.act(a => recordFor(a.get(TestTaskManager).state.runs, "synthetic:crashed")?.state);
-            return state === "completed";
-        });
+        await pumpUntil("intent written", async () => peer.items[itemMapKey("groupMembership", "C")] !== undefined);
 
         // A crashed manager cannot record a cancel either, but it is not shutting down and a re-issue after the
         // next start is not the remedy — so it must not claim it is.
@@ -826,6 +823,61 @@ describe("cancel robustness", () => {
 
         // The caller already holds a handle, and it says what happened rather than answering "running" forever.
         expect(handle.status.state).equals("failed");
+
+        await node.close();
+    });
+
+    it("refuses a cancel whose run finished inside the transition window", async () => {
+        const environment = new Environment("test");
+        const peer = new FakePeer("iw");
+        TestTaskManager.peers.set("iw", peer);
+        TestTaskManager.reconcilerPeer = peer;
+
+        // One phase that writes and returns, so the driver's next act is the write advancing past it.
+        let phaseReturned = false;
+        SyntheticTask.phasesByTag["inwindow"] = [
+            {
+                name: "touch",
+                run: async ctx => {
+                    await ctx.setIntent(ctx.resolvePeer("iw"), "groupMembership", "W", {});
+                    phaseReturned = true;
+                },
+            },
+        ];
+
+        const node = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-in-window" });
+        await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
+        let manager!: TestTaskManager;
+        await node.act(a => {
+            manager = a.get(TestTaskManager);
+        });
+        const handle = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "inwindow" }));
+
+        // The mutex is taken before the phase runs, so the write advancing the phase index queues on it. Then
+        // we wait for the phase to have *returned*: the driver has passed its post-phase check on the
+        // transition claim by then, and the loop top it is heading for does not consult that claim at all — so
+        // a cancel accepted now finds a run that goes on to commit `completed`.
+        const release = manager.holdPersistMutex();
+        await pumpUntil("phase returned", () => phaseReturned);
+        const cancelling = MockTime.resolve(
+            node.act(async a => {
+                try {
+                    return await a.get(TestTaskManager).cancel(handle.runId);
+                } catch (e) {
+                    return e;
+                }
+            }),
+            { macrotasks: true },
+        );
+        await MockTime.advance(1);
+        release();
+
+        // Refused, and refused for the right reason: a run that succeeded is not recorded as cancelled and its
+        // priors are not replayed onto the device.
+        expect(await cancelling).instanceOf(TaskNotInFlightError);
+        expect(manager.get(handle.runId)?.status.state).equals("completed");
+        expect(manager.get(handle.runId)?.status.revertRunId).equals(undefined);
+        expect(revertRecordOf(node.stateOf(TestTaskManager).runs, "synthetic:inwindow")).equals(undefined);
 
         await node.close();
     });

--- a/packages/node-manager/test/task/ErrorTaxonomyTest.ts
+++ b/packages/node-manager/test/task/ErrorTaxonomyTest.ts
@@ -19,8 +19,10 @@ import {
     TaskFindingCode,
     TaskIdentityExhaustedError,
     TaskManagerClosingError,
+    TaskNoRollbackError,
     TaskNotARollbackError,
     TaskNotFoundError,
+    TaskNotInFlightError,
     TaskNotRevertibleError,
     TaskPeerUnavailableError,
     TaskRefusedError,
@@ -29,6 +31,7 @@ import {
     TaskSlotDrainingError,
     TaskSlotOccupiedError,
     TaskSlotSettlingError,
+    TaskStoreVersionError,
     TaskSupersededError,
     TaskSuspendedSignal,
     TaskTypeNotRegisteredError,
@@ -58,6 +61,9 @@ const CODES: Array<[TaskRefusedError, TaskFindingCode]> = [
     [new TaskAlreadyUndoneError(""), TaskFindingCode.AlreadyUndone],
     [new TaskAbandonedError(""), TaskFindingCode.Abandoned],
     [new TaskCannotCancelRollbackError(""), TaskFindingCode.CannotCancelRollback],
+    [new TaskNotInFlightError(""), TaskFindingCode.NotInFlight],
+    [new TaskStoreVersionError(""), TaskFindingCode.StoreVersion],
+    [new TaskNoRollbackError(""), TaskFindingCode.NoRollback],
 ];
 
 describe("task error taxonomy", () => {

--- a/packages/node-manager/test/task/RecordSnapshotTest.ts
+++ b/packages/node-manager/test/task/RecordSnapshotTest.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { RUN_STORE_VERSION, RunStore } from "#task/RunStore.js";
+import { RunRecord, TaskPersistence } from "#task/Task.js";
+import { ChangeEntry, RunId, TaskState } from "#task/types.js";
+import { InternalError } from "@matter/general";
+
+/**
+ * What a record carries into storage, and what a store does with a table it cannot read.
+ *
+ * Both are properties of the run table and of nothing else. Driving a task to produce them would make each
+ * case depend on a node, a gate and a clock, and would hide which input the rule actually reads.
+ */
+
+const ENTRY: ChangeEntry = { peerId: "p", kind: "groupMembership", key: "X" };
+
+function persisted(runId: number, state: TaskState, changeSet: ChangeEntry[] = []): TaskPersistence {
+    return {
+        runId: RunId(runId),
+        slotKey: `synthetic:${runId}`,
+        type: "synthetic",
+        params: { tag: String(runId) },
+        phaseIndex: 0,
+        state,
+        changeSet,
+    };
+}
+
+describe("run record snapshots", () => {
+    const record = () => RunRecord.fromPersistence(persisted(1, "failed", [ENTRY]));
+
+    it("removes a field a write drops, and keeps the rest", () => {
+        const snapshot = record().toPersistence({ state: "cancelled" }, ["params"]);
+        expect("params" in snapshot).equals(false);
+        expect(snapshot.state).equals("cancelled");
+        expect(snapshot.changeSet).deep.equals([ENTRY]);
+    });
+
+    it("keeps a field absent once dropped, however many writes follow", () => {
+        const dropped = record();
+        dropped.adoptDrop(["params"]);
+        // Otherwise the key returns holding `undefined` on the next write and "storage omits it" holds for
+        // exactly one write.
+        expect("params" in dropped.toPersistence({ revertRunId: RunId(2) })).equals(false);
+    });
+
+    it("omits every field the run does not have, and none that it must", () => {
+        const snapshot = record().toPersistence();
+        for (const absent of ["externalId", "error", "retireSeq", "revertRunId", "revertOf"]) {
+            expect(absent in snapshot).equals(false);
+        }
+        // The strip is enumerated rather than derived from the values present, so it cannot reach these.
+        for (const required of ["runId", "slotKey", "type", "phaseIndex", "state", "changeSet"]) {
+            expect(required in snapshot).equals(true);
+        }
+    });
+
+    it("refuses a write that both sets a field and drops it", () => {
+        // Which one wins would otherwise be decided by the order the two lists are applied in.
+        expect(() => record().toPersistence({ params: { tag: "new" } }, ["params"])).throws(InternalError);
+    });
+});
+
+describe("run table schema version", () => {
+    it("loads a table written before the version existed", () => {
+        const store = new RunStore();
+        store.load({
+            runs: { "1": persisted(1, "running", [ENTRY]) },
+            nextRunId: 1_000,
+        });
+        expect(store.unreadable).equals(false);
+        expect(store.get(RunId(1))?.state).equals("running");
+    });
+
+    it("reads nothing from a table a newer build wrote", () => {
+        const store = new RunStore();
+        const { resumable } = store.load({
+            runs: { "1": persisted(1, "running", [ENTRY]) },
+            nextRunId: 1_000,
+            runsVersion: RUN_STORE_VERSION + 1,
+        });
+        // Nothing loaded and nothing resumable: the manager refuses new work rather than presenting a table
+        // whose targets it cannot see are taken.
+        expect(store.unreadable).equals(true);
+        expect(resumable).deep.equals([]);
+        expect(store.get(RunId(1))).equals(undefined);
+    });
+});

--- a/packages/node-manager/test/task/RetirementTest.ts
+++ b/packages/node-manager/test/task/RetirementTest.ts
@@ -1,0 +1,276 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
+import { TaskConflictError, TaskNotInFlightError, TaskStoreVersionError, TaskSupersededError } from "#task/errors.js";
+import { RUN_STORE_VERSION } from "#task/RunStore.js";
+import { TaskPersistence } from "#task/Task.js";
+import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
+import { RunId, TaskPhase } from "#task/types.js";
+import { Environment, InternalError, MaybePromise } from "@matter/general";
+import { ClientNode, itemMapKey, ServerNode } from "@matter/node";
+import { MockServerNode } from "@matter/node/testing";
+import { FakePeer, SyntheticTask } from "./helpers.js";
+
+class TestTaskManager extends TaskManagerBehavior {
+    static override readonly schema = TaskManagerBehavior.schema;
+    static peers = new Map<string, FakePeer>();
+    static reconcilerPeer?: FakePeer;
+
+    protected override resolvePeerNode(peerId: string): ClientNode | undefined {
+        return TestTaskManager.peers.get(peerId)?.asNode();
+    }
+    protected override taskReconciler(): ReconcilerBehavior {
+        return TestTaskManager.reconcilerPeer as unknown as ReconcilerBehavior;
+    }
+
+    isAttached(runId: RunId) {
+        return this.internal.runs.isAttached(runId);
+    }
+}
+
+const RootEndpoint = MockServerNode.RootEndpoint.with(TestTaskManager);
+
+const KEY = itemMapKey("groupMembership", "X");
+
+function testPeer(id: string) {
+    const peer = new FakePeer(id);
+    TestTaskManager.peers.set(id, peer);
+    TestTaskManager.reconcilerPeer = peer;
+    return peer;
+}
+
+async function makeNode(environment?: Environment, id = "ledger") {
+    return MockServerNode.create(RootEndpoint, { environment, id });
+}
+
+async function pumpUntil(name: string, condition: () => MaybePromise<boolean>) {
+    for (let i = 0; i < 10_000; i++) {
+        if (await condition()) {
+            return;
+        }
+        await MockTime.advance(1);
+    }
+    throw new InternalError(`Condition "${name}" never held`);
+}
+
+/** Writes one intent and returns, so the run completes having changed something. */
+function touchPhase(peerId: string): TaskPhase {
+    return {
+        name: "touch",
+        run: async ctx => {
+            await ctx.setIntent(ctx.resolvePeer(peerId), "groupMembership", "X", { v: 2 });
+        },
+    };
+}
+
+/** Writes one intent the device never confirms, so the run stays in flight owning its target. */
+function gatingPhase(peerId: string): TaskPhase {
+    return {
+        name: "hold",
+        run: async ctx => {
+            const peer = ctx.resolvePeer(peerId);
+            await ctx.setIntent(peer, "groupMembership", "X", { v: 2 });
+            await ctx.awaitCommitted([{ peer, kind: "groupMembership", key: "X" }]);
+        },
+    };
+}
+
+async function stored(node: ServerNode, runId: RunId): Promise<TaskPersistence | undefined> {
+    return node.act(a => a.get(TestTaskManager).state.runs[String(runId)]);
+}
+
+async function run(node: ServerNode, tag: string, phases: TaskPhase[]) {
+    SyntheticTask.phasesByTag[tag] = phases;
+    await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
+    return node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag }));
+}
+
+async function awaitRetired(node: ServerNode, runId: RunId) {
+    await pumpUntil(`run #${runId} retired`, () =>
+        node.act(a => {
+            const manager = a.get(TestTaskManager);
+            const status = manager.get(runId)?.status;
+            return status !== undefined && status.retireSeq !== undefined && !manager.isAttached(runId);
+        }),
+    );
+}
+
+/**
+ * A run that failed and whose rollback then failed too: the rollback restores the prior value and the
+ * reconciler drops the intent its gate waits for, so it can never commit.
+ */
+async function failedRollback(node: ServerNode, tag: string, peer: FakePeer) {
+    peer.setIntent("groupMembership", "X", { v: 1 });
+    const original = await run(node, tag, [gatingPhase(peer.id)]);
+    await pumpUntil("intent written", () => (peer.items[KEY]?.intent as { v?: number })?.v === 2);
+
+    const rollback = await node.act(a => a.get(TestTaskManager).cancel(original.runId));
+    if (rollback === undefined) {
+        throw new InternalError("cancel produced no rollback");
+    }
+    await pumpUntil("rollback restoring", () => (peer.items[KEY]?.intent as { v?: number })?.v === 1);
+    peer.dropItem("groupMembership", "X");
+    await pumpUntil("rollback failed and retired", () =>
+        node.act(a => {
+            const manager = a.get(TestTaskManager);
+            return manager.get(rollback.runId)?.status.state === "failed" && !manager.isAttached(rollback.runId);
+        }),
+    );
+    return { original, rollback };
+}
+
+/** Runs `fn` and returns whatever it produced, so a test can assert on a refusal without a try/catch. */
+async function attempt<T>(node: ServerNode, fn: (manager: TestTaskManager) => Promise<T>) {
+    return node.act(async a => {
+        try {
+            return await fn(a.get(TestTaskManager));
+        } catch (e) {
+            return e;
+        }
+    });
+}
+
+function reset() {
+    TestTaskManager.peers.clear();
+    TestTaskManager.reconcilerPeer = undefined;
+    for (const tag of Object.keys(SyntheticTask.phasesByTag)) {
+        delete SyntheticTask.phasesByTag[tag];
+    }
+}
+
+describe("run records after a retirement", () => {
+    before(() => MockTime.init());
+    beforeEach(reset);
+
+    it("keeps nothing owed once a run completes cleanly", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("clean");
+        peer.markHas("groupMembership", "X");
+        const handle = await run(node, "clean", [touchPhase("clean")]);
+        await awaitRetired(node, handle.runId);
+
+        const record = await stored(node, handle.runId);
+        expect(record).not.equals(undefined);
+        // An absent key, not a key holding `undefined`: the claim is that key material does not outlive the
+        // work, and a present-but-undefined field would satisfy a looser assertion while still being written.
+        expect("params" in record!).equals(false);
+        // Still answers, which is the whole point of keeping the record.
+        expect(await node.act(a => a.get(TestTaskManager).get(handle.runId)?.status.state)).equals("completed");
+    });
+
+    it("retries a failed rollback with the original's params gone", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("retry");
+        const { original } = await failedRollback(node, "retry", peer);
+
+        const retired = await stored(node, original.runId);
+        expect("params" in retired!).equals(false);
+        expect(retired?.changeSet?.length).equals(1);
+
+        // The proof that retry does not go through the definition: the params it would need are gone, and the
+        // changeSet alone is enough to build the replacement.
+        const retry = await node.act(a => a.get(TestTaskManager).retryRollback(original.runId));
+        expect(retry.status.revertOf).equals(original.runId);
+        expect((await stored(node, original.runId))?.revertRunId).equals(retry.runId);
+    });
+
+    it("refuses to cancel a run that already finished", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("done");
+        peer.markHas("groupMembership", "X");
+        const handle = await run(node, "done", [touchPhase("done")]);
+        await awaitRetired(node, handle.runId);
+
+        await expect(node.act(a => a.get(TestTaskManager).cancel(handle.runId))).rejectedWith(TaskNotInFlightError);
+        expect((await stored(node, handle.runId))?.revertRunId).equals(undefined);
+    });
+
+    it("records the schema version it wrote the table under", async () => {
+        const environment = new Environment("ledger-stamp");
+        {
+            await using node = await makeNode(environment, "stamp");
+            const peer = testPeer("stamp");
+            peer.markHas("groupMembership", "X");
+            const handle = await run(node, "stamp", [touchPhase("stamp")]);
+            await awaitRetired(node, handle.runId);
+        }
+
+        // Read back on a fresh start: the stamp has to be in storage, not merely the default this build would
+        // have supplied anyway, or a later build learns nothing about who wrote the table.
+        await using node = await makeNode(environment, "stamp");
+        expect(await node.act(a => a.get(TestTaskManager).state.runsVersion)).equals(RUN_STORE_VERSION);
+    });
+
+    it("refuses every writing verb, not only run, while the table is unreadable", async () => {
+        const environment = new Environment("unreadable-verbs");
+        let existing!: RunId;
+        {
+            // A real record, written by this build, and then the table stamped as a newer build's. The refusal
+            // is worth having precisely because the run demonstrably exists and the verbs cannot see it.
+            await using seeding = await makeNode(environment, "verbs");
+            const peer = testPeer("verbs");
+            peer.markHas("groupMembership", "X");
+            const handle = await run(seeding, "verbs", [touchPhase("verbs")]);
+            await awaitRetired(seeding, handle.runId);
+            existing = handle.runId;
+            await seeding.act(a => {
+                a.get(TestTaskManager).state.runsVersion = RUN_STORE_VERSION + 1;
+            });
+        }
+
+        await using node = await makeNode(environment, "verbs");
+        // The record is in storage and was not loaded, so a read answers "nothing" — it cannot invent what it
+        // did not read — while a write names the cause instead of claiming the run never existed.
+        expect(await node.act(a => a.get(TestTaskManager).get(existing))).equals(undefined);
+        const verbs: Array<(m: TestTaskManager) => Promise<unknown>> = [
+            m => m.cancel(existing),
+            m => m.abandon(existing),
+            m => m.retryRollback(existing),
+        ];
+        for (const verb of verbs) {
+            expect(await attempt(node, verb)).instanceOf(TaskStoreVersionError);
+        }
+        expect(await attempt(node, async m => m.run(SyntheticTask, { tag: "verbs" }))).instanceOf(
+            TaskStoreVersionError,
+        );
+    });
+
+    it("refuses to retry an undo a later run of the target has superseded", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("superseded");
+
+        // A failed run keeps the values it found, and its own rollback fails too, so both are terminal and the
+        // target is free again.
+        const { original } = await failedRollback(node, "superseded", peer);
+
+        // A second run of the same target commits its own outcome. What the first would restore is historical.
+        peer.markHas("groupMembership", "X");
+        const later = await run(node, "superseded", [touchPhase("superseded")]);
+        await awaitRetired(node, later.runId);
+
+        const refusal = await attempt(node, m => m.retryRollback(original.runId));
+        expect(refusal).instanceOf(TaskSupersededError);
+        expect((refusal as TaskConflictError).owner).equals(later.runId);
+    });
+
+    it("admits nothing when the stored table is newer than this build", async () => {
+        const environment = new Environment("ledger-version");
+        {
+            await using node = await makeNode(environment, "version");
+            await node.act(a => {
+                a.get(TestTaskManager).state.runsVersion = RUN_STORE_VERSION + 1;
+            });
+        }
+
+        await using node = await makeNode(environment, "version");
+        SyntheticTask.phasesByTag["version"] = [touchPhase("version")];
+        await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
+        expect(() => node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "version" }))).throws(
+            TaskStoreVersionError,
+        );
+    });
+});

--- a/packages/node-manager/test/task/RetirementTest.ts
+++ b/packages/node-manager/test/task/RetirementTest.ts
@@ -200,12 +200,18 @@ describe("run records after a retirement", () => {
             await awaitRetired(node, handle.runId);
             finished = handle.runId;
 
-            // Put the record back the way the previous build left it: parameters intact, table unversioned.
+            // Put the record back the way the previous build left it: every key materialised — including the
+            // undefined ones, which is what that build's snapshots did — and the table unversioned.
             await node.act(a => {
                 const manager = a.get(TestTaskManager);
                 manager.state.runs = {
                     ...manager.state.runs,
-                    [String(finished)]: { ...manager.state.runs[String(finished)], params: { tag: "upgrade" } },
+                    [String(finished)]: {
+                        ...manager.state.runs[String(finished)],
+                        params: { tag: "upgrade" },
+                        error: undefined,
+                        revertOf: undefined,
+                    },
                 };
                 manager.state.runsVersion = 1;
             });
@@ -217,7 +223,39 @@ describe("run records after a retirement", () => {
         const record = await stored(node, finished);
         expect(record).not.equals(undefined);
         expect("params" in record!).equals(false);
+        // The key goes, not merely its value — and the same pass normalises the other keys the previous build
+        // materialised empty, because it rebuilds each record through the ordinary snapshot path.
+        expect("error" in record!).equals(false);
+        expect("revertOf" in record!).equals(false);
         expect(await node.act(a => a.get(TestTaskManager).state.runsVersion)).equals(RUN_STORE_VERSION);
+    });
+
+    it("drops a parameter key an older build left present but empty", async () => {
+        const environment = new Environment("upgrade-emptykey");
+        let finished!: RunId;
+        {
+            await using node = await makeNode(environment, "emptykey");
+            const peer = testPeer("emptykey");
+            peer.markHas("groupMembership", "X");
+            const handle = await run(node, "emptykey", [touchPhase("emptykey")]);
+            await awaitRetired(node, handle.runId);
+            finished = handle.runId;
+
+            // A task run with no parameters at all: the previous build still wrote the key, holding `undefined`.
+            await node.act(a => {
+                const manager = a.get(TestTaskManager);
+                manager.state.runs = {
+                    ...manager.state.runs,
+                    [String(finished)]: { ...manager.state.runs[String(finished)], params: undefined },
+                };
+                manager.state.runsVersion = 1;
+            });
+            expect("params" in (await stored(node, finished))!).equals(true);
+        }
+
+        // Testing the value rather than the key would leave this one behind for good: the upgrade runs once.
+        await using node = await makeNode(environment, "emptykey");
+        expect("params" in (await stored(node, finished))!).equals(false);
     });
 
     it("does not put migrated parameters back on the next write of the record", async () => {

--- a/packages/node-manager/test/task/RetirementTest.ts
+++ b/packages/node-manager/test/task/RetirementTest.ts
@@ -223,11 +223,37 @@ describe("run records after a retirement", () => {
         const record = await stored(node, finished);
         expect(record).not.equals(undefined);
         expect("params" in record!).equals(false);
-        // The key goes, not merely its value — and the same pass normalises the other keys the previous build
-        // materialised empty, because it rebuilds each record through the ordinary snapshot path.
-        expect("error" in record!).equals(false);
-        expect("revertOf" in record!).equals(false);
+        // Only the parameters: the other keys the previous build wrote empty are normalised by the next
+        // ordinary write of the record, and this pass does not claim to do it for them.
         expect(await node.act(a => a.get(TestTaskManager).state.runsVersion)).equals(RUN_STORE_VERSION);
+    });
+
+    it("drops the parameters of a record predating per-run identity", async () => {
+        const environment = new Environment("upgrade-legacy");
+        {
+            await using node = await makeNode(environment, "legacy");
+            // The shape `load` discards: a slot key where a run id now goes. It stays in storage, so nothing
+            // will ever rewrite it — and for the group tasks its parameters are raw epoch keys.
+            await node.act(a => {
+                const manager = a.get(TestTaskManager);
+                manager.state.runs = {
+                    ...manager.state.runs,
+                    "synthetic:legacy": {
+                        slotKey: "synthetic:legacy",
+                        type: "synthetic",
+                        params: { epochKey0: "secret" },
+                        phaseIndex: 0,
+                        state: "completed",
+                    } as unknown as TaskPersistence,
+                };
+                manager.state.runsVersion = 1;
+            });
+        }
+
+        await using node = await makeNode(environment, "legacy");
+        const legacy = await node.act(a => a.get(TestTaskManager).state.runs["synthetic:legacy"]);
+        expect(legacy).not.equals(undefined);
+        expect("params" in legacy!).equals(false);
     });
 
     it("drops a parameter key an older build left present but empty", async () => {

--- a/packages/node-manager/test/task/RetirementTest.ts
+++ b/packages/node-manager/test/task/RetirementTest.ts
@@ -189,6 +189,58 @@ describe("run records after a retirement", () => {
         expect((await stored(node, handle.runId))?.revertRunId).equals(undefined);
     });
 
+    it("drops the parameters an older build left on finished records", async () => {
+        const environment = new Environment("upgrade-params");
+        let finished!: RunId;
+        {
+            await using node = await makeNode(environment, "upgrade");
+            const peer = testPeer("upgrade");
+            peer.markHas("groupMembership", "X");
+            const handle = await run(node, "upgrade", [touchPhase("upgrade")]);
+            await awaitRetired(node, handle.runId);
+            finished = handle.runId;
+
+            // Put the record back the way the previous build left it: parameters intact, table unversioned.
+            await node.act(a => {
+                const manager = a.get(TestTaskManager);
+                manager.state.runs = {
+                    ...manager.state.runs,
+                    [String(finished)]: { ...manager.state.runs[String(finished)], params: { tag: "upgrade" } },
+                };
+                manager.state.runsVersion = 1;
+            });
+        }
+
+        // A write replaces only the records its own transaction names, so nothing would ever rewrite a run
+        // that was already finished — and its parameters are the raw keys this version exists to stop storing.
+        await using node = await makeNode(environment, "upgrade");
+        const record = await stored(node, finished);
+        expect(record).not.equals(undefined);
+        expect("params" in record!).equals(false);
+        expect(await node.act(a => a.get(TestTaskManager).state.runsVersion)).equals(RUN_STORE_VERSION);
+    });
+
+    it("leaves an unfinished run's parameters alone on upgrade", async () => {
+        const environment = new Environment("upgrade-inflight");
+        let live!: RunId;
+        {
+            await using node = await makeNode(environment, "inflight");
+            const peer = testPeer("inflight");
+            const handle = await run(node, "inflight", [gatingPhase("inflight")]);
+            await pumpUntil("intent written", () => peer.items[KEY] !== undefined);
+            live = handle.runId;
+            await node.act(a => {
+                a.get(TestTaskManager).state.runsVersion = 1;
+            });
+        }
+
+        // Parameters are what re-drives a run's phases after a restart, so the upgrade must not take them from
+        // work that has not finished.
+        await using node = await makeNode(environment, "inflight");
+        testPeer("inflight");
+        expect((await stored(node, live))?.params).deep.equals({ tag: "inflight" });
+    });
+
     it("records the schema version it wrote the table under", async () => {
         const environment = new Environment("ledger-stamp");
         {
@@ -269,7 +321,7 @@ describe("run records after a retirement", () => {
         await using node = await makeNode(environment, "version");
         SyntheticTask.phasesByTag["version"] = [touchPhase("version")];
         await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
-        expect(() => node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "version" }))).throws(
+        expect(await attempt(node, async m => m.run(SyntheticTask, { tag: "version" }))).instanceOf(
             TaskStoreVersionError,
         );
     });

--- a/packages/node-manager/test/task/RetirementTest.ts
+++ b/packages/node-manager/test/task/RetirementTest.ts
@@ -220,6 +220,39 @@ describe("run records after a retirement", () => {
         expect(await node.act(a => a.get(TestTaskManager).state.runsVersion)).equals(RUN_STORE_VERSION);
     });
 
+    it("does not put migrated parameters back on the next write of the record", async () => {
+        const environment = new Environment("upgrade-rewrite");
+        let original!: RunId;
+        {
+            await using node = await makeNode(environment, "rewrite");
+            const peer = testPeer("rewrite");
+            const failed = await failedRollback(node, "rewrite", peer);
+            original = failed.original.runId;
+
+            // Back to the shape the previous build left: parameters present, table unversioned.
+            await node.act(a => {
+                const manager = a.get(TestTaskManager);
+                manager.state.runs = {
+                    ...manager.state.runs,
+                    [String(original)]: { ...manager.state.runs[String(original)], params: { tag: "rewrite" } },
+                };
+                manager.state.runsVersion = 1;
+            });
+        }
+
+        await using node = await makeNode(environment, "rewrite");
+        const peer = testPeer("rewrite");
+        peer.setIntent("groupMembership", "X", { v: 1 });
+        await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
+        expect("params" in (await stored(node, original))!).equals(false);
+
+        // A snapshot carries every field the record holds, so a write that mentions something else — here the
+        // link to a fresh undo — would re-persist parameters the upgrade only took out of storage. The version
+        // stamp means the upgrade would never run again to remove them.
+        await node.act(a => a.get(TestTaskManager).retryRollback(original));
+        expect("params" in (await stored(node, original))!).equals(false);
+    });
+
     it("leaves an unfinished run's parameters alone on upgrade", async () => {
         const environment = new Environment("upgrade-inflight");
         let live!: RunId;

--- a/packages/node-manager/test/task/RunIdentityTest.ts
+++ b/packages/node-manager/test/task/RunIdentityTest.ts
@@ -12,7 +12,6 @@ import {
     TaskRollbackPendingError,
     TaskSlotAwaitingResumeError,
     TaskSlotOccupiedError,
-    TaskSupersededError,
     TaskTypeNotRegisteredError,
 } from "#task/errors.js";
 import { Revert } from "#task/Revert.js";
@@ -171,8 +170,9 @@ describe("run identity", () => {
     it("keeps every record of cancel, re-run, cancel", async () => {
         await using node = await makeNode();
         touchingPeer("churn");
-        // A changeSet is what makes a cancel produce a rollback record, so the phase must really touch a peer.
-        SyntheticTask.phasesByTag["churn"] = [touchPhase("churn")];
+        // A changeSet is what makes a cancel produce a rollback record, so the phase must really touch a peer —
+        // and it must not finish, because cancel applies to work in flight.
+        SyntheticTask.phasesByTag["churn"] = [gateForever("churn")];
         await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
 
         const peer = TestTaskManager.peers.get("churn")!;
@@ -288,10 +288,10 @@ describe("run identity", () => {
         expect(outcome).instanceOf(TaskSlotOccupiedError);
     });
 
-    it("rolls back a run that retired before a restart", async () => {
+    it("rolls back a run that was still in flight before a restart", async () => {
         const environment = persistentEnvironment();
-        touchingPeer("undo");
-        SyntheticTask.phasesByTag["undo"] = [touchPhase("undo")];
+        const peer = touchingPeer("undo");
+        SyntheticTask.phasesByTag["undo"] = [gateForever("undo")];
 
         let runId: RunId;
         {
@@ -299,20 +299,29 @@ describe("run identity", () => {
             await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
             const handle = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "undo" }));
             runId = handle.runId;
-            await settle(node, "synthetic:undo");
+            await pumpUntil("intent written", async () => peer.items[itemMapKey("groupMembership", "X")] !== undefined);
+            // The changeSet has to reach storage, not merely memory: parking is what writes it, and an
+            // unreachable peer is what parks the gate.
+            peer.setReachable(false);
+            await pumpUntil("changeSet persisted", async () =>
+                node.act(
+                    a => (recordFor(a.get(TestTaskManager).state.runs, "synthetic:undo")?.changeSet?.length ?? 0) > 0,
+                ),
+            );
         }
 
-        // Undo of finished work reads the retained changeSet, so the record has to survive the restart.
+        // The rollback reads the changeSet the run recorded before the stop, so the record has to survive the
+        // restart — and the identity the caller held has to still name it.
         await using node = await makeNode(environment, "undo");
         await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
         const rollback = await node.act(a => a.get(TestTaskManager).cancel(runId));
         expect(rollback?.status.revertOf).equals(runId);
     });
 
-    it("refuses to roll back a retired run whose type nothing has registered", async () => {
+    it("refuses to roll back a run awaiting resume whose type nothing has registered", async () => {
         const environment = persistentEnvironment();
-        touchingPeer("unregistered");
-        SyntheticTask.phasesByTag["unregistered"] = [touchPhase("unregistered")];
+        const peer = touchingPeer("unregistered");
+        SyntheticTask.phasesByTag["unregistered"] = [gateForever("unregistered")];
 
         let runId: RunId;
         {
@@ -320,13 +329,13 @@ describe("run identity", () => {
             await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
             const handle = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "unregistered" }));
             runId = handle.runId;
-            await settle(node, "synthetic:unregistered");
+            await pumpUntil("intent written", async () => peer.items[itemMapKey("groupMembership", "X")] !== undefined);
         }
 
-        // Observing a retired run needs no task; rolling one back does, because revertibility is the task's
+        // Observing an unfinished run needs no task; rolling one back does, because revertibility is the task's
         // decision and a record cannot answer it.
         await using node = await makeNode(environment, "unregistered");
-        expect(await node.act(a => a.get(TestTaskManager).get(runId)?.status.state)).equals("completed");
+        expect(await node.act(a => a.get(TestTaskManager).get(runId)?.status.state)).equals("running");
         await expect((async () => node.act(a => a.get(TestTaskManager).cancel(runId)))()).rejectedWith(
             TaskTypeNotRegisteredError,
         );
@@ -357,30 +366,18 @@ describe("run identity", () => {
     it("refuses a re-run while a rollback of that slot is still live", async () => {
         await using node = await makeNode(undefined, "older");
         const peer = touchingPeer("older");
-        SyntheticTask.phasesByTag["older"] = [touchPhase("older")];
+        SyntheticTask.phasesByTag["older"] = [gateForever("older")];
         await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
 
-        // Two completed runs of one slot, so the rollback in flight is not the newest run's.
         const first = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "older" }));
-        for (let i = 0; i < 10_000 && peer.items[itemMapKey("groupMembership", "X")] === undefined; i++) {
-            await MockTime.advance(1);
-        }
-        await settle(node, "synthetic:older");
-        peer.dropItem("groupMembership", "X");
-
-        const second = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "older" }));
-        for (let i = 0; i < 10_000 && peer.items[itemMapKey("groupMembership", "X")] === undefined; i++) {
-            await MockTime.advance(1);
-        }
-        await settle(node, "synthetic:older");
-        expect(second.runId).not.equals(first.runId);
+        await pumpUntil("intent written", async () => peer.items[itemMapKey("groupMembership", "X")] !== undefined);
 
         // The rollback parks on an unreachable peer, so it stays live while the re-run is attempted.
         peer.setReachable(false);
-        const rollback = await node.act(a => a.get(TestTaskManager).cancel(second.runId));
-        expect(rollback?.status.revertOf).equals(second.runId);
+        const rollback = await node.act(a => a.get(TestTaskManager).cancel(first.runId));
+        expect(rollback?.status.revertOf).equals(first.runId);
 
-        // A rollback rewrites exactly the intents a re-run would re-apply, whichever run of the slot it undoes.
+        // A rollback rewrites exactly the intents a re-run would re-apply.
         let refusal: unknown;
         try {
             await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "older" }));
@@ -394,7 +391,8 @@ describe("run identity", () => {
     it("answers a repeated cancel with the rollback it recorded, once that rollback has finished", async () => {
         await using node = await makeNode(undefined, "recancel");
         const peer = touchingPeer("recancel");
-        SyntheticTask.phasesByTag["recancel"] = [touchPhase("recancel")];
+        // In flight, so the first cancel is accepted rather than refused for a run that already finished.
+        SyntheticTask.phasesByTag["recancel"] = [gateForever("recancel")];
         await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
 
         const handle = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "recancel" }));
@@ -435,8 +433,8 @@ describe("run identity", () => {
 
     it("answers a repeated cancel from the record when the task type is not registered", async () => {
         const environment = persistentEnvironment();
-        touchingPeer("norereg");
-        SyntheticTask.phasesByTag["norereg"] = [touchPhase("norereg")];
+        const peer = touchingPeer("norereg");
+        SyntheticTask.phasesByTag["norereg"] = [gateForever("norereg")];
 
         let runId: RunId;
         let rollbackId: RunId;
@@ -445,7 +443,7 @@ describe("run identity", () => {
             await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
             const handle = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "norereg" }));
             runId = handle.runId;
-            await settle(node, "synthetic:norereg");
+            await pumpUntil("intent written", async () => peer.items[itemMapKey("groupMembership", "X")] !== undefined);
             const rollback = await node.act(a => a.get(TestTaskManager).cancel(runId));
             rollbackId = rollback!.runId;
             await settle(node, `revert:${runId}`);
@@ -458,79 +456,12 @@ describe("run identity", () => {
         expect(again?.runId).equals(rollbackId);
     });
 
-    it("refuses to undo a run a later run of its slot has superseded", async () => {
-        await using node = await makeNode(undefined, "superseded");
-        const peer = touchingPeer("superseded");
-        SyntheticTask.phasesByTag["superseded"] = [touchPhase("superseded")];
-        await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
-
-        const runs = new Array<RunId>();
-        for (let round = 0; round < 2; round++) {
-            const handle = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "superseded" }));
-            for (let i = 0; i < 10_000 && peer.items[itemMapKey("groupMembership", "X")] === undefined; i++) {
-                await MockTime.advance(1);
-            }
-            await settle(node, "synthetic:superseded");
-            peer.dropItem("groupMembership", "X");
-            runs.push(handle.runId);
-        }
-
-        // Undoing a run restores the values it found. A later run of the slot has committed its own since, so
-        // restoring the older run's would overwrite an outcome nobody asked to undo.
-        let refusal: unknown;
-        try {
-            await node.act(a => a.get(TestTaskManager).cancel(runs[0]));
-        } catch (e) {
-            refusal = e;
-        }
-        expect(refusal).instanceOf(TaskSupersededError);
-        expect((refusal as TaskConflictError).owner).equals(runs[1]);
-
-        // The newest run of the slot is still undoable.
-        peer.setReachable(false);
-        const rollback = await node.act(a => a.get(TestTaskManager).cancel(runs[1]));
-        expect(rollback?.status.revertOf).equals(runs[1]);
-    });
-
-    it("refuses a rollback of a retired run whose slot a newer run now owns", async () => {
-        await using node = await makeNode(undefined, "reverseorder");
-        const peer = touchingPeer("reverseorder");
-        SyntheticTask.phasesByTag["reverseorder"] = [touchPhase("reverseorder")];
-        await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
-
-        const older = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "reverseorder" }));
-        for (let i = 0; i < 10_000 && peer.items[itemMapKey("groupMembership", "X")] === undefined; i++) {
-            await MockTime.advance(1);
-        }
-        await settle(node, "synthetic:reverseorder");
-        peer.dropItem("groupMembership", "X");
-
-        // A newer run takes the slot and is held live on a gate that never settles, so reaching the conflict
-        // does not depend on scheduling. Swapped only now, so the older run above still completes and retires.
-        SyntheticTask.phasesByTag["reverseorder"] = [gateForever("reverseorder")];
-        const newer = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "reverseorder" }));
-        expect(newer.runId).not.equals(older.runId);
-        await pumpUntil(
-            "the newer run owns the slot",
-            async () => (await node.act(a => a.get(TestTaskManager).tasks.some(t => t.runId === newer.runId))) === true,
-        );
-        // Asserted rather than assumed: the conflict this test is about exists only while the newer run holds
-        // the slot, so a setup that quietly let it finish would prove nothing.
-        expect(await node.act(a => a.get(TestTaskManager).tasks.map(t => t.runId))).contains(newer.runId);
-
-        let refusal: unknown;
-        try {
-            await node.act(a => a.get(TestTaskManager).cancel(older.runId));
-        } catch (e) {
-            refusal = e;
-        }
-        expect(refusal).instanceOf(TaskSlotOccupiedError);
-    });
-
     it("gives every concurrent cancel of a run the same rollback", async () => {
         await using node = await makeNode(undefined, "racecancel");
         const peer = touchingPeer("racecancel");
-        SyntheticTask.phasesByTag["racecancel"] = [touchPhase("racecancel")];
+        // Held in flight: cancel applies to work that has not finished, so a phase that returns would make
+        // both callers race the run's own completion instead of racing each other.
+        SyntheticTask.phasesByTag["racecancel"] = [gateForever("racecancel")];
         await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
 
         const handle = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "racecancel" }));

--- a/packages/node-manager/test/task/TaskLifecycleTest.ts
+++ b/packages/node-manager/test/task/TaskLifecycleTest.ts
@@ -257,7 +257,7 @@ describe("Task lifecycle", () => {
     });
 
     describe("cancel", () => {
-        it("cancelling a completed task spawns a revert that removes items in reverse order", async () => {
+        it("cancelling an in-flight task spawns a revert that removes items in reverse order", async () => {
             const environment = new Environment("test");
             const peer = new FakePeer("cp");
             TestTaskManager.peers.set("cp", peer);
@@ -274,12 +274,16 @@ describe("Task lifecycle", () => {
                         await ctx.setIntent(node, "groupMembership", "B", {});
                     },
                 },
+                // Cancel applies to work in flight, so the run has to still be in it — with both intents
+                // already written, which is what the rollback undoes.
+                { name: "hold", run: () => new Promise<void>(() => {}) },
             ];
 
             const node = await makeNode(environment);
             await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
             await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "cancel" }));
-            await awaitState(node, "synthetic:cancel", "completed");
+            // Phase 0 done and its write landed: both intents are in the changeSet the rollback will undo.
+            await awaitPhase(node, "synthetic:cancel", 1);
 
             const handle = await node.act(a => cancelSlot(a.get(TestTaskManager), "synthetic:cancel"));
             expect(handle?.status.revertOf).equals(
@@ -298,9 +302,8 @@ describe("Task lifecycle", () => {
             ]);
             expect(peer.items[itemMapKey("groupMembership", "A")]).equals(undefined);
             expect(peer.items[itemMapKey("groupMembership", "B")]).equals(undefined);
-            // Cancelling an already-completed task spawns the revert but leaves the original's truthful state.
             const status = await node.act(a => statusOfSlot(a.get(TestTaskManager), "synthetic:cancel"));
-            expect(status?.state).equals("completed");
+            expect(status?.state).equals("cancelled");
             expect(status?.revertRunId).equals(handle?.runId);
             await node.close();
         });
@@ -310,17 +313,15 @@ describe("Task lifecycle", () => {
             const peer = new FakePeer("rr");
             TestTaskManager.peers.set("rr", peer);
             TestTaskManager.reconcilerPeer = peer;
-            peer.markHas("groupMembership", "1");
-
             SyntheticTask.phasesByTag["rerun"] = [gatePhase("rr", "groupMembership", "1")];
 
             const node = await makeNode(environment);
             await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
             await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "rerun" }));
-            await awaitState(node, "synthetic:rerun", "completed");
-
-            // The peer goes away, so the rollback parks instead of finishing.
+            // The device never confirms, so the run is still in flight with its intent written — and the write
+            // that records it is what parking produces, so the peer goes away first.
             peer.setReachable(false);
+            await awaitState(node, "synthetic:rerun", "parked");
             const revert = await node.act(a => cancelSlot(a.get(TestTaskManager), "synthetic:rerun"));
             expect(revert?.status.slotKey).equals(
                 `revert:${requireStatusOfSlot(await node.act(a => a.get(TestTaskManager)), "synthetic:rerun").runId}`,

--- a/packages/node-manager/test/task/TaskLifecycleTest.ts
+++ b/packages/node-manager/test/task/TaskLifecycleTest.ts
@@ -275,8 +275,10 @@ describe("Task lifecycle", () => {
                     },
                 },
                 // Cancel applies to work in flight, so the run has to still be in it — with both intents
-                // already written, which is what the rollback undoes.
-                { name: "hold", run: () => new Promise<void>(() => {}) },
+                // already written, which is what the rollback undoes. The hold gates on the peer rather than
+                // on a bare promise: `#unwind` awaits the running phase, and a phase that cannot observe its
+                // abort would hang the cancel instead of being stopped by it.
+                gatePhase("cp", "groupMembership", "A"),
             ];
 
             const node = await makeNode(environment);

--- a/packages/node-manager/test/task/TaskManagerBehaviorTest.ts
+++ b/packages/node-manager/test/task/TaskManagerBehaviorTest.ts
@@ -387,8 +387,17 @@ describe("TaskManagerBehavior", () => {
     it("distinguishes an id no live task answers to from a task with nothing to roll back", async () => {
         const environment = new Environment("test");
         const node = await MockServerNode.create(RootEndpoint, { environment, id: "tm-cancel-unknown" });
-        // In flight and touching nothing: cancel applies to it, and there is still nothing to undo.
-        SyntheticTask.phasesByTag["nothing"] = [{ name: "a", run: () => new Promise<void>(() => {}) }];
+        // In flight and touching nothing: cancel applies to it, and there is still nothing to undo. The wait
+        // is on the task context's gate, not a bare promise — `#unwind` awaits the running phase, so a phase
+        // deaf to its own abort would hang the cancel rather than be stopped by it.
+        SyntheticTask.phasesByTag["nothing"] = [
+            {
+                name: "a",
+                run: async ctx => {
+                    await ctx.awaitGate([], () => false);
+                },
+            },
+        ];
         await node.act(a => a.get(TaskManagerBehavior).register(SyntheticTask));
         await node.act(a => a.get(TaskManagerBehavior).run(SyntheticTask, { tag: "nothing" }));
 

--- a/packages/node-manager/test/task/TaskManagerBehaviorTest.ts
+++ b/packages/node-manager/test/task/TaskManagerBehaviorTest.ts
@@ -387,10 +387,10 @@ describe("TaskManagerBehavior", () => {
     it("distinguishes an id no live task answers to from a task with nothing to roll back", async () => {
         const environment = new Environment("test");
         const node = await MockServerNode.create(RootEndpoint, { environment, id: "tm-cancel-unknown" });
-        SyntheticTask.phasesByTag["nothing"] = [{ name: "a", run: async () => {} }];
+        // In flight and touching nothing: cancel applies to it, and there is still nothing to undo.
+        SyntheticTask.phasesByTag["nothing"] = [{ name: "a", run: () => new Promise<void>(() => {}) }];
         await node.act(a => a.get(TaskManagerBehavior).register(SyntheticTask));
         await node.act(a => a.get(TaskManagerBehavior).run(SyntheticTask, { tag: "nothing" }));
-        await awaitTaskDone(node, "synthetic:nothing");
 
         // A task that touched nothing has nothing to roll back, and says so.
         expect(await node.act(a => cancelSlot(a.get(TaskManagerBehavior), "synthetic:nothing"))).equals(undefined);

--- a/packages/node-manager/test/task/TransitionsTest.ts
+++ b/packages/node-manager/test/task/TransitionsTest.ts
@@ -12,6 +12,7 @@ import {
     TaskCancelledSignal,
     TaskCannotCancelRollbackError,
     TaskManagerClosingError,
+    TaskNoRollbackError,
     TaskNotARollbackError,
     TaskNotFoundError,
     TaskRollbackPendingError,
@@ -965,7 +966,7 @@ describe("retryRollback", () => {
             node.act(a => a.get(TestTaskManager).get(handle.runId)?.status.state === "completed"),
         );
 
-        expect(await attempt(node, m => m.retryRollback(handle.runId))).instanceOf(ImplementationError);
+        expect(await attempt(node, m => m.retryRollback(handle.runId))).instanceOf(TaskNoRollbackError);
     });
 
     it("leaves the original naming the old rollback when the retry's write is refused", async () => {

--- a/packages/node-manager/test/task/groups/AddNodeToGroupIntegrationTest.ts
+++ b/packages/node-manager/test/task/groups/AddNodeToGroupIntegrationTest.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { TaskNotInFlightError } from "#task/errors.js";
 import { ADD_NODE_TO_GROUP_TYPE, AddNodeToGroup, AddNodeToGroupParams } from "#task/groups/AddNodeToGroup.js";
 import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { DesiredStateBehavior, itemMapKey, NetworkClient, ServerNode } from "@matter/node";
@@ -16,7 +17,7 @@ import { MockServerNode, MockSite, subscribedPeer } from "@matter/node/testing";
 import { SustainedSubscription } from "@matter/protocol";
 import { EndpointNumber, GroupId } from "@matter/types";
 import { GroupKeyManagement } from "@matter/types/clusters/group-key-management";
-import { cancelSlot, recordFor, requireRecordFor, revertRecordOf, revertSlotOf, statusOfSlot } from "../helpers.js";
+import { cancelSlot, recordFor, revertRecordOf, statusOfSlot } from "../helpers.js";
 
 const { TrustFirst } = GroupKeyManagement.GroupKeySecurityPolicy;
 
@@ -119,7 +120,7 @@ describe("AddNodeToGroup task integration (single peer)", () => {
         expect(isMember(device)).equals(true);
     });
 
-    it("cancel reverts the three items and drops membership", async () => {
+    it("declines cancel of a completed add, leaving the three items and membership in place", async () => {
         await using site = new MockSite();
         const { controller, device } = await site.addCommissionedPair({
             controller: { type: ControllerRoot },
@@ -131,31 +132,30 @@ describe("AddNodeToGroup task integration (single peer)", () => {
         await awaitState(controller, TASK_ID, "completed");
         expect(isMember(device)).equals(true);
 
-        const handle = await MockTime.resolve(
-            controller.act(agent => cancelSlot(agent.get(TaskManagerBehavior), TASK_ID)),
-            {
-                macrotasks: true,
-            },
-        );
-        expect(handle?.status.revertOf).equals(
-            requireRecordFor(controller.stateOf(TaskManagerBehavior).runs, TASK_ID).runId,
-        );
-        await awaitState(
-            controller,
-            (await controller.act(a => revertSlotOf(a.get(TaskManagerBehavior).state.runs, TASK_ID)))!,
-            "completed",
-        );
+        // Once the add succeeded it is done: undoing it is `RemoveNodeFromGroup`, which reads the device's
+        // current state, rather than a replay of what this run found.
+        let refusal: unknown;
+        try {
+            await MockTime.resolve(
+                controller.act(agent => cancelSlot(agent.get(TaskManagerBehavior), TASK_ID)),
+                {
+                    macrotasks: true,
+                },
+            );
+        } catch (e) {
+            refusal = e;
+        }
+        expect(refusal).instanceOf(TaskNotInFlightError);
 
-        expect(itemState(peer, "groupKey", String(GROUP_KEY_SET_ID))).equals(undefined);
-        expect(itemState(peer, "groupKeyMap", String(GROUP))).equals(undefined);
-        expect(itemState(peer, "endpointGroupMembership", MEMBERSHIP_KEY)).equals(undefined);
-        expect(isMember(device)).equals(false);
-        // Cancelling an already-completed task spawns the revert but leaves the original's truthful state.
+        expect(itemState(peer, "groupKey", String(GROUP_KEY_SET_ID))).equals("committed");
+        expect(itemState(peer, "groupKeyMap", String(GROUP))).equals("committed");
+        expect(itemState(peer, "endpointGroupMembership", MEMBERSHIP_KEY)).equals("committed");
+        expect(isMember(device)).equals(true);
         const status = await controller.act(agent => statusOfSlot(agent.get(TaskManagerBehavior), TASK_ID));
         expect(status?.state).equals("completed");
-        expect(status?.revertRunId).equals(
-            revertRecordOf(controller.stateOf(TaskManagerBehavior).runs, TASK_ID)?.runId,
-        );
+        // Nothing was spawned, so the run names no rollback.
+        expect(status?.revertRunId).equals(undefined);
+        expect(revertRecordOf(controller.stateOf(TaskManagerBehavior).runs, TASK_ID)).equals(undefined);
     });
 
     it("resumes a parked task across a controller restart", async () => {

--- a/packages/node-manager/test/task/groups/RollbackIntegrationTest.ts
+++ b/packages/node-manager/test/task/groups/RollbackIntegrationTest.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { TaskFailedError } from "#task/errors.js";
+import { TaskFailedError, TaskNotInFlightError } from "#task/errors.js";
 import { ADD_NODE_TO_GROUP_TYPE, AddNodeToGroup, AddNodeToGroupParams } from "#task/groups/AddNodeToGroup.js";
+import { REMOVE_NODE_FROM_GROUP_TYPE, RemoveNodeFromGroup } from "#task/groups/RemoveNodeFromGroup.js";
 import { TaskDefinition } from "#task/Task.js";
 import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { TaskContext } from "#task/types.js";
@@ -184,7 +185,7 @@ describe("Rollback task integration (single peer)", () => {
         expect(isMember(device)).equals(false);
     });
 
-    it("cancel returns a revert handle that completes and leaves the original truthful", async () => {
+    it("declines cancel of a completed add and leaves the device provisioned", async () => {
         await using site = new MockSite();
         const { controller, device } = await site.addCommissionedPair({
             controller: { type: ControllerRoot },
@@ -196,30 +197,29 @@ describe("Rollback task integration (single peer)", () => {
         await awaitState(controller, TASK_ID, "completed");
         expect(isMember(device)).equals(true);
 
-        const handle = await MockTime.resolve(
-            controller.act(agent => cancelSlot(agent.get(TaskManagerBehavior), TASK_ID)),
-            { macrotasks: true },
-        );
-        expect(handle?.status.revertOf).equals(
-            requireRecordFor(controller.stateOf(TaskManagerBehavior).runs, TASK_ID).runId,
-        );
+        // Reversing a change that succeeded is a new action: `RemoveNodeFromGroup` reads what the device holds
+        // now and reference-counts the shared entries, where replaying this run's priors could not.
+        let refusal: unknown;
+        try {
+            await MockTime.resolve(
+                controller.act(agent => cancelSlot(agent.get(TaskManagerBehavior), TASK_ID)),
+                {
+                    macrotasks: true,
+                },
+            );
+        } catch (e) {
+            refusal = e;
+        }
+        expect(refusal).instanceOf(TaskNotInFlightError);
 
-        // revertOf is part of the revert's persisted seed, so it's readable before the revert has run at all.
-        const revertOf = await controller.act(
-            agent => revertRecordOf(agent.get(TaskManagerBehavior).state.runs, TASK_ID)?.revertOf,
+        // Refused, so nothing was spawned and nothing was written.
+        expect(await controller.act(a => revertRecordOf(a.get(TaskManagerBehavior).state.runs, TASK_ID))).equals(
+            undefined,
         );
-        expect(revertOf).equals(requireRecordFor(controller.stateOf(TaskManagerBehavior).runs, TASK_ID).runId);
-
-        await awaitState(
-            controller,
-            (await controller.act(a => revertSlotOf(a.get(TaskManagerBehavior).state.runs, TASK_ID)))!,
-            "completed",
-        );
-
-        expect(itemState(peer, "groupKey", String(GROUP_KEY_SET_ID))).equals(undefined);
-        expect(itemState(peer, "groupKeyMap", String(GROUP))).equals(undefined);
-        expect(itemState(peer, "endpointGroupMembership", `${GROUP}:${PARAMS.endpoint}`)).equals(undefined);
-        expect(isMember(device)).equals(false);
+        expect(itemState(peer, "groupKey", String(GROUP_KEY_SET_ID))).equals("committed");
+        expect(itemState(peer, "groupKeyMap", String(GROUP))).equals("committed");
+        expect(itemState(peer, "endpointGroupMembership", `${GROUP}:${PARAMS.endpoint}`)).equals("committed");
+        expect(isMember(device)).equals(true);
 
         const status = await controller.act(agent => statusOfSlot(agent.get(TaskManagerBehavior), TASK_ID));
         expect(status?.state).equals("completed");
@@ -307,7 +307,7 @@ describe("Rollback task integration (single peer)", () => {
         expect(isMember(device)).equals(false);
     });
 
-    it("cancelling one endpoint's membership leaves the other endpoint and the shared items intact", async () => {
+    it("removing one endpoint's membership leaves the other endpoint and the shared items intact", async () => {
         await using site = new MockSite();
         const { controller, device } = await site.addCommissionedPair({
             controller: { type: ControllerRoot },
@@ -329,17 +329,10 @@ describe("Rollback task integration (single peer)", () => {
         await controller.act(agent => agent.get(TaskManagerBehavior).run(AddNodeToGroup, { ...PARAMS, endpoint: 2 }));
         await awaitState(controller, idEp2, "completed");
 
-        await MockTime.resolve(
-            controller.act(agent => cancelSlot(agent.get(TaskManagerBehavior), idEp1)),
-            {
-                macrotasks: true,
-            },
+        await controller.act(agent =>
+            agent.get(TaskManagerBehavior).run(RemoveNodeFromGroup, { peerId: "peer1", endpoint: 1, groupId: GROUP }),
         );
-        await awaitState(
-            controller,
-            (await controller.act(a => revertSlotOf(a.get(TaskManagerBehavior).state.runs, idEp1)))!,
-            "completed",
-        );
+        await awaitState(controller, `${REMOVE_NODE_FROM_GROUP_TYPE}:peer1:${GROUP}:1`, "completed");
 
         expect(itemState(peer, "endpointGroupMembership", `${GROUP}:1`)).equals(undefined);
         expect(itemState(peer, "endpointGroupMembership", `${GROUP}:2`)).equals("committed");

--- a/packages/node-manager/test/task/groups/RotateGroupKeyIntegrationTest.ts
+++ b/packages/node-manager/test/task/groups/RotateGroupKeyIntegrationTest.ts
@@ -7,6 +7,7 @@
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
 import {
     TaskConflictError,
+    TaskNotInFlightError,
     TaskNotRevertibleError,
     TaskRollbackPendingError,
     TaskSlotOccupiedError,
@@ -795,9 +796,10 @@ describe("RotateGroupKey task integration (two members)", () => {
             expect(Bytes.areEqual(deviceKey0(device, GROUP_KEY_SET_ID), NEW_KEY)).equals(true);
         }
 
+        // Refused for being finished before revertibility is even asked.
         await expect(controller.act(a => cancelSlot(a.get(TaskManagerBehavior), ROTATE_SLOT))).rejectedWith(
-            TaskNotRevertibleError,
-            "forward-only",
+            TaskNotInFlightError,
+            "already finished",
         );
 
         // Declined with zero side effects: no revert spawned, task stays completed, both devices keep the new key.

--- a/packages/node-manager/test/task/helpers.ts
+++ b/packages/node-manager/test/task/helpers.ts
@@ -56,8 +56,8 @@ export function liveRecord(manager: TaskManagerBehavior, runId: RunId): RunRecor
  */
 export function onPersisted(record: RunRecord, hook: (persisted: TaskPersistence) => void): void {
     const original = record.toPersistence.bind(record);
-    record.toPersistence = next => {
-        const persisted = original(next);
+    record.toPersistence = (next, drop) => {
+        const persisted = original(next, drop);
         hook(persisted);
         return persisted;
     };


### PR DESCRIPTION
Fifth step of the task-layer redesign, on top of `node-manager`. Two user-visible changes and one storage
change, all in the unreleased `@matter/node-manager` package.

## A finished task no longer keeps its parameters

A task's parameters are what the manager needs to re-drive its phases after a restart. Once the task has
finished there is nothing left to re-drive, but the parameters stayed in storage for the life of the record —
and for the group tasks those parameters are raw encryption keys (`AddNodeToGroup`'s `epochKey0`,
`RotateGroupKey`'s `newEpochKey`). They are dropped when a task reaches its final state, whatever that state
is.

Undoing a task replays the prior values it captured before writing, never its parameters, so nothing that
could still happen needs them. The cost, stated rather than argued away: this forecloses a future
retry-the-original verb and "what was it trying to write" forensics. The written intents remain in peer
desired state and the captured values still name every touched slot.

**Retrying an undo had to stop asking the task definition anything.** It used to rebuild the definition from
the stored parameters purely to ask whether the task may be undone at all — a question already answered when
the first undo was created. Rebuilding refuses parameters it cannot interpret, so with them gone it would have
thrown an uninterpretable error at the caller. A retry now builds the replacement from the captured values
alone, and the guard chain stays where a *new* undo is decided.

## Cancelling a finished task no longer undoes it

Restoring the values a finished task found would overwrite whatever has legitimately happened since, so
reversing a finished change is a new task the caller starts. For groups that is `RemoveNodeFromGroup`, which
reads what the device holds now and reference-counts entries other groups still share — something a replay of
recorded values cannot do. The parent design legislated this; the code had not caught up.

`cancel` now refuses a finished task that has no undo of its own (`TaskNotInFlightError`). One that already has
an undo is still answered with it, and one cancelled with nothing to undo still answers "nothing to roll back".
The order matters: reporting an existing undo comes first, or a second cancel stops being owed the first's.

**The refusal is asked twice, and the second time is the one that matters.** A task can reach its own outcome
after the cancel has been accepted: the phase loop consults the cancel only between phases, and the check that
ends the loop consults nothing. A task held on the write advancing its phase index passes its last check and
records success anyway. Without re-taking the decision once the driver has stopped, a task that succeeded end
to end was recorded as cancelled and its captured values were replayed onto the device.
`CancelRobustnessTest` constructs that window by holding the persist mutex across the phase's return.

## Storage: removing a field, and a schema version

Saying "remove this field" was not previously expressible. A write carries the state a task is about to adopt,
and a field left undefined there means "unchanged" — deliberately, because an earlier attempt to express
"unchanged" as undefined erased a task's place in the retirement order. Writes gain a separate list of fields
to remove, with three rules, each of which a review round turned into a defect first:

- a write may set a field or remove it, never both, or the order the two lists are applied in silently decides
  which wins;
- a stored record carries every field the task holds, so a write that does not mention a field preserves it;
- and it carries no field holding undefined, or a removed field reappears empty on the very next write.

The stored table also gains a schema version, so a later build can refuse a table it would misread rather than
half-reading it. It is stamped with every write rather than defaulted to the current version: stored state
records what a write *changed*, so a version that always equals the reading build's own is never written and
tells the next build nothing. A table from the future is not loaded and every write is refused — presenting an
empty table would let new work start against devices those unread records own.

This does not fix the downgrade it was motivated by: an older build has no check and never will. What it buys
is that every build from here on can detect a table it must not touch.

Also removes `TaskStatus.detail`, which nothing produced and nothing read.

## Scope that was cut, and why

This step was originally the whole of "the ledger" — retention, an operator-attention flag, `resolve`/`clear`,
an outcome-record cap and supersession-as-an-event — and all of it was built before being cut back. It keyed
liability ("does the controller still owe this device a change?") on the **run**, when that is a property of a
**target**. Every site then needed a predicate translating back, and two review rounds over the built code
found a new class of defect each time in the same two units: eviction and `clear` forgetting a task whose undo
was still driving, `resolve` discharging values an undo was mid-replay, and supersession firing on retirements
that wrote nothing or were themselves about to be undone.

Rather than a third patch round, that half is redesigned per-target in
`docs/superpowers/specs/2026-09-02-node-manager-target-liability.md`: one row per target that owes something,
holding a stack of outstanding write-sets, where "only the top may be undone" is a structural invariant instead
of a derived verdict. Supersession stays exactly as step 4 shipped it in the meantime. `externalId` single-use
was also cut — it is an identity concern that got mixed in here.

## Verification

CI does not run for a PR targeting `node-manager` (every workflow is `branches: [main]`), so the local gates
are the authority:

- `npm run build-clean`, `npm run format`, `npm run lint` clean
- `@matter/node-manager` **256/256** in ESM, CJS and Web (244 on the base)
- full repository suite green: 33 suites, 0 failures
- ten mutations across the new and changed branches applied one at a time, all ten turning a test red —
  including the in-window cancel re-check and the version stamp

Reviewed by four passes (blind adversarial, claims audit, blast radius, test adequacy) over the superset this
was cut from, then a further blind pass over the reduced diff pointed at cut-back damage, which is what found
the in-window cancel defect.

No `CHANGELOG.md` entry, consistent with steps 1-4 and with step 4's decision to file one entry when the
umbrella PR leaves draft. Note that entry becomes due the moment this package reaches main: cancel refusing
finished tasks and the removal of `TaskStatus.detail` are the two behaviour changes needing a name there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
