### PR TITLE
Stop the Bluetooth driver on shutdown in every adapter state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,7 @@ The main work (all changes without a GitHub username in brackets in the below li
     - Fix: A disconnect that never completes no longer leaves the channel request pending forever
     - Fix: Aborting a BLE connection attempt now stops its retries and releases a link the attempt already established
     - Fix: Stopping an advertisement that was still waiting for the Bluetooth adapter retracts it, so the adapter powering on no longer starts an advertisement that was already given up on
+    - Fix: Shutdown no longer hangs when Bluetooth is enabled but no adapter is usable; the Bluetooth driver is now always stopped, which releases the handle that kept the process alive
 
 - @matter/nodejs-shell
     - Fix: A cluster whose ID lies outside the ranges the specification allows is addressable instead of raising an error

--- a/packages/nodejs-ble/src/NobleBleClient.ts
+++ b/packages/nodejs-ble/src/NobleBleClient.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Bytes, Diagnostic, Instant, Logger, Time } from "@matter/general";
+import { Bytes, Diagnostic, Logger } from "@matter/general";
 import { require } from "@matter/nodejs-ble/require";
 import { MatterBle } from "@matter/protocol";
 import type { Noble, Peripheral } from "@stoprocent/noble";
@@ -207,9 +207,6 @@ export class NobleBleClient {
         } catch (error) {
             logger.info("Error stopping Noble:", error);
         }
-
-        // Defer listener removal so noble.stop() can finish its internal event roundtrip
-        Time.getTimer("noble-cleanup", Instant, () => noble.removeAllListeners()).start();
     }
 
     [Diagnostic.name] = "BLE client";

--- a/packages/nodejs-ble/src/NobleBleClient.ts
+++ b/packages/nodejs-ble/src/NobleBleClient.ts
@@ -40,6 +40,13 @@ export function nobleDisconnectReason(reason: unknown) {
     return reason === undefined ? "unknown" : String(reason);
 }
 
