### PR TITLE
fix(testing): a mock clock stands still while the host does crypto

### DIFF
--- a/packages/general/test/time/MockTimeResolveTest.ts
+++ b/packages/general/test/time/MockTimeResolveTest.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const FAKE_TIME = 36000000;
+
+const nodeCrypto = (globalThis as any).process?.getBuiltinModule?.("crypto");
+
+describe("MockTime.resolve", () => {
+    beforeEach(() => MockTime.reset(FAKE_TIME));
+
+    it("holds virtual time while host crypto is pending", async () => {
+        await MockTime.resolve(
+            (async () => {
+                for (let i = 0; i < 5; i++) {
+                    await crypto.subtle.digest("SHA-256", new Uint8Array([i]));
+                }
+            })(),
+        );
+
+        expect(MockTime.nowMs).equal(FAKE_TIME);
+    });
+
+    it("charges at most one step for a gap between host operations", async () => {
+        await MockTime.resolve(
+            (async () => {
+                for (let i = 0; i < 5; i++) {
+                    await crypto.subtle.digest("SHA-256", new Uint8Array([i]));
+                    await MockTime.macrotask;
+                    await Promise.resolve();
+                }
+            })(),
+        );
+
+        expect(MockTime.nowMs - FAKE_TIME).most(500);
+    });
+
+    it("holds virtual time while a host crypto callback is pending", async function () {
+        if (nodeCrypto?.pbkdf2 === undefined) {
+            this.skip();
+        }
+
+        await MockTime.resolve(
+            new Promise<void>((resolve, reject) =>
+                nodeCrypto.pbkdf2("password", "salt", 1000, 16, "sha256", (cause: Error | null) =>
+                    cause ? reject(cause) : resolve(),
+                ),
+            ),
+        );
+
+        expect(MockTime.nowMs).equal(FAKE_TIME);
+    });
+
+    it("abandons a host operation that does not settle", async () => {
+        let settleStalledOp!: () => void;
+        try {
+            void MockTime.requireHostAsync(new Promise<void>(resolve => (settleStalledOp = resolve)));
+
+            let fired = false;
+            MockTime.getTimer("Test", 100, () => (fired = true)).start();
+
+            await MockTime.resolve(
+                new Promise<void>(resolve => {
+                    MockTime.getTimer("Resolver", 100, resolve).start();
+                }),
+            );
+
+            expect(fired).equal(true);
+            expect(MockTime.pendingHostAsyncOps).equal(0);
+
+            // An abandoned operation may never settle, so the next test must not inherit it
+            expect(MockTime.dependentCount).least(1);
+            MockTime.reset(FAKE_TIME);
+            expect(MockTime.dependentCount).equal(0);
+        } finally {
+            settleStalledOp?.();
+        }
+    });
+
+    it("charges each host operation its own budget", async () => {
+        let settleStalledOp!: () => void;
+        try {
+            void MockTime.requireHostAsync(new Promise<void>(resolve => (settleStalledOp = resolve)));
+
+            await MockTime.resolve(
+                (async () => {
+                    for (let i = 0; i < 5; i++) {
+                        await crypto.subtle.digest("SHA-256", new Uint8Array([i]));
+                    }
+                })(),
+            );
+
+            expect(MockTime.nowMs - FAKE_TIME).most(500);
+        } finally {
+            settleStalledOp?.();
+        }
+    });
+
+    it("stops waiting on macrotasks for a host operation that does not settle", async () => {
+        let settleStalledOp!: () => void;
+        try {
+            void MockTime.requireHostAsync(new Promise<void>(resolve => (settleStalledOp = resolve)));
+
+            await MockTime.macrotasks;
+
+            expect(MockTime.pendingHostAsyncOps).equal(0);
+        } finally {
+            settleStalledOp?.();
+        }
+    });
+
+    it("registers no host operation when crypto rejects its arguments", async function () {
+        if (nodeCrypto?.pbkdf2 === undefined) {
+            this.skip();
+        }
+
+        expect(() => nodeCrypto.pbkdf2("password", "salt", 1000, 16, "not-a-digest")).throws(Error);
+
+        expect(MockTime.pendingHostAsyncOps).equal(0);
+    });
+});

