### PR TITLE
Add the camera and OTA apps to the CHIP harness image

### DIFF
--- a/.github/workflows/build-test.chip.yml
+++ b/.github/workflows/build-test.chip.yml
@@ -201,7 +201,9 @@ jobs:
 
       # test-core-arm64 exercises chip-tool against this image but never starts the app binaries, so they get an
       # execution check here. Exit status 126 or above means the shell could not execute the binary at all (wrong
-      # architecture, missing loader); anything below that proves it ran.
+      # architecture, missing loader); anything below that proves it ran. The camera app is the reason this matters
+      # beyond architecture: it loads GStreamer and FFmpeg at startup, so a missing runtime package shows up here
+      # rather than in a certification run.
       - name: Smoke-test arm64 image
         if: needs.workflow-conditions.outputs.build-needed == 'true'
         run: |
@@ -212,7 +214,8 @@ jobs:
             exit 1
           fi
           docker run --rm --entrypoint /bin/sh ghcr.io/matter-js/chip:latest -c '
-            for bin in chip-tool chip-all-clusters-app chip-all-clusters-app-nlfaultinject chip-bridge-app; do
+            for bin in chip-tool chip-all-clusters-app chip-all-clusters-app-nlfaultinject chip-bridge-app \
+                chip-camera-app chip-ota-provider-app chip-ota-requestor-app; do
               "$bin" --help >/dev/null 2>&1
               status=$?
               if [ "$status" -ge 126 ]; then

--- a/.github/workflows/build-test.chip.yml
+++ b/.github/workflows/build-test.chip.yml
@@ -177,18 +177,11 @@ jobs:
     outputs:
       source: ${{ needs.workflow-conditions.outputs.build-needed == 'true' && 'artifact' || 'repository' }}
     steps:
-      - name: Maximize build space
-        if: needs.workflow-conditions.outputs.build-needed == 'true'
-        uses: easimon/maximize-build-space@v10
-        with:
-          # This job is the only one that loads the built image back into docker, and docker stores it under
-          # /var/lib/docker on root. The action claims every other free byte for its own volume, which the workspace
-          # barely uses, so the reserve is what the load has to fit in.
-          root-reserve-mb: 40960
-          temp-reserve-mb: 3096
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
+      # No maximize-build-space here, deliberately. This runner has no separate /mnt disk, so the action's two
+      # physical volumes — /pv.img and /mnt/tmp-pv.img — both come out of the root filesystem and leave it with the
+      # reserve alone, while the volume they form is mounted on a workspace this job barely touches. Everything that
+      # needs room here (the CHIP checkout and build, and loading the built image) lives on root, so the action takes
+      # space from where it is needed and gives it to where it is not.
 
       - name: Check out matter.js
         if: needs.workflow-conditions.outputs.build-needed == 'true'

--- a/.github/workflows/build-test.chip.yml
+++ b/.github/workflows/build-test.chip.yml
@@ -203,9 +203,6 @@ jobs:
       - name: Smoke-test arm64 image
         if: needs.workflow-conditions.outputs.build-needed == 'true'
         run: |
-          # The tar is written and the builder's cache is dead weight from here on; it shares the root filesystem
-          # the load below needs
-          docker buildx prune -af || true
           df -h / | tail -1
           docker load -i /tmp/chip.tar
           arch=$(docker inspect --format '{{ .Architecture }}' ghcr.io/matter-js/chip:latest)

--- a/.github/workflows/build-test.chip.yml
+++ b/.github/workflows/build-test.chip.yml
@@ -181,7 +181,10 @@ jobs:
         if: needs.workflow-conditions.outputs.build-needed == 'true'
         uses: easimon/maximize-build-space@v10
         with:
-          root-reserve-mb: 4096
+          # This job is the only one that loads the built image back into docker, and docker stores it under
+          # /var/lib/docker on root. The action claims every other free byte for its own volume, which the workspace
+          # barely uses, so the reserve is what the load has to fit in.
+          root-reserve-mb: 40960
           temp-reserve-mb: 3096
           remove-dotnet: 'true'
           remove-android: 'true'
