### PR TITLE
(node-manager) Stop keeping a run's undo data once nothing can replay it

### DIFF
--- a/packages/node-manager/src/task/RunStore.ts
+++ b/packages/node-manager/src/task/RunStore.ts
@@ -8,7 +8,7 @@ import { ImplementationError, InternalError } from "@matter/general";
 import { TaskIdentityExhaustedError } from "./errors.js";
 import { Execution } from "./Execution.js";
 import { RunRecord, TaskPersistence } from "./Task.js";
-import { RetireSeq, RunId, Teardown, TaskState } from "./types.js";
+import { isRunId, RetireSeq, RunId, Teardown, TaskState } from "./types.js";
 
 const TERMINAL_STATES: ReadonlySet<TaskState> = new Set<TaskState>(["completed", "failed", "cancelled", "abandoned"]);
 
@@ -124,7 +124,7 @@ export class RunStore {
             // `runs` is schema type `any`, so a corrupt table reaches here as arbitrary values. Refusing names
             // the cause; letting it through seeds the identity counter with `NaN`, after which every
             // allocation is `NaN` and no run is ever addressable again.
-            if (!Number.isSafeInteger(stored?.runId)) {
+            if (!isRunId(stored?.runId)) {
                 throw new InternalError(`Stored task record has no usable run identity: ${JSON.stringify(stored)}`);
             }
             highest = Math.max(highest, stored.runId);

--- a/packages/node-manager/src/task/RunStore.ts
+++ b/packages/node-manager/src/task/RunStore.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ImplementationError } from "@matter/general";
+import { ImplementationError, InternalError } from "@matter/general";
 import { TaskIdentityExhaustedError } from "./errors.js";
 import { Execution } from "./Execution.js";
-import { runKey, RunRecord, TaskPersistence } from "./Task.js";
+import { RunRecord, TaskPersistence } from "./Task.js";
 import { RetireSeq, RunId, Teardown, TaskState } from "./types.js";
 
 const TERMINAL_STATES: ReadonlySet<TaskState> = new Set<TaskState>(["completed", "failed", "cancelled", "abandoned"]);
@@ -102,12 +102,13 @@ export class RunStore {
     readonly #slots = new Map<string, RunId>();
 
     /**
-     * Load persisted state. `externalId` is not persisted as an index of its own: it is derived from the
-     * records that carry it, so it cannot drift from them.
+     * Load persisted state. Nothing is returned: what resumes is {@link resumable}, which re-derives rather
+     * than handing back a list that a later attach would make stale.
+     *
+     * `externalId` is not persisted as an index of its own: it is derived from the records that carry it, so
+     * it cannot drift from them.
      */
-    load(snapshot: Partial<RunStoreSnapshot> | undefined): { resumable: RunRecord[]; discarded: number } {
-        const resumable = new Array<RunRecord>();
-        let discarded = 0;
+    load(snapshot: Partial<RunStoreSnapshot> | undefined): void {
         let highest = 0;
 
         const version = snapshot?.runsVersion ?? 1;
@@ -116,34 +117,25 @@ export class RunStore {
             // targets they own. Every verb refuses while this is set, rather than answering "no such run" for
             // runs that demonstrably exist in the table.
             this.#unreadable = true;
-            return { resumable, discarded };
+            return;
         }
 
         for (const stored of Object.values(snapshot?.runs ?? {})) {
-            // Pre-runId records name their slot where a runId now goes; they cannot be resumed under an
-            // identity they never had.
-            if (typeof stored?.runId !== "number") {
-                discarded++;
-                continue;
+            // `runs` is schema type `any`, so a corrupt table reaches here as arbitrary values. Refusing names
+            // the cause; letting it through seeds the identity counter with `NaN`, after which every
+            // allocation is `NaN` and no run is ever addressable again.
+            if (!Number.isSafeInteger(stored?.runId)) {
+                throw new InternalError(`Stored task record has no usable run identity: ${JSON.stringify(stored)}`);
             }
             highest = Math.max(highest, stored.runId);
-            // A terminal record carries its place in the retirement order, because the write that records an
-            // outcome stamps it. One without is from a build that wrote the outcome and the order separately;
-            // it has no position, so it would sort ahead of every sequenced run of its slot and let an older
-            // run's rollback overwrite it.
-            if (isTerminal(stored.state) && stored.retireSeq === undefined) {
-                discarded++;
-                continue;
-            }
             const record = RunRecord.fromPersistence(stored);
             this.#records.set(record.runId, record);
             if (!isTerminal(record.state)) {
                 this.#slots.set(record.slotKey, record.runId);
-                resumable.push(record);
             }
         }
-        // The persisted counter is a high-water mark, so it is authoritative where present; seeding above the
-        // highest surviving id covers a store whose counter predates this scheme.
+        // The persisted counter is a high-water mark, so it is authoritative; seeding above the highest
+        // surviving id keeps allocation monotonic if a write of the counter was refused.
         this.#nextRunId = Math.max(snapshot?.nextRunId ?? 1, highest + 1);
         // Whatever the last start persisted is what is durable; anything beyond it must be reserved again.
         this.#reservedBelow = Math.max(snapshot?.nextRunId ?? 1, this.#nextRunId);
@@ -151,7 +143,6 @@ export class RunStore {
             snapshot?.nextRetireSeq ?? 1,
             ...[...this.#records.values()].map(r => (r.retireSeq ?? 0) + 1),
         );
-        return { resumable, discarded };
     }
 
     /**
@@ -364,19 +355,14 @@ export class RunStore {
         this.#executions.set(execution.runId, execution);
     }
 
-    /** Give up responsibility without retiring — a run left for the next start. */
-    detach(runId: RunId): void {
-        this.#executions.delete(runId);
-    }
-
     /**
      * The place in the retirement order this run would take, or `undefined` if it is not the slot's owner or
      * already has one.
      *
-     * Allocated for the write that records the outcome, so the two land together: a terminal record that
-     * reached storage without an order is discarded at load, because it has no position among the runs of its
-     * slot. A refused write leaves a gap in the sequence, which costs nothing — the order only ever has to be
-     * increasing.
+     * Allocated for the write that records the outcome, so the two land together: a terminal record without an
+     * order sorts as `retireSeq ?? 0`, ahead of every sequenced run of its slot, and {@link supersederOf} then
+     * cannot see it as a superseder. A refused write leaves a gap in the sequence, which costs nothing — the
+     * order only ever has to be increasing.
      */
     nextRetirement(record: RunRecord): RetireSeq | undefined {
         if (this.#slots.get(record.slotKey) !== record.runId || record.retireSeq !== undefined) {
@@ -442,23 +428,5 @@ export class RunStore {
             }
         }
         return undefined;
-    }
-
-    /**
-     * The whole table as storage would hold it. Not how the manager writes — it records the runs a transaction
-     * names, so a run this process never loaded is not erased by one that did — so this exists for a caller
-     * that wants the table as a value.
-     */
-    snapshot(): RunStoreSnapshot {
-        const runs: Record<string, TaskPersistence> = {};
-        for (const [runId, record] of this.#records) {
-            runs[runKey(runId)] = record.toPersistence();
-        }
-        return {
-            runs,
-            nextRunId: this.#nextRunId,
-            nextRetireSeq: this.#nextRetireSeq,
-            runsVersion: RUN_STORE_VERSION,
-        };
     }
 }

--- a/packages/node-manager/src/task/RunStore.ts
+++ b/packages/node-manager/src/task/RunStore.ts
@@ -120,12 +120,15 @@ export class RunStore {
             return;
         }
 
-        for (const stored of Object.values(snapshot?.runs ?? {})) {
+        for (const [key, stored] of Object.entries(snapshot?.runs ?? {})) {
             // `runs` is schema type `any`, so a corrupt table reaches here as arbitrary values. Refusing names
             // the cause; letting it through seeds the identity counter with `NaN`, after which every
             // allocation is `NaN` and no run is ever addressable again.
+            //
+            // The record itself never reaches the message: `params` and `changeSet` carry raw key material, and
+            // a group task's `bigint` would make serializing it throw before this error could be constructed.
             if (!isRunId(stored?.runId)) {
-                throw new InternalError(`Stored task record has no usable run identity: ${JSON.stringify(stored)}`);
+                throw new InternalError(`Stored task record "${key}" has no usable run identity`);
             }
             highest = Math.max(highest, stored.runId);
             const record = RunRecord.fromPersistence(stored);

--- a/packages/node-manager/src/task/Task.ts
+++ b/packages/node-manager/src/task/Task.ts
@@ -134,7 +134,10 @@ export class RunRecord implements RunView {
         // it — a transition that must remove something says so with a value.
         for (const [key, value] of Object.entries(next ?? {})) {
             if (value !== undefined) {
-                Object.assign(persisted, { [key]: value });
+                // Arrays copied for the same reason the base snapshot copies `changeSet`: the caller's literal
+                // is adopted onto the live record after the write, so sharing it would leave storage holding
+                // the array a phase then appends to.
+                Object.assign(persisted, { [key]: Array.isArray(value) ? [...value] : value });
             }
         }
         // Removal is a separate list for that reason: `undefined` in `next` cannot express it.

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -62,6 +62,29 @@ export interface TaskHandle {
     readonly status: TaskStatus;
 }
 
+/** What a cancel did to the device. */
+export enum TaskCancelOutcome {
+    /** An undo is running. */
+    RollingBack = "rollingBack",
+    /** The run had changed nothing, so there was nothing to undo. */
+    NothingToUndo = "nothingToUndo",
+    /**
+     * The run changed the device and those changes stand: it passed the point beyond which its type declines
+     * to be reverted, which it can do while the cancel is being accepted.
+     */
+    Irreversible = "irreversible",
+}
+
+/**
+ * What {@link TaskManagerBehavior.cancel} did.
+ *
+ * An outcome rather than an optional handle, because "no undo is running" has two meanings a caller must act on
+ * differently: the device is as it was, or the device is changed and will stay that way.
+ */
+export type TaskCancellation =
+    | { outcome: TaskCancelOutcome.RollingBack; rollback: TaskHandle }
+    | { outcome: TaskCancelOutcome.NothingToUndo | TaskCancelOutcome.Irreversible; rollback?: undefined };
+
 /**
  * A task's rollback with the two operations that keep it consistent with its record: {@link discard} forgets a
  * rollback whose record was refused, {@link start} begins driving one whose record is durable.
@@ -604,8 +627,12 @@ export class TaskManagerBehavior extends Behavior {
      * overwrite whatever has legitimately happened since — reversing a finished change is a new task the caller
      * starts. A run whose rollback already exists is answered with that rollback, whatever its state.
      *
-     * A handle is the rollback. `undefined` means there is nothing to roll back — the run wrote nothing, or it
-     * was already cancelled with nothing to undo. {@link TaskNotFoundError} is an identity no run answers to.
+     * Answers what happened to the device, not merely whether an undo exists. {@link TaskCancelOutcome.RollingBack}
+     * carries the rollback; {@link TaskCancelOutcome.NothingToUndo} means the device is as it was; and
+     * {@link TaskCancelOutcome.Irreversible} means the run changed the device and those changes stand, because
+     * it passed the point beyond which its type declines to be reverted — which it can do *while the cancel is
+     * being accepted*, since the entry check and the decision after the unwind read different phase indexes.
+     * {@link TaskNotFoundError} is an identity no run answers to.
      *
      * A rollback is not cancelled: {@link TaskCannotCancelRollbackError} points at {@link abandon}, which
      * records that the undo was given up on rather than that nothing needed it.
@@ -613,7 +640,7 @@ export class TaskManagerBehavior extends Behavior {
      * Throws {@link TaskManagerClosingError} if shutdown intervenes before the cancel can be recorded; the task
      * then keeps its non-terminal state and the cancel must be re-issued after the next start.
      */
-    async cancel(runId: RunId): Promise<TaskHandle | undefined> {
+    async cancel(runId: RunId): Promise<TaskCancellation> {
         for (let pending = this.#pendingTransition(runId); pending !== undefined;) {
             await pending;
             pending = this.#pendingTransition(runId);
@@ -639,10 +666,12 @@ export class TaskManagerBehavior extends Behavior {
         const existing = this.internal.runs.rollbackFor(runId);
         if (existing !== undefined) {
             this.#refuseIfProvisional(existing, `Cannot answer for the rollback of ${runLabel(runId)}`);
-            return this.#handle(existing);
+            return { outcome: TaskCancelOutcome.RollingBack, rollback: this.#handle(existing) };
         }
         if (record.state === "cancelled") {
-            return undefined;
+            // Already cancelled and holding no rollback: whatever it had written was either nothing or beyond
+            // undoing, and its priors are gone either way, so `wrote` is the only surviving witness.
+            return { outcome: this.#cancelledOutcome(record) };
         }
         // A finished run is not stopped, and its changes are not rewound: restoring the values it found would
         // overwrite whatever has legitimately happened since, so reversing a successful change is a new action
@@ -672,7 +701,7 @@ export class TaskManagerBehavior extends Behavior {
     }
 
     /** The part of a cancel that decides and writes, with this run's outcome already claimed. */
-    async #recordCancellation(record: RunRecord, bound: BoundDefinition): Promise<TaskHandle | undefined> {
+    async #recordCancellation(record: RunRecord, bound: BoundDefinition): Promise<TaskCancellation> {
         // The entry check answered about the run as it was before the unwind. Its driver may have reached an
         // outcome of its own inside the transition window — the loop consults the claim only between phases —
         // and a run that finished is not undone, whichever side of the window it finished on. `abandon` asks
@@ -684,7 +713,7 @@ export class TaskManagerBehavior extends Behavior {
             this.internal.runs.commitRetirement(record);
             const rollback = this.internal.runs.rollbackFor(record.runId);
             if (rollback !== undefined) {
-                return this.#handle(rollback);
+                return { outcome: TaskCancelOutcome.RollingBack, rollback: this.#handle(rollback) };
             }
             throw new TaskNotInFlightError(
                 `Cannot cancel ${runLabel(record.runId)}: it finished (${record.state}) while the cancel was being accepted`,
@@ -734,7 +763,19 @@ export class TaskManagerBehavior extends Behavior {
         // raced this one must be told about the rollback the first created, not told there was nothing to roll
         // back — and it may reach here before the write recording the link has landed.
         const rollback = this.internal.runs.rollbackFor(record.runId);
-        return rollback === undefined ? undefined : this.#handle(rollback);
+        return rollback === undefined
+            ? { outcome: this.#cancelledOutcome(record) }
+            : { outcome: TaskCancelOutcome.RollingBack, rollback: this.#handle(rollback) };
+    }
+
+    /**
+     * Why a cancelled run has no undo: it never reached the device, or it reached it and cannot be taken back.
+     *
+     * Reads {@link RunRecord.wrote} rather than the change set, which a retirement has already emptied — the
+     * two facts were split for exactly this reason.
+     */
+    #cancelledOutcome(record: RunRecord): TaskCancelOutcome.NothingToUndo | TaskCancelOutcome.Irreversible {
+        return record.wrote ? TaskCancelOutcome.Irreversible : TaskCancelOutcome.NothingToUndo;
     }
 
     /**

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -64,8 +64,11 @@ export interface TaskHandle {
 
 /** What a cancel did to the device. */
 export enum TaskCancelOutcome {
-    /** An undo is running. */
-    RollingBack = "rollingBack",
+    /**
+     * An undo exists. {@link TaskCancellation.rollback} names it, and its `status` says how far it has got —
+     * a rollback recorded by an earlier cancel may already have concluded.
+     */
+    Rollback = "rollback",
     /** The run had changed nothing, so there was nothing to undo. */
     NothingToUndo = "nothingToUndo",
     /**
@@ -82,7 +85,7 @@ export enum TaskCancelOutcome {
  * differently: the device is as it was, or the device is changed and will stay that way.
  */
 export type TaskCancellation =
-    | { outcome: TaskCancelOutcome.RollingBack; rollback: TaskHandle }
+    | { outcome: TaskCancelOutcome.Rollback; rollback: TaskHandle }
     | { outcome: TaskCancelOutcome.NothingToUndo | TaskCancelOutcome.Irreversible; rollback?: undefined };
 
 /**
@@ -627,7 +630,7 @@ export class TaskManagerBehavior extends Behavior {
      * overwrite whatever has legitimately happened since — reversing a finished change is a new task the caller
      * starts. A run whose rollback already exists is answered with that rollback, whatever its state.
      *
-     * Answers what happened to the device, not merely whether an undo exists. {@link TaskCancelOutcome.RollingBack}
+     * Answers what happened to the device, not merely whether an undo exists. {@link TaskCancelOutcome.Rollback}
      * carries the rollback; {@link TaskCancelOutcome.NothingToUndo} means the device is as it was; and
      * {@link TaskCancelOutcome.Irreversible} means the run changed the device and those changes stand, because
      * it passed the point beyond which its type declines to be reverted — which it can do *while the cancel is
@@ -666,7 +669,7 @@ export class TaskManagerBehavior extends Behavior {
         const existing = this.internal.runs.rollbackFor(runId);
         if (existing !== undefined) {
             this.#refuseIfProvisional(existing, `Cannot answer for the rollback of ${runLabel(runId)}`);
-            return { outcome: TaskCancelOutcome.RollingBack, rollback: this.#handle(existing) };
+            return { outcome: TaskCancelOutcome.Rollback, rollback: this.#handle(existing) };
         }
         if (record.state === "cancelled") {
             // Already cancelled and holding no rollback: whatever it had written was either nothing or beyond
@@ -713,7 +716,7 @@ export class TaskManagerBehavior extends Behavior {
             this.internal.runs.commitRetirement(record);
             const rollback = this.internal.runs.rollbackFor(record.runId);
             if (rollback !== undefined) {
-                return { outcome: TaskCancelOutcome.RollingBack, rollback: this.#handle(rollback) };
+                return { outcome: TaskCancelOutcome.Rollback, rollback: this.#handle(rollback) };
             }
             throw new TaskNotInFlightError(
                 `Cannot cancel ${runLabel(record.runId)}: it finished (${record.state}) while the cancel was being accepted`,
@@ -765,7 +768,7 @@ export class TaskManagerBehavior extends Behavior {
         const rollback = this.internal.runs.rollbackFor(record.runId);
         return rollback === undefined
             ? { outcome: this.#cancelledOutcome(record) }
-            : { outcome: TaskCancelOutcome.RollingBack, rollback: this.#handle(rollback) };
+            : { outcome: TaskCancelOutcome.Rollback, rollback: this.#handle(rollback) };
     }
 
     /**

--- a/packages/node-manager/src/task/TaskManagerBehavior.ts
+++ b/packages/node-manager/src/task/TaskManagerBehavior.ts
@@ -81,15 +81,9 @@ const NO_REVERT: PreparedRevert = { discard() {}, start() {} };
  */
 const RETIRE: ReadonlyArray<DroppableField> = ["params"];
 
-/**
- * Whether a rollback's undo has concluded: it restored the device, or it was called off before it wrote
- * anything. Either way nothing is left to retry or to give up on.
- *
- * `cancelled` is reachable only from a store an earlier build wrote, when cancelling a rollback was still
- * admitted.
- */
+/** Whether a rollback restored the device, so nothing is left to retry or to give up on. */
 function undoConcluded(record: RunRecord): boolean {
-    return record.state === "completed" || record.state === "cancelled";
+    return record.state === "completed";
 }
 
 /** A task registered as live, and whether the caller joined a live task that is already being driven. */
@@ -141,15 +135,12 @@ export class TaskManagerBehavior extends Behavior {
         this.endpoint.behaviors.require(ReconcilerBehavior);
         this.internal.registry = new TaskRegistry();
         this.internal.runs = new RunStore();
-        const { discarded } = this.internal.runs.load({
+        this.internal.runs.load({
             runs: this.state.runs,
             nextRunId: this.state.nextRunId,
             nextRetireSeq: this.state.nextRetireSeq,
             runsVersion: this.state.runsVersion,
         });
-        if (discarded > 0) {
-            logger.warn(`Discarded ${discarded} task record(s) predating per-run identity`);
-        }
         // Registered either way, so the surface a caller sees does not depend on the store: an unreadable
         // store refuses at `run`, with a reason, rather than by claiming a type was never registered.
         this.#registerBuiltins();
@@ -554,8 +545,7 @@ export class TaskManagerBehavior extends Behavior {
         const recorded = this.internal.runs.rollbackFor(runId);
         if (recorded === undefined) {
             // A state a caller cannot always know rather than a mistake it made: a run may never have produced
-            // an undo, and a rollback record that reached storage without a retirement order is discarded at
-            // load, leaving the original naming one nothing holds.
+            // an undo, and one whose write was refused is discarded, leaving the original naming nothing.
             throw new TaskNoRollbackError(`Cannot retry the rollback of ${runLabel(runId)}: it has none`);
         }
         const previous = recorded.runId;
@@ -590,8 +580,8 @@ export class TaskManagerBehavior extends Behavior {
         // from the changeSet alone.
         const revert = this.#spawnRevert(record);
         if (revert.record === undefined) {
-            // Cannot happen: only a completed retirement empties a changeSet, and a completed run never
-            // recorded a rollback to retry.
+            // Cannot happen: priors are kept exactly while a rollback that can replay them exists, and the
+            // guards above have already refused every rollback that concluded.
             throw new InternalError(`${runLabel(runId)} has a rollback but nothing to roll back`);
         }
         try {
@@ -726,6 +716,7 @@ export class TaskManagerBehavior extends Behavior {
                         state: "cancelled",
                         retireSeq: this.internal.runs.nextRetirement(record),
                         revertRunId: revert.record?.runId,
+                        ...this.#retiringPriors(record),
                     },
                     drop: RETIRE,
                 },
@@ -783,8 +774,8 @@ export class TaskManagerBehavior extends Behavior {
                 // retire it because this transition owns the run, so retiring it falls here — and before the
                 // decision below, which depends on the state the driver left behind.
                 //
-                // Unconditional on the retirement order, unlike #retire: a terminal record without one is
-                // discarded at load, so nothing can resume it and holding its target buys nothing.
+                // Unconditional on the retirement order, unlike #retire: load re-slots only non-terminal
+                // records, so nothing can resume this one and holding its target buys nothing.
                 if (isTerminal(record.state)) {
                     this.internal.runs.commitRetirement(record);
                 }
@@ -800,19 +791,23 @@ export class TaskManagerBehavior extends Behavior {
             }
 
             try {
-                await this.#commit({
-                    record,
-                    next: {
-                        state: "abandoned",
-                        // Composed rather than replaced: for a rollback that failed on its own, why it could
-                        // not finish is what an operator needs to decide what to do about the device.
-                        error: this.#abandonReason(record.error, reason),
-                        // Absent for a rollback that already retired on its own failure path, which keeps the
-                        // place it took then.
-                        retireSeq: this.internal.runs.nextRetirement(record),
+                await this.#commit(
+                    {
+                        record,
+                        next: {
+                            state: "abandoned",
+                            // Composed rather than replaced: for a rollback that failed on its own, why it
+                            // could not finish is what an operator needs to decide what to do about the device.
+                            error: this.#abandonReason(record.error, reason),
+                            // Absent for a rollback that already retired on its own failure path, which keeps
+                            // the place it took then.
+                            retireSeq: this.internal.runs.nextRetirement(record),
+                            ...this.#retiringPriors(record),
+                        },
+                        drop: RETIRE,
                     },
-                    drop: RETIRE,
-                });
+                    ...this.#priorsSpentByUndo(record),
+                );
             } catch (e) {
                 if (execution !== undefined) {
                     this.#restoreDriver(record, execution.bound);
@@ -992,6 +987,38 @@ export class TaskManagerBehavior extends Behavior {
     }
 
     /**
+     * What a retirement write records for `record`'s priors.
+     *
+     * Priors are replayed only through a rollback, so a run retiring without one leaves bytes no verb will ever
+     * read — and a prior holds whatever the run overwrote, which for a group key is key material. This covers a
+     * rollback's own priors without naming them: nothing undoes an undo, so a rollback never has a rollback.
+     *
+     * Asks the store rather than the rollback this call prepared, because `#prepareRevert` also declines when
+     * a rollback already exists.
+     */
+    #retiringPriors(record: RunRecord): Partial<TaskPersistence> {
+        return this.internal.runs.rollbackFor(record.runId) === undefined ? { changeSet: [] } : {};
+    }
+
+    /**
+     * The original whose priors `record` spends by concluding, as a second record for its transaction.
+     *
+     * A rollback that completed or was abandoned is the last thing that could have replayed them.
+     * `retryRollback` is the only other writer of a terminal original, and it is refused for exactly as long as
+     * the rollback is attached or in transition — the window this write falls in.
+     */
+    #priorsSpentByUndo(record: RunRecord): RunChange[] {
+        if (record.revertOf === undefined) {
+            return [];
+        }
+        const original = this.internal.runs.get(record.revertOf);
+        if (original === undefined || original.changeSet.length === 0) {
+            return [];
+        }
+        return [{ record: original, next: { changeSet: [] } }];
+    }
+
+    /**
      * Build the rollback of `record` from its changeSet alone.
      *
      * The half of a rollback that needs nothing but the record: what a replacement rollback needs, and what a
@@ -1004,7 +1031,9 @@ export class TaskManagerBehavior extends Behavior {
         // `revertOf` is seeded on every rollback the manager creates, retries included: it is the identity
         // link that refuses a re-run of the original, and a rollback that lacks it excludes nothing.
         const { execution: revert, joined } = this.#spawn(
-            new BoundDefinition(Revert, { originalRunId: record.runId, entries: record.changeSet }),
+            // Copied, not shared: `params` reaches storage by reference, and a phase appends to the record's
+            // changeSet in place, so a shared array would let a later push mutate a persisted rollback's input.
+            new BoundDefinition(Revert, { originalRunId: record.runId, entries: [...record.changeSet] }),
             { revertOf: record.runId },
         );
         // The link is not set here: it is part of the state the caller's write carries, so a refused write
@@ -1094,17 +1123,19 @@ export class TaskManagerBehavior extends Behavior {
                 await this.#commit({ record, next: { phaseIndex: record.phaseIndex + 1 } });
             }
             if (record.state === "running") {
-                // One write carries the outcome and its place in the retirement order. The priors go with it:
-                // reversing a success is a new action the caller starts, so nothing will ever replay them.
-                await this.#commit({
-                    record,
-                    next: {
-                        state: "completed",
-                        retireSeq: this.internal.runs.nextRetirement(record),
-                        changeSet: [],
+                // One write carries the outcome and its place in the retirement order.
+                await this.#commit(
+                    {
+                        record,
+                        next: {
+                            state: "completed",
+                            retireSeq: this.internal.runs.nextRetirement(record),
+                            ...this.#retiringPriors(record),
+                        },
+                        drop: RETIRE,
                     },
-                    drop: RETIRE,
-                });
+                    ...this.#priorsSpentByUndo(record),
+                );
             }
         } catch (e) {
             // Shutdown leaves the task non-terminal for resume; cancel is finalized by cancel() itself.
@@ -1139,16 +1170,6 @@ export class TaskManagerBehavior extends Behavior {
             // The failure, its place in the retirement order and the rollback that undoes it land together, or
             // not at all: written separately, a crash between them leaves a run promising a rollback nothing
             // created.
-            // Past its point of no return there is nothing to restore to, so no verb will ever replay these
-            // priors: `#prepareRevert` declined to create a rollback and `retryRollback` refuses a run with
-            // none. Derived inside the guard that already wraps `#prepareRevert`, because a definition whose
-            // `revertible` throws must not re-reject an otherwise handled drive promise.
-            let replayable = true;
-            try {
-                replayable = execution.bound.revertible(record);
-            } catch (revertibleError) {
-                logger.error(`${runLabel(record.runId)}: cannot ask whether it is revertible`, revertibleError);
-            }
             try {
                 await this.#commit(
                     {
@@ -1158,7 +1179,7 @@ export class TaskManagerBehavior extends Behavior {
                             error,
                             retireSeq: this.internal.runs.nextRetirement(record),
                             revertRunId: revert.record?.runId,
-                            ...(replayable ? {} : { changeSet: [] }),
+                            ...this.#retiringPriors(record),
                         },
                         drop: RETIRE,
                     },
@@ -1252,8 +1273,8 @@ export class TaskManagerBehavior extends Behavior {
      * Record these runs' intended next state in one transaction, and adopt it only once the write has landed.
      *
      * The unit is the transaction, not the field: a run's outcome and its place in the retirement order must
-     * land together or a crash between them leaves a record that load discards, and a run and the rollback it
-     * names must land together or the run promises a rollback nothing created.
+     * land together or a crash between them leaves a terminal record that no longer sorts against its slot,
+     * and a run and the rollback it names must land together or the run promises a rollback nothing created.
      *
      * Nothing is mutated before the write, so a refused write needs no compensation — the run is as it was
      * because it was never changed.

--- a/packages/node-manager/src/task/errors.ts
+++ b/packages/node-manager/src/task/errors.ts
@@ -198,8 +198,7 @@ export class TaskNotARollbackError extends TaskRefusedError {
 }
 
 /**
- * `abandon()` was refused because the undo already concluded: it either restored the device, or was called off
- * before it wrote anything. Nothing is left for an operator to give up on.
+ * `abandon()` was refused because the undo already restored the device. Nothing is left to give up on.
  */
 export class TaskAlreadyUndoneError extends TaskRefusedError {
     override readonly code = TaskFindingCode.AlreadyUndone;
@@ -228,11 +227,10 @@ export class TaskNotInFlightError extends TaskRefusedError {
 }
 
 /**
- * There is no undo of this run to retry: it never produced one — nothing was written, or the task declined to
- * be reverted — or the record of the one it had did not survive a restart.
+ * There is no undo of this run to retry: nothing was written, the task declined to be reverted, or the write
+ * that would have recorded the undo was refused.
  *
- * Ordinary state rather than a caller's mistake, and reachable more often since a cleanly completed run no
- * longer gets a rollback at all.
+ * Ordinary state rather than a caller's mistake: a run that completes cleanly never gets a rollback.
  */
 export class TaskNoRollbackError extends TaskRefusedError {
     override readonly code = TaskFindingCode.NoRollback;

--- a/packages/node-manager/src/task/types.ts
+++ b/packages/node-manager/src/task/types.ts
@@ -17,10 +17,15 @@ import type { ClientNode, ItemMode, ManagedItem } from "@matter/node";
 export type RunId = Branded<number, "RunId">;
 
 export function RunId(value: number): RunId {
-    if (!Number.isSafeInteger(value) || value < 1) {
+    if (!isRunId(value)) {
         throw new ImplementationError(`Invalid run id ${value}`);
     }
-    return value as RunId;
+    return value;
+}
+
+/** Whether a value read from storage can be a {@link RunId}. The one place the rule is stated. */
+export function isRunId(value: unknown): value is RunId {
+    return typeof value === "number" && Number.isSafeInteger(value) && value >= 1;
 }
 
 /**

--- a/packages/node-manager/test/task/CancelRobustnessTest.ts
+++ b/packages/node-manager/test/task/CancelRobustnessTest.ts
@@ -13,7 +13,7 @@ import {
     TaskSlotSettlingError,
 } from "#task/errors.js";
 import { RunRecord } from "#task/Task.js";
-import { TaskHandle, TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
+import { TaskCancellation, TaskCancelOutcome, TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { Teardown, TaskPhase, TaskState } from "#task/types.js";
 import { RunId } from "#task/types.js";
 import { CrashedDependencyError, Environment, InternalError, Lifecycle, MaybePromise } from "@matter/general";
@@ -21,6 +21,7 @@ import { Behavior, ClientNode, ItemKind, itemMapKey } from "@matter/node";
 import { MockServerNode } from "@matter/node/testing";
 import {
     cancelSlot,
+    cancelSlotOutcome,
     FakePeer,
     liveRecord,
     onPersisted,
@@ -225,7 +226,7 @@ describe("cancel robustness", () => {
         });
         await pumpUntil("admission in flight", () => state.entered);
 
-        const cancelling = node.act(a => cancelSlot(a.get(TestTaskManager), "synthetic:pregate"));
+        const cancelling = node.act(a => cancelSlotOutcome(a.get(TestTaskManager), "synthetic:pregate"));
         await pumpUntil("cancel accepted", () =>
             node.act(
                 a =>
@@ -237,9 +238,10 @@ describe("cancel robustness", () => {
 
         const handle = await MockTime.resolve(cancelling);
 
-        // Nothing was written to the peer after the cancel was accepted, so there is nothing to revert.
+        // Nothing was written to the peer after the cancel was accepted, so there is nothing to revert — and
+        // the caller is told the device is untouched, not merely that no undo exists.
         expect(peer.items[itemMapKey("groupMembership", "X")]).equals(undefined);
-        expect(handle).equals(undefined);
+        expect(handle.outcome).equals(TaskCancelOutcome.NothingToUndo);
 
         const status = await node.act(a => statusOfSlot(a.get(TestTaskManager), "synthetic:pregate"));
         expect(status?.state).equals("cancelled");
@@ -264,10 +266,10 @@ describe("cancel robustness", () => {
         const node = await MockServerNode.create(RootEndpoint, { environment, id: "cancel-ctxrace" });
         await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
 
-        let cancelling: Promise<TaskHandle | undefined> | undefined;
+        let cancelling: Promise<TaskCancellation> | undefined;
         TestTaskManager.atContext = manager => {
             TestTaskManager.atContext = undefined;
-            cancelling = cancelSlot(manager, "synthetic:ctxrace");
+            cancelling = cancelSlotOutcome(manager, "synthetic:ctxrace");
         };
         try {
             await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "ctxrace" }));
@@ -276,10 +278,10 @@ describe("cancel robustness", () => {
             TestTaskManager.atContext = undefined;
         }
 
-        const handle = await MockTime.resolve(cancelling);
+        const handle = await MockTime.resolve(cancelling!);
 
         expect(peer.items[itemMapKey("groupMembership", "Z")]).equals(undefined);
-        expect(handle).equals(undefined);
+        expect(handle.outcome).equals(TaskCancelOutcome.NothingToUndo);
         const status = await node.act(a => statusOfSlot(a.get(TestTaskManager), "synthetic:ctxrace"));
         expect(status?.state).equals("cancelled");
 
@@ -771,7 +773,15 @@ describe("cancel robustness", () => {
         // Storage refuses from here on, with the node still running: not shutdown, just a failed write.
         await node.act(a => a.get(TestTaskManager).closePersistMutex());
 
-        await expect((async () => node.act(a => a.get(TestTaskManager).cancel(handle.runId)))()).rejected;
+        await expect(
+            (async () =>
+                node.act(a =>
+                    a
+                        .get(TestTaskManager)
+                        .cancel(handle.runId)
+                        .then(c => c.rollback),
+                ))(),
+        ).rejected;
 
         // A cancel that was never recorded must leave the task exactly as it was — including its driver. The
         // abort stopped the driver and dropped the gate, so without giving both back the task would sit
@@ -863,7 +873,10 @@ describe("cancel robustness", () => {
         const cancelling = MockTime.resolve(
             node.act(async a => {
                 try {
-                    return await a.get(TestTaskManager).cancel(handle.runId);
+                    return await a
+                        .get(TestTaskManager)
+                        .cancel(handle.runId)
+                        .then(c => c.rollback);
                 } catch (e) {
                     return e;
                 }
@@ -917,7 +930,7 @@ describe("cancel robustness", () => {
         // The node crashes, so the write fails inside the state transaction — after the point where the record
         // for a retired run is re-read. A closed mutex fails earlier and would not exercise this at all.
         node.construction.setStatus(Lifecycle.Status.Crashed);
-        await expect(MockTime.resolve(manager.cancel(handle.runId))).rejected;
+        await expect(MockTime.resolve(manager.cancel(handle.runId).then(c => c.rollback))).rejected;
 
         // The rollback was staged and then discarded, so the run must not go on naming it: a record pointing
         // at a rollback nothing created could never be rolled back again.

--- a/packages/node-manager/test/task/RecordSnapshotTest.ts
+++ b/packages/node-manager/test/task/RecordSnapshotTest.ts
@@ -79,7 +79,7 @@ describe("run table schema version", () => {
 
     it("reads nothing from a table a newer build wrote", () => {
         const store = new RunStore();
-        const { resumable } = store.load({
+        store.load({
             runs: { "1": persisted(1, "running", [ENTRY]) },
             nextRunId: 1_000,
             runsVersion: RUN_STORE_VERSION + 1,
@@ -87,7 +87,7 @@ describe("run table schema version", () => {
         // Nothing loaded and nothing resumable: the manager refuses new work rather than presenting a table
         // whose targets it cannot see are taken.
         expect(store.unreadable).equals(true);
-        expect(resumable).deep.equals([]);
+        expect(store.resumable).deep.equals([]);
         expect(store.get(RunId(1))).equals(undefined);
     });
 });

--- a/packages/node-manager/test/task/RetirementTest.ts
+++ b/packages/node-manager/test/task/RetirementTest.ts
@@ -8,6 +8,8 @@ import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
 import {
     TaskConflictError,
     TaskFailedError,
+    TaskAbandonedError,
+    TaskAlreadyUndoneError,
     TaskNoRollbackError,
     TaskNotInFlightError,
     TaskStoreVersionError,
@@ -17,7 +19,7 @@ import { RUN_STORE_VERSION } from "#task/RunStore.js";
 import { TaskDefinition, TaskPersistence } from "#task/Task.js";
 import { TaskHandle, TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { RunId, TaskPhase } from "#task/types.js";
-import { Environment, InternalError, MaybePromise } from "@matter/general";
+import { Environment, ImplementationError, InternalError, MaybePromise } from "@matter/general";
 import { ClientNode, itemMapKey, ServerNode } from "@matter/node";
 import { MockServerNode } from "@matter/node/testing";
 import { FakePeer, SyntheticTask } from "./helpers.js";
@@ -41,6 +43,10 @@ class TestTaskManager extends TaskManagerBehavior {
     /** The priors the loaded twin still holds, which storage alone cannot show. */
     priorsOf(runId: RunId) {
         return this.internal.runs.get(runId)?.changeSet;
+    }
+
+    paramsOf(runId: RunId) {
+        return this.internal.runs.get(runId)?.params;
     }
 }
 
@@ -88,6 +94,47 @@ const ForwardOnlyTask: TaskDefinition<{ tag: string; peerId: string }> = {
                 run: async ctx => {
                     await ctx.setIntent(ctx.resolvePeer(params.peerId), "groupMembership", "X", { v: 2 });
                     throw new TaskFailedError("forward only");
+                },
+            },
+        ];
+    },
+};
+
+/** Writes one intent, then fails, while remaining revertible: the failure path creates a rollback. */
+const FailingRevertibleTask: TaskDefinition<{ tag: string; peerId: string }> = {
+    type: "failing-revertible",
+    slotKeyFor(params) {
+        return `synthetic:${params.tag}`;
+    },
+    phases(params) {
+        return [
+            {
+                name: "write-then-fail",
+                run: async ctx => {
+                    await ctx.setIntent(ctx.resolvePeer(params.peerId), "groupMembership", "X", { v: 2 });
+                    throw new TaskFailedError("failing but revertible");
+                },
+            },
+        ];
+    },
+};
+
+/** Writes one intent, then fails, and cannot answer whether it is revertible. */
+const UnaskableTask: TaskDefinition<{ tag: string; peerId: string }> = {
+    type: "unaskable",
+    slotKeyFor(params) {
+        return `synthetic:${params.tag}`;
+    },
+    revertible(): boolean {
+        throw new ImplementationError("the test cannot say");
+    },
+    phases(params) {
+        return [
+            {
+                name: "write-then-fail",
+                run: async ctx => {
+                    await ctx.setIntent(ctx.resolvePeer(params.peerId), "groupMembership", "X", { v: 2 });
+                    throw new TaskFailedError("unaskable");
                 },
             },
         ];
@@ -160,6 +207,23 @@ async function failedRollback(node: ServerNode, tag: string, peer: FakePeer) {
     return { original, rollback };
 }
 
+/** A run whose rollback is parked on an unreachable peer, so it is live and has written nothing yet. */
+async function parkedRollback(node: ServerNode, tag: string, peer: FakePeer) {
+    peer.setIntent("groupMembership", "X", { v: 1 });
+    const original = await run(node, tag, [gatingPhase(peer.id)]);
+    await pumpUntil("intent written", () => (peer.items[KEY]?.intent as { v?: number })?.v === 2);
+
+    peer.setReachable(false);
+    const rollback = await node.act(a => a.get(TestTaskManager).cancel(original.runId));
+    if (rollback === undefined) {
+        throw new InternalError("cancel produced no rollback");
+    }
+    await pumpUntil("rollback parked", () =>
+        node.act(a => a.get(TestTaskManager).get(rollback.runId)?.status.state === "parked"),
+    );
+    return { original, rollback };
+}
+
 /** Runs `fn` and returns whatever it produced, so a test can assert on a refusal without a try/catch. */
 async function attempt<T>(node: ServerNode, fn: (manager: TestTaskManager) => Promise<T>) {
     return node.act(async a => {
@@ -224,27 +288,6 @@ describe("run records after a retirement", () => {
 
         await expect(node.act(a => a.get(TestTaskManager).cancel(handle.runId))).rejectedWith(TaskNotInFlightError);
         expect((await stored(node, handle.runId))?.revertRunId).equals(undefined);
-    });
-
-    it("leaves an unfinished run's parameters alone on upgrade", async () => {
-        const environment = new Environment("upgrade-inflight");
-        let live!: RunId;
-        {
-            await using node = await makeNode(environment, "inflight");
-            const peer = testPeer("inflight");
-            const handle = await run(node, "inflight", [gatingPhase("inflight")]);
-            await pumpUntil("intent written", () => peer.items[KEY] !== undefined);
-            live = handle.runId;
-            await node.act(a => {
-                a.get(TestTaskManager).state.runsVersion = 1;
-            });
-        }
-
-        // Parameters are what re-drives a run's phases after a restart, so the upgrade must not take them from
-        // work that has not finished.
-        await using node = await makeNode(environment, "inflight");
-        testPeer("inflight");
-        expect((await stored(node, live))?.params).deep.equals({ tag: "inflight" });
     });
 
     it("records the schema version it wrote the table under", async () => {
@@ -404,6 +447,125 @@ describe("run records after a retirement", () => {
         expect(record?.changeSet).deep.equals([]);
         expect(record?.wrote).equals(true);
         expect(await attempt(node, m => m.retryRollback(run1.runId))).instanceOf(TaskNoRollbackError);
+    });
+
+    it("keeps the priors of a failed run its rollback can still replay", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("keeps-priors");
+        const { original } = await failedRollback(node, "keeps-priors", peer);
+
+        expect((await stored(node, original.runId))?.changeSet).not.deep.equals([]);
+    });
+
+    it("drops a rollback's own priors, which nothing can ever replay", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("rollback-priors");
+        const { rollback } = await failedRollback(node, "rollback-priors", peer);
+
+        const record = await stored(node, rollback.runId);
+        expect(record?.state).equals("failed");
+        expect(record?.wrote).equals(true);
+        expect(record?.changeSet).deep.equals([]);
+        expect(await node.act(a => a.get(TestTaskManager).priorsOf(rollback.runId))).deep.equals([]);
+    });
+
+    it("spends the original's priors when its rollback completes, and still refuses a retry", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("undo-completes");
+        const { original, rollback } = await parkedRollback(node, "undo-completes", peer);
+
+        peer.markHas("groupMembership", "X");
+        peer.setReachable(true);
+        await pumpUntil("rollback completed", () =>
+            node.act(a => a.get(TestTaskManager).get(rollback.runId)?.status.state === "completed"),
+        );
+
+        expect((await stored(node, original.runId))?.changeSet).deep.equals([]);
+        expect(await node.act(a => a.get(TestTaskManager).priorsOf(original.runId))).deep.equals([]);
+        // The refusal stays coded: an emptied changeSet must never surface as the "cannot happen" error.
+        expect(await attempt(node, m => m.retryRollback(original.runId))).instanceOf(TaskAlreadyUndoneError);
+    });
+
+    it("spends the original's priors when its rollback is abandoned, and still refuses a retry", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("undo-abandoned");
+        const { original, rollback } = await failedRollback(node, "undo-abandoned", peer);
+
+        await node.act(a => a.get(TestTaskManager).abandon(rollback.runId));
+
+        expect((await stored(node, original.runId))?.changeSet).deep.equals([]);
+        expect(await node.act(a => a.get(TestTaskManager).priorsOf(original.runId))).deep.equals([]);
+        expect(await attempt(node, m => m.retryRollback(original.runId))).instanceOf(TaskAbandonedError);
+    });
+
+    it("gives a rollback its own copy of the priors it replays", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("undo-copy");
+        // Parked, so the rollback still holds its params: a retirement drops them.
+        const { original, rollback } = await parkedRollback(node, "undo-copy", peer);
+
+        const entries = await node.act(
+            a => (a.get(TestTaskManager).paramsOf(rollback.runId) as { entries: unknown[] }).entries,
+        );
+        const priors = await node.act(a => a.get(TestTaskManager).priorsOf(original.runId));
+        expect(entries).not.equals(priors);
+        expect(entries).deep.equals(priors);
+    });
+
+    it("keeps the priors of a run that failed on its own and got a rollback", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("failed-with-undo");
+        peer.setIntent("groupMembership", "X", { v: 1 });
+        peer.setReachable(false);
+
+        await node.act(a => a.get(TestTaskManager).register(FailingRevertibleTask));
+        const failed = await node.act(a =>
+            a.get(TestTaskManager).run(FailingRevertibleTask, {
+                tag: "failed-with-undo",
+                peerId: "failed-with-undo",
+            }),
+        );
+        await awaitRetired(node, failed.runId);
+
+        const record = await stored(node, failed.runId);
+        expect(record?.state).equals("failed");
+        expect(record?.revertRunId).not.equals(undefined);
+        // The rollback exists and is parked, so it can still replay these.
+        expect(record?.changeSet).not.deep.equals([]);
+    });
+
+    it("drops the priors of a run whose type cannot say whether it is revertible", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("unaskable");
+        peer.setIntent("groupMembership", "X", { v: 1 });
+
+        await node.act(a => a.get(TestTaskManager).register(UnaskableTask));
+        const failed = await node.act(a =>
+            a.get(TestTaskManager).run(UnaskableTask, { tag: "unaskable", peerId: "unaskable" }),
+        );
+        await awaitRetired(node, failed.runId);
+
+        const record = await stored(node, failed.runId);
+        expect(record?.state).equals("failed");
+        // No rollback could be prepared, so nothing will ever replay the priors.
+        expect(record?.revertRunId).equals(undefined);
+        expect(record?.changeSet).deep.equals([]);
+        expect(record?.wrote).equals(true);
+        expect(await attempt(node, m => m.retryRollback(failed.runId))).instanceOf(TaskNoRollbackError);
+    });
+
+    it("drops a completed rollback's own priors", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("undo-completes-own");
+        const { rollback } = await parkedRollback(node, "undo-completes-own", peer);
+
+        peer.markHas("groupMembership", "X");
+        peer.setReachable(true);
+        await pumpUntil("rollback completed", () =>
+            node.act(a => a.get(TestTaskManager).get(rollback.runId)?.status.state === "completed"),
+        );
+
+        expect((await stored(node, rollback.runId))?.changeSet).deep.equals([]);
     });
 
     it("is superseded by a later run that reached the device and cannot be undone", async () => {

--- a/packages/node-manager/test/task/RetirementTest.ts
+++ b/packages/node-manager/test/task/RetirementTest.ts
@@ -192,7 +192,12 @@ async function failedRollback(node: ServerNode, tag: string, peer: FakePeer) {
     const original = await run(node, tag, [gatingPhase(peer.id)]);
     await pumpUntil("intent written", () => (peer.items[KEY]?.intent as { v?: number })?.v === 2);
 
-    const rollback = await node.act(a => a.get(TestTaskManager).cancel(original.runId));
+    const rollback = await node.act(a =>
+        a
+            .get(TestTaskManager)
+            .cancel(original.runId)
+            .then(c => c.rollback),
+    );
     if (rollback === undefined) {
         throw new InternalError("cancel produced no rollback");
     }
@@ -214,7 +219,12 @@ async function parkedRollback(node: ServerNode, tag: string, peer: FakePeer) {
     await pumpUntil("intent written", () => (peer.items[KEY]?.intent as { v?: number })?.v === 2);
 
     peer.setReachable(false);
-    const rollback = await node.act(a => a.get(TestTaskManager).cancel(original.runId));
+    const rollback = await node.act(a =>
+        a
+            .get(TestTaskManager)
+            .cancel(original.runId)
+            .then(c => c.rollback),
+    );
     if (rollback === undefined) {
         throw new InternalError("cancel produced no rollback");
     }
@@ -286,7 +296,14 @@ describe("run records after a retirement", () => {
         const handle = await run(node, "done", [touchPhase("done")]);
         await awaitRetired(node, handle.runId);
 
-        await expect(node.act(a => a.get(TestTaskManager).cancel(handle.runId))).rejectedWith(TaskNotInFlightError);
+        await expect(
+            node.act(a =>
+                a
+                    .get(TestTaskManager)
+                    .cancel(handle.runId)
+                    .then(c => c.rollback),
+            ),
+        ).rejectedWith(TaskNotInFlightError);
         expect((await stored(node, handle.runId))?.revertRunId).equals(undefined);
     });
 
@@ -328,7 +345,7 @@ describe("run records after a retirement", () => {
         // did not read — while a write names the cause instead of claiming the run never existed.
         expect(await node.act(a => a.get(TestTaskManager).get(existing))).equals(undefined);
         const verbs: Array<(m: TestTaskManager) => Promise<unknown>> = [
-            m => m.cancel(existing),
+            m => m.cancel(existing).then(c => c.rollback),
             m => m.abandon(existing),
             m => m.retryRollback(existing),
         ];
@@ -370,7 +387,12 @@ describe("run records after a retirement", () => {
         peer.setIntent("groupMembership", "X", { v: 3 });
         const second = await run(node, "later-rollback", [gatingPhase(peer.id)]);
         await pumpUntil("second intent written", () => (peer.items[KEY]?.intent as { v?: number })?.v === 2);
-        const live = await node.act(a => a.get(TestTaskManager).cancel(second.runId));
+        const live = await node.act(a =>
+            a
+                .get(TestTaskManager)
+                .cancel(second.runId)
+                .then(c => c.rollback),
+        );
         expect(live).not.equals(undefined);
 
         // The live rollback undoes the second run, not the first, so it is not the undo that applies here and

--- a/packages/node-manager/test/task/RunIdentityTest.ts
+++ b/packages/node-manager/test/task/RunIdentityTest.ts
@@ -186,7 +186,12 @@ describe("run identity", () => {
             for (let i = 0; i < 10_000 && peer.items[itemMapKey("groupMembership", "X")] === undefined; i++) {
                 await MockTime.advance(1);
             }
-            const revert = await node.act(a => a.get(TestTaskManager).cancel(handle.runId));
+            const revert = await node.act(a =>
+                a
+                    .get(TestTaskManager)
+                    .cancel(handle.runId)
+                    .then(c => c.rollback),
+            );
             expect(revert).not.equals(undefined);
             runIds.push(revert!.runId);
 
@@ -314,7 +319,12 @@ describe("run identity", () => {
         // restart — and the identity the caller held has to still name it.
         await using node = await makeNode(environment, "undo");
         await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
-        const rollback = await node.act(a => a.get(TestTaskManager).cancel(runId));
+        const rollback = await node.act(a =>
+            a
+                .get(TestTaskManager)
+                .cancel(runId)
+                .then(c => c.rollback),
+        );
         expect(rollback?.status.revertOf).equals(runId);
     });
 
@@ -336,9 +346,15 @@ describe("run identity", () => {
         // decision and a record cannot answer it.
         await using node = await makeNode(environment, "unregistered");
         expect(await node.act(a => a.get(TestTaskManager).get(runId)?.status.state)).equals("running");
-        await expect((async () => node.act(a => a.get(TestTaskManager).cancel(runId)))()).rejectedWith(
-            TaskTypeNotRegisteredError,
-        );
+        await expect(
+            (async () =>
+                node.act(a =>
+                    a
+                        .get(TestTaskManager)
+                        .cancel(runId)
+                        .then(c => c.rollback),
+                ))(),
+        ).rejectedWith(TaskTypeNotRegisteredError);
     });
 
     it("refuses an external id a live run of another slot already answers to", async () => {
@@ -374,7 +390,12 @@ describe("run identity", () => {
 
         // The rollback parks on an unreachable peer, so it stays live while the re-run is attempted.
         peer.setReachable(false);
-        const rollback = await node.act(a => a.get(TestTaskManager).cancel(first.runId));
+        const rollback = await node.act(a =>
+            a
+                .get(TestTaskManager)
+                .cancel(first.runId)
+                .then(c => c.rollback),
+        );
         expect(rollback?.status.revertOf).equals(first.runId);
 
         // A rollback rewrites exactly the intents a re-run would re-apply.
@@ -399,7 +420,12 @@ describe("run identity", () => {
         for (let i = 0; i < 10_000 && peer.items[itemMapKey("groupMembership", "X")] === undefined; i++) {
             await MockTime.advance(1);
         }
-        const rollback = await node.act(a => a.get(TestTaskManager).cancel(handle.runId));
+        const rollback = await node.act(a =>
+            a
+                .get(TestTaskManager)
+                .cancel(handle.runId)
+                .then(c => c.rollback),
+        );
         expect(rollback).not.equals(undefined);
 
         // Let the rollback finish and retire, so it no longer answers as live work.
@@ -407,7 +433,12 @@ describe("run identity", () => {
 
         // Cancelling again is idempotent and must keep naming the same rollback. Resolving only live runs here
         // would make the answer depend on whether the rollback happens to have finished yet.
-        const again = await node.act(a => a.get(TestTaskManager).cancel(handle.runId));
+        const again = await node.act(a =>
+            a
+                .get(TestTaskManager)
+                .cancel(handle.runId)
+                .then(c => c.rollback),
+        );
         expect(again?.runId).equals(rollback?.runId);
         expect(again?.status.revertOf).equals(handle.runId);
     });
@@ -444,7 +475,12 @@ describe("run identity", () => {
             const handle = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "norereg" }));
             runId = handle.runId;
             await pumpUntil("intent written", async () => peer.items[itemMapKey("groupMembership", "X")] !== undefined);
-            const rollback = await node.act(a => a.get(TestTaskManager).cancel(runId));
+            const rollback = await node.act(a =>
+                a
+                    .get(TestTaskManager)
+                    .cancel(runId)
+                    .then(c => c.rollback),
+            );
             rollbackId = rollback!.runId;
             await settle(node, `revert:${runId}`);
         }
@@ -452,7 +488,12 @@ describe("run identity", () => {
         // Nothing registers the type on this start. Deciding on a NEW rollback would need the task, because
         // revertibility is the task's decision — but a run that already recorded one is answered by its record.
         await using node = await makeNode(environment, "norereg");
-        const again = await node.act(a => a.get(TestTaskManager).cancel(runId));
+        const again = await node.act(a =>
+            a
+                .get(TestTaskManager)
+                .cancel(runId)
+                .then(c => c.rollback),
+        );
         expect(again?.runId).equals(rollbackId);
     });
 
@@ -474,8 +515,18 @@ describe("run identity", () => {
         // told about the rollback that was created, not told there was nothing to roll back.
         const [first, second] = await MockTime.resolve(
             Promise.all([
-                node.act(a => a.get(TestTaskManager).cancel(handle.runId)),
-                node.act(a => a.get(TestTaskManager).cancel(handle.runId)),
+                node.act(a =>
+                    a
+                        .get(TestTaskManager)
+                        .cancel(handle.runId)
+                        .then(c => c.rollback),
+                ),
+                node.act(a =>
+                    a
+                        .get(TestTaskManager)
+                        .cancel(handle.runId)
+                        .then(c => c.rollback),
+                ),
             ]),
             { macrotasks: true },
         );
@@ -650,7 +701,12 @@ describe("run identity", () => {
 
         let refusal: unknown;
         try {
-            await node.act(a => a.get(TestTaskManager).cancel(parked));
+            await node.act(a =>
+                a
+                    .get(TestTaskManager)
+                    .cancel(parked)
+                    .then(c => c.rollback),
+            );
         } catch (e) {
             refusal = e;
         }

--- a/packages/node-manager/test/task/RunIdentityTest.ts
+++ b/packages/node-manager/test/task/RunIdentityTest.ts
@@ -15,7 +15,7 @@ import {
     TaskTypeNotRegisteredError,
 } from "#task/errors.js";
 import { Revert } from "#task/Revert.js";
-import { RUN_ID_RESERVATION, RunStore } from "#task/RunStore.js";
+import { RUN_ID_RESERVATION } from "#task/RunStore.js";
 import { TaskDefinition, TaskPersistence } from "#task/Task.js";
 import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { RunId, TaskPhase } from "#task/types.js";
@@ -566,33 +566,6 @@ describe("run identity", () => {
         await node.act(a => a.get(TestTaskManager).register(SyntheticTask));
         const next = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag: "fresh" }));
         expect(next.runId).greaterThan(issued);
-    });
-
-    it("discards a terminal record that reached storage without its place in the retirement order", () => {
-        const store = new RunStore();
-        const { resumable, discarded } = store.load({
-            runs: {
-                // Written by a build that recorded the outcome and the order separately, and stopped between
-                // the two. It has no position, so it would sort ahead of every sequenced run of its slot.
-                "run:1": { runId: 1, slotKey: "synthetic:a", type: "synthetic", state: "completed", changeSet: [] },
-                "run:2": {
-                    runId: 2,
-                    slotKey: "synthetic:a",
-                    type: "synthetic",
-                    state: "completed",
-                    retireSeq: 1,
-                    changeSet: [],
-                },
-            } as unknown as Record<string, TaskPersistence>,
-            nextRunId: 3,
-            nextRetireSeq: 2,
-        });
-
-        expect(discarded).equals(1);
-        expect(resumable.length).equals(0);
-        // Only the sequenced run survives, so nothing in the table can be misordered against it.
-        expect(store.get(RunId(1))).equals(undefined);
-        expect(store.get(RunId(2))?.retireSeq).equals(1);
     });
 
     it("refuses an identity the reservation does not cover rather than issuing it", async () => {

--- a/packages/node-manager/test/task/RunStoreTest.ts
+++ b/packages/node-manager/test/task/RunStoreTest.ts
@@ -5,8 +5,9 @@
  */
 
 import { RunStore } from "#task/RunStore.js";
-import { RunRecord } from "#task/Task.js";
+import { RunRecord, TaskPersistence } from "#task/Task.js";
 import { RetireSeq, RunId } from "#task/types.js";
+import { InternalError } from "@matter/general";
 
 /**
  * The store answers these without a node, a gate or a clock, so a table can be built by hand — the only way
@@ -76,6 +77,55 @@ describe("RunStore", () => {
             const later = retired(2, "synthetic:t", 2, "completed", true);
 
             expect(storeWith(earlier, later).supersederOf(RunId(1))?.runId).equals(RunId(2));
+        });
+    });
+    describe("a corrupt stored table", () => {
+        const KEY_MATERIAL = new Uint8Array([1, 2, 3, 4]);
+
+        function loadWith(runId: unknown) {
+            const store = new RunStore();
+            return () =>
+                store.load({
+                    runs: {
+                        "run:1": {
+                            runId,
+                            slotKey: "synthetic:t",
+                            type: "rotateGroupKey",
+                            state: "running",
+                            changeSet: [],
+                            wrote: false,
+                            // What a group task actually carries: raw key material, and a bigint that cannot be
+                            // serialized at all.
+                            params: { newEpochKey: KEY_MATERIAL, epochStartTime0: 1n },
+                        },
+                    } as unknown as Record<string, TaskPersistence>,
+                });
+        }
+
+        // Zero and negatives pass `Number.isSafeInteger` but no caller can build a `RunId` from them, so the
+        // rule the rest of the code enforces has to be the rule here.
+        for (const runId of [0, -1, 1.5, "1", undefined]) {
+            it(`refuses a record whose identity is ${JSON.stringify(runId) ?? "undefined"}`, () => {
+                expect(loadWith(runId)).throws(InternalError);
+            });
+        }
+
+        it("names the record without serializing it", () => {
+            let message = "";
+            try {
+                loadWith(0)();
+            } catch (e) {
+                message = (e as Error).message;
+            }
+            expect(message).contains("run:1");
+            // A `bigint` in params would make serializing the record throw before the refusal could be built,
+            // and its key material would reach the log if it did not.
+            expect(message).not.contains("epochStartTime0");
+            expect(message).not.contains("newEpochKey");
+        });
+
+        it("accepts the smallest identity a caller can hold", () => {
+            expect(loadWith(1)).not.throws();
         });
     });
 });

--- a/packages/node-manager/test/task/TaskLifecycleTest.ts
+++ b/packages/node-manager/test/task/TaskLifecycleTest.ts
@@ -371,7 +371,7 @@ describe("Task lifecycle", () => {
             // the contract: the caller sees which run its name names before acting on it.
             const handle = await node.act(a => {
                 const manager = a.get(TestTaskManager);
-                return manager.cancel(manager.forExternalId("owner")!.runId);
+                return manager.cancel(manager.forExternalId("owner")!.runId).then(c => c.rollback);
             });
             expect(handle?.status.revertOf).equals(
                 requireStatusOfSlot(await node.act(a => a.get(TestTaskManager)), "synthetic:aliascancel").runId,
@@ -477,9 +477,15 @@ describe("Task lifecycle", () => {
             await awaitState(node, "synthetic:blockedcancel", "parked");
 
             await node.act(a => a.get(TestTaskManager).exhaustIdentities());
-            await expect((async () => node.act(a => a.get(TestTaskManager).cancel(handle.runId)))()).rejectedWith(
-                TaskIdentityExhaustedError,
-            );
+            await expect(
+                (async () =>
+                    node.act(a =>
+                        a
+                            .get(TestTaskManager)
+                            .cancel(handle.runId)
+                            .then(c => c.rollback),
+                    ))(),
+            ).rejectedWith(TaskIdentityExhaustedError);
 
             // Memory must not claim a cancel that storage never saw.
             const status = await node.act(a => a.get(TestTaskManager).get(handle.runId)?.status);

--- a/packages/node-manager/test/task/TaskManagerBehaviorTest.ts
+++ b/packages/node-manager/test/task/TaskManagerBehaviorTest.ts
@@ -8,7 +8,7 @@ import { ReconcilerBehavior } from "#ReconcilerBehavior.js";
 import { TaskFailedError, TaskNotFoundError, TaskSlotOccupiedError } from "#task/errors.js";
 import { RotateGroupKey } from "#task/groups/RotateGroupKey.js";
 import { TaskDefinition, RunRecord } from "#task/Task.js";
-import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
+import { TaskCancelOutcome, TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { TaskRegistry } from "#task/TaskRegistry.js";
 import { RetireSeq, RunId, TaskPhase } from "#task/types.js";
 import { Environment, ImplementationError } from "@matter/general";
@@ -435,8 +435,11 @@ describe("TaskManagerBehavior", () => {
         await node2.act(a => a.get(TaskManagerBehavior).register(SyntheticTask));
 
         expect(await node2.act(a => a.get(TaskManagerBehavior).get(RunId(7))?.status.state)).equals("cancelled");
-        // Its changeSet is empty, so there is nothing to roll back — a different answer from "never existed".
-        expect(await node2.act(a => a.get(TaskManagerBehavior).cancel(RunId(7)))).equals(undefined);
+        // It changed nothing, so there is nothing to roll back — a different answer from "never existed", and
+        // a different answer again from a run whose changes cannot be taken back.
+        expect(await node2.act(a => a.get(TaskManagerBehavior).cancel(RunId(7)))).deep.equals({
+            outcome: TaskCancelOutcome.NothingToUndo,
+        });
         await expect((async () => node2.act(a => a.get(TaskManagerBehavior).cancel(RunId(999))))()).rejectedWith(
             TaskNotFoundError,
         );

--- a/packages/node-manager/test/task/TransitionsTest.ts
+++ b/packages/node-manager/test/task/TransitionsTest.ts
@@ -22,7 +22,7 @@ import {
 } from "#task/errors.js";
 import { TaskDefinition } from "#task/Task.js";
 import { RunRecord } from "#task/Task.js";
-import { TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
+import { TaskCancelOutcome, TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { RunId, TaskPhase } from "#task/types.js";
 import { Environment, ImplementationError, InternalError, Lifecycle, MaybePromise } from "@matter/general";
 import { ClientNode, itemMapKey, ServerNode } from "@matter/node";
@@ -180,7 +180,12 @@ async function parkedRollback(node: ServerNode, tag: string, peer: FakePeer) {
     await pumpUntil("intent written", () => peer.items[KEY] !== undefined);
 
     peer.setReachable(false);
-    const rollback = await node.act(a => a.get(TestTaskManager).cancel(original.runId));
+    const rollback = await node.act(a =>
+        a
+            .get(TestTaskManager)
+            .cancel(original.runId)
+            .then(c => c.rollback),
+    );
     if (rollback === undefined) {
         throw new InternalError("cancel produced no rollback");
     }
@@ -201,7 +206,12 @@ async function failedRollback(node: ServerNode, tag: string, peer: FakePeer) {
     const original = await node.act(a => a.get(TestTaskManager).run(SyntheticTask, { tag }));
     await pumpUntil("intent written", () => (peer.items[KEY]?.intent as { v?: number })?.v === 2);
 
-    const first = await node.act(a => a.get(TestTaskManager).cancel(original.runId));
+    const first = await node.act(a =>
+        a
+            .get(TestTaskManager)
+            .cancel(original.runId)
+            .then(c => c.rollback),
+    );
     if (first === undefined) {
         throw new InternalError("cancel produced no rollback");
     }
@@ -534,11 +544,12 @@ describe("cancel and abandon", () => {
         const release = await node.act(a => a.get(TestTaskManager).holdPersistMutex());
         const cancelling = node.act(a => a.get(TestTaskManager).cancel(running.runId));
         release();
-        const rollback = await cancelling;
+        const cancellation = await cancelling;
 
-        // By the time the cancel decided, the run was past its point of no return, so there is no undo — and
-        // nothing else will ever replay what it recorded.
-        expect(rollback).equals(undefined);
+        // By the time the cancel decided, the run was past its point of no return. The caller is told the
+        // device keeps those changes — not that there was nothing to undo, which is what it changed.
+        expect(cancellation.outcome).equals(TaskCancelOutcome.Irreversible);
+        expect(cancellation.rollback).equals(undefined);
         const record = await node.act(a => a.get(TestTaskManager).state.runs[String(running.runId)]);
         expect(record.state).equals("cancelled");
         expect(record.wrote).equals(true);
@@ -589,7 +600,12 @@ describe("cancel and abandon", () => {
 
         // The cancel's write is held, so its rollback is admitted but not yet driving.
         const release = await node.act(a => a.get(TestTaskManager).holdPersistMutex());
-        const cancelling = node.act(a => a.get(TestTaskManager).cancel(original.runId));
+        const cancelling = node.act(a =>
+            a
+                .get(TestTaskManager)
+                .cancel(original.runId)
+                .then(c => c.rollback),
+        );
         let rollbackId: RunId | undefined;
         await pumpUntil("rollback admitted", () =>
             node.act(a => {
@@ -747,7 +763,7 @@ describe("cancel and abandon", () => {
             ),
         );
 
-        const outcome = await attempt(node, m => m.cancel(original.runId));
+        const outcome = await attempt(node, m => m.cancel(original.runId).then(c => c.rollback));
         release();
         await retrying;
 
@@ -811,7 +827,7 @@ describe("cancel and abandon", () => {
         const peer = testPeer("nocancel");
         const { rollback } = await parkedRollback(node, "nocancel", peer);
 
-        const outcome = await attempt(node, m => m.cancel(rollback.runId));
+        const outcome = await attempt(node, m => m.cancel(rollback.runId).then(c => c.rollback));
 
         expect(outcome).instanceOf(TaskCannotCancelRollbackError);
         expect((outcome as Error).message).contains("abandon");
@@ -893,7 +909,12 @@ describe("retryRollback", () => {
 
         // The cancel's write is held, so its rollback is admitted but the original does not name it yet.
         const release = await node.act(a => a.get(TestTaskManager).holdPersistMutex());
-        const cancelling = node.act(a => a.get(TestTaskManager).cancel(original.runId));
+        const cancelling = node.act(a =>
+            a
+                .get(TestTaskManager)
+                .cancel(original.runId)
+                .then(c => c.rollback),
+        );
         await pumpUntil("rollback admitted", () =>
             node.act(a => a.get(TestTaskManager).tasks.some(t => t.status.revertOf === original.runId)),
         );

--- a/packages/node-manager/test/task/TransitionsTest.ts
+++ b/packages/node-manager/test/task/TransitionsTest.ts
@@ -241,8 +241,6 @@ const UndoingTask: TaskDefinition<{ tag: string }> = {
     undoes: () => RunId(9_999),
 };
 
-let legacyRollbackId: RunId;
-
 function reset() {
     TestTaskManager.peers.clear();
     TestTaskManager.reconcilerPeer = undefined;
@@ -252,7 +250,31 @@ function reset() {
     }
 }
 
-describe("abandon", () => {
+/**
+ * A task that stops being revertible once it is past its first phase, so a cancel accepted while the driver is
+ * held on the write that advances the phase index answers differently before and after the unwind.
+ */
+const PointOfNoReturnTask: TaskDefinition<{ tag: string; peerId: string }> = {
+    type: "point-of-no-return",
+    slotKeyFor: params => `synthetic:${params.tag}`,
+    revertible(run) {
+        return (run.phaseIndex ?? 0) < 1;
+    },
+    notRevertibleReason: "past the point of no return",
+    phases(params) {
+        return [
+            {
+                name: "write",
+                run: async ctx => {
+                    await ctx.setIntent(ctx.resolvePeer(params.peerId), "groupMembership", "X", { v: 2 });
+                },
+            },
+            { name: "hold", run: () => new Promise<void>(() => {}) },
+        ];
+    },
+};
+
+describe("cancel and abandon", () => {
     before(() => MockTime.init());
     beforeEach(reset);
 
@@ -466,16 +488,62 @@ describe("abandon", () => {
         expect(writes).equals(0);
     });
 
-    it("leaves the undone run's record untouched", async () => {
+    it("spends the undone run's priors and leaves the rest of its record alone", async () => {
         await using node = await makeNode();
         const peer = testPeer("untouched");
         const { original, rollback } = await parkedRollback(node, "untouched", peer);
 
+        // Serialised, so the comparison cannot be satisfied by both sides being the same live object.
         const persisted = () =>
-            node.act(a => JSON.stringify(a.get(TestTaskManager).state.runs[String(original.runId)]));
+            node.act(a =>
+                JSON.stringify({ ...a.get(TestTaskManager).state.runs[String(original.runId)], changeSet: 0 }),
+            );
+        const priors = () => node.act(a => a.get(TestTaskManager).state.runs[String(original.runId)].changeSet);
         const before = await persisted();
+        expect(await priors()).not.deep.equals([]);
+
         await node.act(a => a.get(TestTaskManager).abandon(rollback.runId));
+
+        expect(await priors()).deep.equals([]);
         expect(await persisted()).equals(before);
+    });
+
+    it("spends the undone run's priors on the in-memory twin too", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("untouched-memory");
+        const { original, rollback } = await parkedRollback(node, "untouched-memory", peer);
+
+        await node.act(a => a.get(TestTaskManager).abandon(rollback.runId));
+
+        const record = await node.act(a => a.get(TestTaskManager).record(original.runId) as RunRecord);
+        expect(record.changeSet).deep.equals([]);
+    });
+
+    it("drops the priors of a run that crossed its point of no return inside the cancel", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("pnr");
+        peer.setIntent("groupMembership", "X", { v: 1 });
+        await node.act(a => a.get(TestTaskManager).register(PointOfNoReturnTask));
+        const running = await node.act(a =>
+            a.get(TestTaskManager).run(PointOfNoReturnTask, { tag: "pnr", peerId: "pnr" }),
+        );
+        await pumpUntil("first phase wrote", () => (peer.items[KEY]?.intent as { v?: number })?.v === 2);
+
+        // The driver is held on the write that advances its phase index, so it has already passed the check
+        // that would have stopped it. The cancel's entry check still sees phase 0, where the run is revertible.
+        const release = await node.act(a => a.get(TestTaskManager).holdPersistMutex());
+        const cancelling = node.act(a => a.get(TestTaskManager).cancel(running.runId));
+        release();
+        const rollback = await cancelling;
+
+        // By the time the cancel decided, the run was past its point of no return, so there is no undo — and
+        // nothing else will ever replay what it recorded.
+        expect(rollback).equals(undefined);
+        const record = await node.act(a => a.get(TestTaskManager).state.runs[String(running.runId)]);
+        expect(record.state).equals("cancelled");
+        expect(record.wrote).equals(true);
+        expect(record.revertRunId).equals(undefined);
+        expect(record.changeSet).deep.equals([]);
     });
 
     it("refuses a run of the undone target while the abandon is in flight", async () => {
@@ -738,35 +806,6 @@ describe("abandon", () => {
         expect(outcome).instanceOf(TaskSupersededError);
     });
 
-    it("answers a rollback an older build recorded as cancelled", async () => {
-        const environment = new Environment("abandon-legacy");
-        {
-            await using seed = await makeNode(environment, "legacy");
-            const peer = testPeer("legacy");
-            const { rollback } = await parkedRollback(seed, "legacy", peer);
-            // Ended first, so nothing is driving it and its record can be rewritten into the shape a build
-            // that still admitted `cancel` of a rollback left behind: called off, with nothing undone and
-            // nothing saying the device was left part-changed.
-            await seed.act(a => a.get(TestTaskManager).abandon(rollback.runId));
-            await seed.act(a => {
-                const manager = a.get(TestTaskManager);
-                const stored = { ...manager.state.runs };
-                stored[String(rollback.runId)] = { ...stored[String(rollback.runId)], state: "cancelled" };
-                manager.state.runs = stored;
-            });
-            legacyRollbackId = rollback.runId;
-        }
-
-        await using node = await makeNode(environment, "legacy");
-        expect((await statusOf(node, legacyRollbackId))?.state).equals("cancelled");
-        expect(await attempt(node, m => m.abandon(legacyRollbackId))).instanceOf(TaskAlreadyUndoneError);
-    });
-});
-
-describe("cancel of a rollback", () => {
-    before(() => MockTime.init());
-    beforeEach(reset);
-
     it("is refused, and points at abandon", async () => {
         await using node = await makeNode();
         const peer = testPeer("nocancel");
@@ -888,27 +927,6 @@ describe("retryRollback", () => {
             Object.values(a.get(TestTaskManager).state.runs).filter(r => r.revertOf === original.runId),
         );
         expect(rollbacks.map(r => r.runId)).deep.equals([rollback.runId]);
-    });
-
-    it("refuses a rollback an older build recorded as cancelled", async () => {
-        const environment = new Environment("retry-legacy");
-        let originalId: RunId;
-        {
-            await using seed = await makeNode(environment, "retrylegacy");
-            const peer = testPeer("retrylegacy");
-            const { original, rollback } = await parkedRollback(seed, "retrylegacy", peer);
-            originalId = original.runId;
-            await seed.act(a => a.get(TestTaskManager).abandon(rollback.runId));
-            await seed.act(a => {
-                const manager = a.get(TestTaskManager);
-                const stored = { ...manager.state.runs };
-                stored[String(rollback.runId)] = { ...stored[String(rollback.runId)], state: "cancelled" };
-                manager.state.runs = stored;
-            });
-        }
-
-        await using node = await makeNode(environment, "retrylegacy");
-        expect(await attempt(node, m => m.retryRollback(originalId))).instanceOf(TaskAlreadyUndoneError);
     });
 
     it("refuses a rollback an operator abandoned", async () => {

--- a/packages/node-manager/test/task/TransitionsTest.ts
+++ b/packages/node-manager/test/task/TransitionsTest.ts
@@ -928,6 +928,24 @@ describe("retryRollback", () => {
         expect(outcome).instanceOf(TaskRollbackPendingError);
     });
 
+    it("answers a concluded rollback without claiming an undo is still running", async () => {
+        await using node = await makeNode();
+        const peer = testPeer("concluded-cancel");
+        const { original, rollback } = await parkedRollback(node, "concluded-cancel", peer);
+
+        peer.markHas("groupMembership", "X");
+        peer.setReachable(true);
+        await pumpUntil("rollback completed", () =>
+            node.act(a => a.get(TestTaskManager).get(rollback.runId)?.status.state === "completed"),
+        );
+
+        // The outcome says an undo exists, not that one is in flight: `rollbackFor` answers for a recorded
+        // rollback whatever its state, so a caller that read the outcome as "still running" would wait forever.
+        const cancellation = await node.act(a => a.get(TestTaskManager).cancel(original.runId));
+        expect(cancellation.outcome).equals(TaskCancelOutcome.Rollback);
+        expect(cancellation.rollback?.status.state).equals("completed");
+    });
+
     it("refuses a rollback that already restored the device", async () => {
         await using node = await makeNode();
         const peer = testPeer("concluded");

--- a/packages/node-manager/test/task/helpers.ts
+++ b/packages/node-manager/test/task/helpers.ts
@@ -5,7 +5,7 @@
  */
 
 import { RunRecord, TaskDefinition, TaskPersistence } from "#task/Task.js";
-import { TaskHandle, TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
+import { TaskCancellation, TaskHandle, TaskManagerBehavior } from "#task/TaskManagerBehavior.js";
 import { PlannedChange, RunId, TaskPhase, TaskStatus } from "#task/types.js";
 import { Immutable, InternalError, Observable } from "@matter/general";
 import { ClientNode, DesiredStateBehavior, ItemKind, ItemMode, ItemState, ManagedItem, itemMapKey } from "@matter/node";
@@ -354,6 +354,11 @@ export function requireStatusOfSlot(manager: TaskManagerBehavior, slotKey: strin
 
 /** Cancel the newest run of a slot, or report that nothing answers to it. */
 export function cancelSlot(manager: TaskManagerBehavior, slotKey: string): Promise<TaskHandle | undefined> {
+    return cancelSlotOutcome(manager, slotKey).then(c => c.rollback);
+}
+
+/** As {@link cancelSlot}, for a test asserting what the cancel did rather than which rollback it produced. */
+export function cancelSlotOutcome(manager: TaskManagerBehavior, slotKey: string): Promise<TaskCancellation> {
     const runId = runIdOfSlot(manager, slotKey);
     if (runId === undefined) {
         // Mirrors cancel() of a run nothing answers to, so a test asserting that outcome still exercises it.


### PR DESCRIPTION
## What this changes

A task run records the values it overwrote on a device, so that a rollback can put them back. For a group key those values are key material.

Until now they were kept on several paths where no rollback existed, or could ever exist:

- a run whose rollback finished restoring the device
- a run whose rollback an operator gave up on
- a run for which no rollback was ever created
- **every rollback's own recorded values** — nothing undoes an undo, so nothing can ever read them

On each of those the values stayed in storage for the life of the node with nothing able to read them again.

One rule now decides this at every retirement: **the recorded values survive only while a rollback that can replay them exists.** That covers a rollback's own values without naming them, because a rollback never has a rollback. It replaces two hand-placed clears and the whole "can this type be reverted" consultation on the failure path — a run whose type cannot answer the question, or answers no, gets no rollback and therefore keeps nothing.

The two writes that end a rollback for good — it restored the device, or an operator abandoned it — additionally clear the values of the run it was undoing, in the same transaction that ends the rollback. That is safe because the only other writer of a finished run's record is refused for exactly as long as the rollback is being decided.

## Deletions

The package is unreleased and no store outside development has ever been written, so machinery that only served stores from earlier builds goes rather than being maintained: two load-time discards with their warning and counter, an unused table snapshot and a detach helper, and a rollback state this build cannot produce. The tests that existed only to hand-fabricate those states go with them.

A corrupt run identity in storage is now refused with a typed error. Previously it seeded the identity counter with `NaN`, after which no run was addressable for the life of the process.

## Notes for the reviewer

- A rollback is given a **copy** of the values it replays rather than sharing the original's array. The original's array is appended to in place by a running phase, and reaches storage by reference, so sharing it would let a later append mutate a persisted rollback's input.
- There is one reachable path where a cancel commits with recorded values and no rollback: a run can cross its point of no return *inside* the cancel, because the entry check and the post-unwind check ask the same question at different times. It has a test.
- No CHANGELOG entry: this package is unreleased and absent from the changelog, consistent with every prior change to it.

## Verification

`npm run build-clean`, `npm run format-verify`, `npm run lint` and the full `npm test` all pass. node-manager is 273/273 across ESM, CJS and Web.

Every added branch was mutation-tested. All four sites of the retirement rule and both sites of the rollback-concludes write are killed by a named test, as is the copy. Two branches survive deliberately: one writes a byte-identical no-op when removed, and one is unreachable for the reason its own comment gives.

CI does not run on this base — every workflow is `branches: [main]` — so the gates above are the authority.

## Not in this change

Removing a peer can re-issue that peer's local id to a different physical device, because the id counter is seeded from the surviving stores. That is a defect in `@matter/node`, and fixing it needs either an asynchronous `allocateId` or a reserved block with a re-reservation policy. It is a design decision in a shared package touching commissioning identity, so it does not belong here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