--- a/packages/general/test/time/MockTimeResolveTest.ts
+++ b/packages/general/test/time/MockTimeResolveTest.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// MockTime lives in @matter/testing, which has no dependencies and no suite of its own, so its tests live here
+
 const FAKE_TIME = 36000000;
 
 const nodeCrypto = (globalThis as any).process?.getBuiltinModule?.("crypto");
@@ -69,6 +71,7 @@ describe("MockTime.resolve", () => {
 
             expect(fired).equal(true);
             expect(MockTime.pendingHostAsyncOps).equal(0);
+            expect(MockTime.abandonedHostAsyncOps).equal(1);
 
             // An abandoned operation may never settle, so the next test must not inherit it
             expect(MockTime.dependentCount).least(1);
@@ -93,6 +96,27 @@ describe("MockTime.resolve", () => {
             );
 
             expect(MockTime.nowMs - FAKE_TIME).most(500);
+        } finally {
+            settleStalledOp?.();
+        }
+    });
+
+    it("charges one yield per turn however many waits overlap", async () => {
+        let settleStalledOp!: () => void;
+        try {
+            void MockTime.requireHostAsync(new Promise<void>(resolve => (settleStalledOp = resolve)));
+
+            const turns = () =>
+                (async () => {
+                    for (let i = 0; i < 5; i++) {
+                        await MockTime.macrotask;
+                    }
+                })();
+
+            await Promise.all([MockTime.resolve(turns()), MockTime.resolve(turns()), MockTime.resolve(turns())]);
+
+            // Three waits spinning over the same five turns charge those five turns once, not once per wait
+            expect(MockTime.hostAsyncYieldsCharged).most(8);
         } finally {
             settleStalledOp?.();
         }

--- a/packages/testing/src/mocks/crypto.ts
+++ b/packages/testing/src/mocks/crypto.ts
@@ -9,9 +9,9 @@
  * pending.  Node.js crypto.subtle methods only resolve on macrotask boundaries, so MockTime's default microtask yields
  * will hang if a crypto operation is in flight.
  *
- * Each patched method registers its promise via {@link MockTime.requireMacrotasks}, which keeps MockTime in macrotask
- * mode for the duration of the operation.  Overlapping operations are handled naturally by the ref-counted dependent
- * set.
+ * Each patched method registers its promise via {@link MockTime.requireHostAsync}, which keeps MockTime in macrotask
+ * mode and withholds virtual time for the duration of the operation.  Overlapping operations are handled naturally by
+ * the ref-counted dependent set.
  */
 
 import { MockTime } from "./time.js";
@@ -38,13 +38,12 @@ if (typeof crypto !== "undefined" && crypto.subtle) {
             continue;
         }
         (subtle as any)[name] = function (...args: any[]) {
-            return MockTime.requireMacrotasks(original.apply(subtle, args));
+            return MockTime.requireHostAsync(original.apply(subtle, args));
         };
     }
 }
 
-// Node.js's callback-based crypto methods (hkdf, pbkdf2) also resolve on macrotask boundaries via libuv's thread
-// pool. Wrap the callbacks so MockTime stays in macrotask mode while they're pending.
+// Node.js's callback-based crypto methods (hkdf, pbkdf2) also settle on host time via libuv's thread pool
 const nodeCrypto = (globalThis as any).process?.getBuiltinModule?.("crypto");
 if (nodeCrypto) {
     for (const name of ["hkdf", "pbkdf2"]) {
@@ -54,13 +53,18 @@ if (nodeCrypto) {
         }
         nodeCrypto[name] = function (...args: any[]) {
             const callback = args[args.length - 1];
-            let resolve: () => void;
-            void MockTime.requireMacrotasks(new Promise<void>(r => (resolve = r)));
+            let resolve!: () => void;
+            const settled = new Promise<void>(r => (resolve = r));
             args[args.length - 1] = (...cbArgs: any[]) => {
                 resolve();
                 callback(...cbArgs);
             };
-            return original.apply(this, args);
+
+            // Argument validation throws before the operation is scheduled, so registration follows the call that
+            // guarantees the callback runs
+            const result = original.apply(this, args);
+            void MockTime.requireHostAsync(settled);
+            return result;
         };
     }
 }

