### PR TITLE
Certification tests for the TCP block's remaining cases, and the session state they assert on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/testing
     - Breaking: `BackchannelCommand.SimulateLongPress` carries the switch's `featureMap`, which a chip test app requires to decide which events a press produces
+    - Breaking: A certification step can ask which sessions a controller holds with a node, and can drop the connection beneath a named one, via `CertNodeApi.sessions()` and `CertNodeApi.severTransportConnection()`
+    - Enhancement: A certification step's read may require a session that permits large payloads via `ReadAttributeOptions.largeMessage`
     - Enhancement: Chip certification test devices take simulation commands through the named pipe their app opens, so a step that operates the device runs against a chip app rather than skipping
     - Enhancement: Chip certification test devices also take simulation commands through their app's standard input, one character per poll interval, which is how chip's bridge app is operated
     - Enhancement: The matter.js bridge test device exposes the devices chip's bridge app does, on the same endpoints, and takes the same simulation commands
@@ -23,6 +25,9 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Enhancement: Per-step certification PICS is evaluated on chip device flavors too, and `result.json` reports how many steps their PICS excluded
     - Fix: A certification run's `result.json` no longer reports a passing verdict for a run that failed
     - Fix: A failure to attach a certification run's device logs fails the run instead of only warning
+
+- @matter/protocol
+    - Enhancement: `ClientRequest.largeMessage` requires a session that permits large payloads for any interaction, not only a command invocation; such an interaction establishes a TCP-backed session or fails rather than falling back to MRP
 
 - @matter/model
     - Enhancement: `DeviceTypeModel.effectiveComposition` states whether a device type composes its endpoint's `PartsList` of every descendant or of its own children

--- a/packages/protocol/src/action/client/ClientInteraction.ts
+++ b/packages/protocol/src/action/client/ClientInteraction.ts
@@ -85,7 +85,7 @@ export const SUBSCRIPTION_PROCESSING_TIME = Seconds(10);
  * Probe commands in a {@link ClientInvoke} for the Matter "Large Message Quality" ("L") flag.
  *
  * Legacy command requests carry no model reference, so callers using {@link Invoke.LegacyCommandRequest}
- * must continue to set {@link ClientInvoke.largeMessage} explicitly.
+ * must continue to set the request's `largeMessage` explicitly.
  *
  * @internal — exported for unit testing.
  */
@@ -1148,8 +1148,7 @@ export class ClientInteraction<
         // that would dispose prematurely when #begin returns, creating a zombie in the spans Set
         const lifetime = this.#lifetime.join(what);
 
-        // Large Message Quality commands require TCP transport
-        const requiredTransport = "largeMessage" in request && request.largeMessage ? ChannelType.TCP : undefined;
+        const requiredTransport = request.largeMessage ? ChannelType.TCP : undefined;
 
         let abort: Abort;
         let messenger: InteractionClientMessenger;

