### PR TITLE
feat(protocol): let a BLE transport state which peripherals it can still reach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/protocol
     - Enhancement: `ClientRequest.largeMessage` requires a session that permits large payloads for any interaction, not only a command invocation; such an interaction establishes a TCP-backed session or fails rather than falling back to MRP
+    - Enhancement: A `BleScannerClient` may state via the new optional `isPeripheralReachable()` whether a peripheral it discovered can still be reached, and the scanner offers only reachable peripherals for commissioning. A transport that routes BLE through remote proxies no longer offers peripherals whose proxy is gone, and offers them again once it can reach them
 
 - @matter/model
     - Enhancement: `DeviceTypeModel.effectiveComposition` states whether a device type composes its endpoint's `PartsList` of every descendant or of its own children

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ The main work (all changes without a GitHub username in brackets in the below li
 
 - @matter/protocol
     - Enhancement: `ClientRequest.largeMessage` requires a session that permits large payloads for any interaction, not only a command invocation; such an interaction establishes a TCP-backed session or fails rather than falling back to MRP
-    - Enhancement: A `BleScannerClient` may state via the new optional `isPeripheralReachable()` whether a peripheral it discovered can still be reached, and the scanner offers only reachable peripherals for commissioning. A transport that routes BLE through remote proxies no longer offers peripherals whose proxy is gone, and offers them again once it can reach them
+    - Enhancement: A `BleScannerClient` may state via the new optional `isPeripheralReachable()` whether a peripheral it discovered can still be reached, and the scanner offers only reachable peripherals for commissioning. A transport that routes BLE through remote proxies no longer offers peripherals whose proxy is gone
+    - Fix: A running BLE discovery is woken by any advertisement of a device matching its query, not only by an address it has never seen, so a device that becomes a candidate again during the discovery is handed to it. Each device is still offered once per discovery
     - Fix: A session or exchange ending because its transport connection dropped reports `TransportClosedError` instead of an untyped error
     - Fix: A CASE pairing failure reaches the caller even when reporting it to the peer fails; the report's own failure is logged instead of replacing the pairing error
 

--- a/packages/protocol/src/common/BleScanner.ts
+++ b/packages/protocol/src/common/BleScanner.ts
@@ -396,7 +396,10 @@ export class BleScanner implements Scanner {
                 }
             }
 
-            await this.#registerWaiterPromise(queryKey, remainingTime, false, queryResolver);
+            // Wake on any advertisement of a candidate, not only an address never seen: the loop's own set decides
+            // what is news, so a peripheral that becomes a candidate again is delivered without the scanner
+            // tracking why it was not one before.
+            await this.#registerWaiterPromise(queryKey, remainingTime, true, queryResolver);
         }
         await this.#client.stopScanning();
         return this.#getCommissionableDevices(identifier).map(({ deviceData }) => deviceData);