--- a/packages/testing/src/mocks/crypto.ts
+++ b/packages/testing/src/mocks/crypto.ts
@@ -10,8 +10,8 @@
  * will hang if a crypto operation is in flight.
  *
  * Each patched method registers its promise via {@link MockTime.requireHostAsync}, which keeps MockTime in macrotask
- * mode and withholds virtual time for the duration of the operation.  Overlapping operations are handled naturally by
- * the ref-counted dependent set.
+ * mode and withholds virtual time for the duration of the operation.  MockTime tracks each registration separately,
+ * so overlapping operations are handled naturally.
  */
 
 import { MockTime } from "./time.js";

--- a/packages/testing/src/mocks/time.ts
+++ b/packages/testing/src/mocks/time.ts
@@ -29,7 +29,63 @@ type TimerCallback = () => any;
 type MockTimeLike = typeof MockTime;
 export interface MockTime extends MockTimeLike {}
 
-const macrotaskDependents = new Set<Promise<unknown>>();
+/**
+ * An operation that only settles on a macrotask boundary.  A "host" dependent additionally settles on host time
+ * rather than virtual time, so virtual time must stand still while it is pending.  An abandoned dependent still
+ * requires macrotask yields to settle but no longer holds virtual time.
+ */
+interface Dependent {
+    host: boolean;
+    yields: number;
+    abandoned: boolean;
+}
+
+const dependents = new Map<Promise<unknown>, Dependent>();
+
+/**
+ * Yields a single host operation may withhold virtual time for.  The budget is per operation, so a slow operation
+ * cannot spend the budget of one that starts alongside it.  An operation over budget is abandoned: it still requires
+ * macrotask yields to settle but no longer withholds virtual time, so an operation that never settles costs one
+ * bounded delay rather than a stalled clock.
+ */
+const MAX_HOST_ASYNC_YIELDS = 200;
+
+function register<T>(dependent: Promise<T>, host: boolean) {
+    const registered = dependent.finally(() => {
+        dependents.delete(registered);
+    });
+    dependents.set(registered, { host, yields: 0, abandoned: false });
+    return registered;
+}
+
+/**
+ * Charge one yield to every host operation that withholds virtual time, abandoning those over budget.  Reports
+ * whether virtual time must stand still.
+ */
+function chargeHostAsync() {
+    let withholding = false;
+    for (const dependent of dependents.values()) {
+        if (!dependent.host || dependent.abandoned) {
+            continue;
+        }
+        if (dependent.yields >= MAX_HOST_ASYNC_YIELDS) {
+            dependent.abandoned = true;
+            continue;
+        }
+        dependent.yields++;
+        withholding = true;
+    }
+    return withholding;
+}
+
+function hasActiveDependents() {
+    for (const dependent of dependents.values()) {
+        if (!dependent.abandoned) {
+            return true;
+        }
+    }
+    return false;
+}
 
 const timerNames = new WeakMap<TimerCallback, string>();
 