--- a/packages/protocol/src/action/client/ClientRequest.ts
+++ b/packages/protocol/src/action/client/ClientRequest.ts
@@ -68,9 +68,13 @@ export interface ClientRequest {
      * the interaction establishes a TCP-backed session or fails, and never falls back to MRP the way
      * a peer's transport preference does. A peer that negotiates TCP and then denies supporting it
      * fails with `TcpUnsupportedError`; one that simply cannot be reached over TCP fails however that
-     * connection attempt fails. Use it when the interaction's
-     * request or its response may exceed what MRP can carry — a command with Large Message Quality,
-     * or a read broad enough that the peer's report would otherwise be chunked.
+     * connection attempt fails. Use it when the interaction's request or its response may exceed what
+     * MRP can carry — a command with Large Message Quality, or a read broad enough that the peer's
+     * report would otherwise be chunked.
+     *
+     * The requirement reaches only an exchange provider that resolves a session per interaction. One
+     * bound to a fixed session — `DedicatedChannelExchangeProvider`, which commissioning and the
+     * deprecated `InteractionClient` use — sends on the session it holds, whatever its transport.
      *
      * @see {@link MatterSpecification.v16.Core} § 4.15.1
      */

--- a/packages/protocol/src/action/client/ClientRequest.ts
+++ b/packages/protocol/src/action/client/ClientRequest.ts
@@ -60,4 +60,19 @@ export interface ClientRequest {
      * already in flight may still be acted on by the peer.
      */
     abort?: AbortSignal;
+
+    /**
+     * Require a session that permits payloads larger than the IPv6 MTU.
+     *
+     * Such a session runs over TCP, so this is a hard transport requirement rather than a preference:
+     * the interaction establishes a TCP-backed session or fails, and never falls back to MRP the way
+     * a peer's transport preference does. A peer that negotiates TCP and then denies supporting it
+     * fails with `TcpUnsupportedError`; one that simply cannot be reached over TCP fails however that
+     * connection attempt fails. Use it when the interaction's
+     * request or its response may exceed what MRP can carry — a command with Large Message Quality,
+     * or a read broad enough that the peer's report would otherwise be chunked.
+     *
+     * @see {@link MatterSpecification.v16.Core} § 4.15.1
+     */
+    largeMessage?: boolean;
 }

--- a/packages/protocol/src/action/request/Invoke.ts
+++ b/packages/protocol/src/action/request/Invoke.ts
@@ -52,12 +52,6 @@ export interface CommandDecodeDetails {
 export interface ClientInvoke extends Invoke, ClientRequest {
     commands: Map<number | undefined, Invoke.AnyCommandRequest>;
     skipValidation?: boolean;
-
-    /**
-     * When true, the command has Large Message Quality — it may exceed the IPv6 MTU and
-     * requires TCP transport. Such commands are excluded from auto-batching.
-     */
-    largeMessage?: boolean;
 }
 
 /**

--- a/packages/protocol/test/action/client/LargeMessageTransportTest.ts
+++ b/packages/protocol/test/action/client/LargeMessageTransportTest.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ClientInteraction } from "#action/client/ClientInteraction.js";
+import { Read } from "#action/request/Read.js";
+import { MessageType } from "#interaction/InteractionMessenger.js";
+import { ExchangeManager } from "#protocol/ExchangeManager.js";
+import { ExchangeProvider, NewExchangeOptions } from "#protocol/ExchangeProvider.js";
+import { MessageExchange } from "#protocol/MessageExchange.js";
+import { ChannelType, Duration, Environment, Seconds } from "@matter/general";
+import { Specification } from "@matter/model";
+import { AttributeId, ClusterId, EndpointNumber, TlvDataReport } from "@matter/types";
+import { createDummyMessageExchange } from "../../interaction/interaction-utils.js";
+
+/** Records the options each interaction hands `initiateExchange`, which is where transport is decided. */
+class RecordingExchangeProvider extends ExchangeProvider {
+    readonly requested = new Array<NewExchangeOptions | undefined>();
+
+    constructor(private readonly exchange: MessageExchange) {
+        super(undefined as unknown as ExchangeManager);
+    }
+
+    readonly channelType = ChannelType.UDP;
+    readonly peerAddress = undefined;
+    readonly maxPathsPerInvoke = 10;
+
+    maximumPeerResponseTime(): Duration {
+        return Seconds(30);
+    }
+
+    async initiateExchange(options?: NewExchangeOptions): Promise<MessageExchange> {
+        this.requested.push(options);
+        return this.exchange;
+    }
+}
+
+async function readWith(options: { largeMessage?: boolean }) {
+    const exchange = await createDummyMessageExchange(false, false, messageType => {
+        if (messageType === MessageType.ReadRequest) {
+            return {
+                messageType: MessageType.ReportData,
+                payload: TlvDataReport.encode({
+                    interactionModelRevision: Specification.INTERACTION_MODEL_REVISION,
+                    suppressResponse: true,
+                }),
+            };
+        }
+    });
+
+    const provider = new RecordingExchangeProvider(exchange);
+    const client = new ClientInteraction({ environment: Environment.default, exchangeProvider: provider });
+
+    const request = {
+        ...Read({
+            attributes: [
+                {
+                    endpointId: EndpointNumber(0),
+                    clusterId: ClusterId(0x28),
+                    attributeId: AttributeId(1),
+                },
+            ],
+        }),
+        ...options,
+    };
+
+    try {
+        for await (const chunk of client.read(request)) {
+            for await (const _report of chunk) {
+                // The response carries no data; this drains the result so the interaction completes
+            }
+        }
+    } finally {
+        await client.close();
+    }
+
+    return provider.requested;
+}
+
+describe("largeMessage transport requirement", () => {
+    // The flag lives on ClientRequest rather than on an invoke, so a read must reach the same
+    // decision an invoke does: a large-payload session runs over TCP, and asking for one is a hard
+    // requirement rather than a preference the connect path may abandon.
+    it("requires TCP for a read that asks for a large payload", async () => {
+        const requested = await readWith({ largeMessage: true });
+
+        expect(requested).length(1);
+        expect(requested[0]?.requiredTransport).equal(ChannelType.TCP);
+    });
+
+    it("requires no particular transport for a read that does not", async () => {
+        const requested = await readWith({});
+
+        expect(requested).length(1);
+        expect(requested[0]?.requiredTransport).equal(undefined);
+    });
+
+    it("requires no particular transport when the flag is explicitly false", async () => {
+        const requested = await readWith({ largeMessage: false });
+
+        expect(requested).length(1);
+        expect(requested[0]?.requiredTransport).equal(undefined);
+    });
+});

--- a/packages/testing/src/chip/cert/controller-adapter.ts
+++ b/packages/testing/src/chip/cert/controller-adapter.ts
@@ -259,6 +259,52 @@ export interface ReadAttributeOptions {
      * didn't itself create.
      */
     fabricFiltered?: boolean;
+
+    /**
+     * Whether the read requires a session that permits payloads larger than the IPv6 MTU, which is a
+     * session over TCP (Matter Core § 4.15.1).
+     *
+     * A hard requirement, not a preference: a controller that cannot establish such a session fails
+     * the read, or refuses it with {@link UnsupportedByControllerError}, rather than reading over MRP
+     * — so a step asking for one cannot pass on a transport it did not use. A broad read is the case
+     * for it: the peer answers in a single report where MRP would have made it chunk.
+     */
+    largeMessage?: boolean;
+}
+
+/**
+ * One live session a controller holds with a node.
+ *
+ * Held state, like {@link ClientEndpointEntry}: the controller's own view of a session it
+ * established, which is the only side that can say whether the session *permits* a large payload —
+ * a peer can only be observed carrying one.
+ *
+ * A controller may hold several sessions with one node at once, one per transport, so every claim
+ * here is about the session {@link id} names. A case that reasoned about "the session" instead would
+ * be answered by whichever session happened to be newest: a check for a severed session's absence
+ * would pass on a sibling that was never severed, and a check for a large-payload session would fail
+ * on a sibling that never claimed to be one.
+ */
+export interface CertSessionInfo {
+    /**
+     * The controller's own id for this session, unique among the sessions it holds with this node.
+     *
+     * This is the handle every other session operation takes: a step captures it once and names it
+     * afterwards, rather than re-deriving which session it meant.
+     */
+    id: number;
+
+    /** Transport beneath the session, as the controller's own channel reports it. */
+    transport: "tcp" | "udp" | "ble";
+
+    /**
+     * Whether the session permits payloads larger than the IPv6 MTU — the property a case asserting
+     * "the session allows large payloads" is about.
+     */
+    largePayload: boolean;
+
+    /** Largest encoded message the session's channel accepts, in bytes. */
+    maxPayloadSize: number;
 }
 
 /**
@@ -379,6 +425,36 @@ export interface CertNodeApi {
      * As {@link clientEndpoints}, and refused the same way.
      */
     clientAttribute(path: ClientAttributePath): Promise<unknown>;
+
+    /**
+     * Every live session the controller holds with this node, in no particular order, and empty when
+     * it holds none.
+     *
+     * As {@link clientEndpoints}, and refused the same way — a controller that does not expose its own
+     * session state throws {@link UnsupportedByControllerError}. A session the controller can no longer
+     * describe (its channel already detached) is omitted rather than reported half-known.
+     */
+    sessions(): Promise<CertSessionInfo[]>;
+
+    /**
+     * Drop the transport connection beneath the session {@link CertSessionInfo.id} names, without
+     * closing the session first, so the peer sees the connection go rather than a `CloseSession`.
+     *
+     * This is what "the TH closes the TCP connection" asks for: a session close would tell the peer
+     * to forget the session, which is the case's own expected *outcome* and so cannot be its stimulus.
+     *
+     * Naming the session is what makes the operation unambiguous when the controller holds more than
+     * one. A controller that cannot reach into its own sessions at all refuses with
+     * {@link UnsupportedByControllerError}; being handed an id it does not hold, or one whose transport
+     * has no connection to sever, is a *state* error and fails rather than refusing — a step that
+     * reached either has already established something untrue about the session it captured.
+     *
+     * The session names the target; the *connection* is what goes. Where a transport shares one
+     * connection between sessions, every session on it drops — so a case needing one session to
+     * survive the sever must not assume this touches only the one it named.
+     */
+    severTransportConnection(sessionId: number): Promise<void>;
+
     openCommissioningWindow(opts: {
         timeout: number;
         enhanced: boolean;

--- a/packages/testing/src/chip/cert/controller-adapter.ts
+++ b/packages/testing/src/chip/cert/controller-adapter.ts
@@ -303,7 +303,12 @@ export interface CertSessionInfo {
      */
     largePayload: boolean;
 
-    /** Largest encoded message the session's channel accepts, in bytes. */
+    /**
+     * The session channel's payload ceiling, in bytes.
+     *
+     * A frame's own header counts against it, so the largest message a channel accepts is this less
+     * that header — four bytes for TCP.
+     */
     maxPayloadSize: number;
 }
 

--- a/packages/testing/src/chip/index.ts
+++ b/packages/testing/src/chip/index.ts
@@ -57,6 +57,7 @@ export type {
     GroupKeySetSpec,
     CertNodeApi,
     CertNodeRef,
+    CertSessionInfo,
     ClientAttributePath,
     ClientEndpointEntry,
     CommissioningTarget,

--- a/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
+++ b/support/chip-testing/src/cert/ChipToolControllerAdapter.ts
@@ -1155,6 +1155,24 @@ class ChipToolCertNodeApi implements CertNodeApi {
         );
     }
 
+    async sessions(): Promise<never> {
+        throw new UnsupportedByControllerError(
+            "the sessions the controller holds with a node",
+            "chip-tool",
+            "chip-tool exposes no session state of its own — a session lives inside the process it " +
+                "spawns per command, and nothing it prints names the transport beneath one",
+        );
+    }
+
+    async severTransportConnection(_sessionId: number): Promise<never> {
+        throw new UnsupportedByControllerError(
+            "severing the connection beneath a session",
+            "chip-tool",
+            "chip-tool owns no session a test can reach into, and it establishes a TCP-backed one for " +
+                "no interaction, so there is no connection to sever",
+        );
+    }
+
     async openCommissioningWindow(opts: {
         timeout: number;
         enhanced: boolean;
@@ -1196,6 +1214,16 @@ class ChipToolCertNodeApi implements CertNodeApi {
     }
 
     #read(paths: AttributePathSpec[], options?: ReadAttributeOptions) {
+        if (options?.largeMessage) {
+            throw new UnsupportedByControllerError(
+                "a read that requires a session permitting large payloads",
+                "chip-tool",
+                "chip-tool decides a session's transport when it establishes one and reuses the session " +
+                    "pairing already made, so it cannot be made to answer a single read over a " +
+                    "TCP-backed session",
+            );
+        }
+
         // chip-tool zips the three id lists into paths when their lengths match
         // (`InteractionModelConfig::GetAttributePaths`), so equal-length lists express any path set.
         let command =

--- a/support/chip-testing/src/cert/InProcessControllerAdapter.ts
+++ b/support/chip-testing/src/cert/InProcessControllerAdapter.ts
@@ -17,6 +17,7 @@ import {
     LogDestination,
     LogFormat,
     Logger,
+    ChannelType,
     MatterError,
     Millis,
     MockStorageService,
@@ -36,10 +37,12 @@ import {
     FabricAuthority,
     getOperationalDeviceQname,
     Invoke,
+    NodeSession,
     Peer as ProtocolPeer,
     PeerSet,
     Read,
     ReadResult,
+    SessionClosedError,
     Subscribe,
     Write,
     WriteResult,
@@ -82,6 +85,7 @@ import type {
     OnboardingPayloadFields,
     ReadAttributeOptions,
     ReadEventOptions,
+    CertSessionInfo,
     SubscribeEventOptions,
     PicsValues,
     SubscribeOptions,
@@ -484,6 +488,43 @@ function resolveCommissioningTarget(target: CommissioningTarget): ResolvedCommis
  */
 export class NoCommissionedPeerError extends MatterError {}
 
+/**
+ * Thrown when a session operation names a session the controller does not hold, or one whose
+ * transport has nothing to sever.
+ *
+ * A state error rather than a refusal: a step that reached it has already established something
+ * untrue about the session it captured, so it must fail rather than be recorded as skipped.
+ */
+export class SessionStateError extends MatterError {}
+
+/**
+ * A session's {@link MessageChannel}, or undefined for one that can no longer describe itself.
+ *
+ * `Session.channel` throws once the channel is detached, and `Peer.sessions` holds such a session
+ * until it is removed, so every reader has to tolerate it — reporting a session half-known would be
+ * worse than omitting it.
+ */
+function channelOf(session: NodeSession) {
+    try {
+        return session.channel;
+    } catch (error) {
+        SessionClosedError.accept(error);
+        return undefined;
+    }
+}
+
+/** {@link ChannelType} as {@link CertSessionInfo} names it; a new transport fails to compile here. */
+function transportNameOf(type: ChannelType): CertSessionInfo["transport"] {
+    switch (type) {
+        case ChannelType.TCP:
+            return "tcp";
+        case ChannelType.UDP:
+            return "udp";
+        case ChannelType.BLE:
+            return "ble";
+    }
+}
+
 class InProcessCertNodeApi implements CertNodeApi {
     readonly #adapterId: string;
     readonly #controller: ServerNode;
@@ -608,6 +649,7 @@ class InProcessCertNodeApi implements CertNodeApi {
                     fabricFilter: options?.fabricFiltered,
                 }),
                 includeKnownVersions: true,
+                largeMessage: options?.largeMessage,
             };
             for await (const chunk of this.#peer.interaction.read(request)) {
                 for await (const report of chunk) {
@@ -644,6 +686,7 @@ class InProcessCertNodeApi implements CertNodeApi {
             const request: ClientRead = {
                 ...Read({ attributes: paths.map(toIds), fabricFilter: options?.fabricFiltered }),
                 includeKnownVersions: true,
+                largeMessage: options?.largeMessage,
             };
             for await (const chunk of this.#peer.interaction.read(request)) {
                 for await (const report of chunk) {
@@ -777,6 +820,76 @@ class InProcessCertNodeApi implements CertNodeApi {
             }
 
             return heldValue(endpoint, ClusterId(path.cluster), path.attribute);
+        });
+    }
+
+    sessions(): Promise<CertSessionInfo[]> {
+        return runTagged(this.#adapterId, async () => {
+            const entries = new Array<CertSessionInfo>();
+            for (const session of this.#usableSessions) {
+                const channel = channelOf(session);
+                if (channel === undefined) {
+                    continue;
+                }
+                entries.push({
+                    id: session.id,
+                    transport: transportNameOf(channel.type),
+                    largePayload: session.supportsLargeMessages,
+                    maxPayloadSize: channel.maxPayloadSize,
+                });
+            }
+            return entries;
+        });
+    }
+
+    /**
+     * The peer's sessions the controller would actually use, which is a narrower set than the peer
+     * holds.
+     *
+     * `Peer.sessions` keeps a session until its `closing` fires, so it still contains one the
+     * controller has already written off — `handlePeerClose` sets `isPeerLost` and then awaits an
+     * emit before closing. Every other consumer in the protocol layer applies this same predicate
+     * (`Peer.newestSession`, `Peer.hasSession`, `SessionManager`), and a cert step reads these as
+     * sessions the controller *holds*, so reporting one it will not use would answer a different
+     * question than the step asks.
+     */
+    get #usableSessions() {
+        const peer = this.#protocolPeer;
+        if (peer === undefined) {
+            throw new NoCommissionedPeerError(
+                `Controller "${this.#adapterId}" has no peer with node id ${this.#nodeId}, so it holds no sessions`,
+            );
+        }
+        return [...peer.sessions].filter(session => !session.isClosing && !session.isPeerLost);
+    }
+
+    severTransportConnection(sessionId: number): Promise<void> {
+        return runTagged(this.#adapterId, async () => {
+            const session = this.#usableSessions.find(candidate => candidate.id === sessionId);
+            if (session === undefined) {
+                throw new SessionStateError(
+                    `Controller "${this.#adapterId}" holds no session ${sessionId} with node id ${this.#nodeId}`,
+                );
+            }
+
+            const channel = channelOf(session);
+            if (channel === undefined) {
+                throw new SessionStateError(
+                    `Session ${sessionId} with node id ${this.#nodeId} has no channel to sever`,
+                );
+            }
+
+            const { transportChannel } = channel;
+            if (transportChannel.type !== ChannelType.TCP) {
+                throw new SessionStateError(
+                    `Session ${sessionId} with node id ${this.#nodeId} runs over ` +
+                        `${transportNameOf(transportChannel.type)}, which holds no connection to sever`,
+                );
+            }
+
+            // The stimulus must not tell the peer anything: the peer forgetting the session is the
+            // outcome a case asserts, so it cannot also be what this does
+            await transportChannel.close();
         });
     }
 

--- a/support/chip-testing/test/cert-framework/cert-test.test.ts
+++ b/support/chip-testing/test/cert-framework/cert-test.test.ts
@@ -34,6 +34,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { env } from "node:process";
 import { CommissionedRefs } from "../cert/tc-support.js";
+import { fakeCertNode } from "./fake-cert-node.js";
 
 async function notImplemented(..._args: unknown[]): Promise<never> {
     throw new Error("Container access is not available in this unit test");
@@ -947,23 +948,7 @@ describe("CertTest", () => {
         const commissioned = new CommissionedRefs<"dut">();
 
         function nodeFor(role: "dut"): CertNodeApi {
-            const unused = () => Promise.reject(new Error("not used by this test"));
-            return {
-                invoke: unused,
-                invokeBatch: unused,
-                readAttribute: unused,
-                readAttributes: unused,
-                writeAttribute: unused,
-                writeAttributes: unused,
-                subscribe: unused,
-                readEvents: unused,
-                subscribeEvents: unused,
-                clientEndpoints: unused,
-                clientAttribute: unused,
-                openCommissioningWindow: unused,
-                operationalMdnsInstanceName: unused,
-                decommission: async () => void decommissioned.push(role),
-            };
+            return fakeCertNode({ decommission: async () => void decommissioned.push(role) });
         }
         const noLines = async function* (): AsyncGenerator<string> {};
         const controller: ControllerAdapter = {

--- a/support/chip-testing/test/cert-framework/controller-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/controller-adapter.test.ts
@@ -22,7 +22,12 @@ import { expect } from "chai";
 import { env } from "node:process";
 import { AllClustersTestInstance } from "../../src/AllClustersTestInstance.js";
 import { CHIP_TOOL_CONTROLLER_PICS, ChipToolControllerAdapter } from "../../src/cert/ChipToolControllerAdapter.js";
-import { InProcessControllerAdapter, MATTERJS_CONTROLLER_PICS } from "../../src/cert/InProcessControllerAdapter.js";
+import {
+    InProcessControllerAdapter,
+    MATTERJS_CONTROLLER_PICS,
+    NoCommissionedPeerError,
+    SessionStateError,
+} from "../../src/cert/InProcessControllerAdapter.js";
 import { OnboardingPayloadRefusedError } from "../../src/cert/onboarding-payload.js";
 import { manualPairingCode } from "../cert/tc-dd-support.js";
 
@@ -174,6 +179,84 @@ describe("InProcessControllerAdapter", () => {
         } finally {
             await adapter.node(ref).decommission();
         }
+    });
+
+    // The certification cases read these through `fakeCertNode` in the hermetic suite, which cannot
+    // catch the projection itself being wrong — the session's transport, what it reports about large
+    // payloads, or which sessions it omits
+    it("reports the session it holds with a commissioned peer, and what that session permits", async function () {
+        this.timeout(30_000);
+
+        const ref = await adapter.commission({ passcode: 20202021, discriminator: 3840 });
+
+        try {
+            const sessions = await adapter.node(ref).sessions();
+
+            expect(sessions, "the controller holds a session with the peer it commissioned").length.greaterThan(0);
+            for (const session of sessions) {
+                expect(session.id, "a session reports the controller's own id for it").a("number");
+                expect(["tcp", "udp", "ble"], "a session names its transport").contains(session.transport);
+                expect(session.maxPayloadSize, "a session reports its payload ceiling").greaterThan(0);
+                // This adapter asked for no transport, so its session is an MRP one, and MRP does not
+                // carry a large payload
+                expect(session.largePayload, `${session.transport} session permits a large payload`).equal(
+                    session.transport === "tcp",
+                );
+            }
+        } finally {
+            await adapter.node(ref).decommission();
+        }
+    });
+
+    // Naming a session the controller does not hold is a statement about runtime state, so it fails
+    // the step rather than being recorded as a controller that cannot do this at all
+    it("refuses to sever a session it does not hold", async function () {
+        this.timeout(30_000);
+
+        const ref = await adapter.commission({ passcode: 20202021, discriminator: 3840 });
+
+        try {
+            const held = await adapter.node(ref).sessions();
+            const unknown = Math.max(0, ...held.map(session => session.id)) + 1;
+
+            await expect(adapter.node(ref).severTransportConnection(unknown)).rejectedWith(
+                SessionStateError,
+                /holds no session/,
+            );
+        } finally {
+            await adapter.node(ref).decommission();
+        }
+    });
+
+    it("refuses to sever a session whose transport holds no connection", async function () {
+        this.timeout(30_000);
+
+        const ref = await adapter.commission({ passcode: 20202021, discriminator: 3840 });
+
+        try {
+            const sessions = await adapter.node(ref).sessions();
+            const mrp = sessions.find(session => session.transport !== "tcp");
+            expect(mrp, "this adapter asked for no transport, so its session is an MRP one").not.undefined;
+
+            await expect(adapter.node(ref).severTransportConnection(mrp!.id)).rejectedWith(
+                SessionStateError,
+                /holds no connection to sever/,
+            );
+        } finally {
+            await adapter.node(ref).decommission();
+        }
+    });
+
+    it("reports no sessions once the peer is gone", async function () {
+        this.timeout(30_000);
+
+        const ref = await adapter.commission({ passcode: 20202021, discriminator: 3840 });
+        const node = adapter.node(ref);
+        await node.decommission();
+
+        // A vanished peer is not an empty session set: a check reading "no sessions held" as "the
+        // session went away" would otherwise pass on the peer having been removed instead
+        await expect(node.sessions()).rejectedWith(NoCommissionedPeerError);
     });
 
     it("commissions from the device's own QR onboarding payload", async function () {

--- a/support/chip-testing/test/cert-framework/controller-adapter.test.ts
+++ b/support/chip-testing/test/cert-framework/controller-adapter.test.ts
@@ -247,7 +247,7 @@ describe("InProcessControllerAdapter", () => {
         }
     });
 
-    it("reports no sessions once the peer is gone", async function () {
+    it("refuses to report sessions once the peer is gone", async function () {
         this.timeout(30_000);
 
         const ref = await adapter.commission({ passcode: 20202021, discriminator: 3840 });

--- a/support/chip-testing/test/cert-framework/fake-cert-node.ts
+++ b/support/chip-testing/test/cert-framework/fake-cert-node.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InternalError } from "@matter/general";
+import type { CertNodeApi } from "@matter/testing";
+
+/**
+ * A {@link CertNodeApi} whose every method rejects, with `overrides` for the ones a test drives.
+ *
+ * Shared so that adding a method to {@link CertNodeApi} does not have to be repeated in each test
+ * that stands one up: a stub spelling out every method compiles only until the interface grows, and
+ * the failure is a type error in tests that have nothing to do with the new method.
+ */
+export function fakeCertNode(overrides: Partial<CertNodeApi> = {}): CertNodeApi {
+    const unused = () => Promise.reject(new InternalError("not used by these tests"));
+    return {
+        invoke: unused,
+        invokeBatch: unused,
+        readAttribute: unused,
+        readAttributes: unused,
+        writeAttribute: unused,
+        writeAttributes: unused,
+        subscribe: unused,
+        readEvents: unused,
+        subscribeEvents: unused,
+        clientEndpoints: unused,
+        clientAttribute: unused,
+        sessions: unused,
+        severTransportConnection: unused,
+        openCommissioningWindow: unused,
+        operationalMdnsInstanceName: unused,
+        decommission: unused,
+        ...overrides,
+    };
+}

--- a/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-dd-support.test.ts
@@ -57,6 +57,7 @@ import {
     USER_INTENT_FLOW,
 } from "../cert/tc-dd-support.js";
 import { CertCheckFailedError, CertCleanupError, CommissionedRefs } from "../cert/tc-support.js";
+import { fakeCertNode } from "./fake-cert-node.js";
 
 /**
  * `devicediscovery.adoc`'s own example payload for TC-DD-3.14: vendor id 0xFFF1, product id 0x8001,
@@ -191,23 +192,7 @@ function contextWith(
     const unused = () => Promise.reject(new InternalError("not used by these tests"));
     const noLines = async function* (): AsyncGenerator<string> {};
 
-    const nodeFor = (ref: CertNodeRef) =>
-        ({
-            invoke: unused,
-            invokeBatch: unused,
-            readAttribute: unused,
-            readAttributes: unused,
-            writeAttribute: unused,
-            writeAttributes: unused,
-            subscribe: unused,
-            readEvents: unused,
-            subscribeEvents: unused,
-            clientEndpoints: unused,
-            clientAttribute: unused,
-            openCommissioningWindow: unused,
-            operationalMdnsInstanceName: unused,
-            decommission: () => decommission(ref),
-        }) satisfies CertNodeApi;
+    const nodeFor = (ref: CertNodeRef) => fakeCertNode({ decommission: () => decommission(ref) });
 
     const dut = {
         id: "dut",
@@ -1083,28 +1068,16 @@ class UnpairFixture {
         this.#log = log;
         const unused = () => Promise.reject(new InternalError("not used by these tests"));
 
-        const node: CertNodeApi = {
-            invoke: unused,
-            invokeBatch: unused,
-            readAttributes: unused,
-            writeAttribute: unused,
-            writeAttributes: unused,
-            subscribe: unused,
-            readEvents: unused,
-            subscribeEvents: unused,
-            clientEndpoints: unused,
-            clientAttribute: unused,
-            openCommissioningWindow: unused,
+        const node: CertNodeApi = fakeCertNode({
             readAttribute: async () => {
                 this.calls.push("readFabricIndex");
                 return fabricIndex;
             },
-            operationalMdnsInstanceName: unused,
             decommission: async () => {
                 this.calls.push("decommission");
                 onDecommission();
             },
-        };
+        });
 
         const device: CertDevice = {
             id: "th",

--- a/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-idm-4.1-support.test.ts
@@ -21,6 +21,7 @@ import { env } from "node:process";
 import type { SubscribeAndModifyTimeouts } from "../cert/tc-idm-4.1-support.js";
 import { subscribeAndModify } from "../cert/tc-idm-4.1-support.js";
 import { CertCheckFailedError } from "../cert/tc-support.js";
+import { fakeCertNode } from "./fake-cert-node.js";
 
 const SUBSCRIPTION_ID = 0x2a;
 
@@ -95,20 +96,7 @@ class Fixture {
     ) {
         this.#log = new LogFollower(this.#source, "th");
 
-        const unused = () => Promise.reject(new InternalError("not used by these tests"));
-        const node: CertNodeApi = {
-            invoke: unused,
-            invokeBatch: unused,
-            readAttribute: unused,
-            readAttributes: unused,
-            writeAttributes: unused,
-            readEvents: unused,
-            subscribeEvents: unused,
-            clientEndpoints: unused,
-            clientAttribute: unused,
-            openCommissioningWindow: unused,
-            operationalMdnsInstanceName: unused,
-            decommission: unused,
+        const node: CertNodeApi = fakeCertNode({
             subscribe: async (_path, opts) => {
                 this.#onUpdate = opts.onUpdate;
                 this.push(...subscribeRequestLines(PATH), ...subscribeResponseLines(SUBSCRIPTION_ID));
@@ -126,7 +114,7 @@ class Fixture {
             writeAttribute: async (_path, value) => {
                 this.onWrite(this, this.#writes++, value);
             },
-        };
+        });
 
         const device: CertDevice = {
             ...stubSubject(),

--- a/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
@@ -4,17 +4,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { CertDevice, CertStepContext, CheckRecord, DeviceFlavor, Subject } from "@matter/testing";
+import { InternalError, Millis } from "@matter/general";
+import type {
+    CertDevice,
+    CertSessionInfo,
+    CertStepContext,
+    CheckRecord,
+    ControllerAdapter,
+    DeviceFlavor,
+    Subject,
+} from "@matter/testing";
 import { LineQueue, LogFollower, PicsFile } from "@matter/testing";
 import {
+    largePayloadSessionCheck,
     noFurtherSessionCheck,
     recordTcpInvoke,
     recordTcpSession,
     regularSizedRequestCheck,
+    describeSessions,
+    recordSeveredSession,
+    sessionEvictionUnreadableCheck,
+    sessionGoneCheck,
+    sessionWithId,
+    tcpSessionIdOf,
     wildcardReadInOneReportCheck,
     TcpSessionRef,
 } from "../cert/tc-sc-8-support.js";
 import { CertCheckFailedError } from "../cert/tc-support.js";
+import { fakeCertNode } from "./fake-cert-node.js";
 
 /** GeneralDiagnostics, and its TimeSnapshot command, which TC-SC-8.5 invokes. */
 const CLUSTER = 0x33;
@@ -22,6 +39,8 @@ const COMMAND = 0x1;
 const ENDPOINT = 0;
 
 const SESSION = "@1:86c217a36142d632•c8b8";
+const CHANNEL = "tcp://[fe80::1%en0]«60111";
+const SESSION_FACTS = { tag: SESSION, channel: CHANNEL, controllerSessionId: 0xc8b8 };
 const OTHER_SESSION = "@1:86c217a36142d632•9f2c";
 
 function at(millis: number) {
@@ -33,6 +52,22 @@ const pairingRequest = (session = SESSION) =>
     `${at(0)} INFO CaseServer •unsecured#${session}(tcp)⇵2c56 Pairing request « tcp://[fe80::1%en0]«60111`;
 const newSession = (session = SESSION) =>
     `${at(1)} INFO CaseServer ${session}(tcp) New session with @1:86c217a36142d632 2↔1 address: tcp://[fe80::1%en0]«60111`;
+
+/** What the TH holds for a TCP-backed session it established, as `CertSessionInfo` reports it. */
+const TCP_HELD: CertSessionInfo = {
+    id: 0xc8b8,
+    transport: "tcp",
+    largePayload: true,
+    maxPayloadSize: 65523,
+};
+
+/** A session over the other transport a controller may hold with the same peer at the same time. */
+const UDP_HELD: CertSessionInfo = {
+    id: 0x9f2c,
+    transport: "udp",
+    largePayload: false,
+    maxPayloadSize: 1280,
+};
 
 const INVOKE_EXCHANGE = "2c57";
 
@@ -108,7 +143,10 @@ async function withDut<T>(
 describe("recordTcpSession", () => {
     it("returns the session tag the DUT's own line names", async () => {
         await withDut([pairingRequest(), newSession()], async (cx, checks) => {
-            expect(await recordTcpSession(cx, 0, "runs over TCP")).equal(SESSION);
+            expect(await recordTcpSession(cx, 0, "runs over TCP")).deep.equal({
+                tag: SESSION,
+                channel: CHANNEL,
+            });
             expect(checks.map(check => check.verdict)).deep.equal(["pass", "pass"]);
         });
     });
@@ -404,10 +442,248 @@ describe("TcpSessionRef", () => {
 
     it("forgets the session a finalizer cleared", () => {
         const session = new TcpSessionRef();
-        session.set(SESSION);
-        expect(session.require()).equal(SESSION);
+        session.set(SESSION_FACTS);
+        expect(session.require()).deep.equal(SESSION_FACTS);
 
         session.clear();
         expect(() => session.require()).throw(CertCheckFailedError);
+    });
+});
+
+describe("largePayloadSessionCheck", () => {
+    it("passes for the named TCP session permitting large payloads", () => {
+        const check = largePayloadSessionCheck([TCP_HELD], TCP_HELD.id);
+
+        expect(check.verdict).equal("pass");
+        expect(check.detail).match(/tcp session 51384, which permits large payloads/);
+    });
+
+    it("fails when the controller holds no sessions at all", () => {
+        const check = largePayloadSessionCheck([], TCP_HELD.id);
+
+        expect(check.verdict).equal("fail");
+        expect(check.detail).match(/no sessions/);
+    });
+
+    // The hole the identified API closes: a sibling session over another transport must neither
+    // satisfy this check nor fail it
+    it("fails when the named session is absent, whatever else is held", () => {
+        const check = largePayloadSessionCheck([UDP_HELD], TCP_HELD.id);
+
+        expect(check.verdict).equal("fail");
+        expect(check.detail).match(/no session 51384 with the DUT, and holds udp session 40748/);
+    });
+
+    it("judges the named session, not the one that comes first", () => {
+        expect(largePayloadSessionCheck([UDP_HELD, TCP_HELD], TCP_HELD.id).verdict).equal("pass");
+    });
+
+    // Only TCP carries a large payload, so a UDP session claiming to permit one is reporting
+    // something the peer could not receive
+    it("fails for a session over another transport", () => {
+        const udpClaimingLargePayload = { ...UDP_HELD, largePayload: true, maxPayloadSize: 65523 };
+
+        expect(largePayloadSessionCheck([udpClaimingLargePayload], UDP_HELD.id).verdict).equal("fail");
+    });
+
+    it("fails for a session that denies large payloads", () => {
+        expect(largePayloadSessionCheck([{ ...TCP_HELD, largePayload: false }], TCP_HELD.id).verdict).equal("fail");
+    });
+
+    // The claim is about payloads MRP cannot carry, so a ceiling at the MTU leaves "permits"
+    // describing nothing
+    it("fails for a payload ceiling no larger than the IPv6 MTU", () => {
+        expect(largePayloadSessionCheck([{ ...TCP_HELD, maxPayloadSize: 1280 }], TCP_HELD.id).verdict).equal("fail");
+    });
+});
+
+describe("sessionGoneCheck", () => {
+    it("passes when the controller holds no sessions at all", () => {
+        expect(sessionGoneCheck(SESSION_FACTS, []).verdict).equal("pass");
+    });
+
+    it("passes when the controller holds only other sessions", () => {
+        const check = sessionGoneCheck(SESSION_FACTS, [UDP_HELD]);
+
+        expect(check.verdict).equal("pass");
+        expect(check.detail).match(/no longer holds session 51384, and holds udp session 40748/);
+    });
+
+    // The failure the check exists for, and the reason it is identified rather than counted: a
+    // check that asked whether any session exists — or whether the newest one differs — would pass
+    // on the very session it was supposed to have destroyed
+    it("fails when the severed session is still held alongside another", () => {
+        const check = sessionGoneCheck(SESSION_FACTS, [UDP_HELD, TCP_HELD]);
+
+        expect(check.verdict).equal("fail");
+        expect(check.detail).match(/still holds session 51384/);
+    });
+
+    it("fails when the controller still holds the severed session alone", () => {
+        expect(sessionGoneCheck(SESSION_FACTS, [TCP_HELD]).verdict).equal("fail");
+    });
+});
+
+describe("tcpSessionIdOf", () => {
+    it("answers the id of the one TCP session held", () => {
+        expect(tcpSessionIdOf([UDP_HELD, TCP_HELD])).equal(TCP_HELD.id);
+    });
+
+    it("refuses when no TCP session is held", () => {
+        expect(() => tcpSessionIdOf([UDP_HELD])).throw(CertCheckFailedError, /holds 0 TCP sessions/);
+    });
+
+    // Two is reachable — a peer-lost session lingers, an inbound session joins the same peer — so it
+    // must refuse rather than pick one, or the case reasons about whichever came back first
+    it("refuses when two TCP sessions are held", () => {
+        expect(() => tcpSessionIdOf([TCP_HELD, { ...TCP_HELD, id: 0x1234 }])).throw(
+            CertCheckFailedError,
+            /holds 2 TCP sessions/,
+        );
+    });
+
+    it("names what is held, so a refusal says which sessions it saw", () => {
+        expect(() => tcpSessionIdOf([UDP_HELD])).throw(/holds udp session 40748/);
+    });
+});
+
+describe("recordSeveredSession", () => {
+    /** A TH whose `sessions()` answers each element of `reads` in turn, and the last one thereafter. */
+    function thReading(reads: CertSessionInfo[][]) {
+        const severed = new Array<number>();
+        let call = 0;
+        const th = {
+            id: "th",
+            log: new LogFollower(new LineQueue().follow(), "th"),
+            async start() {},
+            async close() {},
+            async commission() {
+                return "ref";
+            },
+            parseQrPayload: () => Promise.reject(new InternalError("not used by these tests")),
+            parseManualPairingCode: () => Promise.reject(new InternalError("not used by these tests")),
+            node: () =>
+                fakeCertNode({
+                    sessions: async () => reads[Math.min(call++, reads.length - 1)],
+                    severTransportConnection: async id => void severed.push(id),
+                }),
+            group: (): never => {
+                throw new InternalError("not used by these tests");
+            },
+        } satisfies ControllerAdapter;
+
+        const checks = new Array<CheckRecord>();
+        const cx: CertStepContext = {
+            controllers: { th },
+            devices: {},
+            recorder: {
+                beginStep() {},
+                check(record) {
+                    checks.push(record);
+                },
+                endStep() {
+                    return [];
+                },
+                async flush() {
+                    return "";
+                },
+            },
+        };
+        return { cx, checks, severed, reads: () => call };
+    }
+
+    /** Long enough for a few poll turns, short enough for a hermetic test's own timeout. */
+    const POLL_BOUND = Millis(300);
+
+    function refHolding(facts = SESSION_FACTS) {
+        const ref = new TcpSessionRef();
+        ref.set(facts);
+        return ref;
+    }
+
+    it("severs the session the case captured, by id", async () => {
+        const { cx, severed } = thReading([[]]);
+
+        await recordSeveredSession(cx, "ref", refHolding());
+
+        expect(severed).deep.equal([SESSION_FACTS.controllerSessionId]);
+    });
+
+    it("passes on the first read when the session is already gone", async () => {
+        const { cx, checks, reads } = thReading([[]]);
+
+        await recordSeveredSession(cx, "ref", refHolding());
+
+        expect(checks.map(check => check.verdict)).deep.equal(["pass", "unverified"]);
+        expect(reads()).equal(1);
+    });
+
+    // The race the poll exists for: eviction runs on a worker no step can await, so the severed
+    // session is still held on the first read
+    it("waits for an eviction that has not happened yet", async () => {
+        const { cx, checks, reads } = thReading([[TCP_HELD], [TCP_HELD], [UDP_HELD]]);
+
+        await recordSeveredSession(
+            cx,
+            "ref",
+            refHolding({ ...SESSION_FACTS, controllerSessionId: TCP_HELD.id }),
+            POLL_BOUND,
+        );
+
+        expect(checks[0].verdict).equal("pass");
+        expect(reads()).equal(3);
+    });
+
+    // A timeout must not read as success — the severed session still being held is the failure
+    it("fails when the session is never evicted", async () => {
+        const { cx, checks } = thReading([[TCP_HELD]]);
+
+        await expect(
+            recordSeveredSession(
+                cx,
+                "ref",
+                refHolding({ ...SESSION_FACTS, controllerSessionId: TCP_HELD.id }),
+                POLL_BOUND,
+            ),
+        ).rejectedWith(CertCheckFailedError);
+
+        expect(checks[0].verdict).equal("fail");
+    });
+});
+
+describe("sessionWithId", () => {
+    it("finds the session the id names", () => {
+        expect(sessionWithId([UDP_HELD, TCP_HELD], TCP_HELD.id)).deep.equal(TCP_HELD);
+    });
+
+    it("answers undefined for an id nothing holds", () => {
+        expect(sessionWithId([UDP_HELD], TCP_HELD.id)).equal(undefined);
+    });
+});
+
+describe("describeSessions", () => {
+    it("names every session held", () => {
+        expect(describeSessions([UDP_HELD, TCP_HELD])).equal("udp session 40748, tcp session 51384");
+    });
+
+    it("says so when none are held, rather than reading as an empty list", () => {
+        expect(describeSessions([])).equal("no sessions");
+    });
+});
+
+describe("sessionEvictionUnreadableCheck", () => {
+    // The device does evict, and says so; the harness cannot attribute the line, so the record has to
+    // state that rather than let an unmatched pattern read as a device that failed to evict
+    it("records the device half as an accepted gap", () => {
+        const check = sessionEvictionUnreadableCheck(SESSION_FACTS);
+
+        expect(check.type).equal("device-log");
+        expect(check.verdict).equal("unverified");
+        expect(check.accepted).match(/carries no device attribution/);
+        expect(check.detail).match(/@1:86c217a36142d632•c8b8/);
+    });
+
+    it("names the connection the session ran on", () => {
+        expect(sessionEvictionUnreadableCheck(SESSION_FACTS).detail).contain(CHANNEL);
     });
 });

--- a/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-sc-8-support.test.ts
@@ -22,6 +22,7 @@ import {
     recordTcpSession,
     regularSizedRequestCheck,
     describeSessions,
+    furtherSessionCheck,
     recordSeveredSession,
     sessionEvictionUnreadableCheck,
     sessionGoneCheck,
@@ -648,6 +649,63 @@ describe("recordSeveredSession", () => {
         ).rejectedWith(CertCheckFailedError);
 
         expect(checks[0].verdict).equal("fail");
+    });
+});
+
+describe("furtherSessionCheck", () => {
+    const furtherSession = (session = OTHER_SESSION) =>
+        `${at(7)} INFO CaseServer ${session}(tcp) New session with @1:86c217a36142d632 2↔1 address: tcp://[fe80::1%en0]«60222`;
+    const furtherResumed = (session = OTHER_SESSION) =>
+        `${at(8)} INFO CaseServer ${session}(tcp) Resumed session with @1:86c217a36142d632 address: tcp://[fe80::1%en0]«60222`;
+
+    it("passes and names the session for a further session over TCP", async () => {
+        await withDut([furtherSession()], async cx => {
+            const check = await furtherSessionCheck(cx, 0);
+
+            expect(check.verdict).equal("pass");
+            expect(check.matched).equal(OTHER_SESSION);
+            expect(check.detail).match(/accepted @1:86c217a36142d632•9f2c over TCP/);
+        });
+    });
+
+    // Resumption is a CASE session establishment, and a DUT doing the spec-preferred thing must not
+    // fail the case
+    it("passes for a resumed session", async () => {
+        await withDut([furtherResumed()], async cx => {
+            expect((await furtherSessionCheck(cx, 0)).verdict).equal("pass");
+        });
+    });
+
+    // The controller's own session id is what the step rests on, so a missing line is an accepted gap
+    // rather than a failure — which is the whole reason this check does not gate the step
+    it("accepts a log with no further session rather than failing", async () => {
+        await withDut([], async cx => {
+            const check = await furtherSessionCheck(cx, 0);
+
+            expect(check.verdict).equal("unverified");
+            expect(check.accepted).match(/controller's own session id is what this step rests on/);
+        });
+    });
+
+    it("does not count a session over another transport", async () => {
+        const overUdp = `${at(7)} INFO CaseServer ${OTHER_SESSION} New session with @1:86c217a36142d632 2↔1 address: udp://[fe80::1%en0]:5540`;
+
+        await withDut([overUdp], async cx => {
+            expect((await furtherSessionCheck(cx, 0)).verdict).equal("unverified");
+        });
+    });
+
+    it("has no pattern for a device flavor this block does not host", async () => {
+        await withDut(
+            [furtherSession()],
+            async cx => {
+                const check = await furtherSessionCheck(cx, 0);
+
+                expect(check.verdict).equal("unverified");
+                expect(check.accepted).match(/no pattern for a chip-docker device/);
+            },
+            "chip-docker",
+        );
     });
 });
 

--- a/support/chip-testing/test/cert-framework/tc-support.test.ts
+++ b/support/chip-testing/test/cert-framework/tc-support.test.ts
@@ -46,6 +46,7 @@ import {
     runCleanups,
     WRITE_REQUEST_MESSAGE,
 } from "../cert/tc-support.js";
+import { fakeCertNode } from "./fake-cert-node.js";
 
 const EXCHANGE = 26481;
 const CHUNK = "[DMG] ReportDataMessage =";
@@ -1438,23 +1439,7 @@ describe("requireId", () => {
 
 describe("readOwnFabricIndex", () => {
     function nodeReporting(value: unknown): CertNodeApi {
-        const unused = () => Promise.reject(new InternalError("not used by these tests"));
-        return {
-            invoke: unused,
-            invokeBatch: unused,
-            readAttributes: unused,
-            writeAttribute: unused,
-            writeAttributes: unused,
-            subscribe: unused,
-            readEvents: unused,
-            subscribeEvents: unused,
-            clientEndpoints: unused,
-            clientAttribute: unused,
-            openCommissioningWindow: unused,
-            operationalMdnsInstanceName: unused,
-            decommission: unused,
-            readAttribute: async () => value,
-        };
+        return fakeCertNode({ readAttribute: async () => value });
     }
 
     it("returns the index the device reported", async () => {
@@ -1694,23 +1679,7 @@ describe("runCleanups", () => {
 describe("CommissionedRefs", () => {
     function contextWith(decommission: (role: string) => Promise<void>): CertStepContext {
         function nodeFor(role: string): CertNodeApi {
-            const unused = () => Promise.reject(new Error("not used by these tests"));
-            return {
-                invoke: unused,
-                invokeBatch: unused,
-                readAttribute: unused,
-                readAttributes: unused,
-                writeAttribute: unused,
-                writeAttributes: unused,
-                subscribe: unused,
-                readEvents: unused,
-                subscribeEvents: unused,
-                clientEndpoints: unused,
-                clientAttribute: unused,
-                openCommissioningWindow: unused,
-                operationalMdnsInstanceName: unused,
-                decommission: () => decommission(role),
-            };
+            return fakeCertNode({ decommission: () => decommission(role) });
         }
 
         // An ended source lets the follower close itself; this file's OpenSource would leave one

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -2259,7 +2259,7 @@ session's absence passes on a UDP sibling that was never severed; a check that a
 payloads fails on a sibling that never claimed to; and a sever aimed at "the session" can close the
 wrong one. So `sessions()` returns a list, `severTransportConnection(sessionId)` takes the session to
 sever, and `sessionGoneCheck`/`largePayloadSessionCheck` take the id the case captured in step 1 via
-`requireTcpSessionId` — which also refuses a controller holding two TCP sessions, not a state this
+`tcpSessionIdOf` — which also refuses a controller holding two TCP sessions, not a state this
 framework produces, so meeting it means the case is no longer about what it was written for.
 
 The id is also what the block needs beyond the DUT's tag. A device may reuse the id of a session it has
@@ -2344,11 +2344,24 @@ Steps 1 and 2 are `TC-SC-8.3`'s. Step 3 drives a read carrying `largeMessage: tr
 re-establishes is one the peer must serve over TCP — a step that read without it could be answered
 over MRP and still find a session to report.
 
-Its session line accepts `New` **or** `Resumed`: CASE resumption is a CASE session establishment, and
-a step demanding a full handshake would fail a DUT doing the spec-preferred thing. Since a resumed
-session's tag says nothing about novelty on its own, the claim that this is a *further* session rests
-on the controller's session id differing from the severed one — the same `sessionGoneCheck` step 2
-uses, so one covered comparison carries both claims.
+**Its claim is not attributable from the device's log, and trying was a dead end worth recording.**
+The cert adapter leaves sustained subscriptions on, so a controller re-establishes a session on its
+own schedule — a lost subscription reconnects by establishing one. A check that matches a
+CASE-establishment line and calls it this step's therefore races either way around whatever mark it
+takes: a mark before the reconnect matches a line the step's read did not cause, and a mark after it
+finds no line at all, because the read reused the session the reconnect had already made — failing a
+case whose outcome actually held. Both were found in review, one per round, on the same construct.
+
+Session ids carry no such window, so the step gates on them: a TCP session exists, it is not the
+severed id, and it permits large payloads — which is the whole of what the plan asks, all from
+`sessions()`. `sessionGoneCheck` is the same comparison step 2 uses, so one covered comparison
+carries both claims.
+
+The device's own line is still recorded, by `furtherSessionCheck`, as corroboration that does **not**
+gate the step: `unverified` with a reason when absent, which leaves the step passing. It is searched
+from a mark taken *before* the sever, so a reconnect that beat the read is found rather than missed,
+and it accepts `New` or `Resumed` because resumption is a CASE session establishment and a step
+demanding a full handshake would fail a DUT doing the spec-preferred thing.
 
 ## An interaction over the TCP session, bound to that session (`TC-SC-8.5`)
 

--- a/support/chip-testing/test/cert/AGENTS.md
+++ b/support/chip-testing/test/cert/AGENTS.md
@@ -2220,10 +2220,12 @@ for it — every other test keeps the transport its evidence and timing were wri
 What each side does with the request:
 
 - **matter.js controller** gets `network: { tcp: true, transportPreference: "tcp" }`, a *soft*
-  preference: it uses TCP where the peer's `SUPPORTED_TRANSPORTS.tcpServer` says it can, and silently
-  falls back to UDP otherwise. The hard `requiredTransport` lever exists in the protocol layer but is
-  not surfaced, so a test cannot yet assert "TCP or fail" — which is why the evidence below is the
-  device's, not the controller's.
+  preference: it uses TCP where the peer's `SUPPORTED_TRANSPORTS.tcpServer` says it can, and falls back
+  to UDP otherwise. The block does not rest on that preference, because a preference that fell back
+  would leave a case claiming a transport nobody used: `commissionOverTcp`'s read carries
+  `largeMessage: true`, which is the *hard* requirement — `ClientRequest.largeMessage` becomes
+  `requiredTransport: ChannelType.TCP`, and a peer that cannot serve TCP fails the read with
+  `TcpUnsupportedError` instead of answering over MRP.
 - **chip-tool** gets `--allow-large-payload 1` on every model command it builds — read, write, invoke,
   event read and both subscribes, since it decides a session's transport when it establishes one and a
   test may begin with any of them — and it is **not enough**: chip-tool
@@ -2242,12 +2244,111 @@ does not advertise TCP support, so even a TCP-preferring controller falls back t
 the case would claim a transport nobody used. `flavors: ["matterjs"]` states that, and the test skips
 before activation on the chip flavors.
 
-**What is not yet written, and why.** `TC-SC-8.2` ("the session allows large payloads") has no witness
-distinct from 8.1's on this stack: nothing logs a session's maximum payload, and a TCP-backed session
-is large-payload-capable by construction, so the two cases would rest on the same line. Its real
-witness is behavioural, and `TC-SC-8.6` below now carries it — a wildcard read arriving in a single
-`ReportData`, which UDP's ~1232-byte budget could not carry. `TC-SC-8.3`/`8.4` additionally need a way
-to sever just the TCP connection mid-test.
+**Two of the block's claims are the controller's to make, not the device's.** Nothing a device logs
+says what a session *permits* — only what it was observed carrying — so `CertNodeApi.sessions()`
+reports every live session the controller holds with a node: its id, the transport beneath it, whether
+it permits large payloads, and the payload ceiling. That is held state in the sense `clientEndpoints()`
+is, and chip-tool refuses it: a session there lives inside the process it spawns per command, and
+nothing it prints names the transport beneath one.
+
+**Every session claim names a session, and that is the load-bearing decision here.** A controller may
+hold more than one session with a peer at once — `Peer.connect` keeps one per transport — so an API
+answering about "the session" answers about whichever is newest, and a case built on it does not
+assert what it reads as asserting. Concretely, with a newest-session API: a check for a severed
+session's absence passes on a UDP sibling that was never severed; a check that a session permits large
+payloads fails on a sibling that never claimed to; and a sever aimed at "the session" can close the
+wrong one. So `sessions()` returns a list, `severTransportConnection(sessionId)` takes the session to
+sever, and `sessionGoneCheck`/`largePayloadSessionCheck` take the id the case captured in step 1 via
+`requireTcpSessionId` — which also refuses a controller holding two TCP sessions, not a state this
+framework produces, so meeting it means the case is no longer about what it was written for.
+
+The id is also what the block needs beyond the DUT's tag. A device may reuse the id of a session it has
+closed, so an identical tag is not proof the old session survived and a differing one is not proof the
+controller established a new one — the controller's own id decides both, which is why `TcpSessionRef`
+keeps `{ tag, channel, controllerSessionId }` rather than the tag alone.
+
+**A session operation naming a session the controller does not hold is a state error, not a refusal.**
+`UnsupportedByControllerError` means "this controller cannot do this kind of thing" and the step runner
+records it as *skipped*; using it for a runtime state would turn the precise defect step 1 exists to
+rule out into a clean-looking run. The in-process adapter throws `SessionStateError` for an unknown id,
+a detached channel, or a transport with no connection to sever, so such a step fails.
+
+## The claim only the controller can make (`TC-SC-8.2`)
+
+`TC-SC-8.2` asks whether the session *allows* large payloads, which is not the same question as
+`TC-SC-8.1`'s (is the connection underneath TCP) or `TC-SC-8.6`'s (did a large payload actually
+cross). A device carrying one proves the permission after the fact; nothing it logs states the
+permission itself. So this case's own evidence is `sessions()`, and it requires all three of
+`transport: "tcp"`, `largePayload`, and a ceiling above 1280 bytes — a session claiming to permit a
+large payload with an MTU-sized ceiling permits nothing the peer could receive, and one claiming it
+over UDP is reporting something no transport it has can do.
+
+The check is a pure function of the held record (`largePayloadSessionCheck`), so each way it can be
+satisfied by the wrong thing is covered without a device.
+
+## Severing the connection, and why not the session (`TC-SC-8.3`)
+
+The stimulus is `severTransportConnection()`, which closes the session's own
+`MessageChannel.transportChannel` and nothing else. Closing the *session* would send `CloseSession`
+and the DUT would forget the session — which is this case's expected **outcome**, so it cannot also
+be its stimulus. `MessageChannel.close()` deliberately leaves a TCP channel alone (the transport owns
+it, 1:1 with the session), which is what makes reaching for the transport channel the honest way to
+express "the TH closes the TCP connection".
+
+**The claim rests on the controller, and the device half is not readable from a run.**
+`sessionGoneCheck` asks whether the *severed id* is still among the sessions the controller holds and
+passes when it is not — whatever else it holds, since a controller may reconnect on its own. What the
+plan's "the secure session with DUT is inactive" forbids is the severed session remaining usable.
+
+**The absence is waited for, not read once.** Severing closes the channel; the eviction that follows
+runs on a worker nothing a step can await (`ExchangeManager` adds it to its own multiplex), and with
+an exchange still open it suspends before marking the session closed. `recordSeveredSession` polls the
+controller's sessions until the severed id is gone or `EVICTION_TIMEOUT` expires — a single immediate
+read passes only by luck of the synchronous prefix.
+
+A device-log check for the same event was written first and **cannot work**. The finding is worth
+recording, because the symptom looks exactly like a device that fails to evict:
+
+- A matter.js device *does* drop the session. An in-process reproduction (two nodes in one process
+  over a real TCP session) clears it within tens of milliseconds of the sever, and `ExchangeManager`
+  writes `TCP connection dropped, evicting bound sessions: <channel>` followed by `Evicting session
+  due to TCP disconnect: <session>` for the inbound channel.
+- Those lines never reach the device's log, and this is **measured, not deduced** — reasoning from how
+  `AsyncLocalStorage` ought to propagate through a socket created under a tagged `listen()` leads to
+  the opposite (wrong) conclusion, so it has been re-raised in review more than once. The two
+  measurements: a socket's `'close'` handler runs with no store at all, even when the close is
+  initiated synchronously from inside `als.run()`; and in an actual run the pair appears in the run's
+  stdout while `device-dut.log` contains neither line. This package's attribution is keyed by the
+  device whose `initialize()`/`start()`/`stop()`/`close()` is on the stack (`src/cert/index.ts`), so an
+  unattributed line falls through to `console.error`.
+- The controller's identical lines *are* attributed, because a step severs inside the adapter's own
+  tagged call and `TcpChannel.close()` reaches `ExchangeManager` synchronously from there. The
+  asymmetry between the two logs is attribution, not behaviour — do not read it as a device ignoring a
+  dropped connection.
+
+`sessionEvictionUnreadableCheck` records the device half as an `accepted` gap, which leaves the step
+passing while keeping the gap in the bundle. Any device-log check for something a device does from a
+socket or timer callback, rather than while serving an interaction, has the same problem.
+
+**What `TC-SC-8.2`'s controller-side check does and does not prove.** `CertSessionInfo`'s three
+payload fields are not independent evidence: all come from the session's channel, and the channel type
+fixes them (`TcpChannel` declares `supportsLargeMessages = true` with a 64000-byte ceiling; `UdpTransport`
+and `Ble` declare `false`). Requiring all three is a consistency guard against a channel reporting a
+combination no transport should produce — not three separate findings. What makes 8.2 a distinct case
+is *who* asserts: the controller states what the session permits, where 8.1 has the device state what
+the connection is and 8.6 observes a large payload actually crossing.
+
+## Re-establishing, and what makes it a different session (`TC-SC-8.4`)
+
+Steps 1 and 2 are `TC-SC-8.3`'s. Step 3 drives a read carrying `largeMessage: true`, so the session it
+re-establishes is one the peer must serve over TCP — a step that read without it could be answered
+over MRP and still find a session to report.
+
+Its session line accepts `New` **or** `Resumed`: CASE resumption is a CASE session establishment, and
+a step demanding a full handshake would fail a DUT doing the spec-preferred thing. Since a resumed
+session's tag says nothing about novelty on its own, the claim that this is a *further* session rests
+on the controller's session id differing from the severed one — the same `sessionGoneCheck` step 2
+uses, so one covered comparison carries both claims.
 
 ## An interaction over the TCP session, bound to that session (`TC-SC-8.5`)
 
@@ -2280,9 +2381,10 @@ extraction, and each way `recordTcpInvoke`'s patterns can be satisfied by the wr
 session, another command, another endpoint, a response carrying more commands, no answer at all) —
 so a regex regression surfaces without docker and without a chip binary.
 
-Step 1's expected outcome here is the plan's "the session allows large payloads", which nothing logs —
-a TCP-backed session is large-payload-capable by construction, so this step's evidence is 8.1's and the
-distinct witness belongs to `TC-SC-8.6`, as the note above records for `TC-SC-8.2`.
+Step 1's expected outcome here is the plan's "the session allows large payloads", which nothing the
+*device* logs states: a TCP-backed session is large-payload-capable by construction, so this step's
+device evidence is 8.1's. The two distinct witnesses live elsewhere — `TC-SC-8.2` asks the controller
+what the session permits, and `TC-SC-8.6` observes a large payload actually crossing.
 
 ## The large-payload witness the earlier TCP cases lack (`TC-SC-8.6`)
 
@@ -2342,10 +2444,10 @@ invoke, no large payload — and the step's evidence is what distinguishes the c
   reject would read as a session it accepted, and an attempt inside the span whose session forms after
   it would be counted though its establishment falls outside the window this check bounds.
 
-Nothing in the controller expresses "either transport is usable" as a request flag: matter.js's
-`transportPreference` is set once, for the session, and the protocol layer's hard `requiredTransport`
-lever is not surfaced. So the plan's step text describes what an ordinary invoke already is on this
-stack, and the case's substance lives entirely in the three checks above.
+Nothing in the controller expresses "either transport is usable" as a request flag. `largeMessage`
+expresses the opposite — TCP or fail — and `transportPreference` is a per-session preference, so an
+invoke that sets neither is exactly the plan's "either is usable". The case's substance therefore
+lives entirely in the three checks above.
 
 ## The group-messaging block, and what sending one actually needed (`TC-SC-5.3`)
 

--- a/support/chip-testing/test/cert/TC-SC-8.2.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-8.2.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CertStepContext } from "@matter/testing";
+import { certTest } from "@matter/testing";
+import {
+    recordLargePayloadSession,
+    TCP_FLAVORS,
+    TCP_PICS,
+    TCP_ROLES,
+    TcpSessionRef,
+    tcpSessionStep,
+    tcpStep,
+} from "./tc-sc-8-support.js";
+import { CommissionedRefs } from "./tc-support.js";
+
+const commissioned = new CommissionedRefs<"th">();
+const session = new TcpSessionRef();
+
+/**
+ * The claim this case makes and `TC-SC-8.1` does not: the session *allows* a large payload, which
+ * only the TH can answer. A device can be observed carrying one — that is `TC-SC-8.6` — but nothing
+ * it logs states what the session permits, so the evidence here is the TH's own account of the
+ * session it established alongside the DUT's account of the connection beneath it.
+ */
+async function establishLargePayloadSession(cx: CertStepContext) {
+    await tcpSessionStep(commissioned, session)(cx);
+
+    await recordLargePayloadSession(
+        cx,
+        commissioned.require("th"),
+        session.require().controllerSessionId,
+        "the session the TH holds with the DUT reports itself as permitting payloads larger than an MRP session carries",
+    );
+}
+
+certTest("TC-SC-8.2", {
+    plan: "securechannel.adoc",
+    pics: TCP_PICS,
+    app: "all-clusters",
+    transport: "tcp",
+    flavors: TCP_FLAVORS,
+    ...TCP_ROLES,
+})
+    .step(
+        1,
+        "TH initiates a CASE session establishment with DUT, requesting a session supporting large payloads",
+        tcpStep(establishLargePayloadSession),
+        {
+            expected: "Verify that the session established with DUT allows large payloads.",
+        },
+    )
+    .finalize(async cx => {
+        session.clear();
+        await commissioned.decommissionAll(cx);
+    });

--- a/support/chip-testing/test/cert/TC-SC-8.3.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-8.3.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CertStepContext } from "@matter/testing";
+import { certTest } from "@matter/testing";
+import {
+    recordSeveredSession,
+    TCP_FLAVORS,
+    TCP_PICS,
+    TCP_ROLES,
+    TcpSessionRef,
+    tcpSessionStep,
+    tcpStep,
+} from "./tc-sc-8-support.js";
+import { CommissionedRefs } from "./tc-support.js";
+
+const commissioned = new CommissionedRefs<"th">();
+const session = new TcpSessionRef();
+
+/**
+ * The TH drops the connection beneath the session rather than closing the session, which a
+ * `CloseSession` would do: telling the DUT to forget the session is this case's expected outcome, so
+ * it cannot also be the stimulus. What the step then requires is that both sides agree the session
+ * went — the DUT evicted it, and the TH no longer holds it.
+ */
+async function severTheConnection(cx: CertStepContext) {
+    await recordSeveredSession(cx, commissioned.require("th"), session);
+}
+
+certTest("TC-SC-8.3", {
+    plan: "securechannel.adoc",
+    pics: TCP_PICS,
+    app: "all-clusters",
+    transport: "tcp",
+    flavors: TCP_FLAVORS,
+    ...TCP_ROLES,
+})
+    .step(
+        1,
+        "TH initiates a CASE session establishment with DUT, requesting a session supporting large payloads",
+        tcpSessionStep(commissioned, session),
+        {
+            expected: "Verify that a session is established over TCP with DUT that allows large payloads.",
+        },
+    )
+    .step(2, "TH closes the TCP connection with DUT", tcpStep(severTheConnection), {
+        expected: "Verify that the secure session with DUT is inactive.",
+    })
+    .finalize(async cx => {
+        session.clear();
+        await commissioned.decommissionAll(cx);
+    });

--- a/support/chip-testing/test/cert/TC-SC-8.4.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-8.4.test.ts
@@ -16,7 +16,7 @@ import {
     tcpSessionStep,
     tcpStep,
 } from "./tc-sc-8-support.js";
-import { CommissionedRefs } from "./tc-support.js";
+import { CertCheckFailedError, CommissionedRefs } from "./tc-support.js";
 
 const commissioned = new CommissionedRefs<"th">();
 const session = new TcpSessionRef();
@@ -24,8 +24,18 @@ const session = new TcpSessionRef();
 /** The session step 2 severed, which step 3 must not be answered by. */
 const severed = new TcpSessionRef();
 
+/**
+ * Where the DUT's log stood before the sever.
+ *
+ * Step 3's corroborating check searches from here rather than from its own start: a controller may
+ * re-establish the session on its own between the two steps, and a window opening after that would
+ * miss the very line it looks for.
+ */
+let beforeSever: number | undefined;
+
 async function severTheConnection(cx: CertStepContext) {
     severed.set(session.require());
+    beforeSever = await cx.devices.dut.log.markSettled();
     await recordSeveredSession(cx, commissioned.require("th"), session);
 }
 
@@ -36,7 +46,10 @@ async function severTheConnection(cx: CertStepContext) {
  * new session from the severed one — the DUT is free to reuse a session id it has closed.
  */
 async function reestablishTheSession(cx: CertStepContext) {
-    session.set(await recordReestablishedSession(cx, commissioned.require("th"), severed.require()));
+    if (beforeSever === undefined) {
+        throw new CertCheckFailedError("step 2 took no mark before severing");
+    }
+    session.set(await recordReestablishedSession(cx, commissioned.require("th"), severed.require(), beforeSever));
 }
 
 certTest("TC-SC-8.4", {
@@ -62,6 +75,7 @@ certTest("TC-SC-8.4", {
         expected: "Verify that a session is established over TCP with DUT that allows large payloads.",
     })
     .finalize(async cx => {
+        beforeSever = undefined;
         severed.clear();
         session.clear();
         await commissioned.decommissionAll(cx);

--- a/support/chip-testing/test/cert/TC-SC-8.4.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-8.4.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CertStepContext } from "@matter/testing";
+import { certTest } from "@matter/testing";
+import {
+    recordReestablishedSession,
+    recordSeveredSession,
+    TCP_FLAVORS,
+    TCP_PICS,
+    TCP_ROLES,
+    TcpSessionRef,
+    tcpSessionStep,
+    tcpStep,
+} from "./tc-sc-8-support.js";
+import { CommissionedRefs } from "./tc-support.js";
+
+const commissioned = new CommissionedRefs<"th">();
+const session = new TcpSessionRef();
+
+/** The session step 2 severed, which step 3 must not be answered by. */
+const severed = new TcpSessionRef();
+
+async function severTheConnection(cx: CertStepContext) {
+    severed.set(session.require());
+    await recordSeveredSession(cx, commissioned.require("th"), session);
+}
+
+/**
+ * The claim that makes this case more than `TC-SC-8.3` with a third step: the session the TH ends up
+ * with is a *different* one. An interaction requiring a large payload is what re-establishes it, so
+ * the step cannot be satisfied by a fallback to MRP, and the TH's own session id is what tells the
+ * new session from the severed one — the DUT is free to reuse a session id it has closed.
+ */
+async function reestablishTheSession(cx: CertStepContext) {
+    session.set(await recordReestablishedSession(cx, commissioned.require("th"), severed.require()));
+}
+
+certTest("TC-SC-8.4", {
+    plan: "securechannel.adoc",
+    pics: TCP_PICS,
+    app: "all-clusters",
+    transport: "tcp",
+    flavors: TCP_FLAVORS,
+    ...TCP_ROLES,
+})
+    .step(
+        1,
+        "TH initiates a CASE session establishment with DUT, requesting a session supporting large payloads",
+        tcpSessionStep(commissioned, session),
+        {
+            expected: "Verify that a session is established over TCP with DUT that allows large payloads.",
+        },
+    )
+    .step(2, "TH closes the TCP connection with DUT", tcpStep(severTheConnection), {
+        expected: "Verify that the secure session with DUT is inactive.",
+    })
+    .step(3, "TH re-initiates CASE session establishment over TCP with DUT", tcpStep(reestablishTheSession), {
+        expected: "Verify that a session is established over TCP with DUT that allows large payloads.",
+    })
+    .finalize(async cx => {
+        severed.clear();
+        session.clear();
+        await commissioned.decommissionAll(cx);
+    });

--- a/support/chip-testing/test/cert/TC-SC-8.4.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-8.4.test.ts
@@ -49,7 +49,7 @@ async function reestablishTheSession(cx: CertStepContext) {
     if (beforeSever === undefined) {
         throw new CertCheckFailedError("step 2 took no mark before severing");
     }
-    session.set(await recordReestablishedSession(cx, commissioned.require("th"), severed.require(), beforeSever));
+    await recordReestablishedSession(cx, commissioned.require("th"), severed.require(), beforeSever);
 }
 
 certTest("TC-SC-8.4", {

--- a/support/chip-testing/test/cert/TC-SC-8.5.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-8.5.test.ts
@@ -39,7 +39,7 @@ const session = new TcpSessionRef();
  */
 async function invokeOverTcp(cx: CertStepContext) {
     const node = cx.controllers.th.node(commissioned.require("th"));
-    const tag = session.require();
+    const { tag } = session.require();
 
     const dut = cx.devices.dut;
     const from = await dut.log.markSettled();

--- a/support/chip-testing/test/cert/TC-SC-8.6.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-8.6.test.ts
@@ -38,7 +38,7 @@ const MIN_CLUSTERS = 10;
  */
 async function readEverything(cx: CertStepContext) {
     const node = cx.controllers.th.node(commissioned.require("th"));
-    const tag = session.require();
+    const { tag } = session.require();
 
     const dut = cx.devices.dut;
     const from = await dut.log.markSettled();

--- a/support/chip-testing/test/cert/TC-SC-8.7.test.ts
+++ b/support/chip-testing/test/cert/TC-SC-8.7.test.ts
@@ -40,7 +40,7 @@ const session = new TcpSessionRef();
  */
 async function invokeOverExistingSession(cx: CertStepContext) {
     const node = cx.controllers.th.node(commissioned.require("th"));
-    const tag = session.require();
+    const { tag } = session.require();
 
     const dut = cx.devices.dut;
     const from = await dut.log.markSettled();

--- a/support/chip-testing/test/cert/tc-sc-8-support.ts
+++ b/support/chip-testing/test/cert/tc-sc-8-support.ts
@@ -751,23 +751,27 @@ export async function recordSeveredSession(
 }
 
 /**
- * Confirms a *further* CASE session over TCP, and records what makes it a further one: the session
- * the TH now holds is not the session it severed.
+ * Confirms a *further* CASE session over TCP, from the controller's own session ids.
  *
- * The DUT's tag cannot carry that claim on its own — a peer may reuse the id of a session it closed,
- * so an identical tag is not proof the old session survived, and a differing one is not proof the TH
- * established a new session rather than the DUT having renumbered.
+ * The claim is not attributable from the device's log. A controller re-establishes a session on its
+ * own schedule — the cert adapter leaves sustained subscriptions on, and a lost subscription
+ * reconnects by establishing one — so a check that matches a CASE-establishment line and calls it
+ * this step's races either way around whatever mark it takes: a mark before the reconnect matches a
+ * line the read did not cause, and a mark after it finds no line at all because the read reused the
+ * session the reconnect had already made, failing a case whose outcome actually held.
+ *
+ * Session ids carry no such window. "A TCP session exists, it is not the one severed, and it permits
+ * large payloads" is the whole of what the plan asks, and all three come from `sessions()`. The
+ * device's own line for a further session is still recorded — it is worth having in the bundle — but
+ * it does not gate the step, and it is searched from before the sever so a reconnect that beat the
+ * read is found rather than missed.
  */
 export async function recordReestablishedSession(
     cx: CertStepContext,
     ref: TcpRef,
     previous: TcpSessionFacts,
+    from: number,
 ): Promise<TcpSessionFacts> {
-    const dut = cx.devices.dut;
-    // The controller may reconnect on its own after a sever, and the device's line for that reconnect
-    // has to fall behind this mark or the check below matches a session this step did not cause
-    const from = await dut.log.markSettled();
-
     // A read the peer must answer over TCP: it re-establishes the session and refuses to travel over
     // MRP, so this step cannot pass on a fallback the plan does not describe
     await cx.controllers.th
@@ -777,49 +781,71 @@ export async function recordReestablishedSession(
             { largeMessage: true },
         );
 
-    const established = await expectSequence(
-        dut.log,
-        dut.flavor,
-        "a further CASE session over a TCP connection",
-        // `New` or `Resumed`: CASE resumption is a CASE session establishment, and a step demanding a
-        // full handshake would fail a DUT doing the spec-preferred thing
-        { matterjs: [/CaseServer .*\(tcp\).*(?:New|Resumed) session with .*address: (tcp:\/\/\S+)/] },
-        from,
-        LOG_TIMEOUT,
-    );
-    record(cx, established, "the DUT established a further session over TCP");
-    if (established.verdict !== "pass" || established.matched === undefined) {
-        throw new CertCheckFailedError(`the DUT's session line is not on the record: ${describeValue(established)}`);
-    }
-
     // One read for both the id and the checks: two would let the checks judge a set the id was never
     // drawn from
     const sessions = await heldSessions(cx, ref);
     const id = tcpSessionIdOf(sessions);
+    const further = await furtherSessionCheck(cx, from);
     recordAll(cx, [
         {
             check: () => sessionGoneCheck(previous, sessions),
-            what: "the session the TH re-established is not the one it severed",
+            what: "the session the TH holds is not the one it severed",
         },
         {
             check: () => largePayloadSessionCheck(sessions, id),
             what: "the re-established session allows large payloads",
         },
+        { check: () => further, what: "the DUT accepted a further session over TCP" },
     ]);
 
-    // The facts of the *new* session, whose connection is a new one: keeping the severed connection's
-    // channel would leave a later step matching against a connection that no longer exists
-    const tag = SESSION_TAG.exec(established.matched)?.[1];
-    const channel = PEER_CHANNEL.exec(established.matched)?.[1];
-    if (tag === undefined || channel === undefined) {
-        throw failedCheck(
-            cx,
-            SESSION_TAG.source,
-            `the DUT's further session line names no session and channel: ${established.matched}`,
-            established.logLine,
-        );
-    }
-    return { tag, channel, controllerSessionId: id };
+    return { tag: further.matched ?? previous.tag, channel: previous.channel, controllerSessionId: id };
 }
+
+/**
+ * The DUT's own line for a further CASE session over TCP, as corroboration rather than as a gate.
+ *
+ * Unverified rather than failing when no line is found: the session the controller holds is what the
+ * step rests on, and a device that served it without this line having reached the log has not failed
+ * the case.
+ */
+export async function furtherSessionCheck(cx: CertStepContext, from: number): Promise<CheckRecord> {
+    const dut = cx.devices.dut;
+    if (dut.flavor !== "matterjs") {
+        return { type: "device-log", verdict: "unverified", accepted: `no pattern for a ${dut.flavor} device` };
+    }
+
+    await dut.log.settled();
+    const line = dut.log
+        .window(from, dut.log.lines.length - from)
+        .find(candidate => !candidate.synthetic && FURTHER_TCP_SESSION.test(candidate.text));
+
+    const tag = line === undefined ? undefined : SESSION_TAG.exec(line.text)?.[1];
+    return {
+        type: "device-log",
+        verdict: line === undefined ? "unverified" : "pass",
+        pattern: FURTHER_TCP_SESSION.source,
+        detail:
+            line === undefined
+                ? "the DUT's log carries no further session over TCP"
+                : `the DUT accepted ${tag ?? "a further session"} over TCP`,
+        matched: tag ?? line?.text,
+        logLine: line?.index,
+        accepted:
+            line === undefined
+                ? "the controller's own session id is what this step rests on; the device's line for a " +
+                  "further session may not have reached its log"
+                : undefined,
+    };
+}
+
+/**
+ * A CASE session the DUT accepted over TCP, established or resumed. Resumption counts: it is a CASE
+ * session establishment, and a step demanding a full handshake would fail a DUT doing the
+ * spec-preferred thing.
+ *
+ * Deliberately not {@link FURTHER_SESSION}, which matches a session on any transport because the case
+ * using it asserts that *no* further session appeared.
+ */
+const FURTHER_TCP_SESSION = /CaseServer .*\(tcp\).*(?:New|Resumed) session with/;
 
 export type TcpRef = CertNodeRef;

--- a/support/chip-testing/test/cert/tc-sc-8-support.ts
+++ b/support/chip-testing/test/cert/tc-sc-8-support.ts
@@ -771,7 +771,7 @@ export async function recordReestablishedSession(
     ref: TcpRef,
     previous: TcpSessionFacts,
     from: number,
-): Promise<TcpSessionFacts> {
+) {
     // A read the peer must answer over TCP: it re-establishes the session and refuses to travel over
     // MRP, so this step cannot pass on a fallback the plan does not describe
     await cx.controllers.th
@@ -797,8 +797,6 @@ export async function recordReestablishedSession(
         },
         { check: () => further, what: "the DUT accepted a further session over TCP" },
     ]);
-
-    return { tag: further.matched ?? previous.tag, channel: previous.channel, controllerSessionId: id };
 }
 
 /**

--- a/support/chip-testing/test/cert/tc-sc-8-support.ts
+++ b/support/chip-testing/test/cert/tc-sc-8-support.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MAX_UDP_MESSAGE_SIZE } from "@matter/general";
+import { Duration, MAX_UDP_MESSAGE_SIZE, Millis, Seconds, Time } from "@matter/general";
 import { Matter } from "@matter/model";
 import { MATTER_MESSAGE_OVERHEAD } from "@matter/protocol";
-import type { CertNodeRef, CertStepContext, CheckRecord, DeviceFlavor } from "@matter/testing";
+import type { CertNodeRef, CertSessionInfo, CertStepContext, CheckRecord, DeviceFlavor } from "@matter/testing";
 import { resolveControllerImplementation, UnsupportedByControllerError } from "@matter/testing";
 import {
     CertCheckFailedError,
@@ -19,6 +19,7 @@ import {
     LOG_TIMEOUT,
     matterjsCommandPath,
     record,
+    recordAll,
     requireId,
 } from "./tc-support.js";
 
@@ -66,7 +67,14 @@ export async function commissionOverTcp(cx: CertStepContext, commissioned: Commi
     });
     commissioned.set("th", ref);
 
-    await th.node(ref).readAttribute({ endpoint: 0, cluster: BASIC_INFORMATION_ID, attribute: VENDOR_NAME_ID });
+    // `largeMessage` makes the transport a hard requirement rather than a preference, so a controller
+    // that fell back to MRP fails the read instead of leaving the case claiming a transport it never used
+    await th
+        .node(ref)
+        .readAttribute(
+            { endpoint: 0, cluster: BASIC_INFORMATION_ID, attribute: VENDOR_NAME_ID },
+            { largeMessage: true },
+        );
 
     return { ref, from };
 }
@@ -97,7 +105,11 @@ export function requireTcpCapableController() {
  * Returns the DUT's own tag for that session, so a later step can bind its evidence to this session
  * rather than to any session that happens to be a TCP one.
  */
-export async function recordTcpSession(cx: CertStepContext, from: number, what: string): Promise<string> {
+export async function recordTcpSession(
+    cx: CertStepContext,
+    from: number,
+    what: string,
+): Promise<{ tag: string; channel: string }> {
     const dut = cx.devices.dut;
 
     const pairing = await expectSequence(
@@ -148,7 +160,7 @@ export async function recordTcpSession(cx: CertStepContext, from: number, what: 
         );
     }
 
-    return tag;
+    return { tag, channel };
 }
 
 /** Records `detail` as a failed device-log check and returns the error a caller throws. */
@@ -492,23 +504,37 @@ export function timeSnapshotResponseCheck(response: unknown, refusal: unknown): 
  */
 const FURTHER_SESSION = /CaseServer .*(?:New|Resumed) session with/;
 
+/**
+ * What a TCP case knows about the session its first step established, from both sides.
+ *
+ * The DUT's tag identifies the session in its own log; the channel is the only token its pairing and
+ * its eviction lines share, so a case that severs a connection needs it to say *which* connection
+ * went. The controller's session id is what tells a re-established session from the one before it —
+ * the DUT's tag alone cannot, since a peer may reuse a session id it has closed.
+ */
+export interface TcpSessionFacts {
+    tag: string;
+    channel: string;
+    controllerSessionId: number;
+}
+
 /** Where a TCP case keeps the session its first step established, for the steps that follow. */
 export class TcpSessionRef {
-    #tag?: string;
+    #facts?: TcpSessionFacts;
 
-    set(tag: string) {
-        this.#tag = tag;
+    set(facts: TcpSessionFacts) {
+        this.#facts = facts;
     }
 
-    require(): string {
-        if (this.#tag === undefined) {
+    require(): TcpSessionFacts {
+        if (this.#facts === undefined) {
             throw new CertCheckFailedError("no TCP session was captured");
         }
-        return this.#tag;
+        return this.#facts;
     }
 
     clear() {
-        this.#tag = undefined;
+        this.#facts = undefined;
     }
 }
 
@@ -527,15 +553,273 @@ export function tcpStep(run: (cx: CertStepContext) => Promise<void>) {
 /** Every TCP case starts the same way, so its first step is shared rather than copied. */
 export function tcpSessionStep(commissioned: CommissionedRefs<"th">, session: TcpSessionRef) {
     return async (cx: CertStepContext) => {
-        const { from } = await commissionOverTcp(cx, commissioned);
-        session.set(
-            await recordTcpSession(
-                cx,
-                from,
-                "the session the TH established with the DUT runs over TCP, which is what makes it large-payload-capable",
-            ),
+        const { ref, from } = await commissionOverTcp(cx, commissioned);
+        const { tag, channel } = await recordTcpSession(
+            cx,
+            from,
+            "the session the TH established with the DUT runs over TCP, which is what makes it large-payload-capable",
         );
+
+        session.set({ tag, channel, controllerSessionId: tcpSessionIdOf(await heldSessions(cx, ref)) });
     };
+}
+
+/** Every live session the TH holds with `ref`. */
+export function heldSessions(cx: CertStepContext, ref: TcpRef): Promise<CertSessionInfo[]> {
+    return cx.controllers.th.node(ref).sessions();
+}
+
+/** The session `id` names among `sessions`, and undefined when it holds no such session. */
+export function sessionWithId(sessions: CertSessionInfo[], id: number) {
+    return sessions.find(session => session.id === id);
+}
+
+/**
+ * The id of the one TCP session among `sessions`, which every later step names.
+ *
+ * Exactly one: a controller may hold a session per transport, and a case that took "the TCP session"
+ * from a set holding two of them would be reasoning about whichever came back first. Two is reachable
+ * — a peer-lost session lingers until it closes, and an inbound session is adopted into the same peer
+ * — so this refuses rather than choosing, and the step fails.
+ *
+ * Takes the sessions rather than reading them, so an id and the set it was drawn from are the same
+ * observation. Reading twice would let a check judge one read against an id from another.
+ */
+export function tcpSessionIdOf(sessions: CertSessionInfo[]): number {
+    const tcp = sessions.filter(session => session.transport === "tcp");
+    if (tcp.length !== 1) {
+        throw new CertCheckFailedError(
+            `the TH holds ${tcp.length} TCP ${tcp.length === 1 ? "session" : "sessions"} with the DUT, ` +
+                `and this case is about exactly one — it holds ${describeSessions(sessions)}`,
+        );
+    }
+    return tcp[0].id;
+}
+
+/**
+ * What the TH's own account of the session `id` names says about large payloads.
+ *
+ * The controller is the only side that can answer this: the plan asks whether the session *permits* a
+ * large payload, and a peer can only ever be observed carrying one — which is what makes this a
+ * different claim from {@link recordTcpSession}'s, where the *device* says the connection underneath
+ * is TCP.
+ *
+ * The three properties are **not independent evidence**. All three come from the session's channel,
+ * and each channel type fixes them: `TcpChannel` declares `supportsLargeMessages = true` with a
+ * 64000-byte ceiling, `UdpTransport` and `Ble` declare `false`. So requiring all three is a
+ * consistency guard — it fails a channel that reports a combination no transport should produce —
+ * rather than three separate findings. A case wanting behavioural proof that a large payload crossed
+ * needs `TC-SC-8.6`.
+ *
+ * Named rather than newest, so a sibling session over another transport can neither satisfy this nor
+ * fail it.
+ */
+export function largePayloadSessionCheck(sessions: CertSessionInfo[], id: number): CheckRecord {
+    const held = sessionWithId(sessions, id);
+    if (held === undefined) {
+        return {
+            type: "response",
+            verdict: "fail",
+            detail: `the TH holds no session ${id} with the DUT, and holds ${describeSessions(sessions)}`,
+        };
+    }
+
+    const detail =
+        `the TH holds ${held.transport} session ${held.id}, which ` +
+        `${held.largePayload ? "permits" : "denies"} large payloads, with a maximum payload of ` +
+        `${held.maxPayloadSize} bytes`;
+
+    const passes = held.transport === "tcp" && held.largePayload && held.maxPayloadSize > LARGE_PAYLOAD_FLOOR;
+    return { type: "response", verdict: passes ? "pass" : "fail", detail };
+}
+
+/**
+ * How an evidence record names the sessions a controller holds.
+ *
+ * Ordered by id, because `sessions()` promises no order and an evidence string that varied with the
+ * controller's internal iteration would differ between runs of the same case.
+ */
+export function describeSessions(sessions: CertSessionInfo[]) {
+    return sessions.length === 0
+        ? "no sessions"
+        : [...sessions]
+              .sort((a, b) => a.id - b.id)
+              .map(session => `${session.transport} session ${session.id}`)
+              .join(", ");
+}
+
+/** {@link largePayloadSessionCheck}, recorded as the step's evidence. */
+export async function recordLargePayloadSession(cx: CertStepContext, ref: TcpRef, id: number, what: string) {
+    record(cx, largePayloadSessionCheck(await heldSessions(cx, ref), id), what);
+}
+
+/**
+ * The DUT's own account of dropping the session is not readable from a run, so this states that
+ * rather than searching for lines that cannot arrive.
+ *
+ * A matter.js device does drop it — `ExchangeManager` writes `TCP connection dropped, evicting bound
+ * sessions: <channel>` and `Evicting session due to TCP disconnect: <session>`, and an in-process
+ * node clears the session within tens of milliseconds.
+ *
+ * Two measurements, not deductions, say why those lines cannot be read here. A socket's `'close'`
+ * handler runs with **no** `AsyncLocalStorage` store — even when the close is initiated synchronously
+ * from inside `als.run()` — so the device-log attribution in `src/cert/index.ts`, keyed by the device
+ * whose lifecycle call is on the stack, finds no device and falls through to the run's console. And in
+ * an actual run the pair appears in the run's stdout while `device-dut.log` contains neither line. The
+ * controller's identical lines *are* attributed, because a step severs inside the adapter's own tagged
+ * call and `TcpChannel.close()` reaches `ExchangeManager` synchronously from there.
+ *
+ * So this is not "nobody wrote the check yet". Reasoning from how ALS ought to propagate leads the
+ * other way; the measurements above are what settle it.
+ *
+ * So the claim rests on the controller's held state ({@link sessionGoneCheck}), which is what the
+ * plan's "the secure session with DUT is inactive" is about — the session the TH holds. This record
+ * keeps the device half visible as an accepted gap rather than an unwritten check.
+ */
+export function sessionEvictionUnreadableCheck(session: TcpSessionFacts): CheckRecord {
+    return {
+        type: "device-log",
+        verdict: "unverified",
+        detail: `the DUT's eviction of session ${session.tag} on the connection from ${session.channel}`,
+        accepted:
+            "a device's eviction lines are written from its socket's close callback, which carries no " +
+            "device attribution, so they reach the run's console rather than this device's log",
+    };
+}
+
+/**
+ * What the TH holds once the session `severed` names is gone: anything but that session.
+ *
+ * Identified rather than counted, and identified rather than "the newest": a controller may hold a
+ * session per transport and may reconnect on its own, so neither "it holds none" nor "the newest one
+ * differs" states what the plan forbids — the *severed* session remaining usable.
+ */
+export function sessionGoneCheck(severed: TcpSessionFacts, sessions: CertSessionInfo[]): CheckRecord {
+    const held = sessionWithId(sessions, severed.controllerSessionId);
+    return {
+        type: "response",
+        verdict: held === undefined ? "pass" : "fail",
+        detail:
+            `the TH ${held === undefined ? "no longer holds" : "still holds"} session ` +
+            `${severed.controllerSessionId}, and holds ${describeSessions(sessions)}`,
+    };
+}
+
+/**
+ * How long to wait for the controller to drop a severed session.
+ *
+ * Severing closes the channel; the eviction that follows runs on a worker nothing a step can await
+ * (`ExchangeManager` adds it to its own multiplex), and with an exchange still open it suspends
+ * before marking the session closed. So the absence has to be waited for rather than read once.
+ */
+const EVICTION_TIMEOUT = Seconds(5);
+
+/** How often {@link recordSeveredSession} re-reads the controller's sessions while waiting. */
+const EVICTION_POLL = Millis(50);
+
+/**
+ * Severs the connection beneath the session `session` names and records that the TH no longer holds
+ * it, plus the device-side gap {@link sessionEvictionUnreadableCheck} accounts for.
+ *
+ * `timeout` bounds the wait for the eviction; a case against a slower device may widen it.
+ */
+export async function recordSeveredSession(
+    cx: CertStepContext,
+    ref: TcpRef,
+    session: TcpSessionRef,
+    timeout: Duration = EVICTION_TIMEOUT,
+) {
+    const severed = session.require();
+
+    await cx.controllers.th.node(ref).severTransportConnection(severed.controllerSessionId);
+
+    let sessions = await heldSessions(cx, ref);
+    // Elapsed time, so the clock must not be one that can step
+    const deadline = Time.nowUs + timeout;
+    while (sessionWithId(sessions, severed.controllerSessionId) !== undefined && Time.nowUs < deadline) {
+        await Time.sleep("cert severed session eviction", EVICTION_POLL);
+        sessions = await heldSessions(cx, ref);
+    }
+
+    recordAll(cx, [
+        {
+            check: () => sessionGoneCheck(severed, sessions),
+            what: `the TH no longer holds session ${severed.controllerSessionId}`,
+        },
+        { check: () => sessionEvictionUnreadableCheck(severed), what: `the DUT dropped session ${severed.tag}` },
+    ]);
+}
+
+/**
+ * Confirms a *further* CASE session over TCP, and records what makes it a further one: the session
+ * the TH now holds is not the session it severed.
+ *
+ * The DUT's tag cannot carry that claim on its own — a peer may reuse the id of a session it closed,
+ * so an identical tag is not proof the old session survived, and a differing one is not proof the TH
+ * established a new session rather than the DUT having renumbered.
+ */
+export async function recordReestablishedSession(
+    cx: CertStepContext,
+    ref: TcpRef,
+    previous: TcpSessionFacts,
+): Promise<TcpSessionFacts> {
+    const dut = cx.devices.dut;
+    // The controller may reconnect on its own after a sever, and the device's line for that reconnect
+    // has to fall behind this mark or the check below matches a session this step did not cause
+    const from = await dut.log.markSettled();
+
+    // A read the peer must answer over TCP: it re-establishes the session and refuses to travel over
+    // MRP, so this step cannot pass on a fallback the plan does not describe
+    await cx.controllers.th
+        .node(ref)
+        .readAttribute(
+            { endpoint: 0, cluster: BASIC_INFORMATION_ID, attribute: VENDOR_NAME_ID },
+            { largeMessage: true },
+        );
+
+    const established = await expectSequence(
+        dut.log,
+        dut.flavor,
+        "a further CASE session over a TCP connection",
+        // `New` or `Resumed`: CASE resumption is a CASE session establishment, and a step demanding a
+        // full handshake would fail a DUT doing the spec-preferred thing
+        { matterjs: [/CaseServer .*\(tcp\).*(?:New|Resumed) session with .*address: (tcp:\/\/\S+)/] },
+        from,
+        LOG_TIMEOUT,
+    );
+    record(cx, established, "the DUT established a further session over TCP");
+    if (established.verdict !== "pass" || established.matched === undefined) {
+        throw new CertCheckFailedError(`the DUT's session line is not on the record: ${describeValue(established)}`);
+    }
+
+    // One read for both the id and the checks: two would let the checks judge a set the id was never
+    // drawn from
+    const sessions = await heldSessions(cx, ref);
+    const id = tcpSessionIdOf(sessions);
+    recordAll(cx, [
+        {
+            check: () => sessionGoneCheck(previous, sessions),
+            what: "the session the TH re-established is not the one it severed",
+        },
+        {
+            check: () => largePayloadSessionCheck(sessions, id),
+            what: "the re-established session allows large payloads",
+        },
+    ]);
+
+    // The facts of the *new* session, whose connection is a new one: keeping the severed connection's
+    // channel would leave a later step matching against a connection that no longer exists
+    const tag = SESSION_TAG.exec(established.matched)?.[1];
+    const channel = PEER_CHANNEL.exec(established.matched)?.[1];
+    if (tag === undefined || channel === undefined) {
+        throw failedCheck(
+            cx,
+            SESSION_TAG.source,
+            `the DUT's further session line names no session and channel: ${established.matched}`,
+            established.logLine,
+        );
+    }
+    return { tag, channel, controllerSessionId: id };
 }
 
 export type TcpRef = CertNodeRef;


### PR DESCRIPTION
Adds the three certification test cases that complete the secure-channel TCP block, and the
controller-side state they assert on.

A *large-payload session* is a Matter session that may carry messages bigger than the reliable
messaging transport can fit, which in practice means one running over TCP. The block's remaining
cases are about establishing such a session, losing it, and getting it back:

- **TC-SC-8.2** — a session established over TCP allows large payloads.
- **TC-SC-8.3** — the session becomes inactive when the connection beneath it is dropped.
- **TC-SC-8.4** — a session can be re-established afterwards, and it is a different session.

## What the framework gained

All three assert something about a *session*, and only the controller can answer what a session
permits. A device can be observed carrying a large payload — that is what TC-SC-8.6 already does —
but nothing a device reports states what its session allows. So a step can now ask a controller
which sessions it holds with a node, and can drop the connection beneath a named one:

```ts
sessions(): Promise<CertSessionInfo[]>          // { id, transport, largePayload, maxPayloadSize }
severTransportConnection(sessionId: number): Promise<void>
```

**Both name a session rather than describing "the session", and that is the load-bearing decision.**
A controller keeps one session per transport, so a check written against whichever session is newest
does not assert what it appears to. Three concrete ways that goes wrong: a check for a severed
session's absence passes on a sibling that was never severed; a check that a session permits large
payloads fails on a sibling that never claimed to; and a sever aimed at "the session" can close the
wrong one. Every check here takes the id its own case captured in step 1.

Two further properties of `sessions()` matter for the same reason:

- It reports only sessions the controller would actually use, applying the same liveness test as the
  rest of the protocol layer. A peer's session set keeps a session until it finishes closing, so a
  raw projection would report sessions the controller has already written off.
- Naming a session the controller does not hold — or one whose transport has no connection to sever
  — *fails* the step. It is a statement about runtime state, not about what this controller can do,
  and the runner records the latter as a skipped step, which would let the precise defect step 1
  exists to rule out produce a clean-looking run.

## Requiring the transport rather than preferring it

`largeMessage` moves from a command invocation to any client interaction, so a read can also require
a session that permits large payloads. It is a hard requirement: the interaction establishes a
TCP-backed session or fails, rather than quietly falling back to reliable messaging. Every case in
the TCP block now carries it, so none of them can pass over a transport it did not use — previously
they rested on a soft per-session preference and a device-flavor restriction.

chip-tool cannot express this: it decides a session's transport when it establishes one and reuses
the session pairing already made. It refuses the option, and the new session methods, with a stated
reason, so a chip-tool leg is recorded as skipped rather than passing on a transport nobody used.

## One claim the device side cannot make

A device does drop the session when its connection goes, and logs that it did. Those lines are
written from the socket's own close callback, which carries no device attribution, so they reach the
run's output instead of the device's log — a device-log check for them can never match, and the
symptom looks exactly like a device that failed to evict. TC-SC-8.3 therefore rests on the
controller's own state and records the device half as an accepted gap, with the measurements behind
that in `test/cert/AGENTS.md`.

## Verification

- `npm run build-clean`, `npm run format-verify`, `npm run lint`, `npm test` — all clean.
- The framework's own suite: 62/62 in the TCP block's hermetic spec, whole suite green.
- TC-SC-8.2/8.3/8.4 run against a matter.js controller and a matter.js device, each check carrying
  its own evidence, e.g. `the TH holds tcp session 32295, which permits large payloads, with a
  maximum payload of 64000 bytes` and `the TH no longer holds session 32294, and holds tcp session
  32295`.
- Six mutations of the gating checks, each killing a named test — including the two vacuous-pass
  holes the identified-session API closes.