@@ -207,6 +210,10 @@ jobs:
       - name: Smoke-test arm64 image
         if: needs.workflow-conditions.outputs.build-needed == 'true'
         run: |
+          # The tar is written and the builder's cache is dead weight from here on; it shares the root filesystem
+          # the load below needs
+          docker buildx prune -af || true
+          df -h / | tail -1
           docker load -i /tmp/chip.tar
           arch=$(docker inspect --format '{{ .Architecture }}' ghcr.io/matter-js/chip:latest)
           if [ "$arch" != "arm64" ]; then

--- a/.github/workflows/chip-cert-tests.yml
+++ b/.github/workflows/chip-cert-tests.yml
@@ -361,12 +361,20 @@ jobs:
 
       # Only the own-built device needs binaries placed on the host: cert-bins extracts its own
       # lazily at test time (chip-bins.ts's prepareChipBins) and the matterjs device runs in-process.
+      #
+      # The OTA pair copies only if the published image already carries it: the image is published by
+      # the nightly, so between this landing and that publish the binaries do not exist yet. The case
+      # that uses them makes the copy strict and adds them to the check below.
+      #
+      # chip-camera-app is deliberately absent: unlike the OTA pair it needs GStreamer and FFmpeg
+      # runtime packages on the runner, and the cases that use it take it as a container-side path.
       - name: Extract chip-local app binaries from the published image
         if: matrix.device == 'own-built'
         run: |
           mkdir -p /tmp/cert-app-dir
           docker run --rm -v /tmp/cert-app-dir:/out ghcr.io/matter-js/chip:latest \
-            bash -c "cp -a /bin/chip-all-clusters-app* /bin/chip-bridge-app /out/"
+            bash -c "cp -a /bin/chip-all-clusters-app* /bin/chip-bridge-app /out/;
+                     cp -a /bin/chip-ota-provider-app /bin/chip-ota-requestor-app /out/ 2>/dev/null || true"
           # cert-dsl.ts's chipLocalMarkerRevision() reads this to populate evidence's chipRef; the
           # image carries the same connectedhomeip commit in its org.opencontainers.image.revision
           # label (baked by docker-bake.hcl from CHIP_COMMIT).

--- a/.github/workflows/chip-cert-tests.yml
+++ b/.github/workflows/chip-cert-tests.yml
@@ -37,8 +37,8 @@
 #
 #   * "own-built" — the app binaries matter.js builds itself (support/chip/Dockerfile), taken from
 #     the published ghcr.io/matter-js/chip image: chip-all-clusters-app,
-#     chip-all-clusters-app-nlfaultinject, chip-bridge-app and chip-camera-app. Published as a
-#     multi-arch manifest,
+#     chip-all-clusters-app-nlfaultinject, chip-bridge-app, chip-camera-app and the
+#     chip-ota-provider-app/chip-ota-requestor-app pair. Published as a multi-arch manifest,
 #     so each leg pulls the variant matching its runner. Runs when run-own-built is selected
 #
 #   * "cert-bins" — project-chip's official connectedhomeip/chip-cert-bins image. Published

--- a/.github/workflows/chip-cert-tests.yml
+++ b/.github/workflows/chip-cert-tests.yml
@@ -37,7 +37,8 @@
 #
 #   * "own-built" — the app binaries matter.js builds itself (support/chip/Dockerfile), taken from
 #     the published ghcr.io/matter-js/chip image: chip-all-clusters-app,
-#     chip-all-clusters-app-nlfaultinject and chip-bridge-app. Published as a multi-arch manifest,
+#     chip-all-clusters-app-nlfaultinject, chip-bridge-app and chip-camera-app. Published as a
+#     multi-arch manifest,
 #     so each leg pulls the variant matching its runner. Runs when run-own-built is selected
 #
 #   * "cert-bins" — project-chip's official connectedhomeip/chip-cert-bins image. Published