@@ -180,6 +236,7 @@ export const MockTime = {
      */
     reset(time: ConstructorParameters<typeof Date>[0] = epoch) {
         callbacks = [];
+        dependents.clear();
         nowMs = new Date(time).getTime();
         defaultToMacrotasks = false;
         MockTime.enable();
@@ -208,12 +265,37 @@ export const MockTime = {
         defaultToMacrotasks = value;
     },
 
+    /**
+     * Register an operation that settles on host time rather than virtual time.  {@link MockTime.resolve} withholds
+     * virtual time for the duration of the operation, so host latency does not expire virtual timers.  Time still
+     * advances in gaps between operations and once an operation exhausts {@link MAX_HOST_ASYNC_YIELDS}.
+     */
+    requireHostAsync<T>(dependent: Promise<T>) {
+        return register(dependent, true);
+    },
+
     requireMacrotasks<T>(dependent: Promise<T>) {
-        dependent = dependent.finally(() => {
-            macrotaskDependents.delete(dependent);
-        });
-        macrotaskDependents.add(dependent);
-        return dependent;
+        return register(dependent, false);
+    },
+
+    /**
+     * Operations {@link MockTime} still tracks, abandoned ones included.  Exposed for tests of MockTime itself.
+     */
+    get dependentCount() {
+        return dependents.size;
+    },
+
+    /**
+     * Host operations currently withholding virtual time.  Exposed for tests of MockTime itself.
+     */
+    get pendingHostAsyncOps() {
+        let count = 0;
+        for (const dependent of dependents.values()) {
+            if (dependent.host && !dependent.abandoned) {
+                count++;
+            }
+        }
+        return count;
     },
 
     atTime<T>(time: number | Date, actor: () => T): T {
@@ -282,12 +364,14 @@ export const MockTime = {
     },
 
     /**
-     * Wait for all registered macrotask dependencies to complete.
+     * Wait for all registered macrotask dependencies to complete.  A host dependency over budget is abandoned here as
+     * it is in {@link MockTime.resolve}, so one that never settles cannot stall the wait.
      */
     get macrotasks() {
         return (async () => {
-            while (macrotaskDependents.size) {
+            while (hasActiveDependents()) {
                 await MockTime.resolve(this.macrotask);
+                chargeHostAsync();
             }
         })();
     },
@@ -330,7 +414,7 @@ export const MockTime = {
         while (!resolved) {
             // Use macrotask yields when required explicitly or when async operations needing macrotasks (e.g.
             // crypto) are pending
-            if ((macrotasks ?? defaultToMacrotasks) || macrotaskDependents.size) {
+            if ((macrotasks ?? defaultToMacrotasks) || dependents.size) {
                 await MockTime.macrotask;
             } else {
                 await MockTime.yield();
@@ -345,6 +429,12 @@ export const MockTime = {
                 throw new TestTimeoutError(
                     "Promise did not resolve within one (virtual) hour, probably not going to happen",
                 );
+            }
+
+            // Host operations such as crypto settle on host time.  Advancing while one is pending converts host
+            // latency into virtual time, which expires protocol timers that would not expire in production
+            if (chargeHostAsync()) {
+                continue;
             }
 
             if (stepMs) {

--- a/packages/testing/src/mocks/time.ts
+++ b/packages/testing/src/mocks/time.ts
@@ -59,23 +59,55 @@ function register<T>(dependent: Promise<T>, host: boolean) {
 }
 
 /**
- * Charge one yield to every host operation that withholds virtual time, abandoning those over budget.  Reports
- * whether virtual time must stand still.
+ * The waiter currently charging the budget.  Waits nest and overlap, so without a single charger per yield an
+ * operation's budget would drain once per concurrent waiter rather than once per yield.
  */
-function chargeHostAsync() {
+let charger: object | undefined;
+
+/**
+ * Host operations abandoned since the last {@link MockTime.reset}.  Any count above zero means virtual time inflated
+ * with host latency, so a test that fails on protocol timing should be read in that light.
+ */
+let abandonedHostAsyncOps = 0;
+
+/**
+ * Report whether virtual time must stand still for a pending host operation.  The waiter that owns the budget also
+ * charges one yield to each such operation and abandons those over budget.
+ */
+function withholdVirtualTime(waiter: object) {
+    if (charger === undefined) {
+        charger = waiter;
+    }
+    const charging = charger === waiter;
+
     let withholding = false;
     for (const dependent of dependents.values()) {
         if (!dependent.host || dependent.abandoned) {
             continue;
         }
-        if (dependent.yields >= MAX_HOST_ASYNC_YIELDS) {
-            dependent.abandoned = true;
-            continue;
+        if (charging) {
+            if (dependent.yields >= MAX_HOST_ASYNC_YIELDS) {
+                dependent.abandoned = true;
+                abandonedHostAsyncOps++;
+
+                // Virtual time inflates with host latency again from here, which is the defect this budget exists to
+                // contain, so an abandonment must not pass unnoticed
+                console.warn(
+                    `MockTime abandoned a host operation pending for ${MAX_HOST_ASYNC_YIELDS} yields; virtual time may now inflate with host latency`,
+                );
+                continue;
+            }
+            dependent.yields++;
         }
-        dependent.yields++;
         withholding = true;
     }
     return withholding;
+}
+
+function releaseCharger(waiter: object) {
+    if (charger === waiter) {
+        charger = undefined;
+    }
 }
 
 function hasActiveDependents() {
@@ -237,6 +269,7 @@ export const MockTime = {
     reset(time: ConstructorParameters<typeof Date>[0] = epoch) {
         callbacks = [];
         dependents.clear();
+        abandonedHostAsyncOps = 0;
         nowMs = new Date(time).getTime();
         defaultToMacrotasks = false;
         MockTime.enable();
@@ -276,6 +309,26 @@ export const MockTime = {
 
     requireMacrotasks<T>(dependent: Promise<T>) {
         return register(dependent, false);
+    },
+
+    /**
+     * The largest yield count charged to a pending host operation.  Exposed for tests of MockTime itself.
+     */
+    get hostAsyncYieldsCharged() {
+        let yields = 0;
+        for (const dependent of dependents.values()) {
+            if (dependent.host && dependent.yields > yields) {
+                yields = dependent.yields;
+            }
+        }
+        return yields;
+    },
+
+    /**
+     * Host operations abandoned since the last {@link MockTime.reset}.  Exposed for tests of MockTime itself.
+     */
+    get abandonedHostAsyncOps() {
+        return abandonedHostAsyncOps;
     },
 
     /**
@@ -369,9 +422,14 @@ export const MockTime = {
      */
     get macrotasks() {
         return (async () => {
-            while (hasActiveDependents()) {
-                await MockTime.resolve(this.macrotask);
-                chargeHostAsync();
+            const waiter = {};
+            try {
+                while (hasActiveDependents()) {
+                    await MockTime.resolve(this.macrotask);
+                    withholdVirtualTime(waiter);
+                }
+            } finally {
+                releaseCharger(waiter);
             }
         })();
     },
@@ -410,48 +468,53 @@ export const MockTime = {
         );
 
         let timeAdvanced = 0;
+        const waiter = {};
 
-        while (!resolved) {
-            // Use macrotask yields when required explicitly or when async operations needing macrotasks (e.g.
-            // crypto) are pending
-            if ((macrotasks ?? defaultToMacrotasks) || dependents.size) {
-                await MockTime.macrotask;
-            } else {
-                await MockTime.yield();
+        try {
+            while (!resolved) {
+                // Use macrotask yields when required explicitly or when async operations needing macrotasks (e.g.
+                // crypto) are pending
+                if ((macrotasks ?? defaultToMacrotasks) || dependents.size) {
+                    await MockTime.macrotask;
+                } else {
+                    await MockTime.yield();
+                }
+
+                if (resolved) {
+                    break;
+                }
+
+                // If we've advanced more than one hour, assume we've hung
+                if (timeAdvanced > 60 * 60 * 1000) {
+                    throw new TestTimeoutError(
+                        "Promise did not resolve within one (virtual) hour, probably not going to happen",
+                    );
+                }
+
+                // Host operations such as crypto settle on host time.  Advancing while one is pending converts host
+                // latency into virtual time, which expires protocol timers that would not expire in production
+                if (withholdVirtualTime(waiter)) {
+                    continue;
+                }
+
+                if (stepMs) {
+                    await this.advance(stepMs);
+                    timeAdvanced += stepMs;
+                } else {
+                    // 100ms steps give ~200 yields before a 10-second mock timeout fires, sufficient for realistic
+                    // async chains
+                    await this.advance(100);
+                    timeAdvanced += 100;
+                }
+
+                if (resolved) {
+                    break;
+                }
+
+                await this.yield();
             }
-
-            if (resolved) {
-                break;
-            }
-
-            // If we've advanced more than one hour, assume we've hung
-            if (timeAdvanced > 60 * 60 * 1000) {
-                throw new TestTimeoutError(
-                    "Promise did not resolve within one (virtual) hour, probably not going to happen",
-                );
-            }
-
-            // Host operations such as crypto settle on host time.  Advancing while one is pending converts host
-            // latency into virtual time, which expires protocol timers that would not expire in production
-            if (chargeHostAsync()) {
-                continue;
-            }
-
-            if (stepMs) {
-                await this.advance(stepMs);
-                timeAdvanced += stepMs;
-            } else {
-                // 100ms steps give ~200 yields before a 10-second mock timeout fires, sufficient for realistic
-                // async chains
-                await this.advance(100);
-                timeAdvanced += 100;
-            }
-
-            if (resolved) {
-                break;
-            }
-
-            await this.yield();
+        } finally {
+            releaseCharger(waiter);
         }
 
         if (error !== undefined) {


### PR DESCRIPTION
## Problem

The mock clock our tests run on advanced 100 ms for every turn of the event loop, including turns where the only thing outstanding was a real cryptographic operation running on one of Node's background threads. Those operations complete on the machine's clock, not on the test's simulated clock, so the amount of simulated time a test consumed depended on how busy the machine was.

On a loaded CI runner this expired protocol timers that would never expire in production. In the nightly failures below, a device handling the certificate step of commissioning burned more than 39 seconds of simulated time between receiving `addNoc` and answering it — past the point where the controller gives up on a peer that stopped responding — so commissioning aborted:

```
Operation aborted
  at ControllerCommissioningFlow.#certificates
Caused by: Peer is no longer responding to active session (timed out after 39.2s)
```

Whichever test happened to commission a pair of nodes failed, so one cause surfaced as five unrelated-looking failures over the last two weeks:

| Run | Failing test |
| --- | --- |
| 34669583633 (nightly, 09-12) | `split commissioning ➡ leaves no phantom peer when the node cannot be reached` |
| 34182527651 (nightly, 09-08) | `ClientTuningTest ➡ wifi-operational peers use the wifi profile with a 1s MRP margin` |
| 34308323563 (nightly, 09-09) | `ClientInvoke ➡ rejects pending commands when batcher is closed` |
| 34092195416 (PR) | `ClientNodeTcp ➡ attempts TCP when session parameters omit TCP support but mDNS advertises a TCP server` |
| 33811688243 (PR) | `ClientNode ➡ commissions and initializes endpoints even with a leave event in initial subscription data` |

Measured on an idle machine, 60 `crypto.subtle` operations cost 24.5 seconds of simulated time in 30 ms of real time. They now cost none.

## Change

The crypto mocks register their operations as settling on host time, and the mock clock stands still while one is outstanding.

Each operation carries its own yield counter, and one waiter charges it per yield however many waits overlap, so the budget counts turns rather than waiters and means the same thing whether the wait arrived through `resolve()` or through the wait for outstanding operations. The counter is per operation, but a turn is a turn: an operation is charged for every turn that elapses while it is outstanding, including turns another operation caused.

An operation that exhausts its budget is abandoned: it still receives the event-loop turns it needs to finish, but no longer holds the clock. This bounds the cost of an operation that never settles — it delays the hang detector once instead of stalling simulated time for the rest of the test — and keeps the wait for outstanding operations from blocking forever. Because abandonment restores the original defect for that operation, it writes a warning and increments a counter that `reset()` clears, so a timing failure can be read for whether the clock inflated.

Supporting changes:

- The two collections tracking outstanding operations become one map whose entries carry their kind, so the two cannot disagree about what is pending.
- The Node callback-based crypto methods (`pbkdf2`, `hkdf`) register only after the call that guarantees their callback runs. Argument validation throws synchronously, which previously left a registration behind that nothing could ever clear.
- `reset()` drops tracked operations, so one test cannot inherit a stalled operation from another.
- `MockTime` gains four deliberately test-only accessors: `dependentCount`, `pendingHostAsyncOps`, `abandonedHostAsyncOps` and `hostAsyncYieldsCharged`.

Simulated time still advances by one step in a gap between two host operations; a full commissioning accrues roughly half a second that way, against a 39.2 second budget.

No `CHANGELOG.md` entry: the change is confined to test infrastructure.

## Verification

- `npm run build-clean`, `npm run format`, `npm run lint`, full `npm test` green.
- `packages/node` CJS suite three times green, and twice more green under twelve busy cores.
- Budget margin, empirically: full runs of `packages/node` and `packages/protocol` abandon nothing, under load included. The only abandonment warnings in the whole suite come from the two tests that stall an operation on purpose.
- Nine mutations applied and each killed by a named test: the hold removed; the budget unbounded; the budget shared across operations instead of per operation; every waiter charging instead of one; the abandonment counter not incremented; the charge removed from the wait for outstanding operations; the `reset()` cleanup removed; the callback-based crypto path reverted to the old registration; registration moved back before the call.