--- a/packages/protocol/src/common/BleScanner.ts
+++ b/packages/protocol/src/common/BleScanner.ts
@@ -33,6 +33,14 @@ export interface BleScannerClient {
     setDiscoveryCallback(callback: (peripheral: BlePeripheral, data: Bytes) => void): void;
     startScanning(): Promise<void>;
     stopScanning(): Promise<void>;
+
+    /**
+     * Whether a peripheral discovered earlier can still be reached. A transport that routes through remote proxies
+     * loses access to a peripheral when the proxy that reported it goes away, and a peripheral it cannot reach is no
+     * candidate for commissioning. A client that omits this keeps every discovered peripheral available; the record
+     * stays either way, so a peripheral becomes a candidate again as soon as it is reachable again.
+     */
+    isPeripheralReachable?(address: string): boolean;
 }
 
 export type CommissionableDeviceData = CommissionableDevice & {
@@ -81,7 +89,14 @@ export class BleScanner implements Scanner {
         if (device === undefined) {
             throw new BleError(`No device found for address ${address}`);
         }
+        if (!this.#isReachable(address)) {
+            throw new BleError(`Device with address ${address} is currently not reachable`);
+        }
         return device;
+    }
+
+    #isReachable(address: string) {
+        return this.#client.isPeripheralReachable?.(address) ?? true;
     }
 
     /**
@@ -264,9 +279,9 @@ export class BleScanner implements Scanner {
 
     #getCommissionableDevices(identifier: CommissionableDeviceIdentifiers) {
         // Newest first so ordered consumers (e.g. parallel PASE discovery) prefer the freshest advertisement
-        const storedRecords = Array.from(this.#discoveredMatterDevices.values()).sort(
-            (a, b) => b.lastSeen - a.lastSeen,
-        );
+        const storedRecords = Array.from(this.#discoveredMatterDevices.values())
+            .filter(({ peripheral }) => this.#isReachable(peripheral.address))
+            .sort((a, b) => b.lastSeen - a.lastSeen);
 
         const foundRecords = new Array<DiscoveredBleDevice>();
         if ("instanceId" in identifier || "deviceType" in identifier) {

--- a/packages/protocol/src/common/BleScanner.ts
+++ b/packages/protocol/src/common/BleScanner.ts
@@ -171,6 +171,7 @@ export class BleScanner implements Scanner {
             };
             const existing = this.#discoveredMatterDevices.get(address);
             const deviceExisting = existing !== undefined;
+            const withheld = !this.#isReachable(address);
             // A peripheral withheld as unreachable was never offered, so its advertisement resolves waiters that
             // ignore updates — otherwise a continuous discovery would never learn the transport reaches it again.
             const isUpdatedRecord = deviceExisting && !existing.withheld;
@@ -198,11 +199,11 @@ export class BleScanner implements Scanner {
                 hasAdditionalAdvertisementData,
                 serviceDataHex,
                 lastSeen: now,
-                withheld: false,
+                withheld,
             });
 
             const queryKey = this.#findCommissionableQueryIdentifier(deviceData);
-            if (queryKey !== undefined) {
+            if (queryKey !== undefined && !withheld) {
                 this.#finishWaiter(queryKey, true, isUpdatedRecord);
             }
         } catch (error) {

--- a/packages/protocol/src/common/BleScanner.ts
+++ b/packages/protocol/src/common/BleScanner.ts
@@ -87,11 +87,12 @@ export class BleScanner implements Scanner {
     }
 
     public getDiscoveredDevice(address: string): DiscoveredBleDevice {
+        this.#refreshReachability();
         const device = this.#discoveredMatterDevices.get(address);
         if (device === undefined) {
             throw new BleError(`No device found for address ${address}`);
         }
-        if (!this.#isReachable(address)) {
+        if (device.withheld) {
             throw new BleError(`Device with address ${address} is currently not reachable`);
         }
         return device;
@@ -99,6 +100,20 @@ export class BleScanner implements Scanner {
 
     #isReachable(address: string) {
         return this.#client.isPeripheralReachable?.(address) ?? true;
+    }
+
+    /**
+     * Reconcile every record with what the transport reaches now. Reachability is a property of the record, updated
+     * here and when an advertisement writes one, so matching a record and deciding whether it may be offered stay
+     * separate concerns.
+     */
+    #refreshReachability() {
+        if (this.#client.isPeripheralReachable === undefined) {
+            return;
+        }
+        for (const record of this.#discoveredMatterDevices.values()) {
+            record.withheld = !this.#isReachable(record.peripheral.address);
+        }
     }
 
     /**
@@ -285,13 +300,10 @@ export class BleScanner implements Scanner {
         } else return "*";
     }
 
-    #getCommissionableDevices(identifier: CommissionableDeviceIdentifiers) {
+    #getCommissionableDevices(identifier: CommissionableDeviceIdentifiers, includeWithheld = false) {
         // Newest first so ordered consumers (e.g. parallel PASE discovery) prefer the freshest advertisement
         const storedRecords = Array.from(this.#discoveredMatterDevices.values())
-            .filter(record => {
-                record.withheld = !this.#isReachable(record.peripheral.address);
-                return !record.withheld;
-            })
+            .filter(record => includeWithheld || !record.withheld)
             .sort((a, b) => b.lastSeen - a.lastSeen);
 
         const foundRecords = new Array<DiscoveredBleDevice>();
@@ -338,18 +350,19 @@ export class BleScanner implements Scanner {
             return [];
         }
 
-        let storedRecords = this.#getCommissionableDevices(identifier);
+        this.#refreshReachability();
         if (ignoreExistingRecords) {
             // We want to have a fresh discovery result, so clear out the stored records because they might be outdated
-            for (const record of storedRecords) {
+            for (const record of this.#getCommissionableDevices(identifier, true)) {
                 this.#discoveredMatterDevices.delete(record.peripheral.address);
             }
-            storedRecords = [];
         }
+        let storedRecords = ignoreExistingRecords ? [] : this.#getCommissionableDevices(identifier);
         if (storedRecords.length === 0) {
             await this.#client.startScanning();
             await this.#registerWaiterPromise(queryKey, timeout);
 
+            this.#refreshReachability();
             storedRecords = this.#getCommissionableDevices(identifier);
             await this.#client.stopScanning();
         }
@@ -391,6 +404,7 @@ export class BleScanner implements Scanner {
         );
 
         while (!canceled && !this.#closed) {
+            this.#refreshReachability();
             this.#getCommissionableDevices(identifier).forEach(({ deviceData }) => {
                 const { deviceIdentifier } = deviceData;
                 if (!discoveredDevices.has(deviceIdentifier)) {
@@ -410,10 +424,12 @@ export class BleScanner implements Scanner {
             await this.#registerWaiterPromise(queryKey, remainingTime, false, queryResolver);
         }
         await this.#client.stopScanning();
+        this.#refreshReachability();
         return this.#getCommissionableDevices(identifier).map(({ deviceData }) => deviceData);
     }
 
     getDiscoveredCommissionableDevices(identifier: CommissionableDeviceIdentifiers): CommissionableDevice[] {
+        this.#refreshReachability();
         return this.#getCommissionableDevices(identifier).map(({ deviceData }) => deviceData);
     }
 

--- a/packages/protocol/src/common/BleScanner.ts
+++ b/packages/protocol/src/common/BleScanner.ts
@@ -56,8 +56,6 @@ export type DiscoveredBleDevice = {
 type StoredDiscoveredBleDevice = DiscoveredBleDevice & {
     serviceDataHex: string;
     lastSeen: number;
-    /** Set while the transport cannot reach the peripheral, so its return counts as a new discovery. */
-    withheld: boolean;
 };
 
 /** Entries older than this are treated as dead addresses when matching service data arrives from a new address. */