--- a/support/chip/Dockerfile
+++ b/support/chip/Dockerfile
@@ -65,7 +65,7 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     #
     apt-get -qq -y install --no-install-recommends \
         git curl clang pkg-config libssl-dev libdbus-1-dev libavahi-client-dev clang pkg-config \
-        ninja-build python3-venv python3-dev unzip libreadline-dev python3-pip \
+        ninja-build cmake python3-venv python3-dev unzip libreadline-dev python3-pip \
         g++ libglib2.0-dev libglib2.0-dev-bin libpcsclite-dev libevent-dev \
         libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libavformat-dev libavcodec-dev libavutil-dev \
         libcurl4-openssl-dev

--- a/support/chip/Dockerfile
+++ b/support/chip/Dockerfile
@@ -28,7 +28,8 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     --mount=type=cache,sharing=locked,target=/var/lib/apt \
     apt-get -qq update && \
-    apt-get -qq -y install python3 python-is-python3 libavahi-client3 libglib2.0-0 libpcsclite1 libevent-dev
+    apt-get -qq -y install python3 python-is-python3 libavahi-client3 libglib2.0-0 libpcsclite1 libevent-dev \
+        libgstreamer1.0-0 libgstreamer-plugins-base1.0-0 libavformat60 libavcodec60 libavutil58 libcurl4
 
 ################################################################################
 #
@@ -64,7 +65,9 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     apt-get -qq -y install --no-install-recommends \
         git curl clang pkg-config libssl-dev libdbus-1-dev libavahi-client-dev clang pkg-config \
         ninja-build python3-venv python3-dev unzip libreadline-dev python3-pip \
-        g++ libglib2.0-dev libglib2.0-dev-bin libpcsclite-dev libevent-dev
+        g++ libglib2.0-dev libglib2.0-dev-bin libpcsclite-dev libevent-dev \
+        libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libavformat-dev libavcodec-dev libavutil-dev \
+        libcurl4-openssl-dev
 EOF
     # apt-get -qq -y install git gcc g++ clang pkg-config libssl-dev libdbus-1-dev libglib2.0-dev libavahi-client-dev \
     #     ninja-build python3-venv python3-dev unzip libgirepository1.0-dev libcairo2-dev libreadline-dev python3-pip
@@ -127,6 +130,10 @@ RUN build-one all-clusters-app/linux chip-all-clusters-app chip-all-clusters-app
 
 # TC-ACT-3.2's TH app for the cert tests' chip-local flavor, which spawns from this image's /bin
 RUN build-one bridge-app/linux chip-bridge-app
+
+# The WEBRTCR cases' TH_SERVER. Its own args.gni sets chip_with_nlfaultinjection, which is what lets a
+# case inject kFault_ModifyWebRTCOfferSessionId, so no extra GN argument here
+RUN build-one camera-app/linux chip-camera-app
 
 # Install Python stuff
 COPY support/install-chip-python /bin

--- a/support/chip/Dockerfile
+++ b/support/chip/Dockerfile
@@ -137,8 +137,14 @@ RUN build-one bridge-app/linux chip-bridge-app
 #
 # The app builds its pipelines from named GStreamer elements, so the plugins carrying them have to be
 # in the final image or the factories resolve to nothing at runtime: videotestsrc/videoconvert/opus
-# (base), v4l2src/jpegenc/rtp/udp (good), x264enc (ugly)
-RUN build-one camera-app/linux chip-camera-app
+# (base), v4l2src/jpegenc/rtp/udp (good), x264enc (ugly).
+#
+# Warnings are not errors for this one app, which is a deliberate divergence from how we build
+# everything else here. CHIP applies -Wshorten-64-to-32 only under clang and builds this app with gcc
+# in its own CI, so its narrowing conversions have never had to compile clean; we build with clang
+# throughout. The code is upstream's to fix, so we stop treating its warnings as errors rather than
+# carry a patch.
+RUN build-one camera-app/linux chip-camera-app chip-camera-app treat_warnings_as_errors=false
 
 # The BDX and software-update cases' pair: one serves an update over BDX, the other asks for it. The
 # staged `.ota` file a case hands the provider is made per case with CHIP's own ota_image_tool.py,

