### PR TITLE
fix(protocol): treat a peer's zero paths per invoke as one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A `status` field in a cluster that defines its own status codes is now `Status | <Cluster>.StatusCode`, so producing a cluster-specific code needs no cast and consuming one needs narrowing. This affects `DoorLock.SetCredentialResponse` and the DoorLock schedule responses
 
 - @matter/protocol
+    - Fix: A peer that negotiates zero paths per invoke is treated as accepting one path; invoking a command on such a peer previously exhausted the heap and crashed the process
+    - Enhancement: `SessionManager` refuses a local `maxPathsPerInvoke` below one, on construction and via `sessionParameters`
     - Enhancement: A group message's log line names the port beside the multicast address it went to, in the usual IPv6 form (`dest: [ff35:40:…]:5540`)
     - Fix: A command whose payload does not match the command's schema is answered with `INVALID_COMMAND` instead of `FAILURE`
     - Fix: `UpdateFabricLabel` accepts an empty label, as the specification's `max 32` constraint sets no minimum; it previously failed the command

--- a/packages/node/test/node/PeerSessionParametersTest.ts
+++ b/packages/node/test/node/PeerSessionParametersTest.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Crypto, MockCrypto, Seconds } from "@matter/general";
+import { Peer, PeerSet } from "@matter/protocol";
+import { MockSite } from "./mock-site.js";
+
+describe("Peer session parameters", () => {
+    before(() => {
+        MockTime.init();
+    });
+
+    async function commissionedPeer(site: MockSite) {
+        const controller = await site.addController({});
+        const device = await site.addDevice({});
+
+        const controllerCrypto = controller.env.get(Crypto) as MockCrypto;
+        const deviceCrypto = device.env.get(Crypto) as MockCrypto;
+        controllerCrypto.entropic = deviceCrypto.entropic = true;
+
+        await controller.start();
+        const { passcode, discriminator } = device.state.commissioning;
+        await MockTime.resolve(controller.peers.commission({ passcode, discriminator, timeout: Seconds(90) }), {
+            macrotasks: true,
+        });
+
+        controllerCrypto.entropic = deviceCrypto.entropic = false;
+
+        const peers = [...controller.env.get(PeerSet)];
+        expect(peers).length.greaterThan(0);
+        return peers[0] as Peer;
+    }
+
+    // Characterization: the paths per invoke of the session the peer negotiated bounds what we send, even where the
+    // peer's Basic Information cluster reports a higher limit. A missing MAX_PATHS_PER_INVOKE means one path, and the
+    // reference implementation likewise reads only the session's value.
+    it("bounds paths per invoke by the negotiated session rather than the reported attribute", async () => {
+        await using site = new MockSite();
+        const peer = await commissionedPeer(site);
+
+        expect(peer.basicInformation?.maxPathsPerInvoke).equals(10);
+
+        peer.descriptor.sessionParameters = { ...peer.sessionParameters, maxPathsPerInvoke: 1 };
+
+        expect(peer.sessionParameters.maxPathsPerInvoke).equals(1);
+    });
+});