@@ -87,12 +85,11 @@ export class BleScanner implements Scanner {
     }
 
     public getDiscoveredDevice(address: string): DiscoveredBleDevice {
-        this.#refreshReachability();
         const device = this.#discoveredMatterDevices.get(address);
         if (device === undefined) {
             throw new BleError(`No device found for address ${address}`);
         }
-        if (device.withheld) {
+        if (!this.#isReachable(address)) {
             throw new BleError(`Device with address ${address} is currently not reachable`);
         }
         return device;
@@ -100,20 +97,6 @@ export class BleScanner implements Scanner {
 
     #isReachable(address: string) {
         return this.#client.isPeripheralReachable?.(address) ?? true;
-    }
-
-    /**
-     * Reconcile every record with what the transport reaches now. Reachability is a property of the record, updated
-     * here and when an advertisement writes one, so matching a record and deciding whether it may be offered stay
-     * separate concerns.
-     */
-    #refreshReachability() {
-        if (this.#client.isPeripheralReachable === undefined) {
-            return;
-        }
-        for (const record of this.#discoveredMatterDevices.values()) {
-            record.withheld = !this.#isReachable(record.peripheral.address);
-        }
     }
 
     /**
@@ -184,12 +167,7 @@ export class BleScanner implements Scanner {
                 CM: 1, // Can be no other mode,
                 addresses: [{ type: "ble", peripheralAddress: address }],
             };
-            const existing = this.#discoveredMatterDevices.get(address);
-            const deviceExisting = existing !== undefined;
-            const withheld = !this.#isReachable(address);
-            // A peripheral withheld as unreachable was never offered, so its advertisement resolves waiters that
-            // ignore updates — otherwise a continuous discovery would never learn the transport reaches it again.
-            const isUpdatedRecord = deviceExisting && !existing.withheld;
+            const deviceExisting = this.#discoveredMatterDevices.has(address);
             const serviceDataHex = Bytes.toHex(manufacturerServiceData);
             const now = Time.nowMs;
 
@@ -214,12 +192,12 @@ export class BleScanner implements Scanner {
                 hasAdditionalAdvertisementData,
                 serviceDataHex,
                 lastSeen: now,
-                withheld,
             });
 
             const queryKey = this.#findCommissionableQueryIdentifier(deviceData);
-            if (queryKey !== undefined && !withheld) {
-                this.#finishWaiter(queryKey, true, isUpdatedRecord);
+            // An unreachable peripheral is no candidate, so its advertisement must not end a discovery's wait.
+            if (queryKey !== undefined && this.#isReachable(address)) {
+                this.#finishWaiter(queryKey, true, deviceExisting);
             }
         } catch (error) {
             logger.debug(
@@ -300,10 +278,10 @@ export class BleScanner implements Scanner {
         } else return "*";
     }
 
-    #getCommissionableDevices(identifier: CommissionableDeviceIdentifiers, includeWithheld = false) {
+    #getCommissionableDevices(identifier: CommissionableDeviceIdentifiers, includeUnreachable = false) {
         // Newest first so ordered consumers (e.g. parallel PASE discovery) prefer the freshest advertisement
         const storedRecords = Array.from(this.#discoveredMatterDevices.values())
-            .filter(record => includeWithheld || !record.withheld)
+            .filter(({ peripheral }) => includeUnreachable || this.#isReachable(peripheral.address))
             .sort((a, b) => b.lastSeen - a.lastSeen);
 
         const foundRecords = new Array<DiscoveredBleDevice>();
@@ -350,7 +328,6 @@ export class BleScanner implements Scanner {
             return [];
         }
 
-        this.#refreshReachability();
         if (ignoreExistingRecords) {
             // We want to have a fresh discovery result, so clear out the stored records because they might be outdated
             for (const record of this.#getCommissionableDevices(identifier, true)) {
@@ -362,7 +339,6 @@ export class BleScanner implements Scanner {
             await this.#client.startScanning();
             await this.#registerWaiterPromise(queryKey, timeout);
 
-            this.#refreshReachability();
             storedRecords = this.#getCommissionableDevices(identifier);
             await this.#client.stopScanning();
         }
@@ -404,7 +380,6 @@ export class BleScanner implements Scanner {
         );
 
         while (!canceled && !this.#closed) {
-            this.#refreshReachability();
             this.#getCommissionableDevices(identifier).forEach(({ deviceData }) => {
                 const { deviceIdentifier } = deviceData;
                 if (!discoveredDevices.has(deviceIdentifier)) {
@@ -424,12 +399,10 @@ export class BleScanner implements Scanner {
             await this.#registerWaiterPromise(queryKey, remainingTime, false, queryResolver);
         }
         await this.#client.stopScanning();
-        this.#refreshReachability();
         return this.#getCommissionableDevices(identifier).map(({ deviceData }) => deviceData);
     }
 
     getDiscoveredCommissionableDevices(identifier: CommissionableDeviceIdentifiers): CommissionableDevice[] {
-        this.#refreshReachability();
         return this.#getCommissionableDevices(identifier).map(({ deviceData }) => deviceData);
     }
 

--- a/packages/protocol/src/common/BleScanner.ts
+++ b/packages/protocol/src/common/BleScanner.ts
@@ -56,6 +56,8 @@ export type DiscoveredBleDevice = {
 type StoredDiscoveredBleDevice = DiscoveredBleDevice & {
     serviceDataHex: string;
     lastSeen: number;
+    /** Set while the transport cannot reach the peripheral, so its return counts as a new discovery. */
+    withheld: boolean;
 };
 
 /** Entries older than this are treated as dead addresses when matching service data arrives from a new address. */