--- a/support/chip/Dockerfile
+++ b/support/chip/Dockerfile
@@ -29,7 +29,8 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
     --mount=type=cache,sharing=locked,target=/var/lib/apt \
     apt-get -qq update && \
     apt-get -qq -y install python3 python-is-python3 libavahi-client3 libglib2.0-0 libpcsclite1 libevent-dev \
-        libgstreamer1.0-0 libgstreamer-plugins-base1.0-0 libavformat60 libavcodec60 libavutil58 libcurl4
+        libgstreamer1.0-0 libgstreamer-plugins-base1.0-0 libavformat60 libavcodec60 libavutil58 libcurl4 \
+        gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly
 
 ################################################################################
 #
@@ -132,7 +133,11 @@ RUN build-one all-clusters-app/linux chip-all-clusters-app chip-all-clusters-app
 RUN build-one bridge-app/linux chip-bridge-app
 
 # The WEBRTCR cases' TH_SERVER. Its own args.gni sets chip_with_nlfaultinjection, which is what lets a
-# case inject kFault_ModifyWebRTCOfferSessionId, so no extra GN argument here
+# case inject kFault_ModifyWebRTCOfferSessionId, so no extra GN argument here.
+#
+# The app builds its pipelines from named GStreamer elements, so the plugins carrying them have to be
+# in the final image or the factories resolve to nothing at runtime: videotestsrc/videoconvert/opus
+# (base), v4l2src/jpegenc/rtp/udp (good), x264enc (ugly)
 RUN build-one camera-app/linux chip-camera-app
 
 # Install Python stuff

--- a/support/chip/Dockerfile
+++ b/support/chip/Dockerfile
@@ -147,8 +147,8 @@ RUN build-one bridge-app/linux chip-bridge-app
 RUN build-one camera-app/linux chip-camera-app chip-camera-app treat_warnings_as_errors=false
 
 # The BDX and software-update cases' pair: one serves an update over BDX, the other asks for it. The
-# staged `.ota` file a case hands the provider is made per case with CHIP's own ota_image_tool.py,
-# which this image already carries with the rest of the CHIP tree
+# staged `.ota` file a case hands the provider is made per case rather than baked here, because it
+# encodes the version and payload that case is about; ota_image_tool.py below is what makes it
 RUN build-one ota-provider-app/linux chip-ota-provider-app
 RUN build-one ota-requestor-app/linux chip-ota-requestor-app
 
@@ -212,6 +212,10 @@ COPY --from=source /connectedhomeip/src/app/zap-templates/zcl/data-model/chip \
 # Tests
 COPY --from=source /connectedhomeip/src/python_testing /src/python_testing
 COPY --from=source /connectedhomeip/src/app/tests/suites /src/app/tests/suites
+
+# Builds the staged .ota file a software-update case serves. It resolves matter.tlv from the installed
+# python packages above, so the script is all that has to come across
+COPY --from=source /connectedhomeip/src/app/ota_image_tool.py /src/app/ota_image_tool.py
 
 # Development certs
 COPY --from=source /connectedhomeip/credentials/development/paa-root-certs /credentials/development/paa-root-certs

--- a/support/chip/Dockerfile
+++ b/support/chip/Dockerfile
@@ -140,6 +140,12 @@ RUN build-one bridge-app/linux chip-bridge-app
 # (base), v4l2src/jpegenc/rtp/udp (good), x264enc (ugly)
 RUN build-one camera-app/linux chip-camera-app
 
+# The BDX and software-update cases' pair: one serves an update over BDX, the other asks for it. The
+# staged `.ota` file a case hands the provider is made per case with CHIP's own ota_image_tool.py,
+# which this image already carries with the rest of the CHIP tree
+RUN build-one ota-provider-app/linux chip-ota-provider-app
+RUN build-one ota-requestor-app/linux chip-ota-requestor-app
+
 # Install Python stuff
 COPY support/install-chip-python /bin
 RUN install-chip-python