+interface NobleListeners {
+    stateChange: (state: string) => void;
+    discover: (peripheral: Peripheral) => void;
+    scanStart: () => void;
+    scanStop: () => void;
+}
+
 export class NobleBleClient {
     private readonly discoveredPeripherals = new Map<string, { peripheral: Peripheral; matterServiceData: Bytes }>();
     private shouldScan = false;
@@ -48,6 +55,7 @@ export class NobleBleClient {
     #scanDeferred = false;
     private deviceDiscoveredCallback: ((peripheral: Peripheral, manufacturerData: Bytes) => void) | undefined;
     #closing = false;
+    readonly #listeners: NobleListeners;
 
     constructor(options?: BleOptions) {
         const { environment } = options ?? {};
@@ -63,38 +71,45 @@ export class NobleBleClient {
                 }`,
             );
         }*/
-        noble.on("stateChange", state => {
-            this.nobleState = state;
-            logger.debug(`Noble state changed to ${state}`);
-            if (this.#closing) {
-                return;
-            }
-            if (state === "poweredOn") {
-                if (this.shouldScan) {
-                    const deferred = this.#scanDeferred;
-                    this.startScanning().then(
-                        () => {
-                            if (deferred) {
-                                logger.notice("Bluetooth adapter is powered on, BLE discovery started");
-                            }
-                        },
-                        error => logger.error("Cannot start BLE discovery after the adapter powered on:", error),
-                    );
+        this.#listeners = {
+            stateChange: state => {
+                this.nobleState = state;
+                logger.debug(`Noble state changed to ${state}`);
+                if (state === "poweredOn") {
+                    if (this.shouldScan) {
+                        const deferred = this.#scanDeferred;
+                        this.startScanning().then(
+                            () => {
+                                if (deferred) {
+                                    logger.notice("Bluetooth adapter is powered on, BLE discovery started");
+                                }
+                            },
+                            error => logger.error("Cannot start BLE discovery after the adapter powered on:", error),
+                        );
+                    }
+                } else {
+                    this.stopScanning().catch(error => logger.error("Cannot stop BLE discovery:", error));
                 }
-            } else {
-                this.stopScanning().catch(error => logger.error("Cannot stop BLE discovery:", error));
-            }
-        });
-        noble.on("discover", peripheral => this.handleDiscoveredDevice(peripheral));
-        noble.on("scanStart", () => {
-            if (!this.shouldScan) {
-                // Noble sometimes emits scanStart when we did not asked for and misses the scanStop event
-                // TODO: Remove as soon as Noble fixed this behavior
-                return;
-            }
-            this.isScanning = true;
-        });
-        noble.on("scanStop", () => (this.isScanning = false));
+            },
+
+            discover: peripheral => this.handleDiscoveredDevice(peripheral),
+
+            scanStart: () => {
+                if (!this.shouldScan) {
+                    // Noble sometimes emits scanStart when we did not asked for and misses the scanStop event
+                    // TODO: Remove as soon as Noble fixed this behavior
+                    return;
+                }
+                this.isScanning = true;
+            },
+
+            scanStop: () => (this.isScanning = false),
+        };
+
+        noble.on("stateChange", this.#listeners.stateChange);
+        noble.on("discover", this.#listeners.discover);
+        noble.on("scanStart", this.#listeners.scanStart);
+        noble.on("scanStop", this.#listeners.scanStop);
     }
 
     public setDiscoveryCallback(callback: (peripheral: Peripheral, manufacturerData: Bytes) => void) {
@@ -105,6 +120,7 @@ export class NobleBleClient {
     }
 
     public async startScanning() {
+        if (this.#closing) return;
         if (this.isScanning) {
             this.#scanDeferred = false;
             return;
@@ -179,6 +195,11 @@ export class NobleBleClient {
         this.#closing = true;
 
         logger.debug(`Stopping Noble, adapter state is "${this.nobleState}"`);
+
+        noble.off("stateChange", this.#listeners.stateChange);
+        noble.off("discover", this.#listeners.discover);
+        noble.off("scanStart", this.#listeners.scanStart);
+        noble.off("scanStop", this.#listeners.scanStop);
 
         try {
             // Windows holds a referenced handle from the first listener on, radio or not, and only stop() releases it

--- a/packages/nodejs-ble/src/NobleBleClient.ts
+++ b/packages/nodejs-ble/src/NobleBleClient.ts
@@ -67,6 +67,9 @@ export class NobleBleClient {
         noble.on("stateChange", state => {
             this.nobleState = state;
             logger.debug(`Noble state changed to ${state}`);
+            if (this.#closing) {
+                return;
+            }
             if (state === "poweredOn") {
                 if (this.shouldScan) {
                     const deferred = this.#scanDeferred;
@@ -176,11 +179,9 @@ export class NobleBleClient {
         }
         this.#closing = true;
 
-        if (this.nobleState === "poweredOn") {
-            logger.debug("Stopping Noble");
+        logger.debug("Stopping Noble");
 
-            // noble.stop() hangs when BLE isn't powered on (https://github.com/stoprocent/noble/issues/30).
-            // Only attempt the full stop sequence when BLE is actually available.
+        if (this.nobleState === "poweredOn") {
             try {
                 // Workaround: start scanning first so stop gets the HCI response it needs (Linux HCI driver).
                 // TODO Remove when https://github.com/stoprocent/noble/issues/30 got fixed
@@ -190,21 +191,17 @@ export class NobleBleClient {
             } catch (error) {
                 logger.info("Error starting scan during close, proceeding to stop:", error);
             }
-
-            try {
-                noble.stop();
-            } catch (error) {
-                logger.info("Error stopping Noble:", error);
-            }
-
-            // Defer listener removal so noble.stop() can finish its internal event roundtrip
-            Time.getTimer("noble-cleanup", Instant, () => noble.removeAllListeners()).start();
-        } else {
-            logger.debug(`Skip stopping noble because state is "${this.nobleState}"`);
-
-            // No stop needed — remove listeners immediately to release the event loop
-            noble.removeAllListeners();
         }
+
+        try {
+            // Windows holds a referenced handle from the first listener on, radio or not, and only stop() releases it
+            noble.stop();
+        } catch (error) {
+            logger.info("Error stopping Noble:", error);
+        }
+
+        // Defer listener removal so noble.stop() can finish its internal event roundtrip
+        Time.getTimer("noble-cleanup", Instant, () => noble.removeAllListeners()).start();
     }
 
     [Diagnostic.name] = "BLE client";

--- a/packages/nodejs-ble/src/NobleBleClient.ts
+++ b/packages/nodejs-ble/src/NobleBleClient.ts
@@ -71,6 +71,11 @@ export class NobleBleClient {
                 }`,
             );
         }*/
+        // Noble starts its bindings a tick after the first listener attaches, and a close in that
+        // same turn would leave them running; reading the state starts them now and reports what
+        // a binding that could not start already found
+        this.nobleState = noble.state;
+
         this.#listeners = {
             stateChange: state => {
                 this.nobleState = state;

--- a/packages/nodejs-ble/src/NobleBleClient.ts
+++ b/packages/nodejs-ble/src/NobleBleClient.ts
@@ -8,7 +8,6 @@ import { Bytes, Diagnostic, Instant, Logger, Time } from "@matter/general";
 import { require } from "@matter/nodejs-ble/require";
 import { MatterBle } from "@matter/protocol";
 import type { Noble, Peripheral } from "@stoprocent/noble";
-import { platform } from "node:process";
 import { BleOptions } from "./NodeJsBle.js";
 
 const logger = Logger.get("NobleBleClient");
@@ -179,19 +178,7 @@ export class NobleBleClient {
         }
         this.#closing = true;
 
-        logger.debug("Stopping Noble");
-
-        if (this.nobleState === "poweredOn") {
-            try {
-                // Workaround: start scanning first so stop gets the HCI response it needs (Linux HCI driver).
-                // TODO Remove when https://github.com/stoprocent/noble/issues/30 got fixed
-                if (platform !== "win32" && platform !== "darwin") {
-                    noble.startScanning();
-                }
-            } catch (error) {
-                logger.info("Error starting scan during close, proceeding to stop:", error);
-            }
-        }
+        logger.debug(`Stopping Noble, adapter state is "${this.nobleState}"`);
 
         try {
             // Windows holds a referenced handle from the first listener on, radio or not, and only stop() releases it


### PR DESCRIPTION
Fixes #4428

## What was wrong

With Bluetooth enabled on a host that has no usable adapter, the process never exited. Shutdown ran to completion — storage locks released, `Runtime Shutting down` logged — and then the node stayed alive until it was killed.

Noble, the Bluetooth driver library, holds a native handle that keeps Node's event loop alive. Only its `stop()` releases that handle, and on Windows the handle is created as soon as a listener is attached, whether or not a radio exists. `close()` called `stop()` only while the adapter reported `poweredOn`, so in every state a missing or disabled adapter reports (`unsupported`, `poweredOff`, `unknown`) the handle stayed referenced.

## What changed

- `close()` stops the driver in every adapter state. Stopping a driver that never started is harmless: the Windows bindings guard a null manager, the macOS bindings throw and we log it, and the Linux bindings' teardown is bounded by the socket read timeout.
- The client now detaches its own four Noble listeners when it closes, before stopping the driver, instead of leaving them attached until a deferred sweep. No event can reach a closed client, so no handler needs to ask whether a close is under way.
- Starting a scan is refused once a close has begun, as stopping one already was. That call previously raced the driver's teardown.
- Shutdown no longer starts a scan on Linux before stopping. That existed to unblock the driver's poll thread from a blocking read; the Linux driver has set a one second receive timeout since `@stoprocent/bluetooth-hci-socket` 2.2.5, well below the version Noble pulls in, so the poll thread checks for a stop on its own.
- The deferred sweep that removed *all* listeners from Noble is gone. One process shares Noble between clients, so that sweep would have taken another client's listeners with it.
- The debug line reporting the stop now names the adapter state it ran in.

## Verification

Code-verified end to end against the installed Noble and `bluetooth-hci-socket` sources — the Windows null guard, the macOS throw, the Linux `SO_RCVTIMEO` and the poll loop that checks its stop flag against it. Not run on a Windows host without Bluetooth, which is where the reporter saw the hang.

```
$ npm run build-clean
  ✓ Clean (1.3s)
  ✓ Type check (4.7s)
  ✓ Transpile (4.3s)

$ npm run format-verify
All matched files use the correct format.
Finished in 77ms on 2386 files using 14 threads.

$ npm run lint
> oxlint --type-aware --tsconfig tsconfig.json examples packages support
(exit 0)

$ npm test          # in packages/nodejs-ble
Testing @matter/nodejs-ble@0.0.0-git
  ✓ ESM 16/16 (.013s)
  ✓ CJS 16/16 (.0s)
```

No test covers the changed branches: `NobleBleClient` requires the native Noble package in its constructor, so nothing in `test/` can construct it. Verified rather than assumed — each changed branch was reverted in turn and the suite stayed green.

## Not in this change

Noble is a module-level singleton while each client manages its own lifecycle, which is why one client's close stops the driver for all of them and why BLE cannot be brought back up in-process after a shutdown. Every symptom of that predates this change, which narrows the hang without touching the design. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)