@@ -167,7 +169,11 @@ export class BleScanner implements Scanner {
                 CM: 1, // Can be no other mode,
                 addresses: [{ type: "ble", peripheralAddress: address }],
             };
-            const deviceExisting = this.#discoveredMatterDevices.has(address);
+            const existing = this.#discoveredMatterDevices.get(address);
+            const deviceExisting = existing !== undefined;
+            // A peripheral withheld as unreachable was never offered, so its advertisement resolves waiters that
+            // ignore updates — otherwise a continuous discovery would never learn the transport reaches it again.
+            const isUpdatedRecord = deviceExisting && !existing.withheld;
             const serviceDataHex = Bytes.toHex(manufacturerServiceData);
             const now = Time.nowMs;
 
@@ -192,11 +198,12 @@ export class BleScanner implements Scanner {
                 hasAdditionalAdvertisementData,
                 serviceDataHex,
                 lastSeen: now,
+                withheld: false,
             });
 
             const queryKey = this.#findCommissionableQueryIdentifier(deviceData);
             if (queryKey !== undefined) {
-                this.#finishWaiter(queryKey, true, deviceExisting);
+                this.#finishWaiter(queryKey, true, isUpdatedRecord);
             }
         } catch (error) {
             logger.debug(
@@ -280,7 +287,10 @@ export class BleScanner implements Scanner {
     #getCommissionableDevices(identifier: CommissionableDeviceIdentifiers) {
         // Newest first so ordered consumers (e.g. parallel PASE discovery) prefer the freshest advertisement
         const storedRecords = Array.from(this.#discoveredMatterDevices.values())
-            .filter(({ peripheral }) => this.#isReachable(peripheral.address))
+            .filter(record => {
+                record.withheld = !this.#isReachable(record.peripheral.address);
+                return !record.withheld;
+            })
             .sort((a, b) => b.lastSeen - a.lastSeen);
 
         const foundRecords = new Array<DiscoveredBleDevice>();

--- a/packages/protocol/test/common/BleScannerTest.ts
+++ b/packages/protocol/test/common/BleScannerTest.ts
@@ -156,59 +156,6 @@ describe("BleScanner", () => {
             expect(scanner.getDiscoveredDevice("aa:aa:aa:aa:aa:aa")).to.exist;
         });
 
-        it("hands a running discovery a peripheral the transport reaches again", async () => {
-            const client = new MockProxyingBleScannerClient();
-            const scanner = new BleScanner(client);
-
-            const candidates = new Array<string>();
-            const discovery = scanner.findCommissionableDevicesContinuously(
-                { longDiscriminator: 1737 },
-                ({ deviceIdentifier }) => candidates.push(deviceIdentifier),
-            );
-
-            await settleDiscovery();
-            client.unreachable.add("aa:aa:aa:aa:aa:aa");
-            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
-            await settleDiscovery();
-            expect(candidates).to.have.lengthOf(0);
-
-            client.unreachable.delete("aa:aa:aa:aa:aa:aa");
-            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
-            await settleDiscovery();
-
-            expect(candidates).to.deep.equal(["aa:aa:aa:aa:aa:aa"]);
-
-            await scanner.close();
-            await discovery;
-        });
-
-        it("does not offer a peripheral twice when it keeps advertising", async () => {
-            const client = new MockProxyingBleScannerClient();
-            const scanner = new BleScanner(client);
-
-            const candidates = new Array<string>();
-            const discovery = scanner.findCommissionableDevicesContinuously(
-                { longDiscriminator: 1737 },
-                ({ deviceIdentifier }) => candidates.push(deviceIdentifier),
-            );
-
-            await settleDiscovery();
-            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
-            await settleDiscovery();
-
-            client.unreachable.add("aa:aa:aa:aa:aa:aa");
-            expect(scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 1737 })).to.have.lengthOf(0);
-
-            client.unreachable.delete("aa:aa:aa:aa:aa:aa");
-            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
-            await settleDiscovery();
-
-            expect(candidates).to.deep.equal(["aa:aa:aa:aa:aa:aa"]);
-
-            await scanner.close();
-            await discovery;
-        });
-
         it("keeps a one-shot discovery waiting while only unreachable peripherals advertise", async () => {
             const client = new MockProxyingBleScannerClient();
             const scanner = new BleScanner(client);
@@ -241,33 +188,6 @@ describe("BleScanner", () => {
             client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
 
             expect(await discovery).to.have.lengthOf(1);
-        });
-
-        it("hands a discovery a peripheral that became unreachable before the discovery started", async () => {
-            const client = new MockProxyingBleScannerClient();
-            const scanner = new BleScanner(client);
-
-            // Discovered through a transport that is gone by the time commissioning starts, which is what a
-            // BLE proxy that was power-cycled between two commissioning runs looks like.
-            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
-            client.unreachable.add("aa:aa:aa:aa:aa:aa");
-
-            const candidates = new Array<string>();
-            const discovery = scanner.findCommissionableDevicesContinuously(
-                { longDiscriminator: 1737 },
-                ({ deviceIdentifier }) => candidates.push(deviceIdentifier),
-            );
-            await settleDiscovery();
-            expect(candidates).to.have.lengthOf(0);
-
-            client.unreachable.delete("aa:aa:aa:aa:aa:aa");
-            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
-            await settleDiscovery();
-
-            expect(candidates).to.deep.equal(["aa:aa:aa:aa:aa:aa"]);
-
-            await scanner.close();
-            await discovery;
         });
 
         it("purges an unreachable cached peripheral when a discovery asks to ignore existing records", async () => {

--- a/packages/protocol/test/common/BleScannerTest.ts
+++ b/packages/protocol/test/common/BleScannerTest.ts
@@ -208,6 +208,81 @@ describe("BleScanner", () => {
             expect(scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 1737 })).to.have.lengthOf(0);
         });
 
+        it("hands a running discovery a peripheral the transport reaches again", async () => {
+            const client = new MockProxyingBleScannerClient();
+            const scanner = new BleScanner(client);
+
+            const candidates = new Array<string>();
+            const discovery = scanner.findCommissionableDevicesContinuously(
+                { longDiscriminator: 1737 },
+                ({ deviceIdentifier }) => candidates.push(deviceIdentifier),
+            );
+            await settleDiscovery();
+
+            client.unreachable.add("aa:aa:aa:aa:aa:aa");
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+            await settleDiscovery();
+            expect(candidates).to.have.lengthOf(0);
+
+            client.unreachable.delete("aa:aa:aa:aa:aa:aa");
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+            await settleDiscovery();
+
+            expect(candidates).to.deep.equal(["aa:aa:aa:aa:aa:aa"]);
+
+            await scanner.close();
+            await discovery;
+        });
+
+        it("hands a discovery a peripheral that became unreachable before the discovery started", async () => {
+            const client = new MockProxyingBleScannerClient();
+            const scanner = new BleScanner(client);
+
+            // Discovered through a transport that is gone by the time commissioning starts, which is what a BLE
+            // proxy power-cycled between two commissioning runs looks like.
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+            client.unreachable.add("aa:aa:aa:aa:aa:aa");
+
+            const candidates = new Array<string>();
+            const discovery = scanner.findCommissionableDevicesContinuously(
+                { longDiscriminator: 1737 },
+                ({ deviceIdentifier }) => candidates.push(deviceIdentifier),
+            );
+            await settleDiscovery();
+            expect(candidates).to.have.lengthOf(0);
+
+            client.unreachable.delete("aa:aa:aa:aa:aa:aa");
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+            await settleDiscovery();
+
+            expect(candidates).to.deep.equal(["aa:aa:aa:aa:aa:aa"]);
+
+            await scanner.close();
+            await discovery;
+        });
+
+        it("offers a peripheral once however often it advertises", async () => {
+            const client = new MockProxyingBleScannerClient();
+            const scanner = new BleScanner(client);
+
+            const candidates = new Array<string>();
+            const discovery = scanner.findCommissionableDevicesContinuously(
+                { longDiscriminator: 1737 },
+                ({ deviceIdentifier }) => candidates.push(deviceIdentifier),
+            );
+            await settleDiscovery();
+
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+            await settleDiscovery();
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+            await settleDiscovery();
+
+            expect(candidates).to.deep.equal(["aa:aa:aa:aa:aa:aa"]);
+
+            await scanner.close();
+            await discovery;
+        });
+
         it("keeps offering peripherals for a client that states no reachability", () => {
             const client = new MockBleScannerClient();
             const scanner = new BleScanner(client);

--- a/packages/protocol/test/common/BleScannerTest.ts
+++ b/packages/protocol/test/common/BleScannerTest.ts
@@ -35,6 +35,16 @@ class MockProxyingBleScannerClient extends MockBleScannerClient {
     }
 }
 
+/**
+ * Lets a discovery reach its waiter: it starts scanning and evaluates the stored records before it
+ * registers one, and an advertisement arriving while it is still starting up proves nothing.
+ */
+async function settleDiscovery() {
+    for (let i = 0; i < 10; i++) {
+        await MockTime.yield();
+    }
+}
+
 describe("BleScanner", () => {
     before(() => MockTime.enable());
 
@@ -156,14 +166,15 @@ describe("BleScanner", () => {
                 ({ deviceIdentifier }) => candidates.push(deviceIdentifier),
             );
 
+            await settleDiscovery();
             client.unreachable.add("aa:aa:aa:aa:aa:aa");
             client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
-            await MockTime.yield();
+            await settleDiscovery();
             expect(candidates).to.have.lengthOf(0);
 
             client.unreachable.delete("aa:aa:aa:aa:aa:aa");
             client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
-            await MockTime.yield();
+            await settleDiscovery();
 
             expect(candidates).to.deep.equal(["aa:aa:aa:aa:aa:aa"]);
 
@@ -181,15 +192,77 @@ describe("BleScanner", () => {
                 ({ deviceIdentifier }) => candidates.push(deviceIdentifier),
             );
 
+            await settleDiscovery();
             client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
-            await MockTime.yield();
+            await settleDiscovery();
 
             client.unreachable.add("aa:aa:aa:aa:aa:aa");
             expect(scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 1737 })).to.have.lengthOf(0);
 
             client.unreachable.delete("aa:aa:aa:aa:aa:aa");
             client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
-            await MockTime.yield();
+            await settleDiscovery();
+
+            expect(candidates).to.deep.equal(["aa:aa:aa:aa:aa:aa"]);
+
+            await scanner.close();
+            await discovery;
+        });
+
+        it("keeps a one-shot discovery waiting while only unreachable peripherals advertise", async () => {
+            const client = new MockProxyingBleScannerClient();
+            const scanner = new BleScanner(client);
+            client.unreachable.add("aa:aa:aa:aa:aa:aa");
+
+            let settled = false;
+            const discovery = scanner
+                .findCommissionableDevices({ longDiscriminator: 1737 }, Seconds(10))
+                .then(devices => {
+                    settled = true;
+                    return devices;
+                });
+
+            await settleDiscovery();
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+            await settleDiscovery();
+            expect(settled).to.equal(false);
+
+            await MockTime.advance(Seconds(11));
+            expect(await discovery).to.have.lengthOf(0);
+        });
+
+        it("ends a one-shot discovery as soon as a reachable peripheral advertises", async () => {
+            const client = new MockProxyingBleScannerClient();
+            const scanner = new BleScanner(client);
+
+            const discovery = scanner.findCommissionableDevices({ longDiscriminator: 1737 }, Seconds(10));
+            await settleDiscovery();
+
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+
+            expect(await discovery).to.have.lengthOf(1);
+        });
+
+        it("hands a discovery a peripheral that became unreachable before the discovery started", async () => {
+            const client = new MockProxyingBleScannerClient();
+            const scanner = new BleScanner(client);
+
+            // Discovered through a transport that is gone by the time commissioning starts, which is what a
+            // BLE proxy that was power-cycled between two commissioning runs looks like.
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+            client.unreachable.add("aa:aa:aa:aa:aa:aa");
+
+            const candidates = new Array<string>();
+            const discovery = scanner.findCommissionableDevicesContinuously(
+                { longDiscriminator: 1737 },
+                ({ deviceIdentifier }) => candidates.push(deviceIdentifier),
+            );
+            await settleDiscovery();
+            expect(candidates).to.have.lengthOf(0);
+
+            client.unreachable.delete("aa:aa:aa:aa:aa:aa");
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+            await settleDiscovery();
 
             expect(candidates).to.deep.equal(["aa:aa:aa:aa:aa:aa"]);
 

--- a/packages/protocol/test/common/BleScannerTest.ts
+++ b/packages/protocol/test/common/BleScannerTest.ts
@@ -26,6 +26,15 @@ class MockBleScannerClient implements BleScannerClient {
     }
 }
 
+/** A client of a transport that can lose access to a peripheral, such as one routing through proxies. */
+class MockProxyingBleScannerClient extends MockBleScannerClient {
+    readonly unreachable = new Set<string>();
+
+    isPeripheralReachable(address: string) {
+        return !this.unreachable.has(address);
+    }
+}
+
 describe("BleScanner", () => {
     before(() => MockTime.enable());
 
@@ -97,6 +106,53 @@ describe("BleScanner", () => {
 
             expect(scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 1737 })).to.have.lengthOf(1);
             expect(scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 1000 })).to.have.lengthOf(1);
+        });
+    });
+
+    describe("reachability", () => {
+        it("stops offering a peripheral the transport can no longer reach", () => {
+            const client = new MockProxyingBleScannerClient();
+            const scanner = new BleScanner(client);
+
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+            expect(scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 1737 })).to.have.lengthOf(1);
+
+            client.unreachable.add("aa:aa:aa:aa:aa:aa");
+
+            expect(scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 1737 })).to.have.lengthOf(0);
+        });
+
+        it("refuses to hand out a peripheral the transport can no longer reach", () => {
+            const client = new MockProxyingBleScannerClient();
+            const scanner = new BleScanner(client);
+
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+            client.unreachable.add("aa:aa:aa:aa:aa:aa");
+
+            expect(() => scanner.getDiscoveredDevice("aa:aa:aa:aa:aa:aa")).to.throw("is currently not reachable");
+        });
+
+        it("offers a peripheral again once the transport reaches it again", () => {
+            const client = new MockProxyingBleScannerClient();
+            const scanner = new BleScanner(client);
+
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+            client.unreachable.add("aa:aa:aa:aa:aa:aa");
+            expect(scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 1737 })).to.have.lengthOf(0);
+
+            client.unreachable.delete("aa:aa:aa:aa:aa:aa");
+
+            expect(scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 1737 })).to.have.lengthOf(1);
+            expect(scanner.getDiscoveredDevice("aa:aa:aa:aa:aa:aa")).to.exist;
+        });
+
+        it("keeps offering peripherals for a client that states no reachability", () => {
+            const client = new MockBleScannerClient();
+            const scanner = new BleScanner(client);
+
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+
+            expect(scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 1737 })).to.have.lengthOf(1);
         });
     });
 