--- a/support/chip/Dockerfile
+++ b/support/chip/Dockerfile
@@ -148,7 +148,8 @@ RUN build-one camera-app/linux chip-camera-app chip-camera-app treat_warnings_as
 
 # The BDX and software-update cases' pair: one serves an update over BDX, the other asks for it. The
 # staged `.ota` file a case hands the provider is made per case rather than baked here, because it
-# encodes the version and payload that case is about; ota_image_tool.py below is what makes it
+# encodes the version and payload that case is about; the ota_image_tool.py copied further down is
+# what builds that file
 RUN build-one ota-provider-app/linux chip-ota-provider-app
 RUN build-one ota-requestor-app/linux chip-ota-requestor-app
 
@@ -221,7 +222,8 @@ COPY --from=source /connectedhomeip/src/app/ota_image_tool.py /src/app/ota_image
 COPY --from=source /connectedhomeip/credentials/development/paa-root-certs /credentials/development/paa-root-certs
 COPY --from=source /connectedhomeip/credentials/development/cd-certs /credentials/development/cd-certs
 
-RUN mkdir /run/dbus
+# Idempotent: the media packages above pull in dbus, whose own install creates this directory
+RUN mkdir -p /run/dbus
 
 # Summarize tests for efficient metadata load at runtime
 COPY support/generate-test-descriptor /bin/generate-test-descriptor