--- a/packages/protocol/src/action/client/ClientInteraction.ts
+++ b/packages/protocol/src/action/client/ClientInteraction.ts
@@ -40,6 +40,7 @@ import {
     Environment,
     Forever,
     ImplementationError,
+    InternalError,
     Instant,
     isObject,
     Lifetime,
@@ -584,6 +585,11 @@ export class ClientInteraction<
         maxPathsPerInvoke: number,
         session?: SessionT,
     ): DecodedInvokeResult {
+        // Batches of zero would never consume a command and allocate without end
+        if (maxPathsPerInvoke < 1) {
+            throw new InternalError(`Cannot split an invoke into batches of ${maxPathsPerInvoke} paths`);
+        }
+
         // Split commands into batches
         const allCommands = [...request.commands.entries()];
         const batches = new Array<ClientInvoke["commands"]>();

--- a/packages/protocol/src/protocol/ExchangeProvider.ts
+++ b/packages/protocol/src/protocol/ExchangeProvider.ts
@@ -75,6 +75,7 @@ export abstract class ExchangeProvider {
     abstract initiateExchange(options?: NewExchangeOptions): Promise<MessageExchange>;
     abstract readonly channelType: ChannelType;
     abstract readonly peerAddress?: PeerAddress;
+    /** The peer's invoke path limit, or undefined where there is no peer to report one. Never below one. */
     abstract readonly maxPathsPerInvoke?: number;
 
     /**

--- a/packages/protocol/src/session/SessionManager.ts
+++ b/packages/protocol/src/session/SessionManager.ts
@@ -67,6 +67,13 @@ function assertActiveThreshold(activeThreshold: Duration) {
     }
 }
 
+/** Reject a locally-configured MaxPathsPerInvoke below the specification's minimum of one. */
+function assertMaxPathsPerInvoke(maxPathsPerInvoke: number) {
+    if (maxPathsPerInvoke < 1) {
+        throw new ImplementationError(`Max Paths Per Invoke of ${maxPathsPerInvoke} is below the minimum of 1`);
+    }
+}
+
 /** Resumption record without a fabric reference but relevant lookup data used internally in SessionManager */
 interface InternalResumptionRecord {
     sharedSecret: Bytes;
@@ -228,6 +235,9 @@ export class SessionManager {
         const {
             fabrics: { crypto },
         } = context;
+        if (context.parameters?.maxPathsPerInvoke !== undefined) {
+            assertMaxPathsPerInvoke(context.parameters.maxPathsPerInvoke);
+        }
         this.#sessionParameters = SessionParameters({ ...SessionParameters.defaults, ...context.parameters });
         assertActiveThreshold(this.#sessionParameters.activeThreshold);
         this.#nextSessionId = crypto.randomUint16;
@@ -336,6 +346,9 @@ export class SessionManager {
     set sessionParameters(parameters: Partial<SessionParameters>) {
         if (parameters.activeThreshold !== undefined) {
             assertActiveThreshold(parameters.activeThreshold);
+        }
+        if (parameters.maxPathsPerInvoke !== undefined) {
+            assertMaxPathsPerInvoke(parameters.maxPathsPerInvoke);
         }
         for (const [key, value] of Object.entries(parameters)) {
             if (value !== undefined) {

--- a/packages/protocol/src/session/SessionManager.ts
+++ b/packages/protocol/src/session/SessionManager.ts
@@ -67,10 +67,16 @@ function assertActiveThreshold(activeThreshold: Duration) {
     }
 }
 
-/** Reject a locally-configured MaxPathsPerInvoke below the specification's minimum of one. */
+/**
+ * Reject a locally-configured MaxPathsPerInvoke that is not a whole count of at least one. The setter installs the
+ * value we advertise without normalizing it, and a fractional count encodes truncated while our own limit keeps the
+ * remainder.
+ */
 function assertMaxPathsPerInvoke(maxPathsPerInvoke: number) {
-    if (maxPathsPerInvoke < 1) {
-        throw new ImplementationError(`Max Paths Per Invoke of ${maxPathsPerInvoke} is below the minimum of 1`);
+    if (!Number.isInteger(maxPathsPerInvoke) || maxPathsPerInvoke < 1) {
+        throw new ImplementationError(
+            `Max Paths Per Invoke of ${maxPathsPerInvoke} is not a whole number of at least 1`,
+        );
     }
 }
 

--- a/packages/protocol/src/session/SessionManager.ts
+++ b/packages/protocol/src/session/SessionManager.ts
@@ -1033,9 +1033,3 @@ export class SessionManager {
         if (this.#nextSessionId === 0) this.#nextSessionId++;
     }
 }
-
-namespace SessionManager {
-    export interface Options {
-        maxPathsPerInvoke?: number;
-    }
-}

--- a/packages/protocol/src/session/SessionParameters.ts
+++ b/packages/protocol/src/session/SessionParameters.ts
@@ -70,8 +70,9 @@ export function SessionParameters(config?: SessionParameters.Config): SessionPar
     }
 
     // The MaxPathsPerInvoke attribute defines zero as "assume one", and the MAX_PATHS_PER_INVOKE session parameter
-    // carries that same attribute
-    if (typeof sanitizedConfig.maxPathsPerInvoke === "number" && sanitizedConfig.maxPathsPerInvoke < 1) {
+    // carries that same attribute. Persisted parameters reach us untyped, so anything but a number of at least one
+    // takes the fallback.
+    if (!(typeof sanitizedConfig.maxPathsPerInvoke === "number" && sanitizedConfig.maxPathsPerInvoke >= 1)) {
         delete sanitizedConfig.maxPathsPerInvoke;
     }
 

--- a/packages/protocol/src/session/SessionParameters.ts
+++ b/packages/protocol/src/session/SessionParameters.ts
@@ -5,6 +5,7 @@
  */
 
 import { SupportedTransportsBitmap, SupportedTransportsSchema } from "#common/SupportedTransportsBitmap.js";
+import { UINT16_MAX } from "@matter/general";
 import { Specification } from "@matter/model";
 import { SessionIntervals } from "./SessionIntervals.js";
 
@@ -70,9 +71,15 @@ export function SessionParameters(config?: SessionParameters.Config): SessionPar
     }
 
     // The MaxPathsPerInvoke attribute defines zero as "assume one", and the MAX_PATHS_PER_INVOKE session parameter
-    // carries that same attribute. Persisted parameters reach us untyped, so anything but a number of at least one
-    // takes the fallback.
-    if (!(typeof sanitizedConfig.maxPathsPerInvoke === "number" && sanitizedConfig.maxPathsPerInvoke >= 1)) {
+    // carries that same attribute as a uint16. Persisted parameters reach us untyped, so anything the wire could not
+    // have carried takes the fallback.
+    const maxPathsPerInvoke = sanitizedConfig.maxPathsPerInvoke;
+    if (
+        typeof maxPathsPerInvoke !== "number" ||
+        !Number.isInteger(maxPathsPerInvoke) ||
+        maxPathsPerInvoke < 1 ||
+        maxPathsPerInvoke > UINT16_MAX
+    ) {
         delete sanitizedConfig.maxPathsPerInvoke;
     }
 

--- a/packages/protocol/src/session/SessionParameters.ts
+++ b/packages/protocol/src/session/SessionParameters.ts
@@ -69,6 +69,12 @@ export function SessionParameters(config?: SessionParameters.Config): SessionPar
         }
     }
 
+    // The MaxPathsPerInvoke attribute defines zero as "assume one", and the MAX_PATHS_PER_INVOKE session parameter
+    // carries that same attribute
+    if (typeof sanitizedConfig.maxPathsPerInvoke === "number" && sanitizedConfig.maxPathsPerInvoke < 1) {
+        delete sanitizedConfig.maxPathsPerInvoke;
+    }
+
     return { ...SessionParameters.fallbacks, ...sanitizedConfig, supportedTransports, maxTcpMessageSize };
 }
 
@@ -104,8 +110,10 @@ export namespace SessionParameters {
         specificationVersion: 0,
 
         /**
-         * Fallback value for the maximum number of paths that can be included in a single invoke message when not provided in
-         * Session parameters.
+         * Fallback value for the maximum number of paths that can be included in a single invoke message when not
+         * provided in, or reported as zero by, Session parameters.
+         *
+         * @see {@link MatterSpecification.v16.Core} § 11.1.5.23
          */
         maxPathsPerInvoke: 1,
 

--- a/packages/protocol/test/action/InvokeLargeMessageTest.ts
+++ b/packages/protocol/test/action/InvokeLargeMessageTest.ts
@@ -297,7 +297,12 @@ describe("Invoke largeMessage flag", () => {
                 request.largeMessage = true;
             }
             if (!request.largeMessage) {
-                if (request.invokeRequests.length === 1 && request.batchDuration !== false && maxPathsPerInvoke > 1) {
+                if (
+                    request.invokeRequests.length === 1 &&
+                    request.batchDuration !== false &&
+                    maxPathsPerInvoke > 1 &&
+                    !request.suppressResponse
+                ) {
                     const endpointId = request.invokeRequests[0].commandPath.endpointId;
                     if (endpointId !== undefined && endpointId !== 0 && !request.timedRequest) {
                         return "batched";

--- a/packages/protocol/test/action/InvokeLargeMessageTest.ts
+++ b/packages/protocol/test/action/InvokeLargeMessageTest.ts
@@ -297,7 +297,7 @@ describe("Invoke largeMessage flag", () => {
                 request.largeMessage = true;
             }
             if (!request.largeMessage) {
-                if (request.invokeRequests.length === 1 && request.batchDuration !== false && maxPathsPerInvoke) {
+                if (request.invokeRequests.length === 1 && request.batchDuration !== false && maxPathsPerInvoke > 1) {
                     const endpointId = request.invokeRequests[0].commandPath.endpointId;
                     if (endpointId !== undefined && endpointId !== 0 && !request.timedRequest) {
                         return "batched";

--- a/packages/protocol/test/action/client/ClientInteractionInvokeTest.ts
+++ b/packages/protocol/test/action/client/ClientInteractionInvokeTest.ts
@@ -12,7 +12,16 @@ import { MessageType } from "#interaction/InteractionMessenger.js";
 import { ExchangeManager } from "#protocol/ExchangeManager.js";
 import { ExchangeProvider } from "#protocol/ExchangeProvider.js";
 import { ExchangeReceiveOptions, MessageExchange } from "#protocol/MessageExchange.js";
-import { AbortedError, ChannelType, ClosedError, createPromise, Duration, Environment, Seconds } from "@matter/general";
+import {
+    AbortedError,
+    ChannelType,
+    ClosedError,
+    createPromise,
+    Duration,
+    Environment,
+    InternalError,
+    Seconds,
+} from "@matter/general";
 import { Specification } from "@matter/model";
 import {
     ClusterId,
@@ -367,6 +376,26 @@ describe("ClientInteraction invoke commandRef wire handling", () => {
                 clusterStatus: undefined,
             },
         ]);
+    });
+
+    it("refuses to split an invoke for a provider reporting no usable path limit", async () => {
+        const sentRequests = new Array<InvokeRequest>();
+        const client = new ClientInteraction({
+            environment: Environment.default,
+            exchangeProvider: new RefLessDeviceExchangeProvider(0, sentRequests),
+        });
+
+        try {
+            await expect(
+                (async () => {
+                    for await (const _chunk of client.invoke(twoOnOffCommands()));
+                })(),
+            ).rejectedWith(InternalError);
+        } finally {
+            await client.close();
+        }
+
+        expect(sentRequests.length).equals(0);
     });
 
     it("aborts an in-flight batch on close instead of awaiting its response", async () => {

--- a/packages/protocol/test/session/SecureSessionTest.ts
+++ b/packages/protocol/test/session/SecureSessionTest.ts
@@ -66,6 +66,25 @@ describe("SecureSession", () => {
         });
     }
 
+    describe("session parameters", () => {
+        it("assumes one path per invoke for a peer that reports zero", () => {
+            const session = new NodeSession({
+                crypto,
+                id: 1,
+                fabric: undefined,
+                peerNodeId: NodeId.UNSPECIFIED_NODE_ID,
+                peerSessionId: 0x8d4b,
+                decryptKey: DECRYPT_KEY,
+                encryptKey: ENCRYPT_KEY,
+                attestationKey: new Uint8Array(),
+                isInitiator: true,
+                sessionParameters: { maxPathsPerInvoke: 0 },
+            });
+
+            expect(session.parameters.maxPathsPerInvoke).equals(1);
+        });
+    });
+
     describe("peer loss", () => {
         it("conveys the initiating exchange to its subscriptions", async () => {
             const session = secureSession();

--- a/packages/protocol/test/session/SessionManagerTest.ts
+++ b/packages/protocol/test/session/SessionManagerTest.ts
@@ -564,6 +564,39 @@ describe("SessionManager", () => {
         });
     });
 
+    describe("max paths per invoke validation", () => {
+        function newManager(parameters: Partial<SessionParameters>) {
+            const storage = new MemoryStorageDriver();
+            storage.initialize();
+            return new SessionManager({
+                parameters: parameters as SessionParameters,
+                fabrics: new FabricManager(new StandardCrypto()),
+                storage: new StorageContext(storage, ["context"]),
+            });
+        }
+
+        it("rejects a local max paths per invoke of zero on construction", () => {
+            expect(() => newManager({ maxPathsPerInvoke: 0 })).throws(ImplementationError, "Max Paths Per Invoke");
+        });
+
+        it("rejects a local max paths per invoke of zero via the setter", async () => {
+            const sessionManager = newManager({});
+            await sessionManager.construction.ready;
+
+            expect(() => (sessionManager.sessionParameters = { maxPathsPerInvoke: 0 })).throws(
+                ImplementationError,
+                "Max Paths Per Invoke",
+            );
+        });
+
+        it("accepts a local max paths per invoke of one", async () => {
+            const sessionManager = newManager({ maxPathsPerInvoke: 1 });
+            await sessionManager.construction.ready;
+
+            expect(sessionManager.sessionParameters.maxPathsPerInvoke).equals(1);
+        });
+    });
+
     describe("session parameter setter", () => {
         function newManager(parameters: Partial<SessionParameters>) {
             const storage = new MemoryStorageDriver();

--- a/packages/protocol/test/session/SessionManagerTest.ts
+++ b/packages/protocol/test/session/SessionManagerTest.ts
@@ -589,6 +589,16 @@ describe("SessionManager", () => {
             );
         });
 
+        it("rejects a local max paths per invoke that is not a whole count", async () => {
+            const sessionManager = newManager({});
+            await sessionManager.construction.ready;
+
+            expect(() => (sessionManager.sessionParameters = { maxPathsPerInvoke: 2.5 })).throws(
+                ImplementationError,
+                "Max Paths Per Invoke",
+            );
+        });
+
         it("accepts a local max paths per invoke of one", async () => {
             const sessionManager = newManager({ maxPathsPerInvoke: 1 });
             await sessionManager.construction.ready;

--- a/packages/protocol/test/session/SessionParametersTest.ts
+++ b/packages/protocol/test/session/SessionParametersTest.ts
@@ -14,6 +14,20 @@ describe("SessionParameters", () => {
         expect(params.activeInterval).equal(Hours(2));
     });
 
+    describe("maxPathsPerInvoke", () => {
+        it("honors a peer-reported limit above one", () => {
+            expect(SessionParameters({ maxPathsPerInvoke: 9 }).maxPathsPerInvoke).equal(9);
+        });
+
+        it("assumes one when the peer reports zero", () => {
+            expect(SessionParameters({ maxPathsPerInvoke: 0 }).maxPathsPerInvoke).equal(1);
+        });
+
+        it("assumes one when the peer reports no limit", () => {
+            expect(SessionParameters({ maxPathsPerInvoke: undefined }).maxPathsPerInvoke).equal(1);
+        });
+    });
+
     describe("TCP spec-version gate", () => {
         it("keeps TCP support for peers reporting spec version >= 1.5.0", () => {
             const params = SessionParameters({

--- a/packages/protocol/test/session/SessionParametersTest.ts
+++ b/packages/protocol/test/session/SessionParametersTest.ts
@@ -27,9 +27,16 @@ describe("SessionParameters", () => {
             expect(SessionParameters({ maxPathsPerInvoke: undefined }).maxPathsPerInvoke).equal(1);
         });
 
-        it("assumes one for a persisted limit that is not a usable number", () => {
-            for (const maxPathsPerInvoke of [Number.NaN, -1, "10", null]) {
-                expect(SessionParameters({ maxPathsPerInvoke } as SessionParameters.Config).maxPathsPerInvoke).equal(1);
+        it("honors the highest limit the wire can carry", () => {
+            expect(SessionParameters({ maxPathsPerInvoke: 0xffff }).maxPathsPerInvoke).equal(0xffff);
+        });
+
+        it("assumes one for a persisted limit the wire could not have carried", () => {
+            for (const maxPathsPerInvoke of [Number.NaN, Infinity, -1, 2.5, 0x10000, "10", null]) {
+                expect(SessionParameters({ maxPathsPerInvoke } as SessionParameters.Config).maxPathsPerInvoke).equal(
+                    1,
+                    `for ${String(maxPathsPerInvoke)}`,
+                );
             }
         });
     });

--- a/packages/protocol/test/session/SessionParametersTest.ts
+++ b/packages/protocol/test/session/SessionParametersTest.ts
@@ -26,6 +26,12 @@ describe("SessionParameters", () => {
         it("assumes one when the peer reports no limit", () => {
             expect(SessionParameters({ maxPathsPerInvoke: undefined }).maxPathsPerInvoke).equal(1);
         });
+
+        it("assumes one for a persisted limit that is not a usable number", () => {
+            for (const maxPathsPerInvoke of [Number.NaN, -1, "10", null]) {
+                expect(SessionParameters({ maxPathsPerInvoke } as SessionParameters.Config).maxPathsPerInvoke).equal(1);
+            }
+        });
     });
 
     describe("TCP spec-version gate", () => {


### PR DESCRIPTION
## What

A Matter node states how many command paths it accepts in a single invoke message. It states this twice: as the `MaxPathsPerInvoke` attribute of its Basic Information cluster, and as the `MAX_PATHS_PER_INVOKE` session parameter it sends while establishing a CASE or PASE session. The specification defines a reported zero as meaning one (core § 11.1.5.23), but matter.js stored whatever the peer sent.

Invoking a command on a peer that reported zero then divided the command list into batches of zero. A batch of zero consumes no command, so the division never ends and allocates on every pass until the process exhausts its heap and dies — a single command was enough, no batch required. Two ways to reach it: a device that reports zero of its own accord, and, because the session parameters in CASE Sigma2 are not covered by the signature, anything on the local network rewriting a healthy device's response.

## Change

- `SessionParameters()` keeps a paths-per-invoke value only if it is an integer the wire could have carried, one through `UINT16_MAX`, and takes its fallback of one otherwise. This is the single door every peer-supplied value passes through — the session itself, the peer descriptor, CASE and Sigma2 resumption, restored resumption records and persisted commissioning parameters — so a zero already on disk heals on the next read with no storage migration.

  The field is a uint16 on the wire (`PaseMessages.ts:43`), but persisted parameters arrive untyped, and three of those values misbehave in different ways: `NaN` passes any lower bound because every comparison against it is false, an infinite value compares greater than any command count and so disables splitting entirely, and a fractional one yields batches above the stated limit because a slice truncates its bounds.
- `#invokeWithSplitting` raises `InternalError` on a path count below one. No caller can reach it now, but the division depends on the count being positive, so the requirement states itself where it is depended upon rather than at each of the two places the count is read.
- `SessionManager` refuses a `maxPathsPerInvoke` that is not a whole count of at least one for *our own* session parameters, on construction and through the `sessionParameters` setter, rather than quietly correcting it. These are the values we advertise to peers, the setter installs them without normalizing, and a consumer of `@matter/protocol` that builds its own `SessionManager` has no Basic Information cluster to supply a sane value. This mirrors the existing `assertActiveThreshold` guard beside it and throws `ImplementationError`.

  The check stops at whole and at least one rather than repeating the wire range, because the attribute this value is fed from already refuses an out-of-range or infinite write with `IntegerRangeError` and `TlvUInt16` refuses one at encode. A fractional value is the case neither catches: it reaches the wire truncated while our own limit keeps the remainder.
- Removed `SessionManager.Options`, which had no reader and sat in a namespace that was never exported.

The two directions stay separate, and this change keeps them that way. What *we* accept comes from our own Basic Information attribute and is what we advertise and enforce on inbound invokes. What we may *send* comes only from what the peer stated: the session parameter bounds it, with the peer's attribute as the fallback until a session exists. A `ServerNode` reaches neither new guard through ordinary configuration — its Basic Information behavior replaces a configured zero with the default during initialization, and the model's `min 1` constraint refuses a later write.

## Tests

Twelve added, each verified to fail with its production change reverted:

- `SessionParameters` resolves zero and absent to one, keeps a real limit and the highest the wire can carry, and falls back for a value the wire could not have carried (`NaN`, `Infinity`, negative, fractional, above `UINT16_MAX`, string, null)
- `SecureSession` built from session parameters reporting zero exposes one
- `SessionManager` rejects zero on construction and via the setter, rejects a fractional count, and accepts one
- Splitting an invoke for a provider reporting zero paths rejects with `InternalError` and sends nothing

The last one closes the loop the crash report identified. Its absence is not merely a coverage gap: with the guard weakened so a zero reaches the division, that test reproduces the reported `FATAL ERROR ... Ineffective mark-compacts near heap limit ... JavaScript heap out of memory` rather than failing an assertion. Both ends of the failure are therefore covered — the input can no longer be zero, and the division refuses a zero if one ever arrives by another route.

One characterization test pins that a negotiated session bounds paths per invoke even where the peer's attribute reports more — reading the attribute as an upper bound instead would send a peer more paths than its session allows, which is also how the reference implementation reads it.

Also corrected the routing model in `InvokeLargeMessageTest`, which stands in for `ClientInteraction.invoke` dispatch: it gated batching on a truthy path limit where production gates on more than one, and omitted the condition that keeps a suppress-response command out of a batch.

One cast appears in the new tests, `as SessionParameters.Config`, to pass the values the type forbids — which is the case being tested.

## Verification

`npm run build-clean`, `npm run format-verify`, `npm run lint` and `npm test` all clean from the repository root.

Addresses matter-js/matterjs-server#1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)