--- a/packages/protocol/test/common/BleScannerTest.ts
+++ b/packages/protocol/test/common/BleScannerTest.ts
@@ -270,6 +270,24 @@ describe("BleScanner", () => {
             await discovery;
         });
 
+        it("purges an unreachable cached peripheral when a discovery asks to ignore existing records", async () => {
+            const client = new MockProxyingBleScannerClient();
+            const scanner = new BleScanner(client);
+
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+            client.unreachable.add("aa:aa:aa:aa:aa:aa");
+
+            const discovery = scanner.findCommissionableDevices({ longDiscriminator: 1737 }, Seconds(10), true);
+            await settleDiscovery();
+
+            // The purged record must not come back through a reachability change alone.
+            client.unreachable.delete("aa:aa:aa:aa:aa:aa");
+            await MockTime.advance(Seconds(11));
+
+            expect(await discovery).to.have.lengthOf(0);
+            expect(scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 1737 })).to.have.lengthOf(0);
+        });
+
         it("keeps offering peripherals for a client that states no reachability", () => {
             const client = new MockBleScannerClient();
             const scanner = new BleScanner(client);

--- a/packages/protocol/test/common/BleScannerTest.ts
+++ b/packages/protocol/test/common/BleScannerTest.ts
@@ -146,6 +146,57 @@ describe("BleScanner", () => {
             expect(scanner.getDiscoveredDevice("aa:aa:aa:aa:aa:aa")).to.exist;
         });
 
+        it("hands a running discovery a peripheral the transport reaches again", async () => {
+            const client = new MockProxyingBleScannerClient();
+            const scanner = new BleScanner(client);
+
+            const candidates = new Array<string>();
+            const discovery = scanner.findCommissionableDevicesContinuously(
+                { longDiscriminator: 1737 },
+                ({ deviceIdentifier }) => candidates.push(deviceIdentifier),
+            );
+
+            client.unreachable.add("aa:aa:aa:aa:aa:aa");
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+            await MockTime.yield();
+            expect(candidates).to.have.lengthOf(0);
+
+            client.unreachable.delete("aa:aa:aa:aa:aa:aa");
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+            await MockTime.yield();
+
+            expect(candidates).to.deep.equal(["aa:aa:aa:aa:aa:aa"]);
+
+            await scanner.close();
+            await discovery;
+        });
+
+        it("does not offer a peripheral twice when it keeps advertising", async () => {
+            const client = new MockProxyingBleScannerClient();
+            const scanner = new BleScanner(client);
+
+            const candidates = new Array<string>();
+            const discovery = scanner.findCommissionableDevicesContinuously(
+                { longDiscriminator: 1737 },
+                ({ deviceIdentifier }) => candidates.push(deviceIdentifier),
+            );
+
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+            await MockTime.yield();
+
+            client.unreachable.add("aa:aa:aa:aa:aa:aa");
+            expect(scanner.getDiscoveredCommissionableDevices({ longDiscriminator: 1737 })).to.have.lengthOf(0);
+
+            client.unreachable.delete("aa:aa:aa:aa:aa:aa");
+            client.discover("aa:aa:aa:aa:aa:aa", SERVICE_DATA_A);
+            await MockTime.yield();
+
+            expect(candidates).to.deep.equal(["aa:aa:aa:aa:aa:aa"]);
+
+            await scanner.close();
+            await discovery;
+        });
+
         it("keeps offering peripherals for a client that states no reachability", () => {
             const client = new MockBleScannerClient();
             const scanner = new BleScanner(client);


### PR DESCRIPTION
## What

`BleScannerClient` gains an optional `isPeripheralReachable(address)`. `BleScanner` offers only reachable peripherals as commissioning candidates, and refuses to hand one out for a channel. Clients that omit the hook — noble and react-native, both local adapters — are unaffected.

## Why

A local BLE adapter reaches whatever it discovered, so the scanner's assumption that a discovered peripheral stays usable holds there. It does not hold for a transport that routes BLE through remote proxies, where access to a peripheral disappears with the proxy that reported it.

Reported downstream as [matter-js/matterjs-server#1048](https://github.com/matter-js/matterjs-server/issues/1048): a peripheral discovered through one BLE proxy was still offered as a candidate four hours later, after that proxy was long gone. Commissioning consumed the candidate and failed at transport level with `No connected BLE proxy client owns peripheral …`, while the device itself was advertising and reachable through a different proxy.

The record is filtered, not deleted, so a transport that regains access to a peripheral offers it again immediately rather than waiting for a new advertisement.

## What this deliberately does not do

The same downstream report also covers a second problem: `findCommissionableDevicesContinuously` dedupes on `deviceIdentifier`, which for BLE is the peripheral address, so an address whose attempt failed cannot produce a second attempt in that discovery run even when the device keeps advertising.

I implemented a fix for that here and withdrew it. Making the scanner re-deliver a candidate breaks the `Scanner` contract (`for each new discovered device the provided callback is called`, which `CommissionableMdnsScanner` enforces with its `seen` set), and the consumers rely on it: `PaseDiscovery.onDiscovered` has no in-flight guard and would start a second parallel PASE to the same node; `CommissioningDiscovery` would reject the retry with `a commission attempt is already in progress` and `ParallelPaseDiscovery` would record that rejection as a genuine attempt failure; the cross-device PASE stagger is derived from the delivery index, so retries of one failing device delay the first attempt of every other device; and `ContinuousDiscovery` would return and emit the same `ClientNode` twice, which mDNS never does.

Retry state — attempt count, in-flight, backoff — belongs where attempts are registered, not in a scanner that cannot see any of it. Happy to open an issue with that proposal if the direction is welcome.

## How the wake-up works, after four review rounds

Three revisions tried to teach the scanner which change is worth waking a discovery for, by storing eligibility on the record, and review found a new class of defect in that machinery each time: the loop never woke at all; an advertisement then woke it without checking reachability, ending a one-shot scan early; and the eligibility mark could be consumed by any unrelated read between the transition and the next advertisement.

None of that state is needed. The continuous loop already knows what it has delivered, so the scanner does not have to: it is woken by any advertisement of a device matching the query (`resolveOnUpdatedRecords`), and the loop's own set decides what is news. An unreachable peripheral is no candidate, so its advertisement wakes nobody. Reachability is asked, never stored — nothing can be consumed.

The one behavioural change for BLE transports without the hook is that a continuous discovery now re-evaluates on every matching advertisement rather than only on unseen addresses. Devices are still handed out once per discovery.

## Tests

Eight in `BleScannerTest`, each mutation-checked:

- restoring `resolveOnUpdatedRecords = false` reds the two wake-up tests
- dropping the reachability filter reds the offering tests
- dropping the check in `getDiscoveredDevice` reds the handout test
- letting an unreachable advertisement resolve a waiter reds the one-shot test
- purging only reachable records reds the `ignoreExistingRecords` test
- defaulting the hook to `false` instead of `true` reds six pre-existing tests, which is the evidence that a client without the hook is unaffected

## Verification

```
$ npm run build          # clean
$ npm run format-verify  # All matched files use the correct format. (2386 files)
$ npm run lint           # clean
$ npm test -w @matter/protocol
  ✓ ESM 1585/1585   ✓ CJS 1585/1585   ✓ Web 1585/1585
$ npm test -w @matter/node
  ✓ ESM 1993/1993   ✓ CJS 1993/1993   ✓ Web 1993/1993
$ npm test -w @matter/nodejs-ble
  ✓ ESM 16/16       ✓ CJS 16/16
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