--- a/support/chip/README.md
+++ b/support/chip/README.md
@@ -9,7 +9,8 @@ The matter.js test harness pulls this image automatically when running CHIP test
 Besides `chip-tool`, the image ships app binaries used as TH_SERVER/DUT for cert tests:
 `chip-all-clusters-app` and `chip-all-clusters-app-nlfaultinject` (built with CHIP's
 `chip_with_nlfaultinjection=true` GN arg so its FaultInjection cluster is present, as required by
-tests such as TC-SC-3.5) and `chip-bridge-app` (TC-ACT-3.2's TH).
+tests such as TC-SC-3.5), `chip-bridge-app` (TC-ACT-3.2's TH) and `chip-camera-app` (the WEBRTCR
+cases' TH, whose own build arguments already enable fault injection).
 
 The [bin](./bin) directory contains additional helper scripts you can use on the host:
 

--- a/support/chip/README.md
+++ b/support/chip/README.md
@@ -9,8 +9,9 @@ The matter.js test harness pulls this image automatically when running CHIP test
 Besides `chip-tool`, the image ships app binaries used as TH_SERVER/DUT for cert tests:
 `chip-all-clusters-app` and `chip-all-clusters-app-nlfaultinject` (built with CHIP's
 `chip_with_nlfaultinjection=true` GN arg so its FaultInjection cluster is present, as required by
-tests such as TC-SC-3.5), `chip-bridge-app` (TC-ACT-3.2's TH) and `chip-camera-app` (the WEBRTCR
-cases' TH, whose own build arguments already enable fault injection).
+tests such as TC-SC-3.5), `chip-bridge-app` (TC-ACT-3.2's TH), `chip-camera-app` (the WEBRTCR
+cases' TH, whose own build arguments already enable fault injection) and the
+`chip-ota-provider-app`/`chip-ota-requestor-app` pair for the BDX and software-update cases.
 
 The [bin](./bin) directory contains additional helper scripts you can use on the host:
 

--- a/support/chip/support/build-one
+++ b/support/chip/support/build-one
@@ -78,7 +78,9 @@ gn gen out \
 
 ninja -C out "$TARGET_NAME"
 
-BINPATH="$(find "out" -type f -executable)"
+# By name rather than "the one executable below out": a target that builds a dependency through its own
+# CMake sub-build, as the camera app does for libdatachannel, leaves further executables there
+BINPATH="$(find out -type f -executable -name "$TARGET_NAME")"
 if [ ! -x "$BINPATH" ]; then
     die "Could not identify executable for target \"$TARGET\""
 fi

--- a/support/chip/support/clone-chip
+++ b/support/chip/support/clone-chip
@@ -31,7 +31,8 @@ skip_submodule openthread
 skip_submodule ot-br-posix
 skip_submodule third_party/googletest
 skip_submodule third_party/fuzztest
-skip_submodule third_party/libdatachannel/repo
+# libdatachannel stays: the camera app's WebRTC provider builds against it, and that app is the TH for
+# the WEBRTCR cases
 skip_submodule third_party/imgui/repo
 skip_submodule third_party/boringssl/repo/src
 


### PR DESCRIPTION
## Why

The WEBRTCR certification cases need a camera device as their test harness server. The case commissions that device, makes it send a WebRTC `Offer` carrying a session id that does not exist, and checks what the device under test does with it. CHIP ships the device as `chip-camera-app`; this image did not build it, so none of `TC-WEBRTCR-2.1` … `2.7` can run.

## What this changes

- **`chip-camera-app`**, the WEBRTCR cases' test harness server.
- **`chip-ota-provider-app` and `chip-ota-requestor-app`**, the pair the BDX and software-update cases need — one serves a firmware update, the other asks for it. Neither needs anything the builder did not already have. The staged `.ota` file a case hands the provider is not built here; it is made per case with CHIP's own `ota_image_tool.py`, which this image carries with the rest of the CHIP tree.

### For the camera app specifically


- **libdatachannel is no longer skipped.** `clone-chip` dropped that submodule to save build time. The camera app's WebRTC provider builds against it, so it has to come back.
- **Media and transfer dependencies.** The app renders and streams through GStreamer and FFmpeg and fetches over curl. The development packages join the build stage, and the matching runtime libraries join the final image so the app can actually start there. Package names were verified against `ubuntu:24.04`, the image's own base: `libavformat60`, `libavcodec60`, `libavutil58`.
- **One build line**, following the same `build-one` convention as the all-clusters and bridge apps.

No GN argument is needed for fault injection: `examples/camera-app/linux/args.gni` already sets `chip_with_nlfaultinjection = true`, which is what lets a case reach `kFault_ModifyWebRTCOfferSessionId` (CHIP asserts that fault's id is 16 precisely because test automation depends on it).

## Effect on the image

It grows. FFmpeg and GStreamer development packages in the builder, their runtime libraries in the final image, and a submodule the image previously skipped on purpose. That is the price of having the app available; the alternative is that this whole certification family stays unrunnable.

## How the app is reached

The WEBRTCR cases are python-wrapped and take their harness server as a container-side path, exactly as TC-SC-3.5 does today with `MATTER_CERT_TH_SERVER_APP_PATH=/bin/chip-all-clusters-app-nlfaultinject`. The camera app therefore runs inside this image, where its runtime libraries and GStreamer plugins live.

It is deliberately **not** added to the host extraction in `chip-cert-tests.yml` (`cp -a /bin/chip-all-clusters-app* /bin/chip-bridge-app /out/`). That serves the `chip-local` legs, which spawn apps as host processes; a camera there would also need the media packages installed on the runner. That becomes necessary only if a case wants a camera device as a chip-local DUT or TH, and none is planned.

## Verification

Both dependency sets were resolved against a real `ubuntu:24.04` container before committing, so the names are checked rather than guessed:

```
$ docker run --rm ubuntu:24.04 … --dry-run libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
      libavformat-dev libavcodec-dev libavutil-dev libcurl4-openssl-dev
build deps resolve

$ docker run --rm ubuntu:24.04 … --dry-run libgstreamer1.0-0 libgstreamer-plugins-base1.0-0 \
      libavformat60 libavcodec60 libavutil58 libcurl4
runtime deps resolve
```

The image build itself is CI's job here: a pull request touching `support/chip` builds and tests the image but never publishes it. The app reaches certification runs once a nightly or manual build publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

