### PR TITLE
fix(node-manager): record that a task run changed the device, apart from what it would restore

### DIFF
--- a/packages/node-manager/src/task/RunStore.ts
+++ b/packages/node-manager/src/task/RunStore.ts
@@ -307,10 +307,17 @@ export class RunStore {
     }
 
     /**
-     * A retired run of the same slot that finished after `runId`, if there is one.
+     * A retired run of the same slot that finished after `runId` having written something, if there is one.
      *
      * Undoing a run restores the values it found, so a later run of the same slot having since committed its
-     * own makes those values historical: applying them would overwrite an outcome nobody asked to undo.
+     * own makes those values historical: applying them would overwrite an outcome nobody asked to undo. A
+     * later run that wrote nothing left those values exactly as this one found them, so it makes nothing
+     * historical — and refusing on it would strand the earlier run's changes on the device with no way back.
+     * Two shapes reach that state: a run `#admit` fails before any peer is touched, and one that completes
+     * without changing anything, such as a removal whose peer is already decommissioned.
+     *
+     * Asks {@link RunRecord.wrote} rather than the changeSet, which holds only what an undo would restore and
+     * is empty once nothing can restore it.
      */
     supersederOf(runId: RunId): RunRecord | undefined {
         const record = this.#records.get(runId);
@@ -323,6 +330,7 @@ export class RunStore {
                 other.runId !== runId &&
                 other.slotKey === record.slotKey &&
                 isTerminal(other.state) &&
+                other.wrote &&
                 (other.retireSeq ?? 0) > retiredAt
             ) {
                 return other;
@@ -414,16 +422,6 @@ export class RunStore {
         }
         const recorded = this.#records.get(runId)?.revertRunId;
         return recorded === undefined ? undefined : this.#records.get(recorded);
-    }
-
-    /**
-     * The rollback that applies to `undone`'s target: the live one, otherwise the one `undone` names.
-     *
-     * A wider question than {@link rollbackFor}, and the one supersession asks: a rollback of a *later* run of
-     * the same target makes an earlier run's priors historical without that earlier run ever naming it.
-     */
-    rollbackApplyingTo(undone: RunRecord): RunRecord | undefined {
-        return this.liveRollbackOfTarget(undone.slotKey) ?? this.rollbackFor(undone.runId);
     }
 
     /**

--- a/packages/node-manager/src/task/RunningTaskContext.ts
+++ b/packages/node-manager/src/task/RunningTaskContext.ts
@@ -74,6 +74,9 @@ export class RunningTaskContext implements TaskContext {
         const existing = peer.stateOf(DesiredStateBehavior).items[itemMapKey(kind, key)];
         const prior = existing === undefined ? undefined : { intent: existing.intent, mode: existing.mode };
         this.record.changeSet.push({ peerId: peer.id, kind, key, prior });
+        // Permanent, unlike the entries: a retirement drops what a run would restore once nothing can restore
+        // it, and every other run of the target still has to know this one reached the device.
+        this.record.wrote = true;
     }
 
     async removeIntentIfUnreferenced(peer: ClientNode, kind: string, key: string): Promise<boolean> {

--- a/packages/node-manager/src/task/Task.ts
+++ b/packages/node-manager/src/task/Task.ts
@@ -22,6 +22,12 @@ export interface TaskPersistence {
     state: TaskState;
     externalId?: string;
     changeSet: ChangeEntry[];
+    /**
+     * Whether this run wrote an intent. Separate from {@link changeSet}, which holds what a rollback would
+     * restore and is dropped once nothing can restore it — a run that changed the device stays a run that
+     * changed the device.
+     */
+    wrote: boolean;
     error?: string;
     /** Order in which runs retired. The only ordering key for history; never use `runId`. */
     retireSeq?: RetireSeq;
@@ -65,6 +71,7 @@ export class RunRecord implements RunView {
     phaseIndex: number;
     state: TaskState;
     changeSet: ChangeEntry[];
+    wrote: boolean;
     error?: string;
     retireSeq?: RetireSeq;
     revertRunId?: RunId;
@@ -85,6 +92,7 @@ export class RunRecord implements RunView {
         this.phaseIndex = persisted?.phaseIndex ?? 0;
         this.state = persisted?.state ?? "running";
         this.changeSet = persisted?.changeSet ?? new Array<ChangeEntry>();
+        this.wrote = persisted?.wrote ?? false;
         this.error = persisted?.error;
         this.retireSeq = persisted?.retireSeq;
         this.revertRunId = persisted?.revertRunId;
@@ -115,6 +123,7 @@ export class RunRecord implements RunView {
             state: this.state,
             externalId: this.externalId,
             changeSet: [...this.changeSet],
+            wrote: this.wrote,
             error: this.error,
             retireSeq: this.retireSeq,
             revertRunId: this.revertRunId,
@@ -191,6 +200,7 @@ export interface RunView {
     readonly phaseIndex: number;
     readonly state: TaskState;
     readonly changeSet: readonly ChangeEntry[];
+    readonly wrote: boolean;
     readonly externalId?: string;
     readonly error?: string;
     readonly retireSeq?: RetireSeq;

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -159,7 +159,6 @@ export class TaskManagerBehavior extends Behavior {
             );
             return;
         }
-        this.#retireStoredParams();
         // Reserved here rather than on the first record write: on a fresh store nothing has been written yet,
         // so without this the very first identity would be handed out uncovered.
         this.#reserveIdentities();
@@ -169,58 +168,6 @@ export class TaskManagerBehavior extends Behavior {
         } else {
             this.reactTo(this.#rootNode.lifecycle.online, this.#resumePersisted);
         }
-    }
-
-    /**
-     * Drop `params` from records an older build left finished.
-     *
-     * A write replaces only the records its own transaction names, so a run that was already terminal when
-     * this build first ran is never rewritten — and would keep the parameters this version exists to stop
-     * storing, including the raw epoch keys the group tasks take. Nothing else will ever touch those records,
-     * so the upgrade has to.
-     *
-     * Over the stored table, not the loaded one, and by key rather than by value. Three things follow from
-     * that, each of which was wrong first:
-     *
-     * - A record `load` discarded — one from before per-run identity, which it leaves in storage under a key
-     *   that is not a run id — is exactly a record nothing will ever rewrite. It has no in-memory twin, so it
-     *   is edited in place; anything that needed a {@link RunRecord} would skip it and keep its keys forever.
-     * - The *key* goes, not its value: a snapshot from the previous build materialised every field it knew,
-     *   including the empty ones, so a finished task that ran without parameters carries an empty `params`.
-     * - A record this process did load has a twin in memory, and that twin has to lose the field too, or the
-     *   next write of it puts the field straight back — and the version stamp means this pass never runs
-     *   again to take it off.
-     */
-    #retireStoredParams(): void {
-        if (this.state.runsVersion >= RUN_STORE_VERSION) {
-            return;
-        }
-        const runs = { ...this.state.runs };
-        let retired = 0;
-        for (const [key, persisted] of Object.entries(runs)) {
-            if (persisted === undefined || !isTerminal(persisted.state)) {
-                continue;
-            }
-            const stale = RETIRE.filter(field => field in persisted);
-            if (stale.length === 0) {
-                continue;
-            }
-            const migrated = { ...persisted };
-            for (const field of stale) {
-                delete migrated[field];
-            }
-            runs[key] = migrated;
-            if (typeof persisted.runId === "number") {
-                this.internal.runs.get(persisted.runId)?.adoptDrop(stale);
-            }
-            retired++;
-        }
-        if (retired > 0) {
-            this.state.runs = runs;
-            logger.info(`Dropped the stored parameters of ${retired} finished task record(s) on upgrade`);
-        }
-        // Stamped even when nothing needed dropping, so the scan runs once rather than on every start.
-        this.state.runsVersion = RUN_STORE_VERSION;
     }
 
     #resumePersisted(): void {
@@ -643,7 +590,8 @@ export class TaskManagerBehavior extends Behavior {
         // from the changeSet alone.
         const revert = this.#spawnRevert(record);
         if (revert.record === undefined) {
-            // Cannot happen: a run with a rollback wrote something, and nothing removes a changeSet.
+            // Cannot happen: only a completed retirement empties a changeSet, and a completed run never
+            // recorded a rollback to retry.
             throw new InternalError(`${runLabel(runId)} has a rollback but nothing to roll back`);
         }
         try {
@@ -899,15 +847,15 @@ export class TaskManagerBehavior extends Behavior {
                     : `Cannot abandon ${runLabel(record.runId)}: it is not a rollback; its rollback is ${runLabel(rollback)}`,
             );
         }
-        // Another rollback applies to this target now, so abandoning this one forecloses nothing and would
-        // record that an undo still in progress was given up on.
-        const undone = this.internal.runs.get(record.revertOf);
-        const applicable = undone === undefined ? undefined : this.internal.runs.rollbackApplyingTo(undone);
-        if (applicable !== undefined && applicable.runId !== record.runId) {
-            this.#refuseIfProvisional(applicable, `Cannot abandon ${runLabel(record.runId)}`);
+        // A retry has replaced this rollback, so abandoning it would record that an undo still in progress
+        // was given up on. Scoped to the run this one undoes rather than to its target: abandon records the
+        // disposition of an undo that already exists, it never creates one.
+        const replacement = this.internal.runs.rollbackFor(record.revertOf);
+        if (replacement !== undefined && replacement.runId !== record.runId) {
+            this.#refuseIfProvisional(replacement, `Cannot abandon ${runLabel(record.runId)}`);
             throw new TaskSupersededError(
-                `Cannot abandon ${runLabel(record.runId)}: ${runLabel(applicable.runId)} is the rollback that now applies to ${undone?.slotKey ?? "its target"}`,
-                applicable.runId,
+                `Cannot abandon ${runLabel(record.runId)}: ${runLabel(replacement.runId)} is the rollback that now applies to ${runLabel(record.revertOf)}`,
+                replacement.runId,
             );
         }
         if (undoConcluded(record)) {
@@ -1146,10 +1094,15 @@ export class TaskManagerBehavior extends Behavior {
                 await this.#commit({ record, next: { phaseIndex: record.phaseIndex + 1 } });
             }
             if (record.state === "running") {
-                // One write carries the outcome and its place in the retirement order.
+                // One write carries the outcome and its place in the retirement order. The priors go with it:
+                // reversing a success is a new action the caller starts, so nothing will ever replay them.
                 await this.#commit({
                     record,
-                    next: { state: "completed", retireSeq: this.internal.runs.nextRetirement(record) },
+                    next: {
+                        state: "completed",
+                        retireSeq: this.internal.runs.nextRetirement(record),
+                        changeSet: [],
+                    },
                     drop: RETIRE,
                 });
             }
@@ -1186,6 +1139,16 @@ export class TaskManagerBehavior extends Behavior {
             // The failure, its place in the retirement order and the rollback that undoes it land together, or
             // not at all: written separately, a crash between them leaves a run promising a rollback nothing
             // created.
+            // Past its point of no return there is nothing to restore to, so no verb will ever replay these
+            // priors: `#prepareRevert` declined to create a rollback and `retryRollback` refuses a run with
+            // none. Derived inside the guard that already wraps `#prepareRevert`, because a definition whose
+            // `revertible` throws must not re-reject an otherwise handled drive promise.
+            let replayable = true;
+            try {
+                replayable = execution.bound.revertible(record);
+            } catch (revertibleError) {
+                logger.error(`${runLabel(record.runId)}: cannot ask whether it is revertible`, revertibleError);
+            }
             try {
                 await this.#commit(
                     {
@@ -1195,6 +1158,7 @@ export class TaskManagerBehavior extends Behavior {
                             error,
                             retireSeq: this.internal.runs.nextRetirement(record),
                             revertRunId: revert.record?.runId,
+                            ...(replayable ? {} : { changeSet: [] }),
                         },
                         drop: RETIRE,
                     },

--- a/packages/node-manager/test/task/CancelRobustnessTest.ts
+++ b/packages/node-manager/test/task/CancelRobustnessTest.ts
@@ -627,6 +627,7 @@ describe("cancel robustness", () => {
                     phaseIndex: 0,
                     state: "running",
                     changeSet: [],
+                    wrote: false,
                 },
             };
         });
@@ -894,7 +895,7 @@ describe("cancel robustness", () => {
         TestTaskManager.peers.set("rw", peer);
         TestTaskManager.reconcilerPeer = peer;
 
-        // Completes on its own, so the run retires with a changeSet a later cancel can act on.
+        // Completes on its own, so the run reaches a terminal state without a cancel deciding it.
         SyntheticTask.phasesByTag["retiredwrite"] = [
             {
                 name: "touch",

--- a/packages/node-manager/test/task/RecordSnapshotTest.ts
+++ b/packages/node-manager/test/task/RecordSnapshotTest.ts
@@ -26,6 +26,7 @@ function persisted(runId: number, state: TaskState, changeSet: ChangeEntry[] = [
         params: { tag: String(runId) },
         phaseIndex: 0,
         state,
+        wrote: changeSet.length > 0,
         changeSet,
     };
 }
@@ -54,7 +55,7 @@ describe("run record snapshots", () => {
             expect(absent in snapshot).equals(false);
         }
         // The strip is enumerated rather than derived from the values present, so it cannot reach these.
-        for (const required of ["runId", "slotKey", "type", "phaseIndex", "state", "changeSet"]) {
+        for (const required of ["runId", "slotKey", "type", "phaseIndex", "state", "changeSet", "wrote"]) {
             expect(required in snapshot).equals(true);
         }
     });

--- a/packages/node-manager/test/task/RetirementTest.ts
+++ b/packages/node-manager/test/task/RetirementTest.ts
@@ -5,10 +5,17 @@
  */
 
 import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
-import { TaskConflictError, TaskNotInFlightError, TaskStoreVersionError, TaskSupersededError } from "#task/errors.js";
+import {
+    TaskConflictError,
+    TaskFailedError,
+    TaskNoRollbackError,
+    TaskNotInFlightError,
+    TaskStoreVersionError,
+    TaskSupersededError,
+} from "#task/errors.js";
 import { RUN_STORE_VERSION } from "#task/RunStore.js";
-import { TaskPersistence } from "#task/Task.js";
-import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
+import { TaskDefinition, TaskPersistence } from "#task/Task.js";
+import { TaskHandle, TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { RunId, TaskPhase } from "#task/types.js";
 import { Environment, InternalError, MaybePromise } from "@matter/general";
 import { ClientNode, itemMapKey, ServerNode } from "@matter/node";
@@ -29,6 +36,11 @@ class TestTaskManager extends TaskManagerBehavior {
 
     isAttached(runId: RunId) {
         return this.internal.runs.isAttached(runId);
+    }
+
+    /** The priors the loaded twin still holds, which storage alone cannot show. */
+    priorsOf(runId: RunId) {
+        return this.internal.runs.get(runId)?.changeSet;
     }
 }
 
@@ -56,6 +68,31 @@ async function pumpUntil(name: string, condition: () => MaybePromise<boolean>) {
     }
     throw new InternalError(`Condition "${name}" never held`);
 }
+
+/** Writes one intent, then fails, and declares itself past the point of no return. */
+const ForwardOnlyTask: TaskDefinition<{ tag: string; peerId: string }> = {
+    type: "forward-only",
+    // Deliberately the same slot shape as SyntheticTask: supersession is per target, so a test about one run
+    // burying another has to put both on one slot.
+    slotKeyFor(params) {
+        return `synthetic:${params.tag}`;
+    },
+    revertible() {
+        return false;
+    },
+    notRevertibleReason: "the test says so",
+    phases(params) {
+        return [
+            {
+                name: "write-then-fail",
+                run: async ctx => {
+                    await ctx.setIntent(ctx.resolvePeer(params.peerId), "groupMembership", "X", { v: 2 });
+                    throw new TaskFailedError("forward only");
+                },
+            },
+        ];
+    },
+};
 
 /** Writes one intent and returns, so the run completes having changed something. */
 function touchPhase(peerId: string): TaskPhase {
@@ -189,134 +226,6 @@ describe("run records after a retirement", () => {
         expect((await stored(node, handle.runId))?.revertRunId).equals(undefined);
     });
 
-    it("drops the parameters an older build left on finished records", async () => {
-        const environment = new Environment("upgrade-params");
-        let finished!: RunId;
-        {
-            await using node = await makeNode(environment, "upgrade");
-            const peer = testPeer("upgrade");
-            peer.markHas("groupMembership", "X");
-            const handle = await run(node, "upgrade", [touchPhase("upgrade")]);
-            await awaitRetired(node, handle.runId);
-            finished = handle.runId;
-
-            // Put the record back the way the previous build left it: every key materialised — including the
-            // undefined ones, which is what that build's snapshots did — and the table unversioned.
-            await node.act(a => {
-                const manager = a.get(TestTaskManager);
-                manager.state.runs = {
-                    ...manager.state.runs,
-                    [String(finished)]: {
-                        ...manager.state.runs[String(finished)],
-                        params: { tag: "upgrade" },
-                        error: undefined,
-                        revertOf: undefined,
-                    },
-                };
-                manager.state.runsVersion = 1;
-            });
-        }
-
-        // A write replaces only the records its own transaction names, so nothing would ever rewrite a run
-        // that was already finished — and its parameters are the raw keys this version exists to stop storing.
-        await using node = await makeNode(environment, "upgrade");
-        const record = await stored(node, finished);
-        expect(record).not.equals(undefined);
-        expect("params" in record!).equals(false);
-        // Only the parameters: the other keys the previous build wrote empty are normalised by the next
-        // ordinary write of the record, and this pass does not claim to do it for them.
-        expect(await node.act(a => a.get(TestTaskManager).state.runsVersion)).equals(RUN_STORE_VERSION);
-    });
-
-    it("drops the parameters of a record predating per-run identity", async () => {
-        const environment = new Environment("upgrade-legacy");
-        {
-            await using node = await makeNode(environment, "legacy");
-            // The shape `load` discards: a slot key where a run id now goes. It stays in storage, so nothing
-            // will ever rewrite it — and for the group tasks its parameters are raw epoch keys.
-            await node.act(a => {
-                const manager = a.get(TestTaskManager);
-                manager.state.runs = {
-                    ...manager.state.runs,
-                    "synthetic:legacy": {
-                        slotKey: "synthetic:legacy",
-                        type: "synthetic",
-                        params: { epochKey0: "secret" },
-                        phaseIndex: 0,
-                        state: "completed",
-                    } as unknown as TaskPersistence,
-                };
-                manager.state.runsVersion = 1;
-            });
-        }
-
-        await using node = await makeNode(environment, "legacy");
-        const legacy = await node.act(a => a.get(TestTaskManager).state.runs["synthetic:legacy"]);
-        expect(legacy).not.equals(undefined);
-        expect("params" in legacy!).equals(false);
-    });
-
-    it("drops a parameter key an older build left present but empty", async () => {
-        const environment = new Environment("upgrade-emptykey");
-        let finished!: RunId;
-        {
-            await using node = await makeNode(environment, "emptykey");
-            const peer = testPeer("emptykey");
-            peer.markHas("groupMembership", "X");
-            const handle = await run(node, "emptykey", [touchPhase("emptykey")]);
-            await awaitRetired(node, handle.runId);
-            finished = handle.runId;
-
-            // A task run with no parameters at all: the previous build still wrote the key, holding `undefined`.
-            await node.act(a => {
-                const manager = a.get(TestTaskManager);
-                manager.state.runs = {
-                    ...manager.state.runs,
-                    [String(finished)]: { ...manager.state.runs[String(finished)], params: undefined },
-                };
-                manager.state.runsVersion = 1;
-            });
-            expect("params" in (await stored(node, finished))!).equals(true);
-        }
-
-        // Testing the value rather than the key would leave this one behind for good: the upgrade runs once.
-        await using node = await makeNode(environment, "emptykey");
-        expect("params" in (await stored(node, finished))!).equals(false);
-    });
-
-    it("does not put migrated parameters back on the next write of the record", async () => {
-        const environment = new Environment("upgrade-rewrite");
-        let original!: RunId;
-        {
-            await using node = await makeNode(environment, "rewrite");
-            const peer = testPeer("rewrite");
-            const failed = await failedRollback(node, "rewrite", peer);
-            original = failed.original.runId;
-
-            // Back to the shape the previous build left: parameters present, table unversioned.
-            await node.act(a => {
-                const manager = a.get(TestTaskManager);
-                manager.state.runs = {
-                    ...manager.state.runs,
-                    [String(original)]: { ...manager.state.runs[String(original)], params: { tag: "rewrite" } },
-                };
-                manager.state.runsVersion = 1;
-            });
-        }
-
-        await using node = await makeNode(environment, "rewrite");
-        const peer = testPeer("rewrite");
-        peer.setIntent("groupMembership", "X", { v: 1 });
-        await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
-        expect("params" in (await stored(node, original))!).equals(false);
-
-        // A snapshot carries every field the record holds, so a write that mentions something else — here the
-        // link to a fresh undo — would re-persist parameters the upgrade only took out of storage. The version
-        // stamp means the upgrade would never run again to remove them.
-        await node.act(a => a.get(TestTaskManager).retryRollback(original));
-        expect("params" in (await stored(node, original))!).equals(false);
-    });
-
     it("leaves an unfinished run's parameters alone on upgrade", async () => {
         const environment = new Environment("upgrade-inflight");
         let live!: RunId;
@@ -399,6 +308,117 @@ describe("run records after a retirement", () => {
         // A second run of the same target commits its own outcome. What the first would restore is historical.
         peer.markHas("groupMembership", "X");
         const later = await run(node, "superseded", [touchPhase("superseded")]);
+        await awaitRetired(node, later.runId);
+
+        const refusal = await attempt(node, m => m.retryRollback(original.runId));
+        expect(refusal).instanceOf(TaskSupersededError);
+        expect((refusal as TaskConflictError).owner).equals(later.runId);
+    });
+
+    it("abandons a failed rollback while a rollback of a later run of the target is live", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("later-rollback");
+
+        // The first run's undo failed, so the target is free and its changes are still on the device.
+        const { original, rollback } = await failedRollback(node, "later-rollback", peer);
+
+        // A second run of the same target is cancelled, and its undo parks: a rollback of a *later* run,
+        // undoing values the first run never wrote.
+        peer.setIntent("groupMembership", "X", { v: 3 });
+        const second = await run(node, "later-rollback", [gatingPhase(peer.id)]);
+        await pumpUntil("second intent written", () => (peer.items[KEY]?.intent as { v?: number })?.v === 2);
+        const live = await node.act(a => a.get(TestTaskManager).cancel(second.runId));
+        expect(live).not.equals(undefined);
+
+        // The live rollback undoes the second run, not the first, so it is not the undo that applies here and
+        // refusing on it would leave the first run's changes with no disposition at all.
+        const abandoned = await node.act(a => a.get(TestTaskManager).abandon(rollback.runId, "operator"));
+        expect(abandoned.status.state).equals("abandoned");
+        expect(await node.act(a => a.get(TestTaskManager).get(original.runId)?.status.state)).equals("cancelled");
+    });
+
+    it("is not superseded by a later run that completed without changing anything", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("noop-completion");
+
+        const { original } = await failedRollback(node, "noop-completion", peer);
+
+        // Completes without touching a peer, as a removal does when its node is already decommissioned.
+        const later = await run(node, "noop-completion", [{ name: "noop", run: async () => {} }]);
+        await awaitRetired(node, later.runId);
+        expect((await stored(node, later.runId))?.wrote).equals(false);
+
+        const retry = await attempt(node, m => m.retryRollback(original.runId));
+        expect(retry).not.instanceOf(Error);
+        expect((retry as TaskHandle).status.revertOf).equals(original.runId);
+    });
+
+    it("is not superseded by a later run that reached no phase", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("no-phase");
+
+        const { original } = await failedRollback(node, "no-phase", peer);
+
+        // The later run touches nothing before it fails, so what the first would restore is still current.
+        const later = await run(node, "no-phase", [
+            {
+                name: "throw",
+                run: async () => new Promise<void>((_, reject) => reject(new TaskFailedError("nope"))),
+            },
+        ]);
+        await awaitRetired(node, later.runId);
+        expect((await stored(node, later.runId))?.changeSet).deep.equals([]);
+
+        const retry = await attempt(node, m => m.retryRollback(original.runId));
+        expect(retry).not.instanceOf(Error);
+        expect((retry as TaskHandle).status.revertOf).equals(original.runId);
+    });
+
+    it("drops the priors of a run that completed", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("completed-priors");
+        peer.setIntent("groupMembership", "X", { v: 1 });
+
+        const done = await run(node, "completed-priors", [touchPhase("completed-priors")]);
+        await awaitRetired(node, done.runId);
+
+        const record = await stored(node, done.runId);
+        expect("changeSet" in (record ?? {})).equals(true);
+        expect(record?.changeSet).deep.equals([]);
+    });
+
+    it("drops the priors of a run that cannot be undone, and still records that it wrote", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("forward-only");
+        peer.setIntent("groupMembership", "X", { v: 1 });
+
+        await node.act(a => a.get(TestTaskManager).register(ForwardOnlyTask));
+        const run1 = await node.act(a =>
+            a.get(TestTaskManager).run(ForwardOnlyTask, { tag: "forward-only", peerId: "forward-only" }),
+        );
+        await awaitRetired(node, run1.runId);
+
+        const record = await stored(node, run1.runId);
+        expect(record?.state).equals("failed");
+        // Nothing can ever replay them, so they go — while `wrote` keeps saying the device was changed.
+        expect(record?.changeSet).deep.equals([]);
+        expect(record?.wrote).equals(true);
+        expect(await attempt(node, m => m.retryRollback(run1.runId))).instanceOf(TaskNoRollbackError);
+    });
+
+    it("is superseded by a later run that reached the device and cannot be undone", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("forward-only-superseder");
+
+        const { original } = await failedRollback(node, "forward-only-superseder", peer);
+
+        await node.act(a => a.get(TestTaskManager).register(ForwardOnlyTask));
+        const later = await node.act(a =>
+            a.get(TestTaskManager).run(ForwardOnlyTask, {
+                tag: "forward-only-superseder",
+                peerId: "forward-only-superseder",
+            }),
+        );
         await awaitRetired(node, later.runId);
 
         const refusal = await attempt(node, m => m.retryRollback(original.runId));

--- a/packages/node-manager/test/task/RunStoreTest.ts
+++ b/packages/node-manager/test/task/RunStoreTest.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { RunStore } from "#task/RunStore.js";
+import { RunRecord } from "#task/Task.js";
+import { RetireSeq, RunId } from "#task/types.js";
+
+/**
+ * The store answers these without a node, a gate or a clock, so a table can be built by hand — the only way
+ * to reach a rollback that holds its slot with no execution attached, which no public verb constructs.
+ */
+function storeWith(...records: RunRecord[]) {
+    const store = new RunStore();
+    for (const record of records) {
+        store.admit(record);
+        // A terminal record hands its slot back, exactly as its retirement write does; otherwise the next run
+        // of the same target cannot be admitted.
+        if (record.state !== "running") {
+            store.commitRetirement(record);
+        }
+    }
+    return store;
+}
+
+function retired(
+    runId: number,
+    slotKey: string,
+    seq: number,
+    state: "completed" | "failed" | "cancelled",
+    wrote = false,
+) {
+    return new RunRecord(RunId(runId), slotKey, "synthetic", undefined, {
+        state,
+        retireSeq: RetireSeq(seq),
+        wrote,
+    });
+}
+
+describe("RunStore", () => {
+    describe("liveRollbackOfTarget", () => {
+        it("finds a rollback that holds its slot with nothing driving it", () => {
+            // The shape a restart produces: the record is loaded and owns its slot, but no execution has been
+            // attached to it yet. `isAttached` is false here and the rollback is nonetheless live — a re-run
+            // of the target would rewrite exactly the intents it is going to restore.
+            const undone = retired(1, "synthetic:t", 1, "cancelled", true);
+            const rollback = new RunRecord(RunId(2), "revert:1", "revert", undefined, { revertOf: RunId(1) });
+            const store = storeWith(undone, rollback);
+
+            expect(store.isAttached(RunId(2))).equals(false);
+            expect(store.liveRollbackOfTarget("synthetic:t")?.runId).equals(RunId(2));
+        });
+    });
+
+    describe("supersederOf", () => {
+        it("counts a later run that wrote", () => {
+            const earlier = retired(1, "synthetic:t", 1, "cancelled", true);
+            const later = retired(2, "synthetic:t", 2, "failed", true);
+
+            expect(storeWith(earlier, later).supersederOf(RunId(1))?.runId).equals(RunId(2));
+        });
+
+        it("ignores a later run that reached no phase", () => {
+            const earlier = retired(1, "synthetic:t", 1, "cancelled", true);
+            const later = retired(2, "synthetic:t", 2, "failed");
+
+            expect(storeWith(earlier, later).supersederOf(RunId(1))).equals(undefined);
+        });
+
+        it("counts a later run whose priors its retirement dropped", () => {
+            // A retirement empties the changeSet once nothing can replay it; `wrote` is what still says the
+            // device was changed, so the earlier run's priors are historical either way.
+            const earlier = retired(1, "synthetic:t", 1, "cancelled", true);
+            const later = retired(2, "synthetic:t", 2, "completed", true);
+
+            expect(storeWith(earlier, later).supersederOf(RunId(1))?.runId).equals(RunId(2));
+        });
+    });
+});

--- a/packages/node-manager/test/task/TaskManagerBehaviorTest.ts
+++ b/packages/node-manager/test/task/TaskManagerBehaviorTest.ts
@@ -423,6 +423,7 @@ describe("TaskManagerBehavior", () => {
                     params: { tag: "orphan" },
                     phaseIndex: 1,
                     state: "cancelled",
+                    wrote: false,
                     retireSeq: RetireSeq(1),
                     changeSet: [],
                 },


### PR DESCRIPTION
A task run kept one field for two facts: the values it replaced, which an undo replays, and whether it reached the device at all, which every later run of the same target needs to know. Deciding supersession from that one field meant the two could not both be right.

### The two facts are now separate

A run records that it wrote at the moment it writes, and keeps that for good. What it would restore is dropped as soon as nothing can replay it:

- when the run **completed** — reversing a success is a new action the caller starts, never a replay of what the run found;
- when it retired **past its point of no return** — no undo of it can ever be created.

For the group tasks those replaced values are the epoch keys of the key set that was rotated away, so they no longer outlive the work that used them.

### Two ways a later run wrongly blocked an earlier undo

Both disappear with the same change, because supersession now asks whether the later run actually wrote:

- a run rejected before it reached a device;
- a run that **completed without changing anything** — a removal whose node is already decommissioned, or one whose entries are all still referenced.

Neither makes an earlier run's recorded values out of date, so the operator keeps the only way back from changes that are still on the device.

### Giving up on a failed undo no longer depends on unrelated work

Abandoning it was refused whenever an undo of some *later* run of the same target was running. That undo restores different values, so the refusal foreclosed nothing and left the first run's changes with no disposition at all. Abandoning records what happens to an undo that already exists and never creates one, so it now asks only whether this undo has been replaced by a retry.

### Removed: the startup upgrade passes

This package is unreleased — nothing outside development has ever written the run table — so a record left by an "older build" does not exist. The startup pass that dropped parameters from such records went with the one this change would otherwise have added.

That is not incidental cleanup. Treating the never-rewritten-record constraint as real is what pushed two facts onto one field in the first place: with no way to revisit a finished record, "what an undo would restore" had to double as "this run reached the device". Once the constraint is dropped, the facts can simply be stored separately.

`RUN_STORE_VERSION` and the unreadable-table guard stay. They cost nothing and start earning the day this ships.

### Verification

`npm run build-clean`, `npm run format-verify`, `npm run lint` clean; node-manager 271/271 across ESM, CJS and Web; full repository suite green.

Mutation-proven per branch: four mutations of the production code, each killed by a named test — removing the supersession condition, never recording that a run wrote, and each of the two points where replaced values are dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
